### PR TITLE
Support user selection for O365 tools in app-only auth

### DIFF
--- a/parrot/tools/o365/base.py
+++ b/parrot/tools/o365/base.py
@@ -37,6 +37,13 @@ class O365ToolArgsSchema(AbstractToolArgsSchema):
         default=None,
         description="User assertion token for OBO flow"
     )
+    user_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "Target mailbox user principal name or ID. Required when using app-only "
+            "(client credentials) authentication to access user-specific resources."
+        )
+    )
 
 
 class O365Tool(AbstractTool):
@@ -123,7 +130,9 @@ class O365Tool(AbstractTool):
 
         # Check cache
         if cache_key in self._client_cache:
-            return self._client_cache[cache_key]
+            cached_client = self._client_cache[cache_key]
+            cached_client.set_auth_mode(auth_mode)
+            return cached_client
 
         # Create new client
         client_credentials = self.credentials.copy()
@@ -139,6 +148,7 @@ class O365Tool(AbstractTool):
             credentials=client_credentials
         )
         client.processing_credentials()
+        client.set_auth_mode(auth_mode)
 
         try:
             if auth_mode == O365AuthMode.DIRECT:

--- a/parrot/tools/o365/tools.py
+++ b/parrot/tools/o365/tools.py
@@ -113,6 +113,7 @@ class CreateDraftMessageTool(O365Tool):
         bcc_recipients = kwargs.get('bcc_recipients', [])
         importance = kwargs.get('importance', 'normal')
         is_html = kwargs.get('is_html', False)
+        user_id = kwargs.get('user_id')
 
         # Build message object
         message = Message()
@@ -143,7 +144,8 @@ class CreateDraftMessageTool(O365Tool):
 
         try:
             # Create the draft
-            draft = await client.graph_client.me.messages.post(message)
+            mailbox = client.get_user_context(user_id=user_id)
+            draft = await mailbox.messages.post(message)
 
             self.logger.info(f"Created draft message: {draft.id}")
 
@@ -276,6 +278,7 @@ class CreateEventTool(O365Tool):
         attendee_emails = kwargs.get('attendees', [])
         is_online_meeting = kwargs.get('is_online_meeting', False)
         is_all_day = kwargs.get('is_all_day', False)
+        user_id = kwargs.get('user_id')
 
         # Build event object
         event = Event()
@@ -319,7 +322,8 @@ class CreateEventTool(O365Tool):
 
         try:
             # Create the event
-            created_event = await client.graph_client.me.events.post(event)
+            mailbox = client.get_user_context(user_id=user_id)
+            created_event = await mailbox.events.post(event)
 
             self.logger.info(f"Created event: {created_event.id}")
 
@@ -438,10 +442,12 @@ class SearchEmailTool(O365Tool):
         max_results = min(kwargs.get('max_results', 10), 50)  # Cap at 50
         include_attachments = kwargs.get('include_attachments', False)
         order_by = kwargs.get('order_by', 'receivedDateTime desc')
+        user_id = kwargs.get('user_id')
 
         try:
             # Build the request
-            request_builder = client.graph_client.me.messages
+            mailbox = client.get_user_context(user_id=user_id)
+            request_builder = mailbox.messages
 
             # Apply folder filter if not default
             folder_map = {
@@ -453,7 +459,7 @@ class SearchEmailTool(O365Tool):
 
             if folder.lower() in folder_map:
                 folder_name = folder_map[folder.lower()]
-                request_builder = client.graph_client.me.mail_folders.by_mail_folder_id(
+                request_builder = mailbox.mail_folders.by_mail_folder_id(
                     folder_name
                 ).messages
 
@@ -631,6 +637,7 @@ class SendEmailTool(O365Tool):
         importance = kwargs.get('importance', 'normal')
         is_html = kwargs.get('is_html', False)
         save_to_sent = kwargs.get('save_to_sent_items', True)
+        user_id = kwargs.get('user_id')
 
         # Build message object
         message = Message()
@@ -661,7 +668,8 @@ class SendEmailTool(O365Tool):
 
         try:
             # Send the email
-            await client.graph_client.me.send_mail.post(
+            mailbox = client.get_user_context(user_id=user_id)
+            await mailbox.send_mail.post(
                 body={
                     "message": message,
                     "saveToSentItems": save_to_sent


### PR DESCRIPTION
## Summary
- add a mailbox selector to Office365 tool arguments for app-only scenarios
- teach the O365 client to remember auth mode and resolve the correct user context
- update draft, search, event, and send tools to honor the selected mailbox

## Testing
- pytest tests/test_fsm.py *(fails: missing navconfig dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68f0430b2fc08330a1ac7797548d79d4