### PR TITLE
fix: remove setuptools-scm to fix cibuildwheel release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Extract version from tag
-        id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -47,7 +43,7 @@ jobs:
         env:
           CIBW_ARCHS: x86_64
           CIBW_BEFORE_BUILD: "curl https://sh.rustup.rs -sSf | sh -s -- -y && source $HOME/.cargo/env"
-          CIBW_ENVIRONMENT: "PATH=/root/.cargo/bin:$PATH SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.version.outputs.VERSION }}"
+          CIBW_ENVIRONMENT: "PATH=/root/.cargo/bin:$PATH"
           RUST_SUBPACKAGE_PATH: src/parrot/yaml_rs
           CIBW_BUILD: "cp3{10,11,12}-*"
         run: |

--- a/packages/ai-parrot/pyproject.toml
+++ b/packages/ai-parrot/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     "setuptools>=67.6.1",
-    "setuptools_scm[toml]>=6.0",
     "Cython==3.0.11",
     "wheel>=0.44.0"
 ]
@@ -9,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ai-parrot"
-dynamic = ["version"]
+version = "0.24.0"
 description = "Framework for building AI agents for Navigator"
 authors = [
     {name = "Jesus Lara", email = "jesuslara@phenobarbital.info"}
@@ -493,9 +492,6 @@ Funding = "https://paypal.me/phenobarbital"
 [tool.setuptools]
 # license lives at repo root; omitted to avoid setuptools path restriction
 
-[tool.setuptools_scm]
-root = "../.."
-write_to = "packages/ai-parrot/src/parrot/_version.py"
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
setuptools-scm fails inside cibuildwheel containers because the .git directory is not available and write_to resolves to an invalid path. Replace with a static version in pyproject.toml.