### PR TITLE
Fix PandasAgent forecast revenue document retrieval

### DIFF
--- a/parrot/stores/kb/local.py
+++ b/parrot/stores/kb/local.py
@@ -348,6 +348,7 @@ class LocalKB(AbstractKnowledgeBase):
                     'source': result.metadata.get('source', 'unknown')
                 } for result in results
             )
+            return formatted_results
 
         except Exception as e:
             self.logger.error(f"Search error in KB '{self.name}': {e}")


### PR DESCRIPTION
The search method built formatted_results but never returned them, causing the method to implicitly return None on successful execution. This resulted in empty kb_context even when FAISS found matching documents.