### PR TITLE
Debug WebScrapingTool Selenium connection issue

### DIFF
--- a/parrot/tools/scraping/tool.py
+++ b/parrot/tools/scraping/tool.py
@@ -250,9 +250,7 @@ If no selectors are provided and full_page is False, the tool will still return 
                         "metadata": r.metadata,
                         "success": r.success,
                         "error_message": r.error_message,
-                        "content": r.content,
-                        'bs': r.bs_soup
-
+                        "content": r.content
                     } for r in results
                 ],
                 "metadata": {


### PR DESCRIPTION
Remove BeautifulSoup object from result dictionary to fix JSON serialization error. The bs_soup field was being included in the result which caused serialization failures when the GoogleGenAIClient tried to convert the result to JSON.

The raw HTML content is already available in the 'content' field, so the BeautifulSoup object is only needed internally during processing and should not be exposed in the API response.

Fixes:
- Removed 'bs': r.bs_soup from result dictionary in _execute method
- Result now only includes JSON-serializable fields