### PR TITLE
Add Jira webhook assignment intake flow with Telegram integration

### DIFF
--- a/packages/ai-parrot/src/parrot/bots/jira_specialist.py
+++ b/packages/ai-parrot/src/parrot/bots/jira_specialist.py
@@ -1291,6 +1291,8 @@ class JiraSpecialist(Agent):
         """
         if event.event_type == "jira.assigned":
             return await self.handle_jira_assignment(event.payload)
+        if event.event_type == "jira.ready_for_test":
+            return await self.handle_ready_for_test(event.payload)
         self.logger.info(
             "JiraSpecialist: ignoring hook event %s (hook_id=%s)",
             event.event_type,
@@ -1461,6 +1463,107 @@ class JiraSpecialist(Agent):
                 "status": "error",
                 "issue_key": issue_key,
                 "developer_id": developer.id,
+                "error": str(exc),
+            }
+
+    async def handle_ready_for_test(
+        self,
+        payload: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Notify the QA channel when a ticket transitions to "Ready For Test".
+
+        The destination channel id is read from ``navconfig.config`` key
+        ``JIRA_TEST_WEBHOOK_CHANNEL``. The message announces that the
+        developer has finished the development phase and the ticket is
+        entering the testing phase.
+
+        Args:
+            payload: The ``HookEvent.payload`` emitted by
+                :class:`JiraWebhookHook`. Expected to contain
+                ``issue_key``, ``summary``, ``priority``, ``assignee`` and
+                (optionally) ``user`` (the actor who moved the ticket).
+
+        Returns:
+            Result dict with ``status`` (``ok``/``skipped``/``error``),
+            ``issue_key`` and, on skip/error, ``reason``.
+        """
+        issue_key = payload.get("issue_key")
+        if not issue_key:
+            return {"status": "skipped", "reason": "missing issue_key"}
+
+        channel_id = config.get("JIRA_TEST_WEBHOOK_CHANNEL")
+        if not channel_id:
+            self.logger.warning(
+                "handle_ready_for_test: JIRA_TEST_WEBHOOK_CHANNEL is not "
+                "configured; skipping notification for %s.",
+                issue_key,
+            )
+            return {
+                "status": "skipped",
+                "issue_key": issue_key,
+                "reason": "JIRA_TEST_WEBHOOK_CHANNEL is not configured",
+            }
+
+        if not self._wrapper or not getattr(self._wrapper, "bot", None):
+            self.logger.error(
+                "handle_ready_for_test: no Telegram wrapper attached; "
+                "cannot notify channel for %s.",
+                issue_key,
+            )
+            return {
+                "status": "error",
+                "issue_key": issue_key,
+                "reason": "no Telegram wrapper attached",
+            }
+
+        summary = payload.get("summary") or ""
+        priority = payload.get("priority") or "—"
+        assignee = payload.get("assignee") or {}
+        actor = payload.get("user") or {}
+
+        developer_name = (
+            assignee.get("display_name")
+            or assignee.get("name")
+            or actor.get("displayName")
+            or actor.get("name")
+            or "El desarrollador"
+        )
+
+        text = (
+            f"🧪 *Ready For Test*: `{issue_key}`\n\n"
+            f"*{summary}*\n"
+            f"Prioridad: {priority}\n"
+            f"Asignado a: {developer_name}\n\n"
+            f"✅ *{developer_name}* ha terminado la fase de desarrollo.\n"
+            f"🚦 El ticket entra en la fase de *testing*."
+        )
+
+        try:
+            await self._wrapper.bot.send_message(
+                chat_id=channel_id,
+                text=text,
+                parse_mode="Markdown",
+            )
+            self.logger.info(
+                "Ready-for-test notification sent for %s to channel %s",
+                issue_key,
+                channel_id,
+            )
+            return {
+                "status": "ok",
+                "issue_key": issue_key,
+                "channel_id": channel_id,
+            }
+        except Exception as exc:
+            self.logger.error(
+                "Failed to notify ready-for-test for %s: %s",
+                issue_key,
+                exc,
+                exc_info=True,
+            )
+            return {
+                "status": "error",
+                "issue_key": issue_key,
                 "error": str(exc),
             }
 

--- a/packages/ai-parrot/src/parrot/bots/jira_specialist.py
+++ b/packages/ai-parrot/src/parrot/bots/jira_specialist.py
@@ -44,6 +44,7 @@ from parrot_tools.jiratoolkit import JiraToolkit
 from parrot.models.google import GoogleModel
 from parrot.integrations.telegram import TelegramHumanTool, telegram_chat_scope
 from parrot.auth.credentials import OAuthCredentialResolver
+from parrot.core.hooks.models import HookEvent
 
 # ──────────────────────────────────────────────────────────────
 # Models
@@ -254,6 +255,56 @@ If the developer reports a blocker during the day, capture it:
 - Add the `blocked` label. If the blocker names another person or team,
   propose an @mention in the comment with
   `ask_human(interaction_type="approval", ...)`.
+
+### Assignment intake (triggered by a Jira webhook when a ticket is
+### assigned to a developer)
+
+When the Jira webhook reports an assignment and you are asked to run
+the "assignment intake flow":
+
+1. Greet the developer briefly in Spanish and show the ticket key,
+   summary, priority and reporter you were given in the instruction
+   (do NOT call `jira_get_issue` again unless the instruction explicitly
+   asks for it — the data is already there).
+
+2. Ask all three answers in a single structured form:
+   ```
+   ask_human(
+     interaction_type="form",
+     question="Se te asignó <KEY>: <summary>. ¿Aceptas la tarea? Indica "
+              "fecha tope y estimación de esfuerzo.",
+     form_schema={
+       "type": "object",
+       "properties": {
+         "due_date": {"type": "string",
+                       "description": "Fecha tope (YYYY-MM-DD)"},
+         "estimate": {"type": "string",
+                       "description": "Estimación (ej. '1d', '4h', '30m')"},
+         "decision": {"type": "string", "enum": ["accept", "reject"],
+                       "description": "¿Aceptas la tarea?"}
+       },
+       "required": ["due_date", "estimate", "decision"]
+     }
+   )
+   ```
+
+3. If `decision == "accept"`:
+   - Call `jira_update_issue` with `fields={"duedate": "<due_date>",
+     "timetracking": {"originalEstimate": "<estimate>"}}`.
+   - Call `jira_add_comment` on the ticket: `Task accepted. Due: <date>.
+     Estimate: <estimate>.`
+   - Call `jira_transition_issue` moving the ticket to `In Progress`.
+   - Reply to the developer confirming the outcome.
+
+4. If `decision == "reject"`:
+   - Ask for the rejection reason with a second `ask_human`
+     (`interaction_type="free_text"`, one sentence is enough).
+   - Post the reason as a Jira comment prefixed with
+     `Task rejected by <developer>. Reason:`.
+   - Do NOT transition or reassign — leave the ticket for the manager.
+   - Reply to the developer acknowledging the rejection.
+
+5. Cancellation / timeout rules from the top of this prompt still apply.
 
 ### End-of-day wrap (triggered by the scheduled run or `/eod` style prompt)
 
@@ -1219,6 +1270,199 @@ class JiraSpecialist(Agent):
             status["developers"].append(dev_status)
 
         return status
+
+    # ──────────────────────────────────────────────────────────
+    # Jira Webhook: Assignment Handler
+    # ──────────────────────────────────────────────────────────
+
+    async def handle_hook_event(self, event: HookEvent) -> Optional[Dict[str, Any]]:
+        """Route :class:`HookEvent` instances emitted by ``JiraWebhookHook``.
+
+        Currently handles ``jira.assigned`` events by forwarding to
+        :meth:`handle_jira_assignment`. Other event types fall back to
+        logging so they remain observable even without bespoke routing.
+
+        Args:
+            event: The hook event forwarded by ``HookManager``.
+
+        Returns:
+            The per-developer result dict from :meth:`handle_jira_assignment`
+            when the event is a Jira assignment; otherwise ``None``.
+        """
+        if event.event_type == "jira.assigned":
+            return await self.handle_jira_assignment(event.payload)
+        self.logger.info(
+            "JiraSpecialist: ignoring hook event %s (hook_id=%s)",
+            event.event_type,
+            event.hook_id,
+        )
+        return None
+
+    def _resolve_developer_from_assignee(
+        self,
+        assignee: Optional[Dict[str, Any]],
+    ) -> Optional[Developer]:
+        """Match an assignee dict against the configured developer roster.
+
+        Tries, in order, ``email`` / ``name`` / ``display_name`` against the
+        developer's ``jira_username`` / ``username`` / ``name`` (case-insensitive).
+
+        Args:
+            assignee: Dict with the Jira assignee fields (``email``,
+                ``display_name``, ``name``, ``account_id``).
+
+        Returns:
+            The matching :class:`Developer` or ``None`` if no match.
+        """
+        if not assignee:
+            return None
+        if not self._developers:
+            self._developers = self._load_developers_sync()
+        if not self._developers:
+            return None
+
+        candidates = [
+            (assignee.get("email") or "").lower(),
+            (assignee.get("name") or "").lower(),
+            (assignee.get("display_name") or "").lower(),
+        ]
+        candidates = [c for c in candidates if c]
+
+        for dev in self._developers:
+            fields = [
+                (dev.jira_username or "").lower(),
+                (dev.username or "").lower(),
+                (dev.name or "").lower(),
+            ]
+            if any(c and c in fields for c in candidates):
+                return dev
+        return None
+
+    async def handle_jira_assignment(
+        self,
+        payload: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Kick off the assignment conversation with the developer on Telegram.
+
+        Invoked by the :class:`JiraWebhookHook` when a ticket is assigned
+        (either on creation with a non-null assignee or via an ``assignee``
+        change in the changelog).
+
+        The developer receives a prompt on Telegram asking them to provide:
+
+        * a **due date** (ISO ``YYYY-MM-DD``),
+        * an **original estimate** (``1d``, ``4h``, ``30m``…),
+        * and to **accept** or **reject** the assignment.
+
+        On accept, the agent posts the estimate as ``timetracking.originalEstimate``,
+        writes the due date, and transitions the issue to ``In Progress``.
+        On reject, the agent posts a Jira comment with the reason and leaves
+        the ticket untouched so a manager can reassign.
+
+        Args:
+            payload: The ``HookEvent.payload`` emitted by
+                :class:`JiraWebhookHook`. Must contain ``issue_key`` and
+                either ``new_assignee`` or ``assignee`` dicts.
+
+        Returns:
+            Result dict with ``status`` (``ok``/``skipped``/``error``),
+            ``issue_key``, and — on skip/error — ``reason``.
+        """
+        issue_key = payload.get("issue_key")
+        if not issue_key:
+            return {"status": "skipped", "reason": "missing issue_key"}
+
+        assignee = payload.get("new_assignee") or payload.get("assignee")
+        developer = self._resolve_developer_from_assignee(assignee)
+        if developer is None:
+            self.logger.info(
+                "handle_jira_assignment: no developer mapping for %s on %s",
+                (assignee or {}).get("display_name"),
+                issue_key,
+            )
+            return {
+                "status": "skipped",
+                "issue_key": issue_key,
+                "reason": "assignee is not a configured developer",
+            }
+
+        summary = payload.get("summary") or ""
+        priority = payload.get("priority") or "—"
+        reporter = payload.get("reporter") or "—"
+        status = payload.get("status") or "—"
+
+        instruction = (
+            f"A Jira ticket has just been assigned to {developer.name} "
+            f"(jira_username={developer.jira_username}).\n\n"
+            f"Ticket: {issue_key}\n"
+            f"Summary: {summary}\n"
+            f"Priority: {priority}\n"
+            f"Status: {status}\n"
+            f"Reporter: {reporter}\n\n"
+            "Run the assignment intake flow in Spanish:\n"
+            "1. Greet the developer and show the ticket above.\n"
+            "2. Call `ask_human` with interaction_type=\"form\" and "
+            "form_schema properties `due_date` (string, ISO YYYY-MM-DD), "
+            "`estimate` (string, e.g. '1d', '4h', '30m'), and `decision` "
+            "(string enum: 'accept' or 'reject'). All three are required. "
+            "The `question` field should clearly state that we need a due "
+            f"date, a time estimate, and whether they accept {issue_key}.\n"
+            "3. If `decision == 'accept'`:\n"
+            "   - Call `jira_update_issue` to set `duedate` to the provided "
+            "date and `timetracking.originalEstimate` to the provided "
+            "estimate.\n"
+            "   - Call `jira_add_comment` posting: 'Task accepted. Due: "
+            "<date>. Estimate: <estimate>.'\n"
+            "   - Call `jira_transition_issue` to move the ticket to "
+            f"'{self._standup_config.in_progress_transition}'.\n"
+            "   - Reply to the developer confirming the due date, estimate, "
+            "and the new status.\n"
+            "4. If `decision == 'reject'`:\n"
+            "   - Call `ask_human` with interaction_type=\"free_text\" "
+            "asking for the rejection reason (one sentence is enough).\n"
+            "   - Call `jira_add_comment` posting: 'Task rejected by "
+            "<developer>. Reason: <reason>.' Do NOT transition or reassign "
+            "the ticket; leave it for a manager to reassign.\n"
+            "   - Reply to the developer acknowledging the rejection.\n"
+            "5. If `ask_human` returns a cancellation or timeout, follow "
+            "the cancellation rule and stop immediately."
+        )
+
+        today = date.today().isoformat()
+        session_id = f"assignment-{developer.id}-{issue_key}-{today}"
+
+        try:
+            with telegram_chat_scope(developer.telegram_chat_id):
+                message = await self.ask(
+                    question=instruction,
+                    user_id=developer.id,
+                    session_id=session_id,
+                )
+            self.logger.info(
+                "Assignment intake completed for %s on %s",
+                developer.name,
+                issue_key,
+            )
+            return {
+                "status": "ok",
+                "issue_key": issue_key,
+                "developer_id": developer.id,
+                "output": getattr(message, "output", None),
+            }
+        except Exception as exc:
+            self.logger.error(
+                "Assignment intake failed for %s on %s: %s",
+                developer.name,
+                issue_key,
+                exc,
+                exc_info=True,
+            )
+            return {
+                "status": "error",
+                "issue_key": issue_key,
+                "developer_id": developer.id,
+                "error": str(exc),
+            }
 
     @telegram_callback(
         prefix="create_ticket",

--- a/packages/ai-parrot/src/parrot/core/hooks/jira_webhook.py
+++ b/packages/ai-parrot/src/parrot/core/hooks/jira_webhook.py
@@ -133,8 +133,11 @@ class JiraWebhookHook(BaseHook):
                     return "unassigned"
             for item in items:
                 if item.get("field") == "status":
-                    if (item.get("toString") or "").lower() == "closed":
+                    to_status = (item.get("toString") or "").strip().lower()
+                    if to_status == "closed":
                         return "closed"
+                    if to_status in ("ready for test", "ready for testing"):
+                        return "ready_for_test"
                     return "updated"
             return "updated"
         return None

--- a/packages/ai-parrot/src/parrot/core/hooks/jira_webhook.py
+++ b/packages/ai-parrot/src/parrot/core/hooks/jira_webhook.py
@@ -1,7 +1,7 @@
 """Jira webhook hook — receives and parses Jira issue events."""
 import hashlib
 import hmac
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from aiohttp import web
 
@@ -62,23 +62,37 @@ class JiraWebhookHook(BaseHook):
 
             issue = payload.get("issue", {})
             fields = issue.get("fields", {})
+            assignee_field = fields.get("assignee") or {}
+            event_payload: Dict[str, Any] = {
+                "webhook_event": payload.get("webhookEvent"),
+                "event_type": event_type,
+                "issue_key": issue.get("key"),
+                "issue_id": issue.get("id"),
+                "summary": fields.get("summary", ""),
+                "description": fields.get("description"),
+                "status": (fields.get("status") or {}).get("name"),
+                "priority": (fields.get("priority") or {}).get("name"),
+                "project_key": (fields.get("project") or {}).get("key"),
+                "reporter": (fields.get("reporter") or {}).get("displayName"),
+                "assignee": {
+                    "account_id": assignee_field.get("accountId"),
+                    "email": assignee_field.get("emailAddress"),
+                    "display_name": assignee_field.get("displayName"),
+                    "name": assignee_field.get("name"),
+                },
+                "changelog": payload.get("changelog"),
+                "user": payload.get("user", {}),
+                "timestamp": payload.get("timestamp"),
+            }
+
+            if event_type == "assigned":
+                prev, curr = self._extract_assignee_change(payload)
+                event_payload["previous_assignee"] = prev
+                event_payload["new_assignee"] = curr
+
             event = self._make_event(
                 event_type=f"jira.{event_type}",
-                payload={
-                    "webhook_event": payload.get("webhookEvent"),
-                    "event_type": event_type,
-                    "issue_key": issue.get("key"),
-                    "issue_id": issue.get("id"),
-                    "summary": fields.get("summary", ""),
-                    "description": fields.get("description"),
-                    "status": (fields.get("status") or {}).get("name"),
-                    "priority": (fields.get("priority") or {}).get("name"),
-                    "project_key": (fields.get("project") or {}).get("key"),
-                    "reporter": (fields.get("reporter") or {}).get("displayName"),
-                    "changelog": payload.get("changelog"),
-                    "user": payload.get("user", {}),
-                    "timestamp": payload.get("timestamp"),
-                },
+                payload=event_payload,
                 task=f"Jira issue {event_type}: {issue.get('key')} — {fields.get('summary', '')}",
             )
             await self.on_event(event)
@@ -103,6 +117,9 @@ class JiraWebhookHook(BaseHook):
     def _classify_event(payload: Dict[str, Any]) -> Optional[str]:
         webhook_event = payload.get("webhookEvent", "")
         if webhook_event == "jira:issue_created":
+            fields = (payload.get("issue") or {}).get("fields") or {}
+            if (fields.get("assignee") or {}).get("accountId"):
+                return "assigned"
             return "created"
         if webhook_event == "jira:issue_deleted":
             return "deleted"
@@ -110,9 +127,53 @@ class JiraWebhookHook(BaseHook):
             changelog = payload.get("changelog", {})
             items = changelog.get("items", [])
             for item in items:
+                if item.get("field") == "assignee":
+                    if item.get("to"):
+                        return "assigned"
+                    return "unassigned"
+            for item in items:
                 if item.get("field") == "status":
                     if (item.get("toString") or "").lower() == "closed":
                         return "closed"
                     return "updated"
             return "updated"
         return None
+
+    @staticmethod
+    def _extract_assignee_change(
+        payload: Dict[str, Any],
+    ) -> Tuple[Optional[Dict[str, Optional[str]]], Optional[Dict[str, Optional[str]]]]:
+        """Extract previous/current assignee from a Jira changelog payload.
+
+        Returns a tuple of ``(previous, current)`` dicts (or ``None`` when a
+        side is empty). Each dict carries ``account_id`` and ``display_name``.
+
+        On ``jira:issue_created`` no changelog exists, so the previous side
+        is ``None`` and the current side is sourced from the issue fields.
+        """
+        items = (payload.get("changelog") or {}).get("items") or []
+        for item in items:
+            if item.get("field") == "assignee":
+                prev = None
+                curr = None
+                if item.get("from"):
+                    prev = {
+                        "account_id": item.get("from"),
+                        "display_name": item.get("fromString"),
+                    }
+                if item.get("to"):
+                    curr = {
+                        "account_id": item.get("to"),
+                        "display_name": item.get("toString"),
+                    }
+                return prev, curr
+
+        assignee = (
+            ((payload.get("issue") or {}).get("fields") or {}).get("assignee") or {}
+        )
+        if assignee:
+            return None, {
+                "account_id": assignee.get("accountId"),
+                "display_name": assignee.get("displayName"),
+            }
+        return None, None

--- a/packages/ai-parrot/tests/core/hooks/test_jira_webhook_classify.py
+++ b/packages/ai-parrot/tests/core/hooks/test_jira_webhook_classify.py
@@ -1,0 +1,134 @@
+"""Unit tests for JiraWebhookHook._classify_event + _extract_assignee_change.
+
+Covers the new ``assigned`` / ``unassigned`` branches added to support the
+Jira → Telegram assignment-intake flow.
+"""
+from __future__ import annotations
+
+import pytest
+
+from parrot.core.hooks.jira_webhook import JiraWebhookHook
+
+
+class TestClassifyEvent:
+    def test_issue_created_without_assignee_is_created(self):
+        payload = {
+            "webhookEvent": "jira:issue_created",
+            "issue": {"key": "NAV-1", "fields": {"assignee": None}},
+        }
+        assert JiraWebhookHook._classify_event(payload) == "created"
+
+    def test_issue_created_with_assignee_is_assigned(self):
+        payload = {
+            "webhookEvent": "jira:issue_created",
+            "issue": {
+                "key": "NAV-1",
+                "fields": {"assignee": {"accountId": "abc", "displayName": "Jane"}},
+            },
+        }
+        assert JiraWebhookHook._classify_event(payload) == "assigned"
+
+    def test_issue_updated_assignee_changed_is_assigned(self):
+        payload = {
+            "webhookEvent": "jira:issue_updated",
+            "issue": {"key": "NAV-1"},
+            "changelog": {
+                "items": [
+                    {
+                        "field": "assignee",
+                        "from": None,
+                        "to": "abc",
+                        "fromString": None,
+                        "toString": "Jane",
+                    }
+                ]
+            },
+        }
+        assert JiraWebhookHook._classify_event(payload) == "assigned"
+
+    def test_issue_updated_assignee_cleared_is_unassigned(self):
+        payload = {
+            "webhookEvent": "jira:issue_updated",
+            "issue": {"key": "NAV-1"},
+            "changelog": {
+                "items": [
+                    {
+                        "field": "assignee",
+                        "from": "abc",
+                        "to": None,
+                        "fromString": "Jane",
+                        "toString": None,
+                    }
+                ]
+            },
+        }
+        assert JiraWebhookHook._classify_event(payload) == "unassigned"
+
+    def test_assignee_wins_over_status_change(self):
+        payload = {
+            "webhookEvent": "jira:issue_updated",
+            "issue": {"key": "NAV-1"},
+            "changelog": {
+                "items": [
+                    {
+                        "field": "status",
+                        "toString": "In Progress",
+                    },
+                    {
+                        "field": "assignee",
+                        "from": None,
+                        "to": "abc",
+                        "toString": "Jane",
+                    },
+                ]
+            },
+        }
+        assert JiraWebhookHook._classify_event(payload) == "assigned"
+
+    def test_status_closed_still_classified_when_no_assignee_change(self):
+        payload = {
+            "webhookEvent": "jira:issue_updated",
+            "issue": {"key": "NAV-1"},
+            "changelog": {
+                "items": [{"field": "status", "toString": "Closed"}]
+            },
+        }
+        assert JiraWebhookHook._classify_event(payload) == "closed"
+
+    def test_unknown_webhook_event_returns_none(self):
+        assert JiraWebhookHook._classify_event({"webhookEvent": "jira:sprint_started"}) is None
+
+
+class TestExtractAssigneeChange:
+    def test_extracts_assignee_from_changelog(self):
+        payload = {
+            "changelog": {
+                "items": [
+                    {
+                        "field": "assignee",
+                        "from": "old-id",
+                        "to": "new-id",
+                        "fromString": "Old Dev",
+                        "toString": "New Dev",
+                    }
+                ]
+            }
+        }
+        prev, curr = JiraWebhookHook._extract_assignee_change(payload)
+        assert prev == {"account_id": "old-id", "display_name": "Old Dev"}
+        assert curr == {"account_id": "new-id", "display_name": "New Dev"}
+
+    def test_created_event_has_no_previous(self):
+        payload = {
+            "issue": {
+                "fields": {
+                    "assignee": {"accountId": "abc", "displayName": "Jane"}
+                }
+            }
+        }
+        prev, curr = JiraWebhookHook._extract_assignee_change(payload)
+        assert prev is None
+        assert curr == {"account_id": "abc", "display_name": "Jane"}
+
+    def test_returns_none_pair_when_nothing_present(self):
+        assert JiraWebhookHook._extract_assignee_change({}) == (None, None)

--- a/packages/ai-parrot/tests/core/hooks/test_jira_webhook_classify.py
+++ b/packages/ai-parrot/tests/core/hooks/test_jira_webhook_classify.py
@@ -95,6 +95,20 @@ class TestClassifyEvent:
         }
         assert JiraWebhookHook._classify_event(payload) == "closed"
 
+    @pytest.mark.parametrize(
+        "to_status",
+        ["Ready For Test", "ready for test", "Ready for Testing", "READY FOR TESTING"],
+    )
+    def test_status_ready_for_test_is_classified(self, to_status):
+        payload = {
+            "webhookEvent": "jira:issue_updated",
+            "issue": {"key": "NAV-1"},
+            "changelog": {
+                "items": [{"field": "status", "toString": to_status}]
+            },
+        }
+        assert JiraWebhookHook._classify_event(payload) == "ready_for_test"
+
     def test_unknown_webhook_event_returns_none(self):
         assert JiraWebhookHook._classify_event({"webhookEvent": "jira:sprint_started"}) is None
 

--- a/packages/ai-parrot/tests/test_jira_assignment.py
+++ b/packages/ai-parrot/tests/test_jira_assignment.py
@@ -1,0 +1,157 @@
+"""Tests for the Jira → Telegram assignment intake flow on JiraSpecialist."""
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from parrot.bots.jira_specialist import Developer, JiraSpecialist
+
+
+class TestJiraAssignmentHandler(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        # Isolate external dependencies the same way test_jira_callbacks.py does.
+        self.redis_patcher = patch("redis.asyncio.from_url")
+        self.mock_redis = self.redis_patcher.start()
+        self.mock_redis.return_value = AsyncMock()
+
+        self.jira_patcher = patch("parrot.bots.jira_specialist.JiraToolkit")
+        self.jira_patcher.start()
+
+        self.config_patcher = patch("parrot.bots.jira_specialist.config")
+        mock_config = self.config_patcher.start()
+        mock_config.get.return_value = "dummy"
+        mock_config.getlist.return_value = []
+
+        self.agent = JiraSpecialist()
+        self.agent.ask = AsyncMock(return_value=object())
+        self.agent._developers = [
+            Developer(
+                id="35",
+                name="Jesus Lara",
+                username="jlara@trocglobal.com",
+                jira_username="jesuslarag@gmail.com",
+                telegram_chat_id=286137732,
+                manager_chat_id=286137732,
+            )
+        ]
+
+    async def asyncTearDown(self):
+        self.redis_patcher.stop()
+        self.jira_patcher.stop()
+        self.config_patcher.stop()
+
+    async def test_resolve_developer_by_email(self):
+        dev = self.agent._resolve_developer_from_assignee(
+            {"email": "jesuslarag@gmail.com", "display_name": "Jesus Lara"}
+        )
+        self.assertIsNotNone(dev)
+        self.assertEqual(dev.id, "35")
+
+    async def test_resolve_developer_by_display_name(self):
+        dev = self.agent._resolve_developer_from_assignee(
+            {"display_name": "Jesus Lara"}
+        )
+        self.assertIsNotNone(dev)
+
+    async def test_resolve_developer_unknown_returns_none(self):
+        dev = self.agent._resolve_developer_from_assignee(
+            {"email": "stranger@example.com"}
+        )
+        self.assertIsNone(dev)
+
+    async def test_handle_assignment_skips_when_assignee_unknown(self):
+        result = await self.agent.handle_jira_assignment(
+            {
+                "issue_key": "NAV-123",
+                "summary": "New ticket",
+                "new_assignee": {"email": "stranger@example.com"},
+            }
+        )
+        self.assertEqual(result["status"], "skipped")
+        self.assertEqual(result["issue_key"], "NAV-123")
+        self.agent.ask.assert_not_called()
+
+    async def test_handle_assignment_skips_without_issue_key(self):
+        result = await self.agent.handle_jira_assignment({})
+        self.assertEqual(result["status"], "skipped")
+        self.agent.ask.assert_not_called()
+
+    async def test_handle_assignment_asks_developer(self):
+        result = await self.agent.handle_jira_assignment(
+            {
+                "issue_key": "NAV-456",
+                "summary": "Fix login bug",
+                "priority": "High",
+                "status": "To Do",
+                "reporter": "PM",
+                "new_assignee": {
+                    "email": "jesuslarag@gmail.com",
+                    "display_name": "Jesus Lara",
+                },
+            }
+        )
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["issue_key"], "NAV-456")
+        self.assertEqual(result["developer_id"], "35")
+
+        self.agent.ask.assert_called_once()
+        call = self.agent.ask.call_args
+        question = call.kwargs["question"]
+        self.assertIn("NAV-456", question)
+        self.assertIn("Jesus Lara", question)
+        self.assertIn("due_date", question)
+        self.assertIn("estimate", question)
+        self.assertIn("decision", question)
+        self.assertEqual(call.kwargs["user_id"], "35")
+
+
+class TestHandleHookEventRouting(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.redis_patcher = patch("redis.asyncio.from_url")
+        self.redis_patcher.start()
+        self.jira_patcher = patch("parrot.bots.jira_specialist.JiraToolkit")
+        self.jira_patcher.start()
+        self.config_patcher = patch("parrot.bots.jira_specialist.config")
+        mock_config = self.config_patcher.start()
+        mock_config.get.return_value = "dummy"
+        mock_config.getlist.return_value = []
+
+        self.agent = JiraSpecialist()
+        self.agent.handle_jira_assignment = AsyncMock(
+            return_value={"status": "ok"}
+        )
+
+    async def asyncTearDown(self):
+        self.redis_patcher.stop()
+        self.jira_patcher.stop()
+        self.config_patcher.stop()
+
+    async def test_assigned_event_routes_to_handler(self):
+        from parrot.core.hooks.models import HookEvent, HookType
+
+        event = HookEvent(
+            hook_id="h1",
+            hook_type=HookType.JIRA_WEBHOOK,
+            event_type="jira.assigned",
+            payload={"issue_key": "NAV-1"},
+        )
+        result = await self.agent.handle_hook_event(event)
+        self.agent.handle_jira_assignment.assert_awaited_once_with(
+            {"issue_key": "NAV-1"}
+        )
+        self.assertEqual(result, {"status": "ok"})
+
+    async def test_other_events_are_ignored(self):
+        from parrot.core.hooks.models import HookEvent, HookType
+
+        event = HookEvent(
+            hook_id="h1",
+            hook_type=HookType.JIRA_WEBHOOK,
+            event_type="jira.closed",
+            payload={"issue_key": "NAV-1"},
+        )
+        result = await self.agent.handle_hook_event(event)
+        self.assertIsNone(result)
+        self.agent.handle_jira_assignment.assert_not_awaited()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/ai-parrot/tests/test_jira_assignment.py
+++ b/packages/ai-parrot/tests/test_jira_assignment.py
@@ -118,6 +118,9 @@ class TestHandleHookEventRouting(unittest.IsolatedAsyncioTestCase):
         self.agent.handle_jira_assignment = AsyncMock(
             return_value={"status": "ok"}
         )
+        self.agent.handle_ready_for_test = AsyncMock(
+            return_value={"status": "ok", "channel_id": "-100123"}
+        )
 
     async def asyncTearDown(self):
         self.redis_patcher.stop()
@@ -139,6 +142,21 @@ class TestHandleHookEventRouting(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(result, {"status": "ok"})
 
+    async def test_ready_for_test_event_routes_to_handler(self):
+        from parrot.core.hooks.models import HookEvent, HookType
+
+        event = HookEvent(
+            hook_id="h1",
+            hook_type=HookType.JIRA_WEBHOOK,
+            event_type="jira.ready_for_test",
+            payload={"issue_key": "NAV-1"},
+        )
+        result = await self.agent.handle_hook_event(event)
+        self.agent.handle_ready_for_test.assert_awaited_once_with(
+            {"issue_key": "NAV-1"}
+        )
+        self.assertEqual(result["status"], "ok")
+
     async def test_other_events_are_ignored(self):
         from parrot.core.hooks.models import HookEvent, HookType
 
@@ -151,6 +169,75 @@ class TestHandleHookEventRouting(unittest.IsolatedAsyncioTestCase):
         result = await self.agent.handle_hook_event(event)
         self.assertIsNone(result)
         self.agent.handle_jira_assignment.assert_not_awaited()
+        self.agent.handle_ready_for_test.assert_not_awaited()
+
+
+class TestHandleReadyForTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.redis_patcher = patch("redis.asyncio.from_url")
+        self.redis_patcher.start()
+        self.jira_patcher = patch("parrot.bots.jira_specialist.JiraToolkit")
+        self.jira_patcher.start()
+        self.config_patcher = patch("parrot.bots.jira_specialist.config")
+        self.mock_config = self.config_patcher.start()
+        self.mock_config.getlist.return_value = []
+
+        def _config_get(key, *args, **kwargs):
+            if key == "JIRA_TEST_WEBHOOK_CHANNEL":
+                return "-1001234567890"
+            return "dummy"
+
+        self.mock_config.get.side_effect = _config_get
+
+        self.agent = JiraSpecialist()
+        self.mock_wrapper = AsyncMock()
+        self.mock_wrapper.bot = AsyncMock()
+        self.agent.set_wrapper(self.mock_wrapper)
+
+    async def asyncTearDown(self):
+        self.redis_patcher.stop()
+        self.jira_patcher.stop()
+        self.config_patcher.stop()
+
+    async def test_skips_when_missing_issue_key(self):
+        result = await self.agent.handle_ready_for_test({})
+        self.assertEqual(result["status"], "skipped")
+        self.mock_wrapper.bot.send_message.assert_not_called()
+
+    async def test_skips_when_channel_not_configured(self):
+        self.mock_config.get.side_effect = lambda *a, **kw: None
+        result = await self.agent.handle_ready_for_test(
+            {"issue_key": "NAV-1"}
+        )
+        self.assertEqual(result["status"], "skipped")
+        self.assertIn("JIRA_TEST_WEBHOOK_CHANNEL", result["reason"])
+        self.mock_wrapper.bot.send_message.assert_not_called()
+
+    async def test_errors_when_wrapper_missing(self):
+        self.agent._wrapper = None
+        result = await self.agent.handle_ready_for_test(
+            {"issue_key": "NAV-1"}
+        )
+        self.assertEqual(result["status"], "error")
+
+    async def test_sends_notification_to_channel(self):
+        payload = {
+            "issue_key": "NAV-789",
+            "summary": "Fix login flow",
+            "priority": "High",
+            "assignee": {"display_name": "Jesus Lara"},
+        }
+        result = await self.agent.handle_ready_for_test(payload)
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["channel_id"], "-1001234567890")
+
+        self.mock_wrapper.bot.send_message.assert_awaited_once()
+        kwargs = self.mock_wrapper.bot.send_message.call_args.kwargs
+        self.assertEqual(kwargs["chat_id"], "-1001234567890")
+        self.assertIn("NAV-789", kwargs["text"])
+        self.assertIn("Ready For Test", kwargs["text"])
+        self.assertIn("Jesus Lara", kwargs["text"])
+        self.assertIn("testing", kwargs["text"].lower())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR implements a complete Jira → Telegram assignment intake flow that allows developers to accept or reject ticket assignments directly through Telegram, with automatic Jira updates on acceptance.

## Key Changes

### JiraSpecialist Bot (`jira_specialist.py`)
- **New webhook handler**: `handle_hook_event()` routes `HookEvent` instances from `JiraWebhookHook`, dispatching `jira.assigned` and `jira.ready_for_test` events to specialized handlers
- **Assignment intake flow**: `handle_jira_assignment()` sends a structured form to the developer via Telegram asking for:
  - Due date (ISO YYYY-MM-DD format)
  - Time estimate (e.g., "1d", "4h", "30m")
  - Accept/reject decision
- **Developer resolution**: `_resolve_developer_from_assignee()` matches Jira assignee data (email, name, display_name) against configured developers using case-insensitive comparison
- **Ready-for-test notifications**: `handle_ready_for_test()` sends formatted messages to a QA channel when tickets transition to "Ready For Test" status
- **Automatic Jira updates**: On acceptance, the bot updates the issue with due date, time estimate, adds a confirmation comment, and transitions to "In Progress"; on rejection, posts the reason as a comment and leaves the ticket for manager reassignment

### Jira Webhook Hook (`jira_webhook.py`)
- **Enhanced event classification**: `_classify_event()` now detects:
  - `assigned`: Issues created with assignee or assignee field changed to non-null
  - `unassigned`: Assignee field cleared
  - `ready_for_test`: Status transitions to "Ready For Test" (case-insensitive)
- **Assignee extraction**: New `_extract_assignee_change()` method extracts previous/current assignee from changelog items or issue fields, returning structured dicts with `account_id` and `display_name`
- **Enriched payload**: Event payloads now include `new_assignee`, `previous_assignee`, and full issue metadata for downstream handlers

### Tests
- **Assignment handler tests** (`test_jira_assignment.py`): Cover developer resolution, skipping unknown assignees, and the full assignment intake flow
- **Hook event routing tests**: Verify correct dispatch of `jira.assigned` and `jira.ready_for_test` events, and that unknown events are ignored
- **Ready-for-test handler tests**: Validate channel notification logic, configuration checks, and message formatting
- **Webhook classification tests** (`test_jira_webhook_classify.py`): Comprehensive coverage of event classification logic and assignee extraction from various payload structures

## Implementation Details

- Uses `telegram_chat_scope()` to route Telegram messages to the correct developer's chat
- Session IDs follow pattern `assignment-{developer_id}-{issue_key}-{date}` for tracking
- Developer matching is case-insensitive and tries multiple fields (email, name, display_name) against configured identifiers
- Error handling logs failures but returns structured result dicts for observability
- Spanish language support for developer-facing prompts (greeting, form questions, notifications)

https://claude.ai/code/session_01QUWKNYxHJ1mdd6Zav4iNK5