### PR TITLE
feat(handlers): add POST to ChatbotUsageHandler and write to BigQuery

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,7 +60,7 @@ class Main(AppHandler):
         # Prompt Library:
         PromptLibraryManagement.configure(self.app, '/api/v1/chatbots/prompt_library')
         # Questions (Usage handler, for sharing)
-        ChatbotUsageHandler.configure(self.app, '/api/v1/chatbots/usage')
+        ChatbotUsageHandler.configure(self.app, '/api/v1/chatbots_usage')
         self.app.router.add_view(
             '/api/v1/chatbots/questions/{sid}',
             ChatbotSharingQuestion


### PR DESCRIPTION
## Summary
- **Add POST to ChatbotUsageHandler**: records usage events directly in BigQuery.
- **Normalize payload**: UUIDs/timestamps, compute `_at`, enrich `origin`, `User-Agent`, `user_id`.
- **Route change**: `/api/v1/chatbots/usage` → `/api/v1/chatbots_usage`.
- **Connection setup**: remove class-level `credentials`; resolved in `get_connection`.

## Breaking change
- **Route changed**: update clients/integrations to `/api/v1/chatbots_usage`.

## Details
- Implement `get_connection` using BigQuery via `AsyncDB` (`force_closing=False`).
- `POST` flow: validate/parse payload → normalize types (`sid`, `chatbot_id`, `event_timestamp`) → enrich with request metadata → ensure `_at` exists → write to `navigator.chatbots_usage` using `conn.write`.

## Testing
- Expect `201` on valid payload and row inserted in BigQuery.
- Example request:
```bash
curl -X POST http://<host>/api/v1/chatbots_usage \
  -H "Content-Type: application/json" \
  -d '{
  "chatbot_id": "a6fcfaef-fe01-4040-94f3-bb418054ab5b",
  "user_id": 35,
  "sid": "24292fac-b46d-447e-a4f7-f88d68e9c998",
  "source_path": "web",
  "platform": "web",
  "origin": "landing_page",
  "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
  "question": "¿Cuál es el horario de atención?",
  "response": "Nuestro horario de atención es de lunes a viernes de 9am a 6pm.",
  "used_at": 1694011223,
  "event_timestamp": "2025-09-06T14:20:00Z",
  "_at": "2025-09-06T14:20:00Z"
  }'
```

## Migration
- Update API gateway/routes and client SDKs to use `/api/v1/chatbots_usage`.
- Adjust monitoring/dashboards for the new endpoint path.

## Risks/Notes
- Requires valid BigQuery credentials and dataset/table access.
- Depends on navigator auth/session for resolving `user_id` when omitted.

## Checklist
- [x] Handler updated and linted
- [x] Route updated
- [ ] Update docs to reflect route change

