### PR TITLE
Add multi-mode crew execution support in ask interface

### DIFF
--- a/crew-builder/src/lib/api/crew/crew.ts
+++ b/crew-builder/src/lib/api/crew/crew.ts
@@ -62,7 +62,7 @@ export interface ExecuteCrewOptions {
 
 export async function executeCrew(
   crewId: string,
-  query: string,
+  query: string | Record<string, unknown>,
   options: ExecuteCrewOptions = {}
 ) {
   const payload = {

--- a/crew-builder/src/routes/crew/ask/+page.svelte
+++ b/crew-builder/src/routes/crew/ask/+page.svelte
@@ -8,11 +8,22 @@
   import { markdownToHtml } from '$lib/utils/markdown';
   import { LoadingSpinner } from '../../../components';
 
+  type CrewExecutionMode = 'sequential' | 'parallel' | 'loop' | 'flow';
+
   interface CrewSummary {
     crew_id: string;
     name: string;
     description?: string;
-    execution_mode?: string;
+    execution_mode?: CrewExecutionMode;
+  }
+
+  interface CrewAgentSummary {
+    agent_id: string;
+    name?: string | null;
+  }
+
+  interface CrewDetails extends CrewSummary {
+    agents?: CrewAgentSummary[];
   }
 
   interface CrewJobStatus {
@@ -21,7 +32,7 @@
     status: string;
     message?: string;
     result?: {
-      output?: string;
+      output?: unknown;
       response?: Record<string, { input?: string; output?: string }>;
     };
     [key: string]: unknown;
@@ -42,17 +53,47 @@
   let crewsLoading = false;
   let crewsError = '';
   let selectedCrewId = '';
+
+  let crewDetails: CrewDetails | null = null;
+  let crewDetailsLoading = false;
+  let crewDetailsError = '';
+  let lastLoadedCrewId: string | null = null;
+  let pendingCrewId: string | null = null;
+  let detailsRequestId = 0;
+
   let question = '';
+  let parallelInputMode: 'shared' | 'custom' = 'shared';
+  let parallelSharedTask = '';
+  let parallelAgentTasks: Record<string, string> = {};
+  let parallelSynthesisPrompt = '';
+  let parallelAllResults = false;
+  let loopInitialTask = '';
+  let loopCondition = '';
+  let loopMaxIterations = 4;
+  let loopAgentSequence: string[] = [];
+  let loopSynthesisPrompt = '';
+  let flowInitialTask = '';
+  let flowSynthesisPrompt = '';
+
   let jobStatus: CrewJobStatus | null = null;
   let statusMessage = '';
   let jobError = '';
   let isSubmitting = false;
+
   let rawAgentResponses: [string, AgentResponse][] = [];
   let agentResponses: AgentResponseView[] = [];
   const crewSelectId = 'crew-select';
 
+  let selectedCrew: CrewSummary | null = null;
+  let currentMode: CrewExecutionMode = 'sequential';
+  let finalOutputRaw: unknown = null;
+  let finalOutputHtml = '';
+  let finalOutputList: unknown[] = [];
+  let finalOutputListHtml: string[] = [];
+  let draggingIndex: number | null = null;
+
   $: selectedCrew = crews.find((crewItem) => crewItem.crew_id === selectedCrewId) ?? null;
-  $: finalOutputHtml = jobStatus?.result?.output ? markdownToHtml(jobStatus.result.output) : '';
+  $: currentMode = (crewDetails?.execution_mode ?? selectedCrew?.execution_mode ?? 'sequential') as CrewExecutionMode;
   $: rawAgentResponses =
     jobStatus?.result?.response && typeof jobStatus.result.response === 'object'
       ? (Object.entries(jobStatus.result.response) as [string, AgentResponse][])
@@ -65,6 +106,165 @@
         ? markdownToHtml(details.output)
         : ''
   }));
+  $: finalOutputRaw = jobStatus?.result?.output ?? null;
+  $: finalOutputHtml =
+    typeof finalOutputRaw === 'string' && finalOutputRaw.trim()
+      ? markdownToHtml(finalOutputRaw)
+      : '';
+  $: finalOutputList = Array.isArray(finalOutputRaw) ? (finalOutputRaw as unknown[]) : [];
+  $: finalOutputListHtml = finalOutputList.map((item) => {
+    if (typeof item === 'string') {
+      return item.trim() ? markdownToHtml(item) : '';
+    }
+    try {
+      return markdownToHtml('```json\n' + JSON.stringify(item, null, 2) + '\n```');
+    } catch (error) {
+      return markdownToHtml(String(item));
+    }
+  });
+  $: if (selectedCrewId) {
+    if (selectedCrewId !== pendingCrewId && selectedCrewId !== lastLoadedCrewId) {
+      pendingCrewId = selectedCrewId;
+      void loadCrewDetails(selectedCrewId);
+    }
+  } else if (lastLoadedCrewId || pendingCrewId) {
+    crewDetails = null;
+    crewDetailsError = '';
+    lastLoadedCrewId = null;
+    pendingCrewId = null;
+    loopAgentSequence = [];
+    initializeAgentPrompts([]);
+  }
+
+  function extractErrorMessage(error: unknown, fallback: string) {
+    let responseMessage: string | undefined;
+
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'response' in error &&
+      (error as Record<string, unknown>).response &&
+      typeof (error as Record<string, unknown>).response === 'object'
+    ) {
+      const response = (error as { response?: Record<string, unknown> }).response;
+      const data = response?.data;
+      if (
+        data &&
+        typeof data === 'object' &&
+        'message' in data &&
+        typeof (data as Record<string, unknown>).message === 'string'
+      ) {
+        responseMessage = (data as { message?: string }).message;
+      }
+    }
+
+    if (responseMessage) {
+      return responseMessage;
+    }
+
+    if (error instanceof Error && typeof error.message === 'string') {
+      return error.message;
+    }
+
+    return fallback;
+  }
+
+  function initializeAgentPrompts(agentIds: string[]) {
+    const prompts: Record<string, string> = {};
+    for (const id of agentIds) {
+      if (typeof id === 'string' && id) {
+        prompts[id] = '';
+      }
+    }
+    parallelAgentTasks = prompts;
+  }
+
+  function setParallelAgentTask(agentId: string, value: string) {
+    parallelAgentTasks = { ...parallelAgentTasks, [agentId]: value };
+  }
+
+  function getAgentDisplayName(agentId: string) {
+    const agent = crewDetails?.agents?.find((item) => item.agent_id === agentId);
+    return agent?.name?.trim() || agentId;
+  }
+
+  function moveAgentInSequence(fromIndex: number, toIndex: number) {
+    if (fromIndex === toIndex || fromIndex < 0 || toIndex < 0) {
+      return;
+    }
+    const updated = [...loopAgentSequence];
+    if (fromIndex >= updated.length) {
+      return;
+    }
+    const [moved] = updated.splice(fromIndex, 1);
+    const clampedIndex = Math.min(Math.max(toIndex, 0), updated.length);
+    updated.splice(clampedIndex, 0, moved);
+    loopAgentSequence = updated;
+  }
+
+  function moveAgentUp(index: number) {
+    if (index <= 0) {
+      return;
+    }
+    moveAgentInSequence(index, index - 1);
+  }
+
+  function moveAgentDown(index: number) {
+    if (index >= loopAgentSequence.length - 1) {
+      return;
+    }
+    moveAgentInSequence(index, index + 1);
+  }
+
+  function handleDragStart(event: DragEvent, index: number) {
+    draggingIndex = index;
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = 'move';
+      event.dataTransfer.setData('text/plain', index.toString());
+    }
+  }
+
+  function handleDragOver(event: DragEvent) {
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'move';
+    }
+  }
+
+  function handleDrop(event: DragEvent, index: number) {
+    event.preventDefault();
+    const data = event.dataTransfer?.getData('text/plain');
+    const fromIndex = draggingIndex ?? (data ? parseInt(data, 10) : -1);
+    if (Number.isNaN(fromIndex) || fromIndex < 0) {
+      draggingIndex = null;
+      return;
+    }
+    moveAgentInSequence(fromIndex, index);
+    draggingIndex = null;
+  }
+
+  function handleDropAtEnd(event: DragEvent) {
+    event.preventDefault();
+    const data = event.dataTransfer?.getData('text/plain');
+    const fromIndex = draggingIndex ?? (data ? parseInt(data, 10) : -1);
+    if (Number.isNaN(fromIndex) || fromIndex < 0) {
+      draggingIndex = null;
+      return;
+    }
+    const updated = [...loopAgentSequence];
+    if (fromIndex >= updated.length) {
+      draggingIndex = null;
+      return;
+    }
+    const [moved] = updated.splice(fromIndex, 1);
+    updated.push(moved);
+    loopAgentSequence = updated;
+    draggingIndex = null;
+  }
+
+  function handleDragEnd() {
+    draggingIndex = null;
+  }
 
   async function fetchCrews(initialCrewId?: string | null) {
     crewsLoading = true;
@@ -73,7 +273,13 @@
     try {
       const response = await crewApi.listCrews();
       const list = Array.isArray(response?.crews) ? (response.crews as CrewSummary[]) : [];
-      crews = list;
+      crews = list.map((item) => ({
+        ...item,
+        execution_mode:
+          typeof item.execution_mode === 'string'
+            ? (item.execution_mode as CrewExecutionMode)
+            : undefined
+      }));
 
       if (initialCrewId) {
         const exists = list.some((item) => item.crew_id === initialCrewId);
@@ -83,29 +289,57 @@
       }
     } catch (error) {
       console.error('Failed to load crews', error);
-      let responseMessage: string | undefined;
-      if (
-        typeof error === 'object' &&
-        error !== null &&
-        'response' in error &&
-        error.response &&
-        typeof error.response === 'object' &&
-        'data' in error.response &&
-        error.response.data &&
-        typeof error.response.data === 'object' &&
-        'message' in error.response.data &&
-        typeof error.response.data.message === 'string'
-      ) {
-        responseMessage = error.response.data.message;
-      }
-      const fallbackMessage =
-        error instanceof Error && typeof error.message === 'string'
-          ? error.message
-          : 'Unable to load crews at this time.';
-      crewsError = responseMessage ?? fallbackMessage;
+      crewsError = extractErrorMessage(error, 'Unable to load crews at this time.');
       crews = [];
     } finally {
       crewsLoading = false;
+    }
+  }
+
+  async function loadCrewDetails(crewId: string) {
+    pendingCrewId = crewId;
+    const currentRequest = ++detailsRequestId;
+    crewDetailsLoading = true;
+    crewDetailsError = '';
+
+    try {
+      const response = await crewApi.getCrewById(crewId);
+      if (currentRequest !== detailsRequestId) {
+        return;
+      }
+
+      const details = (response ?? {}) as CrewDetails;
+      const agents = Array.isArray(details?.agents)
+        ? details.agents.filter((agent): agent is CrewAgentSummary => typeof agent?.agent_id === 'string')
+        : [];
+
+      crewDetails = {
+        ...details,
+        agents
+      };
+      lastLoadedCrewId = crewId;
+      loopAgentSequence = agents.map((agent) => agent.agent_id);
+      initializeAgentPrompts(loopAgentSequence);
+      resetQuestion();
+    } catch (error) {
+      if (currentRequest !== detailsRequestId) {
+        return;
+      }
+      console.error('Failed to load crew details', error);
+      crewDetails = null;
+      loopAgentSequence = [];
+      initializeAgentPrompts([]);
+      crewDetailsError = extractErrorMessage(
+        error,
+        'Unable to load crew details. Please try again.'
+      );
+      lastLoadedCrewId = crewId;
+      resetQuestion();
+    } finally {
+      if (currentRequest === detailsRequestId) {
+        crewDetailsLoading = false;
+        pendingCrewId = null;
+      }
     }
   }
 
@@ -118,9 +352,89 @@
       return;
     }
 
-    if (!question.trim()) {
-      jobError = 'Please provide a question or task for the crew.';
-      return;
+    const executionOptions: crewApi.ExecuteCrewOptions = {
+      kwargs: {}
+    };
+    let queryPayload: string | Record<string, string>;
+
+    if (currentMode === 'parallel') {
+      if (parallelInputMode === 'shared') {
+        if (!parallelSharedTask.trim()) {
+          jobError = 'Please provide a shared task for the crew.';
+          return;
+        }
+        queryPayload = parallelSharedTask.trim();
+      } else {
+        const entries = Object.entries(parallelAgentTasks ?? {});
+        if (!entries.length) {
+          jobError = 'No agents available to run in parallel.';
+          return;
+        }
+        const missingPrompts = entries.filter(([, prompt]) => !prompt?.trim());
+        if (missingPrompts.length) {
+          jobError = 'Please provide a prompt for each agent.';
+          return;
+        }
+        const customTasks: Record<string, string> = {};
+        for (const [agentId, prompt] of entries) {
+          customTasks[agentId] = prompt.trim();
+        }
+        queryPayload = customTasks;
+      }
+
+      if (parallelSynthesisPrompt.trim()) {
+        executionOptions.synthesis_prompt = parallelSynthesisPrompt.trim();
+      }
+
+      const kwargs: Record<string, unknown> = {};
+      if (parallelAllResults) {
+        kwargs.all_results = true;
+      }
+      executionOptions.kwargs = kwargs;
+    } else if (currentMode === 'loop') {
+      if (!loopInitialTask.trim()) {
+        jobError = 'Please provide an initial task to start the loop.';
+        return;
+      }
+      if (!loopCondition.trim()) {
+        jobError = 'Please provide a condition to stop the loop.';
+        return;
+      }
+
+      const iterations = Math.max(1, Number(loopMaxIterations) || 1);
+
+      queryPayload = loopInitialTask.trim();
+      const kwargs: Record<string, unknown> = {
+        condition: loopCondition.trim(),
+        max_iterations: iterations
+      };
+      if (loopAgentSequence.length) {
+        kwargs.agent_sequence = [...loopAgentSequence];
+      }
+
+      if (loopSynthesisPrompt.trim()) {
+        executionOptions.synthesis_prompt = loopSynthesisPrompt.trim();
+      }
+
+      executionOptions.kwargs = kwargs;
+    } else if (currentMode === 'flow') {
+      if (!flowInitialTask.trim()) {
+        jobError = 'Please provide an initial task for the flow execution.';
+        return;
+      }
+
+      queryPayload = flowInitialTask.trim();
+
+      if (flowSynthesisPrompt.trim()) {
+        executionOptions.synthesis_prompt = flowSynthesisPrompt.trim();
+      }
+    } else {
+      if (!question.trim()) {
+        jobError = 'Please provide a question or task for the crew.';
+        return;
+      }
+
+      queryPayload = question.trim();
     }
 
     isSubmitting = true;
@@ -128,7 +442,7 @@
     jobStatus = null;
 
     try {
-      const execution = await crewApi.executeCrew(selectedCrewId, question.trim());
+      const execution = await crewApi.executeCrew(selectedCrewId, queryPayload, executionOptions);
       jobStatus = execution;
       statusMessage = execution?.message ?? 'Crew execution started.';
 
@@ -141,26 +455,7 @@
       statusMessage = finalStatus?.message ?? `Crew status: ${finalStatus?.status ?? 'unknown'}`;
     } catch (error) {
       console.error('Failed to execute crew', error);
-      let responseMessage: string | undefined;
-      if (
-        typeof error === 'object' &&
-        error !== null &&
-        'response' in error &&
-        error.response &&
-        typeof error.response === 'object' &&
-        'data' in error.response &&
-        error.response.data &&
-        typeof error.response.data === 'object' &&
-        'message' in error.response.data &&
-        typeof error.response.data.message === 'string'
-      ) {
-        responseMessage = error.response.data.message;
-      }
-      const fallbackMessage =
-        error instanceof Error && typeof error.message === 'string'
-          ? error.message
-          : 'Unable to execute the crew. Please try again.';
-      jobError = responseMessage ?? fallbackMessage;
+      jobError = extractErrorMessage(error, 'Unable to execute the crew. Please try again.');
     } finally {
       isSubmitting = false;
     }
@@ -168,9 +463,33 @@
 
   function resetQuestion() {
     question = '';
+    parallelSharedTask = '';
+    parallelSynthesisPrompt = '';
+    parallelAllResults = false;
+    parallelInputMode = 'shared';
+    loopInitialTask = '';
+    loopCondition = '';
+    loopMaxIterations = 4;
+    loopSynthesisPrompt = '';
+    flowInitialTask = '';
+    flowSynthesisPrompt = '';
+    if (loopAgentSequence.length) {
+      initializeAgentPrompts(loopAgentSequence);
+    } else {
+      parallelAgentTasks = {};
+    }
     jobStatus = null;
     jobError = '';
     statusMessage = '';
+  }
+
+  function retryLoadCrewDetails() {
+    if (!selectedCrewId) {
+      return;
+    }
+    lastLoadedCrewId = null;
+    pendingCrewId = null;
+    void loadCrewDetails(selectedCrewId);
   }
 
   onMount(() => {
@@ -189,8 +508,8 @@
       <div>
         <h1 class="text-3xl font-bold text-base-content">Ask a Crew</h1>
         <p class="mt-2 text-base text-base-content/70">
-          Select one of your existing crews and send a Markdown-formatted question. We'll execute the crew and
-          display the collective response alongside each agent's contribution.
+          Select one of your existing crews and configure how it should run. Provide prompts, loop conditions, or
+          synthesis instructions and review both the final outcome and each agent's contribution.
         </p>
       </div>
       <a class="btn btn-ghost" href="/">
@@ -230,7 +549,7 @@
               {/each}
             </select>
             {#if selectedCrew}
-              <div class="space-y-1 text-sm text-base-content/70">
+              <div class="space-y-2 text-sm text-base-content/70">
                 <p>
                   <span class="font-semibold">Crew ID:</span> {selectedCrew.crew_id}
                   <span class="mx-2">·</span>
@@ -239,16 +558,297 @@
                 <p class="text-xs text-base-content/60">
                   {selectedCrew.description || 'No description provided'}
                 </p>
+                {#if crewDetails?.agents}
+                  <p class="text-xs text-base-content/60">
+                    <span class="font-semibold text-base-content">Agents:</span> {crewDetails.agents.length}
+                  </p>
+                {/if}
+              </div>
+            {/if}
+            {#if crewDetailsLoading}
+              <div class="mt-3 flex items-center gap-3 rounded-lg border border-dashed border-base-300 p-3 text-sm text-base-content/70">
+                <LoadingSpinner size="sm" center={false} />
+                <span>Loading crew details…</span>
+              </div>
+            {:else if crewDetailsError}
+              <div class="alert alert-warning mt-3">
+                <span>{crewDetailsError}</span>
+                <button type="button" class="btn btn-sm" on:click={retryLoadCrewDetails}>
+                  Retry
+                </button>
               </div>
             {/if}
           {/if}
         </div>
 
-        <MarkdownEditor
-          bind:value={question}
-          helperText="Supports headings, lists, inline code, and more."
-          disabled={isSubmitting || crewsLoading}
-        />
+        {#if selectedCrew}
+          <div class="rounded-lg border border-base-300 bg-base-200/60 px-4 py-3 text-sm text-base-content/70">
+            <span class="font-semibold text-base-content">Execution mode:</span>
+            <span class="ml-2 capitalize">{currentMode}</span>
+            {#if crewDetails?.agents}
+              <span class="ml-4 text-base-content/60">
+                <span class="font-semibold text-base-content">Agents:</span> {crewDetails.agents.length}
+              </span>
+            {/if}
+          </div>
+        {/if}
+
+        {#if currentMode === 'parallel'}
+          <div class="space-y-6">
+            <div class="rounded-lg border border-base-300 bg-base-100 p-4">
+              <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <h3 class="text-lg font-semibold text-base-content">Parallel tasks</h3>
+                  <p class="text-sm text-base-content/70">Choose how prompts are distributed across agents.</p>
+                </div>
+              </div>
+              <div class="mt-4 flex flex-col gap-2 md:flex-row md:items-center">
+                <label class="flex cursor-pointer items-center gap-2 rounded-lg border border-base-300 bg-base-200/60 px-3 py-2 text-sm">
+                  <input
+                    type="radio"
+                    class="radio radio-sm"
+                    value="shared"
+                    bind:group={parallelInputMode}
+                    disabled={isSubmitting || crewDetailsLoading}
+                  />
+                  <span>Single prompt for all agents</span>
+                </label>
+                <label class="flex cursor-pointer items-center gap-2 rounded-lg border border-base-300 bg-base-200/60 px-3 py-2 text-sm">
+                  <input
+                    type="radio"
+                    class="radio radio-sm"
+                    value="custom"
+                    bind:group={parallelInputMode}
+                    disabled={isSubmitting || crewDetailsLoading || !(crewDetails?.agents?.length)}
+                  />
+                  <span>Custom prompt per agent</span>
+                </label>
+              </div>
+              {#if parallelInputMode === 'shared'}
+                <div class="mt-4">
+                  <MarkdownEditor
+                    bind:value={parallelSharedTask}
+                    helperText="This prompt will be sent to every agent."
+                    disabled={isSubmitting || crewsLoading || crewDetailsLoading}
+                  />
+                </div>
+              {:else}
+                <div class="mt-4 space-y-4">
+                  {#if crewDetailsLoading}
+                    <div class="flex items-center gap-3 text-sm text-base-content/70">
+                      <LoadingSpinner size="sm" center={false} />
+                      <span>Loading agent details…</span>
+                    </div>
+                  {:else if crewDetailsError}
+                    <p class="text-sm text-error">Crew details are unavailable. Retry loading above.</p>
+                  {:else if !crewDetails?.agents?.length}
+                    <p class="text-sm text-base-content/60">This crew does not have any agents configured.</p>
+                  {:else}
+                    {#each crewDetails.agents as agent (agent.agent_id)}
+                      <div class="space-y-2 rounded-lg border border-base-300 bg-base-200/60 p-3">
+                        <div class="flex flex-wrap items-center justify-between gap-2">
+                          <span class="font-semibold text-base-content">{agent.name?.trim() || agent.agent_id}</span>
+                          <span class="badge badge-outline text-xs">{agent.agent_id}</span>
+                        </div>
+                        <textarea
+                          class="textarea textarea-bordered w-full text-sm"
+                          rows="3"
+                          value={parallelAgentTasks[agent.agent_id] ?? ''}
+                          on:input={(event) =>
+                            setParallelAgentTask(agent.agent_id, (event.currentTarget as HTMLTextAreaElement).value)
+                          }
+                          placeholder="Enter a prompt for this agent"
+                          disabled={isSubmitting}
+                        ></textarea>
+                      </div>
+                    {/each}
+                  {/if}
+                </div>
+              {/if}
+            </div>
+
+            <div class="rounded-lg border border-base-300 bg-base-100 p-4">
+              <h3 class="text-lg font-semibold text-base-content">Synthesis</h3>
+              <p class="text-sm text-base-content/70">
+                Provide an optional synthesis prompt to summarize the combined results.
+              </p>
+              <textarea
+                class="textarea textarea-bordered mt-3 w-full text-sm"
+                rows="3"
+                bind:value={parallelSynthesisPrompt}
+                placeholder="Ask the crew to synthesize the parallel outputs (optional)"
+                disabled={isSubmitting}
+              ></textarea>
+              <label class="mt-4 flex items-center justify-between gap-3 rounded-lg border border-base-300 bg-base-200/60 px-4 py-3 text-sm text-base-content">
+                <span>Return each agent result separately</span>
+                <input type="checkbox" class="toggle" bind:checked={parallelAllResults} disabled={isSubmitting} />
+              </label>
+              <p class="mt-2 text-xs text-base-content/60">
+                When enabled, the final output will be a list of each agent&apos;s response.
+              </p>
+            </div>
+          </div>
+        {:else if currentMode === 'loop'}
+          <div class="space-y-6">
+            <div class="space-y-4 rounded-lg border border-base-300 bg-base-100 p-4">
+              <div>
+                <h3 class="text-lg font-semibold text-base-content">Loop configuration</h3>
+                <p class="text-sm text-base-content/70">
+                  Provide the initial task and stopping criteria for the loop.
+                </p>
+              </div>
+              <MarkdownEditor
+                bind:value={loopInitialTask}
+                helperText="Initial task for the first iteration."
+                disabled={isSubmitting || crewsLoading || crewDetailsLoading}
+              />
+              <div class="grid gap-4 md:grid-cols-2">
+                <label class="form-control w-full">
+                  <span class="label-text text-sm font-semibold text-base-content">Stopping condition</span>
+                  <input
+                    type="text"
+                    class="input input-bordered mt-2"
+                    bind:value={loopCondition}
+                    placeholder="Stop when..."
+                    disabled={isSubmitting}
+                  />
+                  <span class="mt-1 text-xs text-base-content/60">
+                    Example: “Stop when the reviewer marks the report as FINAL”.
+                  </span>
+                </label>
+                <label class="form-control w-full">
+                  <span class="label-text text-sm font-semibold text-base-content">Max iterations</span>
+                  <input
+                    type="number"
+                    class="input input-bordered mt-2"
+                    min="1"
+                    bind:value={loopMaxIterations}
+                    disabled={isSubmitting}
+                  />
+                  <span class="mt-1 text-xs text-base-content/60">
+                    Safety limit for how many times the loop can run.
+                  </span>
+                </label>
+              </div>
+            </div>
+
+            <div class="space-y-3 rounded-lg border border-base-300 bg-base-100 p-4">
+              <div class="flex flex-wrap items-center justify-between gap-2">
+                <h3 class="text-lg font-semibold text-base-content">Agent sequence</h3>
+                <span class="text-xs text-base-content/60">Drag and drop to reorder</span>
+              </div>
+              {#if crewDetailsLoading}
+                <div class="flex items-center gap-3 text-sm text-base-content/70">
+                  <LoadingSpinner size="sm" center={false} />
+                  <span>Loading agents…</span>
+                </div>
+              {:else if !loopAgentSequence.length}
+                <p class="text-sm text-base-content/60">No agents available for loop execution.</p>
+              {:else}
+                <ul class="space-y-2">
+                  {#each loopAgentSequence as agentId, index (agentId)}
+                    <li
+                      class:opacity-60={draggingIndex === index}
+                      class="flex items-center justify-between gap-3 rounded-lg border border-base-300 bg-base-100 p-3"
+                      draggable={!isSubmitting}
+                      on:dragstart={(event) => handleDragStart(event, index)}
+                      on:dragover={handleDragOver}
+                      on:drop={(event) => handleDrop(event, index)}
+                      on:dragend={handleDragEnd}
+                    >
+                      <div>
+                        <p class="font-semibold text-base-content">{getAgentDisplayName(agentId)}</p>
+                        <p class="text-xs text-base-content/60">{agentId}</p>
+                      </div>
+                      <div class="flex items-center gap-2">
+                        <button
+                          type="button"
+                          class="btn btn-ghost btn-xs"
+                          on:click={() => moveAgentUp(index)}
+                          disabled={index === 0 || isSubmitting}
+                          aria-label={`Move ${getAgentDisplayName(agentId)} up`}
+                          title="Move up"
+                        >
+                          ↑
+                        </button>
+                        <button
+                          type="button"
+                          class="btn btn-ghost btn-xs"
+                          on:click={() => moveAgentDown(index)}
+                          disabled={index === loopAgentSequence.length - 1 || isSubmitting}
+                          aria-label={`Move ${getAgentDisplayName(agentId)} down`}
+                          title="Move down"
+                        >
+                          ↓
+                        </button>
+                      </div>
+                    </li>
+                  {/each}
+                </ul>
+                <div
+                  class="rounded-lg border border-dashed border-base-300 bg-base-200/60 p-3 text-center text-xs text-base-content/60"
+                  on:dragover={handleDragOver}
+                  on:drop={handleDropAtEnd}
+                >
+                  Drop here to move an agent to the end of the sequence
+                </div>
+              {/if}
+            </div>
+
+            <div class="rounded-lg border border-base-300 bg-base-100 p-4">
+              <h3 class="text-lg font-semibold text-base-content">Synthesis</h3>
+              <p class="text-sm text-base-content/70">
+                Optionally summarize the loop results after the stopping condition is met.
+              </p>
+              <textarea
+                class="textarea textarea-bordered mt-3 w-full text-sm"
+                rows="3"
+                bind:value={loopSynthesisPrompt}
+                placeholder="Ask the crew to synthesize the loop outputs (optional)"
+                disabled={isSubmitting}
+              ></textarea>
+            </div>
+          </div>
+        {:else if currentMode === 'flow'}
+          <div class="space-y-6">
+            <div class="space-y-4 rounded-lg border border-base-300 bg-base-100 p-4">
+              <div>
+                <h3 class="text-lg font-semibold text-base-content">Flow execution</h3>
+                <p class="text-sm text-base-content/70">
+                  Provide the starting task for the workflow defined in the crew builder.
+                </p>
+              </div>
+              <MarkdownEditor
+                bind:value={flowInitialTask}
+                helperText="Initial task for the flow execution."
+                disabled={isSubmitting || crewsLoading || crewDetailsLoading}
+              />
+              <p class="text-xs text-base-content/60">
+                The execution order follows the flow configuration from the crew builder.
+              </p>
+            </div>
+
+            <div class="rounded-lg border border-base-300 bg-base-100 p-4">
+              <h3 class="text-lg font-semibold text-base-content">Synthesis</h3>
+              <p class="text-sm text-base-content/70">
+                Optionally summarize results from the completed flow.
+              </p>
+              <textarea
+                class="textarea textarea-bordered mt-3 w-full text-sm"
+                rows="3"
+                bind:value={flowSynthesisPrompt}
+                placeholder="Ask the crew to synthesize the flow outputs (optional)"
+                disabled={isSubmitting}
+              ></textarea>
+            </div>
+          </div>
+        {:else}
+          <MarkdownEditor
+            bind:value={question}
+            helperText="Supports headings, lists, inline code, and more."
+            disabled={isSubmitting || crewsLoading}
+          />
+        {/if}
 
         {#if jobError}
           <div class="alert alert-error">
@@ -309,6 +909,21 @@
               {#if finalOutputHtml}
                 <div class="mt-3 space-y-2 text-base leading-relaxed text-base-content">
                   {@html finalOutputHtml}
+                </div>
+              {:else if finalOutputList.length}
+                <div class="mt-3 space-y-3">
+                  {#each finalOutputList as item, index (index)}
+                    <div class="rounded-lg border border-base-300 bg-base-100 p-3">
+                      <div class="text-sm font-semibold text-base-content">Result {index + 1}</div>
+                      {#if finalOutputListHtml[index]}
+                        <div class="mt-2 space-y-2 text-sm leading-relaxed text-base-content">
+                          {@html finalOutputListHtml[index]}
+                        </div>
+                      {:else}
+                        <p class="mt-2 text-sm text-base-content/70">{String(item ?? '')}</p>
+                      {/if}
+                    </div>
+                  {/each}
                 </div>
               {:else}
                 <p class="mt-3 text-base-content/70">No final output was returned.</p>

--- a/parrot/handlers/crew/handler.py
+++ b/parrot/handlers/crew/handler.py
@@ -499,6 +499,34 @@ class CrewHandler(BaseView):
                             tasks=tasks,
                             **execution_kwargs
                         )
+                    elif mode == ExecutionMode.LOOP:
+                        if not isinstance(query, str):
+                            raise ValueError("Loop execution requires a string query for the initial task")
+
+                        loop_condition = execution_kwargs.pop('condition', None)
+                        if not loop_condition or not isinstance(loop_condition, str):
+                            raise ValueError("Loop execution requires a 'condition' string in kwargs")
+
+                        agent_sequence = execution_kwargs.pop('agent_sequence', None)
+                        if agent_sequence is not None:
+                            if not isinstance(agent_sequence, list):
+                                raise ValueError("'agent_sequence' must be a list of agent identifiers")
+                            if not all(isinstance(agent_id, str) for agent_id in agent_sequence):
+                                raise ValueError("'agent_sequence' values must be strings")
+
+                        max_iterations = execution_kwargs.pop('max_iterations', None)
+                        if max_iterations is None:
+                            max_iterations = 2
+                        elif not isinstance(max_iterations, int):
+                            raise ValueError("'max_iterations' must be an integer")
+
+                        result = await crew.run_loop(
+                            initial_task=query,
+                            condition=loop_condition,
+                            agent_sequence=agent_sequence,
+                            max_iterations=max_iterations,
+                            **execution_kwargs
+                        )
                     elif mode == ExecutionMode.FLOW:
                         result = await crew.run_flow(
                             initial_task=query,

--- a/parrot/handlers/crew/models.py
+++ b/parrot/handlers/crew/models.py
@@ -16,6 +16,7 @@ class ExecutionMode(str, Enum):
     SEQUENTIAL = "sequential"
     PARALLEL = "parallel"
     FLOW = "flow"
+    LOOP = "loop"
 
 
 class JobStatus(str, Enum):


### PR DESCRIPTION
## Summary
- add a loop execution mode to the crew API models and allow the handler to dispatch run_loop with validation
- allow the client executeCrew helper to send structured payloads for parallel runs
- extend the Ask a Crew page with configuration UIs for parallel, loop, and flow executions, including per-agent prompts, synthesis prompts, and drag-and-drop sequencing

## Testing
- pytest tests/test_agent_crew_examples.py::test_run_loop *(fails: ImportError: cannot import name 'LLM_PRESETS')*

------
https://chatgpt.com/codex/tasks/task_e_68faa25188608330930732b60bebc267