### PR TITLE
Add GCP provider support to CloudSploit toolkit

### DIFF
--- a/parrot/tools/cloudsploit/__init__.py
+++ b/parrot/tools/cloudsploit/__init__.py
@@ -1,5 +1,6 @@
 """CloudSploit Security Scanning Toolkit for AI-Parrot."""
 from .models import (
+    CloudProvider,
     CloudSploitConfig,
     ComparisonReport,
     ComplianceFramework,
@@ -12,6 +13,7 @@ from .toolkit import CloudSploitToolkit
 
 __all__ = [
     "CloudSploitToolkit",
+    "CloudProvider",
     "CloudSploitConfig",
     "ScanResult",
     "ScanFinding",

--- a/parrot/tools/cloudsploit/models.py
+++ b/parrot/tools/cloudsploit/models.py
@@ -22,6 +22,13 @@ class ComplianceFramework(str, Enum):
     PCI = "pci"
 
 
+class CloudProvider(str, Enum):
+    """Supported cloud providers for CloudSploit scans."""
+    AWS = "aws"
+    GCP = "google"
+    AZURE = "azure"
+
+
 class ScanFinding(BaseModel):
     """A single finding from a CloudSploit scan."""
     plugin: str = Field(..., description="Plugin identifier")
@@ -81,6 +88,11 @@ class CloudSploitConfig(BaseModel):
         description="Path to CloudSploit CLI when not using Docker"
     )
 
+    cloud_provider: CloudProvider = Field(
+        default=CloudProvider.AWS,
+        description="Cloud provider target for scans (aws, google, azure)"
+    )
+
     # AWS credentials — explicit keys
     aws_access_key_id: Optional[str] = Field(
         default=None, description="AWS access key ID"
@@ -106,6 +118,15 @@ class CloudSploitConfig(BaseModel):
     )
     aws_sdk_load_config: str = Field(
         default="1", description="Enable AWS SDK load config (AWS_SDK_LOAD_CONFIG)"
+    )
+
+    # GCP credentials
+    gcp_project_id: Optional[str] = Field(
+        default=None, description="Google Cloud project ID"
+    )
+    gcp_credentials_path: Optional[str] = Field(
+        default=None,
+        description="Path to GCP service account JSON file"
     )
     timeout_seconds: int = Field(
         default=600, description="Maximum scan duration in seconds"

--- a/parrot/tools/cloudsploit/toolkit.py
+++ b/parrot/tools/cloudsploit/toolkit.py
@@ -47,7 +47,7 @@ class CloudSploitToolkit(AbstractToolkit):
         ignore_ok: bool = False,
         suppress: Optional[list[str]] = None,
     ) -> ScanResult:
-        """Run a CloudSploit security scan against AWS infrastructure.
+        """Run a CloudSploit security scan against cloud infrastructure.
 
         Args:
             plugins: Specific plugins to run. If None, runs all plugins.
@@ -195,8 +195,8 @@ class CloudSploitToolkit(AbstractToolkit):
 
         Args:
             severity: Filter by severity level (OK, WARN, FAIL, UNKNOWN).
-            category: Filter by AWS service category (e.g., EC2, S3, IAM).
-            region: Filter by AWS region.
+            category: Filter by service category (e.g., EC2, S3, IAM).
+            region: Filter by cloud region.
 
         Returns:
             List of finding dictionaries matching the filters.

--- a/tests/tools/cloudsploit/test_models.py
+++ b/tests/tools/cloudsploit/test_models.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from parrot.tools.cloudsploit.models import (
     SeverityLevel,
     ComplianceFramework,
+    CloudProvider,
     ScanFinding,
     ScanSummary,
     ScanResult,
@@ -137,6 +138,13 @@ class TestScanSummary:
         assert summary.duration_seconds == 123.45
 
 
+class TestCloudProvider:
+    def test_values(self):
+        assert CloudProvider.AWS.value == "aws"
+        assert CloudProvider.GCP.value == "google"
+        assert CloudProvider.AZURE.value == "azure"
+
+
 class TestCloudSploitConfig:
     def test_default_values(self):
         config = CloudSploitConfig()
@@ -148,6 +156,7 @@ class TestCloudSploitConfig:
         assert config.aws_access_key_id is None
         assert config.aws_profile is None
         assert config.results_dir is None
+        assert config.cloud_provider == CloudProvider.AWS
 
     def test_explicit_credentials(self):
         config = CloudSploitConfig(
@@ -178,6 +187,16 @@ class TestCloudSploitConfig:
     def test_govcloud_mode(self):
         config = CloudSploitConfig(govcloud=True)
         assert config.govcloud is True
+
+    def test_gcp_config(self):
+        config = CloudSploitConfig(
+            cloud_provider=CloudProvider.GCP,
+            gcp_project_id="my-project",
+            gcp_credentials_path="/tmp/gcp.json",
+        )
+        assert config.cloud_provider == CloudProvider.GCP
+        assert config.gcp_project_id == "my-project"
+        assert config.gcp_credentials_path == "/tmp/gcp.json"
 
     def test_custom_timeout(self):
         config = CloudSploitConfig(timeout_seconds=1200)


### PR DESCRIPTION
### Motivation
- Enable CloudSploit-based scans against Google Cloud Platform (GCP) in addition to existing AWS support so the toolkit can scan multiple cloud providers.

### Description
- Introduced a new `CloudProvider` enum with values `aws`, `google`, and `azure` and exported it from the CloudSploit package (`parrot/tools/cloudsploit/models.py`, `parrot/tools/cloudsploit/__init__.py`).
- Extended `CloudSploitConfig` to include `cloud_provider`, `gcp_project_id`, and `gcp_credentials_path` for provider selection and GCP credential configuration (`parrot/tools/cloudsploit/models.py`).
- Updated `CloudSploitExecutor` to be provider-aware: it now builds provider-specific environment variables (AWS env only for AWS scans; `PROJECT` and `GOOGLE_APPLICATION_CREDENTIALS` for GCP), always passes a `--cloud <provider>` CLI flag, and gates `--govcloud` to AWS-only scans (`parrot/tools/cloudsploit/executor.py`).
- Made toolkit wording provider-neutral in `CloudSploitToolkit` docstrings (`parrot/tools/cloudsploit/toolkit.py`).
- Added/updated unit tests to cover the new enum and GCP behaviors (tests added/modified in `tests/tools/cloudsploit/test_models.py` and `tests/tools/cloudsploit/test_executor.py`).

### Testing
- Compiled the modified modules successfully with `python -m py_compile parrot/tools/cloudsploit/models.py parrot/tools/cloudsploit/executor.py parrot/tools/cloudsploit/toolkit.py tests/tools/cloudsploit/test_executor.py tests/tools/cloudsploit/test_models.py` (success).
- Ran `pytest -q tests/tools/cloudsploit/test_models.py tests/tools/cloudsploit/test_executor.py`, which failed during test collection due to a pre-existing repository import issue (`ModuleNotFoundError: No module named 'parrot.exceptions'`), preventing full test execution on this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e02a1d7f08330b9c49628c60215e4)