### PR TITLE
Add crew question workflow with markdown editor

### DIFF
--- a/crew-builder/src/lib/components/JsonTreeNode.svelte
+++ b/crew-builder/src/lib/components/JsonTreeNode.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+  export let label: string | null = null;
+  export let value: unknown;
+  export let depth = 0;
+
+  const isArray = Array.isArray(value);
+  const isObject = value !== null && typeof value === 'object' && !isArray;
+  const isExpandable = isArray || isObject;
+
+  $: entries = (() => {
+    if (isArray) {
+      return (value as unknown[]).map((item, index) => ({ key: `[${index}]`, value: item }));
+    }
+    if (isObject) {
+      return Object.entries(value as Record<string, unknown>).map(([key, entry]) => ({
+        key,
+        value: entry
+      }));
+    }
+    return [];
+  })();
+
+  function describeValue(): string {
+    if (isArray) {
+      return `Array(${entries.length})`;
+    }
+    if (isObject) {
+      return `Object(${entries.length})`;
+    }
+    if (value === null) {
+      return 'null';
+    }
+    return typeof value;
+  }
+
+  function formatPrimitive(data: unknown): string {
+    if (typeof data === 'string') {
+      return `"${data}"`;
+    }
+    if (typeof data === 'number' || typeof data === 'boolean') {
+      return String(data);
+    }
+    if (data === null) {
+      return 'null';
+    }
+    if (typeof data === 'undefined') {
+      return 'undefined';
+    }
+    return JSON.stringify(data);
+  }
+
+  const displayLabel = label ?? 'value';
+</script>
+
+<div class={`space-y-1 ${depth === 0 ? '' : 'border-l border-base-300 pl-3'}`}>
+  {#if isExpandable}
+    <details class="group space-y-1" open={depth < 1}>
+      <summary class="cursor-pointer select-none text-sm font-semibold text-base-content">
+        <span>{displayLabel}</span>
+        <span class="ml-2 text-xs font-normal text-base-content/60">{describeValue()}</span>
+      </summary>
+      <div class="ml-3 space-y-1">
+        {#each entries as entry (entry.key)}
+          <svelte:self label={entry.key} value={entry.value} depth={depth + 1} />
+        {/each}
+      </div>
+    </details>
+  {:else}
+    <div class="flex items-start gap-2 text-sm text-base-content">
+      <span class="font-semibold text-base-content/70">{displayLabel}:</span>
+      <code class="rounded bg-base-200 px-1 py-0.5 text-xs text-base-content">
+        {formatPrimitive(value)}
+      </code>
+    </div>
+  {/if}
+</div>

--- a/crew-builder/src/lib/components/JsonViewer.svelte
+++ b/crew-builder/src/lib/components/JsonViewer.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import JsonTreeNode from './JsonTreeNode.svelte';
+
+  export let data: unknown;
+  export let title = 'Advanced results';
+</script>
+
+<div class="space-y-3">
+  <div class="collapse collapse-arrow rounded-lg border border-base-300 bg-base-200">
+    <input type="checkbox" />
+    <div class="collapse-title text-sm font-semibold uppercase tracking-wide text-base-content/70">
+      {title}
+    </div>
+    <div class="collapse-content">
+      {#if data !== undefined}
+        <div class="overflow-x-auto">
+          <JsonTreeNode value={data} label="root" />
+        </div>
+      {:else}
+        <p class="text-sm text-base-content/60">No data available.</p>
+      {/if}
+    </div>
+  </div>
+</div>

--- a/crew-builder/src/lib/components/MarkdownEditor.svelte
+++ b/crew-builder/src/lib/components/MarkdownEditor.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import { markdownToHtml } from '$lib/utils/markdown';
+
+  export let label = 'Question';
+  export let value = '';
+  export let placeholder = 'Write your prompt using Markdown...';
+  export let helperText = '';
+  export let disabled = false;
+
+  $: previewHtml = markdownToHtml(value ?? '');
+</script>
+
+<div class="space-y-2">
+  {#if label}
+    <label class="block text-sm font-semibold text-base-content/80">{label}</label>
+  {/if}
+
+  <div class="grid gap-4 md:grid-cols-2">
+    <textarea
+      bind:value
+      {disabled}
+      rows="12"
+      class="textarea textarea-bordered w-full resize-y"
+      placeholder={placeholder}
+    />
+
+    <div class="rounded-lg border border-base-300 bg-base-200 p-4">
+      <div class="mb-2 text-xs font-semibold uppercase tracking-wide text-base-content/60">
+        Preview
+      </div>
+      {#if previewHtml}
+        <div class="space-y-2 text-sm leading-relaxed text-base-content" aria-live="polite">
+          {@html previewHtml}
+        </div>
+      {:else}
+        <p class="text-sm text-base-content/60">The rendered Markdown will appear here.</p>
+      {/if}
+    </div>
+  </div>
+
+  {#if helperText}
+    <p class="text-xs text-base-content/60">{helperText}</p>
+  {/if}
+</div>

--- a/crew-builder/src/lib/utils/markdown.ts
+++ b/crew-builder/src/lib/utils/markdown.ts
@@ -1,0 +1,122 @@
+const HEADING_REGEX = /^(#{1,6})\s+(.*)$/;
+const LIST_ITEM_REGEX = /^\s*[-*+]\s+(.*)$/;
+const CODE_BLOCK_REGEX = /^```/;
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function renderInlineMarkdown(value: string): string {
+  let result = escapeHtml(value);
+
+  // Links [text](url)
+  result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, text, url) => {
+    const safeUrl = url.trim();
+    const safeText = text.trim().length ? text.trim() : safeUrl;
+    return `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer">${safeText}</a>`;
+  });
+
+  // Bold **text** or __text__
+  result = result.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+  result = result.replace(/__([^_]+)__/g, '<strong>$1</strong>');
+
+  // Italic *text* or _text_
+  result = result.replace(/(^|[^*])\*([^*]+)\*(?!\*)/g, '$1<em>$2</em>');
+  result = result.replace(/(^|[^_])_([^_]+)_(?!_)/g, '$1<em>$2</em>');
+
+  // Inline code `code`
+  result = result.replace(/`([^`]+)`/g, '<code>$1</code>');
+
+  return result;
+}
+
+function renderCodeBlock(lines: string[]): string {
+  const escaped = lines.map(escapeHtml).join('\n');
+  return `<pre><code>${escaped}\n</code></pre>`;
+}
+
+export function markdownToHtml(markdown: string): string {
+  if (!markdown?.trim()) {
+    return '';
+  }
+
+  const lines = markdown.replace(/\r\n/g, '\n').split('\n');
+  const html: string[] = [];
+  let listItems: string[] = [];
+  let codeBlock: string[] | null = null;
+
+  const flushList = () => {
+    if (!listItems.length) return;
+    html.push('<ul>');
+    for (const item of listItems) {
+      html.push(`<li>${renderInlineMarkdown(item)}</li>`);
+    }
+    html.push('</ul>');
+    listItems = [];
+  };
+
+  const flushParagraph = (content: string) => {
+    if (!content.trim()) {
+      html.push('<br />');
+      return;
+    }
+    html.push(`<p>${renderInlineMarkdown(content)}</p>`);
+  };
+
+  for (const line of lines) {
+    if (CODE_BLOCK_REGEX.test(line.trim())) {
+      if (codeBlock) {
+        html.push(renderCodeBlock(codeBlock));
+        codeBlock = null;
+      } else {
+        flushList();
+        codeBlock = [];
+      }
+      continue;
+    }
+
+    if (codeBlock) {
+      codeBlock.push(line);
+      continue;
+    }
+
+    const headingMatch = line.match(HEADING_REGEX);
+    if (headingMatch) {
+      flushList();
+      const level = Math.min(headingMatch[1].length, 6);
+      const content = renderInlineMarkdown(headingMatch[2]);
+      html.push(`<h${level}>${content}</h${level}>`);
+      continue;
+    }
+
+    const listMatch = line.match(LIST_ITEM_REGEX);
+    if (listMatch) {
+      listItems.push(listMatch[1]);
+      continue;
+    }
+
+    flushList();
+
+    if (!line.trim()) {
+      html.push('<br />');
+      continue;
+    }
+
+    flushParagraph(line);
+  }
+
+  if (codeBlock) {
+    html.push(renderCodeBlock(codeBlock));
+  }
+
+  flushList();
+
+  return html.join('\n');
+}
+
+export default markdownToHtml;

--- a/crew-builder/src/routes/+page.svelte
+++ b/crew-builder/src/routes/+page.svelte
@@ -340,6 +340,9 @@
                           <a class="btn btn-ghost btn-xs" href={`/builder?crew_id=${crewItem.crew_id}`}>
                             View
                           </a>
+                          <a class="btn btn-primary btn-xs" href={`/crew/ask?crew_id=${crewItem.crew_id}`}>
+                            Ask
+                          </a>
                         </div>
                       </td>
                     </tr>
@@ -419,6 +422,25 @@
                 />
               </svg>
               Crew Builder
+            </a>
+          </li>
+          <li>
+            <a href="/crew/ask">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                class="h-5 w-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M7 8h10M7 12h6m-5 8l-4 4v-4H4a3 3 0 01-3-3V5a3 3 0 013-3h16a3 3 0 013 3v10a3 3 0 01-3 3H9z"
+                />
+              </svg>
+              Ask a Crew
             </a>
           </li>
           <li>

--- a/crew-builder/src/routes/crew/ask/+page.svelte
+++ b/crew-builder/src/routes/crew/ask/+page.svelte
@@ -1,0 +1,344 @@
+<script lang="ts" context="module">
+  export const ssr = false;
+</script>
+
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { get } from 'svelte/store';
+  import { page } from '$app/stores';
+  import { crew as crewApi } from '$lib/api';
+  import MarkdownEditor from '$lib/components/MarkdownEditor.svelte';
+  import JsonViewer from '$lib/components/JsonViewer.svelte';
+  import { markdownToHtml } from '$lib/utils/markdown';
+  import { LoadingSpinner } from '../../../components';
+
+  interface CrewSummary {
+    crew_id: string;
+    name: string;
+    description?: string;
+    execution_mode?: string;
+  }
+
+  interface CrewJobStatus {
+    job_id: string;
+    crew_id: string;
+    status: string;
+    message?: string;
+    result?: {
+      output?: string;
+      response?: Record<string, { input?: string; output?: string }>;
+    };
+    [key: string]: unknown;
+  }
+
+  interface AgentResponse {
+    input?: string;
+    output?: string;
+  }
+
+  interface AgentResponseView {
+    name: string;
+    input?: string;
+    outputHtml: string;
+  }
+
+  let crews: CrewSummary[] = [];
+  let crewsLoading = false;
+  let crewsError = '';
+  let selectedCrewId = '';
+  let question = '';
+  let jobStatus: CrewJobStatus | null = null;
+  let statusMessage = '';
+  let jobError = '';
+  let isSubmitting = false;
+
+  $: selectedCrew = crews.find((crewItem) => crewItem.crew_id === selectedCrewId) ?? null;
+  $: finalOutputHtml = jobStatus?.result?.output ? markdownToHtml(jobStatus.result.output) : '';
+  $: rawAgentResponses =
+    jobStatus?.result?.response && typeof jobStatus.result.response === 'object'
+      ? (Object.entries(jobStatus.result.response) as [string, AgentResponse][])
+      : [];
+  $: agentResponses: AgentResponseView[] = rawAgentResponses.map(([name, details]) => ({
+    name,
+    input: typeof details?.input === 'string' ? details.input : undefined,
+    outputHtml:
+      typeof details?.output === 'string' && details.output.trim()
+        ? markdownToHtml(details.output)
+        : ''
+  }));
+
+  async function fetchCrews(initialCrewId?: string | null) {
+    crewsLoading = true;
+    crewsError = '';
+
+    try {
+      const response = await crewApi.listCrews();
+      const list = Array.isArray(response?.crews) ? (response.crews as CrewSummary[]) : [];
+      crews = list;
+
+      if (initialCrewId) {
+        const exists = list.some((item) => item.crew_id === initialCrewId);
+        if (exists) {
+          selectedCrewId = initialCrewId;
+        }
+      }
+    } catch (error) {
+      console.error('Failed to load crews', error);
+      let responseMessage: string | undefined;
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'response' in error &&
+        error.response &&
+        typeof error.response === 'object' &&
+        'data' in error.response &&
+        error.response.data &&
+        typeof error.response.data === 'object' &&
+        'message' in error.response.data &&
+        typeof error.response.data.message === 'string'
+      ) {
+        responseMessage = error.response.data.message;
+      }
+      const fallbackMessage =
+        error instanceof Error && typeof error.message === 'string'
+          ? error.message
+          : 'Unable to load crews at this time.';
+      crewsError = responseMessage ?? fallbackMessage;
+      crews = [];
+    } finally {
+      crewsLoading = false;
+    }
+  }
+
+  async function handleSubmit(event: Event) {
+    event.preventDefault();
+    jobError = '';
+
+    if (!selectedCrewId) {
+      jobError = 'Please choose a crew to ask your question.';
+      return;
+    }
+
+    if (!question.trim()) {
+      jobError = 'Please provide a question or task for the crew.';
+      return;
+    }
+
+    isSubmitting = true;
+    statusMessage = '';
+    jobStatus = null;
+
+    try {
+      const execution = await crewApi.executeCrew(selectedCrewId, question.trim());
+      jobStatus = execution;
+      statusMessage = execution?.message ?? 'Crew execution started.';
+
+      if (!execution?.job_id) {
+        throw new Error('The crew execution did not return a job identifier.');
+      }
+
+      const finalStatus = await crewApi.pollJobUntilComplete(execution.job_id, 2000, 120);
+      jobStatus = finalStatus as CrewJobStatus;
+      statusMessage = finalStatus?.message ?? `Crew status: ${finalStatus?.status ?? 'unknown'}`;
+    } catch (error) {
+      console.error('Failed to execute crew', error);
+      let responseMessage: string | undefined;
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'response' in error &&
+        error.response &&
+        typeof error.response === 'object' &&
+        'data' in error.response &&
+        error.response.data &&
+        typeof error.response.data === 'object' &&
+        'message' in error.response.data &&
+        typeof error.response.data.message === 'string'
+      ) {
+        responseMessage = error.response.data.message;
+      }
+      const fallbackMessage =
+        error instanceof Error && typeof error.message === 'string'
+          ? error.message
+          : 'Unable to execute the crew. Please try again.';
+      jobError = responseMessage ?? fallbackMessage;
+    } finally {
+      isSubmitting = false;
+    }
+  }
+
+  function resetQuestion() {
+    question = '';
+    jobStatus = null;
+    jobError = '';
+    statusMessage = '';
+  }
+
+  onMount(() => {
+    const initialCrewId = get(page).url.searchParams.get('crew_id');
+    fetchCrews(initialCrewId);
+  });
+</script>
+
+<svelte:head>
+  <title>Ask a Crew</title>
+</svelte:head>
+
+<div class="min-h-screen bg-base-200/60 py-10">
+  <div class="mx-auto max-w-5xl space-y-8 px-4">
+    <div>
+      <h1 class="text-3xl font-bold text-base-content">Ask a Crew</h1>
+      <p class="mt-2 text-base text-base-content/70">
+        Select one of your existing crews and send a Markdown-formatted question. We'll execute the crew and
+        display the collective response alongside each agent's contribution.
+      </p>
+    </div>
+
+    <section class="rounded-xl bg-base-100 p-6 shadow">
+      <form class="space-y-6" on:submit={handleSubmit}>
+        <div class="space-y-2">
+          <label class="block text-sm font-semibold text-base-content/80">Select crew</label>
+          {#if crewsLoading}
+            <div class="flex items-center gap-3 rounded-lg border border-dashed border-base-300 p-4 text-sm text-base-content/70">
+              <LoadingSpinner size="sm" center={false} />
+              <span>Loading crews…</span>
+            </div>
+          {:else if crewsError}
+            <div class="alert alert-error">
+              <span>{crewsError}</span>
+              <button type="button" class="btn btn-sm" on:click={() => fetchCrews(selectedCrewId)}>
+                Retry
+              </button>
+            </div>
+          {:else}
+            <select
+              class="select select-bordered w-full"
+              bind:value={selectedCrewId}
+            >
+              <option value="" disabled selected={!selectedCrewId}>
+                Choose a crew to query
+              </option>
+              {#each crews as crewItem (crewItem.crew_id)}
+                <option value={crewItem.crew_id}>
+                  {crewItem.name} — {crewItem.crew_id}
+                </option>
+              {/each}
+            </select>
+            {#if selectedCrew}
+              <div class="space-y-1 text-sm text-base-content/70">
+                <p>
+                  <span class="font-semibold">Crew ID:</span> {selectedCrew.crew_id}
+                  <span class="mx-2">·</span>
+                  <span class="font-semibold">Mode:</span> {selectedCrew.execution_mode || '—'}
+                </p>
+                <p class="text-xs text-base-content/60">
+                  {selectedCrew.description || 'No description provided'}
+                </p>
+              </div>
+            {/if}
+          {/if}
+        </div>
+
+        <MarkdownEditor
+          bind:value={question}
+          helperText="Supports headings, lists, inline code, and more."
+          disabled={isSubmitting || crewsLoading}
+        />
+
+        {#if jobError}
+          <div class="alert alert-error">
+            <span>{jobError}</span>
+          </div>
+        {/if}
+
+        <div class="flex flex-wrap gap-3">
+          <button type="submit" class="btn btn-primary" disabled={isSubmitting || !selectedCrewId}>
+            {#if isSubmitting}
+              <span class="loading loading-spinner"></span>
+              Running…
+            {:else}
+              Ask Crew
+            {/if}
+          </button>
+          <button type="button" class="btn btn-ghost" on:click={resetQuestion} disabled={isSubmitting}>
+            Clear
+          </button>
+        </div>
+      </form>
+    </section>
+
+    {#if isSubmitting}
+      <div class="flex items-center justify-center gap-3 rounded-xl border border-dashed border-base-300 bg-base-100 p-6 text-base-content/70">
+        <LoadingSpinner text="Waiting for the crew to finish…" />
+      </div>
+    {/if}
+
+    {#if statusMessage}
+      <div class="alert alert-info">
+        <div>
+          <span class="font-semibold">Status:</span>
+          <span class="ml-2">{statusMessage}</span>
+        </div>
+        {#if jobStatus}
+          <span class="badge badge-outline">{jobStatus.status}</span>
+        {/if}
+      </div>
+    {/if}
+
+    {#if jobStatus}
+      <section class="space-y-6">
+        <div class="rounded-xl bg-base-100 p-6 shadow">
+          <div class="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <h2 class="text-2xl font-semibold text-base-content">Crew response</h2>
+              <p class="text-sm text-base-content/70">Job ID: {jobStatus.job_id}</p>
+            </div>
+            <div class="badge badge-primary badge-outline text-base-content">
+              {jobStatus.status}
+            </div>
+          </div>
+
+          <div class="mt-6 space-y-4">
+            <div class="rounded-lg border border-base-300 bg-base-200 p-4">
+              <h3 class="text-lg font-semibold text-base-content">Final output</h3>
+              {#if finalOutputHtml}
+                <div class="mt-3 space-y-2 text-base leading-relaxed text-base-content">
+                  {@html finalOutputHtml}
+                </div>
+              {:else}
+                <p class="mt-3 text-base-content/70">No final output was returned.</p>
+              {/if}
+            </div>
+
+            {#if agentResponses.length}
+              <div class="rounded-lg border border-base-300 bg-base-200 p-4">
+                <h3 class="text-lg font-semibold text-base-content">Agents responses</h3>
+                <div class="mt-4 space-y-4">
+                  {#each agentResponses as agent (agent.name)}
+                    <div class="rounded-lg border border-base-300 bg-base-100 p-4">
+                      <h4 class="text-base font-semibold text-base-content">{agent.name}</h4>
+                      {#if agent.input}
+                        <p class="mt-2 text-sm text-base-content/70">
+                          <span class="font-semibold">Input:</span> {agent.input}
+                        </p>
+                      {/if}
+                      {#if agent.outputHtml}
+                        <div class="mt-3 space-y-2 text-sm leading-relaxed text-base-content">
+                          {@html agent.outputHtml}
+                        </div>
+                      {:else}
+                        <p class="mt-3 text-sm text-base-content/60">No output recorded for this agent.</p>
+                      {/if}
+                    </div>
+                  {/each}
+                </div>
+              </div>
+            {/if}
+          </div>
+        </div>
+
+        <JsonViewer data={jobStatus} title="Advanced results" />
+      </section>
+    {/if}
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add a dedicated Ask a Crew page that lets users select a crew, compose markdown queries, and review the aggregated results with per-agent responses and a collapsible advanced JSON view
- introduce reusable MarkdownEditor, JsonViewer, and JsonTreeNode components backed by a local markdown renderer utility
- surface quick access to the new workflow from the dashboard navigation and crew list actions

## Testing
- npm run check *(fails: `svelte-kit` command not found because project dependencies are not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fa5a35cbc483308daead6aa593b294