### PR TITLE
Add PageIndex toolkit for document indexing and search

### DIFF
--- a/packages/ai-parrot/src/parrot/tools/pageindex_toolkit.py
+++ b/packages/ai-parrot/src/parrot/tools/pageindex_toolkit.py
@@ -1,0 +1,141 @@
+"""Toolkit wrapper around the PageIndex indexing and retrieval pipeline."""
+from __future__ import annotations
+
+import uuid
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+from parrot.models.google import GoogleModel
+from parrot.pageindex.llm_adapter import PageIndexLLMAdapter
+from parrot.pageindex.md_builder import md_to_tree
+from parrot.pageindex.retriever import PageIndexRetriever
+from parrot.pageindex.utils import write_node_id
+from parrot.tools.decorators import tool_schema
+from parrot.tools.toolkit import AbstractToolkit
+
+
+class IndexDocumentsInput(BaseModel):
+    """Input schema for PageIndex document indexing."""
+
+    documents: list[str] = Field(..., min_length=1, description="Markdown/text documents to index.")
+    document_names: Optional[list[str]] = Field(
+        default=None,
+        description="Optional names aligned 1:1 with `documents`.",
+    )
+
+
+class SearchDocumentsInput(BaseModel):
+    """Input schema for PageIndex search."""
+
+    index_id: str = Field(..., description="Index ID returned by index_documents.")
+    query: str = Field(..., min_length=1, description="Natural-language search query.")
+    include_tree_context: bool = Field(
+        default=False,
+        description="Include formatted tree context in the response.",
+    )
+
+
+class PageIndexToolkit(AbstractToolkit):
+    """Index markdown documents and search them with the PageIndex algorithm."""
+
+    name = "pageindex"
+    description = (
+        "Toolkit for document indexing and retrieval using PageIndex tree-search "
+        "with Google Gemini Flash Lite."
+    )
+
+    def __init__(
+        self,
+        model: str = GoogleModel.GEMINI_3_FLASH_LITE_PREVIEW.value,
+        client: Any | None = None,
+        **kwargs: Any,
+    ):
+        super().__init__(**kwargs)
+        self.model = model
+        if client is None:
+            from parrot.clients.google import GoogleGenAIClient
+
+            client = GoogleGenAIClient(model=model)
+        self._client = client
+        self._adapter = PageIndexLLMAdapter(client=self._client, model=model)
+        self._indices: dict[str, dict[str, Any]] = {}
+
+    async def stop(self) -> None:
+        """Close the underlying LLM client when supported."""
+        close_fn = getattr(self._client, "close", None)
+        if callable(close_fn):
+            await close_fn()
+
+    @tool_schema(IndexDocumentsInput)
+    async def index_documents(
+        self,
+        documents: list[str],
+        document_names: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        """Build a PageIndex tree for one or more markdown/text documents."""
+        if document_names and len(document_names) != len(documents):
+            raise ValueError("document_names must match documents length")
+
+        merged_structure: list[dict[str, Any]] = []
+        normalized_names = document_names or [f"document_{idx + 1}.md" for idx in range(len(documents))]
+
+        for idx, content in enumerate(documents):
+            doc_name = normalized_names[idx]
+            doc_tree = await md_to_tree(
+                md_text=content,
+                adapter=self._adapter,
+                doc_name=doc_name,
+                options={"model": self.model},
+            )
+
+            doc_node = {
+                "title": doc_name,
+                "summary": f"Indexed source document: {doc_name}",
+                "nodes": doc_tree.get("structure", []),
+            }
+            merged_structure.append(doc_node)
+
+        write_node_id(merged_structure)
+        tree = {"doc_name": "pageindex_collection", "structure": merged_structure}
+        index_id = str(uuid.uuid4())
+        retriever = PageIndexRetriever(tree=tree, adapter=self._adapter, model=self.model)
+        self._indices[index_id] = {"tree": tree, "retriever": retriever}
+
+        return {
+            "status": "indexed",
+            "index_id": index_id,
+            "model": self.model,
+            "document_count": len(documents),
+        }
+
+    @tool_schema(SearchDocumentsInput)
+    async def search_documents(
+        self,
+        index_id: str,
+        query: str,
+        include_tree_context: bool = False,
+    ) -> dict[str, Any]:
+        """Search an existing PageIndex index and return matching context."""
+        record = self._indices.get(index_id)
+        if not record:
+            return {
+                "status": "not_found",
+                "message": f"Unknown index_id: {index_id}",
+            }
+
+        retriever: PageIndexRetriever = record["retriever"]
+        search_result = await retriever.search(query)
+        context = await retriever.retrieve(query)
+
+        response: dict[str, Any] = {
+            "status": "ok",
+            "index_id": index_id,
+            "query": query,
+            "thinking": search_result.thinking,
+            "node_list": search_result.node_list,
+            "context": context,
+        }
+        if include_tree_context:
+            response["tree_context"] = retriever.get_tree_context(include_summaries=True)
+        return response

--- a/packages/ai-parrot/tests/test_pageindex_toolkit.py
+++ b/packages/ai-parrot/tests/test_pageindex_toolkit.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import asyncio
+
+from parrot.tools.pageindex_toolkit import PageIndexToolkit
+
+
+class _FakeClient:
+    async def close(self):
+        return None
+
+
+class _FakeSearchResult:
+    def __init__(self, thinking: str, node_list: list[int]):
+        self.thinking = thinking
+        self.node_list = node_list
+
+
+class _FakeRetriever:
+    def __init__(self, tree, adapter, model):
+        self.tree = tree
+
+    async def search(self, query: str):
+        return _FakeSearchResult(thinking=f"searching {query}", node_list=[1, 2])
+
+    async def retrieve(self, query: str):
+        return f"context for {query}"
+
+    def get_tree_context(self, include_summaries: bool = True):
+        return "tree-context"
+
+
+async def _fake_md_to_tree(md_text, adapter, options, doc_name):
+    return {
+        "doc_name": doc_name,
+        "structure": [{"title": "Intro", "text": md_text}],
+    }
+
+
+def test_pageindex_toolkit_index_and_search(monkeypatch):
+    monkeypatch.setattr("parrot.tools.pageindex_toolkit.md_to_tree", _fake_md_to_tree)
+    monkeypatch.setattr("parrot.tools.pageindex_toolkit.PageIndexRetriever", _FakeRetriever)
+
+    toolkit = PageIndexToolkit(client=_FakeClient())
+
+    index_result = asyncio.run(
+        toolkit.index_documents(
+            documents=["# Doc A\nBody", "# Doc B\nBody"],
+            document_names=["a.md", "b.md"],
+        )
+    )
+
+    assert index_result["status"] == "indexed"
+    assert index_result["document_count"] == 2
+    assert index_result["index_id"]
+
+    search_result = asyncio.run(
+        toolkit.search_documents(
+            index_id=index_result["index_id"],
+            query="find intro",
+            include_tree_context=True,
+        )
+    )
+
+    assert search_result["status"] == "ok"
+    assert search_result["node_list"] == [1, 2]
+    assert search_result["context"] == "context for find intro"
+    assert search_result["tree_context"] == "tree-context"
+
+
+def test_pageindex_toolkit_search_unknown_index():
+    toolkit = PageIndexToolkit(client=_FakeClient())
+
+    result = asyncio.run(toolkit.search_documents(index_id="missing", query="anything"))
+
+    assert result["status"] == "not_found"


### PR DESCRIPTION
### Motivation
- Provide an agent-accessible toolkit that indexes markdown/text documents into a PageIndex tree and performs tree-search retrieval using the existing PageIndex pipeline.
- Use Gemini (via `GoogleGenAIClient`) as the default LLM for reasoning over document structure while allowing dependency injection for environments without the Google SDK.

### Description
- Add `PageIndexToolkit` (subclass of `AbstractToolkit`) that exposes two tools: `index_documents` and `search_documents`, with input schemas `IndexDocumentsInput` and `SearchDocumentsInput` declared via `@tool_schema`.
- `index_documents` builds per-document PageIndex trees using `md_to_tree`, merges them into a collection, assigns node IDs with `write_node_id`, creates a `PageIndexRetriever`, and returns an `index_id` for later queries.
- `search_documents` looks up the in-memory index by `index_id`, runs `retriever.search` and `retriever.retrieve`, and returns `thinking`, `node_list`, and `context` with an optional `tree_context` when requested.
- Default LLM model is `GoogleModel.GEMINI_3_FLASH_LITE_PREVIEW`, and the toolkit accepts an injected `client` (e.g., a `GoogleGenAIClient` or a test double) to avoid hard dependency on the Google SDK at import time.

### Testing
- Ran `PYTHONPATH=packages/ai-parrot/src pytest -q packages/ai-parrot/tests/test_pageindex_toolkit.py` with a test client and monkeypatched PageIndex internals; final run passed all tests.
- Initial test runs showed import failures when the Google SDK (`google.genai`) was not available, so the toolkit was made client-injectable to allow tests to run without that dependency.
- Final result: `2 passed, 1 warning` for the pageindex toolkit tests under the adjusted test environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8ec4a4cb48330bd184114cb5be332)