### PR TITLE
Add Parrot MCP server service

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,6 +21,7 @@ from parrot.handlers.o365_auth import (
     O365InteractiveAuthSessions,
     O365InteractiveAuthSessionDetail,
 )
+from parrot.services import ParrotMCPServer
 from parrot.services.o365_remote_auth import RemoteAuthManager
 from parrot.handlers.jobs.worker import configure_redis_queue, configure_job_manager
 from resources.example import ExampleAsyncView
@@ -109,6 +110,10 @@ class Main(AppHandler):
         ## NextStop
         nextstop = NextStopAgent(app=self.app)
         nextstop.setup(self.app, '/api/v1/agents/nextstop')
+
+        # MCP server lifecycle management
+        self.mcp_server = ParrotMCPServer()
+        self.mcp_server.setup(self.app)
 
     async def on_prepare(self, request, response):
         """

--- a/parrot/conf.py
+++ b/parrot/conf.py
@@ -56,6 +56,24 @@ if isinstance(MCP_SERVER_DIR, str):
 if not MCP_SERVER_DIR.exists():
     MCP_SERVER_DIR.mkdir(parents=True, exist_ok=True)
 
+# MCP Server defaults
+MCP_SERVER_TRANSPORT = config.get('MCP_SERVER_TRANSPORT', fallback='http')
+MCP_SERVER_HOST = config.get('MCP_SERVER_HOST', fallback='0.0.0.0')
+MCP_SERVER_PORT = config.getint('MCP_SERVER_PORT', fallback=8080)
+MCP_SERVER_NAME = config.get('MCP_SERVER_NAME', fallback='ai-parrot-tools')
+MCP_SERVER_DESCRIPTION = config.get(
+    'MCP_SERVER_DESCRIPTION',
+    fallback='AI-Parrot MCP Tooling'
+)
+MCP_SERVER_LOG_LEVEL = config.get('MCP_SERVER_LOG_LEVEL', fallback='INFO')
+
+# Default tools that should be started with the MCP server
+MCP_STARTED_TOOLS = {
+    'MSTeamsToolkit': 'parrot.tools.msteams',
+    'PDFPrintTool': 'parrot.tools.pdfprint',
+    'JiraToolkit': 'parrot.tools.jiratoolkit',
+}
+
 # Agents-Bots Prompt directory:
 AGENTS_BOTS_PROMPT_DIR = config.get(
     'AGENTS_BOTS_PROMPT_DIR',

--- a/parrot/conf.py
+++ b/parrot/conf.py
@@ -58,7 +58,7 @@ if not MCP_SERVER_DIR.exists():
 
 # MCP Server defaults
 MCP_SERVER_TRANSPORT = config.get('MCP_SERVER_TRANSPORT', fallback='http')
-MCP_SERVER_HOST = config.get('MCP_SERVER_HOST', fallback='0.0.0.0')
+MCP_SERVER_HOST = config.get('MCP_SERVER_HOST', fallback='127.0.0.1')
 MCP_SERVER_PORT = config.getint('MCP_SERVER_PORT', fallback=8080)
 MCP_SERVER_NAME = config.get('MCP_SERVER_NAME', fallback='ai-parrot-tools')
 MCP_SERVER_DESCRIPTION = config.get(

--- a/parrot/services/__init__.py
+++ b/parrot/services/__init__.py
@@ -1,1 +1,3 @@
 """Parrot service helpers."""
+
+from .mcp_server import ParrotMCPServer  # noqa: F401

--- a/parrot/services/mcp_server.py
+++ b/parrot/services/mcp_server.py
@@ -151,7 +151,7 @@ class ParrotMCPServer:
 
         if isinstance(instance, AbstractToolkit):
             await self._maybe_start_toolkit(instance, class_name)
-            return [tool for tool in instance.get_tools() if isinstance(tool, AbstractTool)]
+            return list(instance.get_tools())
 
         if isinstance(instance, AbstractTool):
             return [instance]

--- a/parrot/services/mcp_server.py
+++ b/parrot/services/mcp_server.py
@@ -1,0 +1,177 @@
+"""Utilities for starting the MCP server inside the aiohttp application."""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import inspect
+from importlib import import_module
+from typing import Dict, List, Optional
+
+from aiohttp import web
+from navconfig.logging import logging
+
+from ..conf import (
+    MCP_SERVER_DESCRIPTION,
+    MCP_SERVER_HOST,
+    MCP_SERVER_LOG_LEVEL,
+    MCP_SERVER_NAME,
+    MCP_SERVER_PORT,
+    MCP_SERVER_TRANSPORT,
+    MCP_STARTED_TOOLS,
+)
+from ..mcp.server import MCPServer, MCPServerConfig
+from ..tools.abstract import AbstractTool
+from ..tools.toolkit import AbstractToolkit
+
+
+class ParrotMCPServer:
+    """Manage lifecycle of an MCP server attached to an aiohttp app."""
+
+    def __init__(
+        self,
+        *,
+        transport: Optional[str] = None,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
+        tools: Optional[Dict[str, str]] = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        log_level: Optional[str] = None,
+    ) -> None:
+        self.transport = (transport or MCP_SERVER_TRANSPORT or "http").lower()
+        self.host = host or MCP_SERVER_HOST
+        self.port = port or MCP_SERVER_PORT
+        self.name = name or MCP_SERVER_NAME
+        self.description = description or MCP_SERVER_DESCRIPTION
+        self.log_level = log_level or MCP_SERVER_LOG_LEVEL
+        self.tools_config = tools or MCP_STARTED_TOOLS
+
+        self.logger = logging.getLogger("Parrot.MCPServer")
+        self.app: Optional[web.Application] = None
+        self.server: Optional[MCPServer] = None
+        self._server_task: Optional[asyncio.Task] = None
+
+    def setup(self, app: web.Application) -> None:
+        """Register lifecycle hooks inside the aiohttp application."""
+        self.app = app
+        app["parrot_mcp_server"] = self
+        app.on_startup.append(self.on_startup)
+        app.on_shutdown.append(self.on_shutdown)
+        self.logger.debug("ParrotMCPServer registered on aiohttp signals")
+
+    async def on_startup(self, app: web.Application) -> None:  # pylint: disable=unused-argument
+        """Start the MCP server once aiohttp finishes bootstrapping."""
+        tools = await self._load_configured_tools()
+        if not tools:
+            self.logger.info("No MCP tools configured to start")
+            return
+
+        config = MCPServerConfig(
+            name=self.name,
+            description=self.description,
+            transport=self.transport,
+            host=self.host,
+            port=self.port,
+            log_level=self.log_level,
+        )
+        self.server = MCPServer(config)
+        self.server.register_tools(tools)
+
+        start_coro = self.server.start()
+        if self.transport == "stdio":
+            self._server_task = asyncio.create_task(start_coro)
+            self.logger.info("Spawned stdio MCP server task")
+        else:
+            await start_coro
+            self.logger.info(
+                "MCP server started using %s transport on %s:%s",
+                self.transport,
+                self.host,
+                self.port,
+            )
+
+    async def on_shutdown(self, app: web.Application) -> None:  # pylint: disable=unused-argument
+        """Stop the MCP server when aiohttp starts shutting down."""
+        if not self.server:
+            return
+
+        try:
+            await self.server.stop()
+        except Exception as exc:  # pragma: no cover - logging path
+            self.logger.error("Failed stopping MCP server: %s", exc)
+
+        if self._server_task and not self._server_task.done():
+            self._server_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._server_task
+        self._server_task = None
+        self.server = None
+        self.logger.info("MCP server shutdown complete")
+
+    async def _load_configured_tools(self) -> List[AbstractTool]:
+        """Instantiate every tool declared in configuration."""
+        loaded: List[AbstractTool] = []
+
+        if not self.tools_config:
+            return loaded
+
+        for class_name, module_path in self.tools_config.items():
+            try:
+                module = import_module(module_path)
+                tool_cls = getattr(module, class_name)
+            except (ImportError, AttributeError) as exc:
+                self.logger.error(
+                    "Unable to import MCP tool %s from %s: %s",
+                    class_name,
+                    module_path,
+                    exc,
+                )
+                continue
+
+            instances = await self._initialize_tool(tool_cls, class_name)
+            if not instances:
+                continue
+
+            loaded.extend(instances)
+
+        self.logger.info("Loaded %s MCP tools", len(loaded))
+        return loaded
+
+    async def _initialize_tool(
+        self,
+        tool_cls,
+        class_name: str,
+    ) -> List[AbstractTool]:
+        """Instantiate either a toolkit or an individual AbstractTool."""
+        try:
+            instance = tool_cls()
+        except Exception as exc:
+            self.logger.error("Unable to instantiate %s: %s", class_name, exc)
+            return []
+
+        if isinstance(instance, AbstractToolkit):
+            await self._maybe_start_toolkit(instance, class_name)
+            return [tool for tool in instance.get_tools() if isinstance(tool, AbstractTool)]
+
+        if isinstance(instance, AbstractTool):
+            return [instance]
+
+        self.logger.warning(
+            "Configured MCP entry %s is neither an AbstractTool nor AbstractToolkit",
+            class_name,
+        )
+        return []
+
+    async def _maybe_start_toolkit(self, toolkit: AbstractToolkit, class_name: str) -> None:
+        """Call toolkit.start() when available."""
+        start_method = getattr(toolkit, "start", None)
+        if not start_method:
+            return
+
+        try:
+            result = start_method()
+            if inspect.isawaitable(result):
+                await result
+            self.logger.debug("Toolkit %s started", class_name)
+        except Exception as exc:  # pragma: no cover - logging path
+            self.logger.error("Toolkit %s failed during startup: %s", class_name, exc)

--- a/parrot/services/mcp_server.py
+++ b/parrot/services/mcp_server.py
@@ -164,12 +164,8 @@ class ParrotMCPServer:
 
     async def _maybe_start_toolkit(self, toolkit: AbstractToolkit, class_name: str) -> None:
         """Call toolkit.start() when available."""
-        start_method = getattr(toolkit, "start", None)
-        if not start_method:
-            return
-
         try:
-            result = start_method()
+            result = toolkit.start()
             if inspect.isawaitable(result):
                 await result
             self.logger.debug("Toolkit %s started", class_name)

--- a/parrot/tools/toolkit.py
+++ b/parrot/tools/toolkit.py
@@ -158,6 +158,13 @@ class AbstractToolkit(ABC):
         self._tool_cache: Dict[str, ToolkitTool] = {}
         self._tools_generated = False
 
+    async def start(self) -> None:
+        """
+        Optional startup logic for the toolkit.
+        Override in subclasses if needed.
+        """
+        return None
+
     def get_tools(self) -> List[AbstractTool]:
         """
         Get all tools from this toolkit.

--- a/parrot/tools/toolkit.py
+++ b/parrot/tools/toolkit.py
@@ -163,7 +163,7 @@ class AbstractToolkit(ABC):
         Optional startup logic for the toolkit.
         Override in subclasses if needed.
         """
-        return None
+        pass
 
     def get_tools(self) -> List[AbstractTool]:
         """


### PR DESCRIPTION
## Summary
- add configuration defaults and MCP tool registry entries so the application knows what to expose
- extend AbstractToolkit with an async start hook and implement a ParrotMCPServer service that loads toolkits and manages the MCP server lifecycle
- wire the new service into the main aiohttp app so it automatically starts and stops with the server

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916868167a4833086691c2dd5a0fab7)