### PR TITLE
Support datasource-based datasets in DatasetManagerHandler; add Airtable & Smartsheet sources

### DIFF
--- a/parrot/handlers/datasets.py
+++ b/parrot/handlers/datasets.py
@@ -29,7 +29,7 @@ from ..models.datasets import (
     DatasetQueryRequest,
     DatasetUploadResponse,
 )
-from ..tools.dataset_manager import DatasetManager
+from ..tools.dataset_manager import DatasetEntry, DatasetManager
 from .user_objects import UserObjectsHandler
 
 if TYPE_CHECKING:
@@ -65,21 +65,19 @@ def _clone_agent_dm(agent: object, logger: object) -> DatasetManager | None:
     user_dm = DatasetManager()
     for name, entry in agent_dm._datasets.items():
         try:
+            cloned_entry = DatasetEntry(
+                name=name,
+                source=entry.source,
+                metadata=dict(entry.metadata or {}),
+                is_active=entry.is_active,
+                auto_detect_types=entry.auto_detect_types,
+                cache_ttl=entry.cache_ttl,
+            )
             if entry.loaded and entry.df is not None:
-                user_dm.add_dataframe(
-                    name=name,
-                    df=entry.df,
-                    metadata=entry.metadata,
-                    is_active=entry.is_active,
-                )
-            elif entry.query_slug:
-                user_dm.add_query(
-                    name=name,
-                    query_slug=entry.query_slug,
-                    metadata=entry.metadata,
-                )
-                if not entry.is_active:
-                    user_dm.deactivate(name)
+                cloned_entry._df = entry.df.copy(deep=True)
+            if entry.column_types:
+                cloned_entry._column_types = dict(entry.column_types)
+            user_dm._datasets[name] = cloned_entry
         except Exception as exc:
             logger.warning("Failed to clone dataset '%s' from agent: %s", name, exc)
 
@@ -356,12 +354,10 @@ class DatasetManagerHandler(BaseView):
             return self.json_response({"error": str(e)}, status=500)
 
     async def post(self) -> web.Response:
-        """Add a query slug as a new dataset.
+        """Add a dataset from query/sql/datasource configuration.
 
         Body: DatasetQueryRequest
 
-        Note: Raw SQL queries are not directly supported. Use query_slug
-        to reference pre-configured queries in QuerySource.
         """
         agent_id = self.request.match_info.get("agent_id")
         if not agent_id:
@@ -383,6 +379,96 @@ class DatasetManagerHandler(BaseView):
         try:
             dm = await self._get_dataset_manager(agent_id)
 
+            if request_body.datasource:
+                ds = request_body.datasource
+                ds_type = str(ds.get("type", "")).lower().strip()
+                metadata = {"description": request_body.description or ""}
+                if ds.get("metadata") and isinstance(ds.get("metadata"), dict):
+                    metadata.update(ds.get("metadata"))
+
+                if ds_type == "query_slug":
+                    slug = ds.get("slug") or ds.get("query_slug")
+                    if not slug:
+                        return self.json_response({"error": "datasource.slug is required for query_slug"}, status=400)
+                    dm.add_query(name=request_body.name, query_slug=slug, metadata=metadata)
+                elif ds_type == "sql":
+                    sql = ds.get("sql")
+                    driver = ds.get("driver")
+                    if not sql or not driver:
+                        return self.json_response({"error": "datasource.sql and datasource.driver are required for sql"}, status=400)
+                    dm.add_sql_source(
+                        name=request_body.name,
+                        sql=sql,
+                        driver=driver,
+                        dsn=ds.get("dsn"),
+                        metadata=metadata,
+                        cache_ttl=int(ds.get("cache_ttl", 3600)),
+                    )
+                elif ds_type == "table":
+                    table = ds.get("table")
+                    driver = ds.get("driver")
+                    if not table or not driver:
+                        return self.json_response({"error": "datasource.table and datasource.driver are required for table"}, status=400)
+                    await dm.add_table_source(
+                        name=request_body.name,
+                        table=table,
+                        driver=driver,
+                        dsn=ds.get("dsn"),
+                        credentials=ds.get("credentials"),
+                        metadata=metadata,
+                        cache_ttl=int(ds.get("cache_ttl", 3600)),
+                        strict_schema=bool(ds.get("strict_schema", True)),
+                    )
+                elif ds_type == "airtable":
+                    base_id = ds.get("base_id")
+                    table = ds.get("table")
+                    api_key = ds.get("api_key")
+                    if not base_id or not table:
+                        return self.json_response({"error": "datasource.base_id and datasource.table are required for airtable"}, status=400)
+                    await dm.add_airtable_source(
+                        name=request_body.name,
+                        base_id=base_id,
+                        table=table,
+                        api_key=api_key,
+                        view=ds.get("view"),
+                        metadata=metadata,
+                        cache_ttl=int(ds.get("cache_ttl", 3600)),
+                        fetch_on_create=True,
+                    )
+                elif ds_type == "smartsheet":
+                    sheet_id = ds.get("sheet_id")
+                    access_token = ds.get("access_token")
+                    if not sheet_id:
+                        return self.json_response({"error": "datasource.sheet_id is required for smartsheet"}, status=400)
+                    await dm.add_smartsheet_source(
+                        name=request_body.name,
+                        sheet_id=str(sheet_id),
+                        access_token=access_token,
+                        metadata=metadata,
+                        cache_ttl=int(ds.get("cache_ttl", 3600)),
+                        fetch_on_create=True,
+                    )
+                elif ds_type == "dataframe":
+                    data = ds.get("data")
+                    if data is None:
+                        return self.json_response({"error": "datasource.data is required for dataframe"}, status=400)
+                    df = pd.DataFrame(data)
+                    dm.add_dataframe(request_body.name, df, metadata=metadata)
+                else:
+                    return self.json_response({"error": f"Unsupported datasource type '{ds_type}'"}, status=400)
+
+                if ds.get("refresh"):
+                    await dm.materialize(request_body.name, force_refresh=True)
+
+                return self.json_response(
+                    {
+                        "name": request_body.name,
+                        "type": ds_type,
+                        "message": f"Datasource dataset '{request_body.name}' added successfully",
+                    },
+                    status=201,
+                )
+
             if request_body.query_slug:
                 dm.add_query(
                     name=request_body.name,
@@ -402,7 +488,7 @@ class DatasetManagerHandler(BaseView):
                 query_type = "query"
             else:
                 return self.json_response(
-                    {"error": "Either 'query' or 'query_slug' must be provided"},
+                    {"error": "Either 'query', 'query_slug', or 'datasource' must be provided"},
                     status=400,
                 )
 
@@ -414,7 +500,6 @@ class DatasetManagerHandler(BaseView):
                 },
                 status=201,
             )
-
         except KeyError:
             return self.json_response(
                 {"error": f"Agent '{agent_id}' not found"}, status=404

--- a/parrot/handlers/datasets.py
+++ b/parrot/handlers/datasets.py
@@ -458,7 +458,18 @@ class DatasetManagerHandler(BaseView):
                     return self.json_response({"error": f"Unsupported datasource type '{ds_type}'"}, status=400)
 
                 if ds.get("refresh"):
-                    await dm.materialize(request_body.name, force_refresh=True)
+                    # Only support automatic refresh for datasource types that can
+                    # be materialized without additional parameters. For other
+                    # types, return a controlled 400 instead of risking a 500.
+                    if ds_type in ("airtable", "smartsheet", "query_slug", "dataframe"):
+                        await dm.materialize(request_body.name, force_refresh=True)
+                    else:
+                        return self.json_response(
+                            {
+                                "error": f"Refresh is not supported for datasource type '{ds_type}' via this endpoint"
+                            },
+                            status=400,
+                        )
 
                 return self.json_response(
                     {

--- a/parrot/handlers/datasets.py
+++ b/parrot/handlers/datasets.py
@@ -386,6 +386,20 @@ class DatasetManagerHandler(BaseView):
                 if ds.get("metadata") and isinstance(ds.get("metadata"), dict):
                     metadata.update(ds.get("metadata"))
 
+                raw_cache_ttl = ds.get("cache_ttl", 3600)
+                try:
+                    cache_ttl = int(raw_cache_ttl)
+                except (TypeError, ValueError):
+                    return self.json_response(
+                        {"error": "datasource.cache_ttl must be an integer (seconds)"},
+                        status=400,
+                    )
+                if cache_ttl < 0:
+                    return self.json_response(
+                        {"error": "datasource.cache_ttl must be a non-negative integer (seconds)"},
+                        status=400,
+                    )
+
                 if ds_type == "query_slug":
                     slug = ds.get("slug") or ds.get("query_slug")
                     if not slug:
@@ -402,7 +416,7 @@ class DatasetManagerHandler(BaseView):
                         driver=driver,
                         dsn=ds.get("dsn"),
                         metadata=metadata,
-                        cache_ttl=int(ds.get("cache_ttl", 3600)),
+                        cache_ttl=cache_ttl,
                     )
                 elif ds_type == "table":
                     table = ds.get("table")
@@ -416,7 +430,7 @@ class DatasetManagerHandler(BaseView):
                         dsn=ds.get("dsn"),
                         credentials=ds.get("credentials"),
                         metadata=metadata,
-                        cache_ttl=int(ds.get("cache_ttl", 3600)),
+                        cache_ttl=cache_ttl,
                         strict_schema=bool(ds.get("strict_schema", True)),
                     )
                 elif ds_type == "airtable":
@@ -432,7 +446,7 @@ class DatasetManagerHandler(BaseView):
                         api_key=api_key,
                         view=ds.get("view"),
                         metadata=metadata,
-                        cache_ttl=int(ds.get("cache_ttl", 3600)),
+                        cache_ttl=cache_ttl,
                         fetch_on_create=True,
                     )
                 elif ds_type == "smartsheet":
@@ -445,7 +459,7 @@ class DatasetManagerHandler(BaseView):
                         sheet_id=str(sheet_id),
                         access_token=access_token,
                         metadata=metadata,
-                        cache_ttl=int(ds.get("cache_ttl", 3600)),
+                        cache_ttl=cache_ttl,
                         fetch_on_create=True,
                     )
                 elif ds_type == "dataframe":

--- a/parrot/models/datasets.py
+++ b/parrot/models/datasets.py
@@ -50,6 +50,13 @@ class DatasetQueryRequest(BaseModel):
     description: Optional[str] = Field(
         default="", description="Dataset description"
     )
+    datasource: Optional[dict] = Field(
+        default=None,
+        description=(
+            "Datasource configuration. Supported types: dataframe, query_slug, "
+            "sql, table, airtable, smartsheet"
+        ),
+    )
 
     def validate_query_source(self) -> None:
         """Ensure exactly one of query or query_slug is provided.
@@ -57,8 +64,16 @@ class DatasetQueryRequest(BaseModel):
         Raises:
             ValueError: If neither or both query sources are provided.
         """
+        if self.datasource:
+            source_type = self.datasource.get("type")
+            if not source_type:
+                raise ValueError("datasource.type is required when datasource is provided")
+            return
+
         if not self.query and not self.query_slug:
-            raise ValueError("Either 'query' or 'query_slug' must be provided")
+            raise ValueError(
+                "Either 'query', 'query_slug', or 'datasource' must be provided"
+            )
         if self.query and self.query_slug:
             raise ValueError("Provide either 'query' or 'query_slug', not both")
 

--- a/parrot/models/datasets.py
+++ b/parrot/models/datasets.py
@@ -59,10 +59,12 @@ class DatasetQueryRequest(BaseModel):
     )
 
     def validate_query_source(self) -> None:
-        """Ensure exactly one of query or query_slug is provided.
+        """Ensure exactly one of query, query_slug, or datasource is provided.
 
         Raises:
-            ValueError: If neither or both query sources are provided.
+            ValueError: If none of the query sources are provided, if both query
+                and query_slug are provided, or if datasource is provided without
+                a valid ``type`` field.
         """
         if self.datasource:
             source_type = self.datasource.get("type")

--- a/parrot/tools/dataset_manager/sources/__init__.py
+++ b/parrot/tools/dataset_manager/sources/__init__.py
@@ -14,6 +14,8 @@ from .memory import InMemorySource
 from .query_slug import MultiQuerySlugSource, QuerySlugSource
 from .sql import SQLQuerySource
 from .table import TableSource
+from .airtable import AirtableSource
+from .smartsheet import SmartsheetSource
 
 __all__ = [
     "DataSource",
@@ -22,4 +24,6 @@ __all__ = [
     "QuerySlugSource",
     "SQLQuerySource",
     "TableSource",
+    "AirtableSource",
+    "SmartsheetSource",
 ]

--- a/parrot/tools/dataset_manager/sources/airtable.py
+++ b/parrot/tools/dataset_manager/sources/airtable.py
@@ -1,0 +1,92 @@
+"""Airtable DataSource implementation."""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Optional
+from urllib.parse import quote
+
+import aiohttp
+import pandas as pd
+
+from .base import DataSource
+
+
+class AirtableSource(DataSource):
+    """Datasource backed by an Airtable table."""
+
+    def __init__(
+        self,
+        base_id: str,
+        table: str,
+        api_key: Optional[str] = None,
+        view: Optional[str] = None,
+    ) -> None:
+        self.base_id = base_id
+        self.table = table
+        self.api_key = api_key or os.getenv("AIRTABLE_API_KEY")
+        self.view = view
+        self._schema: Dict[str, str] = {}
+
+    @property
+    def cache_key(self) -> str:
+        return f"airtable:{self.base_id}:{self.table}"
+
+    def describe(self) -> str:
+        return f"Airtable base '{self.base_id}', table '{self.table}'"
+
+    def _headers(self) -> Dict[str, str]:
+        if not self.api_key:
+            raise ValueError("Airtable API key is required")
+        token = self.api_key
+        if not token.startswith("Bearer "):
+            token = f"Bearer {token}"
+        return {"Authorization": token}
+
+    async def _fetch_records(self, max_records: Optional[int] = None) -> list[dict[str, Any]]:
+        url = f"https://api.airtable.com/v0/{self.base_id}/{quote(self.table, safe='')}"
+        params: Dict[str, Any] = {"pageSize": 100}
+        if self.view:
+            params["view"] = self.view
+        if max_records:
+            params["maxRecords"] = max_records
+
+        records: list[dict[str, Any]] = []
+        async with aiohttp.ClientSession(headers=self._headers()) as session:
+            offset: Optional[str] = None
+            while True:
+                local_params = params.copy()
+                if offset:
+                    local_params["offset"] = offset
+                async with session.get(url, params=local_params) as response:
+                    if response.status >= 400:
+                        text = await response.text()
+                        raise RuntimeError(f"Airtable request failed ({response.status}): {text}")
+                    payload = await response.json()
+                records.extend(payload.get("records", []))
+                offset = payload.get("offset")
+                if not offset:
+                    break
+                if max_records and len(records) >= max_records:
+                    return records[:max_records]
+
+        return records
+
+    async def prefetch_schema(self) -> Dict[str, str]:
+        records = await self._fetch_records(max_records=1)
+        if not records:
+            self._schema = {}
+            return self._schema
+
+        fields = records[0].get("fields", {})
+        self._schema = {k: type(v).__name__ for k, v in fields.items()}
+        return self._schema
+
+    async def fetch(self, max_records: Optional[int] = None, **params) -> pd.DataFrame:
+        if params.get("view"):
+            self.view = params["view"]
+        records = await self._fetch_records(max_records=max_records)
+        data = [r.get("fields", {}) for r in records]
+        df = pd.DataFrame(data)
+        if self._schema == {} and not df.empty:
+            self._schema = {col: str(dtype) for col, dtype in df.dtypes.items()}
+        return df

--- a/parrot/tools/dataset_manager/sources/airtable.py
+++ b/parrot/tools/dataset_manager/sources/airtable.py
@@ -43,11 +43,16 @@ class AirtableSource(DataSource):
             token = f"Bearer {token}"
         return {"Authorization": token}
 
-    async def _fetch_records(self, max_records: Optional[int] = None) -> list[dict[str, Any]]:
+    async def _fetch_records(
+        self,
+        max_records: Optional[int] = None,
+        view: Optional[str] = None,
+    ) -> list[dict[str, Any]]:
         url = f"https://api.airtable.com/v0/{self.base_id}/{quote(self.table, safe='')}"
         params: Dict[str, Any] = {"pageSize": 100}
-        if self.view:
-            params["view"] = self.view
+        effective_view = view if view is not None else self.view
+        if effective_view:
+            params["view"] = effective_view
         if max_records:
             params["maxRecords"] = max_records
 
@@ -83,9 +88,8 @@ class AirtableSource(DataSource):
         return self._schema
 
     async def fetch(self, max_records: Optional[int] = None, **params) -> pd.DataFrame:
-        if params.get("view"):
-            self.view = params["view"]
-        records = await self._fetch_records(max_records=max_records)
+        view = params.get("view", self.view)
+        records = await self._fetch_records(max_records=max_records, view=view)
         data = [r.get("fields", {}) for r in records]
         df = pd.DataFrame(data)
         if self._schema == {} and not df.empty:

--- a/parrot/tools/dataset_manager/sources/airtable.py
+++ b/parrot/tools/dataset_manager/sources/airtable.py
@@ -29,7 +29,8 @@ class AirtableSource(DataSource):
 
     @property
     def cache_key(self) -> str:
-        return f"airtable:{self.base_id}:{self.table}"
+        view_part = self.view or "default"
+        return f"airtable:{self.base_id}:{self.table}:view={view_part}"
 
     def describe(self) -> str:
         return f"Airtable base '{self.base_id}', table '{self.table}'"

--- a/parrot/tools/dataset_manager/sources/smartsheet.py
+++ b/parrot/tools/dataset_manager/sources/smartsheet.py
@@ -1,0 +1,74 @@
+"""Smartsheet DataSource implementation."""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Optional
+
+import aiohttp
+import pandas as pd
+
+from .base import DataSource
+
+
+class SmartsheetSource(DataSource):
+    """Datasource backed by a Smartsheet sheet."""
+
+    def __init__(self, sheet_id: str, access_token: Optional[str] = None) -> None:
+        self.sheet_id = str(sheet_id)
+        self.access_token = access_token or os.getenv("SMARTSHEET_ACCESS_TOKEN")
+        self._schema: Dict[str, str] = {}
+
+    @property
+    def cache_key(self) -> str:
+        return f"smartsheet:{self.sheet_id}"
+
+    def describe(self) -> str:
+        return f"Smartsheet sheet '{self.sheet_id}'"
+
+    def _headers(self) -> Dict[str, str]:
+        if not self.access_token:
+            raise ValueError("Smartsheet access token is required")
+        token = self.access_token
+        if not token.startswith("Bearer "):
+            token = f"Bearer {token}"
+        return {"Authorization": token}
+
+    async def _fetch_sheet(self) -> Dict[str, Any]:
+        url = f"https://api.smartsheet.com/2.0/sheets/{self.sheet_id}"
+        async with aiohttp.ClientSession(headers=self._headers()) as session:
+            async with session.get(url) as response:
+                if response.status >= 400:
+                    text = await response.text()
+                    raise RuntimeError(
+                        f"Smartsheet request failed ({response.status}): {text}"
+                    )
+                return await response.json()
+
+    @staticmethod
+    def _row_to_dict(row: Dict[str, Any], columns_by_id: Dict[int, str]) -> Dict[str, Any]:
+        values: Dict[str, Any] = {}
+        for cell in row.get("cells", []):
+            column_name = columns_by_id.get(cell.get("columnId"))
+            if not column_name:
+                continue
+            values[column_name] = cell.get("value")
+        return values
+
+    async def prefetch_schema(self) -> Dict[str, str]:
+        payload = await self._fetch_sheet()
+        columns = payload.get("columns", [])
+        self._schema = {c.get("title", f"col_{i}"): c.get("type", "unknown") for i, c in enumerate(columns)}
+        return self._schema
+
+    async def fetch(self, **params) -> pd.DataFrame:
+        payload = await self._fetch_sheet()
+        columns = payload.get("columns", [])
+        rows = payload.get("rows", [])
+        columns_by_id = {int(c["id"]): c.get("title", str(c["id"])) for c in columns if "id" in c}
+
+        records = [self._row_to_dict(row, columns_by_id) for row in rows]
+        df = pd.DataFrame(records)
+
+        if not self._schema:
+            self._schema = {c.get("title", f"col_{i}"): c.get("type", "unknown") for i, c in enumerate(columns)}
+        return df

--- a/parrot/tools/dataset_manager/tool.py
+++ b/parrot/tools/dataset_manager/tool.py
@@ -38,7 +38,7 @@ class DatasetInfo(BaseModel):
     name: str = Field(description="Dataset name/identifier")
     alias: Optional[str] = Field(default=None, description="Standardized alias (df1, df2, etc.)")
     description: str = Field(default="", description="Dataset description")
-    source_type: Literal["dataframe", "query_slug", "sql", "table"] = Field(
+    source_type: Literal["dataframe", "query_slug", "sql", "table", "airtable", "smartsheet"] = Field(
         default="dataframe",
         description="Type of data source backing this dataset"
     )
@@ -265,6 +265,8 @@ class DatasetEntry:
         from .sources.query_slug import QuerySlugSource, MultiQuerySlugSource
         from .sources.sql import SQLQuerySource
         from .sources.table import TableSource
+        from .sources.airtable import AirtableSource
+        from .sources.smartsheet import SmartsheetSource
 
         _source_type_map: Dict[type, str] = {
             InMemorySource: "dataframe",
@@ -272,6 +274,8 @@ class DatasetEntry:
             MultiQuerySlugSource: "query_slug",
             SQLQuerySource: "sql",
             TableSource: "table",
+            AirtableSource: "airtable",
+            SmartsheetSource: "smartsheet",
         }
         source_type = _source_type_map.get(type(self.source), "dataframe")
 
@@ -793,6 +797,81 @@ class DatasetManager(AbstractToolkit):
         self._datasets[name] = entry
         self.logger.debug(f"SQL source '{name}' registered ({driver})")
         return f"SQL source '{name}' registered ({driver})."
+
+
+    async def add_airtable_source(
+        self,
+        name: str,
+        base_id: str,
+        table: str,
+        api_key: Optional[str] = None,
+        view: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        cache_ttl: int = 3600,
+        fetch_on_create: bool = True,
+    ) -> str:
+        """Register an Airtable table source and optionally fetch immediately."""
+        from .sources.airtable import AirtableSource
+
+        source = AirtableSource(
+            base_id=base_id,
+            table=table,
+            api_key=api_key,
+            view=view,
+        )
+        await source.prefetch_schema()
+        entry = DatasetEntry(
+            name=name,
+            source=source,
+            metadata=metadata or {},
+            cache_ttl=cache_ttl,
+            auto_detect_types=self.auto_detect_types,
+        )
+        self._datasets[name] = entry
+
+        if fetch_on_create:
+            await self.materialize(name, force_refresh=True)
+
+        if self.generate_guide:
+            self.df_guide = self._generate_dataframe_guide()
+
+        self.logger.debug("Airtable source '%s' registered (%s/%s)", name, base_id, table)
+        return f"Airtable source '{name}' registered ({base_id}/{table})."
+
+    async def add_smartsheet_source(
+        self,
+        name: str,
+        sheet_id: str,
+        access_token: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        cache_ttl: int = 3600,
+        fetch_on_create: bool = True,
+    ) -> str:
+        """Register a Smartsheet source and optionally fetch immediately."""
+        from .sources.smartsheet import SmartsheetSource
+
+        source = SmartsheetSource(
+            sheet_id=sheet_id,
+            access_token=access_token,
+        )
+        await source.prefetch_schema()
+        entry = DatasetEntry(
+            name=name,
+            source=source,
+            metadata=metadata or {},
+            cache_ttl=cache_ttl,
+            auto_detect_types=self.auto_detect_types,
+        )
+        self._datasets[name] = entry
+
+        if fetch_on_create:
+            await self.materialize(name, force_refresh=True)
+
+        if self.generate_guide:
+            self.df_guide = self._generate_dataframe_guide()
+
+        self.logger.debug("Smartsheet source '%s' registered (%s)", name, sheet_id)
+        return f"Smartsheet source '{name}' registered ({sheet_id})."
 
     def remove(self, name: str) -> str:
         """Remove a dataset from the catalog."""

--- a/parrot/tools/dataset_manager/tool.py
+++ b/parrot/tools/dataset_manager/tool.py
@@ -854,7 +854,11 @@ class DatasetManager(AbstractToolkit):
             sheet_id=sheet_id,
             access_token=access_token,
         )
-        await source.prefetch_schema()
+        # Skip prefetch_schema when fetch_on_create=True: fetch() will
+        # populate the schema as part of materialization, avoiding a
+        # redundant API round-trip.
+        if not fetch_on_create:
+            await source.prefetch_schema()
         entry = DatasetEntry(
             name=name,
             source=source,

--- a/tests/handlers/test_dataset_handler.py
+++ b/tests/handlers/test_dataset_handler.py
@@ -526,6 +526,82 @@ class TestDatasetManagerHandlerPost:
             assert result['name'] == 'orders'
             assert result['type'] == 'query'
 
+
+    @pytest.mark.asyncio
+    async def test_add_datasource_airtable(self):
+        """POST adds Airtable datasource and eagerly fetches it."""
+        dm = DatasetManager()
+
+        with patch('parrot.handlers.datasets.get_session', new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {"agent_dataset_manager": dm}
+
+            handler = DatasetManagerHandler.__new__(DatasetManagerHandler)
+            handler.logger = MagicMock()
+            handler._user_objects_handler = None
+            handler.request = MockRequest(
+                match_info={'agent_id': 'agent'},
+                json_data={
+                    'name': 'airtable_ds',
+                    'datasource': {
+                        'type': 'airtable',
+                        'base_id': 'app123',
+                        'table': 'Sales',
+                        'api_key': 'token'
+                    }
+                }
+            )
+
+            def json_response(data, status=200):
+                return web.json_response(data, status=status)
+            handler.json_response = json_response
+
+            with patch.object(dm, 'add_airtable_source', new_callable=AsyncMock) as mock_add:
+                response = await handler.post()
+                import json
+                result = json.loads(response.body.decode())
+
+                assert response.status == 201
+                assert result['name'] == 'airtable_ds'
+                assert result['type'] == 'airtable'
+                mock_add.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_add_datasource_smartsheet(self):
+        """POST adds Smartsheet datasource and eagerly fetches it."""
+        dm = DatasetManager()
+
+        with patch('parrot.handlers.datasets.get_session', new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {"agent_dataset_manager": dm}
+
+            handler = DatasetManagerHandler.__new__(DatasetManagerHandler)
+            handler.logger = MagicMock()
+            handler._user_objects_handler = None
+            handler.request = MockRequest(
+                match_info={'agent_id': 'agent'},
+                json_data={
+                    'name': 'smartsheet_ds',
+                    'datasource': {
+                        'type': 'smartsheet',
+                        'sheet_id': 'sheet_1',
+                        'access_token': 'token'
+                    }
+                }
+            )
+
+            def json_response(data, status=200):
+                return web.json_response(data, status=status)
+            handler.json_response = json_response
+
+            with patch.object(dm, 'add_smartsheet_source', new_callable=AsyncMock) as mock_add:
+                response = await handler.post()
+                import json
+                result = json.loads(response.body.decode())
+
+                assert response.status == 201
+                assert result['name'] == 'smartsheet_ds'
+                assert result['type'] == 'smartsheet'
+                mock_add.assert_awaited_once()
+
     @pytest.mark.asyncio
     async def test_post_neither_query_nor_slug(self):
         """POST returns 400 when neither query nor slug provided."""


### PR DESCRIPTION
### Motivation
- Bring DatasetManagerHandler in line with the new DataSource concept so POST can accept structured datasource configurations (not just legacy query/query_slug) and preserve richer source metadata when seeding user session managers. 
- Provide built-in connectors for common sheet/table sources (Airtable and Smartsheet) so datasets can be registered and optionally eagerly fetched at creation. 

### Description
- Extended the POST dataset API to accept a `datasource` object in `DatasetQueryRequest` and validate `datasource.type`, while preserving legacy `query` / `query_slug` behavior. 
- Updated `DatasetManagerHandler` to handle `datasource` payloads for `query_slug`, `sql`, `table`, `dataframe`, `airtable`, and `smartsheet`, with per-type validation and optional `refresh`/materialize semantics. 
- Adjusted agent-to-user cloning to copy `DatasetEntry` instances (including `source`, `_column_types`, and any preloaded `_df`) instead of only transferring loaded DataFrames or slugs. 
- Added two DataSource implementations and integration points: `AirtableSource` and `SmartsheetSource`, exported from the dataset sources package, and added `DatasetManager` helper methods `add_airtable_source(...)` and `add_smartsheet_source(...)` which prefetch schema and can fetch on create. 
- Added unit tests for the handler flows that exercise Airtable/Smartsheet datasource POST behavior and updated source-type mappings and DatasetEntry -> DatasetInfo serialization to include the new types. 

### Testing
- Compiled the modified modules successfully with `python -m compileall parrot/handlers/datasets.py parrot/models/datasets.py parrot/tools/dataset_manager/tool.py parrot/tools/dataset_manager/sources/airtable.py parrot/tools/dataset_manager/sources/smartsheet.py tests/handlers/test_dataset_handler.py` which produced no syntax errors. 
- Ran the dataset handler tests with `pytest -q tests/handlers/test_dataset_handler.py` but test collection failed in this environment due to a missing runtime import (`parrot.exceptions` not present), so the full test suite could not be executed here. 
- New handler unit tests for Airtable/Smartsheet were added to `tests/handlers/test_dataset_handler.py` and are ready to run in a CI environment with the full project imports available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac070554c08330aaa98daafb7c50de)