### PR TITLE
Add LLM retry logic for failed output parsing

### DIFF
--- a/parrot/outputs/__init__.py
+++ b/parrot/outputs/__init__.py
@@ -22,11 +22,22 @@ Each output type is rendered appropriately based on the output mode (Terminal, H
 HTML mode generates embeddable widgets for integration with Streamlit, Gradio, web apps, etc.
 """
 from ..models.outputs import OutputMode, OutputType
-from .formatter import OutputFormatter
+from .formatter import (
+    OutputFormatter,
+    OutputRetryConfig,
+    OutputRetryResult,
+    DEFAULT_RETRY_PROMPTS,
+)
+from .formats import RenderResult, RenderError
 
 
 __all__ = (
     'OutputMode',
     'OutputType',
     'OutputFormatter',
+    'OutputRetryConfig',
+    'OutputRetryResult',
+    'DEFAULT_RETRY_PROMPTS',
+    'RenderResult',
+    'RenderError',
 )

--- a/parrot/outputs/formats/__init__.py
+++ b/parrot/outputs/formats/__init__.py
@@ -98,6 +98,8 @@ def has_system_prompt(mode: OutputMode) -> bool:
     return mode in _PROMPTS
 
 
+from .base import RenderResult, RenderError
+
 __all__ = (
     'RENDERERS',
     'register_renderer',
@@ -105,4 +107,6 @@ __all__ = (
     'Renderer',
     'get_output_prompt',
     'has_system_prompt',
+    'RenderResult',
+    'RenderError',
 )

--- a/parrot/outputs/formatter.py
+++ b/parrot/outputs/formatter.py
@@ -1,29 +1,195 @@
 from __future__ import annotations
 import sys
-from typing import Any, Optional, Tuple
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional, Tuple, Callable, TYPE_CHECKING, List
 from .formats import get_renderer, get_output_prompt, has_system_prompt
 from ..models.outputs import OutputMode
 from ..template.engine import TemplateEngine
+
+if TYPE_CHECKING:
+    from ..clients.base import AbstractClient
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class OutputRetryConfig:
+    """Configuration for LLM-based output retry on parsing failures.
+
+    When output parsing fails (e.g., malformed JSON for ECharts), this config
+    controls how the system will use an LLM to attempt to fix the output.
+
+    Attributes:
+        max_retries: Maximum number of retry attempts (default: 2)
+        retry_on_parse_error: Whether to retry on parsing/validation errors
+        retry_model: Optional specific model to use for retries (uses client default if None)
+        retry_temperature: Temperature for retry requests (lower = more deterministic)
+        retry_max_tokens: Max tokens for retry response
+        include_original_prompt: Whether to include the original user prompt in retry
+        custom_retry_prompts: Optional dict mapping OutputMode to custom retry prompts
+    """
+    max_retries: int = 2
+    retry_on_parse_error: bool = True
+    retry_model: Optional[str] = None
+    retry_temperature: float = 0.1
+    retry_max_tokens: int = 4096
+    include_original_prompt: bool = True
+    custom_retry_prompts: dict = field(default_factory=dict)
+
+    def get_retry_prompt(self, mode: OutputMode) -> Optional[str]:
+        """Get custom retry prompt for a specific output mode."""
+        return self.custom_retry_prompts.get(mode)
+
+
+# Default retry prompts for different output modes
+DEFAULT_RETRY_PROMPTS = {
+    OutputMode.ECHARTS: """You are a JSON repair assistant. The previous LLM response attempted to generate an ECharts configuration but produced invalid output.
+
+**Your task:** Fix the malformed JSON and return ONLY a valid ECharts JSON configuration.
+
+**Original Output (with error):**
+```
+{original_output}
+```
+
+**Error encountered:**
+{error_message}
+
+**Requirements:**
+1. Return ONLY valid JSON inside a ```json code block
+2. The JSON must be a valid ECharts option object
+3. Must include at least 'series', 'dataset', or 'options' key
+4. Fix any syntax errors (missing commas, quotes, brackets)
+5. Do NOT add explanations - just the fixed JSON
+
+**Fixed JSON:**""",
+
+    OutputMode.JSON: """You are a JSON repair assistant. The previous response contained malformed JSON.
+
+**Original Output:**
+```
+{original_output}
+```
+
+**Error:**
+{error_message}
+
+**Task:** Return ONLY the corrected, valid JSON inside a ```json code block. No explanations.""",
+
+    OutputMode.PLOTLY: """You are a Python code repair assistant. The previous response attempted to generate Plotly visualization code but it failed.
+
+**Original Code:**
+```python
+{original_output}
+```
+
+**Error:**
+{error_message}
+
+**Task:** Fix the Python code to create a valid Plotly figure. Return ONLY the corrected code inside a ```python code block.""",
+
+    OutputMode.YAML: """You are a YAML repair assistant. The previous response contained malformed YAML.
+
+**Original Output:**
+```yaml
+{original_output}
+```
+
+**Error:**
+{error_message}
+
+**Task:** Return ONLY the corrected, valid YAML. No explanations.""",
+}
+
+
+@dataclass
+class OutputRetryResult:
+    """Result from an output retry attempt.
+
+    Attributes:
+        success: Whether the retry produced valid output
+        content: The formatted content (original or fixed)
+        wrapped_content: Optional wrapped version (e.g., HTML)
+        retry_count: Number of retry attempts made
+        original_error: The original error that triggered retry
+        final_error: The final error if all retries failed (None if success)
+    """
+    success: bool
+    content: Any
+    wrapped_content: Optional[Any]
+    retry_count: int = 0
+    original_error: Optional[str] = None
+    final_error: Optional[str] = None
 
 
 class OutputFormatter:
     """
     Formatter for AI responses supporting multiple output modes.
+
+    Supports LLM-based retry for fixing malformed outputs (e.g., invalid JSON).
+    When a rendering fails due to parsing errors, the formatter can use an LLM
+    client to attempt to fix the output automatically.
+
+    Example usage with retry:
+        ```python
+        from parrot.clients.claude import AnthropicClient
+        from parrot.outputs.formatter import OutputFormatter, OutputRetryConfig
+
+        # Create LLM client for retries
+        client = AnthropicClient()
+
+        # Configure retry behavior
+        retry_config = OutputRetryConfig(
+            max_retries=2,
+            retry_temperature=0.1
+        )
+
+        # Create formatter with retry support
+        formatter = OutputFormatter(
+            llm_client=client,
+            retry_config=retry_config
+        )
+
+        # Format with automatic retry on failure
+        result = await formatter.format_with_retry(
+            mode=OutputMode.ECHARTS,
+            data=response,
+            original_prompt="Create a bar chart showing sales data"
+        )
+
+        if result.success:
+            print("Output formatted successfully")
+        else:
+            print(f"Failed after {result.retry_count} retries: {result.final_error}")
+        ```
     """
 
-    def __init__(self, template_engine: Optional[TemplateEngine] = None):
+    def __init__(
+        self,
+        template_engine: Optional[TemplateEngine] = None,
+        llm_client: Optional["AbstractClient"] = None,
+        retry_config: Optional[OutputRetryConfig] = None,
+    ):
         """
         Initialize the OutputFormatter.
 
         Args:
             template_engine: Optional TemplateEngine instance for template-based rendering.
-            If not provided, a new one will be created when needed.
+                If not provided, a new one will be created when needed.
+            llm_client: Optional LLM client instance for retry functionality.
+                Required for format_with_retry() to work.
+            retry_config: Optional retry configuration. If not provided,
+                defaults will be used when retry is attempted.
         """
         self._is_ipython = self._detect_ipython()
         self._is_notebook = self._detect_notebook()
         self._environment = self._detect_environment()
         self._renderers = {}
         self._template_engine = template_engine
+        self._llm_client = llm_client
+        self._retry_config = retry_config or OutputRetryConfig()
 
     def _detect_environment(self) -> str:
         if self._is_ipython:
@@ -150,3 +316,414 @@ class OutputFormatter:
         renderer = self._get_renderer(OutputMode.TEMPLATE_REPORT)
         if hasattr(renderer, 'add_template'):
             renderer.add_template(name, content)
+
+    # =========================================================================
+    # LLM Retry Functionality
+    # =========================================================================
+
+    def set_llm_client(self, client: "AbstractClient") -> None:
+        """
+        Set or update the LLM client used for retry operations.
+
+        Args:
+            client: An AbstractClient instance (Claude, GPT, etc.)
+        """
+        self._llm_client = client
+
+    def set_retry_config(self, config: OutputRetryConfig) -> None:
+        """
+        Set or update the retry configuration.
+
+        Args:
+            config: OutputRetryConfig instance
+        """
+        self._retry_config = config
+
+    @property
+    def llm_client(self) -> Optional["AbstractClient"]:
+        """Get the current LLM client."""
+        return self._llm_client
+
+    @property
+    def retry_config(self) -> OutputRetryConfig:
+        """Get the current retry configuration."""
+        return self._retry_config
+
+    def _get_retry_prompt(
+        self,
+        mode: OutputMode,
+        original_output: str,
+        error_message: str,
+        original_prompt: Optional[str] = None
+    ) -> str:
+        """
+        Build the retry prompt for fixing malformed output.
+
+        Args:
+            mode: The OutputMode that failed
+            original_output: The raw output that failed to parse
+            error_message: The error message from the parser
+            original_prompt: Optional original user prompt for context
+
+        Returns:
+            Formatted retry prompt string
+        """
+        # Check for custom prompt in config first
+        custom_prompt = self._retry_config.get_retry_prompt(mode)
+        if custom_prompt:
+            template = custom_prompt
+        else:
+            # Use default or generic prompt
+            template = DEFAULT_RETRY_PROMPTS.get(mode)
+
+        if template:
+            prompt = template.format(
+                original_output=original_output,
+                error_message=error_message
+            )
+        else:
+            # Generic fallback for modes without specific prompts
+            prompt = f"""The previous output was malformed and could not be parsed.
+
+**Original Output:**
+```
+{original_output}
+```
+
+**Error:**
+{error_message}
+
+**Task:** Fix the output to be valid for {mode.value} format. Return ONLY the corrected output."""
+
+        # Optionally include original prompt for context
+        if original_prompt and self._retry_config.include_original_prompt:
+            prompt = f"""**Original User Request:**
+{original_prompt}
+
+{prompt}"""
+
+        return prompt
+
+    def _extract_raw_output(self, data: Any) -> str:
+        """
+        Extract raw output string from response data for retry.
+
+        Args:
+            data: Response data (AIMessage, string, dict, etc.)
+
+        Returns:
+            Raw output string
+        """
+        # Handle AIMessage-like objects
+        if hasattr(data, 'response') and data.response:
+            return str(data.response)
+        if hasattr(data, 'content') and data.content:
+            return str(data.content)
+        if hasattr(data, 'output') and data.output:
+            return str(data.output)
+        if hasattr(data, 'to_text'):
+            return str(data.to_text)
+
+        # Handle dict responses
+        if isinstance(data, dict):
+            if 'response' in data:
+                return str(data['response'])
+            if 'content' in data:
+                return str(data['content'])
+            if 'output' in data:
+                return str(data['output'])
+
+        # Fallback to string conversion
+        return str(data)
+
+    def _is_parse_error_result(
+        self,
+        content: Any,
+        wrapped: Optional[Any],
+        mode: OutputMode
+    ) -> Tuple[bool, Optional[str]]:
+        """
+        Detect if the format result indicates a parsing error.
+
+        Different renderers signal errors differently:
+        - ECharts: Returns error HTML in wrapped content
+        - JSON: May return error message as content
+        - Others: May return None or error strings
+
+        Args:
+            content: The content returned from format()
+            wrapped: The wrapped content returned from format()
+            mode: The output mode used
+
+        Returns:
+            Tuple of (is_error, error_message)
+        """
+        # Check for explicit error indicators in content
+        if content is None:
+            return True, "Renderer returned None content"
+
+        content_str = str(content) if content else ""
+        wrapped_str = str(wrapped) if wrapped else ""
+
+        # Check for common error patterns
+        error_patterns = [
+            "Error parsing",
+            "Invalid JSON",
+            "Validation error",
+            "JSONDecodeError",
+            "SyntaxError",
+            "ParseError",
+            "class='error'",
+            "class=\"error\"",
+            "No ECharts configuration found",
+            "must include 'series'",
+        ]
+
+        for pattern in error_patterns:
+            if pattern in content_str or pattern in wrapped_str:
+                # Extract error message
+                error_msg = content_str if "Error" in content_str else wrapped_str
+                return True, error_msg[:500]  # Truncate long errors
+
+        return False, None
+
+    async def _request_output_fix(
+        self,
+        mode: OutputMode,
+        original_output: str,
+        error_message: str,
+        original_prompt: Optional[str] = None
+    ) -> Optional[Any]:
+        """
+        Request the LLM to fix malformed output.
+
+        Args:
+            mode: The OutputMode that failed
+            original_output: The raw output that failed to parse
+            error_message: The error message from the parser
+            original_prompt: Optional original user prompt for context
+
+        Returns:
+            Fixed response from LLM, or None if request fails
+        """
+        if not self._llm_client:
+            logger.warning(
+                "Cannot retry output fix: no LLM client configured"
+            )
+            return None
+
+        retry_prompt = self._get_retry_prompt(
+            mode=mode,
+            original_output=original_output,
+            error_message=error_message,
+            original_prompt=original_prompt
+        )
+
+        # Get system prompt for the output mode (helps LLM understand the format)
+        system_prompt = self.get_system_prompt(mode)
+        if not system_prompt:
+            system_prompt = f"You are a helpful assistant that fixes malformed {mode.value} output."
+
+        try:
+            # Make LLM request with retry-specific parameters
+            response = await self._llm_client.ask(
+                prompt=retry_prompt,
+                system_prompt=system_prompt,
+                max_tokens=self._retry_config.retry_max_tokens,
+                temperature=self._retry_config.retry_temperature,
+                model=self._retry_config.retry_model,
+            )
+            return response
+        except Exception as e:
+            logger.error(f"LLM retry request failed: {e}")
+            return None
+
+    async def format_with_retry(
+        self,
+        mode: OutputMode,
+        data: Any,
+        original_prompt: Optional[str] = None,
+        llm_client: Optional["AbstractClient"] = None,
+        retry_config: Optional[OutputRetryConfig] = None,
+        **kwargs
+    ) -> OutputRetryResult:
+        """
+        Format output with automatic LLM-based retry on parsing failures.
+
+        This method attempts to format the output normally. If parsing fails,
+        it uses the configured LLM client to request a fix for the malformed
+        output, then retries formatting.
+
+        Args:
+            mode: OutputMode enum value
+            data: The data to format (typically an AIMessage response)
+            original_prompt: Optional original user prompt that generated the data.
+                This provides context to the LLM for better fixes.
+            llm_client: Optional LLM client to use for this call (overrides default)
+            retry_config: Optional retry config for this call (overrides default)
+            **kwargs: Additional arguments passed to the renderer
+
+        Returns:
+            OutputRetryResult with success status, content, and retry information
+
+        Example:
+            ```python
+            result = await formatter.format_with_retry(
+                mode=OutputMode.ECHARTS,
+                data=response,
+                original_prompt="Create a pie chart of quarterly sales"
+            )
+
+            if result.success:
+                # Use result.content and result.wrapped_content
+                display_chart(result.wrapped_content)
+            else:
+                # Handle failure
+                logger.error(f"Format failed: {result.final_error}")
+                show_raw_output(result.content)
+            ```
+        """
+        # Use provided overrides or defaults
+        client = llm_client or self._llm_client
+        config = retry_config or self._retry_config
+
+        # Track retry attempts
+        retry_count = 0
+        original_error: Optional[str] = None
+        current_data = data
+
+        while True:
+            # Attempt to format
+            try:
+                content, wrapped = await self.format(mode, current_data, **kwargs)
+
+                # Check if result indicates a parse error
+                is_error, error_msg = self._is_parse_error_result(
+                    content, wrapped, mode
+                )
+
+                if not is_error:
+                    # Success!
+                    return OutputRetryResult(
+                        success=True,
+                        content=content,
+                        wrapped_content=wrapped,
+                        retry_count=retry_count,
+                        original_error=original_error
+                    )
+
+                # We have a parse error
+                if original_error is None:
+                    original_error = error_msg
+
+                # Check if we should retry
+                if not config.retry_on_parse_error:
+                    logger.debug("Retry disabled, returning error result")
+                    return OutputRetryResult(
+                        success=False,
+                        content=content,
+                        wrapped_content=wrapped,
+                        retry_count=retry_count,
+                        original_error=original_error,
+                        final_error=error_msg
+                    )
+
+                if retry_count >= config.max_retries:
+                    logger.warning(
+                        f"Max retries ({config.max_retries}) exceeded for {mode}"
+                    )
+                    return OutputRetryResult(
+                        success=False,
+                        content=content,
+                        wrapped_content=wrapped,
+                        retry_count=retry_count,
+                        original_error=original_error,
+                        final_error=error_msg
+                    )
+
+                if not client:
+                    logger.warning(
+                        "Cannot retry: no LLM client available"
+                    )
+                    return OutputRetryResult(
+                        success=False,
+                        content=content,
+                        wrapped_content=wrapped,
+                        retry_count=retry_count,
+                        original_error=original_error,
+                        final_error="No LLM client available for retry"
+                    )
+
+                # Attempt retry with LLM fix
+                retry_count += 1
+                logger.info(
+                    f"Attempting retry {retry_count}/{config.max_retries} "
+                    f"for {mode} output"
+                )
+
+                # Extract raw output for retry
+                raw_output = self._extract_raw_output(current_data)
+
+                # Request fix from LLM
+                fixed_response = await self._request_output_fix(
+                    mode=mode,
+                    original_output=raw_output,
+                    error_message=error_msg or "Unknown parsing error",
+                    original_prompt=original_prompt
+                )
+
+                if fixed_response is None:
+                    logger.warning("LLM fix request failed")
+                    return OutputRetryResult(
+                        success=False,
+                        content=content,
+                        wrapped_content=wrapped,
+                        retry_count=retry_count,
+                        original_error=original_error,
+                        final_error="LLM fix request failed"
+                    )
+
+                # Use fixed response for next iteration
+                current_data = fixed_response
+                logger.debug(f"Retry {retry_count}: Got fixed response from LLM")
+
+            except Exception as e:
+                error_msg = str(e)
+                if original_error is None:
+                    original_error = error_msg
+
+                logger.error(f"Format raised exception: {e}")
+
+                # If we can't retry, return failure
+                if retry_count >= config.max_retries or not client:
+                    return OutputRetryResult(
+                        success=False,
+                        content=self._extract_raw_output(data),
+                        wrapped_content=None,
+                        retry_count=retry_count,
+                        original_error=original_error,
+                        final_error=error_msg
+                    )
+
+                # Attempt retry
+                retry_count += 1
+                raw_output = self._extract_raw_output(current_data)
+
+                fixed_response = await self._request_output_fix(
+                    mode=mode,
+                    original_output=raw_output,
+                    error_message=error_msg,
+                    original_prompt=original_prompt
+                )
+
+                if fixed_response is None:
+                    return OutputRetryResult(
+                        success=False,
+                        content=raw_output,
+                        wrapped_content=None,
+                        retry_count=retry_count,
+                        original_error=original_error,
+                        final_error="LLM fix request failed"
+                    )
+
+                current_data = fixed_response

--- a/tests/outputs/test_formatter_retry.py
+++ b/tests/outputs/test_formatter_retry.py
@@ -1,0 +1,625 @@
+"""Tests for OutputFormatter LLM retry functionality."""
+import asyncio
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from parrot.outputs.formatter import (
+    OutputFormatter,
+    OutputRetryConfig,
+    OutputRetryResult,
+    DEFAULT_RETRY_PROMPTS,
+)
+from parrot.outputs.formats.base import RenderResult, RenderError
+from parrot.models.outputs import OutputMode
+
+
+class MockAIMessage:
+    """Mock AIMessage response for testing."""
+
+    def __init__(self, response: str, output=None):
+        self.response = response
+        self.output = output
+        self.content = response
+
+
+class MockLLMClient:
+    """Mock LLM client for testing retry functionality."""
+
+    def __init__(self, responses=None):
+        self.responses = responses or []
+        self.call_count = 0
+        self.calls = []
+
+    async def ask(
+        self,
+        prompt: str,
+        system_prompt: str = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.1,
+        model: str = None,
+        **kwargs
+    ):
+        self.calls.append({
+            'prompt': prompt,
+            'system_prompt': system_prompt,
+            'max_tokens': max_tokens,
+            'temperature': temperature,
+            'model': model,
+        })
+        if self.call_count < len(self.responses):
+            response = self.responses[self.call_count]
+            self.call_count += 1
+            return response
+        raise Exception("No more mock responses")
+
+
+# ============================================================================
+# OutputRetryConfig Tests
+# ============================================================================
+
+
+def test_output_retry_config_defaults():
+    """Test default values for OutputRetryConfig."""
+    config = OutputRetryConfig()
+
+    assert config.max_retries == 2
+    assert config.retry_on_parse_error is True
+    assert config.retry_model is None
+    assert config.retry_temperature == 0.1
+    assert config.retry_max_tokens == 4096
+    assert config.include_original_prompt is True
+    assert config.custom_retry_prompts == {}
+
+
+def test_output_retry_config_custom_values():
+    """Test custom values for OutputRetryConfig."""
+    custom_prompts = {
+        OutputMode.ECHARTS: "Custom ECharts prompt: {original_output}"
+    }
+    config = OutputRetryConfig(
+        max_retries=5,
+        retry_on_parse_error=False,
+        retry_model="gpt-4",
+        retry_temperature=0.5,
+        retry_max_tokens=8192,
+        include_original_prompt=False,
+        custom_retry_prompts=custom_prompts,
+    )
+
+    assert config.max_retries == 5
+    assert config.retry_on_parse_error is False
+    assert config.retry_model == "gpt-4"
+    assert config.retry_temperature == 0.5
+    assert config.retry_max_tokens == 8192
+    assert config.include_original_prompt is False
+    assert OutputMode.ECHARTS in config.custom_retry_prompts
+
+
+def test_output_retry_config_get_custom_prompt():
+    """Test getting custom retry prompt for a mode."""
+    custom_prompts = {
+        OutputMode.JSON: "Fix this JSON: {original_output}"
+    }
+    config = OutputRetryConfig(custom_retry_prompts=custom_prompts)
+
+    assert config.get_retry_prompt(OutputMode.JSON) == "Fix this JSON: {original_output}"
+    assert config.get_retry_prompt(OutputMode.ECHARTS) is None
+
+
+# ============================================================================
+# OutputRetryResult Tests
+# ============================================================================
+
+
+def test_output_retry_result_success():
+    """Test successful retry result."""
+    result = OutputRetryResult(
+        success=True,
+        content="formatted content",
+        wrapped_content="<html>wrapped</html>",
+        retry_count=1,
+        original_error="Initial parse error",
+    )
+
+    assert result.success is True
+    assert result.content == "formatted content"
+    assert result.wrapped_content == "<html>wrapped</html>"
+    assert result.retry_count == 1
+    assert result.original_error == "Initial parse error"
+    assert result.final_error is None
+
+
+def test_output_retry_result_failure():
+    """Test failed retry result."""
+    result = OutputRetryResult(
+        success=False,
+        content="raw output",
+        wrapped_content=None,
+        retry_count=3,
+        original_error="Parse error",
+        final_error="Max retries exceeded",
+    )
+
+    assert result.success is False
+    assert result.retry_count == 3
+    assert result.original_error == "Parse error"
+    assert result.final_error == "Max retries exceeded"
+
+
+# ============================================================================
+# DEFAULT_RETRY_PROMPTS Tests
+# ============================================================================
+
+
+def test_default_retry_prompts_exist():
+    """Test that default retry prompts exist for key modes."""
+    assert OutputMode.ECHARTS in DEFAULT_RETRY_PROMPTS
+    assert OutputMode.JSON in DEFAULT_RETRY_PROMPTS
+    assert OutputMode.PLOTLY in DEFAULT_RETRY_PROMPTS
+    assert OutputMode.YAML in DEFAULT_RETRY_PROMPTS
+
+
+def test_default_retry_prompts_contain_placeholders():
+    """Test that prompts contain required placeholders."""
+    for mode, prompt in DEFAULT_RETRY_PROMPTS.items():
+        assert "{original_output}" in prompt, f"Missing original_output in {mode} prompt"
+        assert "{error_message}" in prompt, f"Missing error_message in {mode} prompt"
+
+
+# ============================================================================
+# OutputFormatter Initialization Tests
+# ============================================================================
+
+
+def test_formatter_initialization_without_retry():
+    """Test formatter initialization without retry components."""
+    formatter = OutputFormatter()
+
+    assert formatter.llm_client is None
+    assert formatter.retry_config is not None
+    assert isinstance(formatter.retry_config, OutputRetryConfig)
+
+
+def test_formatter_initialization_with_llm_client():
+    """Test formatter initialization with LLM client."""
+    mock_client = MockLLMClient()
+    formatter = OutputFormatter(llm_client=mock_client)
+
+    assert formatter.llm_client is mock_client
+
+
+def test_formatter_initialization_with_retry_config():
+    """Test formatter initialization with custom retry config."""
+    config = OutputRetryConfig(max_retries=5)
+    formatter = OutputFormatter(retry_config=config)
+
+    assert formatter.retry_config.max_retries == 5
+
+
+def test_formatter_set_llm_client():
+    """Test setting LLM client after initialization."""
+    formatter = OutputFormatter()
+    mock_client = MockLLMClient()
+
+    assert formatter.llm_client is None
+    formatter.set_llm_client(mock_client)
+    assert formatter.llm_client is mock_client
+
+
+def test_formatter_set_retry_config():
+    """Test updating retry config after initialization."""
+    formatter = OutputFormatter()
+    new_config = OutputRetryConfig(max_retries=10)
+
+    formatter.set_retry_config(new_config)
+    assert formatter.retry_config.max_retries == 10
+
+
+# ============================================================================
+# Retry Prompt Generation Tests
+# ============================================================================
+
+
+def test_get_retry_prompt_uses_default():
+    """Test that default prompts are used when no custom prompt exists."""
+    formatter = OutputFormatter()
+
+    prompt = formatter._get_retry_prompt(
+        mode=OutputMode.ECHARTS,
+        original_output='{"invalid": json',
+        error_message="JSONDecodeError: Expecting value",
+    )
+
+    assert '{"invalid": json' in prompt
+    assert "JSONDecodeError" in prompt
+    assert "ECharts" in prompt or "JSON" in prompt
+
+
+def test_get_retry_prompt_uses_custom():
+    """Test that custom prompts override defaults."""
+    custom_prompt = "Custom prompt: {original_output} - Error: {error_message}"
+    config = OutputRetryConfig(
+        custom_retry_prompts={OutputMode.ECHARTS: custom_prompt}
+    )
+    formatter = OutputFormatter(retry_config=config)
+
+    prompt = formatter._get_retry_prompt(
+        mode=OutputMode.ECHARTS,
+        original_output="bad json",
+        error_message="parse error",
+    )
+
+    assert prompt == "Custom prompt: bad json - Error: parse error"
+
+
+def test_get_retry_prompt_includes_original_prompt():
+    """Test that original user prompt is included when configured."""
+    config = OutputRetryConfig(include_original_prompt=True)
+    formatter = OutputFormatter(retry_config=config)
+
+    prompt = formatter._get_retry_prompt(
+        mode=OutputMode.JSON,
+        original_output="invalid",
+        error_message="error",
+        original_prompt="Create a bar chart",
+    )
+
+    assert "Create a bar chart" in prompt
+    assert "Original User Request" in prompt
+
+
+def test_get_retry_prompt_excludes_original_prompt():
+    """Test that original prompt is excluded when configured."""
+    config = OutputRetryConfig(include_original_prompt=False)
+    formatter = OutputFormatter(retry_config=config)
+
+    prompt = formatter._get_retry_prompt(
+        mode=OutputMode.JSON,
+        original_output="invalid",
+        error_message="error",
+        original_prompt="Create a bar chart",
+    )
+
+    assert "Create a bar chart" not in prompt
+
+
+def test_get_retry_prompt_fallback_for_unknown_mode():
+    """Test fallback prompt for modes without specific prompts."""
+    formatter = OutputFormatter()
+
+    prompt = formatter._get_retry_prompt(
+        mode=OutputMode.DEFAULT,  # No specific prompt for DEFAULT
+        original_output="some output",
+        error_message="some error",
+    )
+
+    assert "some output" in prompt
+    assert "some error" in prompt
+
+
+# ============================================================================
+# Raw Output Extraction Tests
+# ============================================================================
+
+
+def test_extract_raw_output_from_aimessage():
+    """Test extracting raw output from AIMessage-like object."""
+    formatter = OutputFormatter()
+    message = MockAIMessage(response="test response")
+
+    output = formatter._extract_raw_output(message)
+    assert output == "test response"
+
+
+def test_extract_raw_output_from_dict():
+    """Test extracting raw output from dictionary."""
+    formatter = OutputFormatter()
+
+    output = formatter._extract_raw_output({"response": "dict response"})
+    assert output == "dict response"
+
+    output = formatter._extract_raw_output({"content": "dict content"})
+    assert output == "dict content"
+
+
+def test_extract_raw_output_from_string():
+    """Test extracting raw output from string."""
+    formatter = OutputFormatter()
+
+    output = formatter._extract_raw_output("plain string")
+    assert output == "plain string"
+
+
+# ============================================================================
+# Parse Error Detection Tests
+# ============================================================================
+
+
+def test_is_parse_error_result_detects_none_content():
+    """Test detection of None content as error."""
+    formatter = OutputFormatter()
+
+    is_error, msg = formatter._is_parse_error_result(None, None, OutputMode.JSON)
+    assert is_error is True
+    assert "None" in msg
+
+
+def test_is_parse_error_result_detects_error_patterns():
+    """Test detection of common error patterns."""
+    formatter = OutputFormatter()
+
+    test_cases = [
+        ("Error parsing JSON", "Error parsing"),
+        ("Invalid JSON: unexpected token", "Invalid JSON"),
+        ("JSONDecodeError: Expecting value", "JSONDecodeError"),
+        ("class='error'>Error</div>", "class='error'"),
+        ("No ECharts configuration found", "No ECharts configuration found"),
+    ]
+
+    for content, expected_pattern in test_cases:
+        is_error, msg = formatter._is_parse_error_result(
+            content, None, OutputMode.JSON
+        )
+        assert is_error is True, f"Failed to detect: {expected_pattern}"
+
+
+def test_is_parse_error_result_valid_content():
+    """Test that valid content is not marked as error."""
+    formatter = OutputFormatter()
+
+    is_error, msg = formatter._is_parse_error_result(
+        '{"valid": "json"}',
+        '<html>valid</html>',
+        OutputMode.JSON
+    )
+    assert is_error is False
+    assert msg is None
+
+
+# ============================================================================
+# Format with Retry Tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_format_with_retry_success_without_retry():
+    """Test successful format that doesn't need retry."""
+    # Create a valid ECharts response
+    valid_json = json.dumps({
+        "title": {"text": "Test Chart"},
+        "series": [{"type": "bar", "data": [1, 2, 3]}]
+    })
+
+    response = MockAIMessage(response=f"```json\n{valid_json}\n```")
+    formatter = OutputFormatter()
+
+    result = await formatter.format_with_retry(
+        mode=OutputMode.ECHARTS,
+        data=response,
+        output_format='html',
+    )
+
+    assert result.success is True
+    assert result.retry_count == 0
+    assert result.original_error is None
+
+
+@pytest.mark.asyncio
+async def test_format_with_retry_no_client_returns_error():
+    """Test that retry without LLM client returns failure."""
+    # Create invalid JSON response
+    response = MockAIMessage(response="```json\n{invalid}\n```")
+    formatter = OutputFormatter()  # No LLM client
+
+    result = await formatter.format_with_retry(
+        mode=OutputMode.ECHARTS,
+        data=response,
+        output_format='html',
+    )
+
+    assert result.success is False
+    assert "No LLM client" in result.final_error
+
+
+@pytest.mark.asyncio
+async def test_format_with_retry_success_after_retry():
+    """Test successful format after LLM retry."""
+    # Create invalid JSON that triggers retry
+    invalid_response = MockAIMessage(response="```json\n{invalid}\n```")
+
+    # Create valid JSON that LLM will "fix" to
+    valid_json = json.dumps({
+        "title": {"text": "Fixed Chart"},
+        "series": [{"type": "bar", "data": [1, 2, 3]}]
+    })
+    fixed_response = MockAIMessage(response=f"```json\n{valid_json}\n```")
+
+    mock_client = MockLLMClient(responses=[fixed_response])
+    formatter = OutputFormatter(llm_client=mock_client)
+
+    result = await formatter.format_with_retry(
+        mode=OutputMode.ECHARTS,
+        data=invalid_response,
+        original_prompt="Create a bar chart",
+        output_format='html',
+    )
+
+    assert result.success is True
+    assert result.retry_count == 1
+    assert mock_client.call_count == 1
+    # Verify original prompt was passed
+    assert "bar chart" in mock_client.calls[0]['prompt']
+
+
+@pytest.mark.asyncio
+async def test_format_with_retry_max_retries_exceeded():
+    """Test that max retries is respected."""
+    # Create responses that always produce invalid output
+    invalid_response = MockAIMessage(response="```json\n{invalid}\n```")
+
+    mock_client = MockLLMClient(responses=[
+        invalid_response,
+        invalid_response,
+        invalid_response,
+    ])
+    config = OutputRetryConfig(max_retries=2)
+    formatter = OutputFormatter(llm_client=mock_client, retry_config=config)
+
+    result = await formatter.format_with_retry(
+        mode=OutputMode.ECHARTS,
+        data=invalid_response,
+        output_format='html',
+    )
+
+    assert result.success is False
+    assert result.retry_count == 2  # Stopped at max_retries
+
+
+@pytest.mark.asyncio
+async def test_format_with_retry_disabled():
+    """Test that retry can be disabled."""
+    invalid_response = MockAIMessage(response="```json\n{invalid}\n```")
+    valid_json = json.dumps({"series": [{"type": "bar", "data": [1]}]})
+    fixed_response = MockAIMessage(response=f"```json\n{valid_json}\n```")
+
+    mock_client = MockLLMClient(responses=[fixed_response])
+    config = OutputRetryConfig(retry_on_parse_error=False)
+    formatter = OutputFormatter(llm_client=mock_client, retry_config=config)
+
+    result = await formatter.format_with_retry(
+        mode=OutputMode.ECHARTS,
+        data=invalid_response,
+        output_format='html',
+    )
+
+    assert result.success is False
+    assert result.retry_count == 0  # No retry attempted
+    assert mock_client.call_count == 0  # Client never called
+
+
+@pytest.mark.asyncio
+async def test_format_with_retry_override_client():
+    """Test overriding LLM client for specific call."""
+    invalid_response = MockAIMessage(response="```json\n{invalid}\n```")
+    valid_json = json.dumps({"series": [{"type": "bar", "data": [1]}]})
+    fixed_response = MockAIMessage(response=f"```json\n{valid_json}\n```")
+
+    default_client = MockLLMClient(responses=[])
+    override_client = MockLLMClient(responses=[fixed_response])
+
+    formatter = OutputFormatter(llm_client=default_client)
+
+    result = await formatter.format_with_retry(
+        mode=OutputMode.ECHARTS,
+        data=invalid_response,
+        llm_client=override_client,  # Override for this call
+        output_format='html',
+    )
+
+    assert result.success is True
+    assert override_client.call_count == 1
+    assert default_client.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_format_with_retry_override_config():
+    """Test overriding retry config for specific call."""
+    invalid_response = MockAIMessage(response="```json\n{invalid}\n```")
+
+    mock_client = MockLLMClient(responses=[
+        invalid_response,
+        invalid_response,
+        invalid_response,
+    ])
+
+    default_config = OutputRetryConfig(max_retries=5)
+    override_config = OutputRetryConfig(max_retries=1)
+
+    formatter = OutputFormatter(llm_client=mock_client, retry_config=default_config)
+
+    result = await formatter.format_with_retry(
+        mode=OutputMode.ECHARTS,
+        data=invalid_response,
+        retry_config=override_config,  # Override for this call
+        output_format='html',
+    )
+
+    assert result.success is False
+    assert result.retry_count == 1  # Used override config's max_retries
+
+
+@pytest.mark.asyncio
+async def test_format_with_retry_llm_request_params():
+    """Test that LLM request uses correct parameters from config."""
+    invalid_response = MockAIMessage(response="```json\n{invalid}\n```")
+    valid_json = json.dumps({"series": [{"type": "bar", "data": [1]}]})
+    fixed_response = MockAIMessage(response=f"```json\n{valid_json}\n```")
+
+    mock_client = MockLLMClient(responses=[fixed_response])
+    config = OutputRetryConfig(
+        retry_temperature=0.5,
+        retry_max_tokens=2048,
+        retry_model="gpt-4",
+    )
+    formatter = OutputFormatter(llm_client=mock_client, retry_config=config)
+
+    await formatter.format_with_retry(
+        mode=OutputMode.ECHARTS,
+        data=invalid_response,
+        output_format='html',
+    )
+
+    assert mock_client.call_count == 1
+    call = mock_client.calls[0]
+    assert call['temperature'] == 0.5
+    assert call['max_tokens'] == 2048
+    assert call['model'] == "gpt-4"
+
+
+# ============================================================================
+# RenderResult and RenderError Tests
+# ============================================================================
+
+
+def test_render_error_creation():
+    """Test RenderError dataclass creation."""
+    error = RenderError(
+        message="Parse failed",
+        error_type="json_parse",
+        raw_output='{"invalid',
+        details={"line": 1, "column": 10}
+    )
+
+    assert error.message == "Parse failed"
+    assert error.error_type == "json_parse"
+    assert error.raw_output == '{"invalid'
+    assert error.details["line"] == 1
+
+
+def test_render_result_success():
+    """Test successful RenderResult creation."""
+    result = RenderResult(
+        success=True,
+        content="formatted",
+        wrapped_content="<html>",
+    )
+
+    assert result.success is True
+    assert result.content == "formatted"
+    assert result.wrapped_content == "<html>"
+    assert result.error is None
+
+
+def test_render_result_with_error():
+    """Test RenderResult with error."""
+    error = RenderError(message="Failed", error_type="validation")
+    result = RenderResult(
+        success=False,
+        content="raw",
+        error=error,
+    )
+
+    assert result.success is False
+    assert result.error is not None
+    assert result.error.message == "Failed"


### PR DESCRIPTION
When output parsing fails (e.g., malformed JSON for ECharts), the OutputFormatter can now use an LLM client to automatically request a fix for the malformed output and retry formatting.

Key changes:
- Add OutputRetryConfig dataclass for retry configuration (max_retries, retry_temperature, retry_model, custom_retry_prompts)
- Add OutputRetryResult dataclass for structured retry results
- Add format_with_retry() method to OutputFormatter that attempts to fix malformed outputs using an LLM
- Add DEFAULT_RETRY_PROMPTS for ECharts, JSON, Plotly, and YAML modes
- Add RenderResult and RenderError dataclasses to BaseRenderer for structured error reporting
- Add comprehensive test suite for retry functionality

Usage example:
```python
from parrot.outputs import OutputFormatter, OutputRetryConfig
from parrot.clients.claude import AnthropicClient

client = AnthropicClient()
config = OutputRetryConfig(max_retries=2, retry_temperature=0.1)
formatter = OutputFormatter(llm_client=client, retry_config=config)

result = await formatter.format_with_retry(
    mode=OutputMode.ECHARTS,
    data=response,
    original_prompt="Create a bar chart"
)
```