### PR TITLE
Add deep-research routing and GPT-5.2 model support to OpenAI client

### DIFF
--- a/parrot/models/openai.py
+++ b/parrot/models/openai.py
@@ -5,6 +5,7 @@ class OpenAIModel(Enum):
     """Enum class for OpenAI models."""
     GPT5_MINI = "gpt-5-mini"
     GPT5 = "gpt-5"
+    GPT5_2 = "gpt-5.2"
     GPT5_CHAT = "gpt-5-chat-latest"
     GPT5_PRO = "gpt-5-pro"
     GPT5_NANO = "gpt-5-nano"


### PR DESCRIPTION
### Motivation
- Support OpenAI "deep research" workflows by allowing the client to route requests to the new deep-research models and include research-specific tooling and payload flags.
- Ensure structured-output support for the new `gpt-5.2` model so JSON/structured outputs work as expected.

### Description
- Add `GPT5_2 = "gpt-5.2"` to the `OpenAIModel` enum and include `OpenAIModel.GPT5_2.value` in `STRUCTURED_OUTPUT_COMPATIBLE_MODELS` so structured output is allowed with that model.
- Add a static helper `OpenAIClient._resolve_deep_research_model` to pick between `o3-deep-research` and `o4-mini-deep-research` and use it when `deep_research` is requested.
- Update `ask` and `ask_stream` routing to honor the `deep_research` flag by switching models when appropriate, merging research tools into the request, and always including a `code_interpreter` tool container with `"memory_limit": "4g"` when `enable_code_interpreter` is set.
- Ensure the `background` flag is propagated into Responses API payloads by adding it to `_prepare_responses_args` and setting `args['background'] = True` when `deep_research` and `background` are both true.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69832b7b15208330a110ccb982b60b97)