### PR TITLE
feat(YoutubeLoader): cookies, Node.js runtime and ejs_script support

### DIFF
--- a/packages/ai-parrot-loaders/src/parrot_loaders/youtube.py
+++ b/packages/ai-parrot-loaders/src/parrot_loaders/youtube.py
@@ -32,6 +32,28 @@ class YoutubeLoader(VideoLoader):
     Loader for Youtube videos.
     """
 
+    def __init__(self, *args, **kwargs):
+        cookies_from_browser = kwargs.pop('cookies_from_browser', None)
+        cookies_file = kwargs.pop('cookies_file', None)
+        super().__init__(*args, **kwargs)
+        self._ydl_cookie_opts: dict = {}
+        if cookies_file:
+            self._ydl_cookie_opts['cookiefile'] = str(cookies_file)
+        elif cookies_from_browser:
+            browser = (
+                cookies_from_browser
+                if isinstance(cookies_from_browser, tuple)
+                else (cookies_from_browser,)
+            )
+            self._ydl_cookie_opts['cookiesfrombrowser'] = browser
+        # Tell yt-dlp to use Node.js for the nsig JavaScript challenge and
+        # allow it to fetch the challenge solver script from GitHub.
+        import shutil
+        _node = shutil.which('node')
+        if _node:
+            self._ydl_cookie_opts['js_runtimes'] = {'node': {'path': _node}}
+            self._ydl_cookie_opts['remote_components'] = ['ejs:github']
+
     def _ensure_video_dir(self, path: Optional[Union[str, Path]]) -> Path:
         """
         Normalize/ensure a usable download directory.
@@ -53,7 +75,7 @@ class YoutubeLoader(VideoLoader):
     def get_video_info(self, url: str) -> dict:
         # Primary: yt-dlp (no download)
         try:
-            ydl_opts = {"quiet": True, "noprogress": True, "skip_download": True}
+            ydl_opts = {"quiet": True, "noprogress": True, "skip_download": True, **self._ydl_cookie_opts}
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                 info = ydl.extract_info(url, download=False)
             upload_date = info.get("upload_date")  # YYYYMMDD
@@ -124,6 +146,7 @@ class YoutubeLoader(VideoLoader):
             ],
             # enforce mono 16k
             "postprocessor_args": ["-ac", "1", "-ar", "16000"],
+            **self._ydl_cookie_opts,
         }
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             info = ydl.extract_info(url, download=True)
@@ -160,6 +183,7 @@ class YoutubeLoader(VideoLoader):
                 "merge_output_format": "mp4",   # or "mkv"
                 "quiet": True,
                 "noprogress": True,
+                **self._ydl_cookie_opts,
             }
 
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:

--- a/packages/ai-parrot-loaders/src/parrot_loaders/youtube.py
+++ b/packages/ai-parrot-loaders/src/parrot_loaders/youtube.py
@@ -35,6 +35,7 @@ class YoutubeLoader(VideoLoader):
     def __init__(self, *args, **kwargs):
         cookies_from_browser = kwargs.pop('cookies_from_browser', None)
         cookies_file = kwargs.pop('cookies_file', None)
+        ejs_script = kwargs.pop('ejs_script', None)
         super().__init__(*args, **kwargs)
         self._ydl_cookie_opts: dict = {}
         if cookies_file:
@@ -46,13 +47,20 @@ class YoutubeLoader(VideoLoader):
                 else (cookies_from_browser,)
             )
             self._ydl_cookie_opts['cookiesfrombrowser'] = browser
-        # Tell yt-dlp to use Node.js for the nsig JavaScript challenge and
-        # allow it to fetch the challenge solver script from GitHub.
+        # Inject Node.js runtime so yt-dlp can solve the nsig JS challenge.
+        # ejs_script: full path to lib.json (e.g. /home/user/yt_ejs/challenge-solver/lib.json).
+        # yt-dlp expects the file at {cachedir}/challenge-solver/lib.json, so we
+        # derive cachedir as the grandparent of the given path.
+        # If not provided, falls back to the default ~/.cache/yt-dlp cache location.
         import shutil
         _node = shutil.which('node')
         if _node:
             self._ydl_cookie_opts['js_runtimes'] = {'node': {'path': _node}}
             self._ydl_cookie_opts['remote_components'] = ['ejs:github']
+            if ejs_script:
+                ejs_path = Path(ejs_script).expanduser().resolve()
+                # cachedir must be the parent of the challenge-solver/ directory
+                self._ydl_cookie_opts['cachedir'] = str(ejs_path.parent.parent)
 
     def _ensure_video_dir(self, path: Optional[Union[str, Path]]) -> Path:
         """


### PR DESCRIPTION
## Summary

- Add `cookies_file` kwarg to authenticate yt-dlp with a Netscape-format cookie file
- Add `cookies_from_browser` kwarg to read cookies directly from an installed browser (e.g. Chrome)
- Add `js_runtimes` + `remote_components` injection so yt-dlp uses Node.js (>= 20) to solve the nsig JS challenge
- Add `ejs_script` kwarg to point yt-dlp to a pre-downloaded EJS challenge-solver `lib.json`, enabling environments without GitHub access (e.g. AWS bastions) to solve the nsig challenge

## Test plan

- [ ] Local: `cookies_from_browser: chrome` downloads a YouTube video without bot-detection error
- [ ] Local: `cookies_file + ejs_script` downloads a YouTube video without nsig challenge error
- [ ] Bastion (Node >= 20): `cookies_file + ejs_script` resolves nsig challenge with cached lib.json
- [ ] Without any cookie kwarg: existing behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)