### PR TITLE
Fix MethodName parameter validation

### DIFF
--- a/parrot/openapi/components.yaml
+++ b/parrot/openapi/components.yaml
@@ -596,7 +596,7 @@ components:
     MethodName:
       name: method_name
       in: path
-      required: false
+      required: true
       description: Nombre del método a invocar en el bot/agent
       schema:
         type: string


### PR DESCRIPTION
## Summary
- mark the MethodName path parameter as required to satisfy OpenAPI validation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f6c8d7ba908330bd9c8924d1a0edc6