### PR TITLE
Implement Jinja2 template rendering for output mode

### DIFF
--- a/examples/outputs/template_report_example.py
+++ b/examples/outputs/template_report_example.py
@@ -1,0 +1,279 @@
+"""
+Example demonstrating the TEMPLATE_REPORT OutputMode.
+
+This example shows how to use Jinja2 templates to render AI outputs
+using the TemplateEngine and TemplateReportRenderer.
+"""
+import asyncio
+from dataclasses import dataclass
+from pydantic import BaseModel
+from parrot.outputs.formatter import OutputFormatter
+from parrot.models.outputs import OutputMode
+
+
+class AnalysisResult(BaseModel):
+    """Example Pydantic model for analysis results"""
+    title: str
+    summary: str
+    findings: list[str]
+    confidence: float
+    recommendations: list[str]
+
+
+@dataclass
+class ReportMetadata:
+    """Example dataclass for report metadata"""
+    author: str
+    date: str
+    version: str
+
+
+async def example_basic_template():
+    """Example 1: Basic template rendering with dictionary data"""
+    print("\n=== Example 1: Basic Template Rendering ===\n")
+
+    # Create formatter
+    formatter = OutputFormatter()
+
+    # Add an HTML template
+    formatter.add_template(
+        "simple_report.html",
+        """
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <title>{{ title }}</title>
+            <style>
+                body { font-family: Arial, sans-serif; margin: 40px; }
+                h1 { color: #333; }
+                .summary { background: #f0f0f0; padding: 15px; border-radius: 5px; }
+            </style>
+        </head>
+        <body>
+            <h1>{{ title }}</h1>
+            <div class="summary">
+                <p>{{ description }}</p>
+            </div>
+        </body>
+        </html>
+        """
+    )
+
+    # Data to render
+    data = {
+        "title": "Simple Report",
+        "description": "This is a simple example of template-based rendering."
+    }
+
+    # Render the template
+    result = await formatter.format_async(
+        OutputMode.TEMPLATE_REPORT,
+        data,
+        template="simple_report.html"
+    )
+
+    print(result)
+
+
+async def example_pydantic_model():
+    """Example 2: Rendering with Pydantic model"""
+    print("\n=== Example 2: Pydantic Model Rendering ===\n")
+
+    formatter = OutputFormatter()
+
+    # Add a detailed analysis template
+    formatter.add_template(
+        "analysis.html",
+        """
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <title>{{ title }}</title>
+            <style>
+                body { font-family: Arial, sans-serif; margin: 40px; }
+                .header { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+                          color: white; padding: 20px; border-radius: 8px; }
+                .summary { background: #f8f9fa; padding: 20px; margin: 20px 0; border-left: 4px solid #667eea; }
+                .findings { margin: 20px 0; }
+                .finding { background: #fff; padding: 10px; margin: 10px 0;
+                          border: 1px solid #ddd; border-radius: 4px; }
+                .confidence { font-size: 24px; font-weight: bold; color: #667eea; }
+                .recommendations { background: #e8f5e9; padding: 15px; border-radius: 8px; }
+            </style>
+        </head>
+        <body>
+            <div class="header">
+                <h1>{{ title }}</h1>
+                <p class="confidence">Confidence: {{ confidence * 100 }}%</p>
+            </div>
+
+            <div class="summary">
+                <h2>Summary</h2>
+                <p>{{ summary }}</p>
+            </div>
+
+            <div class="findings">
+                <h2>Key Findings</h2>
+                {% for finding in findings %}
+                <div class="finding">{{ loop.index }}. {{ finding }}</div>
+                {% endfor %}
+            </div>
+
+            <div class="recommendations">
+                <h2>Recommendations</h2>
+                <ul>
+                {% for rec in recommendations %}
+                    <li>{{ rec }}</li>
+                {% endfor %}
+                </ul>
+            </div>
+        </body>
+        </html>
+        """
+    )
+
+    # Create analysis result
+    analysis = AnalysisResult(
+        title="Market Analysis Report",
+        summary="Comprehensive analysis of market trends and opportunities",
+        findings=[
+            "Strong growth trend in technology sector",
+            "Emerging opportunities in renewable energy",
+            "Increasing consumer demand for sustainable products"
+        ],
+        confidence=0.87,
+        recommendations=[
+            "Increase investment in tech companies",
+            "Explore partnerships in green energy sector",
+            "Develop eco-friendly product lines"
+        ]
+    )
+
+    # Render the template
+    result = await formatter.format_async(
+        OutputMode.TEMPLATE_REPORT,
+        analysis,
+        template="analysis.html"
+    )
+
+    print(result)
+
+
+async def example_markdown_template():
+    """Example 3: Markdown template for reports"""
+    print("\n=== Example 3: Markdown Template ===\n")
+
+    formatter = OutputFormatter()
+
+    # Add a markdown template
+    formatter.add_template(
+        "report.md",
+        """
+# {{ title }}
+
+**Author:** {{ author }}
+**Date:** {{ date }}
+**Version:** {{ version }}
+
+---
+
+## Executive Summary
+
+{{ summary }}
+
+## Detailed Analysis
+
+{% for section, content in analysis.items() %}
+### {{ section }}
+
+{{ content }}
+
+{% endfor %}
+
+## Conclusion
+
+{{ conclusion }}
+
+---
+*Generated using AI-Parrot Template Report*
+        """
+    )
+
+    # Combine data from multiple sources
+    metadata = ReportMetadata(
+        author="AI Assistant",
+        date="2025-11-04",
+        version="1.0"
+    )
+
+    # Mix dataclass and dict data
+    result = await formatter.format_async(
+        OutputMode.TEMPLATE_REPORT,
+        {
+            "title": "Quarterly Business Review",
+            "author": metadata.author,
+            "date": metadata.date,
+            "version": metadata.version,
+            "summary": "This quarter showed strong performance across all metrics.",
+            "analysis": {
+                "Revenue": "Revenue increased by 25% compared to last quarter.",
+                "Customer Growth": "Acquired 1,000 new customers, a 15% increase.",
+                "Product Development": "Launched 3 new features with positive feedback."
+            },
+            "conclusion": "The quarter exceeded expectations with strong growth indicators."
+        },
+        template="report.md"
+    )
+
+    print(result)
+
+
+async def example_with_extra_context():
+    """Example 4: Adding extra context variables"""
+    print("\n=== Example 4: Extra Context Variables ===\n")
+
+    formatter = OutputFormatter()
+
+    formatter.add_template(
+        "email.html",
+        """
+        <!DOCTYPE html>
+        <html>
+        <body>
+            <h2>Hello {{ recipient_name }},</h2>
+            <p>{{ message }}</p>
+            <p><strong>From:</strong> {{ sender_name }}</p>
+            <p><strong>Department:</strong> {{ department }}</p>
+        </body>
+        </html>
+        """
+    )
+
+    # Base data
+    data = {
+        "message": "Your report has been generated successfully."
+    }
+
+    # Render with extra context
+    result = await formatter.format_async(
+        OutputMode.TEMPLATE_REPORT,
+        data,
+        template="email.html",
+        recipient_name="John Doe",
+        sender_name="AI Assistant",
+        department="Analytics"
+    )
+
+    print(result)
+
+
+async def main():
+    """Run all examples"""
+    await example_basic_template()
+    await example_pydantic_model()
+    await example_markdown_template()
+    await example_with_extra_context()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/parrot/outputs/formats/__init__.py
+++ b/parrot/outputs/formats/__init__.py
@@ -42,6 +42,8 @@ def get_renderer(mode: OutputMode) -> Type[Renderer]:
                 import_module('.altair', 'parrot.outputs.formats')
             elif mode == OutputMode.JINJA2:
                 import_module('.jinja2', 'parrot.outputs.formats')
+            elif mode == OutputMode.TEMPLATE_REPORT:
+                import_module('.template_report', 'parrot.outputs.formats')
     try:
         return RENDERERS[mode]
     except KeyError as exc:

--- a/parrot/outputs/formats/template_report.py
+++ b/parrot/outputs/formats/template_report.py
@@ -1,0 +1,143 @@
+from typing import Any, Dict, Optional
+
+from ...models.outputs import OutputMode
+from ...template.engine import TemplateEngine
+from . import register_renderer
+from .base import BaseRenderer
+
+
+@register_renderer(OutputMode.TEMPLATE_REPORT)
+class TemplateReportRenderer(BaseRenderer):
+    """
+    Renders AI output using Jinja2 templates via the TemplateEngine.
+
+    Supports both file-based templates and in-memory templates via add_template().
+    """
+
+    def __init__(self, template_engine: Optional[TemplateEngine] = None):
+        """
+        Initialize the TemplateReportRenderer.
+
+        Args:
+            template_engine: Optional TemplateEngine instance. If not provided,
+                           one will be created on first use.
+        """
+        self._template_engine = template_engine
+
+    @property
+    def template_engine(self) -> TemplateEngine:
+        """
+        Lazy initialization of TemplateEngine if not provided.
+
+        Returns:
+            TemplateEngine instance
+        """
+        if self._template_engine is None:
+            # Initialize with no template directories (will use in-memory only)
+            self._template_engine = TemplateEngine()
+        return self._template_engine
+
+    def add_template(self, name: str, content: str) -> None:
+        """
+        Add an in-memory template to the engine.
+
+        Args:
+            name: Template name (e.g., 'report.html', 'summary.md')
+            content: Jinja2 template content
+
+        Example:
+            renderer.add_template('report.html', '<h1>{{ title }}</h1>')
+        """
+        self.template_engine.add_templates({name: content})
+
+    async def render(self, data: Any, **kwargs: Any) -> str:
+        """
+        Renders data using a Jinja2 template asynchronously.
+
+        Args:
+            data: The data to render. Can be:
+                - dict: passed directly to template
+                - Pydantic model: converted via model_dump()
+                - dataclass: converted via asdict()
+                - any object with attributes: accessible in template
+            **kwargs: Additional arguments:
+                - template: (required) Template name to use
+                - template_engine: (optional) Override the default engine
+                - Additional kwargs are passed to the template context
+
+        Returns:
+            Rendered template content as string
+
+        Raises:
+            ValueError: If template is not provided or not found
+
+        Example:
+            result = await renderer.render(
+                {"title": "Report", "items": [1, 2, 3]},
+                template="report.html"
+            )
+        """
+        # Get template name
+        template_name: str = kwargs.pop("template", None)
+        if not template_name:
+            raise ValueError(
+                "Template name must be provided via 'template' kwarg. "
+                "Example: renderer.render(data, template='report.html')"
+            )
+
+        # Allow overriding the template engine
+        engine = kwargs.pop("template_engine", None) or self.template_engine
+
+        # Prepare the template context
+        context = self._prepare_template_context(data, kwargs)
+
+        # Render the template
+        try:
+            rendered_content = await engine.render(template_name, context)
+            return rendered_content
+        except FileNotFoundError as e:
+            raise ValueError(
+                f"Template '{template_name}' not found. "
+                f"Use add_template() to add in-memory templates or "
+                f"ensure the template exists in the template directories."
+            ) from e
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to render template '{template_name}': {e}"
+            ) from e
+
+    def _prepare_template_context(
+        self, data: Any, extra_kwargs: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Prepare the context dictionary for template rendering.
+
+        Args:
+            data: The main data to render
+            extra_kwargs: Additional kwargs to include in context
+
+        Returns:
+            Dictionary to pass to template
+        """
+        # Start with extra kwargs
+        context = dict(extra_kwargs)
+
+        # Handle different data types
+        if isinstance(data, dict):
+            # Merge dict data with kwargs (data takes precedence)
+            context.update(data)
+        elif hasattr(data, 'model_dump'):
+            # Pydantic model
+            context.update(data.model_dump())
+        elif hasattr(data, '__dataclass_fields__'):
+            # Dataclass
+            from dataclasses import asdict
+            context.update(asdict(data))
+        elif hasattr(data, '__dict__'):
+            # Generic object with attributes
+            context['data'] = data
+        else:
+            # Primitive or unknown type - wrap as 'data'
+            context['data'] = data
+
+        return context

--- a/parrot/outputs/formatter.py
+++ b/parrot/outputs/formatter.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 import sys
-from typing import Any
+from typing import Any, Optional
 
 from .formats import get_renderer
 from ..models.outputs import OutputMode
+from ..template.engine import TemplateEngine
 
 
 class OutputFormatter:
@@ -11,11 +12,19 @@ class OutputFormatter:
     Formatter for AI responses supporting multiple output modes.
     """
 
-    def __init__(self):
+    def __init__(self, template_engine: Optional[TemplateEngine] = None):
+        """
+        Initialize the OutputFormatter.
+
+        Args:
+            template_engine: Optional TemplateEngine instance for template-based rendering.
+                           If not provided, a new one will be created when needed.
+        """
         self._is_ipython = self._detect_ipython()
         self._is_notebook = self._detect_notebook()
         self._environment = self._detect_environment()
         self._renderers = {}
+        self._template_engine = template_engine
 
     def _detect_environment(self) -> str:
         if self._is_ipython:
@@ -42,7 +51,14 @@ class OutputFormatter:
     def _get_renderer(self, mode: OutputMode):
         if mode not in self._renderers:
             renderer_cls = get_renderer(mode)
-            self._renderers[mode] = renderer_cls()
+            # Special handling for TEMPLATE_REPORT renderer to pass TemplateEngine
+            if mode == OutputMode.TEMPLATE_REPORT:
+                # Lazy initialize TemplateEngine if not provided
+                if self._template_engine is None:
+                    self._template_engine = TemplateEngine()
+                self._renderers[mode] = renderer_cls(template_engine=self._template_engine)
+            else:
+                self._renderers[mode] = renderer_cls()
         return self._renderers[mode]
 
     def format(self, mode: OutputMode, data: Any, **kwargs) -> Any:
@@ -77,3 +93,29 @@ class OutputFormatter:
             is_notebook=self._is_notebook,
             **kwargs,
         )
+
+    def add_template(self, name: str, content: str) -> None:
+        """
+        Add an in-memory template for use with TEMPLATE_REPORT mode.
+
+        Args:
+            name: Template name (e.g., 'report.html', 'summary.md')
+            content: Jinja2 template content
+
+        Example:
+            formatter = OutputFormatter()
+            formatter.add_template('report.html', '<h1>{{ title }}</h1>')
+            result = await formatter.format_async(
+                OutputMode.TEMPLATE_REPORT,
+                {"title": "My Report"},
+                template="report.html"
+            )
+        """
+        # Ensure TemplateEngine is initialized
+        if self._template_engine is None:
+            self._template_engine = TemplateEngine()
+
+        # Get or create the TEMPLATE_REPORT renderer to add the template
+        renderer = self._get_renderer(OutputMode.TEMPLATE_REPORT)
+        if hasattr(renderer, 'add_template'):
+            renderer.add_template(name, content)

--- a/tests/outputs/formats/test_template_report.py
+++ b/tests/outputs/formats/test_template_report.py
@@ -1,0 +1,214 @@
+import pytest
+from dataclasses import dataclass
+from pydantic import BaseModel
+from parrot.outputs.formatter import OutputFormatter
+from parrot.models.outputs import OutputMode
+
+
+class UserModel(BaseModel):
+    """Test Pydantic model"""
+    name: str
+    age: int
+    role: str = "user"
+
+
+@dataclass
+class ReportData:
+    """Test dataclass"""
+    title: str
+    items: list
+    count: int
+
+
+@pytest.mark.asyncio
+async def test_template_report_with_dict():
+    """Test template_report with dictionary data"""
+    formatter = OutputFormatter()
+
+    # Add an in-memory template
+    formatter.add_template(
+        "simple.html",
+        "<h1>{{ title }}</h1><p>{{ description }}</p>"
+    )
+
+    data = {
+        "title": "Test Report",
+        "description": "This is a test report"
+    }
+
+    # Render the template
+    result = await formatter.format_async(
+        OutputMode.TEMPLATE_REPORT,
+        data,
+        template="simple.html"
+    )
+
+    assert "<h1>Test Report</h1>" in result
+    assert "<p>This is a test report</p>" in result
+
+
+@pytest.mark.asyncio
+async def test_template_report_with_pydantic():
+    """Test template_report with Pydantic model"""
+    formatter = OutputFormatter()
+
+    # Add an in-memory template
+    formatter.add_template(
+        "user.html",
+        "<div><h2>{{ name }}</h2><p>Age: {{ age }}</p><p>Role: {{ role }}</p></div>"
+    )
+
+    user = UserModel(name="Alice", age=30, role="admin")
+
+    # Render the template
+    result = await formatter.format_async(
+        OutputMode.TEMPLATE_REPORT,
+        user,
+        template="user.html"
+    )
+
+    assert "<h2>Alice</h2>" in result
+    assert "Age: 30" in result
+    assert "Role: admin" in result
+
+
+@pytest.mark.asyncio
+async def test_template_report_with_dataclass():
+    """Test template_report with dataclass"""
+    formatter = OutputFormatter()
+
+    # Add an in-memory template
+    formatter.add_template(
+        "report.html",
+        """
+        <div>
+            <h1>{{ title }}</h1>
+            <p>Total items: {{ count }}</p>
+            <ul>
+            {% for item in items %}
+                <li>{{ item }}</li>
+            {% endfor %}
+            </ul>
+        </div>
+        """
+    )
+
+    report = ReportData(
+        title="Monthly Report",
+        items=["Item 1", "Item 2", "Item 3"],
+        count=3
+    )
+
+    # Render the template
+    result = await formatter.format_async(
+        OutputMode.TEMPLATE_REPORT,
+        report,
+        template="report.html"
+    )
+
+    assert "<h1>Monthly Report</h1>" in result
+    assert "Total items: 3" in result
+    assert "<li>Item 1</li>" in result
+    assert "<li>Item 2</li>" in result
+    assert "<li>Item 3</li>" in result
+
+
+@pytest.mark.asyncio
+async def test_template_report_with_extra_context():
+    """Test template_report with extra context variables"""
+    formatter = OutputFormatter()
+
+    # Add an in-memory template
+    formatter.add_template(
+        "context.html",
+        "<div><h1>{{ title }}</h1><p>{{ extra_info }}</p></div>"
+    )
+
+    data = {"title": "Report"}
+
+    # Render with extra context
+    result = await formatter.format_async(
+        OutputMode.TEMPLATE_REPORT,
+        data,
+        template="context.html",
+        extra_info="Additional information"
+    )
+
+    assert "<h1>Report</h1>" in result
+    assert "<p>Additional information</p>" in result
+
+
+@pytest.mark.asyncio
+async def test_template_report_missing_template():
+    """Test that missing template raises appropriate error"""
+    formatter = OutputFormatter()
+
+    data = {"title": "Test"}
+
+    with pytest.raises(ValueError) as exc_info:
+        await formatter.format_async(
+            OutputMode.TEMPLATE_REPORT,
+            data,
+            template="nonexistent.html"
+        )
+
+    assert "not found" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_template_report_no_template_name():
+    """Test that missing template name raises appropriate error"""
+    formatter = OutputFormatter()
+
+    data = {"title": "Test"}
+
+    with pytest.raises(ValueError) as exc_info:
+        await formatter.format_async(
+            OutputMode.TEMPLATE_REPORT,
+            data
+        )
+
+    assert "Template name must be provided" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_template_report_with_markdown():
+    """Test template_report with markdown template"""
+    formatter = OutputFormatter()
+
+    # Add a markdown template
+    formatter.add_template(
+        "report.md",
+        """
+# {{ title }}
+
+## Summary
+
+{{ summary }}
+
+## Details
+
+{% for item in items %}
+- {{ item }}
+{% endfor %}
+        """
+    )
+
+    data = {
+        "title": "Analysis Report",
+        "summary": "This is a summary of the analysis",
+        "items": ["Finding 1", "Finding 2", "Finding 3"]
+    }
+
+    result = await formatter.format_async(
+        OutputMode.TEMPLATE_REPORT,
+        data,
+        template="report.md"
+    )
+
+    assert "# Analysis Report" in result
+    assert "## Summary" in result
+    assert "This is a summary of the analysis" in result
+    assert "- Finding 1" in result
+    assert "- Finding 2" in result
+    assert "- Finding 3" in result


### PR DESCRIPTION
Implemented a new OutputMode called TEMPLATE_REPORT that uses Jinja2 templates to render AI outputs. This feature integrates the existing TemplateEngine from parrot/template/engine.py with the outputs system.

Changes:
- Created TemplateReportRenderer in parrot/outputs/formats/template_report.py
  - Supports async rendering using TemplateEngine
  - Handles dict, Pydantic models, dataclasses, and generic objects
  - Provides add_template() method for in-memory templates

- Updated OutputFormatter (parrot/outputs/formatter.py)
  - Initialize TemplateEngine and pass to TemplateReportRenderer
  - Added add_template() convenience method
  - Lazy initialization of TemplateEngine when needed

- Updated formats/__init__.py to register TEMPLATE_REPORT renderer

- Added comprehensive tests in tests/outputs/formats/test_template_report.py
  - Tests for dict, Pydantic, dataclass data types
  - Tests for extra context variables
  - Tests for error handling
  - Tests for markdown templates

- Created examples/outputs/template_report_example.py
  - Demonstrates basic template rendering
  - Shows Pydantic model usage
  - Includes markdown template example
  - Shows extra context variables usage

The TEMPLATE_REPORT mode allows users to render AI outputs using custom Jinja2 templates, supporting both file-based and in-memory templates.