### PR TITLE
Handle null Worker_Data in Workday time off balance parsing

### DIFF
--- a/parrot/tools/workday/models.py
+++ b/parrot/tools/workday/models.py
@@ -290,6 +290,7 @@ class WorkdayResponseParser:
         "worker": WorkerModel,
         "organization": OrganizationModel,
         "contact": ContactModel,
+        "time_off_balance": TimeOffBalanceModel,
     }
 
     @staticmethod
@@ -465,6 +466,12 @@ class WorkdayResponseParser:
             Dict with contact data for ContactModel
         """
         worker_data = worker_element.get("Worker_Data", {})
+        if not isinstance(worker_data, dict):
+            # Some Workday tenants return an explicit null for Worker_Data when
+            # the response group omits most sections (e.g. only requesting time
+            # off balance data).  Treat these the same as an empty payload so
+            # downstream parsing logic can continue gracefully.
+            worker_data = {}
         personal = worker_data.get("Personal_Data", {})
         contact_data = personal.get("Contact_Data", {})
 
@@ -987,6 +994,11 @@ class WorkdayResponseParser:
             Dict with time off balance data for TimeOffBalanceModel
         """
         worker_data = worker_element.get("Worker_Data", {})
+        if not isinstance(worker_data, dict):
+            # Some Workday tenants may explicitly return null for Worker_Data
+            # when only a subset of response groups are requested. Treat this
+            # as an empty payload so balance parsing can continue.
+            worker_data = {}
 
         # Time off balance data is typically in a dedicated section
         # The exact structure varies by Workday configuration

--- a/tests/test_workday_models.py
+++ b/tests/test_workday_models.py
@@ -1,0 +1,61 @@
+"""Tests for Workday response models helpers."""
+"""Tests for Workday response models helpers."""
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+
+def _load_workday_models_module():
+    """Load the real workday models module bypassing the lightweight stubs."""
+
+    # Provide a lightweight zeep.helpers implementation so the module can be
+    # imported without the optional zeep dependency during unit tests.
+    if "zeep.helpers" not in sys.modules:
+        zeep_module = types.ModuleType("zeep")
+        helpers_module = types.ModuleType("zeep.helpers")
+
+        def _serialize_object(value, *_args, **_kwargs):
+            return value
+
+        helpers_module.serialize_object = _serialize_object
+        zeep_module.helpers = helpers_module
+        sys.modules.setdefault("zeep", zeep_module)
+        sys.modules.setdefault("zeep.helpers", helpers_module)
+
+    module_path = Path(__file__).resolve().parents[1] / "parrot" / "tools" / "workday" / "models.py"
+    spec = importlib.util.spec_from_file_location("_workday_models", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None  # for mypy/typing tools
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_time_off_balance_response_handles_null_worker_data():
+    """Regression test for null Worker_Data in time off balance responses."""
+
+    workday_models = _load_workday_models_module()
+    WorkdayResponseParser = workday_models.WorkdayResponseParser
+    TimeOffBalanceModel = workday_models.TimeOffBalanceModel
+
+    response = {
+        "Response_Data": {
+            "Worker": [
+                {
+                    "Worker_Data": None,
+                }
+            ]
+        }
+    }
+
+    result = WorkdayResponseParser.parse_time_off_balance_response(
+        response,
+        worker_id="12345",
+    )
+
+    assert isinstance(result, TimeOffBalanceModel)
+    assert result.worker_id == "12345"
+    assert result.balances == []
+    assert result.vacation_balance is None
+


### PR DESCRIPTION
## Summary
- treat null `Worker_Data` payloads as empty when parsing contact and time off balance responses
- register the default time off balance model and add a regression test covering the null payload scenario

## Testing
- pytest tests/test_workday_models.py

------
https://chatgpt.com/codex/tasks/task_e_68fc1414ccc48330818ad57bac29f5f2