### PR TITLE
Support startup registration for plugin agents

### DIFF
--- a/parrot/registry/__init__.py
+++ b/parrot/registry/__init__.py
@@ -1,10 +1,11 @@
-from ..conf import AGENTS_DIR
+from ..conf import AGENTS_DIR, PLUGINS_DIR
 from .registry import AgentRegistry, BotMetadata
 
 
 # Global default registry
 agent_registry = AgentRegistry(
-    agents_dir=AGENTS_DIR
+    agents_dir=AGENTS_DIR,
+    extra_agent_dirs=[PLUGINS_DIR / "agents"]
 )
 
 register_agent = agent_registry.register_bot_decorator  # type: ignore


### PR DESCRIPTION
## Summary
- extend the agent registry so it can scan multiple discovery directories (both the default `agents/` folder and plugin folders)
- normalize module imports per directory with stable namespaces so decorators in plugin agents fire during startup
- wire the global registry to scan the plugins/agents directory so startup agents registered with `@register_agent` are instantiated and added to the bot manager

## Testing
- `pytest -q` *(fails: multiple missing optional dependencies such as folium, querysource, and parrot.tools subpackages, along with unresolved pytest markers)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917dbed54508330a59777e9422a07f0)