### PR TITLE
Fix CSS conflicts with Bootstrap in output formats

### DIFF
--- a/parrot/outputs/formats/card.py
+++ b/parrot/outputs/formats/card.py
@@ -49,8 +49,7 @@ class CardRenderer(BaseRenderer):
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{title}</title>
     <style>
-        * {{ margin: 0; padding: 0; box-sizing: border-box; }}
-        body {{
+        .ap-card-wrapper {{
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             min-height: 100vh;
@@ -58,8 +57,12 @@ class CardRenderer(BaseRenderer):
             align-items: center;
             justify-content: center;
             padding: 20px;
+            box-sizing: border-box;
         }}
-        .card-container {{
+        .ap-card-wrapper * {{
+            box-sizing: border-box;
+        }}
+        .ap-card-container {{
             display: flex;
             flex-wrap: wrap;
             gap: 24px;
@@ -67,7 +70,7 @@ class CardRenderer(BaseRenderer):
             width: 100%;
             justify-content: center;
         }}
-        .metric-card {{
+        .ap-metric-card {{
             background: white;
             border-radius: 16px;
             padding: 28px 32px;
@@ -76,24 +79,24 @@ class CardRenderer(BaseRenderer):
             max-width: 400px;
             transition: transform 0.3s ease, box-shadow 0.3s ease;
         }}
-        .metric-card:hover {{
+        .ap-metric-card:hover {{
             transform: translateY(-5px);
             box-shadow: 0 15px 50px rgba(0, 0, 0, 0.2);
         }}
-        .card-header {{
+        .ap-card-header {{
             display: flex;
             justify-content: space-between;
             align-items: center;
             margin-bottom: 16px;
         }}
-        .card-title {{
+        .ap-card-title {{
             font-size: 15px;
             font-weight: 600;
             color: #64748b;
             text-transform: uppercase;
             letter-spacing: 0.5px;
         }}
-        .card-icon {{
+        .ap-card-icon {{
             width: 48px;
             height: 48px;
             display: flex;
@@ -104,72 +107,74 @@ class CardRenderer(BaseRenderer):
             border-radius: 12px;
             color: white;
         }}
-        .card-value {{
+        .ap-card-value {{
             font-size: 42px;
             font-weight: 700;
             color: #1e293b;
             margin-bottom: 20px;
             line-height: 1;
         }}
-        .comparisons {{
+        .ap-comparisons {{
             display: flex;
             flex-direction: column;
             gap: 12px;
         }}
-        .comparison-item {{
+        .ap-comparison-item {{
             display: flex;
             justify-content: space-between;
             align-items: center;
             padding: 10px 0;
             border-top: 1px solid #f1f5f9;
         }}
-        .comparison-item:first-child {{
+        .ap-comparison-item:first-child {{
             border-top: none;
             padding-top: 0;
         }}
-        .comparison-period {{
+        .ap-comparison-period {{
             font-size: 14px;
             color: #64748b;
             font-weight: 500;
         }}
-        .comparison-value {{
+        .ap-comparison-value {{
             display: flex;
             align-items: center;
             gap: 6px;
             font-size: 16px;
             font-weight: 700;
         }}
-        .comparison-value.increase {{ color: #10b981; }}
-        .comparison-value.decrease {{ color: #ef4444; }}
-        .trend-icon {{ font-size: 14px; }}
+        .ap-comparison-value.increase {{ color: #10b981; }}
+        .ap-comparison-value.decrease {{ color: #ef4444; }}
+        .ap-trend-icon {{ font-size: 14px; }}
     </style>
 </head>
 <body>
-    <div class="card-container">
-        {cards_html}
+    <div class="ap-card-wrapper">
+        <div class="ap-card-container">
+            {cards_html}
+        </div>
     </div>
 </body>
 </html>
 """
 
     SINGLE_CARD_TEMPLATE = """
-        <div class="metric-card">
-            <div class="card-header">
-                <div class="card-title">{title}</div>
+        <div class="ap-metric-card">
+            <div class="ap-card-header">
+                <div class="ap-card-title">{title}</div>
                 {icon_html}
             </div>
-            <div class="card-value">{value}</div>
-            <div class="comparisons">
+            <div class="ap-card-value">{value}</div>
+            <div class="ap-comparisons">
                 {comparisons_html}
             </div>
         </div>
 """
 
     COMPARISON_ITEM_TEMPLATE = """
-                <div class="comparison-item">
-                    <span class="comparison-period">{period}</span>
-                    <div class="comparison-value {trend}">
-                        <span class="trend-icon">{trend_icon}</span>
+                <div class="ap-comparison-item">
+                    <span class="ap-comparison-period">{period}</span>
+                    <div class="ap-comparison-value {trend}">
+                        <span class="ap-trend-icon">{trend_icon}</span>
                         <span>{value}%</span>
                     </div>
                 </div>
@@ -334,7 +339,7 @@ class CardRenderer(BaseRenderer):
         if not icon:
             return ''
         icon_char = self.ICON_MAP.get(icon.lower(), self.ICON_MAP['default'])
-        return f'<div class="card-icon">{icon_char}</div>'
+        return f'<div class="ap-card-icon">{icon_char}</div>'
 
     def _render_comparison_items(self, comparisons: List[Dict]) -> str:
         """Render comparison items HTML"""

--- a/parrot/outputs/formats/chart.py
+++ b/parrot/outputs/formats/chart.py
@@ -49,12 +49,12 @@ class BaseChart(BaseRenderer):
         """Build collapsible code section."""
         highlighted = BaseChart._highlight_code(code, theme)
         return f'''
-        <details class="code-accordion">
-            <summary class="code-header">
+        <details class="ap-code-accordion">
+            <summary class="ap-code-header">
                 <span>{icon} View Code</span>
-                <span class="toggle-icon">▶</span>
+                <span class="ap-toggle-icon">▶</span>
             </summary>
-            <div class="code-content">
+            <div class="ap-code-content">
                 {highlighted}
             </div>
         </details>
@@ -66,12 +66,12 @@ class BaseChart(BaseRenderer):
         highlighted = BaseChart._highlight_code(code, theme)
         return f'''
         {BaseChart._get_chart_styles()}
-        <div class="error-container">
+        <div class="ap-error-container">
             <h3>⚠️ Chart Generation Error</h3>
-            <p class="error-message">{error}</p>
-            <details class="code-accordion" open>
-                <summary class="code-header">Code with Error</summary>
-                <div class="code-content">{highlighted}</div>
+            <p class="ap-error-message">{error}</p>
+            <details class="ap-code-accordion" open>
+                <summary class="ap-code-header">Code with Error</summary>
+                <div class="ap-code-content">{highlighted}</div>
             </details>
         </div>
         '''
@@ -81,39 +81,39 @@ class BaseChart(BaseRenderer):
         """CSS styles specific to charts."""
         return '''
         <style>
-            .chart-container {
+            .ap-chart-container {
                 background: white;
                 border-radius: 8px;
                 box-shadow: 0 2px 8px rgba(0,0,0,0.1);
                 padding: 20px;
                 margin: 20px 0;
             }
-            .chart-wrapper {
+            .ap-chart-wrapper {
                 min-height: 400px;
                 display: flex;
                 justify-content: center;
                 align-items: center;
             }
-            .chart-guidance {
+            .ap-chart-guidance {
                 background: #f0f4ff;
                 border-left: 4px solid #667eea;
                 padding: 16px 20px;
                 border-radius: 6px;
             }
-            .chart-guidance h3 {
+            .ap-chart-guidance h3 {
                 font-size: 16px;
                 font-weight: 600;
                 color: #364152;
             }
-            .chart-guidance ol {
+            .ap-chart-guidance ol {
                 margin: 0 0 0 20px;
                 padding: 0;
             }
-            .chart-guidance li {
+            .ap-chart-guidance li {
                 margin-bottom: 6px;
                 line-height: 1.4;
             }
-            .chart-note {
+            .ap-chart-note {
                 background: #fffaf0;
                 border-left: 4px solid #f6ad55;
                 padding: 12px 16px;
@@ -122,13 +122,13 @@ class BaseChart(BaseRenderer):
                 color: #744210;
                 font-size: 14px;
             }
-            .code-accordion {
+            .ap-code-accordion {
                 margin-top: 20px;
                 border: 1px solid #e0e0e0;
                 border-radius: 6px;
                 overflow: hidden;
             }
-            .code-header {
+            .ap-code-header {
                 background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
                 color: white;
                 padding: 12px 20px;
@@ -139,34 +139,34 @@ class BaseChart(BaseRenderer):
                 font-weight: 600;
                 user-select: none;
             }
-            .code-header:hover {
+            .ap-code-header:hover {
                 background: linear-gradient(135deg, #5568d3 0%, #653a8e 100%);
             }
-            .toggle-icon {
+            .ap-toggle-icon {
                 transition: transform 0.3s ease;
             }
-            details[open] .toggle-icon {
+            details[open] .ap-toggle-icon {
                 transform: rotate(90deg);
             }
-            .code-content {
+            .ap-code-content {
                 background: #272822;
                 padding: 15px;
                 overflow-x: auto;
             }
-            .code-content pre {
+            .ap-code-content pre {
                 margin: 0;
                 font-family: 'Monaco', 'Menlo', 'Consolas', monospace;
                 font-size: 13px;
                 line-height: 1.5;
             }
-            .error-container {
+            .ap-error-container {
                 background: #fff3cd;
                 border: 1px solid #ffc107;
                 border-radius: 8px;
                 padding: 20px;
                 margin: 20px 0;
             }
-            .error-message {
+            .ap-error-message {
                 color: #856404;
                 font-weight: 500;
                 margin: 10px 0;
@@ -200,8 +200,8 @@ class BaseChart(BaseRenderer):
         if mode == 'partial':
             return f'''
             {BaseChart._get_chart_styles()}
-            <div class="chart-container">
-                <div class="chart-wrapper">
+            <div class="ap-chart-container">
+                <div class="ap-chart-wrapper">
                     {chart_content}
                 </div>
             </div>
@@ -222,37 +222,36 @@ class BaseChart(BaseRenderer):
     {extra_head}
 
     <style>
-        * {{
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }}
-
-        body {{
+        .ap-chart-wrapper {{
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
                          'Helvetica Neue', Arial, sans-serif;
             padding: 5px;
             line-height: 1.6;
+            box-sizing: border-box;
         }}
 
-        .media-container {{
+        .ap-chart-wrapper * {{
+            box-sizing: border-box;
+        }}
+
+        .ap-media-container {{
             max-width: 1200px;
             margin: 0 auto;
         }}
 
-        .chart-container {{
+        .ap-chart-container {{
             border-radius: 12px;
             padding: 5px;
         }}
 
-        .chart-wrapper {{
+        .ap-chart-wrapper {{
             min-height: 400px;
             display: flex;
             justify-content: center;
             align-items: center;
         }}
 
-        .code-accordion {{
+        .ap-code-accordion {{
             margin-top: 20px;
             border: 1px solid #e0e0e0;
             border-radius: 8px;
@@ -260,7 +259,7 @@ class BaseChart(BaseRenderer):
             background: white;
         }}
 
-        .code-header {{
+        .ap-code-header {{
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             color: white;
             padding: 14px 20px;
@@ -273,33 +272,33 @@ class BaseChart(BaseRenderer):
             transition: all 0.3s ease;
         }}
 
-        .code-header:hover {{
+        .ap-code-header:hover {{
             background: linear-gradient(135deg, #5568d3 0%, #653a8e 100%);
         }}
 
-        .toggle-icon {{
+        .ap-toggle-icon {{
             transition: transform 0.3s ease;
             font-size: 12px;
         }}
 
-        details[open] .toggle-icon {{
+        details[open] .ap-toggle-icon {{
             transform: rotate(90deg);
         }}
 
-        .code-content {{
+        .ap-code-content {{
             background: #272822;
             padding: 20px;
             overflow-x: auto;
         }}
 
-        .code-content pre {{
+        .ap-code-content pre {{
             margin: 0;
             font-family: 'Monaco', 'Menlo', 'Consolas', 'Courier New', monospace;
             font-size: 14px;
             line-height: 1.6;
         }}
 
-        .error-container {{
+        .ap-error-container {{
             background: #fff3cd;
             border: 2px solid #ffc107;
             border-radius: 8px;
@@ -307,37 +306,39 @@ class BaseChart(BaseRenderer):
             margin: 20px 0;
         }}
 
-        .error-container h3 {{
+        .ap-error-container h3 {{
             color: #856404;
             margin-bottom: 10px;
         }}
 
-        .error-message {{
+        .ap-error-message {{
             color: #856404;
             font-weight: 500;
             margin: 10px 0;
         }}
 
         @media (max-width: 768px) {{
-            body {{
+            .ap-chart-wrapper {{
                 padding: 1px;
             }}
 
-            .chart-container {{
+            .ap-chart-container {{
                 padding: 2px;
             }}
         }}
     </style>
 </head>
 <body>
-    <div class="media-container" id="{container_id}">
-        <div class="chart-container">
-            <div class="chart-wrapper">
-                {chart_content}
+    <div class="ap-chart-wrapper">
+        <div class="ap-media-container" id="{container_id}">
+            <div class="ap-chart-container">
+                <div class="ap-chart-wrapper">
+                    {chart_content}
+                </div>
             </div>
-        </div>
 
-        {code_section}
+            {code_section}
+        </div>
     </div>
 
     <script>

--- a/parrot/outputs/formats/d3.py
+++ b/parrot/outputs/formats/d3.py
@@ -93,7 +93,7 @@ class D3Renderer(BaseChart):
             items = ''.join(f"<li>{html.escape(step)}</li>" for step in teaching_steps)
             guidance_sections.append(
                 f"""
-        <div class=\"chart-guidance\">
+        <div class=\"ap-chart-guidance\">
             <h3>How this chart works</h3>
             <ol>{items}</ol>
         </div>
@@ -103,7 +103,7 @@ class D3Renderer(BaseChart):
         if notes:
             guidance_sections.append(
                 f"""
-        <div class=\"chart-note\"><strong>Notes:</strong> {html.escape(notes)}</div>
+        <div class=\"ap-chart-note\"><strong>Notes:</strong> {html.escape(notes)}</div>
                 """
             )
 

--- a/parrot/outputs/formats/html.py
+++ b/parrot/outputs/formats/html.py
@@ -119,17 +119,17 @@ class HTMLRenderer(BaseRenderer):
         """Format output as a simple HTML string."""
         html_parts = [self._get_html_header()]
         if content := self._get_content(response):
-            html_parts.append(f"<div class='response-container'><h2>🤖 Response</h2><div class='content'>{self._markdown_to_html(content)}</div></div>")
+            html_parts.append(f"<div class='ap-response-container'><h2>🤖 Response</h2><div class='ap-content'>{self._markdown_to_html(content)}</div></div>")
         if kwargs.get('show_tools', False) and hasattr(response, 'tool_calls') and response.tool_calls:
-            html_parts.append(f"<div class='section'><h3>🔧 Tool Calls</h3>{self._create_tools_html(response.tool_calls)}</div>")
+            html_parts.append(f"<div class='ap-section'><h3>🔧 Tool Calls</h3>{self._create_tools_html(response.tool_calls)}</div>")
         html_parts.append('</body></html>')
         return '\n'.join(html_parts)
 
     def _get_html_header(self) -> str:
         return '''
         <!DOCTYPE html><html><head><title>AI Response</title>
-        <style>body { font-family: sans-serif; } .response-container { background: #f0f8ff; }</style>
-        </head><body>
+        <style>.ap-html-wrapper { font-family: sans-serif; } .ap-response-container { background: #f0f8ff; }</style>
+        </head><body class="ap-html-wrapper">
         '''
 
     def _markdown_to_html(self, content: str) -> str:

--- a/parrot/outputs/formats/map.py
+++ b/parrot/outputs/formats/map.py
@@ -687,21 +687,21 @@ class FoliumRenderer(BaseChart):
 
         return '''
         <style>
-            .map-explanation {margin-bottom: 16px;}
-            .map-explanation details {border: 1px solid #e0e0e0; border-radius: 6px; overflow: hidden; background: #ffffff;}
-            .map-explanation summary {background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%); color: #fff; padding: 12px 16px; cursor: pointer; display: flex; justify-content: space-between; align-items: center; font-weight: 600; user-select: none;}
-            .map-explanation .toggle-icon {transition: transform 0.3s ease;}
-            .map-explanation details[open] .toggle-icon {transform: rotate(90deg);}
-            .map-explanation .explanation-content {padding: 12px 16px; background: #f8fafc; color: #1f2937;}
-            .map-explanation p {margin: 0; line-height: 1.6;}
+            .ap-map-explanation {margin-bottom: 16px;}
+            .ap-map-explanation details {border: 1px solid #e0e0e0; border-radius: 6px; overflow: hidden; background: #ffffff;}
+            .ap-map-explanation summary {background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%); color: #fff; padding: 12px 16px; cursor: pointer; display: flex; justify-content: space-between; align-items: center; font-weight: 600; user-select: none;}
+            .ap-map-explanation .ap-toggle-icon {transition: transform 0.3s ease;}
+            .ap-map-explanation details[open] .ap-toggle-icon {transform: rotate(90deg);}
+            .ap-map-explanation .ap-explanation-content {padding: 12px 16px; background: #f8fafc; color: #1f2937;}
+            .ap-map-explanation p {margin: 0; line-height: 1.6;}
         </style>
-        <div class="map-explanation">
+        <div class="ap-map-explanation">
             <details>
                 <summary>
                     <span>📝 Explicación del mapa</span>
-                    <span class="toggle-icon">▶</span>
+                    <span class="ap-toggle-icon">▶</span>
                 </summary>
-                <div class="explanation-content">
+                <div class="ap-explanation-content">
                     <p>{escaped_explanation}</p>
                 </div>
             </details>


### PR DESCRIPTION
Added unique 'ap-' (ai-parrot) prefix to all CSS classes in output format renderers to prevent conflicts with Bootstrap 4 and other external CSS libraries.

Changes:
- card.py: Prefixed all card-related classes (ap-card-*, ap-metric-*, ap-comparison-*)
- chart.py: Prefixed chart classes (ap-chart-*, ap-code-*, ap-error-*) and encapsulated styles
- d3.py: Updated to use new prefixed chart guidance classes
- html.py: Prefixed HTML renderer classes (ap-response-*, ap-html-wrapper)
- map.py: Prefixed map explanation classes (ap-map-explanation, ap-toggle-icon)

All CSS now uses scoped selectors to avoid affecting global styles or Bootstrap components.