### PR TITLE
chore: remove asyncdb-full extra (asyncdb[default] comes via navigato…

### DIFF
--- a/packages/ai-parrot/pyproject.toml
+++ b/packages/ai-parrot/pyproject.toml
@@ -88,11 +88,6 @@ parrot-fs = "parrot.transport.filesystem.cli:main"
 # Extras groups (from FEAT-056 — runtime-dependency-reduction)
 # ---------------------------------------------------------------------------
 
-# asyncdb[default] drivers (deltalake, duckdb, cassandra, redis, influxdb, etc.)
-asyncdb-full = [
-    "asyncdb[default]>=2.11.6",
-]
-
 # All notification backends (msgraph, twilio, o365, etc.)
 notify-all = [
     "async-notify[all]>=1.4.2",


### PR DESCRIPTION
…r-api)

The asyncdb-full extra was redundant — navigator-api already requires asyncdb[boto3,default,uvloop], so declaring it here only bloated the lockfile. The deltalake/duckdb reduction must be done upstream in navigator-api.