### PR TITLE
Fix ECharts rendering by adding display: flex to chart wrapper

### DIFF
--- a/parrot/outputs/formats/chart.py
+++ b/parrot/outputs/formats/chart.py
@@ -87,6 +87,7 @@ class BaseChart(BaseRenderer):
             }
             .ap-chart-wrapper {
                 min-height: 400px;
+                display: flex;
                 justify-content: center;
                 align-items: center;
             }


### PR DESCRIPTION
The .ap-chart-wrapper CSS class had justify-content and align-items properties but was missing display: flex, which prevented these properties from working. This caused charts and legends to not render properly in partial HTML mode.

Fixes rendering issue where ECharts legends and charts were not displayed as expected.