### PR TITLE
Avoid passing max_tokens when unset

### DIFF
--- a/parrot/bots/abstract.py
+++ b/parrot/bots/abstract.py
@@ -1686,16 +1686,21 @@ Use the following information about user's data to guide your responses:
 
             # Make the LLM call using the Claude client
             async with self._llm as client:
-                response = await client.ask(
-                    prompt=question,
-                    system_prompt=system_prompt,
-                    model=kwargs.get('model', self._llm_model),
-                    max_tokens=kwargs.get('max_tokens', self._max_tokens),
-                    temperature=kwargs.get('temperature', self._llm_temp),
-                    user_id=user_id,
-                    session_id=session_id,
-                    use_tools=use_tools,
-                )
+                llm_kwargs = {
+                    "prompt": question,
+                    "system_prompt": system_prompt,
+                    "model": kwargs.get('model', self._llm_model),
+                    "temperature": kwargs.get('temperature', self._llm_temp),
+                    "user_id": user_id,
+                    "session_id": session_id,
+                    "use_tools": use_tools,
+                }
+
+                max_tokens = kwargs.get('max_tokens', self._max_tokens)
+                if max_tokens is not None:
+                    llm_kwargs["max_tokens"] = max_tokens
+
+                response = await client.ask(**llm_kwargs)
 
                 # Extract the vector-specific metadata
                 vector_info = vector_metadata.get('vector', {})
@@ -2015,15 +2020,20 @@ Use the following information about user's data to guide your responses:
 
             # Make the LLM call using the Claude client
             async with self._llm as client:
-                response = await client.ask(
-                    prompt=question,
-                    system_prompt=system_prompt,
-                    model=kwargs.get('model', self._llm_model),
-                    max_tokens=kwargs.get('max_tokens', self._max_tokens),
-                    temperature=kwargs.get('temperature', self._llm_temp),
-                    user_id=user_id,
-                    session_id=session_id,
-                )
+                llm_kwargs = {
+                    "prompt": question,
+                    "system_prompt": system_prompt,
+                    "model": kwargs.get('model', self._llm_model),
+                    "temperature": kwargs.get('temperature', self._llm_temp),
+                    "user_id": user_id,
+                    "session_id": session_id,
+                }
+
+                max_tokens = kwargs.get('max_tokens', self._max_tokens)
+                if max_tokens is not None:
+                    llm_kwargs["max_tokens"] = max_tokens
+
+                response = await client.ask(**llm_kwargs)
 
                 # Set conversation context info
                 response.set_conversation_context_info(
@@ -2437,8 +2447,9 @@ Use the following information about user's data to guide your responses:
             session_id = str(uuid.uuid4())
         turn_id = str(uuid.uuid4())
 
-        # Set default max_tokens to 8192 if not provided
-        max_tokens = kwargs.get('max_tokens', 8192)
+        # Set max_tokens using bot default when provided
+        default_max_tokens = self._max_tokens if self._max_tokens is not None else None
+        max_tokens = kwargs.get('max_tokens', default_max_tokens)
 
         limit = kwargs.get('limit', self.context_search_limit)
         score_threshold = kwargs.get('score_threshold', self.context_score_threshold)
@@ -2492,16 +2503,20 @@ Use the following information about user's data to guide your responses:
 
             # Make the LLM call
             async with self._llm as client:
-                response = await client.ask(
-                    prompt=question,
-                    system_prompt=system_prompt,
-                    model=kwargs.get('model', self._llm_model),
-                    max_tokens=max_tokens,
-                    temperature=kwargs.get('temperature', self._llm_temp),
-                    user_id=user_id,
-                    session_id=session_id,
-                    use_tools=use_tools,
-                )
+                llm_kwargs = {
+                    "prompt": question,
+                    "system_prompt": system_prompt,
+                    "model": kwargs.get('model', self._llm_model),
+                    "temperature": kwargs.get('temperature', self._llm_temp),
+                    "user_id": user_id,
+                    "session_id": session_id,
+                    "use_tools": use_tools,
+                }
+
+                if max_tokens is not None:
+                    llm_kwargs["max_tokens"] = max_tokens
+
+                response = await client.ask(**llm_kwargs)
 
                 # Enhance response with metadata
                 response.set_vector_context_info(


### PR DESCRIPTION
## Summary
- update AbstractBot conversation, invoke, and ask flows to build LLM call arguments dynamically
- only forward max_tokens when a value is configured so clients can use their own defaults
- ensure ask() respects the bot-level default for max_tokens without forcing a fallback value

## Testing
- pytest -q *(fails: missing optional dependencies such as folium, querysource, ultralytics, apscheduler)*

------
https://chatgpt.com/codex/tasks/task_e_68ed8a270cd083308d21be81e5e1b040