### PR TITLE
Add remote Office 365 login UI and API

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,11 @@ from parrot.handlers.bots import (
 from parrot.handlers.chat import (
     BotManagement
 )
+from parrot.handlers.o365_auth import (
+    O365InteractiveAuthSessions,
+    O365InteractiveAuthSessionDetail,
+)
+from parrot.services.o365_remote_auth import RemoteAuthManager
 
 # new resources:
 from resources.nextstop import NextStopAgent
@@ -81,6 +86,18 @@ class Main(AppHandler):
             ToolList,
             name='tools_list'
         )
+        # Office 365 delegated authentication endpoints
+        self.app['o365_auth_manager'] = RemoteAuthManager()
+        self.app.router.add_view(
+            '/api/v1/o365/auth/sessions',
+            O365InteractiveAuthSessions,
+            name='o365_auth_sessions'
+        )
+        self.app.router.add_view(
+            '/api/v1/o365/auth/sessions/{session_id}',
+            O365InteractiveAuthSessionDetail,
+            name='o365_auth_session_detail'
+        )
 
     async def on_prepare(self, request, response):
         """
@@ -112,4 +129,6 @@ class Main(AppHandler):
         on_shutdown.
         description: Signal for customize the response when server is shutting down
         """
-        pass
+        manager = app.get('o365_auth_manager')
+        if manager:
+            await manager.shutdown()

--- a/crew-builder/src/lib/api/index.ts
+++ b/crew-builder/src/lib/api/index.ts
@@ -1,2 +1,3 @@
 export { apiClient } from './client';
 export * as crew from './crew/crew';
+export * as o365 from './o365/auth';

--- a/crew-builder/src/lib/api/o365/auth.ts
+++ b/crew-builder/src/lib/api/o365/auth.ts
@@ -1,0 +1,65 @@
+import { apiClient } from '../client';
+
+export interface StartSessionPayload {
+  scopes?: string[];
+  redirect_uri?: string;
+  credentials?: Record<string, unknown>;
+}
+
+export interface RemoteAuthSummary {
+  expires_on?: number | string;
+  scope?: string;
+  token_source?: string;
+  account?: {
+    home_account_id?: string;
+    environment?: string;
+    username?: string;
+  };
+  user?: {
+    name?: string;
+    preferred_username?: string;
+    oid?: string;
+    tid?: string;
+  };
+}
+
+export interface RemoteAuthSession {
+  session_id: string;
+  status: string;
+  auth_url?: string;
+  device_flow?: {
+    user_code?: string;
+    verification_uri?: string;
+    verification_uri_complete?: string;
+    message?: string;
+    expires_in?: number;
+    interval?: number;
+  };
+  result?: RemoteAuthSummary;
+  error?: string;
+  created_at?: string;
+  updated_at?: string;
+  expires_at?: string;
+}
+
+export async function startInteractiveSession(payload: StartSessionPayload = {}) {
+  const response = await apiClient.post<RemoteAuthSession>(
+    '/api/v1/o365/auth/sessions',
+    payload
+  );
+  return response.data;
+}
+
+export async function getSessionStatus(sessionId: string) {
+  const response = await apiClient.get<RemoteAuthSession>(
+    `/api/v1/o365/auth/sessions/${encodeURIComponent(sessionId)}`
+  );
+  return response.data;
+}
+
+export async function cancelSession(sessionId: string) {
+  const response = await apiClient.delete<{ session_id: string; status: string }>(
+    `/api/v1/o365/auth/sessions/${encodeURIComponent(sessionId)}`
+  );
+  return response.data;
+}

--- a/crew-builder/src/routes/+page.svelte
+++ b/crew-builder/src/routes/+page.svelte
@@ -278,6 +278,16 @@
               </div>
             </div>
           </div>
+
+          <div class="card bg-base-100 shadow-xl">
+            <div class="card-body">
+              <h2 class="card-title">Authorize Office 365</h2>
+              <p>Grant delegated Microsoft 365 access for Parrot tools.</p>
+              <div class="card-actions justify-end">
+                <a class="btn btn-accent" href="/integrations/o365">Open Authorization</a>
+              </div>
+            </div>
+          </div>
         </div>
 
         <!-- Recent Crews -->

--- a/crew-builder/src/routes/integrations/o365/+page.svelte
+++ b/crew-builder/src/routes/integrations/o365/+page.svelte
@@ -1,0 +1,304 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import { browser } from '$app/environment';
+  import { LoadingSpinner } from '$lib/components';
+  import { o365 } from '$lib/api';
+  import type { RemoteAuthSession, RemoteAuthSummary } from '$lib/api/o365/auth';
+
+  let sessionId = $state('');
+  let status = $state('initializing');
+  let loading = $state(true);
+  let polling = $state(false);
+  let errorMessage = $state('');
+  let authUrl = $state('');
+  let deviceFlow = $state<RemoteAuthSession['device_flow'] | null>(null);
+  let resultInfo = $state<RemoteAuthSummary | null>(null);
+  let expiresAt = $state('');
+  let pollHandle: ReturnType<typeof setInterval> | undefined;
+
+  const statusLabel = $derived(() => {
+    switch (status) {
+      case 'authorized':
+        return 'Authorized';
+      case 'failed':
+        return 'Failed';
+      case 'cancelled':
+        return 'Cancelled';
+      case 'expired':
+        return 'Expired';
+      case 'pending':
+        return 'Pending';
+      default:
+        return 'Starting';
+    }
+  });
+
+  const statusBadgeClass = $derived(() => {
+    switch (status) {
+      case 'authorized':
+        return 'badge badge-success badge-lg';
+      case 'failed':
+      case 'cancelled':
+      case 'expired':
+        return 'badge badge-error badge-lg';
+      case 'pending':
+        return 'badge badge-warning badge-lg';
+      default:
+        return 'badge badge-info badge-lg';
+    }
+  });
+
+  const formattedExpiry = $derived(() => {
+    if (!expiresAt) return '';
+    const date = new Date(expiresAt);
+    if (Number.isNaN(date.getTime())) return expiresAt;
+    return date.toLocaleString();
+  });
+
+  function parseError(error: unknown): string {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'response' in error &&
+      error.response &&
+      typeof error.response === 'object' &&
+      'data' in error.response &&
+      error.response.data &&
+      typeof error.response.data === 'object' &&
+      'message' in error.response.data &&
+      typeof error.response.data.message === 'string'
+    ) {
+      return error.response.data.message;
+    }
+
+    if (error instanceof Error && typeof error.message === 'string') {
+      return error.message;
+    }
+
+    return 'An unexpected error occurred while processing the request.';
+  }
+
+  function stopPolling() {
+    if (pollHandle) {
+      clearInterval(pollHandle);
+      pollHandle = undefined;
+    }
+    polling = false;
+  }
+
+  async function pollStatus() {
+    if (!browser || !sessionId) return;
+
+    try {
+      const session = await o365.getSessionStatus(sessionId);
+      status = session.status ?? status;
+      if (session.auth_url && !authUrl) {
+        authUrl = session.auth_url;
+      }
+      if (session.device_flow) {
+        deviceFlow = session.device_flow;
+      }
+      if (session.result) {
+        resultInfo = session.result;
+      }
+      if (session.expires_at) {
+        expiresAt = session.expires_at;
+      }
+      if (session.error) {
+        errorMessage = session.error;
+      }
+
+      if (['authorized', 'failed', 'cancelled', 'expired'].includes(status)) {
+        stopPolling();
+      }
+    } catch (error) {
+      errorMessage = parseError(error);
+      stopPolling();
+    }
+  }
+
+  function startPolling() {
+    if (!browser || !sessionId || polling) return;
+    polling = true;
+    pollStatus();
+    pollHandle = setInterval(pollStatus, 4000);
+  }
+
+  async function startAuthorization() {
+    if (!browser) return;
+
+    stopPolling();
+    loading = true;
+    errorMessage = '';
+    authUrl = '';
+    deviceFlow = null;
+    resultInfo = null;
+    expiresAt = '';
+    status = 'initializing';
+
+    try {
+      const session = await o365.startInteractiveSession();
+      sessionId = session.session_id;
+      status = session.status ?? 'pending';
+      authUrl = session.auth_url ?? '';
+      deviceFlow = session.device_flow ?? null;
+      resultInfo = session.result ?? null;
+      expiresAt = session.expires_at ?? '';
+      loading = false;
+      if (session.error) {
+        errorMessage = session.error;
+      }
+      if (sessionId) {
+        startPolling();
+      }
+    } catch (error) {
+      errorMessage = parseError(error);
+      status = 'failed';
+      loading = false;
+    }
+  }
+
+  async function cancelAuthorization() {
+    if (!browser || !sessionId) return;
+    try {
+      await o365.cancelSession(sessionId);
+      stopPolling();
+      status = 'cancelled';
+    } catch (error) {
+      errorMessage = parseError(error);
+    }
+  }
+
+  function handleRestart() {
+    startAuthorization();
+  }
+
+  onMount(() => {
+    if (!browser) {
+      return;
+    }
+    startAuthorization();
+  });
+
+  onDestroy(() => {
+    stopPolling();
+  });
+</script>
+
+<svelte:head>
+  <title>Office 365 Authorization - Crew Builder</title>
+</svelte:head>
+
+<div class="min-h-screen bg-base-200 py-10">
+  <div class="mx-auto max-w-4xl px-4">
+    <div class="mb-6">
+      <h1 class="text-3xl font-bold">Authorize Office 365 Tools</h1>
+      <p class="text-base-content/70">
+        Complete the Microsoft 365 authentication flow to enable delegated access for Parrot tools.
+      </p>
+    </div>
+
+    <div class="card bg-base-100 shadow-xl">
+      <div class="card-body space-y-6">
+        <div class="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h2 class="card-title">Interactive Login Session</h2>
+            <p class="text-sm text-base-content/70">
+              Follow the steps below to sign in with your Microsoft account. Tokens are stored securely on the server.
+            </p>
+          </div>
+          <span class={statusBadgeClass}>{statusLabel}</span>
+        </div>
+
+        {#if loading && status === 'initializing'}
+          <LoadingSpinner text="Preparing interactive login..." />
+        {:else}
+          {#if errorMessage}
+            <div class="alert alert-error shadow">
+              <span>{errorMessage}</span>
+            </div>
+          {/if}
+
+          {#if status === 'authorized'}
+            <div class="alert alert-success">
+              <span>
+                Authorization complete. {resultInfo?.user?.name || resultInfo?.user?.preferred_username || 'Microsoft account'}
+                is now connected.
+              </span>
+            </div>
+          {/if}
+
+          {#if authUrl}
+            <div class="space-y-3 rounded-lg border border-base-300 bg-base-200/50 p-4">
+              <h3 class="text-lg font-semibold">Sign in with your browser</h3>
+              <p class="text-sm text-base-content/70">
+                Click the button below to open the Microsoft sign-in window. Complete the login and return to this page.
+              </p>
+              <a class="btn btn-primary w-full sm:w-auto" href={authUrl} target="_blank" rel="noopener noreferrer">
+                Open Microsoft Login
+              </a>
+              <div class="text-xs text-base-content/60">
+                Session ID: <span class="font-mono">{sessionId}</span>
+              </div>
+              {#if formattedExpiry}
+                <div class="text-xs text-base-content/60">Expires: {formattedExpiry}</div>
+              {/if}
+            </div>
+          {/if}
+
+          {#if deviceFlow}
+            <div class="space-y-3 rounded-lg border border-dashed border-base-300 bg-base-200/40 p-4">
+              <h3 class="text-lg font-semibold">Use device login</h3>
+              <p class="text-sm text-base-content/70">Visit the verification URL and enter the code below:</p>
+              <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <code class="badge badge-accent badge-lg text-xl">{deviceFlow.user_code}</code>
+                <a
+                  class="link link-primary break-all"
+                  href={deviceFlow.verification_uri_complete || deviceFlow.verification_uri}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {deviceFlow.verification_uri_complete || deviceFlow.verification_uri}
+                </a>
+              </div>
+              {#if deviceFlow.message}
+                <div class="rounded-md bg-base-100 p-3 text-sm text-base-content/70">
+                  {#each deviceFlow.message.split('\n') as line (line)}
+                    <div>{line}</div>
+                  {/each}
+                </div>
+              {/if}
+            </div>
+          {/if}
+
+          {#if !authUrl && !deviceFlow && status === 'pending'}
+            <LoadingSpinner text="Waiting for Microsoft login URL..." />
+          {/if}
+
+          {#if resultInfo && status === 'authorized'}
+            <div class="rounded-lg bg-success/10 p-4 text-sm">
+              {#if resultInfo.user}
+                <div><strong>User:</strong> {resultInfo.user.name || resultInfo.user.preferred_username}</div>
+              {/if}
+              {#if resultInfo.account?.username}
+                <div><strong>Account:</strong> {resultInfo.account.username}</div>
+              {/if}
+              {#if resultInfo.scope}
+                <div><strong>Granted scopes:</strong> {resultInfo.scope}</div>
+              {/if}
+            </div>
+          {/if}
+
+          <div class="divider"></div>
+
+          <div class="flex flex-wrap gap-3">
+            <button class="btn btn-primary" onclick={handleRestart}>Restart authorization</button>
+            {#if status === 'pending'}
+              <button class="btn btn-outline" onclick={cancelAuthorization}>Cancel session</button>
+            {/if}
+          </div>
+        {/if}
+      </div>
+    </div>
+  </div>
+</div>

--- a/parrot/handlers/o365_auth.py
+++ b/parrot/handlers/o365_auth.py
@@ -1,0 +1,105 @@
+"""HTTP handlers for remote Office 365 interactive authentication."""
+from typing import Any, Dict
+
+from navigator_auth.decorators import is_authenticated, user_session
+from navigator.views import BaseView
+
+from ..services.o365_remote_auth import RemoteAuthManager
+
+
+def _get_manager(app) -> RemoteAuthManager:
+    manager = app.get("o365_auth_manager")
+    if manager is None:
+        manager = RemoteAuthManager()
+        app["o365_auth_manager"] = manager
+    return manager
+
+
+@is_authenticated()
+@user_session()
+class O365InteractiveAuthSessions(BaseView):
+    """Create remote Office 365 interactive login sessions."""
+
+    async def post(self):
+        manager = _get_manager(self.request.app)
+        try:
+            payload: Dict[str, Any] = await self.request.json()
+        except Exception:
+            payload = {}
+
+        scopes = payload.get("scopes")
+        if scopes is not None and not isinstance(scopes, list):
+            return self.error(
+                response={"message": "'scopes' must be a list of strings"},
+                status=400,
+            )
+
+        redirect_uri = payload.get("redirect_uri")
+        credentials = payload.get("credentials")
+        if credentials is not None and not isinstance(credentials, dict):
+            return self.error(
+                response={"message": "'credentials' must be an object"},
+                status=400,
+            )
+
+        try:
+            session = await manager.start_session(
+                credentials=credentials,
+                scopes=scopes,
+                redirect_uri=redirect_uri,
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            return self.error(
+                response={"message": f"Failed to start interactive login: {exc}"},
+                status=500,
+            )
+
+        return self.json_response(session, status=201)
+
+
+@is_authenticated()
+@user_session()
+class O365InteractiveAuthSessionDetail(BaseView):
+    """Manage a specific Office 365 interactive login session."""
+
+    async def get(self):
+        session_id = self.request.match_info.get("session_id")
+        if not session_id:
+            return self.error(
+                response={"message": "Missing session_id"},
+                status=400,
+            )
+
+        manager = _get_manager(self.request.app)
+        session = await manager.get_session(session_id)
+        if not session:
+            return self.error(
+                response={"message": "Session not found"},
+                status=404,
+            )
+
+        return self.json_response(session)
+
+    async def delete(self):
+        session_id = self.request.match_info.get("session_id")
+        if not session_id:
+            return self.error(
+                response={"message": "Missing session_id"},
+                status=400,
+            )
+
+        manager = _get_manager(self.request.app)
+        cancelled = await manager.cancel_session(session_id)
+        if not cancelled:
+            return self.error(
+                response={"message": "Session not found"},
+                status=404,
+            )
+
+        return self.json_response({"session_id": session_id, "status": "cancelled"})
+
+
+__all__ = [
+    "O365InteractiveAuthSessions",
+    "O365InteractiveAuthSessionDetail",
+]

--- a/parrot/interfaces/o365.py
+++ b/parrot/interfaces/o365.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, List, Dict
+from typing import Any, Optional, List, Dict, Callable
 import asyncio
 import contextlib
 from concurrent.futures import ThreadPoolExecutor
@@ -763,12 +763,24 @@ class O365Client(CredentialsInterface):
         scopes: Optional[List[str]] = None,
         redirect_uri: str = "http://localhost",
         open_browser: bool = True,
+        login_callback: Optional[Callable[[str], Optional[bool]]] = None,
+        device_flow_callback: Optional[Callable[[Dict[str, Any]], None]] = None,
     ) -> Dict[str, Any]:
         """
         Perform interactive login supporting both public and confidential clients.
 
         - If client_secret is provided: Uses device code flow (confidential client)
         - If no client_secret: Uses interactive browser flow (public client)
+
+        Args:
+            scopes: Requested permission scopes.
+            redirect_uri: Redirect URI to use for interactive login.
+            open_browser: When False, suppress automatic browser launch.
+            login_callback: Optional callback invoked with the interactive login URL
+                when ``open_browser`` is False. Should return ``False`` to prevent the
+                default browser launch behaviour.
+            device_flow_callback: Optional callback invoked with the device flow
+                payload when running the device code flow.
         """
         scopes = self._filter_reserved_scopes(scopes or [
             "User.Read", "Files.ReadWrite.All", "Sites.Read.All"
@@ -822,11 +834,23 @@ class O365Client(CredentialsInterface):
                         f"Failed to create device flow: {flow.get('error_description')}"
                     )
 
-                print("\n" + "=" * 60)
-                print(flow["message"])
-                print("=" * 60 + "\n")
+                if device_flow_callback:
+                    try:
+                        device_flow_callback(flow)
+                    except Exception as callback_error:  # pragma: no cover - defensive
+                        self.logger.warning(
+                            "Device flow callback raised an exception: %s",
+                            callback_error
+                        )
+                else:
+                    print("\n" + "=" * 60)
+                    print(flow["message"])
+                    print("=" * 60 + "\n")
 
-                result = public_app.acquire_token_by_device_flow(flow)
+                loop = asyncio.get_running_loop()
+                result = await loop.run_in_executor(
+                    None, lambda: public_app.acquire_token_by_device_flow(flow)
+                )
                 active_app = public_app
             else:
                 self.logger.info("Starting interactive browser authentication (public client)")
@@ -836,17 +860,32 @@ class O365Client(CredentialsInterface):
                     parsed_uri = urlparse(redirect_uri)
                     if parsed_uri.port:
                         interactive_kwargs["port"] = parsed_uri.port
+                    interactive_kwargs["redirect_uri"] = redirect_uri
 
                 if not open_browser:
                     def _log_login_url(url: str) -> bool:
                         self.logger.info("Interactive authentication URL: %s", url)
+                        if login_callback:
+                            try:
+                                callback_result = login_callback(url)
+                                if callback_result is not None:
+                                    return bool(callback_result)
+                            except Exception as callback_error:  # pragma: no cover - defensive
+                                self.logger.warning(
+                                    "Login callback raised an exception: %s",
+                                    callback_error
+                                )
                         return False
 
                     interactive_kwargs["on_before_launching_ui"] = _log_login_url
 
-                result = public_app.acquire_token_interactive(
-                    scopes=scopes,
-                    **interactive_kwargs
+                loop = asyncio.get_running_loop()
+                result = await loop.run_in_executor(
+                    None,
+                    lambda: public_app.acquire_token_interactive(
+                        scopes=scopes,
+                        **interactive_kwargs
+                    )
                 )
                 active_app = public_app
 

--- a/parrot/services/__init__.py
+++ b/parrot/services/__init__.py
@@ -1,0 +1,1 @@
+"""Parrot service helpers."""

--- a/parrot/services/o365_remote_auth.py
+++ b/parrot/services/o365_remote_auth.py
@@ -1,0 +1,235 @@
+"""Utilities to manage remote Office 365 interactive login sessions."""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional, List
+from uuid import uuid4
+
+from navconfig.logging import logging
+
+from ..interfaces.o365 import O365Client
+
+
+@dataclass
+class RemoteAuthSession:
+    """Metadata for a remote interactive login session."""
+
+    session_id: str
+    status: str = "pending"
+    login_url: Optional[str] = None
+    device_flow: Optional[Dict[str, Any]] = None
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    updated_at: datetime = field(default_factory=datetime.utcnow)
+    expires_at: Optional[datetime] = None
+    result_summary: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+    task: Optional[asyncio.Task] = None
+    client: Optional[O365Client] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {
+            "session_id": self.session_id,
+            "status": self.status,
+            "created_at": self.created_at.isoformat() + "Z",
+            "updated_at": self.updated_at.isoformat() + "Z",
+        }
+        if self.login_url:
+            data["auth_url"] = self.login_url
+        if self.device_flow:
+            data["device_flow"] = self.device_flow
+        if self.expires_at:
+            data["expires_at"] = self.expires_at.isoformat() + "Z"
+        if self.result_summary:
+            data["result"] = self.result_summary
+        if self.error:
+            data["error"] = self.error
+        return data
+
+
+class RemoteAuthManager:
+    """Manage remote Office 365 interactive login sessions."""
+
+    def __init__(self):
+        self._sessions: Dict[str, RemoteAuthSession] = {}
+        self._lock = asyncio.Lock()
+        self.logger = logging.getLogger("Parrot.O365.RemoteAuth")
+
+    async def start_session(
+        self,
+        *,
+        credentials: Optional[Dict[str, Any]] = None,
+        scopes: Optional[List[str]] = None,
+        redirect_uri: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Start a new remote interactive login session."""
+
+        session_id = str(uuid4())
+        session = RemoteAuthSession(session_id=session_id)
+        async with self._lock:
+            self._sessions[session_id] = session
+
+        client = O365Client(credentials=credentials or {})
+        session.client = client
+        client.processing_credentials()
+        client.set_auth_mode("delegated")
+
+        loop = asyncio.get_running_loop()
+        login_url_future: asyncio.Future = loop.create_future()
+        device_flow_future: asyncio.Future = loop.create_future()
+
+        def _login_callback(url: str) -> bool:
+            def _set_login_url() -> None:
+                session.login_url = url
+                session.updated_at = datetime.utcnow()
+                if not login_url_future.done():
+                    login_url_future.set_result(url)
+
+            loop.call_soon_threadsafe(_set_login_url)
+            return False
+
+        def _device_flow_callback(flow: Dict[str, Any]) -> None:
+            def _set_device_flow() -> None:
+                session.device_flow = {
+                    "user_code": flow.get("user_code"),
+                    "verification_uri": flow.get("verification_uri"),
+                    "verification_uri_complete": flow.get("verification_uri_complete"),
+                    "message": flow.get("message"),
+                    "expires_in": flow.get("expires_in"),
+                    "interval": flow.get("interval"),
+                }
+                if flow.get("expires_in"):
+                    session.expires_at = datetime.utcnow() + timedelta(seconds=int(flow["expires_in"]))
+                session.updated_at = datetime.utcnow()
+                if not device_flow_future.done():
+                    device_flow_future.set_result(session.device_flow)
+
+            loop.call_soon_threadsafe(_set_device_flow)
+
+        async def _run_login() -> None:
+            try:
+                result = await client.interactive_login(
+                    scopes=scopes,
+                    redirect_uri=redirect_uri or "http://localhost",
+                    open_browser=False,
+                    login_callback=_login_callback,
+                    device_flow_callback=_device_flow_callback,
+                )
+                summary = self._summarize_result(result)
+                session.result_summary = summary if summary else None
+                session.status = "authorized"
+                session.updated_at = datetime.utcnow()
+            except Exception as exc:  # pragma: no cover - network/auth errors
+                session.status = "failed"
+                session.error = str(exc)
+                session.updated_at = datetime.utcnow()
+                self.logger.error("Remote login session %s failed: %s", session_id, exc)
+            finally:
+                with contextlib.suppress(Exception):
+                    await client.close()
+                session.client = None
+
+        session.task = asyncio.create_task(_run_login())
+
+        waiters = []
+        if not login_url_future.done():
+            waiters.append(login_url_future)
+        if not device_flow_future.done():
+            waiters.append(device_flow_future)
+
+        if waiters:
+            try:
+                await asyncio.wait(waiters, timeout=5, return_when=asyncio.FIRST_COMPLETED)
+            except Exception:  # pragma: no cover - defensive
+                pass
+
+        return session.to_dict()
+
+    async def get_session(self, session_id: str) -> Optional[Dict[str, Any]]:
+        async with self._lock:
+            session = self._sessions.get(session_id)
+        if not session:
+            return None
+
+        if session.status == "pending" and session.expires_at and datetime.utcnow() > session.expires_at:
+            await self._expire_session(session)
+
+        return session.to_dict()
+
+    async def cancel_session(self, session_id: str) -> bool:
+        async with self._lock:
+            session = self._sessions.get(session_id)
+        if not session:
+            return False
+
+        await self._finalize_session(session, status="cancelled", error="Session cancelled by user")
+        return True
+
+    async def shutdown(self) -> None:
+        async with self._lock:
+            sessions = list(self._sessions.values())
+
+        for session in sessions:
+            await self._finalize_session(session, status=session.status)
+
+    async def _expire_session(self, session: RemoteAuthSession) -> None:
+        await self._finalize_session(
+            session,
+            status="expired",
+            error="Authorization session expired before completion",
+        )
+
+    async def _finalize_session(
+        self,
+        session: RemoteAuthSession,
+        *,
+        status: str,
+        error: Optional[str] = None,
+    ) -> None:
+        if session.task and not session.task.done():
+            session.task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await session.task
+        if session.client:
+            with contextlib.suppress(Exception):
+                await session.client.close()
+            session.client = None
+        session.status = status
+        session.error = error
+        session.updated_at = datetime.utcnow()
+
+    def _summarize_result(self, result: Dict[str, Any]) -> Dict[str, Any]:
+        summary: Dict[str, Any] = {}
+        if not result:
+            return summary
+
+        if result.get("expires_on"):
+            summary["expires_on"] = result["expires_on"]
+        if result.get("scope"):
+            summary["scope"] = result["scope"]
+        if result.get("token_source"):
+            summary["token_source"] = result["token_source"]
+
+        account = result.get("account")
+        if isinstance(account, dict):
+            summary["account"] = {
+                "home_account_id": account.get("home_account_id"),
+                "environment": account.get("environment"),
+                "username": account.get("username"),
+            }
+
+        claims = result.get("id_token_claims")
+        if isinstance(claims, dict):
+            summary["user"] = {
+                "name": claims.get("name"),
+                "preferred_username": claims.get("preferred_username"),
+                "oid": claims.get("oid"),
+                "tid": claims.get("tid"),
+            }
+
+        return summary
+
+
+__all__ = ["RemoteAuthManager", "RemoteAuthSession"]


### PR DESCRIPTION
## Summary
- add callback support to the MSAL interactive login flow so the URL and device code can be captured without launching a local browser
- provide a remote Office 365 authentication session manager with API endpoints that front-end clients can poll
- build a Svelte Office 365 authorization page and supporting API helpers, including a dashboard entry point

## Testing
- pytest tests/test_fsm.py *(fails: missing navconfig.exceptions package in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f15e397994833096488435ff4d6999