### PR TITLE
Add chart settings and data tabs for dashboard chart widgets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,6 +246,8 @@ logs/
 etc/
 documents/
 work/
+!/ui/samples/dashboard-test/src/lib/components/settings/
+!/ui/samples/dashboard-test/src/lib/components/settings/**
 
 # Custom Agents:
 plugins/agents/

--- a/ui/samples/dashboard-test/src/lib/components/settings/chart-data-tab.svelte
+++ b/ui/samples/dashboard-test/src/lib/components/settings/chart-data-tab.svelte
@@ -1,0 +1,183 @@
+<script lang="ts">
+    import type { BaseChartWidget } from "../../domain/base-chart-widget.svelte.js";
+    import type { DataSourceConfig } from "../../domain/data-source.svelte.js";
+    import type { QSDataSourceConfig } from "../../domain/qs-datasource.svelte.js";
+
+    interface Props {
+        widget: BaseChartWidget;
+        onConfigChange: (config: {
+            dataSourceType: "rest" | "qs" | "json";
+            restConfig?: DataSourceConfig;
+            qsConfig?: QSDataSourceConfig;
+            jsonConfig?: { mode: "inline" | "url"; json?: string; url?: string };
+        }) => void;
+        onApply: () => void;
+    }
+
+    let { widget, onConfigChange, onApply }: Props = $props();
+
+    let dataSourceType = $state<"rest" | "qs" | "json">(
+        widget.dataSourceType,
+    );
+    let restUrl = $state(widget.restConfig?.url ?? "");
+    let qsSlug = $state(widget.qsConfig?.slug ?? "");
+    let qsBaseUrl = $state(widget.qsConfig?.baseUrl ?? "");
+    let jsonMode = $state<"inline" | "url">(
+        widget.jsonConfig?.mode ?? "inline",
+    );
+    let jsonText = $state(widget.jsonConfig?.json ?? "[]");
+    let jsonUrl = $state(widget.jsonConfig?.url ?? "");
+
+    $effect(() => {
+        const restConfig = restUrl.trim()
+            ? ({ url: restUrl.trim() } as DataSourceConfig)
+            : undefined;
+        const qsConfig = qsSlug.trim()
+            ? ({
+                  slug: qsSlug.trim(),
+                  baseUrl: qsBaseUrl.trim() || undefined,
+              } as QSDataSourceConfig)
+            : undefined;
+
+        const jsonConfig = {
+            mode: jsonMode,
+            json: jsonMode === "inline" ? jsonText : undefined,
+            url: jsonMode === "url" ? jsonUrl.trim() : undefined,
+        };
+
+        onConfigChange({
+            dataSourceType,
+            restConfig,
+            qsConfig,
+            jsonConfig,
+        });
+    });
+</script>
+
+<div class="chart-data">
+    <div class="form-group">
+        <label for="data-source-type">Data Source</label>
+        <select id="data-source-type" bind:value={dataSourceType}>
+            <option value="json">JSON</option>
+            <option value="rest">REST API</option>
+            <option value="qs">QuerySource</option>
+        </select>
+    </div>
+
+    {#if dataSourceType === "rest"}
+        <div class="form-group">
+            <label for="rest-url">REST URL</label>
+            <input
+                id="rest-url"
+                type="url"
+                placeholder="https://api.example.com/data"
+                bind:value={restUrl}
+            />
+        </div>
+    {:else if dataSourceType === "qs"}
+        <div class="form-row">
+            <div class="form-group">
+                <label for="qs-slug">QuerySource Slug</label>
+                <input
+                    id="qs-slug"
+                    type="text"
+                    placeholder="sales-summary"
+                    bind:value={qsSlug}
+                />
+            </div>
+            <div class="form-group">
+                <label for="qs-base-url">QuerySource Base URL</label>
+                <input
+                    id="qs-base-url"
+                    type="url"
+                    placeholder="http://localhost:5000"
+                    bind:value={qsBaseUrl}
+                />
+            </div>
+        </div>
+    {:else}
+        <div class="form-group">
+            <label for="json-mode">JSON Mode</label>
+            <select id="json-mode" bind:value={jsonMode}>
+                <option value="inline">Inline JSON</option>
+                <option value="url">JSON URL</option>
+            </select>
+        </div>
+
+        {#if jsonMode === "inline"}
+            <div class="form-group">
+                <label for="json-inline">JSON Array</label>
+                <textarea
+                    id="json-inline"
+                    rows="6"
+                    bind:value={jsonText}
+                    placeholder='[{"label":"A","value":10}]'
+                ></textarea>
+            </div>
+        {:else}
+            <div class="form-group">
+                <label for="json-url">JSON URL</label>
+                <input
+                    id="json-url"
+                    type="url"
+                    placeholder="https://example.com/data.json"
+                    bind:value={jsonUrl}
+                />
+            </div>
+        {/if}
+    {/if}
+
+    <div class="actions">
+        <button type="button" class="btn-apply" onclick={onApply}>
+            Apply Data
+        </button>
+    </div>
+</div>
+
+<style>
+    .chart-data {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+    }
+
+    .form-row {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 12px;
+    }
+
+    .form-group {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+    }
+
+    .form-group label {
+        font-size: 0.85rem;
+        font-weight: 600;
+    }
+
+    .form-group input,
+    .form-group select,
+    .form-group textarea {
+        padding: 8px 10px;
+        border-radius: 6px;
+        border: 1px solid var(--border, #444);
+        background: var(--surface-2, #1f1f1f);
+        color: inherit;
+    }
+
+    .actions {
+        display: flex;
+        justify-content: flex-end;
+    }
+
+    .btn-apply {
+        background: var(--primary, #1a73e8);
+        color: #fff;
+        border: none;
+        padding: 8px 14px;
+        border-radius: 6px;
+    }
+</style>

--- a/ui/samples/dashboard-test/src/lib/components/settings/chart-settings-tab.svelte
+++ b/ui/samples/dashboard-test/src/lib/components/settings/chart-settings-tab.svelte
@@ -1,0 +1,174 @@
+<script lang="ts">
+    import type {
+        BaseChartWidget,
+        ChartType,
+    } from "../../domain/base-chart-widget.svelte.js";
+
+    interface Props {
+        widget: BaseChartWidget;
+        onConfigChange: (config: {
+            chartType?: ChartType;
+            xAxis?: string;
+            yAxis?: string;
+            labelColumn?: string;
+            dataColumn?: string;
+        }) => void;
+    }
+
+    let { widget, onConfigChange }: Props = $props();
+
+    const chartTypes: Array<{ value: ChartType; label: string }> = [
+        { value: "bar", label: "Bar" },
+        { value: "line", label: "Line" },
+        { value: "area", label: "Area" },
+        { value: "stacked-area", label: "Stacked Area" },
+        { value: "pie", label: "Pie" },
+        { value: "donut", label: "Donut" },
+        { value: "scatter", label: "Scatter" },
+    ];
+
+    let chartType = $state<ChartType>(widget.chartType);
+    let xAxis = $state(widget.xAxis ?? "");
+    let yAxis = $state(widget.yAxis ?? "");
+    let labelColumn = $state(widget.labelColumn ?? "");
+    let dataColumn = $state(widget.dataColumn ?? "");
+
+    let availableColumns = $derived.by(() => {
+        const data = widget.chartData;
+        if (!data.length) return [] as string[];
+        const sample = data.find((row) => typeof row === "object" && row !== null);
+        if (!sample || Array.isArray(sample)) return [] as string[];
+        return Object.keys(sample as Record<string, unknown>);
+    });
+
+    let isPieChart = $derived.by(() => ["pie", "donut"].includes(chartType));
+
+    $effect(() => {
+        onConfigChange({
+            chartType,
+            xAxis,
+            yAxis,
+            labelColumn,
+            dataColumn,
+        });
+    });
+</script>
+
+<div class="chart-settings">
+    <div class="form-group">
+        <label for="chart-type">Chart Type</label>
+        <select id="chart-type" bind:value={chartType}>
+            {#each chartTypes as type}
+                <option value={type.value}>{type.label}</option>
+            {/each}
+        </select>
+    </div>
+
+    {#if isPieChart}
+        <div class="form-row">
+            <div class="form-group">
+                <label for="label-column">Label Column</label>
+                <input
+                    id="label-column"
+                    type="text"
+                    list="chart-column-options"
+                    bind:value={labelColumn}
+                    placeholder="e.g. category"
+                />
+            </div>
+            <div class="form-group">
+                <label for="data-column">Value Column</label>
+                <input
+                    id="data-column"
+                    type="text"
+                    list="chart-column-options"
+                    bind:value={dataColumn}
+                    placeholder="e.g. amount"
+                />
+            </div>
+        </div>
+    {:else}
+        <div class="form-row">
+            <div class="form-group">
+                <label for="x-axis">X Axis</label>
+                <input
+                    id="x-axis"
+                    type="text"
+                    list="chart-column-options"
+                    bind:value={xAxis}
+                    placeholder="e.g. date"
+                />
+            </div>
+            <div class="form-group">
+                <label for="y-axis">Y Axis</label>
+                <input
+                    id="y-axis"
+                    type="text"
+                    list="chart-column-options"
+                    bind:value={yAxis}
+                    placeholder="e.g. total"
+                />
+            </div>
+        </div>
+    {/if}
+
+    {#if availableColumns.length}
+        <p class="helper-text">
+            Available columns: {availableColumns.join(", ")}
+        </p>
+    {:else}
+        <p class="helper-text helper-muted">
+            Load data first to see column suggestions.
+        </p>
+    {/if}
+
+    <datalist id="chart-column-options">
+        {#each availableColumns as column}
+            <option value={column}></option>
+        {/each}
+    </datalist>
+</div>
+
+<style>
+    .chart-settings {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+    }
+
+    .form-row {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 12px;
+    }
+
+    .form-group {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+    }
+
+    .form-group label {
+        font-size: 0.85rem;
+        font-weight: 600;
+    }
+
+    .form-group input,
+    .form-group select {
+        padding: 8px 10px;
+        border-radius: 6px;
+        border: 1px solid var(--border, #444);
+        background: var(--surface-2, #1f1f1f);
+        color: inherit;
+    }
+
+    .helper-text {
+        margin: 0;
+        font-size: 0.8rem;
+        color: var(--text-2, #9aa0a6);
+    }
+
+    .helper-muted {
+        opacity: 0.8;
+    }
+</style>


### PR DESCRIPTION
### Motivation
- The dashboard chart widgets were auto-detecting data but lacked UI to change chart type, X/Y axes or switch data sources, because the settings tab components were missing or ignored by source control.

### Description
- Add `ChartSettingsTab` component at `ui/samples/dashboard-test/src/lib/components/settings/chart-settings-tab.svelte` to allow selecting chart type and X/Y/label/value fields with available-column suggestions.
- Add `ChartDataTab` component at `ui/samples/dashboard-test/src/lib/components/settings/chart-data-tab.svelte` to configure the widget data source (inline JSON, JSON URL, REST, or QuerySource) and trigger data apply/reload.
- Update `.gitignore` so the new settings components under `ui/samples/dashboard-test/src/lib/components/settings/` are tracked by the repository.
- These components integrate with the existing settings modal which already imports `ChartSettingsTab` and `ChartDataTab`, enabling axis/type selection and data-source switching in the modal.

### Testing
- Attempted to run `npm install` in `ui/samples/dashboard-test` to validate the UI build, but the install failed with a `403 Forbidden` while fetching a registry package so the sample app build was not completed.
- No automated unit tests were run as part of this change due to the failed dependency install preventing a full local build/test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b1bb2b6948330b702a54171b6e38d)