### PR TITLE
Align Jira toolkit structured schema with Google requirements

### DIFF
--- a/parrot/clients/google.py
+++ b/parrot/clients/google.py
@@ -198,16 +198,22 @@ class GoogleGenAIClient(AbstractClient):
         if 'anyOf' in schema:
             # Try to find a non-null type from anyOf
             for option in schema['anyOf']:
-                if isinstance(option, dict) and option.get('type') != 'null':
-                    cleaned['type'] = option['type']
-                    # If it's an array, also copy the items
-                    if option.get('type') == 'array' and 'items' in option:
-                        cleaned['items'] = self.clean_google_schema(option['items'])
-                    # Copy other relevant fields
-                    for field in ['description', 'enum', 'default']:
-                        if field in option:
-                            cleaned[field] = option[field]
-                    break
+                if not isinstance(option, dict):
+                    continue
+
+                option_type = option.get('type')
+                if option_type is None or option_type == 'null':
+                    continue
+
+                cleaned['type'] = option_type
+                # If it's an array, also copy the items
+                if option_type == 'array' and 'items' in option:
+                    cleaned['items'] = self.clean_google_schema(option['items'])
+                # Copy other relevant fields
+                for field in ['description', 'enum', 'default']:
+                    if field in option:
+                        cleaned[field] = option[field]
+                break
             else:
                 # Fallback to string if no good type found
                 cleaned['type'] = 'string'

--- a/parrot/tools/jiratoolkit.py
+++ b/parrot/tools/jiratoolkit.py
@@ -52,6 +52,31 @@ from .decorators import tool_schema
 # -----------------------------
 # Input models (schemas)
 # -----------------------------
+STRUCTURED_OUTPUT_FIELD_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "include": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Whitelist of dot-paths to include"
+        },
+        "mapping": {
+            "type": "object",
+            "description": "dest_key -> dot-path mapping",
+            "additionalProperties": {"type": "string"}
+        },
+        "model_path": {
+            "type": "string",
+            "description": "Dotted path to a Pydantic BaseModel subclass"
+        },
+        "strict": {
+            "type": "boolean",
+            "description": "If True, missing paths raise; otherwise they become None"
+        }
+    }
+}
+
+
 class StructuredOutputOptions(BaseModel):
     """Options to shape the output of Jira items into either a whitelist or a Pydantic model.
 
@@ -102,7 +127,11 @@ class GetIssueInput(BaseModel):
     issue: str = Field(description="Issue key or id, e.g., 'JRA-1330'")
     fields: Optional[str] = Field(default=None, description="Fields to fetch (comma-separated) or '*' ")
     expand: Optional[str] = Field(default=None, description="Entities to expand, e.g. 'renderedFields' ")
-    structured: Optional[Union[StructuredOutputOptions, Dict[str, Any]]] = Field(default=None, description="Optional structured output mapping")
+    structured: Optional[StructuredOutputOptions] = Field(
+        default=None,
+        description="Optional structured output mapping",
+        json_schema_extra=STRUCTURED_OUTPUT_FIELD_SCHEMA
+    )
 
 
 class SearchIssuesInput(BaseModel):
@@ -112,7 +141,11 @@ class SearchIssuesInput(BaseModel):
     max_results: int = Field(default=50, description="Max results per page (Jira default 50)")
     fields: Optional[str] = Field(default=None, description="Fields to return (comma-separated) or '*'")
     expand: Optional[str] = Field(default=None, description="Expand options")
-    structured: Optional[Union[StructuredOutputOptions, Dict[str, Any]]] = Field(default=None, description="Optional structured output mapping")
+    structured: Optional[StructuredOutputOptions] = Field(
+        default=None,
+        description="Optional structured output mapping",
+        json_schema_extra=STRUCTURED_OUTPUT_FIELD_SCHEMA
+    )
 
 
 class TransitionIssueInput(BaseModel):


### PR DESCRIPTION
## Summary
- expose a reusable JSON schema description for Jira structured output options
- update Jira toolkit input models to emit explicit object types for the structured argument so Google tool schemas always include a type

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6903955f63dc8330b4090e5719e1233d