### PR TITLE
Add formdesigner field helper catalog and prompt snippets

### DIFF
--- a/packages/parrot-formdesigner/src/parrot/formdesigner/__init__.py
+++ b/packages/parrot-formdesigner/src/parrot/formdesigner/__init__.py
@@ -54,7 +54,13 @@ from .services import (
     SubmissionForwarder,
     ValidationResult,
 )
-from .tools import CreateFormTool, DatabaseFormTool, RequestFormTool
+from .tools import (
+    CreateFormTool,
+    DatabaseFormTool,
+    RequestFormTool,
+    get_form_field_schema_snippets,
+    list_supported_form_field_types,
+)
 
 __all__ = [
     # core — types
@@ -111,6 +117,8 @@ __all__ = [
     "CreateFormTool",
     "DatabaseFormTool",
     "RequestFormTool",
+    "list_supported_form_field_types",
+    "get_form_field_schema_snippets",
     # handlers
     "setup_form_routes",
     "FormAPIHandler",

--- a/packages/parrot-formdesigner/src/parrot/formdesigner/tools/__init__.py
+++ b/packages/parrot-formdesigner/src/parrot/formdesigner/tools/__init__.py
@@ -4,14 +4,21 @@ These tools allow LLMs to interact with the form system:
 - RequestFormTool: request a form to collect parameters for another tool
 - CreateFormTool: create and register a custom form at runtime (TASK-531)
 - DatabaseFormTool: generate a form schema from a database table definition (TASK-544)
+- field_helpers: helper functions for supported field types and snippets
 """
 
 from .request_form import RequestFormTool
 from .create_form import CreateFormTool
 from .database_form import DatabaseFormTool
+from .field_helpers import (
+    get_form_field_schema_snippets,
+    list_supported_form_field_types,
+)
 
 __all__ = [
     "RequestFormTool",
     "CreateFormTool",
     "DatabaseFormTool",
+    "list_supported_form_field_types",
+    "get_form_field_schema_snippets",
 ]

--- a/packages/parrot-formdesigner/src/parrot/formdesigner/tools/create_form.py
+++ b/packages/parrot-formdesigner/src/parrot/formdesigner/tools/create_form.py
@@ -28,12 +28,11 @@ try:
     from parrot.tools.abstract import AbstractTool, ToolResult
 except ImportError as exc:
     raise ImportError(
-        "parrot-formdesigner tools require the 'ai-parrot' package. "
-        "Install it with: uv add ai-parrot"
+        "parrot-formdesigner tools require the 'ai-parrot' package. " "Install it with: uv add ai-parrot"
     ) from exc
 from ..services.registry import FormRegistry
 from ..core.schema import FormSchema
-from ..core.types import FieldType
+from .field_helpers import get_form_field_schema_snippets, list_supported_form_field_types
 from ..services.validators import FormValidator
 
 logger = logging.getLogger(__name__)
@@ -42,7 +41,10 @@ logger = logging.getLogger(__name__)
 # System prompt template
 # ---------------------------------------------------------------------------
 
-_SYSTEM_PROMPT = """You are a form schema generator. Your task is to generate a FormSchema JSON object.
+_FIELD_TYPE_VALUES = ", ".join(list_supported_form_field_types())
+_FIELD_SNIPPETS_JSON = json.dumps(get_form_field_schema_snippets(), indent=2)
+
+_SYSTEM_PROMPT_TEMPLATE = """You are a form schema generator. Your task is to generate a FormSchema JSON object.
 
 The FormSchema must follow this structure:
 {
@@ -53,10 +55,10 @@ The FormSchema must follow this structure:
     {
       "section_id": "string",
       "title": "string (optional)",
-      "fields": [
+        "fields": [
         {
           "field_id": "string (snake_case)",
-          "field_type": "one of: text, text_area, number, integer, boolean, date, datetime, time, select, multi_select, file, image, color, url, email, phone, password, hidden, group, array",
+          "field_type": "one of: __FIELD_TYPES__",
           "label": "string",
           "description": "string (optional)",
           "required": true/false,
@@ -76,6 +78,12 @@ The FormSchema must follow this structure:
   ]
 }
 
+Accepted field types:
+__FIELD_TYPES__
+
+Field snippet reference by type:
+__FIELD_SNIPPETS__
+
 IMPORTANT:
 - Respond with ONLY valid JSON. No markdown, no explanations.
 - Use snake_case for all IDs.
@@ -83,6 +91,9 @@ IMPORTANT:
 - For select/multi_select fields, always include an options array.
 - Generate meaningful field IDs that match the label.
 """
+_SYSTEM_PROMPT = _SYSTEM_PROMPT_TEMPLATE.replace("__FIELD_TYPES__", _FIELD_TYPE_VALUES).replace(
+    "__FIELD_SNIPPETS__", _FIELD_SNIPPETS_JSON
+)
 
 _REFINEMENT_PROMPT = """You are a form schema editor. Your task is to modify an existing FormSchema.
 
@@ -141,6 +152,7 @@ def _extract_json(text: str) -> str:
 # Input schema
 # ---------------------------------------------------------------------------
 
+
 class CreateFormInput(BaseModel):
     """Input schema for the create_form tool.
 
@@ -175,6 +187,7 @@ class CreateFormInput(BaseModel):
 # ---------------------------------------------------------------------------
 # Tool implementation
 # ---------------------------------------------------------------------------
+
 
 class CreateFormTool(AbstractTool):
     """Create a FormSchema from a natural language prompt using an LLM.
@@ -262,9 +275,7 @@ class CreateFormTool(AbstractTool):
                         success=False,
                         status="error",
                         result=None,
-                        metadata={
-                            "error": f"Form '{refine_form_id}' not found in registry"
-                        },
+                        metadata={"error": f"Form '{refine_form_id}' not found in registry"},
                     )
                 messages = self._build_refinement_messages(existing, prompt)
             else:
@@ -278,9 +289,7 @@ class CreateFormTool(AbstractTool):
                     success=False,
                     status="error",
                     result=None,
-                    metadata={
-                        "error": "Failed to generate a valid FormSchema after retries"
-                    },
+                    metadata={"error": "Failed to generate a valid FormSchema after retries"},
                 )
 
             # Check for structural schema issues (circular dependencies)
@@ -296,9 +305,7 @@ class CreateFormTool(AbstractTool):
                 try:
                     await self._registry.register(form, persist=True)
                 except Exception as exc:
-                    self.logger.warning(
-                        "Failed to persist form %s: %s", form.form_id, exc
-                    )
+                    self.logger.warning("Failed to persist form %s: %s", form.form_id, exc)
 
             return ToolResult(
                 success=True,
@@ -333,9 +340,7 @@ class CreateFormTool(AbstractTool):
             {"role": "user", "content": f"Create a form for: {prompt}"},
         ]
 
-    def _build_refinement_messages(
-        self, existing: FormSchema, prompt: str
-    ) -> list[dict[str, str]]:
+    def _build_refinement_messages(self, existing: FormSchema, prompt: str) -> list[dict[str, str]]:
         """Build LLM messages for form refinement.
 
         Args:
@@ -394,9 +399,7 @@ class CreateFormTool(AbstractTool):
                 return str(response.output)
             return str(response)
         else:
-            raise RuntimeError(
-                "LLM client has neither completion() nor ask() method"
-            )
+            raise RuntimeError("LLM client has neither completion() nor ask() method")
 
     async def _generate_with_retry(
         self,
@@ -427,9 +430,7 @@ class CreateFormTool(AbstractTool):
                     data["form_id"] = form_id
                 elif "form_id" not in data or not data["form_id"]:
                     title = data.get("title", "generated-form")
-                    data["form_id"] = _slugify(
-                        title if isinstance(title, str) else "generated-form"
-                    )
+                    data["form_id"] = _slugify(title if isinstance(title, str) else "generated-form")
 
                 form = FormSchema.model_validate(data)
                 return form
@@ -444,9 +445,7 @@ class CreateFormTool(AbstractTool):
                     return None
 
                 # Retry with error feedback
-                self.logger.warning(
-                    "Attempt %d failed (%s), retrying...", attempt + 1, exc
-                )
+                self.logger.warning("Attempt %d failed (%s), retrying...", attempt + 1, exc)
                 retry_content = _RETRY_PROMPT.format(
                     error=str(exc),
                     previous_attempt=json_str or "(no output)",

--- a/packages/parrot-formdesigner/src/parrot/formdesigner/tools/field_helpers.py
+++ b/packages/parrot-formdesigner/src/parrot/formdesigner/tools/field_helpers.py
@@ -1,0 +1,164 @@
+"""Helper utilities for supported form field definitions.
+
+This module centralizes the accepted ``FieldType`` values and provides
+minimal JSON snippets for each field type. These snippets are intended for
+form creation/editing flows where agents or UIs need quick reference payloads.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from ..core.types import FieldType
+
+
+_FIELD_SCHEMA_SNIPPETS: dict[str, dict[str, Any]] = {
+    FieldType.TEXT.value: {
+        "field_id": "full_name",
+        "field_type": "text",
+        "label": "Full name",
+        "required": True,
+    },
+    FieldType.TEXT_AREA.value: {
+        "field_id": "comments",
+        "field_type": "text_area",
+        "label": "Comments",
+    },
+    FieldType.NUMBER.value: {
+        "field_id": "amount",
+        "field_type": "number",
+        "label": "Amount",
+        "constraints": {"min_value": 0},
+    },
+    FieldType.INTEGER.value: {
+        "field_id": "quantity",
+        "field_type": "integer",
+        "label": "Quantity",
+        "constraints": {"min_value": 1},
+    },
+    FieldType.BOOLEAN.value: {
+        "field_id": "accepted_terms",
+        "field_type": "boolean",
+        "label": "I accept terms",
+    },
+    FieldType.DATE.value: {
+        "field_id": "start_date",
+        "field_type": "date",
+        "label": "Start date",
+    },
+    FieldType.DATETIME.value: {
+        "field_id": "appointment_at",
+        "field_type": "datetime",
+        "label": "Appointment time",
+    },
+    FieldType.TIME.value: {
+        "field_id": "preferred_time",
+        "field_type": "time",
+        "label": "Preferred time",
+    },
+    FieldType.SELECT.value: {
+        "field_id": "department",
+        "field_type": "select",
+        "label": "Department",
+        "options": [
+            {"value": "sales", "label": "Sales"},
+            {"value": "support", "label": "Support"},
+        ],
+    },
+    FieldType.MULTI_SELECT.value: {
+        "field_id": "skills",
+        "field_type": "multi_select",
+        "label": "Skills",
+        "options": [
+            {"value": "python", "label": "Python"},
+            {"value": "sql", "label": "SQL"},
+        ],
+    },
+    FieldType.FILE.value: {
+        "field_id": "resume",
+        "field_type": "file",
+        "label": "Resume",
+    },
+    FieldType.IMAGE.value: {
+        "field_id": "profile_image",
+        "field_type": "image",
+        "label": "Profile image",
+    },
+    FieldType.COLOR.value: {
+        "field_id": "theme_color",
+        "field_type": "color",
+        "label": "Theme color",
+        "default": "#0ea5e9",
+    },
+    FieldType.URL.value: {
+        "field_id": "portfolio_url",
+        "field_type": "url",
+        "label": "Portfolio URL",
+    },
+    FieldType.EMAIL.value: {
+        "field_id": "email",
+        "field_type": "email",
+        "label": "Email",
+        "required": True,
+    },
+    FieldType.PHONE.value: {
+        "field_id": "phone_number",
+        "field_type": "phone",
+        "label": "Phone number",
+    },
+    FieldType.PASSWORD.value: {
+        "field_id": "password",
+        "field_type": "password",
+        "label": "Password",
+        "required": True,
+    },
+    FieldType.HIDDEN.value: {
+        "field_id": "record_id",
+        "field_type": "hidden",
+        "label": "Record ID",
+        "default": "{{record_id}}",
+    },
+    FieldType.GROUP.value: {
+        "field_id": "address",
+        "field_type": "group",
+        "label": "Address",
+        "children": [
+            {
+                "field_id": "street",
+                "field_type": "text",
+                "label": "Street",
+            },
+            {
+                "field_id": "city",
+                "field_type": "text",
+                "label": "City",
+            },
+        ],
+    },
+    FieldType.ARRAY.value: {
+        "field_id": "items",
+        "field_type": "array",
+        "label": "Items",
+        "item_template": {
+            "field_id": "item",
+            "field_type": "text",
+            "label": "Item",
+        },
+    },
+}
+
+
+def list_supported_form_field_types() -> list[str]:
+    """Return supported field type values for FormField.field_type."""
+
+    return [field_type.value for field_type in FieldType]
+
+
+def get_form_field_schema_snippets() -> dict[str, dict[str, Any]]:
+    """Return example JSON snippets for each supported field type.
+
+    Returns a copy to avoid accidental mutation by callers.
+    """
+
+    return deepcopy(_FIELD_SCHEMA_SNIPPETS)

--- a/packages/parrot-formdesigner/tests/unit/test_field_helpers.py
+++ b/packages/parrot-formdesigner/tests/unit/test_field_helpers.py
@@ -1,0 +1,26 @@
+"""Unit tests for form field helper utilities."""
+
+from parrot.formdesigner.core.types import FieldType
+from parrot.formdesigner.tools.field_helpers import (
+    get_form_field_schema_snippets,
+    list_supported_form_field_types,
+)
+
+
+def test_supported_field_types_match_enum() -> None:
+    values = list_supported_form_field_types()
+    assert values == [member.value for member in FieldType]
+
+
+def test_field_schema_snippets_cover_all_types() -> None:
+    snippets = get_form_field_schema_snippets()
+    expected_types = {member.value for member in FieldType}
+    assert set(snippets.keys()) == expected_types
+
+
+def test_field_schema_snippets_are_defensive_copy() -> None:
+    snippets = get_form_field_schema_snippets()
+    snippets["text"]["label"] = "Changed"
+
+    fresh = get_form_field_schema_snippets()
+    assert fresh["text"]["label"] == "Full name"


### PR DESCRIPTION
### Motivation
- Provide a single source of truth for supported form `FieldType` values and example JSON snippets so form creation and editing flows (LLM tools and UIs) can reliably reference accepted field payloads.
- Keep `CreateFormTool` guidance and examples automatically synchronized with the enum-backed field types to reduce drift and improve discoverability.

### Description
- Add `parrot.formdesigner.tools.field_helpers` with `list_supported_form_field_types()` and `get_form_field_schema_snippets()` returning defensive copies of canonical examples.
- Update `CreateFormTool` to incorporate accepted field types and a JSON snippet reference into its system prompt by using the new helper functions.
- Export the helper functions from `parrot.formdesigner.tools` and the package top-level `parrot.formdesigner` for easy reuse.
- Add unit tests `packages/parrot-formdesigner/tests/unit/test_field_helpers.py` to validate enum coverage and defensive-copy behavior.

### Testing
- Ran `python -m compileall` against the modified modules which succeeded.
- Ran `black` formatting which completed and reformatted `create_form.py` as part of the changes.
- Ran `pytest -q packages/parrot-formdesigner/tests/unit/test_field_helpers.py packages/parrot-formdesigner/tests/unit/test_create_form_tool.py packages/parrot-formdesigner/tests/unit/test_tools.py` which failed during collection due to missing top-level package import path and missing NavConfig environment assets in this environment.
- Running `PYTHONPATH=packages/parrot-formdesigner/src pytest -q ...` also failed because `navconfig` expects `env` assets (e.g. `env/dev/.env`) that are not available in the current CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d78689d6b08330ad25cb482b5ac13d)