### PR TITLE
feat(planogram): make per-shelf scoring weights configurable from DB

### DIFF
--- a/parrot/models/detections.py
+++ b/parrot/models/detections.py
@@ -242,6 +242,9 @@ class ShelfConfig(BaseModel):
     height_ratio: Optional[float] = Field(default=0.30, description="Height as ratio of ROI (0.30 = 30%)")
     y_start_ratio: Optional[float] = Field(default=None, description="Start Y position as ratio of ROI (for overlapping shelves)")
     is_background: bool = Field(default=False, description="If True, promotional graphics prefer this shelf")
+    product_weight: Optional[float] = Field(default=None, description="Weight of product match in combined score (overrides global)")
+    text_weight: Optional[float] = Field(default=None, description="Weight of text compliance in combined score (overrides global)")
+    visual_weight: Optional[float] = Field(default=None, description="Weight of visual features in combined score (overrides global)")
 
 class TextRequirement(BaseModel):
     """Text requirement for promotional materials"""
@@ -447,7 +450,10 @@ class PlanogramDescriptionFactory:
                 position_strict=shelf_data.get("position_strict", False),
                 height_ratio=shelf_data.get("height_ratio", 0.30),
                 y_start_ratio=shelf_data.get("y_start_ratio"),
-                is_background=shelf_data.get("is_background", False)
+                is_background=shelf_data.get("is_background", False),
+                product_weight=shelf_data.get("product_weight"),
+                text_weight=shelf_data.get("text_weight"),
+                visual_weight=shelf_data.get("visual_weight"),
             )
             shelf_configs.append(shelf_config)
 

--- a/parrot/pipelines/planogram/plan.py
+++ b/parrot/pipelines/planogram/plan.py
@@ -934,10 +934,14 @@ Output a JSON list where each entry contains:
                     (visual_feature_score * visual_feature_weight)
                 )
             else:
+                # Per-shelf weights override globals when defined in planogram_config
+                s_visual_weight = shelf_cfg.visual_weight if shelf_cfg.visual_weight is not None else visual_weight
+                s_text_weight = shelf_cfg.text_weight if shelf_cfg.text_weight is not None else 0.1
+                s_product_weight = shelf_cfg.product_weight if shelf_cfg.product_weight is not None else (1 - s_visual_weight)
                 combined_score = (
-                    basic_score * (1 - visual_weight) +
-                    text_score * 0.1 +
-                    visual_feature_score * visual_weight
+                    basic_score * s_product_weight +
+                    text_score * s_text_weight +
+                    visual_feature_score * s_visual_weight
                 )
 
             combined_score = min(1.0, max(0.0, combined_score))


### PR DESCRIPTION
## Summary

- Added optional `product_weight`, `text_weight`, `visual_weight` fields to `ShelfConfig` model in `parrot/models/detections.py`
- Updated `PlanogramDescriptionFactory` to read these fields from shelf JSON in DB
- Updated non-header scoring in `plan.py` to use per-shelf weights when defined, falling back to previous defaults when not set

## Motivation

Previously, top/middle/bottom shelf scoring used hardcoded weights (`text_score * 0.1`), while only the header (`advertisement_endcap`) was configurable from the DB. This change makes all shelves configurable.

## Backwards Compatibility

No breaking change — all new fields are `Optional` with `default=None`. When absent, original defaults are preserved.

## Test plan

- [ ] Verify existing planograms score identically when no new fields are set in DB
- [ ] Set `product_weight=1.0, text_weight=0.0, visual_weight=0.0` on a shelf config and confirm `combined_score == basic_score`
- [ ] Confirm `epson_ecotank_planogram_config` middle/bottom shelves now show pure product-match score

🤖 Generated with [Claude Code](https://claude.com/claude-code)