### PR TITLE
feat(planogram): FEAT-004 — GraphicPanelDisplay composable type

### DIFF
--- a/parrot/pipelines/planogram/plan.py
+++ b/parrot/pipelines/planogram/plan.py
@@ -13,7 +13,7 @@ from ...models.detections import (
 from ...models.compliance import (
     ComplianceStatus,
 )
-from .types import ProductOnShelves
+from .types import ProductOnShelves, GraphicPanelDisplay
 
 
 class PlanogramCompliance(AbstractPipeline):
@@ -31,6 +31,7 @@ class PlanogramCompliance(AbstractPipeline):
 
     _PLANOGRAM_TYPES = {
         "product_on_shelves": ProductOnShelves,
+        "graphic_panel_display": GraphicPanelDisplay,
     }
 
     def __init__(

--- a/parrot/pipelines/planogram/types/__init__.py
+++ b/parrot/pipelines/planogram/types/__init__.py
@@ -1,8 +1,10 @@
 """Planogram type composables for the Composable Pattern."""
 from .abstract import AbstractPlanogramType
 from .product_on_shelves import ProductOnShelves
+from .graphic_panel_display import GraphicPanelDisplay
 
 __all__ = (
     "AbstractPlanogramType",
     "ProductOnShelves",
+    "GraphicPanelDisplay",
 )

--- a/parrot/pipelines/planogram/types/graphic_panel_display.py
+++ b/parrot/pipelines/planogram/types/graphic_panel_display.py
@@ -1,0 +1,644 @@
+"""GraphicPanelDisplay planogram type composable.
+
+Handles planogram compliance for graphic-panel / signage endcap displays
+(EcoTank endcaps, projector displays, Bose audio displays, etc.).
+
+These displays contain no physical products — compliance is determined by
+verifying that the correct graphic zones are present in the correct
+positions, with the correct text content and (where applicable) the
+correct illumination state.
+"""
+import asyncio
+import json
+from typing import Any, Dict, List, Optional, Tuple
+
+from PIL import Image
+
+from .abstract import AbstractPlanogramType
+from ....models.detections import (
+    Detection,
+    BoundingBox,
+    Detections,
+    ShelfRegion,
+    IdentifiedProduct,
+)
+from ....models.compliance import (
+    ComplianceResult,
+    TextComplianceResult,
+    ComplianceStatus,
+    TextMatcher,
+)
+
+# Default illumination penalty: 1.0 means zone score → 0 when state contradicts config.
+_DEFAULT_ILLUMINATION_PENALTY: float = 1.0
+
+# Key prefix used in visual_features to declare expected illumination state.
+_ILLUMINATION_FEATURE_PREFIX = "illumination_status:"
+
+
+class GraphicPanelDisplay(AbstractPlanogramType):
+    """Composable type for graphic-panel / signage endcap compliance.
+
+    Handles displays where compliance is based on the presence, text
+    content, and illumination state of named graphic zones — not on
+    physical product counting or fact-tag detection.
+
+    Each shelf level in the planogram config maps to one named graphic
+    zone (e.g., header → top graphic, middle → comparison table,
+    bottom → special offer panel).  The LLM is asked to detect those
+    zones via the ``roi_detection_prompt`` defined in the DB config, so
+    no changes to the DB schema are needed.
+
+    Args:
+        pipeline: Parent PlanogramCompliance instance.
+        config: The PlanogramConfig for this compliance run.
+    """
+
+    def __init__(self, pipeline: Any, config: Any) -> None:
+        super().__init__(pipeline, config)
+
+    # ------------------------------------------------------------------
+    # Abstract method implementations
+    # ------------------------------------------------------------------
+
+    async def compute_roi(
+        self,
+        img: Image.Image,
+    ) -> Tuple[
+        Optional[Tuple[int, int, int, int]],
+        Optional[Any],
+        Optional[Any],
+        Optional[Any],
+        List[Any],
+    ]:
+        """Compute the region of interest by locating the graphic endcap boundary.
+
+        Reuses the same LLM ROI prompt logic as ``ProductOnShelves`` —
+        the ``roi_detection_prompt`` stored in the DB config already
+        describes the endcap shape and the model should return an
+        ``endcap`` or ``poster_panel`` detection bounding the whole display.
+
+        Args:
+            img: The input PIL image.
+
+        Returns:
+            Tuple of (endcap_detection, panel_detection, brand_detection,
+            text_detection, raw_detections_list).
+        """
+        planogram_description = self.config.get_planogram_description()
+        return await self._find_display_roi(img, planogram_description)
+
+    async def detect_objects_roi(
+        self,
+        img: Image.Image,
+        roi: Any,
+    ) -> List[Detection]:
+        """Detect named graphic zones within the endcap ROI.
+
+        Sends the cropped ROI image to the LLM using the planogram's
+        ``roi_detection_prompt``.  The prompt should instruct the model to
+        label zones (e.g. ``top_zone``, ``middle_zone``, ``bottom_zone``)
+        corresponding to the graphic panels on the display.
+
+        Args:
+            img: The input PIL image.
+            roi: ROI detection returned by ``compute_roi()``.
+
+        Returns:
+            List of Detection objects for each detected graphic zone.
+        """
+        planogram_description = self.config.get_planogram_description()
+        endcap_det = roi  # roi is the endcap Detection from compute_roi
+
+        if endcap_det is None:
+            self.logger.warning("No ROI found — cannot detect graphic zones.")
+            return []
+
+        # Crop the image to the ROI bbox
+        iw, ih = img.size
+        bbox = endcap_det.bbox
+        x1 = int(bbox.x1 * iw)
+        y1 = int(bbox.y1 * ih)
+        x2 = int(bbox.x2 * iw)
+        y2 = int(bbox.y2 * ih)
+        cropped = img.crop((x1, y1, x2, y2))
+
+        prompt = self.config.roi_detection_prompt or (
+            "Identify all graphic zones in this display. "
+            "Label each zone (top_zone, middle_zone, bottom_zone, etc.) "
+            "and return its bounding box."
+        )
+        image_small = self.pipeline._downscale_image(cropped, max_side=1024, quality=78)
+
+        max_attempts = 2
+        msg = None
+        for attempt in range(max_attempts):
+            try:
+                async with self.pipeline.roi_client as client:
+                    msg = await client.ask_to_image(
+                        image=image_small,
+                        prompt=prompt,
+                        model="gemini-2.5-flash",
+                        no_memory=True,
+                        structured_output=Detections,
+                        max_tokens=8192,
+                    )
+                break
+            except Exception as exc:
+                if attempt < max_attempts - 1:
+                    self.logger.warning(
+                        f"Zone detection attempt {attempt + 1} failed: {exc}; retrying…"
+                    )
+                    await asyncio.sleep(10)
+                else:
+                    raise
+
+        data = msg.structured_output or msg.output or {}
+
+        # Pixel-coordinate recovery (same pattern as ProductOnShelves)
+        if isinstance(data, str):
+            try:
+                raw = json.loads(data)
+                iw_s, ih_s = image_small.size
+                for d in raw.get("detections", []):
+                    b = d.get("bbox", {})
+                    if any(v > 1.0 for v in (b.get("x1", 0), b.get("y1", 0),
+                                             b.get("x2", 0), b.get("y2", 0))):
+                        b["x1"] = min(1.0, max(0.0, b.get("x1", 0) / iw_s))
+                        b["y1"] = min(1.0, max(0.0, b.get("y1", 0) / ih_s))
+                        b["x2"] = min(1.0, max(0.0, b.get("x2", 0) / iw_s))
+                        b["y2"] = min(1.0, max(0.0, b.get("y2", 0) / ih_s))
+                data = Detections(**raw)
+                self.logger.info("Recovered zone detections after normalizing pixel coordinates.")
+            except Exception as parse_err:
+                self.logger.warning(f"Zone coordinate recovery failed: {parse_err}")
+                return []
+
+        return data.detections or []
+
+    async def detect_objects(
+        self,
+        img: Image.Image,
+        roi: Any,
+        macro_objects: Any,
+    ) -> Tuple[List[IdentifiedProduct], List[ShelfRegion]]:
+        """OCR + visual feature verification for each detected graphic zone.
+
+        Maps LLM-detected zone labels (e.g. ``top_zone``) to the planogram
+        config product names (e.g. ``Epson_Top_Not_Backlit``) by position
+        order within each shelf level.  Then runs OCR / visual enrichment
+        on each zone and checks illumination state where the config
+        specifies ``illumination_status`` in ``visual_features``.
+
+        Args:
+            img: The input PIL image.
+            roi: Endcap detection from ``compute_roi()``.
+            macro_objects: Zone detections from ``detect_objects_roi()``.
+
+        Returns:
+            Tuple of (identified_products, shelf_regions).  One
+            ``IdentifiedProduct`` per detected zone, one ``ShelfRegion``
+            per shelf level.
+        """
+        planogram_description = self.config.get_planogram_description()
+        zone_detections: List[Detection] = macro_objects or []
+        shelves = planogram_description.shelves or []
+
+        identified_products: List[IdentifiedProduct] = []
+        shelf_regions: List[ShelfRegion] = []
+
+        # Sort zone detections top-to-bottom so positional mapping is stable.
+        sorted_zones = sorted(
+            zone_detections,
+            key=lambda d: (d.bbox.y1 + d.bbox.y2) / 2.0
+        )
+
+        for shelf_idx, shelf_cfg in enumerate(shelves):
+            shelf_level = shelf_cfg.level
+            products_cfg = shelf_cfg.products or []
+
+            # Map: one zone detection per configured product (by position order)
+            for prod_idx, prod_cfg in enumerate(products_cfg):
+                zone_det: Optional[Detection] = None
+                if prod_idx < len(sorted_zones):
+                    zone_det = sorted_zones[prod_idx]
+
+                visual_features: List[str] = []
+
+                if zone_det is not None:
+                    # Run OCR + visual enrichment on the zone crop
+                    visual_features = await self._enrich_zone(
+                        img=img,
+                        zone_det=zone_det,
+                        roi=roi,
+                        prod_cfg=prod_cfg,
+                        planogram_description=planogram_description,
+                    )
+
+                product = IdentifiedProduct(
+                    product_model=prod_cfg.name,
+                    product_type="graphic_zone",
+                    shelf_location=shelf_level,
+                    confidence=zone_det.confidence if zone_det else 0.0,
+                    brand=getattr(planogram_description, "brand", None),
+                    visual_features=visual_features,
+                )
+                identified_products.append(product)
+
+            shelf_regions.append(
+                ShelfRegion(
+                    level=shelf_level,
+                    detections=[p.detection_box for p in identified_products
+                                if p.shelf_location == shelf_level
+                                and p.detection_box is not None],
+                )
+            )
+
+        return identified_products, shelf_regions
+
+    def check_planogram_compliance(
+        self,
+        identified_products: List[IdentifiedProduct],
+        planogram_description: Any,
+    ) -> List[ComplianceResult]:
+        """Compare detected graphic zones against the expected planogram layout.
+
+        For each shelf level (zone):
+        - Checks zone presence (confidence > 0 → found).
+        - Evaluates text requirements from ``visual_features`` (same mechanism
+          as ``ProductOnShelves``).
+        - Applies illumination check: if ``illumination_status`` is in the
+          config's ``visual_features`` and the detected state contradicts
+          the expected state, applies the configurable ``illumination_penalty``
+          to the zone score (default: 1.0 → score becomes 0).
+
+        No fact-tag, physical product counting, or brand-logo logic is run.
+
+        Args:
+            identified_products: Zone products detected by ``detect_objects()``.
+            planogram_description: Expected planogram layout from config.
+
+        Returns:
+            List of ComplianceResult, one per shelf/zone.
+        """
+        by_shelf: Dict[str, List[IdentifiedProduct]] = {}
+        for p in identified_products:
+            by_shelf.setdefault(p.shelf_location, []).append(p)
+
+        results: List[ComplianceResult] = []
+
+        for shelf_cfg in planogram_description.shelves:
+            shelf_level = shelf_cfg.level
+            products_on_shelf = by_shelf.get(shelf_level, [])
+            products_cfg = shelf_cfg.products or []
+
+            expected_names: List[str] = [p.name for p in products_cfg]
+            found_names: List[str] = []
+            missing: List[str] = []
+            text_results: List[TextComplianceResult] = []
+
+            zone_scores: List[float] = []
+
+            for prod_idx, prod_cfg in enumerate(products_cfg):
+                detected = (
+                    products_on_shelf[prod_idx]
+                    if prod_idx < len(products_on_shelf)
+                    else None
+                )
+
+                zone_found = detected is not None and detected.confidence > 0.0
+
+                if zone_found:
+                    found_names.append(prod_cfg.name)
+                else:
+                    missing.append(prod_cfg.name)
+
+                # Base zone score: 1.0 if found, 0.0 if missing
+                zone_score = 1.0 if zone_found else 0.0
+
+                # ----------------------------------------------------------
+                # Illumination check (configurable penalty)
+                # ----------------------------------------------------------
+                if zone_found and prod_cfg.visual_features:
+                    expected_illum = self._extract_illumination_state(
+                        prod_cfg.visual_features
+                    )
+                    if expected_illum is not None:
+                        detected_features = (
+                            detected.visual_features if detected else []
+                        ) or []
+                        detected_illum = self._extract_illumination_state(
+                            detected_features
+                        )
+                        if detected_illum is not None and detected_illum != expected_illum:
+                            penalty = self._get_illumination_penalty(shelf_cfg)
+                            zone_score *= (1.0 - penalty)
+                            self.logger.debug(
+                                f"Illumination mismatch on zone '{prod_cfg.name}': "
+                                f"expected={expected_illum}, detected={detected_illum}, "
+                                f"penalty={penalty} → zone_score={zone_score:.3f}"
+                            )
+
+                # ----------------------------------------------------------
+                # Text requirement check
+                # ----------------------------------------------------------
+                text_score = 1.0
+                overall_text_ok = True
+                if zone_found and getattr(prod_cfg, "text_requirements", None):
+                    detected_features = (
+                        detected.visual_features if detected else []
+                    ) or []
+                    for text_req in prod_cfg.text_requirements:
+                        result = TextMatcher.check_text_match(
+                            required_text=text_req.required_text,
+                            visual_features=detected_features,
+                            match_type=text_req.match_type,
+                            case_sensitive=text_req.case_sensitive,
+                            confidence_threshold=text_req.confidence_threshold,
+                        )
+                        text_results.append(result)
+                        if not result.found and text_req.mandatory:
+                            overall_text_ok = False
+                    if text_results:
+                        text_score = sum(
+                            r.confidence for r in text_results if r.found
+                        ) / len(text_results)
+
+                zone_scores.append(zone_score)
+
+            # Aggregate score across all zones in this shelf
+            combined_score = (
+                sum(zone_scores) / len(zone_scores) if zone_scores else 0.0
+            )
+            combined_score = min(1.0, max(0.0, combined_score))
+
+            threshold = getattr(
+                shelf_cfg,
+                "compliance_threshold",
+                planogram_description.global_compliance_threshold or 0.8,
+            )
+
+            if combined_score >= threshold:
+                status = ComplianceStatus.COMPLIANT
+            elif combined_score == 0.0 and expected_names:
+                status = ComplianceStatus.MISSING
+            else:
+                status = ComplianceStatus.NON_COMPLIANT
+
+            results.append(
+                ComplianceResult(
+                    shelf_level=shelf_level,
+                    expected_products=expected_names,
+                    found_products=found_names,
+                    missing_products=missing,
+                    unexpected_products=[],  # no unexpected logic for graphic panels
+                    compliance_status=status,
+                    compliance_score=combined_score,
+                    text_compliance_results=text_results,
+                    text_compliance_score=min(1.0, max(0.0, text_score if text_results else 1.0)),
+                    overall_text_compliant=overall_text_ok,
+                    brand_compliance_result=None,
+                )
+            )
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _find_display_roi(
+        self,
+        image: Image.Image,
+        planogram_description: Any,
+    ) -> Tuple[Optional[Any], Optional[Any], None, None, List[Any]]:
+        """Locate the endcap boundary using the LLM ROI prompt.
+
+        Mirrors the logic of ``ProductOnShelves._find_poster()`` but
+        simplified: we only need the endcap bounding box, not poster/brand/
+        text sub-detections.
+
+        Args:
+            image: The input PIL image.
+            planogram_description: Planogram config description.
+
+        Returns:
+            Tuple of (endcap_detection, endcap_detection, None, None, raw_dets).
+        """
+        partial_prompt = self.config.roi_detection_prompt or ""
+        brand = (getattr(planogram_description, "brand", "") or "").strip()
+        tags = [t.strip() for t in getattr(planogram_description, "tags", []) or []]
+        tag_hint = ", ".join(sorted({f"'{t}'" for t in tags if t}))
+
+        image_small = self.pipeline._downscale_image(image, max_side=1024, quality=78)
+        prompt = partial_prompt.format(
+            brand=brand,
+            tag_hint=tag_hint,
+            image_size=image_small.size,
+        ) if partial_prompt else (
+            f"Find the complete endcap display boundary for a {brand} graphic panel. "
+            "Return a bounding box labeled 'endcap' that covers the full display."
+        )
+
+        max_attempts = 2
+        msg = None
+        for attempt in range(max_attempts):
+            try:
+                async with self.pipeline.roi_client as client:
+                    msg = await client.ask_to_image(
+                        image=image_small,
+                        prompt=prompt,
+                        model="gemini-2.5-flash",
+                        no_memory=True,
+                        structured_output=Detections,
+                        max_tokens=8192,
+                    )
+                break
+            except Exception as exc:
+                if attempt < max_attempts - 1:
+                    self.logger.warning(
+                        f"ROI detection attempt {attempt + 1} failed: {exc}; retrying…"
+                    )
+                    await asyncio.sleep(10)
+                else:
+                    raise
+
+        data = msg.structured_output or msg.output or {}
+
+        # Pixel-coordinate recovery (same as ProductOnShelves)
+        if isinstance(data, str):
+            try:
+                raw = json.loads(data)
+                iw, ih = image_small.size
+                for d in raw.get("detections", []):
+                    b = d.get("bbox", {})
+                    if any(v > 1.0 for v in (b.get("x1", 0), b.get("y1", 0),
+                                             b.get("x2", 0), b.get("y2", 0))):
+                        b["x1"] = min(1.0, max(0.0, b.get("x1", 0) / iw))
+                        b["y1"] = min(1.0, max(0.0, b.get("y1", 0) / ih))
+                        b["x2"] = min(1.0, max(0.0, b.get("x2", 0) / iw))
+                        b["y2"] = min(1.0, max(0.0, b.get("y2", 0) / ih))
+                data = Detections(**raw)
+                self.logger.info("Recovered Step 1 detections after normalizing pixel coordinates.")
+            except Exception as parse_err:
+                self.logger.warning(f"Step 1 coordinate recovery failed: {parse_err}")
+                return None, None, None, None, []
+
+        dets = data.detections or []
+        if not dets:
+            return None, None, None, None, []
+
+        def _norm_label(det: Detection) -> str:
+            return (det.label or "").strip().lower()
+
+        # Prefer explicit endcap label; fall back to highest-confidence detection.
+        endcap_det = next(
+            (d for d in dets if _norm_label(d) in ("endcap", "endcap_roi", "endcap-roi", "poster_panel", "poster")),
+            max(dets, key=lambda d: float(d.confidence)) if dets else None,
+        )
+
+        if not endcap_det:
+            self.logger.error("Could not detect the display endcap boundary.")
+            return None, None, None, None, []
+
+        return endcap_det, endcap_det, None, None, dets
+
+    async def _enrich_zone(
+        self,
+        img: Image.Image,
+        zone_det: Detection,
+        roi: Any,
+        prod_cfg: Any,
+        planogram_description: Any,
+    ) -> List[str]:
+        """Run OCR + visual enrichment on a graphic zone.
+
+        Crops the zone from the (already ROI-cropped) image and asks the
+        LLM to verify text and visual features.  Returns the list of
+        confirmed ``visual_features`` strings (e.g.
+        ``["illumination_status: OFF", "ocr: EcoTank"]``).
+
+        Args:
+            img: The full input PIL image.
+            zone_det: The Detection for this zone (normalized to ROI space).
+            roi: The endcap Detection (provides the ROI bbox offset).
+            prod_cfg: The config entry for this zone/product.
+            planogram_description: Full planogram description for context.
+
+        Returns:
+            List of confirmed visual feature strings.
+        """
+        # Determine absolute bbox from ROI-relative zone detection
+        iw, ih = img.size
+        if roi is not None:
+            roi_x1 = roi.bbox.x1 * iw
+            roi_y1 = roi.bbox.y1 * ih
+            roi_x2 = roi.bbox.x2 * iw
+            roi_y2 = roi.bbox.y2 * ih
+            roi_w = roi_x2 - roi_x1
+            roi_h = roi_y2 - roi_y1
+        else:
+            roi_x1, roi_y1, roi_w, roi_h = 0.0, 0.0, float(iw), float(ih)
+
+        abs_x1 = int(roi_x1 + zone_det.bbox.x1 * roi_w)
+        abs_y1 = int(roi_y1 + zone_det.bbox.y1 * roi_h)
+        abs_x2 = int(roi_x1 + zone_det.bbox.x2 * roi_w)
+        abs_y2 = int(roi_y1 + zone_det.bbox.y2 * roi_h)
+
+        # Clamp to image
+        abs_x1 = max(0, min(abs_x1, iw))
+        abs_y1 = max(0, min(abs_y1, ih))
+        abs_x2 = max(abs_x1 + 1, min(abs_x2, iw))
+        abs_y2 = max(abs_y1 + 1, min(abs_y2, ih))
+
+        zone_crop = img.crop((abs_x1, abs_y1, abs_x2, abs_y2))
+        zone_small = self.pipeline._downscale_image(zone_crop, max_side=512, quality=78)
+
+        expected_features = getattr(prod_cfg, "visual_features", []) or []
+        brand = (getattr(planogram_description, "brand", "") or "").strip()
+        zone_name = prod_cfg.name
+
+        features_hint = (
+            "Expected visual features: " + ", ".join(f"'{f}'" for f in expected_features)
+            if expected_features
+            else ""
+        )
+        prompt = (
+            f"This is the '{zone_name}' graphic zone of a {brand} endcap display. "
+            f"{features_hint}\n\n"
+            "Please verify:\n"
+            "1. What text is visible? (prefix with 'ocr:')\n"
+            "2. Is this zone illuminated (backlit/lit) or not? "
+            "   (respond with 'illumination_status: ON' or 'illumination_status: OFF')\n"
+            "3. Any other notable visual features.\n\n"
+            "Return a JSON list of strings, e.g.: "
+            '["illumination_status: OFF", "ocr: EcoTank", "graphic_visible: true"]'
+        )
+
+        visual_features: List[str] = []
+        try:
+            async with self.pipeline.roi_client as client:
+                msg = await client.ask_to_image(
+                    image=zone_small,
+                    prompt=prompt,
+                    model="gemini-2.5-flash",
+                    no_memory=True,
+                    max_tokens=512,
+                )
+            raw_output = msg.output or ""
+            # Extract JSON list from the response
+            import re
+            match = re.search(r'\[.*?\]', raw_output, re.DOTALL)
+            if match:
+                visual_features = json.loads(match.group(0))
+                if not isinstance(visual_features, list):
+                    visual_features = []
+        except Exception as exc:
+            self.logger.warning(
+                f"Zone enrichment failed for '{zone_name}': {exc}"
+            )
+
+        return visual_features
+
+    @staticmethod
+    def _extract_illumination_state(features: List[str]) -> Optional[str]:
+        """Parse the illumination state from a list of visual_features strings.
+
+        Looks for entries matching ``illumination_status: ON`` or
+        ``illumination_status: OFF`` (case-insensitive).
+
+        Args:
+            features: List of visual feature strings.
+
+        Returns:
+            Normalised state string (``"on"`` or ``"off"``) or ``None`` if
+            no illumination feature is present.
+        """
+        for feat in features or []:
+            if isinstance(feat, str) and feat.lower().startswith(_ILLUMINATION_FEATURE_PREFIX.lower()):
+                state = feat[len(_ILLUMINATION_FEATURE_PREFIX):].strip().lower()
+                return state  # "on" or "off"
+        return None
+
+    @staticmethod
+    def _get_illumination_penalty(shelf_cfg: Any) -> float:
+        """Read the configurable illumination penalty from a shelf config.
+
+        The penalty is read from ``shelf_cfg.illumination_penalty`` if set.
+        Defaults to 1.0 (full deduction → score becomes 0).
+
+        Args:
+            shelf_cfg: Shelf configuration object from ``PlanogramConfig``.
+
+        Returns:
+            Penalty weight in [0.0, 1.0].
+        """
+        penalty = getattr(shelf_cfg, "illumination_penalty", None)
+        if penalty is None:
+            # Also check first product in shelf for per-product config
+            products = getattr(shelf_cfg, "products", []) or []
+            if products:
+                penalty = getattr(products[0], "illumination_penalty", None)
+        if penalty is None:
+            penalty = _DEFAULT_ILLUMINATION_PENALTY
+        return float(max(0.0, min(1.0, penalty)))

--- a/tests/test_graphic_panel_display.py
+++ b/tests/test_graphic_panel_display.py
@@ -1,0 +1,367 @@
+"""Unit tests for GraphicPanelDisplay planogram type composable.
+
+Tests cover:
+- Zone detection (all present / missing zone)
+- Illumination check (OFF pass, OFF fail, ON pass)
+- Configurable illumination penalty
+- Text requirement evaluation (pass / fail)
+- No fact-tag / product-counting logic
+- Type registration in _PLANOGRAM_TYPES
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+
+from parrot.pipelines.planogram.types.graphic_panel_display import GraphicPanelDisplay
+from parrot.pipelines.planogram.plan import PlanogramCompliance
+from parrot.models.compliance import ComplianceStatus
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+def _make_pipeline_mock():
+    """Mock PlanogramCompliance pipeline with logger."""
+    mock = MagicMock()
+    mock.logger = MagicMock()
+    return mock
+
+
+def _make_shelf_product(
+    name: str,
+    visual_features=None,
+    text_requirements=None,
+    illumination_penalty=None,
+):
+    """Build a minimal shelf-product config mock."""
+    p = MagicMock()
+    p.name = name
+    p.product_type = "graphic_zone"
+    p.visual_features = visual_features or []
+    p.text_requirements = text_requirements or []
+    if illumination_penalty is not None:
+        p.illumination_penalty = illumination_penalty
+    else:
+        # Mimic "attribute not set" so getattr returns None
+        del p.illumination_penalty
+    return p
+
+
+def _make_shelf_cfg(level: str, products, illumination_penalty=None, compliance_threshold=0.8):
+    """Build a minimal shelf config mock."""
+    s = MagicMock()
+    s.level = level
+    s.products = products
+    s.compliance_threshold = compliance_threshold
+    if illumination_penalty is not None:
+        s.illumination_penalty = illumination_penalty
+    else:
+        del s.illumination_penalty
+    return s
+
+
+def _make_planogram_description(shelves, brand="Epson", global_compliance_threshold=0.8):
+    """Build a minimal planogram description mock."""
+    pd = MagicMock()
+    pd.brand = brand
+    pd.shelves = shelves
+    pd.global_compliance_threshold = global_compliance_threshold
+    return pd
+
+
+def _make_identified_product(name: str, shelf_level: str, confidence=1.0, visual_features=None):
+    """Build an IdentifiedProduct mock."""
+    p = MagicMock()
+    p.product_model = name
+    p.product_type = "graphic_zone"
+    p.shelf_location = shelf_level
+    p.confidence = confidence
+    p.visual_features = visual_features or []
+    p.detection_box = None
+    p.brand = "Epson"
+    return p
+
+
+def _make_config(shelves):
+    """Build a PlanogramConfig mock."""
+    cfg = MagicMock()
+    cfg.roi_detection_prompt = "Find zones"
+    cfg.get_planogram_description = MagicMock(return_value=_make_planogram_description(shelves))
+    return cfg
+
+
+def _make_type(pipeline_mock=None, config_mock=None, shelves=None):
+    """Instantiate GraphicPanelDisplay with mocks."""
+    shelves = shelves or []
+    pipeline = pipeline_mock or _make_pipeline_mock()
+    config = config_mock or _make_config(shelves)
+    return GraphicPanelDisplay(pipeline=pipeline, config=config)
+
+
+# ---------------------------------------------------------------------------
+# Tests: zone detection
+# ---------------------------------------------------------------------------
+
+class TestZoneDetection:
+    """check_planogram_compliance — zone presence logic."""
+
+    def test_zone_detection_all_present(self):
+        """All expected zones detected → compliance_score == 1.0 for each shelf."""
+        header_prod = _make_shelf_product("Epson_Top_Not_Backlit")
+        middle_prod = _make_shelf_product("Epson_Comparison_Table")
+        bottom_prod = _make_shelf_product("Epson_Base_Special_Offer")
+
+        shelves = [
+            _make_shelf_cfg("header", [header_prod]),
+            _make_shelf_cfg("middle", [middle_prod]),
+            _make_shelf_cfg("bottom", [bottom_prod]),
+        ]
+        planogram_description = _make_planogram_description(shelves)
+
+        identified = [
+            _make_identified_product("Epson_Top_Not_Backlit", "header", confidence=0.95),
+            _make_identified_product("Epson_Comparison_Table", "middle", confidence=0.90),
+            _make_identified_product("Epson_Base_Special_Offer", "bottom", confidence=0.88),
+        ]
+
+        gp = _make_type(shelves=shelves)
+        results = gp.check_planogram_compliance(identified, planogram_description)
+
+        assert len(results) == 3
+        for r in results:
+            assert r.compliance_score == pytest.approx(1.0)
+            assert r.compliance_status == ComplianceStatus.COMPLIANT
+
+    def test_zone_detection_missing_zone(self):
+        """Missing mandatory zone → non-compliant with score 0.0."""
+        header_prod = _make_shelf_product("Epson_Top_Not_Backlit")
+        shelves = [_make_shelf_cfg("header", [header_prod])]
+        planogram_description = _make_planogram_description(shelves)
+
+        # No identified products for this shelf
+        identified = []
+
+        gp = _make_type(shelves=shelves)
+        results = gp.check_planogram_compliance(identified, planogram_description)
+
+        assert len(results) == 1
+        assert results[0].compliance_score == pytest.approx(0.0)
+        assert results[0].compliance_status == ComplianceStatus.MISSING
+        assert "Epson_Top_Not_Backlit" in results[0].missing_products
+
+
+# ---------------------------------------------------------------------------
+# Tests: illumination check
+# ---------------------------------------------------------------------------
+
+class TestIlluminationCheck:
+    """Illumination state compliance and configurable penalty."""
+
+    def _run(self, expected_state: str, detected_state: str, penalty=None) -> float:
+        """Helper: build a single-shelf planogram and return compliance_score."""
+        prod_cfg = _make_shelf_product(
+            "Epson_Top_Not_Backlit",
+            visual_features=[f"illumination_status: {expected_state}"],
+        )
+        shelf_cfg = _make_shelf_cfg("header", [prod_cfg])
+        if penalty is not None:
+            shelf_cfg.illumination_penalty = penalty
+
+        planogram_description = _make_planogram_description([shelf_cfg])
+
+        identified = [
+            _make_identified_product(
+                "Epson_Top_Not_Backlit",
+                "header",
+                confidence=0.95,
+                visual_features=[f"illumination_status: {detected_state}"],
+            )
+        ]
+
+        gp = _make_type(shelves=[shelf_cfg])
+        results = gp.check_planogram_compliance(identified, planogram_description)
+        return results[0].compliance_score
+
+    def test_illumination_check_off_pass(self):
+        """Zone expected OFF, detected OFF → no penalty applied."""
+        score = self._run("OFF", "OFF")
+        assert score == pytest.approx(1.0)
+
+    def test_illumination_check_off_fail(self):
+        """Zone expected OFF but detected ON → default penalty=1.0 → score=0."""
+        score = self._run("OFF", "ON")
+        assert score == pytest.approx(0.0)
+
+    def test_illumination_check_on_pass(self):
+        """Zone expected ON, detected ON → no penalty applied."""
+        score = self._run("ON", "ON")
+        assert score == pytest.approx(1.0)
+
+    def test_illumination_penalty_configurable(self):
+        """Custom penalty=0.5 → score halved, not zeroed."""
+        score = self._run("OFF", "ON", penalty=0.5)
+        # zone_score = 1.0, penalty=0.5 → 1.0 * (1 - 0.5) = 0.5
+        assert score == pytest.approx(0.5)
+
+    def test_illumination_no_penalty_when_state_matches(self):
+        """Correct illumination state detected → score unaffected."""
+        score = self._run("ON", "ON", penalty=0.9)
+        assert score == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Tests: text requirement evaluation
+# ---------------------------------------------------------------------------
+
+class TestTextRequirements:
+    """Text requirement check via visual_features."""
+
+    def test_text_requirement_pass(self):
+        """Required text found in OCR features → compliant."""
+        text_req = MagicMock()
+        text_req.required_text = "EcoTank"
+        text_req.match_type = "contains"
+        text_req.case_sensitive = False
+        text_req.confidence_threshold = 0.6
+        text_req.mandatory = True
+
+        prod_cfg = _make_shelf_product(
+            "Epson_Top_Not_Backlit",
+            text_requirements=[text_req],
+        )
+        shelf_cfg = _make_shelf_cfg("header", [prod_cfg])
+        planogram_description = _make_planogram_description([shelf_cfg])
+
+        identified = [
+            _make_identified_product(
+                "Epson_Top_Not_Backlit",
+                "header",
+                visual_features=["ocr: EcoTank Printer"],
+            )
+        ]
+
+        gp = _make_type(shelves=[shelf_cfg])
+
+        from unittest.mock import patch
+        from parrot.models.compliance import TextComplianceResult
+
+        found_result = TextComplianceResult(
+            required_text="EcoTank",
+            found=True,
+            matched_features=["ocr: EcoTank Printer"],
+            confidence=0.9,
+            match_type="contains",
+        )
+
+        with patch(
+            "parrot.pipelines.planogram.types.graphic_panel_display.TextMatcher.check_text_match",
+            return_value=found_result,
+        ):
+            results = gp.check_planogram_compliance(identified, planogram_description)
+
+        assert results[0].overall_text_compliant is True
+        assert any(r.found for r in results[0].text_compliance_results)
+
+    def test_text_requirement_fail(self):
+        """Required text missing from OCR → non-compliant."""
+        text_req = MagicMock()
+        text_req.required_text = "EcoTank"
+        text_req.match_type = "contains"
+        text_req.case_sensitive = False
+        text_req.confidence_threshold = 0.6
+        text_req.mandatory = True
+
+        prod_cfg = _make_shelf_product(
+            "Epson_Top_Not_Backlit",
+            text_requirements=[text_req],
+        )
+        shelf_cfg = _make_shelf_cfg("header", [prod_cfg])
+        planogram_description = _make_planogram_description([shelf_cfg])
+
+        identified = [
+            _make_identified_product(
+                "Epson_Top_Not_Backlit",
+                "header",
+                visual_features=["ocr: some other text"],
+            )
+        ]
+
+        gp = _make_type(shelves=[shelf_cfg])
+
+        from unittest.mock import patch
+        from parrot.models.compliance import TextComplianceResult
+
+        not_found_result = TextComplianceResult(
+            required_text="EcoTank",
+            found=False,
+            matched_features=[],
+            confidence=0.0,
+            match_type="contains",
+        )
+
+        with patch(
+            "parrot.pipelines.planogram.types.graphic_panel_display.TextMatcher.check_text_match",
+            return_value=not_found_result,
+        ):
+            results = gp.check_planogram_compliance(identified, planogram_description)
+
+        assert results[0].overall_text_compliant is False
+        assert all(not r.found for r in results[0].text_compliance_results)
+
+
+# ---------------------------------------------------------------------------
+# Tests: no fact-tag / product counting
+# ---------------------------------------------------------------------------
+
+class TestNoFactTagLogic:
+    """Verify no fact-tag attributes or product-counting logic in compliance output."""
+
+    def test_no_fact_tag_logic(self):
+        """ComplianceResult must not contain fact-tag related attributes."""
+        prod_cfg = _make_shelf_product("Epson_Top_Not_Backlit")
+        shelf_cfg = _make_shelf_cfg("header", [prod_cfg])
+        planogram_description = _make_planogram_description([shelf_cfg])
+
+        identified = [
+            _make_identified_product("Epson_Top_Not_Backlit", "header", confidence=0.9)
+        ]
+
+        gp = _make_type(shelves=[shelf_cfg])
+        results = gp.check_planogram_compliance(identified, planogram_description)
+
+        assert len(results) == 1
+        result = results[0]
+
+        # No brand compliance (graphic panels don't check brand logo)
+        assert result.brand_compliance_result is None
+
+        # No unexpected products (graphic panels don't penalise extras)
+        assert result.unexpected_products == []
+
+        # Compliance result does not have any fact_tag attributes
+        result_dict = result.model_dump()
+        for key in result_dict:
+            assert "fact" not in key.lower(), f"Unexpected fact-related key: {key}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: type registration
+# ---------------------------------------------------------------------------
+
+class TestRegistration:
+    """Verify GraphicPanelDisplay is registered in _PLANOGRAM_TYPES."""
+
+    def test_type_registered(self):
+        """'graphic_panel_display' key must exist in PlanogramCompliance._PLANOGRAM_TYPES."""
+        assert "graphic_panel_display" in PlanogramCompliance._PLANOGRAM_TYPES
+
+    def test_type_resolves_to_correct_class(self):
+        """_PLANOGRAM_TYPES['graphic_panel_display'] must be GraphicPanelDisplay."""
+        cls = PlanogramCompliance._PLANOGRAM_TYPES["graphic_panel_display"]
+        assert cls is GraphicPanelDisplay
+
+    def test_product_on_shelves_still_registered(self):
+        """Existing 'product_on_shelves' registration must not be broken."""
+        assert "product_on_shelves" in PlanogramCompliance._PLANOGRAM_TYPES


### PR DESCRIPTION
## Summary

- Add `GraphicPanelDisplay` as a new `AbstractPlanogramType` subclass for graphic-panel / signage endcap compliance (EcoTank, Projector, Bose audio displays)
- Register `"graphic_panel_display"` in `_PLANOGRAM_TYPES` — no changes to the orchestrator (`plan.py`) routing logic needed
- Zone-based compliance: no physical product counting, no fact-tag detection
- Configurable illumination penalty (default `1.0` → score=0 when detected state contradicts config; overridable per shelf via `illumination_penalty` field)
- 13 unit tests, all green — zero live LLM calls

## Files changed

- `parrot/pipelines/planogram/types/graphic_panel_display.py` — new composable (TASK-011)
- `parrot/pipelines/planogram/types/__init__.py` — export `GraphicPanelDisplay` (TASK-012)
- `parrot/pipelines/planogram/plan.py` — register in `_PLANOGRAM_TYPES` (TASK-012)
- `tests/test_graphic_panel_display.py` — full unit test suite (TASK-013)

## Test plan

- [x] `pytest tests/test_graphic_panel_display.py -v` → 13 passed
- [x] `from parrot.pipelines.planogram.types import GraphicPanelDisplay` works
- [x] `PlanogramCompliance._PLANOGRAM_TYPES["graphic_panel_display"]` resolves correctly
- [x] `"product_on_shelves"` registration untouched (no regression)

## Spec

`sdd/specs/graphic-panel-display.spec.md` — FEAT-004, approved by Jesus Lara.

🤖 Generated with [Claude Code](https://claude.com/claude-code)