### PR TITLE
Add artifact tracking to capture executed SQL queries

### DIFF
--- a/packages/ai-parrot-tools/src/parrot_tools/dataset_manager/tool.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/dataset_manager/tool.py
@@ -350,6 +350,7 @@ class DatasetManager(AbstractToolkit):
         self.df_guide: str = ""
         self.logger = logger
         self._redis: Optional[aioredis.Redis] = None
+        self._artifacts: List[Dict[str, Any]] = []
 
     def set_on_change(self, callback: Callable[[], None]) -> None:
         """Register a callback invoked after dataset mutations (fetch, activate, deactivate)."""
@@ -362,6 +363,16 @@ class DatasetManager(AbstractToolkit):
         from the python_repl_pandas execution environment.
         """
         self._repl_locals_getter = getter
+
+    def drain_artifacts(self) -> List[Dict[str, Any]]:
+        """Return accumulated artifacts and clear the internal list.
+
+        Called by the owning agent after a completion round to transfer
+        artifacts (e.g. executed SQL queries) onto the AIMessage.
+        """
+        artifacts = list(self._artifacts)
+        self._artifacts.clear()
+        return artifacts
 
     def _notify_change(self) -> None:
         """Invoke the on-change callback if registered."""
@@ -1783,6 +1794,14 @@ class DatasetManager(AbstractToolkit):
             # TableSource requires sql — auto-generate a default SELECT when
             # the LLM omits it, matching add_dataset() behaviour (line 696).
             params['sql'] = sql or f"SELECT * FROM {entry.source.table}"
+            # Record the (possibly rewritten) SQL as an artifact so it can
+            # be surfaced on the AIMessage for debugging / transparency.
+            self._artifacts.append({
+                "type": "query",
+                "content": params['sql'],
+                "dataset": resolved,
+                "source": "TableSource",
+            })
             if conditions:
                 params.update(conditions)
             # Table sources ALWAYS re-fetch: the LLM generates a different

--- a/packages/ai-parrot/src/parrot/bots/data.py
+++ b/packages/ai-parrot/src/parrot/bots/data.py
@@ -1396,6 +1396,13 @@ class PandasAgent(BasicAgent):
                     context_length=len(conversation_context) if conversation_context else 0
                 )
 
+                # Transfer artifacts accumulated by DatasetManager
+                # (e.g. executed SQL queries) onto the AIMessage.
+                if self._dataset_manager:
+                    response.artifacts.extend(
+                        self._dataset_manager.drain_artifacts()
+                    )
+
                 response.session_id = session_id
                 response.turn_id = getattr(response, 'turn_id', None) or turn_id
                 data_response: Optional[PandasAgentResponse] = response.output \

--- a/packages/ai-parrot/src/parrot/models/responses.py
+++ b/packages/ai-parrot/src/parrot/models/responses.py
@@ -203,6 +203,10 @@ class AIMessage(BaseModel):
         default_factory=dict,
         description="Additional metadata associated with the response"
     )
+    artifacts: List[Dict[str, Any]] = Field(
+        default_factory=list,
+        description="List of artifacts created during processing (e.g. executed SQL queries, generated code snippets)"
+    )
     output_mode: OutputMode = Field(
         default=OutputMode.DEFAULT,
         description="The output mode used for rendering (markdown, html, json, etc.)"
@@ -263,6 +267,18 @@ class AIMessage(BaseModel):
     def add_tool_call(self, tool_call: ToolCall) -> None:
         """Add a tool call to the response."""
         self.tool_calls.append(tool_call)  # pylint: disable=E1101 # noqa
+
+    def add_artifact(self, artifact_type: str, content: Any, **metadata) -> None:
+        """Add an artifact produced during processing.
+
+        Args:
+            artifact_type: Kind of artifact (e.g. ``"query"``, ``"code"``).
+            content: The artifact payload (SQL string, code snippet, etc.).
+            **metadata: Extra key/value pairs attached to the artifact.
+        """
+        self.artifacts.append(  # pylint: disable=E1101 # noqa
+            {"type": artifact_type, "content": content, **metadata}
+        )
 
     # Context Information:
     @property

--- a/packages/ai-parrot/src/parrot/tools/dataset_manager/tool.py
+++ b/packages/ai-parrot/src/parrot/tools/dataset_manager/tool.py
@@ -517,6 +517,7 @@ class DatasetManager(AbstractToolkit):
         self.logger = logger
         self._redis: Optional[aioredis.Redis] = None
         self._file_entries: Dict[str, FileEntry] = {}
+        self._artifacts: List[Dict[str, Any]] = []
 
     def set_on_change(self, callback: Callable[[], None]) -> None:
         """Register a callback invoked after dataset mutations (fetch, activate, deactivate)."""
@@ -529,6 +530,16 @@ class DatasetManager(AbstractToolkit):
         from the python_repl_pandas execution environment.
         """
         self._repl_locals_getter = getter
+
+    def drain_artifacts(self) -> List[Dict[str, Any]]:
+        """Return accumulated artifacts and clear the internal list.
+
+        Called by the owning agent after a completion round to transfer
+        artifacts (e.g. executed SQL queries) onto the AIMessage.
+        """
+        artifacts = list(self._artifacts)
+        self._artifacts.clear()
+        return artifacts
 
     def _is_protected(self, name: str) -> bool:
         """Check if a dataset name is protected against LLM overwrites."""
@@ -3005,6 +3016,14 @@ class DatasetManager(AbstractToolkit):
                         ),
                     }
             params['sql'] = sql
+            # Record the (possibly rewritten) SQL as an artifact so it can
+            # be surfaced on the AIMessage for debugging / transparency.
+            self._artifacts.append({
+                "type": "query",
+                "content": sql,
+                "dataset": resolved,
+                "source": "TableSource",
+            })
             if conditions:
                 params.update(conditions)
             # Table sources ALWAYS re-fetch: the LLM generates a different


### PR DESCRIPTION
## Summary
This PR adds artifact tracking to the DatasetManager and AIMessage classes to capture and surface executed SQL queries and other artifacts generated during processing. This enables better debugging and transparency by making executed queries visible on the response message.

## Key Changes

- **DatasetManager artifact tracking**: Added `_artifacts` list to both `ai-parrot-tools` and `ai-parrot` DatasetManager implementations to accumulate artifacts during processing
- **Drain artifacts method**: Implemented `drain_artifacts()` method that returns accumulated artifacts and clears the internal list, allowing the owning agent to transfer artifacts to the response
- **SQL query capture**: Modified `fetch_dataset()` to record executed SQL queries (including auto-generated and rewritten ones) as artifacts with metadata about the dataset and source
- **AIMessage artifact support**: Extended `AIMessage` model with:
  - New `artifacts` field to store list of artifacts created during processing
  - `add_artifact()` helper method to easily add artifacts with type, content, and metadata
- **Agent integration**: Updated `DataBot.ask()` to transfer artifacts from DatasetManager to the response message after each completion round

## Implementation Details

- Artifacts are stored as dictionaries with `type`, `content`, and optional metadata fields
- SQL query artifacts include the dataset name and source type for context
- The drain pattern ensures artifacts are transferred exactly once per completion round
- Both `ai-parrot` and `ai-parrot-tools` packages are updated consistently

https://claude.ai/code/session_01AeYDeNSLSRXpFVVZRpLKrJ