### PR TITLE
Refine .gitignore patterns for better path specificity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+/lib/
 lib64/
 parts/
 sdist/
@@ -47,7 +47,7 @@ var/
 wheels/
 share/python-wheels/
 *.egg-info/
-settings/*
+/settings/*
 .installed.cfg
 *.egg
 MANIFEST
@@ -127,9 +127,6 @@ ipython_config.py
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
-!/crew-builder/src/lib/
-!/agentui/src/lib/
-!/ui/samples/dashboard-test/src/lib/
 #   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
 #poetry.lock
 
@@ -239,7 +236,7 @@ runs/
 train/
 
 # Navigator configuration
-settings/
+/settings/
 templates/
 resources/
 logs/
@@ -307,5 +304,3 @@ Thumbs.db
 .idea/
 .vscode/
 
-# Allow src/lib (SvelteKit)
-!src/lib/


### PR DESCRIPTION
## Summary
Updated `.gitignore` file to improve path matching specificity by adding leading slashes to directory patterns and removing outdated exception rules.

## Key Changes
- Added leading slashes (`/`) to `lib/`, `settings/` patterns to match only root-level directories, preventing unintended matches in subdirectories
- Removed outdated negation patterns that were attempting to whitelist `src/lib/` directories across multiple project paths:
  - `!/crew-builder/src/lib/`
  - `!/agentui/src/lib/`
  - `!/ui/samples/dashboard-test/src/lib/`
  - `!src/lib/`

## Implementation Details
The leading slash prefix ensures these patterns only apply to directories at the repository root level, not nested directories with the same name. This prevents accidental ignoring of important source files in subdirectories while maintaining the intended behavior of ignoring root-level build artifacts and configuration directories.

The removal of the negation patterns suggests these whitelisting rules are no longer necessary, likely due to project restructuring or changes in how these directories are managed.

https://claude.ai/code/session_01SzYG8ZpCdAANBu3pf9wn83