### PR TITLE
Add URL-managed image/iframe widgets to Svelte dashboard

### DIFF
--- a/ui/samples/dashboard-test/src/lib/components/dashboard/dashboard-container.svelte
+++ b/ui/samples/dashboard-test/src/lib/components/dashboard/dashboard-container.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
     import { dashboardContainer } from "../../domain/dashboard-container.svelte.js";
+    import { IFrameWidget } from "../../domain/iframe-widget.svelte.js";
+    import { ImageWidget } from "../../domain/image-widget.svelte.js";
     import { Widget } from "../../domain/widget.svelte.js";
     import TabBar from "./tab-bar.svelte";
     import type { WidgetType } from "../../domain/types.js";
@@ -11,11 +13,26 @@
     let activeTab = $derived(dashboardContainer.activeTab);
 
     function handleAddWidget(tab: any, widgetType: WidgetType, name: string) {
-        // Create new widget instance
-        const newWidget = new Widget({
-            title: name,
-            icon: widgetType.icon,
-        });
+        let newWidget: Widget;
+        switch (widgetType.id) {
+            case "iframe":
+                newWidget = new IFrameWidget({
+                    title: name,
+                    icon: widgetType.icon,
+                });
+                break;
+            case "image":
+                newWidget = new ImageWidget({
+                    title: name,
+                    icon: widgetType.icon,
+                });
+                break;
+            default:
+                newWidget = new Widget({
+                    title: name,
+                    icon: widgetType.icon,
+                });
+        }
 
         // Add to the layout of the target tab
         if (tab?.layout) {

--- a/ui/samples/dashboard-test/src/lib/components/modals/widget-settings-modal.svelte
+++ b/ui/samples/dashboard-test/src/lib/components/modals/widget-settings-modal.svelte
@@ -83,6 +83,21 @@
     function handleDialogPointerDown(e: PointerEvent) {
         e.stopPropagation();
     }
+
+    $effect(() => {
+        const activeCustomTab = customTabs.find((tab) => tab.id === activeTabId);
+        if (!activeCustomTab || !renderedTabs.has(activeCustomTab.id)) {
+            return;
+        }
+
+        activeCustomTab.onShow?.();
+        const container = document.querySelector(
+            `.tab-content[data-tab-id="${activeCustomTab.id}"]`,
+        );
+        if (container) {
+            activeCustomTab.render(container as HTMLElement, widget);
+        }
+    });
 </script>
 
 <svelte:window onkeydown={handleKeydown} />

--- a/ui/samples/dashboard-test/src/lib/components/widgets/widget-renderer.svelte
+++ b/ui/samples/dashboard-test/src/lib/components/widgets/widget-renderer.svelte
@@ -3,6 +3,8 @@
     import type { Widget } from "../../domain/widget.svelte.js";
     import { FreeLayout } from "../../domain/layouts/free-layout.svelte.js";
     import { GridLayout } from "../../domain/layouts/grid-layout.svelte.js";
+    import { IFrameWidget } from "../../domain/iframe-widget.svelte.js";
+    import { ImageWidget } from "../../domain/image-widget.svelte.js";
     import ConfirmDialog from "../modals/confirm-dialog.svelte";
     import WidgetSettingsModal from "../modals/widget-settings-modal.svelte";
 
@@ -350,6 +352,31 @@
                 <div class="widget-error">⚠️ {widget.error}</div>
             {:else if content}
                 {@render content()}
+            {:else if widget instanceof ImageWidget}
+                {@const source = widget.getImageSource()}
+                {#if source}
+                    <img
+                        class="widget-media"
+                        src={source}
+                        alt={widget.altText}
+                        style:object-fit={widget.objectFit}
+                    />
+                {:else}
+                    <div class="widget-empty">No image configured</div>
+                {/if}
+            {:else if widget instanceof IFrameWidget}
+                {@const source = widget.getFrameSource()}
+                {#if source}
+                    <iframe
+                        class="widget-media"
+                        src={source}
+                        title={widget.title}
+                        sandbox={widget.sandboxAttr}
+                        allowfullscreen={widget.allowFullscreen}
+                    ></iframe>
+                {:else}
+                    <div class="widget-empty">No URL configured</div>
+                {/if}
             {:else}
                 <div class="widget-empty">No content</div>
             {/if}
@@ -677,6 +704,13 @@
         padding: 0;
         position: relative;
         background: var(--surface, #fff);
+    }
+
+    .widget-media {
+        width: 100%;
+        height: 100%;
+        border: none;
+        display: block;
     }
 
     .widget-loading {

--- a/ui/samples/dashboard-test/src/lib/domain/iframe-widget.svelte.ts
+++ b/ui/samples/dashboard-test/src/lib/domain/iframe-widget.svelte.ts
@@ -1,0 +1,48 @@
+import type { WidgetConfig } from "./widget.svelte.js";
+import { UrlManagedWidget, type UrlManagedConfig } from "./url-managed-widget.svelte.js";
+
+export interface IFrameWidgetConfig extends UrlManagedConfig {
+    sandbox?: string;
+    allowFullscreen?: boolean;
+}
+
+export class IFrameWidget extends UrlManagedWidget {
+    sandboxAttr = $state<string>("allow-scripts allow-same-origin");
+    allowFullscreen = $state<boolean>(true);
+    refreshToken = $state<number>(0);
+
+    constructor(config: IFrameWidgetConfig) {
+        const refreshHandler: WidgetConfig["onRefresh"] = async (widget) => {
+            if (widget instanceof IFrameWidget) {
+                widget.reload();
+            }
+        };
+
+        const { sandbox, allowFullscreen, ...baseConfig } = config;
+        super({
+            ...baseConfig,
+            title: config.title || "Web Content",
+            icon: config.icon ?? "🌐",
+            onRefresh: refreshHandler,
+        });
+
+        this.sandboxAttr = sandbox ?? "allow-scripts allow-same-origin";
+        this.allowFullscreen = allowFullscreen ?? true;
+    }
+
+    reload(): void {
+        this.refreshToken = Date.now();
+    }
+
+    getFrameSource(): string {
+        const source = this.getResolvedSource();
+        if (!source) {
+            return "";
+        }
+        if (!this.refreshToken) {
+            return source;
+        }
+        const separator = source.includes("?") ? "&" : "?";
+        return `${source}${separator}_t=${this.refreshToken}`;
+    }
+}

--- a/ui/samples/dashboard-test/src/lib/domain/image-widget.svelte.ts
+++ b/ui/samples/dashboard-test/src/lib/domain/image-widget.svelte.ts
@@ -1,0 +1,60 @@
+import type { WidgetConfig } from "./widget.svelte.js";
+import { UrlManagedWidget, type UrlManagedConfig } from "./url-managed-widget.svelte.js";
+
+export interface ImageWidgetConfig extends UrlManagedConfig {
+    alt?: string;
+    objectFit?: "contain" | "cover" | "fill" | "none" | "scale-down";
+}
+
+export class ImageWidget extends UrlManagedWidget {
+    altText = $state<string>("");
+    objectFit = $state<"contain" | "cover" | "fill" | "none" | "scale-down">(
+        "contain",
+    );
+    refreshToken = $state<number>(0);
+
+    constructor(config: ImageWidgetConfig) {
+        const refreshHandler: WidgetConfig["onRefresh"] = async (widget) => {
+            if (widget instanceof ImageWidget) {
+                widget.refreshImage();
+            }
+        };
+
+        const { alt, objectFit, ...baseConfig } = config;
+        super({
+            ...baseConfig,
+            title: config.title || "Image",
+            icon: config.icon ?? "🖼️",
+            onRefresh: refreshHandler,
+        });
+
+        this.altText = alt ?? config.title ?? "Image";
+        this.objectFit = objectFit ?? "contain";
+    }
+
+    refreshImage(): void {
+        this.refreshToken = Date.now();
+    }
+
+    getImageSource(): string {
+        const source = this.getResolvedSource();
+        if (!source) {
+            return "";
+        }
+        if (!this.refreshToken) {
+            return source;
+        }
+        const separator = source.includes("?") ? "&" : "?";
+        return `${source}${separator}_t=${this.refreshToken}`;
+    }
+
+    setAlt(text: string): void {
+        this.altText = text;
+    }
+
+    setObjectFit(
+        fit: "contain" | "cover" | "fill" | "none" | "scale-down",
+    ): void {
+        this.objectFit = fit;
+    }
+}

--- a/ui/samples/dashboard-test/src/lib/domain/url-managed-widget.svelte.ts
+++ b/ui/samples/dashboard-test/src/lib/domain/url-managed-widget.svelte.ts
@@ -1,0 +1,136 @@
+import { Widget, type WidgetConfig } from "./widget.svelte.js";
+import type { ConfigTab } from "./types.js";
+
+export interface UrlManagedConfig extends WidgetConfig {
+    url?: string;
+    path?: string;
+}
+
+const sanitizeValue = (value?: string | null): string => {
+    if (!value || value === "undefined") {
+        return "";
+    }
+    return value;
+};
+
+export class UrlManagedWidget extends Widget {
+    url = $state<string>("");
+    path = $state<string>("");
+
+    constructor(config: UrlManagedConfig) {
+        super(config);
+        this.url = sanitizeValue(config.url);
+        this.path = sanitizeValue(config.path);
+    }
+
+    addUrl(url: string): void {
+        this.setUrl(url);
+    }
+
+    addPath(path: string): void {
+        this.setPath(path);
+    }
+
+    setUrl(url: string): void {
+        this.url = sanitizeValue(url);
+    }
+
+    setPath(path: string): void {
+        this.path = sanitizeValue(path);
+    }
+
+    getUrl(): string {
+        return this.url;
+    }
+
+    getPath(): string {
+        return this.path;
+    }
+
+    getResolvedSource(): string {
+        return this.url || this.path;
+    }
+
+    override getConfigTabs(): ConfigTab[] {
+        return [...super.getConfigTabs(), this.createUrlConfigTab()];
+    }
+
+    override onConfigSave(config: Record<string, unknown>): void {
+        super.onConfigSave(config);
+        if (typeof config.url === "string") {
+            this.setUrl(config.url);
+        }
+        if (typeof config.path === "string") {
+            this.setPath(config.path);
+        }
+    }
+
+    protected createUrlConfigTab(): ConfigTab {
+        let urlInput: HTMLInputElement | undefined;
+        let pathInput: HTMLInputElement | undefined;
+
+        const createInput = (
+            label: string,
+            value: string,
+            placeholder: string,
+        ): { wrapper: HTMLDivElement; input: HTMLInputElement } => {
+            const group = document.createElement("div");
+            Object.assign(group.style, { marginBottom: "16px" });
+
+            const inputLabel = document.createElement("label");
+            inputLabel.textContent = label;
+            Object.assign(inputLabel.style, {
+                display: "block",
+                marginBottom: "6px",
+                fontSize: "13px",
+                fontWeight: "500",
+                color: "var(--text, #333)",
+            });
+
+            const input = document.createElement("input");
+            input.type = "text";
+            input.value = value;
+            input.placeholder = placeholder;
+            Object.assign(input.style, {
+                width: "100%",
+                padding: "10px 12px",
+                borderRadius: "6px",
+                border: "1px solid var(--border, #ddd)",
+                fontSize: "14px",
+                boxSizing: "border-box",
+            });
+
+            group.append(inputLabel, input);
+            return { wrapper: group, input };
+        };
+
+        return {
+            id: "url",
+            label: "URL/Path",
+            icon: "🔗",
+            render: (container: HTMLElement) => {
+                container.innerHTML = "";
+
+                const urlGroup = createInput(
+                    "URL",
+                    this.url,
+                    "https://example.com",
+                );
+                urlInput = urlGroup.input;
+
+                const pathGroup = createInput(
+                    "Path",
+                    this.path,
+                    "/path/to/resource",
+                );
+                pathInput = pathGroup.input;
+
+                container.append(urlGroup.wrapper, pathGroup.wrapper);
+            },
+            save: () => ({
+                url: urlInput?.value ?? this.url,
+                path: pathInput?.value ?? this.path,
+            }),
+        };
+    }
+}


### PR DESCRIPTION
### Motivation

- Migrate legacy URL/path-based widget inheritance from the vanilla `ui/Dashboards/src` code into the new Svelte5 sample dashboard so widgets can store and configure external sources. 
- Provide a composable URL/Path management API that can be reused by image, iframe and other URL-based widgets and expose a settings tab for editing those values.

### Description

- Introduce a URL-managed widget base `ui/samples/dashboard-test/src/lib/domain/url-managed-widget.svelte.ts` that holds `url`/`path` state, accessors (`setUrl`, `setPath`, `getResolvedSource`) and a `URL/Path` configuration tab returned from `getConfigTabs()`.
- Add `ImageWidget` and `IFrameWidget` classes in `ui/samples/dashboard-test/src/lib/domain/image-widget.svelte.ts` and `.../iframe-widget.svelte.ts` that inherit from the URL-managed base, implement refresh/reload helpers and expose helper methods (`getImageSource`, `getFrameSource`, `refreshImage`, `reload`).
- Render image/iframe content in the UI by updating `ui/samples/dashboard-test/src/lib/components/widgets/widget-renderer.svelte` to detect `ImageWidget`/`IFrameWidget` instances and inject an `<img>` or `<iframe>` into `.widget-content` with appropriate attributes and styling.
- Wire widget creation flow in `ui/samples/dashboard-test/src/lib/components/dashboard/dashboard-container.svelte` so selecting the “image” or “iframe” types instantiates the new widget classes, and ensure custom settings tabs are rendered by calling `render` and `onShow` in `ui/samples/dashboard-test/src/lib/components/modals/widget-settings-modal.svelte`.

### Testing

- Attempted dependency install with `npm install` inside `ui/samples/dashboard-test` which populated `node_modules` but no automated unit tests were executed.
- Tried to run the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` but it failed with `vite: not found`, so runtime validation of the UI was not completed.
- No automated test suites (unit/integration) were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979f9db7aec83309ad35754f24aac47)