### PR TITLE
Expand Seaborn chart images to fill container

### DIFF
--- a/parrot/outputs/formats/seaborn.py
+++ b/parrot/outputs/formats/seaborn.py
@@ -190,10 +190,10 @@ class SeabornRenderer(BaseChart):
             buffer.close()
 
             chart_html = f'''
-            <div class="seaborn-chart-wrapper" style="margin-bottom: 20px;">
+            <div class="seaborn-chart-wrapper" style="margin-bottom: 20px; width: 100%;">
                 <img id="{img_id}"
                      src="data:image/{img_format};base64,{img_base64}"
-                     style="max-width: 100%; height: auto; display: block; margin: 0 auto;"
+                     style="width: 100%; height: auto; display: block; margin: 0 auto;"
                      alt="Seaborn Chart {i+1}" />
             </div>
             '''


### PR DESCRIPTION
## Summary
- set Seaborn renderer wrappers to span the full container width
- scale embedded chart images to 100% width so they fill their parent container

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924cc1322588330a796cb2bc9878613)