### PR TITLE
Add per-user bot management with encrypted credential storage

### DIFF
--- a/packages/ai-parrot/src/parrot/handlers/agent.py
+++ b/packages/ai-parrot/src/parrot/handlers/agent.py
@@ -6,7 +6,7 @@ with support for multiple output modes and MCP server integration.
 """
 from __future__ import annotations
 import contextlib
-from typing import Dict, Any, List, Union, TYPE_CHECKING
+from typing import Dict, Any, List, Optional, Tuple, Union, TYPE_CHECKING
 import tempfile
 import os
 import time
@@ -905,38 +905,63 @@ class AgentTalk(BaseView):
     async def _get_agent(self, data: Dict[str, Any]) -> Union[AbstractBot, web.Response]:
         """
         Get the agent instance from BotManager.
+
+        Resolution order:
+          1. Per-user bot — session cache (set by UserAgentHandler) or DB
+             lookup via ``BotManager.get_user_bot``.
+          2. System bot — registry / DB via ``BotManager.get_bot``.
+
+        On success returns the bot instance.  The caller can detect a
+        user-bot result by checking ``agent.chatbot_id`` against the
+        session's ``BotManager.USER_BOTS_SESSION_KEY`` map (see
+        :meth:`_resolve_bot`).
         """
-        # Get BotManager
+        bot, _is_user = await self._resolve_bot(data)
+        if isinstance(bot, web.Response):
+            return bot
+        if bot is None:
+            agent_name = self._get_agent_name(data) or "<unknown>"
+            return self.error(f"Agent '{agent_name}' not found.", status=404)
+        return bot
+
+    async def _resolve_bot(
+        self,
+        data: Dict[str, Any],
+    ) -> Tuple[Optional[AbstractBot], bool]:
+        """Resolve a bot, preferring user-defined bots, falling back to system bots.
+
+        Returns ``(bot, is_user_bot)``.  ``bot`` may also be a ``web.Response``
+        when an early-return error condition is hit (e.g. BotManager missing).
+        """
         manager: BotManager = self.request.app.get('bot_manager')
         if not manager:
             return self.json_response(
-                {"error": "BotManager is not installed."},
-                status=500
-            )
+                {"error": "BotManager is not installed."}, status=500,
+            ), False
 
-        # Extract agent name
         agent_name = self._get_agent_name(data)
         if not agent_name:
-            return self.error(
-                "Missing Agent Name",
-                status=400
-            )
+            return self.error("Missing Agent Name", status=400), False
 
-        # Get the agent
+        # 1. Per-user bot — session cache or DB lookup.
+        try:
+            user_bot = await manager.get_user_bot(self.request, agent_name)
+        except Exception as exc:  # noqa: BLE001
+            self.logger.warning(
+                "get_user_bot failed for %s, falling back to system: %s",
+                agent_name, exc,
+            )
+            user_bot = None
+        if user_bot is not None:
+            return user_bot, True
+
+        # 2. System bot.
         try:
             agent: AbstractBot = await manager.get_bot(agent_name)
-            if not agent:
-                return self.error(
-                    f"Agent '{agent_name}' not found.",
-                    status=404
-                )
-            return agent
-        except Exception as e:
-            self.logger.error(f"Error retrieving agent {agent_name}: {e}")
-            return self.error(
-                f"Error retrieving agent: {e}",
-                status=500
-            )
+        except Exception as exc:  # noqa: BLE001
+            self.logger.error(f"Error retrieving agent {agent_name}: {exc}")
+            return self.error(f"Error retrieving agent: {exc}", status=500), False
+        return agent, False
 
     async def _setup_agent_tools(
         self,
@@ -1282,14 +1307,21 @@ class AgentTalk(BaseView):
         method_name = (
             method_name or data.pop('method_name', None) or qs.get('method_name')
         )
-        # Get the agent
-        agent = await self._get_agent(data)
-        if isinstance(agent, web.Response):
-            return agent
+        # Get the agent — user bots win over system bots when both could match.
+        agent_or_response, is_user_bot = await self._resolve_bot(data)
+        if isinstance(agent_or_response, web.Response):
+            return agent_or_response
+        if agent_or_response is None:
+            agent_name = self._get_agent_name(data) or "<unknown>"
+            return self.error(f"Agent '{agent_name}' not found.", status=404)
+        agent: AbstractBot = agent_or_response
 
-        # Load user's tool_manager from session (configured via PATCH)
+        # Load user's tool_manager from session (configured via PATCH).
+        # User-defined bots own their own ToolManager in the session cache
+        # (built when the bot was instantiated from the DB row), so the
+        # per-system-bot ToolManager swap is not applicable to them.
         user_tool_manager = None
-        if request_session:
+        if request_session and not is_user_bot:
             session_key = f"{agent.name}_tool_manager"
             user_tool_manager = request_session.get(session_key)
 

--- a/packages/ai-parrot/src/parrot/handlers/agents/__init__.py
+++ b/packages/ai-parrot/src/parrot/handlers/agents/__init__.py
@@ -1,1 +1,4 @@
 from .abstract import AgentHandler
+from .users import UserAgentHandler
+
+__all__ = ["AgentHandler", "UserAgentHandler"]

--- a/packages/ai-parrot/src/parrot/handlers/agents/users.py
+++ b/packages/ai-parrot/src/parrot/handlers/agents/users.py
@@ -1,0 +1,529 @@
+"""HTTP handler for user-defined bots — ``/api/v1/user_agents``.
+
+Methods:
+    PUT    /api/v1/user_agents               — create
+    PATCH  /api/v1/user_agents/{chatbot_id}  — partial update
+    GET    /api/v1/user_agents               — list current user's bots
+    GET    /api/v1/user_agents/{chatbot_id}  — fetch one
+    DELETE /api/v1/user_agents/{chatbot_id}  — delete row + S3 docs
+
+``mcp_config`` and ``tools_config`` may carry credentials. They are stored as
+AES-GCM encrypted blobs (transparent to the handler via ``UserBotModel``
+accessors) and credential-shaped keys are redacted on GET responses.
+"""
+from __future__ import annotations
+
+import contextlib
+import copy
+import os
+import tempfile
+import uuid
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+from aiohttp import web
+from asyncdb.exceptions import NoDataFound
+from datamodel.parsers.json import json_encoder
+from navconfig.logging import logging
+from navigator_session import get_session
+from navigator.views import BaseView
+from navigator_auth.decorators import is_authenticated, user_session
+
+from ..models import UserBotModel
+
+
+# Keys whose values must never be echoed back in GET responses (case-insensitive).
+_REDACT_KEYS = {
+    "api_key",
+    "apikey",
+    "api-key",
+    "client_secret",
+    "oauth2_client_secret",
+    "password",
+    "token",
+    "secret",
+    "access_token",
+    "refresh_token",
+    "private_key",
+    "bearer",
+}
+
+_REDACT_PLACEHOLDER = "***"
+
+
+def _redact(value: Any) -> Any:
+    """Recursively redact credential-shaped keys in dicts/lists."""
+    if isinstance(value, dict):
+        return {
+            k: (_REDACT_PLACEHOLDER if k.lower() in _REDACT_KEYS else _redact(v))
+            for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact(item) for item in value]
+    return value
+
+
+def _deep_merge(base: Any, patch: Any) -> Any:
+    """Merge ``patch`` into ``base`` recursively for dict/list config blobs.
+
+    For lists of objects-with-name, items in ``patch`` replace items in
+    ``base`` matched by the ``name`` key; otherwise the list is overwritten.
+    Explicit ``None`` in a dict value deletes the key.
+    """
+    if isinstance(base, dict) and isinstance(patch, dict):
+        out = dict(base)
+        for key, val in patch.items():
+            if val is None:
+                out.pop(key, None)
+            elif key in out:
+                out[key] = _deep_merge(out[key], val)
+            else:
+                out[key] = val
+        return out
+    if isinstance(base, list) and isinstance(patch, list):
+        if all(isinstance(it, dict) and "name" in it for it in base + patch):
+            by_name = {it["name"]: copy.deepcopy(it) for it in base}
+            for it in patch:
+                name = it["name"]
+                if it.keys() == {"name"} and "_delete" in it.get("name", ""):
+                    by_name.pop(name, None)
+                else:
+                    by_name[name] = _deep_merge(by_name.get(name, {}), it)
+            return list(by_name.values())
+        return patch
+    return patch
+
+
+@is_authenticated()
+@user_session()
+class UserAgentHandler(BaseView):
+    """CRUD handler for per-user bots."""
+
+    _logger_name: str = "Parrot.UserAgentHandler"
+
+    def post_init(self, *args, **kwargs):
+        self.logger = logging.getLogger(self._logger_name)
+
+    # ------------------------------------------------------------------
+    # Session / auth helpers
+    # ------------------------------------------------------------------
+
+    async def _get_session(self) -> Any:
+        with contextlib.suppress(AttributeError):
+            return self.request.session or await get_session(self.request)
+        return await get_session(self.request)
+
+    async def _resolve_user_id(self) -> Optional[int]:
+        session = await self._get_session()
+        if session is None:
+            return None
+        return session.get("user_id")
+
+    # ------------------------------------------------------------------
+    # Request parsing
+    # ------------------------------------------------------------------
+
+    async def _parse_request(self) -> Tuple[Dict[str, Any], List[Tuple[str, str, str]]]:
+        """Return ``(config_dict, uploaded_temp_files)``.
+
+        ``uploaded_temp_files`` is a list of tuples ``(field_name, original_name, tmp_path)``.
+        Supports both ``application/json`` and ``multipart/form-data`` (the
+        latter expects a ``config`` field with the JSON payload plus optional
+        ``files[]`` entries).
+        """
+        content_type = (self.request.content_type or "").lower()
+        if content_type.startswith("multipart/"):
+            return await self._parse_multipart()
+        try:
+            data = await self.request.json()
+        except Exception:  # noqa: BLE001
+            data = {}
+        return data, []
+
+    async def _parse_multipart(self) -> Tuple[Dict[str, Any], List[Tuple[str, str, str]]]:
+        import json as _json
+        config: Dict[str, Any] = {}
+        uploads: List[Tuple[str, str, str]] = []
+        reader = await self.request.multipart()
+        async for part in reader:
+            if part is None:
+                break
+            field_name = part.name
+            filename = part.filename
+            if filename:
+                # Stream to a temp file so it can be uploaded to S3 afterwards.
+                suffix = os.path.splitext(filename)[1]
+                fd, tmp_path = tempfile.mkstemp(suffix=suffix)
+                try:
+                    with os.fdopen(fd, "wb") as out:
+                        while True:
+                            chunk = await part.read_chunk()
+                            if not chunk:
+                                break
+                            out.write(chunk)
+                except Exception:
+                    if os.path.exists(tmp_path):
+                        os.unlink(tmp_path)
+                    raise
+                uploads.append((field_name or "files", filename, tmp_path))
+            else:
+                value = await part.text()
+                if field_name == "config":
+                    try:
+                        config = _json.loads(value)
+                    except Exception:
+                        return {}, uploads
+                else:
+                    # Allow arbitrary scalar fields to live alongside config JSON.
+                    config[field_name] = value
+        return config, uploads
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    _ALLOWED_FIELDS = {
+        "name", "description", "avatar", "enabled", "timezone",
+        "role", "goal", "backstory", "rationale", "capabilities",
+        "prompt_config", "system_prompt_template", "human_prompt_template",
+        "pre_instructions",
+        "llm", "model_name", "temperature", "max_tokens", "top_k", "top_p",
+        "model_config",
+        "use_vector", "vector_config", "embedding_model",
+        "context_search_limit", "context_score_threshold",
+        "tools_enabled", "auto_tool_detection", "tool_threshold",
+        "operation_mode",
+        "memory_type", "memory_config", "max_context_turns",
+        "use_conversation_history",
+        "permissions", "language", "disclaimer",
+    }
+    _ENCRYPTED_FIELDS = {"mcp_config", "tools_config"}
+
+    def _split_payload(
+        self, data: Dict[str, Any]
+    ) -> Tuple[Dict[str, Any], Optional[List[dict]], Optional[List[dict]]]:
+        """Separate plain columns from encrypted blobs."""
+        plain: Dict[str, Any] = {}
+        for key, value in data.items():
+            if key in self._ALLOWED_FIELDS:
+                plain[key] = value
+        mcp_config = data.get("mcp_config")
+        tools_config = data.get("tools_config")
+        return plain, mcp_config, tools_config
+
+    # ------------------------------------------------------------------
+    # File upload (S3 via FileManagerToolkit)
+    # ------------------------------------------------------------------
+
+    def _file_manager(self):
+        """Return a configured FileManagerToolkit (s3 if configured, else local).
+
+        Falls back to the local fs backend in environments without S3 so dev
+        flows still work.  Production is expected to set ``S3_BUCKET``.
+        """
+        try:
+            from ...tools.filemanager import FileManagerToolkit  # noqa: PLC0415
+        except Exception:
+            return None
+        bucket = os.environ.get("S3_BUCKET") or os.environ.get("AWS_S3_BUCKET")
+        if bucket:
+            try:
+                return FileManagerToolkit(manager_type="s3", bucket=bucket)
+            except Exception as exc:  # noqa: BLE001
+                self.logger.warning("S3 FileManager unavailable, falling back to local: %s", exc)
+        return FileManagerToolkit(manager_type="fs")
+
+    async def _ingest_uploads(
+        self,
+        user_id: int,
+        chatbot_id: str,
+        uploads: List[Tuple[str, str, str]],
+    ) -> List[dict]:
+        if not uploads:
+            return []
+        toolkit = self._file_manager()
+        if toolkit is None:
+            self.logger.warning("FileManager unavailable; skipping document ingestion")
+            return []
+        ingested: List[dict] = []
+        destination = f"users_bots/{user_id}/{chatbot_id}"
+        for _field, original_name, tmp_path in uploads:
+            try:
+                meta = await toolkit.upload_file(
+                    source_path=tmp_path,
+                    destination=destination,
+                    destination_name=original_name,
+                )
+                ingested.append(
+                    {
+                        "name": meta.get("name", original_name),
+                        "path": meta.get("path"),
+                        "url": meta.get("url"),
+                        "size": meta.get("size"),
+                        "content_type": meta.get("content_type"),
+                    }
+                )
+            except Exception as exc:  # noqa: BLE001
+                self.logger.error(
+                    "Failed to upload document %s for bot %s: %s",
+                    original_name, chatbot_id, exc,
+                )
+            finally:
+                if os.path.exists(tmp_path):
+                    with contextlib.suppress(OSError):
+                        os.unlink(tmp_path)
+        return ingested
+
+    async def _delete_documents(self, documents: List[dict]) -> None:
+        if not documents:
+            return
+        toolkit = self._file_manager()
+        if toolkit is None:
+            return
+        for doc in documents:
+            path = doc.get("path")
+            if not path:
+                continue
+            try:
+                await toolkit.delete_file(path=path)
+            except Exception as exc:  # noqa: BLE001
+                self.logger.warning("Best-effort S3 delete failed for %s: %s", path, exc)
+
+    # ------------------------------------------------------------------
+    # DB helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def _db(self):
+        return self.request.app["database"]
+
+    async def _list_bots(self, user_id: int) -> List[UserBotModel]:
+        async with await self._db.acquire() as conn:
+            UserBotModel.Meta.connection = conn
+            try:
+                rows = await UserBotModel.filter(user_id=user_id)
+                return list(rows or [])
+            except Exception as exc:  # noqa: BLE001
+                self.logger.error("List user bots failed for %s: %s", user_id, exc)
+                return []
+
+    async def _get_one(self, user_id: int, chatbot_id: str) -> Optional[UserBotModel]:
+        async with await self._db.acquire() as conn:
+            UserBotModel.Meta.connection = conn
+            try:
+                return await UserBotModel.get(user_id=user_id, chatbot_id=chatbot_id)
+            except NoDataFound:
+                return None
+
+    async def _insert(self, model: UserBotModel) -> UserBotModel:
+        async with await self._db.acquire() as conn:
+            UserBotModel.Meta.connection = conn
+            await model.insert()
+        return model
+
+    async def _update(self, model: UserBotModel) -> UserBotModel:
+        async with await self._db.acquire() as conn:
+            UserBotModel.Meta.connection = conn
+            await model.update()
+        return model
+
+    async def _delete(self, model: UserBotModel) -> None:
+        async with await self._db.acquire() as conn:
+            UserBotModel.Meta.connection = conn
+            await model.delete()
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def _serialize(self, model: UserBotModel) -> Dict[str, Any]:
+        """Render a row for API responses, with credential redaction."""
+        out = model.to_dict() if hasattr(model, "to_dict") else dict(model.__dict__)
+        # Replace encrypted blobs with redacted plaintext
+        out["mcp_config"] = _redact(model.get_mcp_config())
+        out["tools_config"] = _redact(model.get_tools_config())
+        # UUID/datetime serialisation
+        if isinstance(out.get("chatbot_id"), uuid.UUID):
+            out["chatbot_id"] = str(out["chatbot_id"])
+        for ts_key in ("created_at", "updated_at"):
+            if isinstance(out.get(ts_key), datetime):
+                out[ts_key] = out[ts_key].isoformat()
+        return out
+
+    # ------------------------------------------------------------------
+    # PUT — create
+    # ------------------------------------------------------------------
+
+    async def put(self):
+        """Create a new user bot."""
+        user_id = await self._resolve_user_id()
+        if not user_id:
+            return self.error("Authentication required.", status=401)
+
+        data, uploads = await self._parse_request()
+        if not data.get("name"):
+            return self.error("Field 'name' is required.", status=400)
+
+        plain, mcp_cfg, tools_cfg = self._split_payload(data)
+        chatbot_id = uuid.uuid4()
+
+        try:
+            model = UserBotModel(
+                chatbot_id=chatbot_id,
+                user_id=user_id,
+                **plain,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return self.error(f"Invalid configuration: {exc}", status=422)
+
+        # Encrypt credential blobs (RuntimeError -> 503 if vault not configured)
+        try:
+            if mcp_cfg is not None:
+                model.set_mcp_config(mcp_cfg)
+            if tools_cfg is not None:
+                model.set_tools_config(tools_cfg)
+        except RuntimeError as exc:
+            return self.error(f"Vault not configured: {exc}", status=503)
+
+        # Ingest uploaded files (best-effort) and append to documents.
+        ingested = await self._ingest_uploads(user_id, str(chatbot_id), uploads)
+        if ingested:
+            existing_docs = list(model.documents or [])
+            model.documents = existing_docs + ingested
+
+        try:
+            await self._insert(model)
+        except Exception as exc:  # noqa: BLE001
+            self.logger.error("Insert user_bot failed: %s", exc, exc_info=True)
+            return self.error(f"Could not create bot: {exc}", status=400)
+
+        return web.json_response(
+            self._serialize(model),
+            status=201,
+            dumps=json_encoder,
+        )
+
+    # ------------------------------------------------------------------
+    # PATCH — partial update
+    # ------------------------------------------------------------------
+
+    async def patch(self):
+        user_id = await self._resolve_user_id()
+        if not user_id:
+            return self.error("Authentication required.", status=401)
+
+        chatbot_id = self.request.match_info.get("chatbot_id")
+        if not chatbot_id:
+            return self.error("Missing chatbot_id in URL.", status=400)
+
+        existing = await self._get_one(user_id, chatbot_id)
+        if existing is None:
+            return self.error("Bot not found.", status=404)
+
+        data, uploads = await self._parse_request()
+        plain, mcp_cfg, tools_cfg = self._split_payload(data)
+
+        # Apply plain-column patches.
+        for key, value in plain.items():
+            try:
+                setattr(existing, key, value)
+            except Exception as exc:  # noqa: BLE001
+                return self.error(f"Invalid value for {key}: {exc}", status=422)
+
+        # Merge encrypted blobs to preserve untouched credentials.
+        try:
+            if mcp_cfg is not None:
+                merged = _deep_merge(existing.get_mcp_config(), mcp_cfg)
+                existing.set_mcp_config(merged)
+            if tools_cfg is not None:
+                merged = _deep_merge(existing.get_tools_config(), tools_cfg)
+                existing.set_tools_config(merged)
+        except RuntimeError as exc:
+            return self.error(f"Vault not configured: {exc}", status=503)
+
+        # Append any newly uploaded documents.
+        ingested = await self._ingest_uploads(user_id, chatbot_id, uploads)
+        if ingested:
+            existing.documents = list(existing.documents or []) + ingested
+
+        # Optional explicit document removal: payload may include
+        # "documents_remove": [<path>, ...]
+        remove_paths = data.get("documents_remove")
+        if isinstance(remove_paths, list) and remove_paths:
+            keep = [d for d in (existing.documents or []) if d.get("path") not in remove_paths]
+            removed = [d for d in (existing.documents or []) if d.get("path") in remove_paths]
+            await self._delete_documents(removed)
+            existing.documents = keep
+
+        try:
+            await self._update(existing)
+        except Exception as exc:  # noqa: BLE001
+            self.logger.error("Update user_bot failed: %s", exc, exc_info=True)
+            return self.error(f"Could not update bot: {exc}", status=400)
+
+        # Invalidate session cache so next chat rebuilds.
+        from ...manager.manager import BotManager  # noqa: PLC0415
+        session = await self._get_session()
+        BotManager.invalidate_user_bot(session, chatbot_id)
+
+        return web.json_response(
+            self._serialize(existing),
+            status=200,
+            dumps=json_encoder,
+        )
+
+    # ------------------------------------------------------------------
+    # GET — list / fetch one
+    # ------------------------------------------------------------------
+
+    async def get(self):
+        user_id = await self._resolve_user_id()
+        if not user_id:
+            return self.error("Authentication required.", status=401)
+
+        chatbot_id = self.request.match_info.get("chatbot_id")
+        if chatbot_id:
+            row = await self._get_one(user_id, chatbot_id)
+            if row is None:
+                return self.error("Bot not found.", status=404)
+            return web.json_response(self._serialize(row), dumps=json_encoder)
+
+        rows = await self._list_bots(user_id)
+        return web.json_response(
+            {"bots": [self._serialize(r) for r in rows]},
+            dumps=json_encoder,
+        )
+
+    # ------------------------------------------------------------------
+    # DELETE
+    # ------------------------------------------------------------------
+
+    async def delete(self):
+        user_id = await self._resolve_user_id()
+        if not user_id:
+            return self.error("Authentication required.", status=401)
+
+        chatbot_id = self.request.match_info.get("chatbot_id")
+        if not chatbot_id:
+            return self.error("Missing chatbot_id in URL.", status=400)
+
+        row = await self._get_one(user_id, chatbot_id)
+        if row is None:
+            return self.error("Bot not found.", status=404)
+
+        documents = list(row.documents or [])
+
+        try:
+            await self._delete(row)
+        except Exception as exc:  # noqa: BLE001
+            self.logger.error("Delete user_bot failed: %s", exc, exc_info=True)
+            return self.error(f"Could not delete bot: {exc}", status=400)
+
+        # Best-effort S3 cleanup
+        await self._delete_documents(documents)
+
+        from ...manager.manager import BotManager  # noqa: PLC0415
+        session = await self._get_session()
+        BotManager.invalidate_user_bot(session, chatbot_id)
+
+        return web.json_response({"deleted": True, "chatbot_id": chatbot_id})

--- a/packages/ai-parrot/src/parrot/handlers/chat.py
+++ b/packages/ai-parrot/src/parrot/handlers/chat.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Union, TYPE_CHECKING
+from typing import Optional, Union, TYPE_CHECKING
 from collections import defaultdict
 import re
 import uuid
@@ -413,19 +413,27 @@ class ChatHandler(BaseView):
                 },
                 status=404
             )
+        # Resolve user-defined bots first (session cache → DB), then system bots.
+        chatbot: Optional[AbstractBot] = None
+        is_user_bot = False
         try:
-            chatbot: AbstractBot = await manager.get_bot(name)
-            if not chatbot:
-                raise KeyError(
-                    f"Chatbot {name} not found."
-                )
-        except (TypeError, KeyError):
-            return self.json_response(
-                {
-                "message": f"Chatbot {name} not found."
-                },
-                status=404
+            chatbot = await manager.get_user_bot(self.request, name)
+            if chatbot is not None:
+                is_user_bot = True
+        except Exception as exc:  # noqa: BLE001
+            self.logger.warning(
+                "get_user_bot failed for %s, falling back to system: %s", name, exc,
             )
+        if chatbot is None:
+            try:
+                chatbot = await manager.get_bot(name)
+                if not chatbot:
+                    raise KeyError(f"Chatbot {name} not found.")
+            except (TypeError, KeyError):
+                return self.json_response(
+                    {"message": f"Chatbot {name} not found."},
+                    status=404,
+                )
         # getting the question:
         question = data.pop('query', None)
         search_type = data.pop('search_type', 'similarity')

--- a/packages/ai-parrot/src/parrot/handlers/models/__init__.py
+++ b/packages/ai-parrot/src/parrot/handlers/models/__init__.py
@@ -9,6 +9,7 @@ from .bots import (
     PromptCategory,
     create_bot,
 )
+from .users_bots import UserBotModel
 from .understanding import (
     UnderstandingRequest,
     UnderstandingResponse,
@@ -26,6 +27,7 @@ __all__ = [
     "PromptLibrary",
     "PromptCategory",
     "create_bot",
+    "UserBotModel",
     "UnderstandingRequest",
     "UnderstandingResponse",
     "media_type_from_filename",

--- a/packages/ai-parrot/src/parrot/handlers/models/_encrypted_field.py
+++ b/packages/ai-parrot/src/parrot/handlers/models/_encrypted_field.py
@@ -1,0 +1,46 @@
+"""Transparent AES-GCM encryption helpers for postgres TEXT columns.
+
+Used by :class:`UserBotModel` to seal/unseal ``mcp_config`` and ``tools_config``
+blobs which may contain credentials. Reuses the same vault key system as
+:mod:`parrot.handlers.credentials_utils` so existing master keys cover this
+table without further configuration.
+
+Plaintext shape is JSON-serialisable (typically a list of dicts).
+Ciphertext is the base64 string returned by :func:`encrypt_credential`.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from parrot.handlers.credentials_utils import (
+    decrypt_credential,
+    encrypt_credential,
+)
+from parrot.handlers.vault_utils import load_vault_keys
+
+
+def seal(value: Any) -> Optional[str]:
+    """Encrypt a JSON-serialisable value to a base64 ciphertext string.
+
+    Returns ``None`` for empty / falsy values so the column stays NULL.
+    Raises :class:`RuntimeError` if the vault keys are not configured.
+    """
+    if value in (None, [], {}, ""):
+        return None
+    active_key_id, active_key, _ = load_vault_keys()
+    payload = value if isinstance(value, dict) else {"__list__": value}
+    return encrypt_credential(payload, active_key_id, active_key)
+
+
+def unseal(blob: Optional[str]) -> Any:
+    """Decrypt a base64 ciphertext string back to its original value.
+
+    Returns ``None`` if ``blob`` is empty / NULL.
+    """
+    if not blob:
+        return None
+    _, _, all_keys = load_vault_keys()
+    plaintext = decrypt_credential(blob, all_keys)
+    if isinstance(plaintext, dict) and set(plaintext.keys()) == {"__list__"}:
+        return plaintext["__list__"]
+    return plaintext

--- a/packages/ai-parrot/src/parrot/handlers/models/users_bots.py
+++ b/packages/ai-parrot/src/parrot/handlers/models/users_bots.py
@@ -1,0 +1,201 @@
+"""Database model for per-user defined bots (``navigator.users_bots``).
+
+Mirrors :class:`parrot.handlers.models.bots.BotModel` but is keyed by
+``(user_id, chatbot_id)`` so each user owns their own private set of bots.
+
+``mcp_config`` and ``tools_config`` are persisted as AES-GCM encrypted
+base64 blobs because they may carry credentials.  The model exposes the
+plaintext via :meth:`get_mcp_config` / :meth:`get_tools_config` and accepts
+plaintext via :meth:`set_mcp_config` / :meth:`set_tools_config`; encryption
+happens transparently at write time.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any, List, Optional
+
+from datamodel import Field
+from asyncdb.models import Model
+
+from parrot.conf import PARROT_SCHEMA
+
+from ._encrypted_field import seal, unseal
+
+
+def _default_embed_model() -> dict:
+    return {
+        "model_name": "sentence-transformers/all-mpnet-base-v2",
+        "model_type": "huggingface",
+    }
+
+
+class UserBotModel(Model):
+    """Per-user bot definition.
+
+    All fields mirror :class:`BotModel` semantics where applicable, plus
+    ``user_id`` and the explicit ``mcp_config`` / ``tools_config`` /
+    ``vector_config`` / ``documents`` columns asked for by the feature.
+    """
+
+    # Composite identity
+    chatbot_id: uuid.UUID = Field(
+        primary_key=True,
+        required=False,
+        default_factory=uuid.uuid4,
+    )
+    user_id: int = Field(primary_key=True, required=True)
+
+    # Basic bot information
+    name: str = Field(required=True)
+    description: str = Field(required=False)
+    avatar: str = Field(required=False)
+    enabled: bool = Field(required=False, default=True)
+    timezone: str = Field(required=False, default="UTC")
+
+    # Personality
+    role: str = Field(required=False, default="AI Assistant")
+    goal: str = Field(
+        required=False,
+        default="Help users accomplish their tasks effectively.",
+    )
+    backstory: str = Field(
+        required=False,
+        default="I am an AI assistant created to help users with various tasks.",
+    )
+    rationale: str = Field(
+        required=False,
+        default="I maintain a professional tone and provide accurate, helpful information.",
+    )
+    capabilities: str = Field(
+        required=False,
+        default="I can engage in conversation, answer questions, and use tools when needed.",
+    )
+
+    # Prompt configuration (PromptBuilder)
+    prompt_config: dict = Field(required=False, default_factory=dict)
+    system_prompt_template: Optional[str] = Field(required=False, default=None)
+    human_prompt_template: Optional[str] = Field(required=False, default=None)
+    pre_instructions: List[str] = Field(required=False, default_factory=list)
+
+    # LLM configuration
+    llm: str = Field(required=False, default="google")
+    model_name: str = Field(required=False, default="gemini-2.0-flash-001")
+    temperature: float = Field(required=False, default=0.1)
+    max_tokens: int = Field(required=False, default=1024)
+    top_k: int = Field(required=False, default=41)
+    top_p: float = Field(required=False, default=0.9)
+    model_config: dict = Field(required=False, default_factory=dict)
+
+    # Vector store + uploaded documents
+    use_vector: bool = Field(required=False, default=False)
+    vector_config: dict = Field(required=False, default_factory=dict)
+    embedding_model: dict = Field(required=False, default=_default_embed_model)
+    documents: List[dict] = Field(required=False, default_factory=list)
+    context_search_limit: int = Field(required=False, default=10)
+    context_score_threshold: float = Field(required=False, default=0.7)
+
+    # MCP & tools — stored as ENCRYPTED TEXT.
+    # Use the get_*/set_* accessors for plaintext I/O.
+    mcp_config: Optional[str] = Field(required=False, default=None)
+    tools_config: Optional[str] = Field(required=False, default=None)
+    tools_enabled: bool = Field(required=False, default=True)
+    auto_tool_detection: bool = Field(required=False, default=True)
+    tool_threshold: float = Field(required=False, default=0.7)
+    operation_mode: str = Field(required=False, default="adaptive")
+
+    # Memory and conversation
+    memory_type: str = Field(required=False, default="memory")
+    memory_config: dict = Field(required=False, default_factory=dict)
+    max_context_turns: int = Field(required=False, default=5)
+    use_conversation_history: bool = Field(required=False, default=True)
+
+    # Security and permissions
+    permissions: dict = Field(required=False, default_factory=dict)
+
+    # Metadata
+    language: str = Field(required=False, default="en")
+    disclaimer: Optional[str] = Field(required=False, default=None)
+    created_at: datetime = Field(required=False, default=datetime.now)
+    updated_at: datetime = Field(required=False, default=datetime.now)
+
+    class Meta:
+        driver = "pg"
+        name = "users_bots"
+        schema = PARROT_SCHEMA
+        strict = True
+        frozen = False
+
+    # ------------------------------------------------------------------
+    # Encrypted-field accessors
+    # ------------------------------------------------------------------
+
+    def get_mcp_config(self) -> List[dict]:
+        """Return plaintext MCP server configurations."""
+        value = unseal(self.mcp_config)
+        return value if isinstance(value, list) else []
+
+    def set_mcp_config(self, value: Any) -> None:
+        """Encrypt and store MCP server configurations."""
+        self.mcp_config = seal(value or [])
+
+    def get_tools_config(self) -> List[dict]:
+        """Return plaintext tool configurations."""
+        value = unseal(self.tools_config)
+        return value if isinstance(value, list) else []
+
+    def set_tools_config(self, value: Any) -> None:
+        """Encrypt and store tool configurations."""
+        self.tools_config = seal(value or [])
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def to_bot_kwargs(self) -> dict:
+        """Render a kwargs dict suitable for ``BasicBot(**kwargs)``.
+
+        Decrypts ``mcp_config`` and ``tools_config`` so the bot constructor
+        receives plaintext.
+        """
+        tools_config = self.get_tools_config()
+        return {
+            "chatbot_id": self.chatbot_id,
+            "name": self.name,
+            "description": self.description,
+            "role": self.role,
+            "goal": self.goal,
+            "backstory": self.backstory,
+            "rationale": self.rationale,
+            "capabilities": self.capabilities,
+            "system_prompt": self.system_prompt_template,
+            "human_prompt": self.human_prompt_template,
+            "pre_instructions": self.pre_instructions or [],
+            "prompt_preset": (self.prompt_config or {}).get("preset"),
+            "use_llm": self.llm,
+            "model_name": self.model_name,
+            "model_config": self.model_config or {},
+            "temperature": self.temperature,
+            "max_tokens": self.max_tokens,
+            "top_k": self.top_k,
+            "top_p": self.top_p,
+            "embedding_model": self.embedding_model,
+            "use_vectorstore": self.use_vector,
+            "vector_store_config": self.vector_config or {},
+            "context_search_limit": self.context_search_limit,
+            "context_score_threshold": self.context_score_threshold,
+            "tools_enabled": self.tools_enabled,
+            "auto_tool_detection": self.auto_tool_detection,
+            "tool_threshold": self.tool_threshold,
+            "available_tools": [t.get("name") for t in tools_config if t.get("name")],
+            "tools_config": tools_config,
+            "mcp_servers": self.get_mcp_config(),
+            "operation_mode": self.operation_mode,
+            "memory_type": self.memory_type,
+            "memory_config": self.memory_config or {},
+            "max_context_turns": self.max_context_turns,
+            "use_conversation_history": self.use_conversation_history,
+            "permissions": self.permissions or {},
+            "language": self.language,
+            "disclaimer": self.disclaimer,
+        }

--- a/packages/ai-parrot/src/parrot/handlers/models/users_bots_creation.sql
+++ b/packages/ai-parrot/src/parrot/handlers/models/users_bots_creation.sql
@@ -1,0 +1,97 @@
+-- Per-user bot definitions.
+-- mcp_config and tools_config are stored as AES-GCM ciphertext (base64) because
+-- they may carry credentials (api_keys, OAuth client_secret, tool args).
+-- Encryption is performed transparently by parrot.handlers.models.users_bots.UserBotModel
+-- using the navigator-session vault keys (same scheme as user_credentials).
+
+CREATE TABLE IF NOT EXISTS navigator.users_bots (
+    -- Composite identity
+    chatbot_id     UUID NOT NULL DEFAULT uuid_generate_v4(),
+    user_id        INTEGER NOT NULL,
+
+    -- Basic bot information
+    name           VARCHAR NOT NULL,
+    description    TEXT,
+    avatar         TEXT,
+    enabled        BOOLEAN NOT NULL DEFAULT TRUE,
+    timezone       VARCHAR(75) DEFAULT 'UTC',
+
+    -- Personality
+    role           VARCHAR DEFAULT 'AI Assistant',
+    goal           TEXT NOT NULL DEFAULT 'Help users accomplish their tasks effectively.',
+    backstory      TEXT NOT NULL DEFAULT 'I am an AI assistant created to help users with various tasks.',
+    rationale      TEXT NOT NULL DEFAULT 'I maintain a professional tone and provide accurate, helpful information.',
+    capabilities   TEXT DEFAULT 'I can engage in conversation, answer questions, and use tools when needed.',
+
+    -- Prompt configuration (PromptBuilder)
+    prompt_config           JSONB NOT NULL DEFAULT '{}'::JSONB,
+    system_prompt_template  TEXT,
+    human_prompt_template   TEXT,
+    pre_instructions        JSONB DEFAULT '[]'::JSONB,
+
+    -- LLM configuration
+    llm            VARCHAR NOT NULL DEFAULT 'google',
+    model_name     VARCHAR NOT NULL DEFAULT 'gemini-2.0-flash-001',
+    temperature    FLOAT DEFAULT 0.1 CHECK (temperature >= 0 AND temperature <= 2),
+    max_tokens     INTEGER DEFAULT 1024 CHECK (max_tokens > 0),
+    top_k          INTEGER DEFAULT 41 CHECK (top_k > 0),
+    top_p          FLOAT DEFAULT 0.9 CHECK (top_p >= 0 AND top_p <= 1),
+    model_config   JSONB DEFAULT '{}'::JSONB,
+
+    -- Vector store + uploaded documents (S3 paths)
+    use_vector              BOOLEAN DEFAULT FALSE,
+    vector_config           JSONB DEFAULT '{}'::JSONB,
+    embedding_model         JSONB DEFAULT '{"model_name": "sentence-transformers/all-mpnet-base-v2", "model_type": "huggingface"}'::JSONB,
+    documents               JSONB DEFAULT '[]'::JSONB,
+    context_search_limit    INTEGER DEFAULT 10 CHECK (context_search_limit > 0),
+    context_score_threshold FLOAT DEFAULT 0.7 CHECK (context_score_threshold >= 0 AND context_score_threshold <= 1),
+
+    -- MCP & tools — ENCRYPTED at rest (AES-GCM, base64 ciphertext)
+    mcp_config     TEXT,
+    tools_config   TEXT,
+    tools_enabled  BOOLEAN DEFAULT TRUE,
+    auto_tool_detection BOOLEAN DEFAULT TRUE,
+    tool_threshold FLOAT DEFAULT 0.7 CHECK (tool_threshold >= 0 AND tool_threshold <= 1),
+    operation_mode VARCHAR DEFAULT 'adaptive' CHECK (operation_mode IN ('conversational', 'agentic', 'adaptive')),
+
+    -- Memory and conversation
+    memory_type    VARCHAR DEFAULT 'memory' CHECK (memory_type IN ('memory', 'file', 'redis')),
+    memory_config  JSONB DEFAULT '{}'::JSONB,
+    max_context_turns INTEGER DEFAULT 5 CHECK (max_context_turns > 0),
+    use_conversation_history BOOLEAN DEFAULT TRUE,
+
+    -- Security and permissions
+    permissions    JSONB DEFAULT '{}'::JSONB,
+
+    -- Metadata
+    language       VARCHAR(10) DEFAULT 'en',
+    disclaimer     TEXT,
+    created_at     TIMESTAMPTZ DEFAULT NOW(),
+    updated_at     TIMESTAMPTZ DEFAULT NOW(),
+
+    PRIMARY KEY (user_id, chatbot_id),
+    CONSTRAINT unq_users_bots_user_name UNIQUE (user_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_bots_user_id ON navigator.users_bots(user_id);
+CREATE INDEX IF NOT EXISTS idx_users_bots_enabled ON navigator.users_bots(enabled);
+CREATE INDEX IF NOT EXISTS idx_users_bots_chatbot_id ON navigator.users_bots(chatbot_id);
+
+CREATE OR REPLACE FUNCTION update_users_bots_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+DROP TRIGGER IF EXISTS trigger_users_bots_updated_at ON navigator.users_bots;
+CREATE TRIGGER trigger_users_bots_updated_at
+    BEFORE UPDATE ON navigator.users_bots
+    FOR EACH ROW
+    EXECUTE FUNCTION update_users_bots_updated_at();
+
+COMMENT ON TABLE  navigator.users_bots IS 'Per-user user-defined bots. mcp_config and tools_config are AES-GCM encrypted blobs (may carry credentials).';
+COMMENT ON COLUMN navigator.users_bots.mcp_config   IS 'AES-GCM encrypted (base64) blob carrying MCP server configurations (may include credentials).';
+COMMENT ON COLUMN navigator.users_bots.tools_config IS 'AES-GCM encrypted (base64) blob carrying tool configurations (may include credentials).';
+COMMENT ON COLUMN navigator.users_bots.documents    IS 'JSON list of uploaded document descriptors {name, path, url, size, content_type, s3_key}.';

--- a/packages/ai-parrot/src/parrot/manager/manager.py
+++ b/packages/ai-parrot/src/parrot/manager/manager.py
@@ -45,7 +45,9 @@ from ..handlers.dashboard_handler import (
     DashboardTabHandler,
     _ensure_dashboard_indexes,
 )
-from ..handlers.models import BotModel
+from ..handlers.models import BotModel, UserBotModel
+# Per-user bot HTTP handler (PUT/PATCH/GET/DELETE)
+from ..handlers.agents.users import UserAgentHandler
 from ..handlers.stream import StreamHandler
 from ..registry import agent_registry, AgentRegistry, BotConfigStorage
 # Crew:
@@ -679,6 +681,107 @@ class BotManager:
         # Clean up expiration tracking if it exists (but keep class definition)
         self._bot_expiration.pop(name, None)
 
+    # ------------------------------------------------------------------
+    # User-defined bots (per-user, session-cached)
+    # ------------------------------------------------------------------
+
+    USER_BOTS_SESSION_KEY = "_user_bots"
+
+    async def _fetch_user_bot_model(
+        self,
+        user_id: int,
+        chatbot_id: str,
+    ) -> Optional[UserBotModel]:
+        """Load a single ``UserBotModel`` row scoped to ``(user_id, chatbot_id)``."""
+        db = self.app["database"]
+        async with await db.acquire() as conn:
+            UserBotModel.Meta.connection = conn
+            try:
+                return await UserBotModel.get(
+                    user_id=user_id, chatbot_id=chatbot_id
+                )
+            except NoDataFound:
+                return None
+
+    async def _build_user_bot_instance(
+        self,
+        bot_model: UserBotModel,
+    ) -> AbstractBot:
+        """Instantiate and ``configure()`` a bot from a ``UserBotModel`` row."""
+        kwargs = bot_model.to_bot_kwargs()
+        # User bots always use BasicBot — they don't carry a bot_class column.
+        bot = BasicBot(**kwargs)
+        bot.model_id = bot_model.chatbot_id
+        # Apply prompt-layer mutations declared in prompt_config (mirrors system bots).
+        prompt_config_dict = bot_model.prompt_config or {}
+        with contextlib.suppress(Exception):
+            self._apply_prompt_config(bot, prompt_config_dict)
+        await bot.configure(self.app)
+        return bot
+
+    async def get_user_bot(
+        self,
+        request: web.Request,
+        chatbot_id: Any,
+    ) -> Optional[AbstractBot]:
+        """Resolve a user-defined bot via session cache → DB load → instantiate.
+
+        Order of resolution:
+          1. Look in ``request.session[USER_BOTS_SESSION_KEY][chatbot_id]``.
+          2. On miss, query ``navigator.users_bots`` constrained by
+             ``(user_id, chatbot_id)`` from the authenticated session.
+          3. Build the bot instance, cache it on the session, return it.
+
+        Returns ``None`` when the user is not authenticated or no row matches.
+        """
+        try:
+            from navigator_session import get_session  # noqa: PLC0415
+        except ImportError:
+            return None
+
+        try:
+            session = request.session or await get_session(request)
+        except AttributeError:
+            session = await get_session(request)
+        if session is None:
+            return None
+        user_id = session.get("user_id")
+        if not user_id:
+            return None
+
+        cache = session.setdefault(self.USER_BOTS_SESSION_KEY, {})
+        cid = str(chatbot_id)
+        cached = cache.get(cid)
+        if cached is not None:
+            return cached
+
+        bot_model = await self._fetch_user_bot_model(user_id, cid)
+        if bot_model is None:
+            return None
+        try:
+            bot = await self._build_user_bot_instance(bot_model)
+        except Exception as exc:  # noqa: BLE001
+            self.logger.error(
+                "Failed to build user bot %s for user %s: %s",
+                cid,
+                user_id,
+                exc,
+                exc_info=True,
+            )
+            return None
+        cache[cid] = bot
+        return bot
+
+    @classmethod
+    def invalidate_user_bot(cls, session: Any, chatbot_id: Any) -> None:
+        """Drop a user-bot from the session cache (used after PATCH/DELETE)."""
+        if session is None:
+            return
+        cache = session.get(cls.USER_BOTS_SESSION_KEY)
+        if not cache:
+            return
+        cache.pop(str(chatbot_id), None)
+
     def get_bots(self) -> Dict[str, AbstractBot]:
         """Get all Bots declared on Manager."""
         return self._bots
@@ -886,6 +989,15 @@ class BotManager:
         router.add_view(
             '/api/v1/agents/chat/{agent_id}/{method_name}',
             AgentTalk
+        )
+        # User-defined bots: PUT/PATCH/GET/DELETE
+        router.add_view(
+            '/api/v1/user_agents',
+            UserAgentHandler
+        )
+        router.add_view(
+            '/api/v1/user_agents/{chatbot_id}',
+            UserAgentHandler
         )
         # Data Analyst creation route:
         router.add_view(


### PR DESCRIPTION
## Summary
This PR introduces a complete per-user bot management system that allows authenticated users to create, configure, and manage their own private chatbots. User-defined bots are stored in a new `navigator.users_bots` table with transparent AES-GCM encryption for sensitive configuration fields.

## Key Changes

### New User Bot Handler & API
- **`UserAgentHandler`** (`packages/ai-parrot/src/parrot/handlers/agents/users.py`): Complete CRUD HTTP handler for `/api/v1/user_agents` endpoints
  - `PUT` — create new user bot
  - `PATCH` — partial update with deep-merge for config blobs
  - `GET` — list user's bots or fetch single bot
  - `DELETE` — remove bot and associated S3 documents
  - Supports both `application/json` and `multipart/form-data` (for file uploads)
  - Automatic credential redaction on GET responses (masks API keys, tokens, secrets, etc.)

### Database Model & Encryption
- **`UserBotModel`** (`packages/ai-parrot/src/parrot/handlers/models/users_bots.py`): ORM model for per-user bot definitions
  - Composite primary key: `(user_id, chatbot_id)`
  - Mirrors `BotModel` fields with additional `mcp_config` and `tools_config` encrypted columns
  - Transparent encryption/decryption via `get_mcp_config()` / `set_mcp_config()` accessors
  - `to_bot_kwargs()` helper to instantiate `BasicBot` instances
  
- **`_encrypted_field.py`**: Encryption utilities using AES-GCM with vault key system
  - `seal()` — encrypts JSON-serializable values to base64 ciphertext
  - `unseal()` — decrypts ciphertext back to plaintext
  - Reuses existing navigator-session vault infrastructure

- **`users_bots_creation.sql`**: PostgreSQL schema with constraints, indexes, and auto-update trigger

### Bot Manager Integration
- **`BotManager.get_user_bot()`**: Session-cached resolution of user-defined bots
  - Checks session cache first, falls back to DB lookup
  - Instantiates bot from model and caches on session
  - Returns `None` if user not authenticated or bot not found
  
- **`BotManager.invalidate_user_bot()`**: Clears bot from session cache after PATCH/DELETE

### Handler & Chat Integration
- **`AgentHandler._resolve_bot()`**: New method that tries user-bot first, then system bot
  - Returns tuple `(bot, is_user_bot)` for caller awareness
  - Gracefully falls back to system bots on user-bot lookup failure

- **`ChatHandler`**: Updated to resolve user-bots before system bots

### Configuration & Utilities
- **Credential redaction**: `_redact()` function masks credential-shaped keys in nested dicts/lists
- **Deep merge**: `_deep_merge()` for intelligent PATCH updates of config blobs (preserves untouched credentials, supports list-of-objects merging by `name` key)
- **File upload handling**: Multipart parsing with temp file streaming and S3 ingestion via `FileManagerToolkit`
- **Document management**: Track uploaded documents in bot config, support explicit removal via `documents_remove` payload

## Notable Implementation Details
- Encrypted fields are stored as base64 TEXT in PostgreSQL; decryption is transparent to the handler
- User bots are session-cached to avoid repeated DB lookups during a user's session
- File uploads are streamed to temp files before S3 ingestion to avoid memory bloat
- PATCH operations use deep-merge to allow partial updates without losing untouched credentials
- Credential redaction happens on all GET responses (list and fetch) to prevent accidental exposure
- Bot instantiation uses `BasicBot` class (not configurable like system bots)

https://claude.ai/code/session_014cAJ352NZmXTiDxYyph7Vy