### PR TITLE
Fix project toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,10 @@ agents = [
     "duckduckgo-search==7.5.0",
     "google-search-results==2.4.2",
     "google-api-python-client>=2.151.0",
-    "pomegranate==1.1.0",
+    # Ensure compatibility with modern networkx/decorator to avoid downgrading moviepy
+    "pomegranate>=1.1.1",
+    "networkx>=2.6,<3",
+    "decorator>=5",
     "autoviz==0.1.905",
     "spacy==3.8.6",
     "html2text==2025.4.15",
@@ -115,12 +118,16 @@ loaders = [
     "pytorch-metric-learning==2.9.0",
     "nvidia-cudnn-cu12==9.1.0.70",
     "moviepy==2.2.1",
+    # Enforce modern decorator to keep moviepy at 2.x
+    "decorator>=5",
     "ffmpeg==1.4",
 ]
 
 vectors = [
     "torch==2.6.0",  # Pin to working version
     "torchaudio==2.6.0",  # Match torch version
+    # TensorFlow constraints → keep numpy in the compatible 2.1 series
+    "numpy>=2.1,<2.2",
     "tiktoken==0.9.0",
     "accelerate==0.34.2",
     "llama-index==0.12.39",
@@ -217,7 +224,7 @@ eda = [
 
 # Convenience groups
 all = [
-    "ai-parrot[agents,loaders,images,vector,anthropic,openai,google,groq,milvus,chroma]"
+    "ai-parrot[agents,loaders,images,vectors,anthropic,openai,google,groq,milvus,chroma]"
 ]
 
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ agents = [
     "google-api-python-client>=2.151.0",
     # Ensure compatibility with modern networkx/decorator to avoid downgrading moviepy
     "pomegranate>=1.1.1",
-    "networkx>=2.6,<3",
+    "networkx>=3.0",
     "decorator>=5",
     "autoviz==0.1.905",
     "spacy==3.8.6",


### PR DESCRIPTION
Fix on dependencies for parrot 
test install: 
`(ai-parrot) ➜  ai-parrot git:(fix_project_toml) ✗ uv pip install -U ".[vectors,agents,loaders,google]"                                                                                                                                     <region:us-east-1>

Resolved 518 packages in 23.23s
      Built ai-parrot @ file:///home/jelitox/repos/trocglobal/ai-parrot
      Built antlr4-python3-runtime==4.9.3
      Built webrtcvad==2.0.10
      Built julius==0.2.7
      Built docopt==0.6.2
Prepared 118 packages in 21.36s
Uninstalled 61 packages in 555ms
Installed 118 packages in 476ms
 - ai-parrot==0.13.0 (from file:///home/jelitox/repos/trocglobal/ai-parrot)
 + ai-parrot==0.14.1 (from file:///home/jelitox/repos/trocglobal/ai-parrot)
 - aiocsv==1.3.2
 + aiocsv==1.4.0
 + alembic==1.16.5
 + antlr4-python3-runtime==4.9.3
 - anyio==4.10.0
 + anyio==4.11.0
 - asgiref==3.9.1
 + asgiref==3.10.0
 + asteroid-filterbanks==0.4.0
 - asyncdb==2.11.9
 + asyncdb==2.12.0
 - attrs==25.3.0
 + attrs==25.4.0
 + audioread==3.0.1
 + av==15.1.0
 - bcrypt==4.3.0
 + bcrypt==5.0.0
 - beautifulsoup4==4.13.5
 + beautifulsoup4==4.14.2
 + blinker==1.9.0
 - bokeh==3.7.3
 + bokeh==3.8.0
 - cachetools==5.5.2
 + cachetools==6.2.0
 - certifi==2025.8.3
 + certifi==2025.10.5
 - cffi==1.17.1
 + cffi==2.0.0
 - click==8.2.1
 + click==8.3.0
 + colorlog==6.9.0
 + ctranslate2==4.4.0
 - ddgs==9.5.5
 + ddgs==9.6.0
 + docopt==0.6.2
 + einops==0.8.1
 - faker==37.6.0
 + faker==37.8.0
 - fastapi==0.116.1
 + fastapi==0.118.0
 + faster-whisper==1.2.0
 - flatbuffers==25.2.10
 + flatbuffers==25.9.23
 - fonttools==4.59.2
 + fonttools==4.60.1
 - frozenlist==1.7.0
 + frozenlist==1.8.0
 + gitdb==4.0.12
 + gitpython==3.1.45
 - google-api-core==2.25.1
 + google-api-core==2.25.2
 - google-auth==2.40.3
 + google-auth==2.41.1
 - grpcio==1.74.0
 + grpcio==1.75.1
 + httpx-sse==0.4.1
 - huggingface-hub==0.34.4
 + huggingface-hub==0.35.3
 + hyperpyyaml==1.2.2
 - jiter==0.10.0
 + jiter==0.11.0
 + julius==0.2.7
 + lazy-loader==0.4
 + librosa==0.11.0
 + lightning==2.5.5
 + lightning-utilities==0.15.2
 - limits==5.5.0
 + limits==5.6.0
 - llama-index-instrumentation==0.4.0
 + llama-index-instrumentation==0.4.1
 - llvmlite==0.44.0
 + llvmlite==0.45.1
 - lxml==5.3.0
 + lxml==6.0.2
 + mako==1.3.10
 - markitdown==0.1.2
 + markitdown==0.1.3
 - markupsafe==3.0.2
 + markupsafe==3.0.3
 + mcp==1.15.0
 - multidict==6.6.4
 + multidict==6.7.0
 - narwhals==2.5.0
 + narwhals==2.7.0
 - navigator-api==2.14.3
 + navigator-api==2.14.4
 - nltk==3.9.1
 + nltk==3.9.2
 - numba==0.61.0
 + numba==0.62.1
 - numpy==2.3.3
 + numpy==2.1.3
 + omegaconf==2.3.0
 - onnxruntime==1.22.1
 + onnxruntime==1.23.0
 - openai==1.102.0
 + openai==1.109.1
 + optuna==4.5.0
 - panel==1.8.0
 + panel==1.8.1
 - pgvector==0.3.6
 + pgvector==0.4.1
 - pomegranate==1.1.0
 + pomegranate==1.1.2
 + pooch==1.8.2
 - posthog==6.7.4
 + posthog==6.7.6
 + primepy==1.3
 - propcache==0.3.2
 + propcache==0.4.0
 - psutil==7.0.0
 + psutil==7.1.0
 + pyannote-audio==3.4.0
 + pyannote-core==5.0.0
 + pyannote-database==5.1.3
 + pyannote-metrics==3.2.1
 + pyannote-pipeline==3.0.1
 - pydantic==2.11.8
 + pydantic==2.11.10
 + pydantic-settings==2.11.0
 + pydeck==0.9.1
 - pyparsing==3.2.3
 + pyparsing==3.2.5
 + python-multipart==0.0.20
 + pytorch-lightning==2.5.5
 + pytorch-metric-learning==2.9.0
 - pyyaml==6.0.2
 + pyyaml==6.0.3
 - regex==2025.9.1
 + regex==2025.9.18
 + resemblyzer==0.1.4
 + ruamel-yaml==0.18.15
 + ruamel-yaml-clib==0.2.14
 - scikit-learn==1.5.1
 + scikit-learn==1.7.2
 - scipy==1.15.3
 + scipy==1.16.2
 + semver==3.0.4
 - shapely==2.1.1
 + shapely==2.1.2
 - slack-sdk==3.36.0
 + slack-sdk==3.37.0
 + smmap==5.0.2
 + socksio==1.0.0
 + soundfile==0.13.1
 + soxr==1.0.0
 + speechbrain==1.0.3
 + sse-starlette==3.0.2
 - starlette==0.47.3
 + starlette==0.48.0
 - statsmodels==0.14.2
 + statsmodels==0.14.5
 - std-uritemplate==2.0.5
 + std-uritemplate==2.0.6
 + streamlit==1.50.0
 + tensorboardx==2.6.4
 + toml==0.10.2
 + torch-audiomentations==0.12.0
 + torch-pitch-shift==1.2.5
 + torchaudio==2.6.0
 + torchmetrics==1.8.2
 - typer==0.17.4
 + typer==0.19.2
 + typing==3.10.0.0
 - typing-inspection==0.4.1
 + typing-inspection==0.4.2
 + undetected-chromedriver==3.5.5
 - uvicorn==0.35.0
 + uvicorn==0.37.0
 + webrtcvad==2.0.10
 + whisperx==3.4.2
 - xlsxwriter==3.2.0
 + xlsxwriter==3.2.9
 - xxhash==3.5.0
 + xxhash==3.6.0
 - yarl==1.20.1
 + yarl==1.22.0
(ai-parrot) ➜  ai-parrot git:(fix_project_toml) ✗   `