### PR TITLE
Add Slack agent wrapper with command and rich Block Kit support

### DIFF
--- a/parrot/integrations/__init__.py
+++ b/parrot/integrations/__init__.py
@@ -5,12 +5,14 @@ Provides integration modules for various platforms:
 - telegram: Expose agents via Telegram bots
 - msteams: Expose agents via MS Teams bots
 - whatsapp: Expose agents via WhatsApp Business API
+- slack: Expose agents via Slack Events API
 """
 from .models import (
     IntegrationBotConfig,
     TelegramAgentConfig,
     MSTeamsAgentConfig,
     WhatsAppAgentConfig,
+    SlackAgentConfig,
 )
 from .manager import IntegrationBotManager
 
@@ -20,4 +22,5 @@ __all__ = [
     "MSTeamsAgentConfig",
     "WhatsAppAgentConfig",
     "IntegrationBotConfig",
+    "SlackAgentConfig",
 ]

--- a/parrot/integrations/models.py
+++ b/parrot/integrations/models.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Any, Union
 from .telegram.models import TelegramAgentConfig
 from .msteams.models import MSTeamsAgentConfig
 from .whatsapp.models import WhatsAppAgentConfig
+from .slack.models import SlackAgentConfig
 
 
 @dataclass
@@ -28,7 +29,7 @@ class IntegrationBotConfig:
             client_id: "xxx"
             client_secret: "yyy"
     """
-    agents: Dict[str, Union[TelegramAgentConfig, MSTeamsAgentConfig, WhatsAppAgentConfig]] = field(default_factory=dict)
+    agents: Dict[str, Union[TelegramAgentConfig, MSTeamsAgentConfig, WhatsAppAgentConfig, SlackAgentConfig]] = field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'IntegrationBotConfig':
@@ -43,6 +44,8 @@ class IntegrationBotConfig:
                 agents[name] = MSTeamsAgentConfig.from_dict(name, agent_data)
             elif kind == 'whatsapp':
                 agents[name] = WhatsAppAgentConfig.from_dict(name, agent_data)
+            elif kind == 'slack':
+                agents[name] = SlackAgentConfig.from_dict(name, agent_data)
         return cls(agents=agents)
 
     def validate(self) -> List[str]:
@@ -76,5 +79,10 @@ class IntegrationBotConfig:
                 if not agent_config.verify_token:
                     errors.append(
                         f"Agent '{name}': missing verify_token"
+                    )
+            elif isinstance(agent_config, SlackAgentConfig):
+                if not agent_config.bot_token:
+                    errors.append(
+                        f"Agent '{name}': missing bot_token"
                     )
         return errors

--- a/parrot/integrations/slack/__init__.py
+++ b/parrot/integrations/slack/__init__.py
@@ -1,0 +1,6 @@
+"""Slack integration module."""
+
+from .models import SlackAgentConfig
+from .wrapper import SlackAgentWrapper
+
+__all__ = ["SlackAgentConfig", "SlackAgentWrapper"]

--- a/parrot/integrations/slack/models.py
+++ b/parrot/integrations/slack/models.py
@@ -1,0 +1,38 @@
+"""Data models for Slack bot configuration."""
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Any
+from navconfig import config
+
+
+@dataclass
+class SlackAgentConfig:
+    """Configuration for a single agent exposed via Slack."""
+
+    name: str
+    chatbot_id: str
+    bot_token: Optional[str] = None
+    signing_secret: Optional[str] = None
+    kind: str = "slack"
+    welcome_message: Optional[str] = None
+    commands: Dict[str, str] = field(default_factory=dict)
+    allowed_channel_ids: Optional[list[str]] = None
+    webhook_path: Optional[str] = None
+
+    def __post_init__(self):
+        if not self.bot_token:
+            self.bot_token = config.get(f"{self.name.upper()}_SLACK_BOT_TOKEN")
+        if not self.signing_secret:
+            self.signing_secret = config.get(f"{self.name.upper()}_SLACK_SIGNING_SECRET")
+
+    @classmethod
+    def from_dict(cls, name: str, data: Dict[str, Any]) -> 'SlackAgentConfig':
+        return cls(
+            name=name,
+            chatbot_id=data.get("chatbot_id", name),
+            bot_token=data.get("bot_token"),
+            signing_secret=data.get("signing_secret"),
+            welcome_message=data.get("welcome_message"),
+            commands=data.get("commands", {}),
+            allowed_channel_ids=data.get("allowed_channel_ids"),
+            webhook_path=data.get("webhook_path"),
+        )

--- a/parrot/integrations/slack/wrapper.py
+++ b/parrot/integrations/slack/wrapper.py
@@ -1,0 +1,167 @@
+"""Slack Agent Wrapper."""
+import json
+import logging
+from typing import Dict, Any, TYPE_CHECKING
+
+from aiohttp import web, ClientSession
+
+from .models import SlackAgentConfig
+from ..parser import parse_response, ParsedResponse
+from ...models.outputs import OutputMode
+
+if TYPE_CHECKING:
+    from ...bots.abstract import AbstractBot
+    from ...memory import ConversationMemory
+
+
+class SlackAgentWrapper:
+    """Wrap an AI-Parrot agent for Slack Events and slash commands."""
+
+    def __init__(self, agent: 'AbstractBot', config: SlackAgentConfig, app: web.Application):
+        self.agent = agent
+        self.config = config
+        self.app = app
+        self.logger = logging.getLogger(f"SlackWrapper.{config.name}")
+        self.conversations: Dict[str, 'ConversationMemory'] = {}
+
+        safe_id = self.config.chatbot_id.replace(" ", "_").lower()
+        self.events_route = config.webhook_path or f"/api/slack/{safe_id}/events"
+        self.commands_route = f"/api/slack/{safe_id}/commands"
+
+        app.router.add_post(self.events_route, self._handle_events)
+        app.router.add_post(self.commands_route, self._handle_command)
+
+        if auth := app.get("auth"):
+            auth.add_exclude_list(self.events_route)
+            auth.add_exclude_list(self.commands_route)
+
+    def _get_or_create_memory(self, session_id: str) -> 'ConversationMemory':
+        if session_id not in self.conversations:
+            from ...memory import InMemoryConversation
+            self.conversations[session_id] = InMemoryConversation()
+        return self.conversations[session_id]
+
+    def _is_authorized(self, channel_id: str) -> bool:
+        if self.config.allowed_channel_ids is None:
+            return True
+        return channel_id in self.config.allowed_channel_ids
+
+    async def _handle_events(self, request: web.Request) -> web.Response:
+        payload = await request.json()
+        if payload.get("type") == "url_verification":
+            return web.json_response({"challenge": payload.get("challenge")})
+
+        event = payload.get("event", {})
+        if event.get("type") not in {"app_mention", "message"}:
+            return web.json_response({"ok": True})
+        if event.get("subtype") == "bot_message":
+            return web.json_response({"ok": True})
+
+        channel = event.get("channel")
+        if not channel or not self._is_authorized(channel):
+            return web.json_response({"ok": True})
+
+        text = (event.get("text") or "").strip()
+        user = event.get("user") or "unknown"
+        thread_ts = event.get("thread_ts") or event.get("ts")
+        session_id = f"{channel}:{user}"
+        await self._answer(channel=channel, user=user, text=text, thread_ts=thread_ts, session_id=session_id)
+        return web.json_response({"ok": True})
+
+    async def _handle_command(self, request: web.Request) -> web.Response:
+        data = await request.post()
+        channel = data.get("channel_id", "")
+        user = data.get("user_id", "unknown")
+        text = (data.get("text") or "").strip()
+
+        if not channel or not self._is_authorized(channel):
+            return web.json_response({"response_type": "ephemeral", "text": "Unauthorized channel."})
+
+        if text.lower() in {"help", "/help"}:
+            return web.json_response({"response_type": "ephemeral", "text": self._help_text()})
+        if text.lower() in {"clear", "/clear"}:
+            self.conversations.pop(f"{channel}:{user}", None)
+            return web.json_response({"response_type": "ephemeral", "text": "Conversation cleared."})
+        if text.lower() in {"commands", "/commands"}:
+            return web.json_response({"response_type": "ephemeral", "text": "Available commands: help, clear, commands"})
+
+        await self._answer(channel=channel, user=user, text=text, thread_ts=None, session_id=f"{channel}:{user}")
+        return web.json_response({"response_type": "ephemeral", "text": "Processing..."})
+
+    async def _answer(self, channel: str, user: str, text: str, thread_ts: str | None, session_id: str) -> None:
+        memory = self._get_or_create_memory(session_id)
+        try:
+            response = await self.agent.ask(
+                text,
+                memory=memory,
+                output_mode=OutputMode.SLACK,
+                session_id=session_id,
+                user_id=user,
+            )
+        except Exception as exc:
+            self.logger.error("Error generating Slack response: %s", exc, exc_info=True)
+            await self._post_message(channel, "Sorry, I encountered an error while processing your request.", thread_ts=thread_ts)
+            return
+
+        parsed = parse_response(response)
+        blocks = self._build_blocks(parsed)
+        fallback = parsed.text or "Done."
+        await self._post_message(channel, fallback, blocks=blocks, thread_ts=thread_ts)
+
+    @staticmethod
+    def _build_blocks(parsed: ParsedResponse) -> list[Dict[str, Any]]:
+        blocks: list[Dict[str, Any]] = []
+        if parsed.text:
+            blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": parsed.text[:3000]}})
+
+        if parsed.has_code and parsed.code:
+            lang = parsed.code_language or ""
+            blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": f"```{lang}\n{parsed.code}\n```"[:3000]}})
+
+        if parsed.has_table and parsed.table_markdown:
+            blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": f"```\n{parsed.table_markdown}\n```"[:3000]}})
+
+        for img in parsed.images:
+            image_url = str(img)
+            if image_url.startswith("http://") or image_url.startswith("https://"):
+                blocks.append(
+                    {
+                        "type": "image",
+                        "image_url": image_url,
+                        "alt_text": img.name,
+                    }
+                )
+            else:
+                blocks.append({"type": "context", "elements": [{"type": "mrkdwn", "text": f"Image generated: `{img}`"}]})
+
+        return blocks or [{"type": "section", "text": {"type": "mrkdwn", "text": "No content."}}]
+
+    def _help_text(self) -> str:
+        return "Use `/ask <question>` (or configured slash command) to query the agent.\nCommands: help, clear, commands"
+
+    async def _post_message(
+        self,
+        channel: str,
+        text: str,
+        blocks: list[Dict[str, Any]] | None = None,
+        thread_ts: str | None = None,
+    ) -> None:
+        if not self.config.bot_token:
+            self.logger.warning("Slack bot token is not configured; cannot send message")
+            return
+
+        payload: Dict[str, Any] = {"channel": channel, "text": text}
+        if blocks:
+            payload["blocks"] = blocks
+        if thread_ts:
+            payload["thread_ts"] = thread_ts
+
+        headers = {
+            "Authorization": f"Bearer {self.config.bot_token}",
+            "Content-Type": "application/json; charset=utf-8",
+        }
+        async with ClientSession() as session:
+            async with session.post("https://slack.com/api/chat.postMessage", headers=headers, data=json.dumps(payload)) as resp:
+                if resp.status >= 400:
+                    self.logger.error("Slack API error: status=%s body=%s", resp.status, await resp.text())
+

--- a/tests/test_slack_integration.py
+++ b/tests/test_slack_integration.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+from parrot.integrations.parser import ParsedResponse
+from parrot.integrations.slack.wrapper import SlackAgentWrapper
+from parrot.integrations.models import IntegrationBotConfig
+
+
+def test_build_blocks_supports_markdown_code_table_and_images():
+    parsed = ParsedResponse(
+        text="*hello*",
+        code="print('x')",
+        code_language="python",
+        table_markdown="|A|\n|---|\n|1|",
+        images=[Path("https://example.com/img.png"), Path("/tmp/local.png")],
+    )
+
+    blocks = SlackAgentWrapper._build_blocks(parsed)
+
+    assert any(b.get("type") == "section" and b["text"]["type"] == "mrkdwn" for b in blocks)
+    assert any(b.get("type") == "image" for b in blocks)
+    assert any(b.get("type") == "context" for b in blocks)
+
+
+def test_integration_config_parses_slack_kind():
+    cfg = IntegrationBotConfig.from_dict(
+        {
+            "agents": {
+                "sales": {
+                    "kind": "slack",
+                    "chatbot_id": "sales_bot",
+                    "bot_token": "xoxb-123",
+                }
+            }
+        }
+    )
+
+    assert "sales" in cfg.agents
+    assert cfg.validate() == []


### PR DESCRIPTION
### Motivation
- Add Slack as a first-class integration so AI-Parrot agents can be exposed via Slack Events API and slash command webhooks. 
- Provide a simple built-in command surface (`help`, `clear`, `commands`) and per-channel/user conversation memory for interactive Slack usage. 
- Render agent output as Slack Block Kit content (markdown sections, code blocks, tables, images/context) for richer responses. 

### Description
- Add `parrot/integrations/slack/wrapper.py` implementing `SlackAgentWrapper` which handles Events API webhooks, slash commands, per-session memory, agent calls (`agent.ask`) and builds Slack Block Kit payloads for text, code, tables and images. 
- Add `parrot/integrations/slack/models.py` defining `SlackAgentConfig` with env fallback for `bot_token` and `signing_secret`, and `parrot/integrations/slack/__init__.py` to export the Slack integration. 
- Wire Slack into the unified integration model by updating `parrot/integrations/models.py` to recognize `kind: slack` and validate required credentials. 
- Update `parrot/integrations/manager.py` to initialize and track `SlackAgentWrapper` instances during startup and include them in shutdown cleanup. 
- Add unit tests `tests/test_slack_integration.py` that validate block generation and `IntegrationBotConfig` parsing for Slack. 

### Testing
- Static verification: ran `python -m py_compile parrot/integrations/slack/models.py parrot/integrations/slack/wrapper.py parrot/integrations/slack/__init__.py parrot/integrations/models.py parrot/integrations/manager.py parrot/integrations/__init__.py tests/test_slack_integration.py` and it succeeded. 
- Attempted test run with `pytest -q tests/test_slack_integration.py tests/test_integration_wrappers.py` but test collection failed due to missing optional runtime dependencies (`ModuleNotFoundError: markdown2`, `ModuleNotFoundError: aiohttp`) in the environment. 
- Tried to install the missing packages with `pip install aiohttp markdown2 -q` but network/proxy restrictions prevented installation in this environment, so full pytest run could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699444274e6883309b7329bc6aa751bc)