### PR TITLE
feat: show crew list on dashboard

### DIFF
--- a/crew-builder/src/lib/components/Toolbar.svelte
+++ b/crew-builder/src/lib/components/Toolbar.svelte
@@ -39,6 +39,7 @@
   }
 
   function goHome() {
+    crewStore.reset();
     goto('/');
   }
 


### PR DESCRIPTION
## Summary
- fetch the authenticated user's crews from the API on the dashboard and surface them in the My Crews table with loading and error states
- surface the live crew count in the quick stats and provide formatted metadata for each crew entry
- reset the in-progress crew definition when returning home or starting a new build to begin with a clean canvas

## Testing
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68eeb5eb7cec83309edbd8e4fec9cf81