### PR TITLE
Move agent conversations into Crew Builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -244,6 +244,7 @@ work/
 
 # Custom Agents:
 agents/
+!/crew-builder/src/routes/agents/
 
 
 # SvelteKit build

--- a/agentui/src/routes/login/+page.svelte
+++ b/agentui/src/routes/login/+page.svelte
@@ -34,8 +34,9 @@
       // Show toast notification for better UX
       toastStore.error(result.error, 5000);
     } else {
-      // Success - redirect happens in authStore.login
+      loading = false;
       toastStore.success('Login successful! Redirecting...', 2000);
+      goto('/');
     }
   }
 

--- a/crew-builder/src/app.css
+++ b/crew-builder/src/app.css
@@ -16,3 +16,47 @@
 body {
   min-height: 100vh;
 }
+
+.chat-markdown {
+  @apply space-y-3 text-sm leading-relaxed;
+}
+
+.chat-markdown p {
+  margin: 0;
+}
+
+.chat-markdown pre {
+  background: rgba(0, 0, 0, 0.08);
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  overflow-x: auto;
+}
+
+.chat-markdown code {
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
+  font-size: 0.85rem;
+}
+
+.chat-markdown table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.chat-markdown th,
+.chat-markdown td {
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.chat-markdown ul,
+.chat-markdown ol {
+  padding-left: 1.25rem;
+}
+
+.chat-markdown a {
+  color: hsl(var(--p));
+  text-decoration: underline;
+}

--- a/crew-builder/src/components/index.js
+++ b/crew-builder/src/components/index.js
@@ -5,3 +5,5 @@
  */
 export { default as ThemeSwitcher } from './ThemeSwitcher.svelte';
 export { default as LoadingSpinner } from './LoadingSpinner.svelte';
+export { default as BotCard } from '$lib/components/BotCard.svelte';
+export { default as ChatBubble } from '$lib/components/ChatBubble.svelte';

--- a/crew-builder/src/lib/api/bots.ts
+++ b/crew-builder/src/lib/api/bots.ts
@@ -1,0 +1,60 @@
+import { apiClient } from './client';
+
+export type BotSummary = {
+  id: string;
+  chatbot_id: string;
+  name: string;
+  description?: string;
+  category?: string;
+  owner?: string;
+};
+
+type BotApiResponse = {
+  chatbot_id?: string;
+  id?: string;
+  name: string;
+  description?: string;
+  category?: string;
+  owner?: string;
+  created_by?: string;
+};
+
+const mapBot = (bot: BotApiResponse): BotSummary => ({
+  id: bot.chatbot_id || bot.id || bot.name,
+  chatbot_id: bot.chatbot_id || bot.id || bot.name,
+  name: bot.name,
+  description: bot.description || 'No description provided.',
+  category: bot.category || 'General',
+  owner: bot.owner || bot.created_by || 'Unknown'
+});
+
+async function listBots() {
+  const { data } = await apiClient.get('/api/v1/bots');
+  const bots = Array.isArray(data) ? data : data?.bots || [];
+  return {
+    bots: bots.map(mapBot)
+  };
+}
+
+async function getBot(agentId: string) {
+  try {
+    const { data } = await apiClient.get(`/api/v1/bots/${agentId}`);
+    return mapBot(data);
+  } catch (error: any) {
+    if (error?.response?.status === 404) {
+      const { bots } = await listBots();
+      const found = bots.find(
+        (bot) => bot.chatbot_id === agentId || bot.id === agentId || bot.name === agentId
+      );
+      if (found) {
+        return found;
+      }
+    }
+    throw error;
+  }
+}
+
+export const botsApi = {
+  listBots,
+  getBot
+};

--- a/crew-builder/src/lib/api/chat.ts
+++ b/crew-builder/src/lib/api/chat.ts
@@ -1,0 +1,22 @@
+import { apiClient } from './client';
+
+export type ChatRequest = {
+  query: string;
+};
+
+export type ChatResponse = {
+  turn_id: string;
+  input: string;
+  output: string;
+  response: string;
+  [key: string]: any;
+};
+
+async function sendChat(agentId: string, payload: ChatRequest): Promise<ChatResponse> {
+  const { data } = await apiClient.post(`/api/v1/agents/chat/${agentId}`, payload);
+  return data;
+}
+
+export const chatApi = {
+  sendChat
+};

--- a/crew-builder/src/lib/api/index.ts
+++ b/crew-builder/src/lib/api/index.ts
@@ -1,3 +1,5 @@
 export { apiClient } from './client';
 export * as crew from './crew/crew';
 export * as o365 from './o365/auth';
+export * as bots from './bots';
+export * as chat from './chat';

--- a/crew-builder/src/lib/components/BotCard.svelte
+++ b/crew-builder/src/lib/components/BotCard.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import type { BotSummary } from '$lib/api/bots';
+
+  export let bot: BotSummary;
+
+  function handleClick() {
+    goto(`/agents/${bot.chatbot_id}`);
+  }
+</script>
+
+<button
+  class="card group cursor-pointer border border-base-200 bg-base-100/80 text-left transition hover:-translate-y-1 hover:border-primary/50 hover:shadow-xl"
+  type="button"
+  on:click={handleClick}
+>
+  <div class="card-body gap-4">
+    <div class="flex items-center gap-3">
+      <div class="rounded-2xl bg-primary/10 p-3 text-primary">🤖</div>
+      <div>
+        <h3 class="text-xl font-semibold text-base-content">{bot.name}</h3>
+        <p class="text-xs uppercase tracking-wide text-base-content/50">{bot.category}</p>
+      </div>
+    </div>
+    <p class="text-sm text-base-content/70">
+      {bot.description}
+    </p>
+    <div class="flex items-center justify-between text-xs text-base-content/60">
+      <span>Owner: {bot.owner}</span>
+      <span class="font-semibold text-primary group-hover:text-secondary">Start chat →</span>
+    </div>
+  </div>
+</button>

--- a/crew-builder/src/lib/components/ChatBubble.svelte
+++ b/crew-builder/src/lib/components/ChatBubble.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+
+  const props = $props<{
+    role?: 'user' | 'assistant';
+    content?: string;
+    timestamp?: string;
+    turnId?: string;
+    selectable?: boolean;
+    selected?: boolean;
+  }>();
+
+  const role = $derived(props.role ?? 'user');
+  const content = $derived(props.content ?? '');
+  const timestamp = $derived(props.timestamp ?? '');
+  const turnId = $derived(props.turnId);
+  const selectable = $derived(props.selectable ?? false);
+  const selected = $derived(props.selected ?? false);
+
+  const dispatch = createEventDispatcher<{ select: { turnId: string } }>();
+
+  const sanitizedHtml = $derived(() => {
+    if (!content) return '';
+    const escaped = content
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+    return escaped.replace(/\n/g, '<br />');
+  });
+
+  function handleClick() {
+    if (selectable && turnId) {
+      dispatch('select', { turnId });
+    }
+  }
+</script>
+
+<div
+  class={`flex ${role === 'user' ? 'justify-end' : 'justify-start'}`}
+  on:click={handleClick}
+>
+  <div
+    class={`max-w-3xl rounded-3xl border ${
+      role === 'user'
+        ? 'bg-primary text-primary-content border-primary/20'
+        : 'bg-base-200/70 text-base-content border-base-300'
+    } p-4 text-sm shadow-sm transition ${selectable ? 'cursor-pointer hover:ring-2 hover:ring-primary/40' : ''} ${
+      selected ? 'ring-2 ring-primary' : ''
+    }`}
+  >
+    <div class="mb-2 flex items-center gap-2 text-xs opacity-70">
+      <span class="font-semibold capitalize">{role}</span>
+      <span>•</span>
+      <span>{new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
+    </div>
+
+    {#if role === 'assistant'}
+      <div class="chat-markdown" on:click|stopPropagation>
+        {@html sanitizedHtml}
+      </div>
+    {:else}
+      <p class="whitespace-pre-wrap">{content}</p>
+    {/if}
+  </div>
+</div>

--- a/crew-builder/src/lib/config.ts
+++ b/crew-builder/src/lib/config.ts
@@ -1,0 +1,8 @@
+const DEFAULT_ENV_LABEL = import.meta.env?.VITE_CREW_BUILDER_ENV || 'local';
+const environmentLabel = DEFAULT_ENV_LABEL.trim() || 'local';
+const storageNamespace = `crew-builder.${environmentLabel}`;
+
+export const config = {
+  environmentLabel,
+  conversationStoragePrefix: `${storageNamespace}.conversation`
+};

--- a/crew-builder/src/lib/utils/conversation.ts
+++ b/crew-builder/src/lib/utils/conversation.ts
@@ -1,0 +1,39 @@
+import type { ChatResponse } from '$lib/api/chat';
+import { config } from '$lib/config';
+
+const STORAGE_PREFIX = config.conversationStoragePrefix;
+
+type ConversationPayload = {
+  turns: Record<string, ChatResponse>;
+  order: string[];
+};
+
+function getKey(agentId: string) {
+  return `${STORAGE_PREFIX}.${agentId}`;
+}
+
+export function saveTurn(agentId: string, turn: ChatResponse) {
+  if (typeof window === 'undefined') return;
+  const raw = localStorage.getItem(getKey(agentId));
+  const payload: ConversationPayload = raw ? JSON.parse(raw) : { turns: {}, order: [] };
+  payload.turns[turn.turn_id] = turn;
+  if (!payload.order.includes(turn.turn_id)) {
+    payload.order.push(turn.turn_id);
+  }
+  localStorage.setItem(getKey(agentId), JSON.stringify(payload));
+}
+
+export function getTurn(agentId: string, turnId: string) {
+  if (typeof window === 'undefined') return null;
+  const raw = localStorage.getItem(getKey(agentId));
+  if (!raw) return null;
+  const payload: ConversationPayload = JSON.parse(raw);
+  return payload.turns[turnId] || null;
+}
+
+export function loadConversation(agentId: string) {
+  if (typeof window === 'undefined') return { turns: {}, order: [] };
+  const raw = localStorage.getItem(getKey(agentId));
+  if (!raw) return { turns: {}, order: [] };
+  return JSON.parse(raw) as ConversationPayload;
+}

--- a/crew-builder/src/routes/+page.svelte
+++ b/crew-builder/src/routes/+page.svelte
@@ -288,6 +288,16 @@
               </div>
             </div>
           </div>
+
+          <div class="card bg-base-100 shadow-xl">
+            <div class="card-body">
+              <h2 class="card-title">Talk to Agents</h2>
+              <p>Browse existing agents and start chatting without leaving Crew Builder.</p>
+              <div class="card-actions justify-end">
+                <a class="btn btn-info" href="/agents">Open Agents</a>
+              </div>
+            </div>
+          </div>
         </div>
 
         <!-- Recent Crews -->
@@ -441,6 +451,25 @@
                 />
               </svg>
               Ask a Crew
+            </a>
+          </li>
+          <li>
+            <a href="/agents">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                class="h-5 w-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M8 10h.01M12 10h.01M16 10h.01M9 16h6m2 5a2 2 0 002-2V6a2 2 0 00-2-2H7a2 2 0 00-2 2v13l3-3h10z"
+                />
+              </svg>
+              Agents
             </a>
           </li>
           <li>

--- a/crew-builder/src/routes/agents/+page.svelte
+++ b/crew-builder/src/routes/agents/+page.svelte
@@ -1,0 +1,245 @@
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { goto } from '$app/navigation';
+  import { onMount } from 'svelte';
+  import { authStore } from '$lib/stores/auth.svelte.ts';
+  import { botsApi, type BotSummary } from '$lib/api/bots';
+  import { BotCard, LoadingSpinner, ThemeSwitcher } from '../../components';
+  import { config } from '$lib/config';
+
+  let bots = $state<BotSummary[]>([]);
+  let loading = $state(true);
+  let error = $state('');
+  let searchTerm = $state('');
+  let selectedCategory = $state('All');
+  const categories = $derived(() => {
+    const uniqueCategories = Array.from(
+      new Set(bots.map((bot) => bot.category?.trim() || 'Lifestyle & Wellness'))
+    );
+    return ['All', ...uniqueCategories];
+  });
+
+  $effect(() => {
+    if (!categories.includes(selectedCategory)) {
+      selectedCategory = 'All';
+    }
+  });
+
+  async function fetchBots() {
+    if (!browser) return;
+
+    loading = true;
+    error = '';
+
+    try {
+      const response = await botsApi.listBots();
+      bots = response.bots || [];
+    } catch (err: any) {
+      console.error('Failed to load bots', err);
+      error =
+        err?.response?.data?.message || err?.message || 'Unable to load your agents right now.';
+      bots = [];
+    } finally {
+      loading = false;
+    }
+  }
+
+  let hasFetchedBots = false;
+
+  const filteredBots = $derived(() => {
+    let list = bots;
+
+    if (selectedCategory !== 'All') {
+      list = list.filter(
+        (bot) => (bot.category || 'Lifestyle & Wellness') === selectedCategory
+      );
+    }
+
+    if (searchTerm.trim()) {
+      const search = searchTerm.trim().toLowerCase();
+      list = list.filter(
+        (bot) =>
+          bot.name.toLowerCase().includes(search) ||
+          bot.description?.toLowerCase().includes(search)
+      );
+    }
+
+    return list;
+  });
+
+  function selectCategory(category: string) {
+    selectedCategory = category;
+  }
+
+  function handleLogout() {
+    authStore.logout();
+  }
+
+  const environmentLabel = config.environmentLabel;
+
+  onMount(() => {
+    if (!browser) return;
+
+    const unsubscribe = authStore.subscribe((state) => {
+      if (state.loading) return;
+
+      if (!state.isAuthenticated) {
+        hasFetchedBots = false;
+        if (window.location.pathname !== '/login') {
+          goto('/login');
+        }
+        return;
+      }
+
+      if (!hasFetchedBots) {
+        hasFetchedBots = true;
+        fetchBots();
+      }
+    });
+
+    return () => {
+      hasFetchedBots = false;
+      unsubscribe();
+    };
+  });
+</script>
+
+<svelte:head>
+  <title>Agents - Crew Builder</title>
+</svelte:head>
+
+{#if $authStore.loading}
+  <div class="flex min-h-screen items-center justify-center">
+    <LoadingSpinner text="Loading your workspace..." />
+  </div>
+{:else}
+  <div class="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(79,70,229,0.08),_transparent)]">
+    <div class="flex min-h-screen">
+      <!-- Sidebar -->
+      <aside class="hidden w-64 flex-shrink-0 flex-col border-r border-base-200 bg-base-100/80 p-6 lg:flex">
+        <div class="mb-8 flex items-center gap-3">
+          <div class="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-lg font-semibold text-primary">
+            🦜
+          </div>
+          <div>
+            <p class="text-xs uppercase tracking-[0.2em] text-base-content/60">AI Parrot</p>
+            <h1 class="text-xl font-semibold">Agents</h1>
+          </div>
+        </div>
+
+        <nav class="space-y-2">
+          <p class="text-xs font-semibold uppercase tracking-wide text-base-content/60">Workspace</p>
+          <a class="btn btn-ghost btn-sm justify-start gap-3 text-base-content" href="/builder">
+            <span class="rounded-full bg-primary/10 px-2 py-1 text-xs font-semibold text-primary">New</span>
+            Create agent
+          </a>
+          <a class="btn btn-ghost btn-sm justify-start gap-3 text-base-content" href="/agents">Browse agents</a>
+        </nav>
+
+        <div class="mt-8 space-y-3">
+          <p class="text-xs font-semibold uppercase tracking-wide text-base-content/60">Categories</p>
+          {#each categories as category}
+            <button
+              class={`btn btn-ghost btn-sm w-full justify-between ${
+                selectedCategory === category ? 'bg-primary/10 text-primary' : 'text-base-content/80'
+              }`}
+              type="button"
+              on:click={() => selectCategory(category)}
+            >
+              <span>{category}</span>
+              {#if selectedCategory === category}
+                <span class="text-xs font-semibold">●</span>
+              {/if}
+            </button>
+          {/each}
+        </div>
+
+        <div class="mt-auto rounded-2xl bg-gradient-to-br from-primary to-indigo-600 p-5 text-primary-content">
+          <p class="text-sm font-semibold">Need help?</p>
+          <p class="text-sm opacity-80">Our team is one click away.</p>
+          <button class="btn btn-sm mt-4 border-none bg-white/20 text-white">Contact us</button>
+        </div>
+      </aside>
+
+      <!-- Main content -->
+      <main class="flex-1 p-6 lg:p-10">
+        <div class="mb-8 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <p class="text-sm text-base-content/70">All assistants for specific tasks</p>
+            <h2 class="text-3xl font-bold">Agents</h2>
+            {#if environmentLabel}
+              <div class="badge badge-outline badge-sm mt-2 uppercase tracking-wide">
+                {environmentLabel}
+              </div>
+            {/if}
+          </div>
+          <div class="flex items-center gap-3">
+            <ThemeSwitcher showLabel={false} buttonClass="btn btn-sm btn-ghost" />
+            <button class="btn btn-outline btn-sm" type="button" on:click={handleLogout}>Logout</button>
+          </div>
+        </div>
+
+        <div class="mb-8 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div class="flex items-center gap-3 rounded-2xl border border-base-200 bg-base-100 px-4 py-3 shadow-sm">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-5 w-5 text-base-content/60"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+            <input
+              class="flex-1 bg-transparent text-sm outline-none"
+              placeholder="Search agents"
+              bind:value={searchTerm}
+            />
+          </div>
+          <div class="flex gap-3">
+            <button class="btn btn-primary" type="button" on:click={() => goto('/builder')}>
+              Create AI agent
+            </button>
+            <div class="join">
+              {#each categories.slice(0, 3) as quickCategory}
+                <button
+                  class={`btn btn-ghost btn-sm ${
+                    selectedCategory === quickCategory ? 'btn-active text-primary' : 'text-base-content/70'
+                  }`}
+                  type="button"
+                  on:click={() => selectCategory(quickCategory)}
+                >
+                  {quickCategory}
+                </button>
+              {/each}
+            </div>
+          </div>
+        </div>
+
+        {#if loading}
+          <div class="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+            {#each Array(6) as _, index}
+              <div class="h-48 animate-pulse rounded-3xl bg-base-200/80" aria-hidden="true" />
+            {/each}
+          </div>
+        {:else if error}
+          <div class="rounded-3xl border border-error/30 bg-error/10 p-8 text-center text-error">
+            <p class="text-lg font-semibold">{error}</p>
+            <button class="btn btn-error mt-4" on:click={fetchBots}>Retry</button>
+          </div>
+        {:else if filteredBots.length === 0}
+          <div class="rounded-3xl border border-base-200 bg-base-100 p-10 text-center text-base-content/70">
+            <p class="text-lg font-semibold">No agents match your filters.</p>
+            <p class="mt-2">Try adjusting your search or categories.</p>
+          </div>
+        {:else}
+          <div class="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+            {#each filteredBots as bot (bot.chatbot_id)}
+              <BotCard {bot} />
+            {/each}
+          </div>
+        {/if}
+      </main>
+    </div>
+  </div>
+{/if}

--- a/crew-builder/src/routes/agents/[agentId]/+page.svelte
+++ b/crew-builder/src/routes/agents/[agentId]/+page.svelte
@@ -1,0 +1,288 @@
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { goto } from '$app/navigation';
+  import { onMount } from 'svelte';
+  import { authStore } from '$lib/stores/auth.svelte.ts';
+  import { botsApi, type BotSummary } from '$lib/api/bots';
+  import { chatApi, type ChatResponse } from '$lib/api/chat';
+  import { getTurn, saveTurn, loadConversation } from '$lib/utils/conversation';
+  import { ChatBubble, LoadingSpinner } from '../../../components';
+
+  export let data: { agentId: string };
+
+  let agent: BotSummary | null = $state(null);
+  type ChatMessage = {
+    id: string;
+    role: 'user' | 'assistant';
+    content: string;
+    timestamp: string;
+    turnId?: string;
+  };
+
+  let messages = $state<ChatMessage[]>([]);
+  let input = $state('');
+  let sending = $state(false);
+  let loading = $state(true);
+  let error = $state('');
+  let leftMenu = ['Chat', 'Content', 'Prompts', 'Playbooks'];
+  let selectedMenu = $state('Chat');
+  let selectedTurnId = $state<string | null>(null);
+  let selectedTurn = $state<ChatResponse | null>(null);
+  let storedTurnOrder = $state<string[]>([]);
+
+  const agentId = data.agentId;
+
+  async function loadAgent() {
+    if (!browser) return;
+    loading = true;
+    error = '';
+
+    try {
+      agent = await botsApi.getBot(agentId);
+    } catch (err: any) {
+      console.error('Failed to load agent', err);
+      error = err?.response?.data?.message || 'Unable to load the agent right now.';
+      agent = null;
+    } finally {
+      loading = false;
+    }
+  }
+
+  function loadStoredTurns() {
+    if (!browser) return;
+    const conversation = loadConversation(agentId);
+    storedTurnOrder = conversation.order;
+  }
+
+  async function sendMessage() {
+    if (!input.trim() || sending) return;
+
+    const text = input.trim();
+    input = '';
+
+    const userMessage = {
+      id: crypto.randomUUID(),
+      role: 'user' as const,
+      content: text,
+      timestamp: new Date().toISOString()
+    };
+    messages = [...messages, userMessage];
+    sending = true;
+    error = '';
+
+    try {
+      const response = await chatApi.sendChat(agentId, { query: text });
+      const reply = response?.response || response?.message || 'The agent did not return a response.';
+
+      const assistantMessage = {
+        id: crypto.randomUUID(),
+        role: 'assistant' as const,
+        content: reply,
+        timestamp: new Date().toISOString(),
+        turnId: response?.turn_id
+      };
+      messages = [...messages, assistantMessage];
+      if (response?.turn_id) {
+        saveTurn(agentId, response);
+        loadStoredTurns();
+        selectedTurnId = response.turn_id;
+        selectedTurn = response;
+      }
+    } catch (err: any) {
+      console.error('Chat failed', err);
+      error = err?.response?.data?.message || err?.message || 'Chat failed. Please try again.';
+      messages = messages.filter((message) => message.id !== userMessage.id);
+    } finally {
+      sending = false;
+    }
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      sendMessage();
+    }
+  }
+
+  onMount(() => {
+    if (!browser) return;
+    if (!$authStore.isAuthenticated && !$authStore.loading) {
+      goto('/login');
+      return;
+    }
+    loadAgent();
+    loadStoredTurns();
+  });
+
+  function selectTurn(turnId: string | null | undefined) {
+    if (!turnId) return;
+    selectedTurnId = turnId;
+    selectedTurn = getTurn(agentId, turnId);
+  }
+
+  function handleBubbleSelect(event: CustomEvent<{ turnId: string }>) {
+    selectTurn(event.detail.turnId);
+  }
+</script>
+
+<svelte:head>
+  <title>Chat - {agent?.name || 'Agent'}</title>
+</svelte:head>
+
+{#if loading}
+  <div class="flex min-h-screen items-center justify-center">
+    <LoadingSpinner text="Loading agent..." />
+  </div>
+{:else if !agent}
+  <div class="flex min-h-screen flex-col items-center justify-center gap-4">
+    <p class="text-lg font-semibold text-base-content/80">{error || 'Agent not found.'}</p>
+    <button class="btn btn-primary" on:click={() => goto('/agents')}>Back to agents</button>
+  </div>
+{:else}
+  <div class="min-h-screen bg-base-200/40">
+    <div class="mx-auto flex min-h-screen max-w-[1400px] gap-6 p-4 lg:p-8">
+      <!-- Left rail -->
+      <aside class="hidden w-56 flex-col rounded-3xl bg-base-100 p-6 shadow-xl lg:flex">
+        <div class="mb-6">
+          <p class="text-sm font-semibold text-base-content/60">{agent.category || 'Agent'}</p>
+          <h2 class="text-2xl font-bold">{agent.name}</h2>
+          <p class="text-sm text-base-content/70">{agent.description}</p>
+        </div>
+        <nav class="space-y-2">
+          {#each leftMenu as item}
+            <button
+              class={`btn btn-ghost w-full justify-start ${
+                selectedMenu === item ? 'bg-primary/10 text-primary' : 'text-base-content/80'
+              }`}
+              type="button"
+              on:click={() => (selectedMenu = item)}
+            >
+              {item}
+            </button>
+          {/each}
+        </nav>
+        <div class="mt-auto rounded-2xl bg-gradient-to-br from-primary to-indigo-600 p-4 text-sm text-primary-content">
+          <p class="font-semibold">Coming soon</p>
+          <p class="opacity-80">Quick access to prompts, automations, and knowledge.</p>
+        </div>
+      </aside>
+
+      <!-- Chat area -->
+      <section class="flex flex-1 flex-col gap-4">
+        <div class="rounded-3xl border border-base-200 bg-base-100 p-4 shadow-sm">
+          <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <p class="text-sm text-base-content/60">Chat with</p>
+              <h1 class="text-2xl font-bold">{agent.name}</h1>
+            </div>
+            <div class="flex items-center gap-2 text-sm text-success">
+              <span class="h-2 w-2 rounded-full bg-success"></span>
+              Available
+            </div>
+          </div>
+        </div>
+
+        <div class="flex flex-1 flex-col gap-4 rounded-3xl border border-base-200 bg-base-100 p-6 shadow-lg">
+          <div class="flex-1 space-y-4 overflow-y-auto pr-2">
+            {#if messages.length === 0}
+              <div class="rounded-2xl bg-base-200/60 p-6 text-center text-base-content/70">
+                Say hello to start the conversation.
+              </div>
+            {:else}
+              {#each messages as message (message.id)}
+                <ChatBubble
+                  role={message.role}
+                  content={message.content}
+                  timestamp={message.timestamp}
+                  turnId={message.turnId}
+                  selectable={message.role === 'assistant'}
+                  selected={message.turnId ? message.turnId === selectedTurnId : false}
+                  on:select={handleBubbleSelect}
+                />
+              {/each}
+            {/if}
+          </div>
+
+          {#if error}
+            <div class="rounded-2xl border border-error/40 bg-error/10 p-3 text-sm text-error">
+              {error}
+            </div>
+          {/if}
+
+          <div class="rounded-2xl border border-base-200 bg-base-100/80 p-4">
+            <div class="rounded-2xl border border-base-300 bg-base-200/50">
+              <textarea
+                class="textarea textarea-ghost h-32 w-full resize-none border-none bg-transparent text-base focus:outline-none"
+                placeholder={`Message ${agent.name}`}
+                bind:value={input}
+                on:keydown={handleKeydown}
+              ></textarea>
+            </div>
+            <div class="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div class="flex gap-2 text-sm text-base-content/70">
+                <button class="btn btn-ghost btn-sm" type="button" disabled>
+                  <span>✨</span>
+                  Templates
+                </button>
+                <button class="btn btn-ghost btn-sm" type="button" disabled>
+                  <span>📎</span>
+                  Attach
+                </button>
+              </div>
+              <button class={`btn btn-primary ${sending ? 'loading' : ''}`} on:click={sendMessage} disabled={sending}>
+                {sending ? 'Sending' : 'Send message'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Insights rail -->
+      <aside class="hidden w-72 flex-col gap-4 lg:flex">
+        <div class="rounded-3xl border border-base-200 bg-base-100 p-5">
+          <h3 class="text-lg font-semibold">Recent Turns</h3>
+          <div class="mt-4 space-y-2">
+            {#if storedTurnOrder.length === 0}
+              <p class="text-sm text-base-content/60">Send a message to start tracking turns.</p>
+            {:else}
+              {#each storedTurnOrder.slice().reverse() as turnId}
+                <button
+                  class={`btn btn-ghost btn-sm w-full justify-between ${
+                    selectedTurnId === turnId ? 'bg-primary/10 text-primary' : 'text-base-content/80'
+                  }`}
+                  type="button"
+                  on:click={() => selectTurn(turnId)}
+                >
+                  <span class="truncate">Turn {turnId.slice(0, 6)}</span>
+                  <span>→</span>
+                </button>
+              {/each}
+            {/if}
+          </div>
+        </div>
+
+        <div class="rounded-3xl border border-base-200 bg-base-100 p-5">
+          <h3 class="text-lg font-semibold">Turn details</h3>
+          {#if !selectedTurn}
+            <p class="mt-2 text-sm text-base-content/60">Select a turn to inspect inputs and outputs.</p>
+          {:else}
+            <div class="mt-4 space-y-3 text-sm">
+              <div>
+                <p class="font-semibold text-base-content/70">Prompt</p>
+                <p class="text-base-content">{selectedTurn.input}</p>
+              </div>
+              <div>
+                <p class="font-semibold text-base-content/70">Response</p>
+                <p class="text-base-content">{selectedTurn.output || selectedTurn.response}</p>
+              </div>
+              <div>
+                <p class="font-semibold text-base-content/70">Turn ID</p>
+                <p class="font-mono text-xs text-base-content/80">{selectedTurn.turn_id}</p>
+              </div>
+            </div>
+          {/if}
+        </div>
+      </aside>
+    </div>
+  </div>
+{/if}

--- a/crew-builder/src/routes/agents/[agentId]/+page.ts
+++ b/crew-builder/src/routes/agents/[agentId]/+page.ts
@@ -1,0 +1,7 @@
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ params }) => {
+  return {
+    agentId: params.agentId
+  };
+};


### PR DESCRIPTION
## Summary
- add bot and chat API clients plus supporting config, storage, and UI components so Crew Builder can manage agent conversations
- create Agents listing and chat routes that mirror the AgentUI experience, then expose them via the dashboard CTA and sidebar navigation
- update global styles and gitignore so the shared markdown/chat UI renders correctly inside Crew Builder

## Testing
- not run (npm install fails in this environment with 403 errors while downloading dependencies)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691928aeada88330a2e19b4775d8a1b3)