### PR TITLE
Fix session ID sourcing in AgentTalk and Chat handlers

### DIFF
--- a/parrot/handlers/agent.py
+++ b/parrot/handlers/agent.py
@@ -457,7 +457,7 @@ class AgentTalk(BaseView):
         """
         import uuid
         user_id = data.pop('user_id', None) or self.request.get('user_id', None)
-        session_id = data.pop('session_id', None) or self.request.get('session_id', None)
+        session_id = data.pop('session_id', None)
         # Try to get user_id from request session if not provided
         with contextlib.suppress(AttributeError):
             request_session = self.request.session or await get_session(self.request)
@@ -465,7 +465,7 @@ class AgentTalk(BaseView):
                 user_id = request_session.get('user_id')
         # Generate new session_id if not provided by client (never use browser session)
         if not session_id:
-            session_id = str(uuid.uuid4())
+            session_id = uuid.uuid4().hex
         return user_id, session_id
 
     async def post(self):

--- a/parrot/handlers/chat.py
+++ b/parrot/handlers/chat.py
@@ -363,7 +363,7 @@ class ChatHandler(BaseView):
                 # Generate new UUID if not provided - never use browser session
                 session_id = data.pop('session_id', None)
                 if not session_id:
-                    session_id = str(uuid.uuid4())
+                    session_id = uuid.uuid4().hex
                 user_id = session.get('user_id', None)
                 if method:= self._check_methods(bot, method_name):
                     sig = inspect.signature(method)


### PR DESCRIPTION
### Motivation
- Prevent conversation-history mixing by ensuring handlers only use client-provided `session_id` or a freshly generated session identifier rather than falling back to a browser/request session value.

### Description
- Stop using `self.request.get('session_id', ...)` as a fallback in `AgentTalk._get_user_session` and only accept `session_id` provided in the request body or generate a new one.
- Make session generation produce a compact hex UUID by using `uuid.uuid4().hex` in both `parrot/handlers/agent.py` and `parrot/handlers/chat.py` when `session_id` is missing from the payload.
- Changes applied to `parrot/handlers/agent.py` and `parrot/handlers/chat.py` to implement the above behavior.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972ea73d8dc833095f69e50d5d5546b)