### PR TITLE
Handle option-wrapped ECharts configs

### DIFF
--- a/parrot/outputs/formats/echarts.py
+++ b/parrot/outputs/formats/echarts.py
@@ -113,6 +113,18 @@ class EChartsRenderer(EChartsMapsMixin, BaseChart):
             # Parse JSON
             config = json.loads(cleaned_code)
 
+            # Unwrap common nested structure `{ "option": { ... } }`
+            if (
+                isinstance(config, dict)
+                and 'option' in config
+                and isinstance(config['option'], dict)
+            ):
+                # If the response wraps the actual chart config under an
+                # "option" key, use the inner configuration for validation and
+                # rendering. This aligns with typical ECharts code snippets and
+                # prevents false validation errors.
+                config = config['option']
+
             # Basic validation - check for required structure
             if not isinstance(config, dict):
                 return None, "ECharts config must be a JSON object"

--- a/tests/outputs/formats/test_echarts.py
+++ b/tests/outputs/formats/test_echarts.py
@@ -1,0 +1,26 @@
+import json
+
+from parrot.outputs.formats.echarts import EChartsRenderer
+
+
+def test_echarts_renderer_unwraps_option_key():
+    """Ensure wrapped configurations under `option` are accepted."""
+
+    renderer = EChartsRenderer()
+    wrapped_config = {
+        "option": {
+            "title": {"text": "Wrapped Chart"},
+            "series": [
+                {
+                    "type": "bar",
+                    "data": [1, 2, 3],
+                }
+            ],
+        }
+    }
+
+    config, error = renderer.execute_code(json.dumps(wrapped_config))
+
+    assert error is None
+    assert "series" in config
+    assert config["title"]["text"] == "Wrapped Chart"


### PR DESCRIPTION
## Summary
- unwrap ECharts configurations wrapped under an `option` key before validating
- add a unit test confirming option-wrapped configs are accepted

## Testing
- pytest tests/outputs/formats/test_echarts.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924ca3ba4a08330860bfe27866ada2a)