### PR TITLE
Fix vite preprocess import for Svelte config

### DIFF
--- a/crew-builder/svelte.config.js
+++ b/crew-builder/svelte.config.js
@@ -1,5 +1,5 @@
 import adapter from '@sveltejs/adapter-auto';
-import { vitePreprocess } from '@sveltejs/kit/vite';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 const config = {
   preprocess: vitePreprocess(),


### PR DESCRIPTION
## Summary
- update the Svelte configuration to import `vitePreprocess` from `@sveltejs/vite-plugin-svelte`

## Testing
- npm run check *(fails: `svelte-kit` binary missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ee22e1f06483309379b5a197268cb5