### PR TITLE
fix(PDFMarkdownLoader): remove form-feed characters and normalize blank lines after markdown conversion

### DIFF
--- a/packages/ai-parrot-loaders/src/parrot_loaders/pdfmark.py
+++ b/packages/ai-parrot-loaders/src/parrot_loaders/pdfmark.py
@@ -323,6 +323,10 @@ class PDFMarkdownLoader(BasePDF):
         # Infer headers from flat MarkItDown/pymupdf output
         md_text = self._infer_markdown_headers(md_text)
 
+        # Remove form-feed page-break characters that cause mid-sentence splits
+        md_text = md_text.replace('\x0c', '')
+        md_text = re.sub(r'\n{3,}', '\n\n', md_text)
+
         # Extract PDF metadata
         try:
             pdf = fitz.open(str(path))


### PR DESCRIPTION
## `PDFMarkdownLoader._load()` — form-feed character removal and blank-line normalization

**File:** `ai-parrot/packages/ai-parrot-loaders/src/parrot_loaders/pdfmark.py`

### What changed

```python
# Added after header inference, before metadata extraction:

# Remove form-feed page-break characters that cause mid-sentence splits
md_text = md_text.replace('\x0c', '')
md_text = re.sub(r'\n{3,}', '\n\n', md_text)
```

### Why

PDF converters (both MarkItDown and pymupdf4llm) emit a form-feed character (`\x0c`, ASCII 12) at the boundary between pages. When the markdown splitter encounters this character it treats it as a hard break, causing sentences that naturally continue across pages to be split into separate chunks.

**Example of affected chunk (before fix):**

```
...the assembly procedure requires torque values consistent with
```
*(chunk ends here due to \x0c)*

```
the manufacturer's specification for all fastener grades.
```
*(next chunk starts mid-sentence)*

This caused semantic incoherence in the vector embeddings and degraded retrieval quality.

The `re.sub(r'\n{3,}', '\n\n', md_text)` pass cleans up the extra blank lines that are often left behind after stripping form-feed characters, preventing the splitter from treating large whitespace gaps as section boundaries.