### PR TITLE
Fix Google video reel crash on empty music generation

### DIFF
--- a/parrot/clients/google/generation.py
+++ b/parrot/clients/google/generation.py
@@ -1922,6 +1922,10 @@ Before finalizing, scan and fix any gendered terms. If any banned term appears, 
             ):
                 audio_chunks.extend(chunk)
 
+            if not audio_chunks or len(audio_chunks) < 100:
+                self.logger.warning("Generated music was empty or too short. Skipping.")
+                return None
+
             # Properly encode raw PCM to WAV
             self._save_audio_file(bytes(audio_chunks), file_path, "audio/wav")
             return file_path.with_suffix('.wav')


### PR DESCRIPTION
The `generate_video_reel` method in `GoogleGenAIClient` was crashing when the music generation step (using Lyria) returned empty or insufficient data. This resulted in an empty WAV file being saved, which subsequently caused `ffmpeg` to fail with "Duration: N/A" when MoviePy attempted to process it.

This change adds a validation step in `_generate_reel_music` to ensure that `audio_chunks` contains a meaningful amount of data before attempting to save the file. If the data is insufficient, it logs a warning and returns `None`, allowing the video generation process to continue without the background music, rather than crashing entirely.

---
*PR created automatically by Jules for task [2880736665695404582](https://jules.google.com/task/2880736665695404582) started by @phenobarbital*