### PR TITLE
Ensure Google schemas with properties are typed as objects

### DIFF
--- a/examples/tools/jiratool.py
+++ b/examples/tools/jiratool.py
@@ -21,7 +21,7 @@ async def main():
     print("Available tools:", [tool.name for tool in tools])
 
     # Example: Get issue by key
-    issue = await toolkit.get_issue(
+    issue = await toolkit.jira_get_issue(
         "NAV-5932",
         structured={
         "mapping": {

--- a/parrot/clients/google.py
+++ b/parrot/clients/google.py
@@ -198,19 +198,29 @@ class GoogleGenAIClient(AbstractClient):
         if 'anyOf' in schema:
             # Try to find a non-null type from anyOf
             for option in schema['anyOf']:
-                if isinstance(option, dict) and option.get('type') != 'null':
-                    cleaned['type'] = option['type']
-                    # If it's an array, also copy the items
-                    if option.get('type') == 'array' and 'items' in option:
-                        cleaned['items'] = self.clean_google_schema(option['items'])
-                    # Copy other relevant fields
-                    for field in ['description', 'enum', 'default']:
-                        if field in option:
-                            cleaned[field] = option[field]
-                    break
+                if not isinstance(option, dict):
+                    continue
+
+                option_type = option.get('type')
+                if option_type is None or option_type == 'null':
+                    continue
+
+                cleaned['type'] = option_type
+                # If it's an array, also copy the items
+                if option_type == 'array' and 'items' in option:
+                    cleaned['items'] = self.clean_google_schema(option['items'])
+                # Copy other relevant fields
+                for field in ['description', 'enum', 'default']:
+                    if field in option:
+                        cleaned[field] = option[field]
+                break
             else:
                 # Fallback to string if no good type found
                 cleaned['type'] = 'string'
+
+        # Ensure object-like schemas always advertise an object type
+        if 'properties' in cleaned and cleaned.get('type') != 'object':
+            cleaned['type'] = 'object'
 
         # Remove problematic fields that Google doesn't support
         problematic_fields = {


### PR DESCRIPTION
## Summary
- force cleaned Google function schemas that define properties to declare an object type
- prevent INVALID_ARGUMENT errors when Jira toolkit structured options are optional

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6903955f63dc8330b4090e5719e1233d