### PR TITLE
Fix SvelteKit configuration and flow store

### DIFF
--- a/crew-builder/src/app.html
+++ b/crew-builder/src/app.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%sveltekit.assets%/favicon.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    %sveltekit.head%
+  </head>
+  <body data-sveltekit-preload-data="hover">
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
+</html>

--- a/crew-builder/src/components/ThemeSwitcher.svelte
+++ b/crew-builder/src/components/ThemeSwitcher.svelte
@@ -51,7 +51,7 @@
   <button
     type="button"
     class="btn {buttonClass} gap-2"
-    on:click={toggleDropdown}
+    onclick={toggleDropdown}
     aria-label="Theme Selector"
   >
     <svg
@@ -83,7 +83,7 @@
   {#if showDropdown}
     <div
       class="absolute right-0 z-[100] mt-2 w-64 rounded-box bg-base-100 shadow-2xl"
-      on:click={(e) => e.stopPropagation()}
+      onclick={(event) => event.stopPropagation()}
     >
       <div class="p-3">
         <!-- Search Input -->
@@ -106,7 +106,7 @@
             <li>
               <button
                 class:active={themeStore.currentTheme === theme}
-                on:click={() => selectTheme(theme)}
+                onclick={() => selectTheme(theme)}
                 data-theme={theme}
               >
                 <div class="flex w-full items-center justify-between">
@@ -136,7 +136,7 @@
       <div class="border-t border-base-300 p-2">
         <button
           class="btn btn-sm btn-block"
-          on:click={() => themeStore.toggleDarkMode()}
+          onclick={() => themeStore.toggleDarkMode()}
         >
           Toggle Dark Mode
         </button>

--- a/crew-builder/src/lib/api/client.ts
+++ b/crew-builder/src/lib/api/client.ts
@@ -14,10 +14,14 @@ apiClient.interceptors.request.use(
     if (browser) {
       const token = localStorage.getItem('token');
       if (token) {
-        config.headers = {
-          ...config.headers,
-          Authorization: `Bearer ${token}`
-        };
+        if (config.headers && typeof config.headers.set === 'function') {
+          config.headers.set('Authorization', `Bearer ${token}`);
+        } else {
+          config.headers = {
+            ...(config.headers ?? {}),
+            Authorization: `Bearer ${token}`
+          };
+        }
       }
     }
 

--- a/crew-builder/src/lib/components/ConfigPanel.svelte
+++ b/crew-builder/src/lib/components/ConfigPanel.svelte
@@ -96,11 +96,22 @@
 </script>
 
 <div class="fixed inset-0 z-40 flex justify-end">
-  <div class="absolute inset-0 bg-base-content/40" on:click={() => dispatch('close')} />
+  <div
+    class="absolute inset-0 bg-base-content/40"
+    role="button"
+    tabindex="0"
+    onclick={() => dispatch('close')}
+    onkeydown={(event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        dispatch('close');
+      }
+    }}
+  ></div>
   <aside class="relative z-10 flex h-full w-full max-w-md flex-col bg-base-100 shadow-2xl">
     <header class="flex items-center justify-between border-b border-base-200 px-6 py-4">
       <h2 class="text-lg font-semibold">Configure Agent</h2>
-      <button class="btn btn-circle btn-ghost btn-sm" on:click={() => dispatch('close')} aria-label="Close">
+      <button class="btn btn-circle btn-ghost btn-sm" onclick={() => dispatch('close')} aria-label="Close">
         ✕
       </button>
     </header>
@@ -109,14 +120,14 @@
       <button
         class={`btn btn-sm flex-1 ${editMode === 'form' ? 'btn-primary' : 'btn-outline'}`}
         type="button"
-        on:click={() => switchMode('form')}
+        onclick={() => switchMode('form')}
       >
         Form
       </button>
       <button
         class={`btn btn-sm flex-1 ${editMode === 'json' ? 'btn-primary' : 'btn-outline'}`}
         type="button"
-        on:click={() => switchMode('json')}
+        onclick={() => switchMode('json')}
       >
         JSON
       </button>
@@ -124,7 +135,7 @@
 
     <section class="flex-1 overflow-y-auto px-6 py-4">
       {#if editMode === 'form'}
-        <form class="flex flex-col gap-4 text-sm" on:submit|preventDefault={handleSave}>
+        <form class="flex flex-col gap-4 text-sm" onsubmit|preventDefault={handleSave}>
           <label class="form-control w-full">
             <span class="label-text">Agent ID*</span>
             <input class="input input-bordered" bind:value={formData.agent_id} placeholder="e.g., researcher" required />
@@ -163,7 +174,7 @@
               {#each availableTools as tool}
                 <label class={`flex items-center justify-between rounded-lg border px-4 py-2 ${formData.tools.includes(tool) ? 'border-primary bg-primary/10' : 'border-base-200'}`}>
                   <span>{tool}</span>
-                  <input type="checkbox" class="checkbox" checked={formData.tools.includes(tool)} on:change={() => toggleTool(tool)} />
+                  <input type="checkbox" class="checkbox" checked={formData.tools.includes(tool)} onchange={() => toggleTool(tool)} />
                 </label>
               {/each}
             </div>
@@ -175,7 +186,7 @@
               rows="6"
               bind:value={formData.system_prompt}
               placeholder="You are an expert AI agent..."
-            />
+            ></textarea>
           </label>
         </form>
       {:else}
@@ -184,7 +195,7 @@
             class={`textarea textarea-bordered h-80 font-mono text-xs ${jsonError ? 'textarea-error' : ''}`}
             bind:value={jsonText}
             placeholder="Paste or edit JSON configuration..."
-          />
+          ></textarea>
           {#if jsonError}
             <div class="alert alert-error text-sm">
               <span>{jsonError}</span>
@@ -195,12 +206,12 @@
     </section>
 
     <footer class="flex items-center gap-2 border-t border-base-200 px-6 py-4">
-      <button class="btn btn-error btn-sm" type="button" on:click={handleDelete}>Delete</button>
-      <span class="flex-1" />
-      <button class="btn btn-ghost btn-sm" type="button" on:click={() => dispatch('close')}>
+      <button class="btn btn-error btn-sm" type="button" onclick={handleDelete}>Delete</button>
+      <span class="flex-1"></span>
+      <button class="btn btn-ghost btn-sm" type="button" onclick={() => dispatch('close')}>
         Cancel
       </button>
-      <button class="btn btn-primary btn-sm" type="button" on:click={handleSave}>
+      <button class="btn btn-primary btn-sm" type="button" onclick={handleSave}>
         Save
       </button>
     </footer>

--- a/crew-builder/src/lib/components/ThemeToggle.svelte
+++ b/crew-builder/src/lib/components/ThemeToggle.svelte
@@ -19,14 +19,14 @@
 </script>
 
 <div class="flex items-center gap-2">
-  <button class="btn btn-sm btn-ghost" type="button" on:click={handleToggle} aria-label="Toggle theme">
+  <button class="btn btn-sm btn-ghost" type="button" onclick={handleToggle} aria-label="Toggle theme">
     <span class="hidden sm:inline">Toggle</span>
     <span class="sm:hidden">🌓</span>
   </button>
   <select
     class="select select-bordered select-sm"
     bind:value={selectedTheme}
-    on:change={handleChange}
+    onchange={handleChange}
     aria-label="Select theme"
   >
     {#each themeOptions as option}

--- a/crew-builder/src/lib/components/Toolbar.svelte
+++ b/crew-builder/src/lib/components/Toolbar.svelte
@@ -79,7 +79,7 @@
           class="input input-bordered input-sm"
           type="text"
           bind:value={crewName}
-          on:change={updateMetadata}
+          onchange={updateMetadata}
           placeholder="Crew name..."
         />
       </label>
@@ -89,13 +89,13 @@
           class="input input-bordered input-sm"
           type="text"
           bind:value={crewDescription}
-          on:change={updateMetadata}
+          onchange={updateMetadata}
           placeholder="Description..."
         />
       </label>
       <label class="form-control w-full max-w-[160px]">
         <span class="label-text">Execution mode</span>
-        <select class="select select-bordered select-sm" bind:value={executionMode} on:change={updateMetadata}>
+        <select class="select select-bordered select-sm" bind:value={executionMode} onchange={updateMetadata}>
           <option value="sequential">Sequential</option>
           <option value="parallel">Parallel (Coming Soon)</option>
           <option value="hierarchical">Hierarchical (Coming Soon)</option>
@@ -106,13 +106,13 @@
 
   <div class="flex items-center gap-2">
     <ThemeToggle />
-    <button class="btn btn-primary btn-sm" type="button" on:click={() => dispatch('addAgent')}>
+    <button class="btn btn-primary btn-sm" type="button" onclick={() => dispatch('addAgent')}>
       + Agent
     </button>
-    <button class="btn btn-success btn-sm" type="button" on:click={uploadToAPI} disabled={uploading}>
+    <button class="btn btn-success btn-sm" type="button" onclick={uploadToAPI} disabled={uploading}>
       {uploading ? 'Uploading…' : 'Upload'}
     </button>
-    <button class="btn btn-info btn-sm" type="button" on:click={() => dispatch('export')}>
+    <button class="btn btn-info btn-sm" type="button" onclick={() => dispatch('export')}>
       Export JSON
     </button>
   </div>

--- a/crew-builder/src/lib/stores/crewStore.ts
+++ b/crew-builder/src/lib/stores/crewStore.ts
@@ -1,12 +1,12 @@
-import { MarkerType, type Connection, type Edge, type EdgeChange, type Node, type NodeChange } from '@xyflow/svelte';
-import { get, writable } from 'svelte/store';
+import { MarkerType, type Connection, type Edge, type Node } from '@xyflow/svelte';
+import { get, writable, type Subscriber, type Unsubscriber, type Writable } from 'svelte/store';
 
 export interface AgentConfig {
   model: string;
   temperature: number;
 }
 
-export interface AgentNodeData {
+export interface AgentNodeData extends Record<string, unknown> {
   agent_id: string;
   name: string;
   agent_class: string;
@@ -39,11 +39,43 @@ const initialState: CrewState = {
   nextNodeId: 1
 };
 
+function mapStore<T>(
+  subscribeState: (run: Subscriber<CrewState>, invalidate?: (value?: CrewState) => void) => Unsubscriber,
+  updateState: (updater: (state: CrewState) => CrewState) => void,
+  selector: (state: CrewState) => T,
+  assign: (state: CrewState, value: T) => CrewState
+): Writable<T> {
+  return {
+    subscribe(run, invalidate) {
+      return subscribeState((state) => run(selector(state)), invalidate);
+    },
+    set(value) {
+      updateState((state) => assign(state, value));
+    },
+    update(updater) {
+      updateState((state) => assign(state, updater(selector(state))));
+    }
+  };
+}
+
 function createCrewStore() {
-  const { subscribe, set, update } = writable<CrewState>(initialState);
+  const store = writable<CrewState>(initialState);
+  const { subscribe, set, update } = store;
+
+  const nodes = mapStore<Node<AgentNodeData>[]>(subscribe, update, (state) => state.nodes, (state, value) => ({
+    ...state,
+    nodes: value
+  }));
+
+  const edges = mapStore<Edge[]>(subscribe, update, (state) => state.edges, (state, value) => ({
+    ...state,
+    edges: value
+  }));
 
   return {
     subscribe,
+    nodes,
+    edges,
     addAgent: () => {
       update((state) => {
         const nodeId = `agent-${state.nextNodeId}`;
@@ -123,40 +155,6 @@ function createCrewStore() {
         };
       });
     },
-    updateNodes: (changes: NodeChange<AgentNodeData>[]) => {
-      update((state) => {
-        let updatedNodes = [...state.nodes];
-
-        for (const change of changes) {
-          if (change.type === 'position' && change.position) {
-            const index = updatedNodes.findIndex((node) => node.id === change.id);
-            if (index !== -1) {
-              updatedNodes[index] = {
-                ...updatedNodes[index],
-                position: change.position
-              };
-            }
-          } else if (change.type === 'remove') {
-            updatedNodes = updatedNodes.filter((node) => node.id !== change.id);
-          }
-        }
-
-        return { ...state, nodes: updatedNodes };
-      });
-    },
-    updateEdges: (changes: EdgeChange[]) => {
-      update((state) => {
-        let updatedEdges = [...state.edges];
-
-        for (const change of changes) {
-          if (change.type === 'remove') {
-            updatedEdges = updatedEdges.filter((edge) => edge.id !== change.id);
-          }
-        }
-
-        return { ...state, edges: updatedEdges };
-      });
-    },
     updateMetadata: (metadata: Partial<CrewMetadata>) => {
       update((state) => ({
         ...state,
@@ -164,7 +162,7 @@ function createCrewStore() {
       }));
     },
     exportToJSON: () => {
-      const currentState = get({ subscribe });
+      const currentState = get(store);
       const executionOrder = buildExecutionOrder(currentState.nodes, currentState.edges);
 
       const agents = executionOrder.map((node) => ({

--- a/crew-builder/src/routes/+page.svelte
+++ b/crew-builder/src/routes/+page.svelte
@@ -60,7 +60,7 @@
 
           <!-- User Menu -->
           <div class="dropdown dropdown-end">
-            <button tabindex="0" class="btn btn-circle btn-ghost">
+            <button class="btn btn-circle btn-ghost">
               <div class="avatar placeholder">
                 <div class="w-10 rounded-full bg-primary text-primary-content">
                   <span class="text-xs">
@@ -70,7 +70,6 @@
               </div>
             </button>
             <ul
-              tabindex="0"
               class="menu dropdown-content menu-sm z-[1] mt-3 w-52 rounded-box bg-base-100 p-2 shadow"
             >
               <li class="menu-title">
@@ -78,7 +77,7 @@
               </li>
               <li><a href="/profile">Profile</a></li>
               <li><a href="/settings">Settings</a></li>
-              <li><button on:click={handleLogout}>Logout</button></li>
+              <li><button onclick={handleLogout}>Logout</button></li>
             </ul>
           </div>
         </div>

--- a/crew-builder/src/routes/builder/+page.svelte
+++ b/crew-builder/src/routes/builder/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onDestroy } from 'svelte';
   import { Background, Controls, MiniMap, SvelteFlow } from '@xyflow/svelte';
   import type { Edge as FlowEdge, Node as FlowNode } from '@xyflow/svelte';
   import '@xyflow/svelte/dist/style.css';
@@ -13,19 +12,16 @@
     agentNode: AgentNode
   } as const;
 
+  const nodesStore = crewStore.nodes;
+  const edgesStore = crewStore.edges;
+
   let nodes: FlowNode[] = [];
   let edges: FlowEdge[] = [];
   let selectedNodeId: string | null = null;
   let showConfigPanel = false;
 
-  const unsubscribe = crewStore.subscribe((value) => {
-    nodes = value.nodes;
-    edges = value.edges;
-  });
-
-  onDestroy(() => {
-    unsubscribe();
-  });
+  $: nodes = $nodesStore as FlowNode[];
+  $: edges = $edgesStore as FlowEdge[];
 
   $: selectedNode = nodes.find((node) => node.id === selectedNodeId);
 
@@ -36,14 +32,6 @@
 
   function handleConnect(event: CustomEvent) {
     crewStore.addEdge(event.detail);
-  }
-
-  function handleNodesChange(event: CustomEvent) {
-    crewStore.updateNodes(event.detail);
-  }
-
-  function handleEdgesChange(event: CustomEvent) {
-    crewStore.updateEdges(event.detail);
   }
 
   function handleAddAgent() {
@@ -85,14 +73,12 @@
   <section class="relative flex-1">
     <SvelteFlow
       {nodeTypes}
-      {nodes}
-      {edges}
+      nodes={nodesStore}
+      edges={edgesStore}
       class="h-full w-full"
       fitView
       on:nodeclick={handleNodeClick}
       on:connect={handleConnect}
-      on:nodeschange={handleNodesChange}
-      on:edgeschange={handleEdgesChange}
     >
       <Controls />
       <Background />

--- a/crew-builder/src/routes/login/+page.svelte
+++ b/crew-builder/src/routes/login/+page.svelte
@@ -107,7 +107,7 @@
               <button
                 type="button"
                 class="btn btn-ghost btn-sm absolute right-1 top-1"
-                on:click={togglePasswordVisibility}
+                onclick={togglePasswordVisibility}
                 tabindex="-1"
               >
                 {#if showPassword}

--- a/crew-builder/tsconfig.json
+++ b/crew-builder/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": "./.svelte-kit/tsconfig.json",
-  "compilerOptions": {
-    "baseUrl": "."
-  }
+  "extends": "./.svelte-kit/tsconfig.json"
 }


### PR DESCRIPTION
## Summary
- add the missing SvelteKit app template and align the TypeScript config with the framework defaults
- expose node and edge writables from the crew store and wire the builder view directly to them for the current @xyflow/svelte API
- update axios auth headers and modernise component event handlers and overlays for accessibility and Svelte 5 compatibility

## Testing
- npm run check *(fails: local install omits @sveltejs/kit so the svelte-kit binary is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68ee24b3dc288330a2f9d014c0e5f6cf