### PR TITLE
Use AgentMemory for PandasAgent followups

### DIFF
--- a/parrot/bots/data.py
+++ b/parrot/bots/data.py
@@ -24,6 +24,7 @@ from ..models.responses import AIMessage, AgentResponse
 from ..models.outputs import OutputMode, StructuredOutputConfig, OutputFormat
 from ..conf import REDIS_HISTORY_URL, STATIC_DIR
 from ..bots.prompts import OUTPUT_SYSTEM_PROMPT
+from ..memory import AgentMemory
 
 
 Scalar = Union[str, int, float, bool, None]
@@ -340,6 +341,7 @@ class PandasAgent(BasicAgent):
             **kwargs
         )
         self.description = "A specialized agent for data analysis using pandas DataFrames"
+        self.agent_memory = AgentMemory()
 
     def agent_tools(self) -> List[AbstractTool]:
         """
@@ -844,7 +846,7 @@ class PandasAgent(BasicAgent):
                 )
 
                 response.session_id = session_id
-                response.turn_id = turn_id
+                response.turn_id = getattr(response, 'turn_id', None) or turn_id
                 data_response: Optional[PandasAgentResponse] = response.output \
                     if isinstance(response.output, PandasAgentResponse) else None
 
@@ -877,6 +879,12 @@ class PandasAgent(BasicAgent):
 
                 # Return the final AIMessage response
                 response.data = response.data.to_dict(orient='records') if response.data is not None else None
+                answer_text = getattr(response, 'response', None) or response.content
+                await self.agent_memory.store_interaction(
+                    response.turn_id,
+                    question,
+                    answer_text,
+                )
                 return response
 
         except Exception as e:
@@ -885,6 +893,55 @@ class PandasAgent(BasicAgent):
             )
             # Return error response
             raise
+
+    async def followup(
+        self,
+        question: str,
+        turn_id: str,
+        data: Any,
+        session_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        use_conversation_history: bool = True,
+        memory: Optional[Any] = None,
+        ctx: Optional[Any] = None,
+        structured_output: Optional[Any] = None,
+        output_mode: Any = None,
+        format_kwargs: dict = None,
+        return_structured: bool = True,
+        **kwargs
+    ) -> AIMessage:
+        """Generate a follow-up question using a previous turn as context."""
+        if not turn_id:
+            raise ValueError("turn_id is required for follow-up questions")
+
+        session_id = session_id or str(uuid.uuid4())
+        user_id = user_id or "anonymous"
+
+        previous_interaction = await self.agent_memory.get(turn_id)
+        if not previous_interaction:
+            raise ValueError(f"No conversation turn found for turn_id {turn_id}")
+
+        context_str = data if isinstance(data, str) else str(data)
+        followup_prompt = (
+            "Based on the previous question "
+            f"{previous_interaction['question']} and answer {previous_interaction['answer']} "
+            f"and using this data as context {context_str}, you need to answer this question:\n"
+            f"{question}"
+        )
+
+        return await self.ask(
+            question=followup_prompt,
+            session_id=session_id,
+            user_id=user_id,
+            use_conversation_history=use_conversation_history,
+            memory=memory,
+            ctx=ctx,
+            structured_output=structured_output,
+            output_mode=output_mode,
+            format_kwargs=format_kwargs,
+            return_structured=return_structured,
+            **kwargs,
+        )
 
     def add_dataframe(
         self,

--- a/parrot/memory/__init__.py
+++ b/parrot/memory/__init__.py
@@ -2,6 +2,7 @@ from .abstract import ConversationMemory, ConversationHistory, ConversationTurn
 from .mem import InMemoryConversation
 from .redis import RedisConversation
 from .file import FileConversationMemory
+from .agent import AgentMemory
 
 
 __all__ = [
@@ -10,5 +11,6 @@ __all__ = [
     "ConversationTurn",
     "InMemoryConversation",
     "FileConversationMemory",
-    "RedisConversation"
+    "RedisConversation",
+    "AgentMemory",
 ]

--- a/parrot/memory/agent.py
+++ b/parrot/memory/agent.py
@@ -1,0 +1,31 @@
+"""Simple in-memory storage for agent interactions keyed by turn_id."""
+
+import asyncio
+from typing import Any, Dict, Optional
+
+
+class AgentMemory:
+    """Store and retrieve agent interactions by turn identifier."""
+
+    def __init__(self) -> None:
+        self._interactions: Dict[str, Dict[str, Any]] = {}
+        self._lock = asyncio.Lock()
+
+    async def store_interaction(self, turn_id: str, question: str, answer: Any) -> None:
+        """Persist a question/answer pair under the provided turn identifier."""
+        if not turn_id:
+            raise ValueError("turn_id is required to store an interaction")
+
+        async with self._lock:
+            self._interactions[turn_id] = {
+                "question": question,
+                "answer": answer,
+            }
+
+    async def get(self, turn_id: str) -> Optional[Dict[str, Any]]:
+        """Retrieve a stored interaction by turn identifier."""
+        if not turn_id:
+            return None
+
+        async with self._lock:
+            return self._interactions.get(turn_id)


### PR DESCRIPTION
## Summary
- add an AgentMemory helper to store per-turn PandasAgent interactions
- persist ask() question and answer pairs for follow-up lookup instead of scanning conversation history
- expose AgentMemory through the memory package for reuse

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692044a1f6388330a62338bfd86e8f2b)