### PR TITLE
fix(formdesigner): honour setup_form_routes prefix across HTML + JSON

### DIFF
--- a/packages/parrot-formdesigner/src/parrot/formdesigner/handlers/api.py
+++ b/packages/parrot-formdesigner/src/parrot/formdesigner/handlers/api.py
@@ -339,10 +339,11 @@ class FormAPIHandler:
                 status=500,
             )
         title = (result.result or {}).get("title", "")
+        prefix = request.app.get("_form_prefix", "")
         return web.json_response({
             "form_id": form_id,
             "title": title,
-            "url": f"/forms/{form_id}",
+            "url": f"{prefix}/forms/{form_id}",
         })
 
     async def update_form(self, request: web.Request) -> web.Response:
@@ -598,8 +599,9 @@ class FormAPIHandler:
                 status=500,
             )
         title = (result.result or {}).get("title", "")
+        prefix = request.app.get("_form_prefix", "")
         return web.json_response({
             "form_id": form_id,
             "title": title,
-            "url": f"/forms/{form_id}",
+            "url": f"{prefix}/forms/{form_id}",
         })

--- a/packages/parrot-formdesigner/src/parrot/formdesigner/handlers/forms.py
+++ b/packages/parrot-formdesigner/src/parrot/formdesigner/handlers/forms.py
@@ -1,6 +1,11 @@
 """HTML page handlers for parrot-formdesigner.
 
 Serves the form builder UI: index, gallery, render form, submit form.
+
+Every handler reads the optional URL mount prefix from
+``request.app["_form_prefix"]`` (populated by ``setup_form_routes``) and
+forwards it to the page-template builders so that links and form
+actions match the routes registered by aiohttp.
 """
 
 from __future__ import annotations
@@ -17,6 +22,16 @@ from ..services.registry import FormRegistry
 from ..services.validators import FormValidator
 from ..renderers.jsonschema import JsonSchemaRenderer
 from .templates import error_page, form_page, gallery_page, index_page, page_shell, schema_page
+
+
+def _prefix(request: web.Request) -> str:
+    """Return the form-designer mount prefix for this request.
+
+    Reads the value populated by ``setup_form_routes`` at registration
+    time. Falls back to ``""`` when the app was wired without a prefix
+    (legacy behaviour, routes at root).
+    """
+    return request.app.get("_form_prefix", "")
 
 
 class FormPageHandler:
@@ -49,8 +64,9 @@ class FormPageHandler:
         Returns:
             HTML page response.
         """
+        p = _prefix(request)
         return web.Response(
-            text=page_shell("Create a Form", index_page()),
+            text=page_shell("Create a Form", index_page(prefix=p), prefix=p),
             content_type="text/html",
         )
 
@@ -63,10 +79,11 @@ class FormPageHandler:
         Returns:
             HTML page response with the form gallery.
         """
+        p = _prefix(request)
         forms = await self.registry.list_forms()
 
         if not forms:
-            items_html = "<p>No forms created yet. <a href='/'>Create one!</a></p>"
+            items_html = f"<p>No forms created yet. <a href='{p}/'>Create one!</a></p>"
         else:
             items = []
             for form in forms:
@@ -77,9 +94,9 @@ class FormPageHandler:
                     f'<span><strong>{escape(title)}</strong> '
                     f'<span style="color:var(--muted);font-size:.85rem">({escape(fid)})</span></span>'
                     f'<span style="display:flex;gap:.5rem;">'
-                    f'<a href="/forms/{escape(fid)}" class="btn btn-secondary" '
+                    f'<a href="{p}/forms/{escape(fid)}" class="btn btn-secondary" '
                     f'style="padding:.35rem .8rem; font-size:.85rem;">Open</a>'
-                    f'<a href="/forms/{escape(fid)}/schema" class="btn btn-secondary" '
+                    f'<a href="{p}/forms/{escape(fid)}/schema" class="btn btn-secondary" '
                     f'style="padding:.35rem .8rem; font-size:.85rem;">Schema</a>'
                     f'</span>'
                     f'</li>'
@@ -87,7 +104,7 @@ class FormPageHandler:
             items_html = f'<ul class="form-list">{"".join(items)}</ul>'
 
         return web.Response(
-            text=page_shell("Gallery", gallery_page(items_html)),
+            text=page_shell("Gallery", gallery_page(items_html), prefix=p),
             content_type="text/html",
         )
 
@@ -100,11 +117,14 @@ class FormPageHandler:
         Returns:
             HTML page with the rendered form, or 404 if not found.
         """
+        p = _prefix(request)
         form_id = request.match_info["form_id"]
         form = await self.registry.get(form_id)
         if form is None:
             return web.Response(
-                text=page_shell("Not Found", error_page("Form not found.")),
+                text=page_shell(
+                    "Not Found", error_page("Form not found.", prefix=p), prefix=p
+                ),
                 status=404,
                 content_type="text/html",
             )
@@ -119,18 +139,18 @@ class FormPageHandler:
         rendered = await self.renderer.render(form, style=style)
         fragment = rendered.content.replace(
             "<form ",
-            f'<form action="/forms/{escape(form_id)}" method="post" ',
+            f'<form action="{p}/forms/{escape(form_id)}" method="post" ',
             1,
         )
 
         title = form.title if isinstance(form.title, str) else form.title.get("en", "Form")
         schema_link = (
             f'<div style="margin-top:1rem;">'
-            f'<a href="/forms/{escape(form_id)}/schema" class="btn btn-secondary"'
+            f'<a href="{p}/forms/{escape(form_id)}/schema" class="btn btn-secondary"'
             f' style="font-size:.85rem;">View JSON Schema</a></div>'
         )
         return web.Response(
-            text=page_shell(title, form_page(fragment) + schema_link),
+            text=page_shell(title, form_page(fragment) + schema_link, prefix=p),
             content_type="text/html",
         )
 
@@ -143,11 +163,14 @@ class FormPageHandler:
         Returns:
             HTML page with pretty-printed JSON Schema and Style Schema.
         """
+        p = _prefix(request)
         form_id = request.match_info["form_id"]
         form = await self.registry.get(form_id)
         if form is None:
             return web.Response(
-                text=page_shell("Not Found", error_page("Form not found.")),
+                text=page_shell(
+                    "Not Found", error_page("Form not found.", prefix=p), prefix=p
+                ),
                 status=404,
                 content_type="text/html",
             )
@@ -163,7 +186,8 @@ class FormPageHandler:
         return web.Response(
             text=page_shell(
                 f"{title} - JSON Schema",
-                schema_page(form_id, title, schema_json, style_json),
+                schema_page(form_id, title, schema_json, style_json, prefix=p),
+                prefix=p,
             ),
             content_type="text/html",
         )
@@ -177,11 +201,14 @@ class FormPageHandler:
         Returns:
             HTML page showing success or re-rendered form with errors.
         """
+        p = _prefix(request)
         form_id = request.match_info["form_id"]
         form = await self.registry.get(form_id)
         if form is None:
             return web.Response(
-                text=page_shell("Not Found", error_page("Form not found.")),
+                text=page_shell(
+                    "Not Found", error_page("Form not found.", prefix=p), prefix=p
+                ),
                 status=404,
                 content_type="text/html",
             )
@@ -203,18 +230,18 @@ class FormPageHandler:
   <pre>{escape(sanitized_json)}</pre>
 </div>
 <div style="display:flex; gap:.75rem;">
-  <a href="/forms/{escape(form_id)}" class="btn btn-secondary">Fill again</a>
-  <a href="/" class="btn btn-primary">Create another form</a>
+  <a href="{p}/forms/{escape(form_id)}" class="btn btn-secondary">Fill again</a>
+  <a href="{p}/" class="btn btn-primary">Create another form</a>
 </div>"""
             return web.Response(
-                text=page_shell(f"{title} - Success", body),
+                text=page_shell(f"{title} - Success", body, prefix=p),
                 content_type="text/html",
             )
 
         rendered = await self.renderer.render(form, prefilled=submission, errors=result.errors)
         fragment = rendered.content.replace(
             "<form ",
-            f'<form action="/forms/{escape(form_id)}" method="post" ',
+            f'<form action="{p}/forms/{escape(form_id)}" method="post" ',
             1,
         )
         error_count = len(result.errors)
@@ -224,6 +251,8 @@ class FormPageHandler:
             f'</div>'
         )
         return web.Response(
-            text=page_shell(title, f'{banner}<div class="card">{fragment}</div>'),
+            text=page_shell(
+                title, f'{banner}<div class="card">{fragment}</div>', prefix=p
+            ),
             content_type="text/html",
         )

--- a/packages/parrot-formdesigner/src/parrot/formdesigner/handlers/templates.py
+++ b/packages/parrot-formdesigner/src/parrot/formdesigner/handlers/templates.py
@@ -1,5 +1,11 @@
 """HTML page templates and CSS for parrot-formdesigner HTTP handlers.
 
+All template builders accept an optional ``prefix`` argument (default
+``""``). When the form-designer routes are mounted behind a URL prefix via
+``setup_form_routes(app, prefix="/form")``, callers resolve the prefix
+with ``request.app.get("_form_prefix", "")`` and pass it through so that
+every rendered link and JS ``fetch()`` target matches the real route.
+
 Extracted from examples/forms/form_server.py.
 """
 
@@ -101,60 +107,115 @@ CSS = """\
 """
 
 
-_AUTH_SCRIPT = """\
+def _normalize_prefix(prefix: str) -> str:
+    """Normalise a URL prefix to the ``""`` or ``"/foo"`` shape.
+
+    The route registrar stores the prefix stripped of trailing slashes
+    (see ``routes.py``). This mirrors that behaviour so the templates
+    produce ``{prefix}/...`` without double slashes at runtime.
+
+    Args:
+        prefix: Raw prefix from ``request.app.get("_form_prefix", "")``.
+
+    Returns:
+        Either the empty string or a string that starts with ``/`` and
+        has no trailing ``/``.
+    """
+    if not prefix:
+        return ""
+    return "/" + prefix.strip("/")
+
+
+def _auth_script(prefix: str = "") -> str:
+    """Build the JWT auth bootstrap ``<script>`` for the admin page shell.
+
+    The script:
+    * Reads ``ai_parrot_token`` from ``localStorage`` and redirects to
+      ``/admin`` when missing (admin login is served by the host app,
+      conventionally at the site root — not under the form prefix).
+    * Monkey-patches ``window.fetch`` so that any same-origin URL
+      starting with ``{prefix}/api/`` (or plain ``/api/`` when no prefix
+      is set) is auto-decorated with ``Authorization: Bearer <token>``.
+    * Handles 401 responses by clearing the stored session and
+      redirecting to ``/admin``.
+
+    Args:
+        prefix: URL prefix where the form-designer routes are mounted
+            (e.g. ``"/form"``). Empty string preserves legacy behaviour.
+
+    Returns:
+        HTML string containing the ``<script>`` element.
+    """
+    p = _normalize_prefix(prefix)
+    api_match = f"'{p}/api/'" if p else "'/api/'"
+    return f"""\
 <script>
-(function() {
+(function() {{
   // Redirect to login if no JWT token is stored.
   var token = localStorage.getItem('ai_parrot_token');
-  if (!token) {
+  if (!token) {{
     window.location.href = '/admin';
     return;
-  }
+  }}
 
   // Monkey-patch fetch to inject Authorization header on same-origin API calls.
   var _origFetch = window.fetch;
-  window.fetch = function(input, init) {
-    init = init || {};
+  window.fetch = function(input, init) {{
+    init = init || {{}};
     var url = (typeof input === 'string') ? input : input.url;
-    if (url.startsWith('/api/')) {
-      init.headers = new Headers(init.headers || {});
-      if (!init.headers.has('Authorization')) {
+    if (url.startsWith({api_match})) {{
+      init.headers = new Headers(init.headers || {{}});
+      if (!init.headers.has('Authorization')) {{
         init.headers.set('Authorization', 'Bearer ' + token);
-      }
-    }
-    return _origFetch.call(this, input, init).then(function(resp) {
-      if (resp.status === 401) {
+      }}
+    }}
+    return _origFetch.call(this, input, init).then(function(resp) {{
+      if (resp.status === 401) {{
         localStorage.removeItem('ai_parrot_token');
         localStorage.removeItem('ai_parrot_session');
         window.location.href = '/admin';
-      }
+      }}
       return resp;
-    });
-  };
-})();
+    }});
+  }};
+}})();
 </script>"""
 
 
-def page_shell(title: str, body: str, locale: str = "en", nav: bool = True) -> str:
+def page_shell(
+    title: str,
+    body: str,
+    locale: str = "en",
+    nav: bool = True,
+    prefix: str = "",
+) -> str:
     """Wrap body HTML in a full page shell.
 
     Injects an authentication script that reads the JWT from localStorage
     and attaches it as an ``Authorization: Bearer`` header on every
-    ``fetch()`` call to ``/api/`` endpoints.  If no token is present the
-    user is redirected to ``/admin``.
+    ``fetch()`` call targeting the form-designer API. If no token is
+    present the user is redirected to ``/admin``.
 
     Args:
         title: Page title shown in the browser tab.
         body: Inner HTML content.
         locale: HTML lang attribute value.
         nav: Whether to include the top navigation links.
+        prefix: URL prefix where the form-designer is mounted. Empty
+            string = legacy behaviour (routes at root).
 
     Returns:
         Complete HTML page string.
     """
+    p = _normalize_prefix(prefix)
     nav_html = ""
     if nav:
-        nav_html = '<div class="nav"><a href="/">New Form</a><a href="/gallery">Gallery</a></div>'
+        nav_html = (
+            f'<div class="nav">'
+            f'<a href="{p}/">New Form</a>'
+            f'<a href="{p}/gallery">Gallery</a>'
+            f'</div>'
+        )
     return f"""\
 <!DOCTYPE html>
 <html lang="{escape(locale)}">
@@ -165,20 +226,28 @@ def page_shell(title: str, body: str, locale: str = "en", nav: bool = True) -> s
   <style>{CSS}</style>
 </head>
 <body>
-  {_AUTH_SCRIPT}
+  {_auth_script(p)}
   {nav_html}
   {body}
 </body>
 </html>"""
 
 
-def index_page() -> str:
+def index_page(prefix: str = "") -> str:
     """Return the HTML body for the index page (prompt builder + DB loader).
+
+    The embedded JavaScript declares a ``FORM_PREFIX`` constant so all
+    ``fetch()`` calls and ``window.location.href`` redirects respect the
+    mount point configured via ``setup_form_routes(..., prefix=...)``.
+
+    Args:
+        prefix: URL prefix where the form-designer is mounted.
 
     Returns:
         HTML body string for the landing page.
     """
-    return """\
+    p = _normalize_prefix(prefix)
+    return f"""\
 <h1>AI Form Builder</h1>
 <p>Describe the form you need in plain language, or load an existing form from the database.</p>
 
@@ -226,21 +295,22 @@ def index_page() -> str:
 </div>
 
 <script>
-function showError(container, message) {
+const FORM_PREFIX = {p!r};
+function showError(container, message) {{
   const banner = document.createElement('div');
   banner.className = 'error-banner';
   banner.textContent = message;
   container.innerHTML = '';
   container.appendChild(banner);
   container.style.display = 'block';
-}
-document.querySelectorAll('.example-chip').forEach(chip => {
-  chip.addEventListener('click', () => {
+}}
+document.querySelectorAll('.example-chip').forEach(chip => {{
+  chip.addEventListener('click', () => {{
     document.getElementById('prompt').value = chip.dataset.prompt;
     document.getElementById('prompt').focus();
-  });
-});
-document.getElementById('create-form').addEventListener('submit', async (e) => {
+  }});
+}});
+document.getElementById('create-form').addEventListener('submit', async (e) => {{
   e.preventDefault();
   const btn = document.getElementById('create-btn');
   const status = document.getElementById('create-status');
@@ -250,32 +320,32 @@ document.getElementById('create-form').addEventListener('submit', async (e) => {
   btn.innerHTML = '<span class="spinner"></span> Generating...';
   status.style.display = 'block';
   status.innerHTML = '<em>Generating form...</em>';
-  try {
-    const res = await fetch('/api/v1/forms', {method:'POST',
-      headers:{'Content-Type':'application/json'}, body:JSON.stringify({prompt})});
+  try {{
+    const res = await fetch(FORM_PREFIX + '/api/v1/forms', {{method:'POST',
+      headers:{{'Content-Type':'application/json'}}, body:JSON.stringify({{prompt}})}});
     const data = await res.json();
-    if (!res.ok) { showError(status, data.error || 'Something went wrong'); return; }
+    if (!res.ok) {{ showError(status, data.error || 'Something went wrong'); return; }}
     window.location.href = data.url;
-  } catch (err) { showError(status, 'Network error: ' + err.message);
-  } finally { btn.disabled = false; btn.innerHTML = 'Generate Form'; }
-});
-async function loadFromDB() {
+  }} catch (err) {{ showError(status, 'Network error: ' + err.message);
+  }} finally {{ btn.disabled = false; btn.innerHTML = 'Generate Form'; }}
+}});
+async function loadFromDB() {{
   const btn = document.getElementById('db-btn');
   const status = document.getElementById('db-status');
   const formid = parseInt(document.getElementById('formid').value, 10);
   const orgid = parseInt(document.getElementById('orgid').value, 10);
-  if (!formid || !orgid) { showError(status, 'Please enter both Form ID and Org ID.'); return; }
+  if (!formid || !orgid) {{ showError(status, 'Please enter both Form ID and Org ID.'); return; }}
   btn.disabled = true; btn.innerHTML = '<span class="spinner"></span> Loading...';
   status.style.display = 'block'; status.innerHTML = '<em>Loading...</em>';
-  try {
-    const res = await fetch('/api/v1/forms/from-db', {method:'POST',
-      headers:{'Content-Type':'application/json'}, body:JSON.stringify({formid, orgid})});
+  try {{
+    const res = await fetch(FORM_PREFIX + '/api/v1/forms/from-db', {{method:'POST',
+      headers:{{'Content-Type':'application/json'}}, body:JSON.stringify({{formid, orgid}})}});
     const data = await res.json();
-    if (!res.ok) { showError(status, data.error || 'Failed to load'); return; }
+    if (!res.ok) {{ showError(status, data.error || 'Failed to load'); return; }}
     window.location.href = data.url;
-  } catch (err) { showError(status, 'Network error: ' + err.message);
-  } finally { btn.disabled = false; btn.innerHTML = 'Load from Database'; }
-}
+  }} catch (err) {{ showError(status, 'Network error: ' + err.message);
+  }} finally {{ btn.disabled = false; btn.innerHTML = 'Load from Database'; }}
+}}
 </script>"""
 
 
@@ -283,7 +353,10 @@ def gallery_page(form_items_html: str) -> str:
     """Return the HTML body for the gallery page.
 
     Args:
-        form_items_html: Pre-rendered HTML for the form list items.
+        form_items_html: Pre-rendered HTML for the form list items. The
+            caller (``FormPageHandler.gallery``) is responsible for
+            prefixing hrefs inside this fragment — ``gallery_page`` never
+            touches URLs.
 
     Returns:
         HTML body string for the gallery page.
@@ -317,7 +390,13 @@ def form_page(form_fragment: str) -> str:
     return f'<div class="card">{form_fragment}</div>'
 
 
-def schema_page(form_id: str, title: str, schema_json: str, style_json: str) -> str:
+def schema_page(
+    form_id: str,
+    title: str,
+    schema_json: str,
+    style_json: str,
+    prefix: str = "",
+) -> str:
     """Return the HTML body for the JSON Schema view page.
 
     Args:
@@ -325,17 +404,19 @@ def schema_page(form_id: str, title: str, schema_json: str, style_json: str) -> 
         title: Human-readable form title.
         schema_json: Pretty-printed JSON Schema string.
         style_json: Pretty-printed Style Schema string.
+        prefix: URL prefix where the form-designer is mounted.
 
     Returns:
         HTML body string with the JSON schema display.
     """
+    p = _normalize_prefix(prefix)
     return f"""\
 <h1>JSON Schema: {escape(title)}</h1>
 <p>Structural JSON Schema for form <code>{escape(form_id)}</code>.</p>
 
 <div style="display:flex; gap:.75rem; margin-bottom:1rem;">
-  <a href="/forms/{escape(form_id)}" class="btn btn-secondary">View Form</a>
-  <a href="/gallery" class="btn btn-secondary">Gallery</a>
+  <a href="{p}/forms/{escape(form_id)}" class="btn btn-secondary">View Form</a>
+  <a href="{p}/gallery" class="btn btn-secondary">Gallery</a>
 </div>
 
 <div class="card">
@@ -351,21 +432,26 @@ def schema_page(form_id: str, title: str, schema_json: str, style_json: str) -> 
 <div class="card">
   <h2 style="margin-bottom:.5rem;">API Endpoints</h2>
   <ul style="margin:0; padding-left:1.2rem;">
-    <li><code>GET /api/v1/forms/{escape(form_id)}</code> — Full FormSchema (JSON)</li>
-    <li><code>GET /api/v1/forms/{escape(form_id)}/schema</code> — JSON Schema</li>
-    <li><code>GET /api/v1/forms/{escape(form_id)}/style</code> — Style Schema</li>
-    <li><code>GET /api/v1/forms/{escape(form_id)}/html</code> — Rendered HTML fragment</li>
+    <li><code>GET {p}/api/v1/forms/{escape(form_id)}</code> — Full FormSchema (JSON)</li>
+    <li><code>GET {p}/api/v1/forms/{escape(form_id)}/schema</code> — JSON Schema</li>
+    <li><code>GET {p}/api/v1/forms/{escape(form_id)}/style</code> — Style Schema</li>
+    <li><code>GET {p}/api/v1/forms/{escape(form_id)}/html</code> — Rendered HTML fragment</li>
   </ul>
 </div>"""
 
 
-def error_page(message: str) -> str:
+def error_page(message: str, prefix: str = "") -> str:
     """Return an error page body.
 
     Args:
         message: Human-readable error message.
+        prefix: URL prefix where the form-designer is mounted.
 
     Returns:
         HTML body string with the error banner.
     """
-    return f'<div class="error-banner">{escape(message)}</div><a href="/">Go back</a>'
+    p = _normalize_prefix(prefix)
+    return (
+        f'<div class="error-banner">{escape(message)}</div>'
+        f'<a href="{p}/">Go back</a>'
+    )

--- a/packages/parrot-formdesigner/tests/unit/test_handlers_prefix.py
+++ b/packages/parrot-formdesigner/tests/unit/test_handlers_prefix.py
@@ -1,0 +1,187 @@
+"""Unit tests for URL-prefix support in parrot-formdesigner handlers.
+
+When ``setup_form_routes(app, prefix="/form")`` is used, every rendered
+link, JS ``fetch()`` URL, and JSON ``url`` response field must carry the
+prefix. These tests lock that contract in so a future refactor cannot
+silently regress to hardcoded paths.
+"""
+from __future__ import annotations
+
+import pytest
+from aiohttp import web
+
+from parrot.formdesigner.core.schema import FormSchema, FormSection, FormField
+from parrot.formdesigner.core.types import FieldType
+from parrot.formdesigner.handlers import setup_form_routes
+from parrot.formdesigner.handlers.templates import (
+    _normalize_prefix,
+    error_page,
+    index_page,
+    page_shell,
+    schema_page,
+)
+from parrot.formdesigner.services import FormRegistry
+
+
+PREFIX = "/form"
+
+
+# ---------------------------------------------------------------------------
+# Pure template functions (no aiohttp)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizePrefix:
+    def test_empty_returns_empty(self) -> None:
+        assert _normalize_prefix("") == ""
+
+    def test_no_leading_slash_gets_one(self) -> None:
+        assert _normalize_prefix("form") == "/form"
+
+    def test_trailing_slash_stripped(self) -> None:
+        assert _normalize_prefix("/form/") == "/form"
+
+    def test_multi_segment_kept(self) -> None:
+        assert _normalize_prefix("/apps/form") == "/apps/form"
+
+
+class TestTemplateBuildersHonorPrefix:
+    def test_page_shell_nav_uses_prefix(self) -> None:
+        html = page_shell("t", "<p>body</p>", prefix=PREFIX)
+        assert 'href="/form/"' in html
+        assert 'href="/form/gallery"' in html
+        # Legacy root-level hrefs MUST NOT leak through when a prefix is set.
+        assert 'href="/">New Form' not in html
+        assert 'href="/gallery"' not in html
+
+    def test_page_shell_no_prefix_preserves_legacy_paths(self) -> None:
+        html = page_shell("t", "<p>body</p>")
+        assert 'href="/">New Form' in html
+        assert 'href="/gallery"' in html
+
+    def test_auth_script_api_match_carries_prefix(self) -> None:
+        html = page_shell("t", "", prefix=PREFIX)
+        # JS guard used to decide when to attach the Bearer token.
+        assert "url.startsWith('/form/api/')" in html
+        assert "url.startsWith('/api/')" not in html
+
+    def test_auth_script_empty_prefix_falls_back_to_api_root(self) -> None:
+        html = page_shell("t", "")
+        assert "url.startsWith('/api/')" in html
+
+    def test_index_page_fetch_targets_use_prefix(self) -> None:
+        html = index_page(prefix=PREFIX)
+        # FORM_PREFIX constant + template literal concat.
+        assert "const FORM_PREFIX = '/form';" in html
+        assert "fetch(FORM_PREFIX + '/api/v1/forms'" in html
+        assert "fetch(FORM_PREFIX + '/api/v1/forms/from-db'" in html
+        # No absolute hardcoded fetch calls.
+        assert "fetch('/api/v1/forms'" not in html
+        assert "fetch('/api/v1/forms/from-db'" not in html
+
+    def test_index_page_empty_prefix_uses_empty_form_prefix(self) -> None:
+        html = index_page()
+        assert "const FORM_PREFIX = '';" in html
+
+    def test_schema_page_links_and_api_docs_use_prefix(self) -> None:
+        html = schema_page("abc", "Title", "{}", "{}", prefix=PREFIX)
+        assert 'href="/form/forms/abc"' in html
+        assert 'href="/form/gallery"' in html
+        assert "GET /form/api/v1/forms/abc" in html
+
+    def test_error_page_go_back_uses_prefix(self) -> None:
+        html = error_page("oops", prefix=PREFIX)
+        assert 'href="/form/"' in html
+
+
+# ---------------------------------------------------------------------------
+# End-to-end aiohttp smoke tests (real request/response cycle)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def registry() -> FormRegistry:
+    return FormRegistry()
+
+
+@pytest.fixture
+def sample_schema() -> FormSchema:
+    return FormSchema(
+        form_id="sample",
+        title="Sample Form",
+        sections=[
+            FormSection(
+                section_id="main",
+                title="Main",
+                fields=[FormField(field_id="name", field_type=FieldType.TEXT, label="Name")],
+            )
+        ],
+    )
+
+
+@pytest.fixture
+def app_with_prefix(registry: FormRegistry) -> web.Application:
+    app = web.Application()
+    setup_form_routes(app, registry=registry, prefix=PREFIX, protect_pages=False)
+    return app
+
+
+@pytest.mark.asyncio
+class TestPrefixRouting:
+    async def test_prefix_stored_in_app(self, app_with_prefix: web.Application) -> None:
+        assert app_with_prefix["_form_prefix"] == PREFIX
+
+    async def test_index_served_under_prefix(self, aiohttp_client, app_with_prefix):
+        client = await aiohttp_client(app_with_prefix)
+        # Legacy root MUST NOT serve the index anymore.
+        resp_root = await client.get("/")
+        assert resp_root.status == 404
+        # Prefixed route does.
+        resp = await client.get("/form/")
+        assert resp.status == 200
+        html = await resp.text()
+        assert "const FORM_PREFIX = '/form';" in html
+        assert 'href="/form/gallery"' in html
+        assert "fetch(FORM_PREFIX + '/api/v1/forms'" in html
+
+    async def test_gallery_page_renders_with_prefix_links(
+        self, aiohttp_client, app_with_prefix, registry, sample_schema
+    ):
+        await registry.register(sample_schema)
+        client = await aiohttp_client(app_with_prefix)
+        resp = await client.get("/form/gallery")
+        assert resp.status == 200
+        html = await resp.text()
+        assert 'href="/form/forms/sample"' in html
+        assert 'href="/form/forms/sample/schema"' in html
+
+    async def test_render_form_action_uses_prefix(
+        self, aiohttp_client, app_with_prefix, registry, sample_schema
+    ):
+        await registry.register(sample_schema)
+        client = await aiohttp_client(app_with_prefix)
+        resp = await client.get("/form/forms/sample")
+        assert resp.status == 200
+        html = await resp.text()
+        assert 'action="/form/forms/sample"' in html
+        assert 'href="/form/forms/sample/schema"' in html
+
+    async def test_schema_page_links_use_prefix(
+        self, aiohttp_client, app_with_prefix, registry, sample_schema
+    ):
+        await registry.register(sample_schema)
+        client = await aiohttp_client(app_with_prefix)
+        resp = await client.get("/form/forms/sample/schema")
+        assert resp.status == 200
+        html = await resp.text()
+        assert 'href="/form/forms/sample"' in html
+        assert "GET /form/api/v1/forms/sample" in html
+
+    async def test_unknown_form_error_link_uses_prefix(
+        self, aiohttp_client, app_with_prefix
+    ):
+        client = await aiohttp_client(app_with_prefix)
+        resp = await client.get("/form/forms/nonexistent")
+        assert resp.status == 404
+        html = await resp.text()
+        assert 'href="/form/"' in html


### PR DESCRIPTION
## Summary

`setup_form_routes(app, prefix="/form")` already plumbed the prefix into the aiohttp router, but the UI/API responses kept emitting hardcoded `/`, `/gallery`, `/forms/{id}`, `/api/v1/forms`, and `/api/v1/forms/from-db` paths. As a result, mounting the form designer behind any non-root prefix broke the admin page — `fetch()` hit routes that no longer existed, got an HTML 404 back, and the JS exploded with `Unexpected non-whitespace character after JSON at position 3`. Every rendered link also pointed outside the mount.

This PR makes the whole form-designer surface prefix-aware while keeping the default (`""`) fully backwards-compatible.

## Changes

### `handlers/templates.py`
- Added optional `prefix` kwarg to `page_shell` / `index_page` / `schema_page` / `error_page` (default `""` preserves legacy behaviour).
- Extracted `_auth_script(prefix)` builder so the fetch-interception guard matches `{prefix}/api/` instead of hardcoded `/api/`.
- Injected `const FORM_PREFIX = <prefix>;` in the admin-page JS and switched both `fetch()` calls to template-literal concatenation.
- Added `_normalize_prefix()` helper that mirrors `routes.py` semantics (strip trailing slashes, ensure leading slash).

### `handlers/forms.py`
- Added `_prefix(request)` helper that reads `request.app["_form_prefix"]`.
- Every handler (`index`, `gallery`, `render_form`, `view_schema`, `submit_form`) resolves the prefix and forwards it to templates, form actions, error pages, and gallery links.

### `handlers/api.py`
- `create_form` and `load_from_db` now compose the returned `url` field as `f"{prefix}/forms/{form_id}"` so clients can redirect without reconstructing the prefix themselves.

### `tests/unit/test_handlers_prefix.py` (new)
- 18 tests, all passing:
  - `_normalize_prefix` edge cases.
  - Template builders honour prefix in nav, fetch targets, schema links, error pages, and auth script.
  - End-to-end aiohttp checks: prefix stored in `app["_form_prefix"]`, legacy root returns 404 when prefix is set, prefixed routes return 200 with prefixed `href` / `action` / `fetch()` URLs.

## Backward compatibility

- All new kwargs default to `""`, so callers that never used the prefix observe identical output.
- The 13 pre-existing failures in `tests/unit/test_handlers.py` are unrelated (navigator-auth fixture setup) and match `dev` unchanged. This PR does not touch them.

## Test plan

- [x] `pytest packages/parrot-formdesigner/tests/unit/test_handlers_prefix.py` → 18/18 pass.
- [x] `pytest packages/parrot-formdesigner/tests/unit/` (full suite) → same pass/fail ratio as `origin/dev` (210 passed, 13 pre-existing failures unchanged).
- [x] Manually verified on staging server: `https://api-ai.trocdigital.io/form/` admin page → both `Generate from prompt` and `Load from DB` buttons work end-to-end without JSON parse errors.
- [ ] CI green on this branch.

## Migration

Users who already configure `setup_form_routes(app, prefix="/foo")` get the fix automatically — no app-side changes needed. Users with no prefix see no difference.

Developed with Spec Driven Development