### PR TITLE
AgentTalk: accept session ToolManager configuration via `tools` / `tool_config` POST payload

### DIFF
--- a/parrot/models/__init__.py
+++ b/parrot/models/__init__.py
@@ -4,7 +4,7 @@ Includes definitions for various data structures used in the application,
 such as responses, outputs, and configurations.
 """
 
-from .basic import OutputFormat, ToolCall, CompletionUsage
+from .basic import OutputFormat, ToolCall, CompletionUsage, ToolConfig
 from .responses import (
     AIMessage,
     SourceDocument,
@@ -35,6 +35,7 @@ __all__ = (
     "OutputFormat",
     "ToolCall",
     "CompletionUsage",
+    "ToolConfig",
     "AIMessage",
     "AIMessageFactory",
     "SourceDocument",

--- a/parrot/models/basic.py
+++ b/parrot/models/basic.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Any
+from typing import Dict, Optional, Any, List
 from enum import Enum
 from pydantic import BaseModel, Field
 
@@ -22,6 +22,12 @@ class ToolCall(BaseModel):
     result: Optional[Any] = None
     error: Optional[str] = None
     execution_time: Optional[float] = None
+
+
+class ToolConfig(BaseModel):
+    """Tool configuration for session-scoped ToolManager setup."""
+    tools: List[Dict[str, Any]] = Field(default_factory=list)
+    mcp_servers: List[Dict[str, Any]] = Field(default_factory=list)
 
 
 class CompletionUsage(BaseModel):


### PR DESCRIPTION
### Motivation
- Allow clients to pass tool definitions and MCP server configs directly to the AgentTalk POST endpoint so frontends can provide a customized per-session ToolManager. 
- Persist per-session ToolManager configuration so agents can be run with a session-scoped toolset instead of only using global ToolManager instances.

### Description
- Add a `ToolConfig` Pydantic model in `parrot/models/basic.py` to represent `{tools: [...], mcp_servers: [...]}` payloads and export it from `parrot/models/__init__.py`.
- Extend `AgentTalk` (`parrot/handlers/agent.py`) to parse `tools` and `tool_config` payloads and validate them via `ToolConfig`, creating a session `ToolManager` when provided (`_configure_tool_manager`).
- Wire MCP server setup into session ToolManagers with a helper `_add_mcp_servers_to_tool_manager`, and assign the constructed `ToolManager` to the agent (`agent.tool_manager`), enabling tools and syncing to the LLM where appropriate.
- Surface configuration validation errors as `400` responses and store `tool_manager` and `tool_config` in the request session when applicable.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69879b0615d0833089cca6a1b0810463)