### PR TITLE
Set up agent creation with dependencies

### DIFF
--- a/parrot/bots/abstract.py
+++ b/parrot/bots/abstract.py
@@ -195,7 +195,7 @@ class AbstractBot(DBInterface, ABC):
         # Definition of LLM Client
         self._llm_raw = llm
         self._llm_model = kwargs.get(
-            'model', getattr(self, 'model_name', self.default_model)
+            'model', getattr(self, 'model', self.default_model)
         )
         self._llm_preset: str = kwargs.get('preset', None)
         self._model_config = kwargs.pop('model_config', None)


### PR DESCRIPTION
Changed AbstractBot.__init__ to check for 'model' class attribute instead of 'model_name', making it consistent with how other parameters (temperature, max_tokens, top_k, top_p) are handled.

This fixes the issue where agents with `model = 'gemini-2.5-pro'` as a class variable were incorrectly using the default model 'gemini-2.5-flash' instead.