### PR TITLE
Add configurable component submodules

### DIFF
--- a/agentui/src/lib/data/mock-data.ts
+++ b/agentui/src/lib/data/mock-data.ts
@@ -145,6 +145,19 @@ const hrModules: Module[] = [
                 icon: 'mdi:account-plus',
                 type: 'module',
                 order: 2
+            },
+            {
+                id: 'sub-emp-hr-chat',
+                slug: 'hr-chat',
+                name: 'HR Chat',
+                description: 'Chat with the HR assistant',
+                icon: 'mdi:robot-outline',
+                type: 'component',
+                path: 'agents/AgentChat.svelte',
+                parameters: {
+                    agent_name: 'hr_agent'
+                },
+                order: 3
             }
         ],
         order: 1

--- a/agentui/src/lib/types/hierarchy.ts
+++ b/agentui/src/lib/types/hierarchy.ts
@@ -52,8 +52,10 @@ export interface Submodule {
     name: string;
     description?: string;
     icon?: string;
-    type: 'container' | 'module'; // tabs vs full-screen
+    type: 'container' | 'module' | 'component'; // tabs vs full-screen
     dashboardConfig?: DashboardConfig;
+    path?: string;
+    parameters?: Record<string, unknown>;
     order?: number;
 }
 


### PR DESCRIPTION
### Motivation

- Allow modules/submodules to render arbitrary Svelte components configured from the submodule data so full‑screen components can be embedded via simple metadata.

### Description

- Extend `Submodule` type to include a new `'component'` type and add `path` and `parameters` fields in `agentui/src/lib/types/hierarchy.ts`.
- Implement dynamic component loading in `agentui/src/routes/program/[slug]/[module]/[submodule]/+page.svelte` using `import.meta.glob` and render the loaded component to cover the module main content area.
- Normalize component parameters (convert snake_case keys to camelCase) before passing them as props to the component via a `normalizeComponentParameters` helper.
- Add a demo HR Chat submodule in `agentui/src/lib/data/mock-data.ts` that maps to `agents/AgentChat.svelte` with `agent_name: 'hr_agent'`.

### Testing

- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and Vite started successfully (UI served at port 4173). (Succeeded)
- Automated browser test: used a Playwright script to visit `/program/hr/employees/hr-chat` and capture a screenshot at `artifacts/hr-chat-component.png` to verify the component rendered; the script completed and produced the artifact. (Succeeded)
- Observed Svelte compile warnings during dev (accessibility and some deprecation notices) but they did not prevent the component from loading. (Informational)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972e3ff7f148330a332a06c59877d2e)