### PR TITLE
Enforce JSON payload for D3 renderer responses

### DIFF
--- a/parrot/bots/prompts/agents.py
+++ b/parrot/bots/prompts/agents.py
@@ -22,6 +22,8 @@ Given the above context, available tools, and conversation history, please provi
 Response Rules (Concise)
 
 • Understand the question, including whether it concerns a past/recent event.
+• When the user requests source code (e.g., JavaScript, D3.js, or other libraries), provide the requested code as plain text without disclaimers about executing it.
+• Remember you are never expected to run or validate code—only to write it faithfully.
 • Trust tools completely: do not alter, reinterpret, or add to tool outputs.
 • Present tool results faithfully; if JSON is returned, show it clearly.
 • Analyze and synthesize only from provided data and tool outputs.

--- a/parrot/outputs/formats/base.py
+++ b/parrot/outputs/formats/base.py
@@ -316,6 +316,36 @@ class BaseChart(BaseRenderer):
                 justify-content: center;
                 align-items: center;
             }
+            .chart-guidance {
+                background: #f0f4ff;
+                border-left: 4px solid #667eea;
+                padding: 16px 20px;
+                margin-bottom: 20px;
+                border-radius: 6px;
+            }
+            .chart-guidance h3 {
+                margin-bottom: 10px;
+                font-size: 16px;
+                font-weight: 600;
+                color: #364152;
+            }
+            .chart-guidance ol {
+                margin: 0 0 0 20px;
+                padding: 0;
+            }
+            .chart-guidance li {
+                margin-bottom: 6px;
+                line-height: 1.4;
+            }
+            .chart-note {
+                background: #fffaf0;
+                border-left: 4px solid #f6ad55;
+                padding: 12px 16px;
+                border-radius: 6px;
+                margin-bottom: 20px;
+                color: #744210;
+                font-size: 14px;
+            }
             .code-accordion {
                 margin-top: 20px;
                 border: 1px solid #e0e0e0;


### PR DESCRIPTION
## Summary
- update the D3 system prompt to require a single ```json block with teaching steps and JavaScript code
- parse the JSON payload in the renderer, surfacing teaching steps and optional notes in the rendered chart
- add shared styling for the new guidance and note sections in chart outputs

## Testing
- python -m compileall parrot/outputs/formats/d3.py parrot/outputs/formats/base.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914c0e1be1483308100eadff45e528d)