### PR TITLE
Streamline PandasAgent metadata handling

### DIFF
--- a/parrot/tools/__init__.py
+++ b/parrot/tools/__init__.py
@@ -4,6 +4,7 @@ Tools infrastructure for building Agents.
 from parrot.plugins import setup_plugin_importer, dynamic_import_helper
 from .pythonrepl import PythonREPLTool
 from .pythonpandas import PythonPandasTool
+from .metadata import MetadataTool
 from .abstract import AbstractTool, ToolResult
 from .google.base import GoogleBaseTool, GoogleToolArgsSchema, GoogleAuthMode
 from .math import MathTool
@@ -31,6 +32,7 @@ __all__ = (
     "DuckDuckGoToolkit",
     "FileReaderTool",
     "YFinanceTool",
+    "MetadataTool",
 )
 
 # Enable dynamic imports

--- a/parrot/tools/metadata.py
+++ b/parrot/tools/metadata.py
@@ -1,0 +1,115 @@
+"""Metadata tool for describing DataFrame schemas to the LLM."""
+from typing import Any, Dict, Optional
+from pydantic import Field
+from .abstract import AbstractTool, AbstractToolArgsSchema
+
+
+class MetadataToolArgs(AbstractToolArgsSchema):
+    """Arguments for the MetadataTool."""
+
+    dataframe: Optional[str] = Field(
+        default=None,
+        description="Name of the DataFrame to inspect"
+    )
+    column: Optional[str] = Field(
+        default=None,
+        description="Specific column within the DataFrame to describe"
+    )
+
+
+class MetadataTool(AbstractTool):
+    """Expose DataFrame metadata (column descriptions, dtypes, EDA, samples) to the agent."""
+
+    name = "dataframe_metadata"
+    description = (
+        "Retrieve metadata about available DataFrames, including schema, EDA stats, and sample rows"
+    )
+    args_schema = MetadataToolArgs
+
+    def __init__(
+        self,
+        metadata: Optional[Dict[str, Dict[str, Any]]] = None,
+        alias_map: Optional[Dict[str, str]] = None,
+        **kwargs
+    ) -> None:
+        super().__init__(**kwargs)
+        self.metadata: Dict[str, Dict[str, Any]] = metadata or {}
+        self.alias_map: Dict[str, str] = alias_map or {}
+
+    def update_metadata(
+        self,
+        metadata: Dict[str, Dict[str, Any]],
+        alias_map: Optional[Dict[str, str]] = None
+    ) -> None:
+        """Update the internal metadata dictionary and alias map."""
+        self.metadata = metadata or {}
+        self.alias_map = alias_map or {}
+
+    async def _execute(
+        self,
+        dataframe: Optional[str] = None,
+        column: Optional[str] = None,
+        **_: Any
+    ) -> Dict[str, Any]:
+        if not self.metadata:
+            return {"message": "No metadata available"}
+
+        if dataframe:
+            return self._describe_dataframe(dataframe, column)
+
+        return {
+            "available_dataframes": [
+                {
+                    "name": name,
+                    "standardized_name": self.alias_map.get(name),
+                    "description": meta.get('description'),
+                    "shape": meta.get('shape'),
+                    "columns": list(meta.get('columns', {}).keys())
+                }
+                for name, meta in self.metadata.items()
+            ]
+        }
+
+    def _describe_dataframe(self, dataframe: str, column: Optional[str] = None) -> Dict[str, Any]:
+        """Describe a dataframe and optionally a specific column."""
+        df_name = self._resolve_dataframe_name(dataframe)
+        df_meta = self.metadata.get(df_name)
+        if not df_meta:
+            raise ValueError(f"DataFrame '{dataframe}' metadata not found")
+
+        if column:
+            column_meta = df_meta.get('columns', {}).get(column)
+            if not column_meta:
+                raise ValueError(
+                    f"Column '{column}' metadata not found for DataFrame '{df_name}'"
+                )
+            return {
+                "dataframe": df_name,
+                "standardized_name": self.alias_map.get(df_name),
+                "column": column,
+                "metadata": column_meta
+            }
+
+        response = {
+            "dataframe": df_name,
+            "standardized_name": self.alias_map.get(df_name)
+        }
+
+        response.update({
+            key: value
+            for key, value in df_meta.items()
+            if key != 'name'
+        })
+
+        return response
+
+    def _resolve_dataframe_name(self, identifier: str) -> str:
+        """Resolve either a standardized key (df1) or original name to metadata key."""
+        if identifier in self.metadata:
+            return identifier
+
+        for name, alias in self.alias_map.items():
+            if alias == identifier:
+                return name
+
+        return identifier


### PR DESCRIPTION
## Summary
- slim the PandasAgent system prompt and direct the LLM to query the new MetadataTool for schema, EDA summaries, and sample rows instead of embedding that detail inline
- enrich the generated metadata with shapes, memory usage, samples, and optional user-provided descriptions while keeping the MetadataTool synchronized (including alias support for df1, df2, etc.)
- expand the MetadataTool responses so the LLM can retrieve full dataset overviews or column-level details along with standardized dataframe aliases

## Testing
- Not Run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915db80f7dc8330a33e651feb3ae4d5)