### PR TITLE
Fix builder page store subscriptions

### DIFF
--- a/crew-builder/src/routes/builder/+page.svelte
+++ b/crew-builder/src/routes/builder/+page.svelte
@@ -26,20 +26,13 @@
 
   // Derived values for UI (not for SvelteFlow)
   let nodes = $state<AgentFlowNode[]>([]);
-  let selectedNode = $derived.by(() => {
-    let result: AgentFlowNode | undefined;
-    const unsub = nodesStore.subscribe(nodes => {
-      result = nodes.find(n => n.id === selectedNodeId);
-    });
-    unsub();
-    return result;
-  });
+  let selectedNode = $derived.by(() => nodes.find((n) => n.id === selectedNodeId));
 
   // Subscribe to nodes for local state
   $effect(() => {
     const unsubscribe = nodesStore.subscribe((value) => {
       nodes = value;
-      console.log('Nodes updated:', nodes.length);
+      console.log('Nodes updated:', value.length);
     });
     return unsubscribe;
   });


### PR DESCRIPTION
## Summary
- simplify the builder page's derived selected node handling to avoid unnecessary subscriptions
- ensure the nodes store subscription no longer reads the tracked state while logging updates

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68ee8646dd748330b4089c73ab86e50c