### PR TITLE
Make Altair charts responsive to container

### DIFF
--- a/parrot/outputs/formats/altair.py
+++ b/parrot/outputs/formats/altair.py
@@ -165,6 +165,20 @@ class AltairRenderer(BaseChart):
 
         try:
             spec = chart_obj.to_dict()
+
+            # Ensure charts expand to the available container space
+            if not spec.get('autosize'):
+                spec['autosize'] = {
+                    'type': 'fit',
+                    'contains': 'padding',
+                    'resize': True
+                }
+
+            config = spec.setdefault('config', {})
+            view_config = config.setdefault('view', {})
+            view_config.setdefault('continuousWidth', 'container')
+            view_config.setdefault('continuousHeight', 400)
+
             spec_json = json.dumps(spec, indent=2)
         except Exception as e:
             return f'''


### PR DESCRIPTION
## Summary
- ensure Altair-rendered charts include autosize defaults so they resize to their container
- add container-aware width/height defaults to the generated Vega-Lite spec for consistent sizing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924dd915acc833088a0911a6fcb22f9)