### PR TITLE
Enable pandas tool execution for chart renderers

### DIFF
--- a/parrot/outputs/formats/d3.py
+++ b/parrot/outputs/formats/d3.py
@@ -50,7 +50,13 @@ Remember:
 class D3Renderer(BaseChart):
     """Renderer for D3.js visualizations"""
 
-    def execute_code(self, code: str) -> Tuple[Any, Optional[str]]:
+    def execute_code(
+        self,
+        code: str,
+        pandas_tool: "PythonPandasTool | None" = None,
+        execution_state: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> Tuple[Any, Optional[str]]:
         """
         For D3, we don't execute JavaScript - just validate and return it.
         """

--- a/parrot/outputs/formats/echarts.py
+++ b/parrot/outputs/formats/echarts.py
@@ -97,7 +97,13 @@ This is a TEXT GENERATION task. Unlike other tasks, for this specific objective,
 class EChartsRenderer(BaseChart):
     """Renderer for Apache ECharts"""
 
-    def execute_code(self, code: str) -> Tuple[Any, Optional[str]]:
+    def execute_code(
+        self,
+        code: str,
+        pandas_tool: "PythonPandasTool | None" = None,
+        execution_state: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> Tuple[Any, Optional[str]]:
         """Parse and validate ECharts JSON configuration."""
         try:
             # Parse JSON


### PR DESCRIPTION
## Summary
- teach the Pandas agent to respect requested output modes and to pass its PythonPandasTool to the formatter whenever non-default renderers are used
- add a shared `execute_code` helper on the base renderer and update the chart renderers to run generated code inside the agent's PythonPandasTool environment
- ensure every chart output mode (Plotly, Matplotlib, Seaborn, Altair, Bokeh, Folium, generic charts, etc.) can resolve artifacts from the shared execution context instead of reconstructing bespoke namespaces

## Testing
- pytest tests/outputs/formats/test_jinja2.py *(fails: async functions are not natively supported; missing async plugin)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917600f2b508330af641f0bb9da5172)