### PR TITLE
Avoid wrapping full HTML output in Panel

### DIFF
--- a/parrot/outputs/formats/html.py
+++ b/parrot/outputs/formats/html.py
@@ -27,6 +27,10 @@ class HTMLRenderer(BaseRenderer):
         """
         Render response as HTML, returning a primary content object and a wrapped HTML string.
         """
+        content = self._get_content(response)
+        if isinstance(content, str) and self._looks_like_html(content):
+            return content, content
+
         use_panel = kwargs.get('use_panel', True) and PANEL_AVAILABLE
 
         if use_panel:
@@ -40,6 +44,13 @@ class HTMLRenderer(BaseRenderer):
             wrapped = html_string
 
         return content, wrapped
+
+    @staticmethod
+    def _looks_like_html(content: str) -> bool:
+        lowered = content.lstrip().lower()
+        if lowered.startswith('<!doctype html') or lowered.startswith('<html'):
+            return True
+        return '<script' in lowered or 'echarts.init' in lowered
 
     def _render_with_panel(self, response: Any, **kwargs) -> Any:
         """


### PR DESCRIPTION
### Motivation
- ECharts/JS-first HTML responses (full HTML documents or script-based charts) were being wrapped with Panel, which prevented the original JS chart (e.g. ECharts map) from executing correctly.
- Need to return raw HTML for responses that are already complete HTML pages or include chart initialization scripts so they can render as intended in the browser/embed.

### Description
- Added early detection of full HTML / script-based content in `parrot/outputs/formats/html.py` and return the raw HTML directly instead of wrapping it in a Panel.
- Implemented a helper `@staticmethod def _looks_like_html(content: str) -> bool` that returns true when content starts with `<!doctype html`/`<html` or contains `<script` or `echarts.init`.
- In `HTMLRenderer.render()` the code now extracts content via `self._get_content(response)` and, if `_looks_like_html` is true, returns `(content, content)` immediately; otherwise it proceeds with the existing Panel or simple-HTML rendering.
- Change limits transformation of already-complete HTML payloads, allowing client-side JS (ECharts) to load and run properly.

### Testing
- No automated tests were run for this change.
- (No automated test failures reported.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944a1c3f5208330a03e33fa34a485a0)