### PR TITLE
Fix matplotlib chart output in GoogleGenAI client

### DIFF
--- a/parrot/models/responses.py
+++ b/parrot/models/responses.py
@@ -600,7 +600,9 @@ class AIMessageFactory:
         # Add these new parameters:
         conversation_history: Optional[Any] = None,
         text_response: Optional[str] = None,
-        files: Optional[List[Path]] = None
+        files: Optional[List[Path]] = None,
+        images: Optional[List[Any]] = None,
+        code: Optional[str] = None
     ) -> AIMessage:
         """Create AIMessage from Gemini/Vertex AI response."""
         # Handle both direct text responses and response objects
@@ -641,6 +643,8 @@ class AIMessageFactory:
             raw_response=response.__dict__ if hasattr(response, '__dict__') else str(response),
             response=content,
             files=files or [],
+            images=images or [],
+            code=code,
         )
 
         if conversation_history:


### PR DESCRIPTION
When Google's Gemini models generate matplotlib charts via code execution, the output is returned in special part types (executable_code, code_execution_result, inline_data) rather than as regular text.

Changes:
- Add handling for code_execution_result parts in _safe_extract_text to extract text output from code execution
- Add handling for executable_code parts for logging/debugging
- Add new _extract_code_execution_content method to extract:
  - Executed Python code
  - Code execution output
  - Generated images (matplotlib charts) from inline_data
  - Images via as_image() method on parts
- Update ask() method to use extracted code execution content
- Update AIMessageFactory.from_gemini to accept images and code parameters
- Populate AIMessage.images and AIMessage.code with extracted content

This fixes the issue where chart generation requests returned only "execution complete" with no actual response content.