### PR TITLE
fix: address code review findings in feat-062-composite-datasets

### DIFF
--- a/packages/ai-parrot/src/parrot/tools/dataset_manager/__init__.py
+++ b/packages/ai-parrot/src/parrot/tools/dataset_manager/__init__.py
@@ -6,8 +6,11 @@ Provides:
 - DatasetEntry: Lifecycle wrapper around a DataSource
 - DatasetInfo: Pydantic schema for dataset metadata exposed to LLM
 - DataSource: Abstract base for all data source types
+- CompositeDataSource / JoinSpec: Virtual JOIN datasets
+- ComputedColumnDef: Post-materialization computed column definition
 """
 from .tool import DatasetManager, DatasetEntry, DatasetInfo
+from .computed import ComputedColumnDef
 from .sources import (
     DataSource,
     InMemorySource,
@@ -17,6 +20,8 @@ from .sources import (
     TableSource,
     AirtableSource,
     SmartsheetSource,
+    CompositeDataSource,
+    JoinSpec,
     IcebergSource,
     MongoSource,
     DeltaTableSource,
@@ -34,7 +39,10 @@ __all__ = [
     "TableSource",
     "AirtableSource",
     "SmartsheetSource",
+    "CompositeDataSource",
+    "JoinSpec",
     "IcebergSource",
     "MongoSource",
     "DeltaTableSource",
+    "ComputedColumnDef",
 ]

--- a/packages/ai-parrot/src/parrot/tools/dataset_manager/computed.py
+++ b/packages/ai-parrot/src/parrot/tools/dataset_manager/computed.py
@@ -147,7 +147,14 @@ def _builtin_concatenate(
 
     Returns:
         DataFrame with the new column appended.
+
+    Raises:
+        ValueError: If ``columns`` is empty.
     """
+    if not columns:
+        raise ValueError(
+            "concatenate requires at least 1 column, got 0"
+        )
     df = df.copy()
     df[field] = df[columns[0]].astype(str)
     for col in columns[1:]:

--- a/packages/ai-parrot/src/parrot/tools/dataset_manager/sources/composite.py
+++ b/packages/ai-parrot/src/parrot/tools/dataset_manager/sources/composite.py
@@ -17,7 +17,7 @@ Key design decisions (from spec):
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional, Set, TYPE_CHECKING, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, TYPE_CHECKING, Union
 
 import pandas as pd
 from pydantic import BaseModel, Field
@@ -51,8 +51,10 @@ class JoinSpec(BaseModel):
     left: str = Field(description="Left dataset name")
     right: str = Field(description="Right dataset name")
     on: Union[str, List[str]] = Field(description="Join column(s)")
-    how: str = Field(default="inner", description="Join type: inner, left, right, outer")
-    suffixes: tuple = Field(default=("", "_right"))
+    how: Literal["inner", "left", "right", "outer"] = Field(
+        default="inner", description="Join type: inner, left, right, outer"
+    )
+    suffixes: Tuple[str, str] = Field(default=("", "_right"))
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -101,13 +103,13 @@ class CompositeDataSource(DataSource):
     # ─────────────────────────────────────────────────────────────
 
     @property
-    def component_names(self) -> Set[str]:
-        """All unique dataset names referenced by the join specs."""
-        names: Set[str] = set()
+    def component_names(self) -> List[str]:
+        """All unique dataset names referenced by the join specs (insertion order)."""
+        seen: Dict[str, None] = {}
         for j in self.joins:
-            names.add(j.left)
-            names.add(j.right)
-        return names
+            seen[j.left] = None
+            seen[j.right] = None
+        return list(seen)
 
     def _get_component_columns(self, ds_name: str) -> List[str]:
         """Return known columns for a component dataset (loaded or schema only).
@@ -130,9 +132,10 @@ class CompositeDataSource(DataSource):
     async def prefetch_schema(self) -> Dict[str, str]:
         """Return a merged schema from all component schemas.
 
-        Collects ``_schema`` dicts from each component's source (available
-        after prefetch for TableSource etc.) and merges them.  If a column
-        appears in multiple components, the last definition wins.
+        Calls ``prefetch_schema()`` on each component source via the
+        ``DataSource`` ABC method.  If a column appears in multiple
+        components, the last definition wins.  Components that fail
+        schema prefetch are skipped with a warning.
 
         Returns:
             Dict mapping column names to their type strings.
@@ -142,15 +145,24 @@ class CompositeDataSource(DataSource):
             entry = self._dm._datasets.get(ds_name)
             if entry is None:
                 continue
-            schema = getattr(entry.source, "_schema", {})
-            merged.update(schema)
+            try:
+                schema = await entry.source.prefetch_schema()
+                merged.update(schema)
+            except Exception as exc:
+                logger.warning(
+                    "CompositeDataSource '%s': prefetch_schema failed for "
+                    "component '%s': %s",
+                    self.name,
+                    ds_name,
+                    exc,
+                )
         return merged
 
-    async def fetch(self, filter: Optional[Dict[str, Any]] = None, **params: Any) -> pd.DataFrame:
+    async def fetch(self, filters: Optional[Dict[str, Any]] = None, **params: Any) -> pd.DataFrame:
         """Materialize all components, apply per-component filters, then JOIN.
 
         Filter propagation:
-            Each key in ``filter`` is applied only to components whose
+            Each key in ``filters`` is applied only to components whose
             column list contains that key.  If a column exists in multiple
             components, all of them receive the filter.
 
@@ -160,10 +172,11 @@ class CompositeDataSource(DataSource):
             each RIGHT component in order.
 
         Args:
-            filter: Optional dict of equality filters.  Scalar values use
+            filters: Optional dict of equality filters.  Scalar values use
                 ``==``; list/tuple/set values use ``isin``.
-            **params: Extra keyword arguments (currently unused but accepted
-                for DataSource interface compliance).
+            **params: Extra keyword arguments forwarded to component
+                materialization.  ``force_refresh`` is honoured: when
+                ``True``, component caches are bypassed.
 
         Returns:
             Joined DataFrame.
@@ -173,7 +186,7 @@ class CompositeDataSource(DataSource):
             ValueError: If a join column is missing from either side.
             ValueError: If ``pd.merge()`` raises ``pd.errors.MergeError``.
         """
-        filter = filter or {}
+        filters = filters or {}
 
         # ── Validate all components exist ──────────────────────────────────
         for ds_name in self.component_names:
@@ -186,18 +199,22 @@ class CompositeDataSource(DataSource):
                 )
 
         # ── Materialise components with per-component filters ──────────────
+        # Honour force_refresh from the caller rather than hard-coding True,
+        # so components can serve cached results when the caller doesn't request
+        # a refresh (prevents redundant DB hits on repeated composite fetches).
+        force_refresh: bool = bool(params.get("force_refresh", False))
+
         component_dfs: Dict[str, pd.DataFrame] = {}
         for ds_name in self.component_names:
             # Determine applicable filter for this component
             comp_cols = self._get_component_columns(ds_name)
             applicable_filter: Dict[str, Any] = {}
-            if filter and comp_cols:
+            if filters and comp_cols:
                 applicable_filter = {
-                    k: v for k, v in filter.items() if k in comp_cols
+                    k: v for k, v in filters.items() if k in comp_cols
                 }
 
-            # Materialise (force_refresh=True per spec — composite always re-fetches)
-            df = await self._dm.materialize(ds_name, force_refresh=True)
+            df = await self._dm.materialize(ds_name, force_refresh=force_refresh)
 
             # Apply component-level filter
             if applicable_filter:

--- a/packages/ai-parrot/src/parrot/tools/dataset_manager/tool.py
+++ b/packages/ai-parrot/src/parrot/tools/dataset_manager/tool.py
@@ -2625,11 +2625,11 @@ class DatasetManager(AbstractToolkit):
 
         params: Dict[str, Any] = {}
         if isinstance(entry.source, CompositeDataSource):
-            # Composites accept a filter dict for per-component filtering.
-            # Always force_refresh so the JOIN reflects current component state.
+            # Composites accept a filters dict for per-component filtering.
+            # Preserve the caller's force_refresh intent — components use their
+            # own caches unless the caller explicitly requests a refresh.
             if conditions:
-                params['filter'] = conditions
-            force_refresh = True
+                params['filters'] = conditions
         elif isinstance(entry.source, (QuerySlugSource, MultiQuerySlugSource, InMemorySource)):
             # These sources do not accept sql or conditions — ignore them
             # to prevent the LLM from accidentally injecting invalid QS conditions.

--- a/tests/tools/dataset_manager/test_composite_source.py
+++ b/tests/tools/dataset_manager/test_composite_source.py
@@ -112,7 +112,9 @@ class TestJoinSpec:
 
 class TestCompositeDataSource:
     def test_component_names(self, composite_source):
-        assert composite_source.component_names == {"history", "locations"}
+        # component_names returns an ordered list (insertion order, deduplicated)
+        assert isinstance(composite_source.component_names, list)
+        assert set(composite_source.component_names) == {"history", "locations"}
 
     def test_has_builtin_cache(self, composite_source):
         assert composite_source.has_builtin_cache is True
@@ -141,7 +143,7 @@ class TestCompositeDataSource:
     @pytest.mark.asyncio
     async def test_filter_propagation_by_year(self, composite_source):
         """Filter on 'year' applies only to history (which has year column)."""
-        result = await composite_source.fetch(filter={"year": 2025})
+        result = await composite_source.fetch(filters={"year": 2025})
         # Only 2 rows have year=2025
         assert len(result) == 2
         assert all(result["year"] == 2025)
@@ -149,7 +151,7 @@ class TestCompositeDataSource:
     @pytest.mark.asyncio
     async def test_filter_propagation_by_city(self, composite_source):
         """Filter on 'city' applies only to locations (which has city column)."""
-        result = await composite_source.fetch(filter={"city": "Miami"})
+        result = await composite_source.fetch(filters={"city": "Miami"})
         assert len(result) == 1
         assert result["city"].iloc[0] == "Miami"
 
@@ -157,7 +159,7 @@ class TestCompositeDataSource:
     async def test_filter_no_error_for_missing_column(self, composite_source):
         """Filter on column that doesn't exist in any component is silently skipped."""
         # The filter is just not applied to either component
-        result = await composite_source.fetch(filter={"nonexistent_col": "value"})
+        result = await composite_source.fetch(filters={"nonexistent_col": "value"})
         # Result is unfiltered join
         assert len(result) == 3
 


### PR DESCRIPTION
- Rename `filter` param to `filters` in CompositeDataSource.fetch() to avoid shadowing Python's built-in filter(); update call site in tool.py and tests
- Replace non-deterministic Set return from component_names with insertion- ordered List[str] using dict.fromkeys pattern; update test assertion
- Remove hardcoded force_refresh=True on component materialization; honour the caller's force_refresh intent via params.get('force_refresh', False) to avoid redundant DB hits on repeated composite fetches
- Fix prefetch_schema() to call await entry.source.prefetch_schema() via the DataSource ABC instead of reading _schema private attribute (phantom API that only exists on TableSource)
- Add empty-columns guard in _builtin_concatenate() with a descriptive ValueError matching the pattern in _builtin_math_operation()
- Tighten JoinSpec.how to Literal["inner","left","right","outer"] so invalid join types are rejected at Pydantic validation time rather than at pd.merge()
- Tighten JoinSpec.suffixes to Tuple[str, str] so 3-element tuples are rejected at validation time
- Export CompositeDataSource, JoinSpec, and ComputedColumnDef from the package-level __init__.py so callers can do `from parrot.tools.dataset_manager import CompositeDataSource`