### PR TITLE
Rename ClaudeClient to AnthropicClient and migrate SDKs

### DIFF
--- a/parrot/clients/__init__.py
+++ b/parrot/clients/__init__.py
@@ -8,7 +8,7 @@ from .base import (
     LLM_PRESETS,
     StreamingRetryConfig
 )
-from .claude import ClaudeClient, ClaudeModel
+from .claude import AnthropicClient, ClaudeClient, ClaudeModel
 from .vertex import VertexAIClient, VertexAIModel
 from .google import GoogleGenAIClient, GoogleModel
 from .gpt import OpenAIClient, OpenAIModel
@@ -16,7 +16,8 @@ from .groq import GroqClient, GroqModel
 
 
 SUPPORTED_CLIENTS = {
-    "claude": ClaudeClient,
+    "claude": AnthropicClient,
+    "anthropic": AnthropicClient,
     "vertexai": VertexAIClient,
     "google": GoogleGenAIClient,
     "openai": OpenAIClient,
@@ -28,7 +29,8 @@ __all__ = (
     "AbstractClient",
     "StreamingRetryConfig",
     "SUPPORTED_CLIENTS",
-    "ClaudeClient",
+    "AnthropicClient",
+    "ClaudeClient",  # Backward compatibility alias
     "ClaudeModel",
     "VertexAIClient",
     "VertexAIModel",

--- a/parrot/clients/claude.py
+++ b/parrot/clients/claude.py
@@ -14,6 +14,8 @@ from pydantic import BaseModel, Field
 from navconfig import config
 from datamodel.exceptions import ParserError  # pylint: disable=E0611 # noqa
 from datamodel.parsers.json import json_decoder  # pylint: disable=E0611 # noqa
+from anthropic import AsyncAnthropic
+from anthropic.types import Message, MessageStreamEvent
 from .base import AbstractClient, BatchRequest, StreamingRetryConfig
 from ..models import (
     AIMessage,
@@ -38,8 +40,8 @@ class ClaudeModel(Enum):
     HAIKU_3_5 = "claude-3-5-haiku-20241022"
 
 
-class ClaudeClient(AbstractClient):
-    """Client for interacting with the Claude API."""
+class AnthropicClient(AbstractClient):
+    """Client for interacting with the Anthropic API using the official SDK."""
     version: str = "2023-06-01"
     client_type: str = "anthropic"
     client_name: str = "claude"
@@ -53,12 +55,30 @@ class ClaudeClient(AbstractClient):
     ):
         self.api_key = api_key or config.get('ANTHROPIC_API_KEY')
         self.base_url = base_url
+        self.client: Optional[AsyncAnthropic] = None
         self.base_headers = {
             "Content-Type": "application/json",
             "x-api-key": self.api_key,
             "anthropic-version": self.version
         }
         super().__init__(**kwargs)
+
+    async def __aenter__(self):
+        """Initialize the Anthropic client."""
+        self.client = AsyncAnthropic(
+            api_key=self.api_key,
+            base_url=self.base_url
+        )
+        # Also initialize session for backward compatibility
+        await super().__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Close the Anthropic client."""
+        if self.client:
+            await self.client.close()
+        # Close session for backward compatibility
+        await super().__aexit__(exc_type, exc_val, exc_tb)
 
     async def ask(
         self,
@@ -79,7 +99,7 @@ class ClaudeClient(AbstractClient):
         Args:
             use_tools: If None, uses instance default. If True/False, overrides for this call.
         """
-        if not self.session:
+        if not self.client:
             raise RuntimeError("Client not initialized. Use async context manager.")
 
         # If use_tools is None, use the instance default
@@ -127,58 +147,60 @@ class ClaudeClient(AbstractClient):
 
         # Handle tool calls in a loop
         while True:
-            async with self.session.post(f"{self.base_url}/v1/messages", json=payload) as response:
-                response.raise_for_status()
-                result = await response.json()
-                # Check if Claude wants to use a tool
-                if result.get("stop_reason") == "tool_use":
-                    tool_results = []
+            # Use the Anthropic SDK to create messages
+            response = await self.client.messages.create(**payload)
+            # Convert Message object to dict for compatibility
+            result = response.model_dump()
 
-                    for content_block in result["content"]:
-                        if content_block["type"] == "tool_use":
-                            tool_name = content_block["name"]
-                            tool_input = content_block["input"]
-                            tool_id = content_block["id"]
+            # Check if Claude wants to use a tool
+            if result.get("stop_reason") == "tool_use":
+                tool_results = []
 
-                            # Create ToolCall object and execute
-                            tc = ToolCall(
-                                id=tool_id,
-                                name=tool_name,
-                                arguments=tool_input
-                            )
+                for content_block in result["content"]:
+                    if content_block["type"] == "tool_use":
+                        tool_name = content_block["name"]
+                        tool_input = content_block["input"]
+                        tool_id = content_block["id"]
 
-                            try:
-                                start_time = time.time()
-                                tool_result = await self._execute_tool(tool_name, tool_input)
-                                execution_time = time.time() - start_time
+                        # Create ToolCall object and execute
+                        tc = ToolCall(
+                            id=tool_id,
+                            name=tool_name,
+                            arguments=tool_input
+                        )
 
-                                tc.result = tool_result
-                                tc.execution_time = execution_time
+                        try:
+                            start_time = time.time()
+                            tool_result = await self._execute_tool(tool_name, tool_input)
+                            execution_time = time.time() - start_time
 
-                                tool_results.append({
-                                    "type": "tool_result",
-                                    "tool_use_id": tool_id,
-                                    "content": str(tool_result)
-                                })
-                            except Exception as e:
-                                tc.error = str(e)
-                                tool_results.append({
-                                    "type": "tool_result",
-                                    "tool_use_id": tool_id,
-                                    "is_error": True,
-                                    "content": str(e)
-                                })
+                            tc.result = tool_result
+                            tc.execution_time = execution_time
 
-                            all_tool_calls.append(tc)
+                            tool_results.append({
+                                "type": "tool_result",
+                                "tool_use_id": tool_id,
+                                "content": str(tool_result)
+                            })
+                        except Exception as e:
+                            tc.error = str(e)
+                            tool_results.append({
+                                "type": "tool_result",
+                                "tool_use_id": tool_id,
+                                "is_error": True,
+                                "content": str(e)
+                            })
 
-                    # Add tool results and continue conversation
-                    messages.append({"role": "assistant", "content": result["content"]})
-                    messages.append({"role": "user", "content": tool_results})
-                    payload["messages"] = messages
-                else:
-                    # No more tool calls, add assistant response and break
-                    messages.append({"role": "assistant", "content": result["content"]})
-                    break
+                        all_tool_calls.append(tc)
+
+                # Add tool results and continue conversation
+                messages.append({"role": "assistant", "content": result["content"]})
+                messages.append({"role": "user", "content": tool_results})
+                payload["messages"] = messages
+            else:
+                # No more tool calls, add assistant response and break
+                messages.append({"role": "assistant", "content": result["content"]})
+                break
 
         # Handle structured output
         final_output = None
@@ -251,7 +273,7 @@ class ClaudeClient(AbstractClient):
         tools: Optional[List[Dict[str, Any]]] = None
     ) -> AsyncIterator[str]:
         """Stream Claude's response using AsyncIterator with optional conversation memory."""
-        if not self.session:
+        if not self.client:
             raise RuntimeError("Client not initialized. Use async context manager.")
 
         # Generate unique turn ID for tracking
@@ -289,11 +311,25 @@ class ClaudeClient(AbstractClient):
                 assistant_content = ""
                 max_tokens_reached = False
                 stop_reason = None
-                async with self.session.post(f"{self.base_url}/v1/messages", json=payload) as response:
-                    # Handle HTTP errors that might warrant retry
-                    if response.status == 429 and retry_config.retry_on_rate_limit:
-                        # Rate limit - retry with backoff
-                        if retry_count < retry_config.max_retries:
+
+                try:
+                    # Use the Anthropic SDK's streaming API
+                    async with self.client.messages.stream(**payload) as stream:
+                        async for text in stream.text_stream:
+                            assistant_content += text
+                            yield text
+
+                        # Get the final message to check stop reason
+                        final_message = await stream.get_final_message()
+                        stop_reason = final_message.stop_reason
+                        if stop_reason == 'max_tokens':
+                            max_tokens_reached = True
+
+                except Exception as e:
+                    # Handle rate limits and server errors
+                    error_str = str(e).lower()
+                    if '429' in error_str or 'rate limit' in error_str:
+                        if retry_config.retry_on_rate_limit and retry_count < retry_config.max_retries:
                             yield f"\n\n⚠️ **Rate limited (attempt {retry_count + 1}). Retrying...**\n\n"
                             retry_count += 1
                             await self._wait_with_backoff(retry_count, retry_config)
@@ -301,41 +337,17 @@ class ClaudeClient(AbstractClient):
                         else:
                             yield f"\n\n❌ **Rate limit exceeded. Max retries reached.**\n"
                             break
-                    elif response.status >= 500 and retry_config.retry_on_server_error:
-                        # Server error - retry
-                        if retry_count < retry_config.max_retries:
-                            yield f"\n\n⚠️ **Server error {response.status} (attempt {retry_count + 1}). Retrying...**\n\n"
+                    elif '5' in error_str[:3]:  # 5xx errors
+                        if retry_config.retry_on_server_error and retry_count < retry_config.max_retries:
+                            yield f"\n\n⚠️ **Server error (attempt {retry_count + 1}). Retrying...**\n\n"
                             retry_count += 1
                             await self._wait_with_backoff(retry_count, retry_config)
                             continue
                         else:
-                            yield f"\n\n❌ **Server error {response.status}. Max retries reached.**\n"
+                            yield f"\n\n❌ **Server error. Max retries reached.**\n"
                             break
-
-                    # Raise for other HTTP errors
-                    response.raise_for_status()
-
-                    async for line in response.content:
-                        line = line.decode('utf-8').strip()
-                        if line.startswith('data: '):
-                            data = line[6:]
-                            if data == '[DONE]':
-                                break
-                            try:
-                                event = json_decoder(data)
-                                # Check for max tokens in Claude's streaming response
-                                if event.get('type') == 'message_stop':
-                                    stop_reason = event.get('stop_reason')
-                                    if stop_reason == 'max_tokens':
-                                        max_tokens_reached = True
-                                elif event.get('type') == 'content_block_delta':
-                                    delta = event.get('delta', {})
-                                    if delta.get('type') == 'text_delta':
-                                        text_chunk = delta.get('text', '')
-                                        assistant_content += text_chunk
-                                        yield text_chunk
-                            except (ParserError, json.JSONDecodeError):
-                                continue
+                    else:
+                        raise
                 # Check if we reached max tokens
                 if max_tokens_reached:
                     if on_max_tokens == "notify":
@@ -393,7 +405,7 @@ class ClaudeClient(AbstractClient):
 
     async def batch_ask(self, requests: List[BatchRequest]) -> List[AIMessage]:
         """Process multiple requests in batch."""
-        if not self.session:
+        if not self.client:
             raise RuntimeError("Client not initialized. Use async context manager.")
 
         # Prepare batch payload in correct format
@@ -407,64 +419,58 @@ class ClaudeClient(AbstractClient):
             ]
         }
 
-        # Add beta header for Message Batches API
-        headers = {"anthropic-beta": "message-batches-2024-09-24"}
-
-        # Create batch
-        async with self.session.post(
-            f"{self.base_url}/v1/messages/batches",
-            json=batch_payload,
-            headers=headers
-        ) as response:
-            response.raise_for_status()
-            batch_info = await response.json()
-            batch_id = batch_info["id"]
+        # Create batch using SDK
+        batch = await self.client.messages.batches.create(**batch_payload)
+        batch_id = batch.id
 
         # Poll for completion
         while True:
-            async with self.session.get(
-                f"{self.base_url}/v1/messages/batches/{batch_id}",
-                headers=headers
-            ) as response:
-                response.raise_for_status()
-                batch_status = await response.json()
+            batch_status = await self.client.messages.batches.retrieve(batch_id)
 
-                if batch_status["processing_status"] == "ended":
-                    break
-                elif batch_status["processing_status"] in ["failed", "canceled"]:
-                    raise RuntimeError(f"Batch processing failed: {batch_status}")
+            if batch_status.processing_status == "ended":
+                break
+            elif batch_status.processing_status in ["failed", "canceled"]:
+                raise RuntimeError(f"Batch processing failed: {batch_status}")
 
-                await asyncio.sleep(5)  # Wait 5 seconds before polling again
+            await asyncio.sleep(5)  # Wait 5 seconds before polling again
 
-        # Retrieve results - the results_url is provided in the batch status
-        results_url = batch_status.get("results_url")
+        # Retrieve results
+        results_url = batch_status.results_url
         if results_url:
-            async with self.session.get(results_url) as response:
-                response.raise_for_status()
-                results_text = await response.text()
+            # Note: SDK may not have direct results download, so we use session for this
+            if not self.session:
+                import aiohttp
+                async with aiohttp.ClientSession() as temp_session:
+                    async with temp_session.get(results_url) as response:
+                        response.raise_for_status()
+                        results_text = await response.text()
+            else:
+                async with self.session.get(results_url) as response:
+                    response.raise_for_status()
+                    results_text = await response.text()
 
-                # Parse JSONL format and convert to AIMessage
-                results = []
-                for line in results_text.strip().split('\n'):
-                    if line:
-                        batch_result = json_decoder(line)
-                        # Extract the response from batch format
-                        if 'response' in batch_result and 'body' in batch_result['response']:
-                            claude_response = batch_result['response']['body']
+            # Parse JSONL format and convert to AIMessage
+            results = []
+            for line in results_text.strip().split('\n'):
+                if line:
+                    batch_result = json_decoder(line)
+                    # Extract the response from batch format
+                    if 'response' in batch_result and 'body' in batch_result['response']:
+                        claude_response = batch_result['response']['body']
 
-                            # Create AIMessage from batch result
-                            ai_message = AIMessageFactory.from_claude(
-                                response=claude_response,
-                                input_text="Batch request",
-                                model=claude_response.get('model', 'unknown'),
-                                turn_id=str(uuid.uuid4())
-                            )
-                            results.append(ai_message)
-                        else:
-                            # Fallback for unexpected format
-                            results.append(batch_result)
+                        # Create AIMessage from batch result
+                        ai_message = AIMessageFactory.from_claude(
+                            response=claude_response,
+                            input_text="Batch request",
+                            model=claude_response.get('model', 'unknown'),
+                            turn_id=str(uuid.uuid4())
+                        )
+                        results.append(ai_message)
+                    else:
+                        # Fallback for unexpected format
+                        results.append(batch_result)
 
-                return results
+            return results
         else:
             raise RuntimeError("No results URL provided in batch status")
 
@@ -552,7 +558,7 @@ class ClaudeClient(AbstractClient):
         Returns:
             AIMessage: The response from Claude about the image.
         """
-        if not self.session:
+        if not self.client:
             raise RuntimeError("Client not initialized. Use async context manager.")
 
         # Generate unique turn ID for tracking
@@ -662,10 +668,9 @@ class ClaudeClient(AbstractClient):
         # Track tool calls (will likely be empty for vision requests)
         all_tool_calls = []
 
-        # Make the API request
-        async with self.session.post(f"{self.base_url}/v1/messages", json=payload) as response:
-            response.raise_for_status()
-            result = await response.json()
+        # Make the API request using SDK
+        response = await self.client.messages.create(**payload)
+        result = response.model_dump()
 
         # Handle structured output
         final_output = None
@@ -747,7 +752,7 @@ class ClaudeClient(AbstractClient):
             user_id (Optional[str]): Optional user identifier for tracking.
             session_id (Optional[str]): Optional session identifier for tracking.
         """
-        if not self.session:
+        if not self.client:
             raise RuntimeError("Client not initialized. Use async context manager.")
 
         self.logger.info(
@@ -779,10 +784,9 @@ class ClaudeClient(AbstractClient):
             "system": system_prompt
         }
 
-        # Make a stateless call to Claude
-        async with self.session.post(f"{self.base_url}/v1/messages", json=payload) as response:
-            response.raise_for_status()
-            result = await response.json()
+        # Make a stateless call to Claude using SDK
+        response = await self.client.messages.create(**payload)
+        result = response.model_dump()
 
         # Create AIMessage using factory
         ai_message = AIMessageFactory.from_claude(
@@ -822,7 +826,7 @@ class ClaudeClient(AbstractClient):
             user_id (Optional[str]): Optional user identifier for tracking.
             session_id (Optional[str]): Optional session identifier for tracking.
         """
-        if not self.session:
+        if not self.client:
             raise RuntimeError("Client not initialized. Use async context manager.")
 
         self.logger.info(
@@ -864,10 +868,9 @@ Requirements:
             "system": system_prompt
         }
 
-        # Make a stateless call to Claude
-        async with self.session.post(f"{self.base_url}/v1/messages", json=payload) as response:
-            response.raise_for_status()
-            result = await response.json()
+        # Make a stateless call to Claude using SDK
+        response = await self.client.messages.create(**payload)
+        result = response.model_dump()
 
         # Create AIMessage using factory
         ai_message = AIMessageFactory.from_claude(
@@ -906,7 +909,7 @@ Requirements:
             user_id (Optional[str]): Optional user identifier for tracking.
             session_id (Optional[str]): Optional session identifier for tracking.
         """
-        if not self.session:
+        if not self.client:
             raise RuntimeError("Client not initialized. Use async context manager.")
 
         turn_id = str(uuid.uuid4())
@@ -932,9 +935,8 @@ Requirements:
             "system": system_prompt
         }
 
-        async with self.session.post(f"{self.base_url}/v1/messages", json=payload) as response:
-            response.raise_for_status()
-            result = await response.json()
+        response = await self.client.messages.create(**payload)
+        result = response.model_dump()
 
         return AIMessageFactory.from_claude(
             response=result,
@@ -967,7 +969,7 @@ Requirements:
             user_id (Optional[str]): Optional user identifier for tracking.
             session_id (Optional[str]): Optional session identifier for tracking.
         """
-        if not self.session:
+        if not self.client:
             raise RuntimeError("Client not initialized. Use async context manager.")
 
         turn_id = str(uuid.uuid4())
@@ -1005,9 +1007,8 @@ Format your response clearly with these sections.
             "system": system_prompt
         }
 
-        async with self.session.post(f"{self.base_url}/v1/messages", json=payload) as response:
-            response.raise_for_status()
-            result = await response.json()
+        response = await self.client.messages.create(**payload)
+        result = response.model_dump()
 
         structured_output = SentimentAnalysis if use_structured else None
         return AIMessageFactory.from_claude(
@@ -1043,7 +1044,7 @@ Format your response clearly with these sections.
             user_id (Optional[str]): Optional user identifier for tracking.
             session_id (Optional[str]): Optional session identifier for tracking.
         """
-        if not self.session:
+        if not self.client:
             raise RuntimeError("Client not initialized. Use async context manager.")
 
         turn_id = str(uuid.uuid4())
@@ -1074,9 +1075,8 @@ Format your response clearly with these sections.
             "system": system_prompt
         }
 
-        async with self.session.post(f"{self.base_url}/v1/messages", json=payload) as response:
-            response.raise_for_status()
-            result = await response.json()
+        response = await self.client.messages.create(**payload)
+        result = response.model_dump()
 
         return AIMessageFactory.from_claude(
             response=result,
@@ -1088,3 +1088,7 @@ Format your response clearly with these sections.
             structured_output=ProductReview,
             tool_calls=[]
         )
+
+
+# Backward compatibility alias
+ClaudeClient = AnthropicClient

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,7 +206,8 @@ whisperx = [
 ]
 
 anthropic = [
-    "anthropic==0.61.0",
+    "anthropic[aiohttp]==0.61.0",
+    "claude-agent-sdk>=0.1.0",
 ]
 
 openai = [


### PR DESCRIPTION
Major Changes:
- Renamed ClaudeClient to AnthropicClient throughout the codebase
- Migrated from raw aiohttp to official anthropic SDK (AsyncAnthropic)
- Added claude-agent-sdk and anthropic[aiohttp] dependencies
- Updated all API calls to use SDK methods:
  - ask() now uses client.messages.create()
  - ask_stream() now uses client.messages.stream()
  - batch_ask() now uses client.messages.batches API
- Maintained backward compatibility with ClaudeClient alias
- All vision, translation, sentiment, and analysis methods updated

Benefits:
- Better type safety with official SDK types
- Automatic retry and error handling from SDK
- Cleaner code with less manual HTTP management
- Future-proof against API changes
- Full async/await support maintained

Breaking Changes:
- None - ClaudeClient remains as backward compatibility alias

Files Modified:
- parrot/clients/claude.py: Core implementation changes
- parrot/clients/__init__.py: Updated imports and exports
- pyproject.toml: Added anthropic[aiohttp] and claude-agent-sdk dependencies