### PR TITLE
Add Sora video generation support to OpenAI client

### DIFF
--- a/examples/next/gpt.py
+++ b/examples/next/gpt.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 import asyncio
 from pydantic import BaseModel
 from parrot.clients.gpt import OpenAIClient, OpenAIModel
+from parrot.models import VideoGenerationPrompt
 
 
 # Example usage and helper functions
@@ -138,6 +139,27 @@ async def example_usage():
             tools=[repl_tool],
         )
         print(response)
+
+
+async def example_video_generation():
+    """Example of generating a video using Sora via the OpenAI client."""
+
+    async with OpenAIClient() as client:
+        video_prompt = VideoGenerationPrompt(
+            prompt=(
+                "A timelapse of a city skyline transitioning from dusk to night, "
+                "with neon lights gradually illuminating the streets."
+            ),
+            model=OpenAIModel.SORA.value,
+            number_of_videos=1,
+            aspect_ratio="16:9",
+            duration=10,
+        )
+
+        response = await client.generate_video(video_prompt)
+
+        print("Video generation metadata:", response.output)
+        print("Saved video files:", [str(path) for path in response.media or []])
 
 
 if __name__ == "__main__":

--- a/parrot/models/openai.py
+++ b/parrot/models/openai.py
@@ -26,3 +26,5 @@ class OpenAIModel(Enum):
     O3_DEEP_RESEARCH = "o3-deep-research"
     GPT_4O = "gpt-4o"
     GPT_IMAGE_1 = "gpt-image-1"
+    SORA = "sora"
+    SORA_2 = "sora-2"


### PR DESCRIPTION
## Summary
- add Sora and Sora 2 entries to the OpenAI model enum
- implement an OpenAIClient.generate_video helper that orchestrates Sora/Sora 2 video generation and handles polling and downloads
- add shared file download handling for video assets and persist generated media locally

## Testing
- python -m compileall parrot/clients/gpt.py parrot/models/openai.py

------
https://chatgpt.com/codex/tasks/task_e_68f8d40b40748330b7c3d5f13363ef58