### PR TITLE
feat(planogram): GraphicPanelDisplay — ROI-based backlight illumination detection

### DIFF
--- a/packages/ai-parrot-pipelines/src/parrot_pipelines/planogram/types/graphic_panel_display.py
+++ b/packages/ai-parrot-pipelines/src/parrot_pipelines/planogram/types/graphic_panel_display.py
@@ -201,6 +201,9 @@ class GraphicPanelDisplay(AbstractPlanogramType):
             per shelf level.
         """
         planogram_description = self.config.get_planogram_description()
+        # plan.py always passes macro_objects=None; detect zones here if needed.
+        if macro_objects is None and roi is not None:
+            macro_objects = await self.detect_objects_roi(img, roi)
         zone_detections: List[Detection] = macro_objects or []
         shelves = planogram_description.shelves or []
 
@@ -213,48 +216,198 @@ class GraphicPanelDisplay(AbstractPlanogramType):
             key=lambda d: (d.bbox.y1 + d.bbox.y2) / 2.0
         )
 
+        # Pre-compute ROI pixel coords for detection_box conversion.
+        from parrot.models.detections import DetectionBox as _DetectionBox
+        iw, ih = img.size
+        if roi is not None:
+            roi_x1_px = roi.bbox.x1 * iw
+            roi_y1_px = roi.bbox.y1 * ih
+            roi_w_px = (roi.bbox.x2 - roi.bbox.x1) * iw
+            roi_h_px = (roi.bbox.y2 - roi.bbox.y1) * ih
+        else:
+            roi_x1_px, roi_y1_px = 0.0, 0.0
+            roi_w_px, roi_h_px = float(iw), float(ih)
+
+        # Running counter across all shelves — prod_idx resets per shelf, so we
+        # cannot use it directly to index sorted_zones.
+        zone_counter = 0
+
+        # Illumination verdict computed once per image (lazy) using the full ROI.
+        # Using the complete endcap gives the LLM comparative context that an
+        # isolated header crop cannot provide.
+        roi_illumination: Optional[str] = None
+
         for shelf_idx, shelf_cfg in enumerate(shelves):
             shelf_level = shelf_cfg.level
             products_cfg = shelf_cfg.products or []
 
             # Map: one zone detection per configured product (by position order)
-            for prod_idx, prod_cfg in enumerate(products_cfg):
+            for prod_cfg in products_cfg:
                 zone_det: Optional[Detection] = None
-                if prod_idx < len(sorted_zones):
-                    zone_det = sorted_zones[prod_idx]
+                if zone_counter < len(sorted_zones):
+                    zone_det = sorted_zones[zone_counter]
+                zone_counter += 1
+
+                # Detect explicit label mismatch: when object_identification_prompt is
+                # used, the LLM returns a deliberate error label (e.g. "ERROR_LIGHT_IS_OFF")
+                # to signal a compliance violation — confidence must NOT be floored.
+                zone_label = (getattr(zone_det, 'label', None) or '').lower() if zone_det else ''
+                is_label_mismatch = zone_det is not None and 'error' in zone_label
+
+                # If degenerate bbox AND no explicit mismatch: synthesise from shelf config
+                # so that _enrich_zone receives a meaningful crop instead of a 1-pixel area.
+                if zone_det is not None and not is_label_mismatch and (
+                    zone_det.bbox.x1 >= zone_det.bbox.x2
+                    or zone_det.bbox.y1 >= zone_det.bbox.y2
+                ):
+                    y_start = float(getattr(shelf_cfg, 'y_start_ratio', 0.0) or 0.0)
+                    height = float(
+                        getattr(shelf_cfg, 'height_ratio', None)
+                        or (1.0 / max(len(shelves), 1))
+                    )
+                    synthetic_bbox = BoundingBox(
+                        x1=0.0, y1=y_start,
+                        x2=1.0, y2=min(1.0, y_start + height),
+                    )
+                    zone_det = Detection(
+                        label=getattr(zone_det, 'label', prod_cfg.name),
+                        confidence=zone_det.confidence,
+                        bbox=synthetic_bbox,
+                        # Preserve content so illumination info from roi_detection_prompt
+                        # (LIGHT_ON / LIGHT_OFF) survives the bbox replacement.
+                        content=getattr(zone_det, 'content', None),
+                    )
+                    self.logger.debug(
+                        "Synthesised bbox for zone '%s' from shelf config "
+                        "(degenerate LLM bbox): y=%.2f..%.2f content=%s",
+                        prod_cfg.name, y_start, y_start + height,
+                        getattr(zone_det, 'content', None),
+                    )
+
+                # Determine if this zone requires an illumination compliance check.
+                zone_has_illum = any(
+                    f.lower().startswith(_ILLUMINATION_FEATURE_PREFIX)
+                    for f in (getattr(prod_cfg, 'visual_features', []) or [])
+                )
 
                 visual_features: List[str] = []
 
-                if zone_det is not None:
-                    # Run OCR + visual enrichment on the zone crop
-                    visual_features = await self._enrich_zone(
-                        img=img,
-                        zone_det=zone_det,
-                        roi=roi,
-                        prod_cfg=prod_cfg,
-                        planogram_description=planogram_description,
+                if is_label_mismatch:
+                    # Deliberate mismatch (e.g. ERROR_LIGHT_IS_OFF): record the
+                    # violation and skip the enrichment LLM call entirely.
+                    visual_features = ['illumination_status: OFF']
+                    self.logger.debug(
+                        "Label mismatch for zone '%s': LLM returned '%s' — marking as not found",
+                        prod_cfg.name, zone_label,
                     )
+                elif zone_det is not None:
+                    if zone_has_illum:
+                        # Evaluate illumination once per image using the FULL ROI crop.
+                        # A dedicated call on the complete endcap gives the LLM the
+                        # comparative context needed to distinguish genuine backlighting
+                        # from ambient store light — something an isolated header crop
+                        # cannot reliably provide.
+                        if roi_illumination is None:
+                            roi_illumination = await self._check_illumination_from_roi(
+                                img=img,
+                                roi=roi,
+                                planogram_description=planogram_description,
+                            )
+                        # Seed visual_features with the authoritative illumination state
+                        # FIRST so that plan.py's appended CONFIRMED features are
+                        # second — _extract_illumination_state uses first-match.
+                        enrich_features = await self._enrich_zone(
+                            img=img,
+                            zone_det=zone_det,
+                            roi=roi,
+                            prod_cfg=prod_cfg,
+                            planogram_description=planogram_description,
+                        )
+                        non_illum = [
+                            f for f in enrich_features
+                            if not f.lower().startswith(_ILLUMINATION_FEATURE_PREFIX)
+                        ]
+                        visual_features = [roi_illumination] + non_illum
+                    else:
+                        # No illumination requirement — run OCR + visual enrichment only.
+                        visual_features = await self._enrich_zone(
+                            img=img,
+                            zone_det=zone_det,
+                            roi=roi,
+                            prod_cfg=prod_cfg,
+                            planogram_description=planogram_description,
+                        )
+
+                # Build pixel-space detection_box from zone normalized coords.
+                det_box: Optional[_DetectionBox] = None
+                if zone_det is not None:
+                    bx1 = int(roi_x1_px + zone_det.bbox.x1 * roi_w_px)
+                    by1 = int(roi_y1_px + zone_det.bbox.y1 * roi_h_px)
+                    bx2 = int(roi_x1_px + zone_det.bbox.x2 * roi_w_px)
+                    by2 = int(roi_y1_px + zone_det.bbox.y2 * roi_h_px)
+                    det_box = _DetectionBox(
+                        x1=max(0, bx1), y1=max(0, by1),
+                        x2=min(iw, bx2), y2=min(ih, by2),
+                        confidence=zone_det.confidence,
+                    )
+
+                # Deliberate mismatch → confidence=0.0 (MISSING, no floor applied).
+                # Normal detection with LLM uncertainty → floor at 0.5 (FOUND).
+                if is_label_mismatch:
+                    prod_confidence = 0.0
+                elif zone_det is not None:
+                    prod_confidence = max(zone_det.confidence, 0.5)
+                else:
+                    prod_confidence = 0.0
 
                 product = IdentifiedProduct(
                     product_model=prod_cfg.name,
-                    product_type="graphic_zone",
+                    product_type=getattr(prod_cfg, 'product_type', 'graphic_zone') or 'graphic_zone',
                     shelf_location=shelf_level,
-                    confidence=zone_det.confidence if zone_det else 0.0,
+                    confidence=prod_confidence,
                     brand=getattr(planogram_description, "brand", None),
                     visual_features=visual_features,
+                    detection_box=det_box,
                 )
                 identified_products.append(product)
 
+            # Build a bbox that spans the zone detections for this shelf,
+            # falling back to a full-image placeholder when none exist.
+            shelf_det_boxes = [
+                p.detection_box for p in identified_products
+                if p.shelf_location == shelf_level and p.detection_box is not None
+            ]
+            if shelf_det_boxes:
+                sx1 = min(b.x1 for b in shelf_det_boxes)
+                sy1 = min(b.y1 for b in shelf_det_boxes)
+                sx2 = max(b.x2 for b in shelf_det_boxes)
+                sy2 = max(b.y2 for b in shelf_det_boxes)
+                shelf_conf = max(b.confidence for b in shelf_det_boxes)
+            else:
+                sx1, sy1, sx2, sy2, shelf_conf = 0, 0, iw, ih, 0.0
             shelf_regions.append(
                 ShelfRegion(
+                    shelf_id=f"{shelf_level}_{shelf_idx}",
+                    bbox=_DetectionBox(x1=sx1, y1=sy1, x2=sx2, y2=sy2, confidence=shelf_conf),
                     level=shelf_level,
-                    detections=[p.detection_box for p in identified_products
-                                if p.shelf_location == shelf_level
-                                and p.detection_box is not None],
+                    detections=shelf_det_boxes,
                 )
             )
 
         return identified_products, shelf_regions
+
+    def _generate_virtual_shelves(
+        self,
+        roi_bbox: Any,
+        image_size: Any,
+        planogram: Any,
+    ) -> List[ShelfRegion]:
+        """No-op for graphic panel displays — shelf regions come from zone detections."""
+        return []
+
+    def _assign_products_to_shelves(self, *args, **kwargs) -> None:
+        """No-op — products are already assigned to zones in detect_objects."""
+        return
 
     def check_planogram_compliance(
         self,
@@ -337,6 +490,12 @@ class GraphicPanelDisplay(AbstractPlanogramType):
                                 f"Illumination mismatch on zone '{prod_cfg.name}': "
                                 f"expected={expected_illum}, detected={detected_illum}, "
                                 f"penalty={penalty} → zone_score={zone_score:.3f}"
+                            )
+                            # Surface the reason in missing_products so the report
+                            # shows WHY the zone failed, not just that it scored 0.
+                            missing.append(
+                                f"{prod_cfg.name} — backlight {detected_illum.upper()} "
+                                f"(required: {expected_illum.upper()})"
                             )
 
                 # ----------------------------------------------------------
@@ -503,6 +662,78 @@ class GraphicPanelDisplay(AbstractPlanogramType):
 
         return endcap_det, endcap_det, None, None, dets
 
+    async def _check_illumination_from_roi(
+        self,
+        img: Image.Image,
+        roi: Any,
+        planogram_description: Any,
+    ) -> str:
+        """Check backlit illumination state using the full endcap ROI image.
+
+        Sending the complete endcap (rather than a cropped header zone) lets
+        the LLM compare the header's brightness against the middle/bottom
+        panels — a reliable signal that an isolated crop cannot provide.
+
+        Returns:
+            'illumination_status: ON' or 'illumination_status: OFF'
+        """
+        iw, ih = img.size
+        if roi is not None:
+            x1 = int(roi.bbox.x1 * iw)
+            y1 = int(roi.bbox.y1 * ih)
+            x2 = int(roi.bbox.x2 * iw)
+            y2 = int(roi.bbox.y2 * ih)
+            roi_crop = img.crop((x1, y1, x2, y2))
+        else:
+            roi_crop = img.copy()
+
+        roi_small = self.pipeline._downscale_image(roi_crop, max_side=800, quality=82)
+        brand = (getattr(planogram_description, 'brand', '') or '').strip()
+        brand_hint = f" {brand}" if brand else ""
+
+        prompt = (
+            f"You are inspecting a retail{brand_hint} endcap display.\n\n"
+            "The TOP section contains a large BACKLIT LIGHTBOX PANEL — a sign "
+            "designed to emit its own light from behind when the backlight is ON.\n\n"
+            "Compare the brightness of the TOP header panel against the MIDDLE and "
+            "BOTTOM panels of the same display:\n"
+            "  • LIGHT_ON — the top panel glows with even internal luminosity; it "
+            "looks self-illuminated and distinctly brighter than the panels below. "
+            "Edges may show a bright border or halo.\n"
+            "  • LIGHT_OFF — the top panel shows the graphic but only under ambient "
+            "store light; no internal glow, similar brightness to the rest of the "
+            "display.\n\n"
+            "Do NOT answer LIGHT_ON just because the room or store is well-lit. "
+            "Look specifically for light emanating FROM WITHIN the header panel.\n\n"
+            "Answer with EXACTLY one word: LIGHT_ON or LIGHT_OFF"
+        )
+
+        raw_answer = ''
+        try:
+            async with self.pipeline.roi_client as client:
+                msg = await client.ask_to_image(
+                    image=roi_small,
+                    prompt=prompt,
+                    model="gemini-2.5-flash",
+                    no_memory=True,
+                    max_tokens=16,
+                )
+            raw_answer = (msg.output or '').strip().upper()
+        except Exception as exc:
+            self.logger.warning(
+                "Illumination ROI check failed: %s — defaulting to ON", exc
+            )
+
+        state = (
+            'illumination_status: OFF'
+            if 'LIGHT_OFF' in raw_answer
+            else 'illumination_status: ON'
+        )
+        self.logger.info(
+            "ROI illumination check → answer=%r  state=%s", raw_answer, state
+        )
+        return state
+
     async def _enrich_zone(
         self,
         img: Image.Image,
@@ -558,9 +789,15 @@ class GraphicPanelDisplay(AbstractPlanogramType):
         brand = (getattr(planogram_description, "brand", "") or "").strip()
         zone_name = prod_cfg.name
 
+        # Exclude illumination_status from the hint — including it biases the LLM
+        # toward confirming the EXPECTED state rather than detecting the ACTUAL state.
+        hint_features = [
+            f for f in expected_features
+            if not f.lower().startswith('illumination_status:')
+        ]
         features_hint = (
-            "Expected visual features: " + ", ".join(f"'{f}'" for f in expected_features)
-            if expected_features
+            "Expected visual features: " + ", ".join(f"'{f}'" for f in hint_features)
+            if hint_features
             else ""
         )
         prompt = (
@@ -568,8 +805,11 @@ class GraphicPanelDisplay(AbstractPlanogramType):
             f"{features_hint}\n\n"
             "Please verify:\n"
             "1. What text is visible? (prefix with 'ocr:')\n"
-            "2. Is this zone illuminated (backlit/lit) or not? "
-            "   (respond with 'illumination_status: ON' or 'illumination_status: OFF')\n"
+            "2. Is this panel illuminated from BEHIND (backlit)? "
+            "   A truly backlit panel emits its own light — look for an even interior glow, "
+            "   bright edge bleed, or a luminous silver/white frame. "
+            "   Do NOT report ON just because the photo is well-lit by ambient room light. "
+            "   Respond ONLY with 'illumination_status: ON' or 'illumination_status: OFF'.\n"
             "3. Any other notable visual features.\n\n"
             "Return a JSON list of strings, e.g.: "
             '["illumination_status: OFF", "ocr: EcoTank", "graphic_visible: true"]'
@@ -586,13 +826,18 @@ class GraphicPanelDisplay(AbstractPlanogramType):
                     max_tokens=512,
                 )
             raw_output = msg.output or ""
-            # Extract JSON list from the response
+            # Extract JSON list from the response.
+            # msg.output may already be a parsed Python list when the client
+            # deserialises the LLM's structured response before returning it.
             import re
-            match = re.search(r'\[.*?\]', raw_output, re.DOTALL)
-            if match:
-                visual_features = json.loads(match.group(0))
-                if not isinstance(visual_features, list):
-                    visual_features = []
+            if isinstance(raw_output, list):
+                visual_features = [f for f in raw_output if isinstance(f, str)]
+            else:
+                match = re.search(r'\[.*?\]', str(raw_output), re.DOTALL)
+                if match:
+                    visual_features = json.loads(match.group(0))
+                    if not isinstance(visual_features, list):
+                        visual_features = []
         except Exception as exc:
             self.logger.warning(
                 f"Zone enrichment failed for '{zone_name}': {exc}"


### PR DESCRIPTION
## Summary

- Adds dedicated `_check_illumination_from_roi` method that sends the **full endcap ROI** to the LLM to detect backlit state (`LIGHT_ON` / `LIGHT_OFF`). Using the complete endcap provides comparative context (header vs. middle/bottom brightness) that an isolated header crop cannot reliably provide.
- Seeds `visual_features` with the illumination verdict **first** so `plan.py`'s appended `CONFIRMED` features lose the first-match race in `_extract_illumination_state` — preventing plan.py's enrichment bias from overriding the actual detection.
- Illumination mismatch now appends a human-readable reason to `missing_products` (e.g. `Epson_Top_Backlit_ON — backlight OFF (required: ON)`) so the compliance report explains **why** a shelf failed, not just that it scored 0%.
- Fixes degenerate-bbox synthesis: when the LLM returns a 1-pixel zone bbox, coords are synthesised from shelf config so `_enrich_zone` receives a valid crop.
- Excludes `illumination_status:` from the enrichment hint to prevent the model from confirming the expected state rather than detecting the actual state.
- Fixes `_enrich_zone` JSON parsing to handle pre-parsed list responses from the client.

## Test plan

- [ ] Backlit endcap photo with light **ON** → HEADER shelf COMPLIANT (score 1.0)
- [ ] Backlit endcap photo with light **OFF** → HEADER shelf NON-COMPLIANT (score 0.0), `missing_products` contains `"... — backlight OFF (required: ON)"`
- [ ] Planograms without `illumination_status:` in `visual_features` → unchanged behavior (skips ROI check)
- [ ] `product_on_shelves` planograms unaffected (separate class)

🤖 Generated with [Claude Code](https://claude.com/claude-code)