### PR TITLE
fix(database-agent): preserve structured QueryResponse over the wire

### DIFF
--- a/packages/ai-parrot/src/parrot/bots/database/agent.py
+++ b/packages/ai-parrot/src/parrot/bots/database/agent.py
@@ -10,7 +10,7 @@ import uuid
 from typing import Any, Dict, List, Optional, Set, Union
 
 from ...models import AIMessage, CompletionUsage
-from ...models.outputs import StructuredOutputConfig
+from ...models.outputs import OutputMode, StructuredOutputConfig
 from ...stores.abstract import AbstractStore
 from ..agent import BasicAgent
 from ..prompts.builder import PromptBuilder
@@ -433,6 +433,10 @@ class DatabaseAgent(BasicAgent):
                 if qr.data and qr.data.data
                 else None
             )
+            # Signal to the HTTP layer that this AIMessage carries a structured
+            # QueryResponse the frontend should render as a SQL artifact card
+            # (explanation + dedicated SQL block) rather than plain markdown.
+            response.output_mode = OutputMode.SQL_ANALYSIS
         else:
             # Free-text fallback
             response.is_structured = False

--- a/packages/ai-parrot/src/parrot/handlers/agent.py
+++ b/packages/ai-parrot/src/parrot/handlers/agent.py
@@ -15,6 +15,7 @@ import uuid
 import asyncio
 from aiohttp import web
 import pandas as pd
+from pydantic import BaseModel
 from datamodel.parsers.json import json_encoder  # noqa  pylint: disable=E0611
 from rich.panel import Panel
 from navconfig.logging import logging
@@ -1963,6 +1964,12 @@ class AgentTalk(BaseView):
                         output = str(output.renderable) if hasattr(output, 'renderable') else str(output)
                 except Exception:
                     output = str(output)
+            elif isinstance(output, BaseModel):
+                # Preserve the full structured payload (e.g. QueryResponse from
+                # DatabaseAgent) so the frontend can render dedicated artifacts.
+                # Previously this branch collapsed the model to ``.explanation``
+                # alone, throwing away ``.query``, ``.data``, etc.
+                output = output.model_dump(mode="json")
             elif hasattr(output, 'explanation'):
                 output = output.explanation
             # Safety net: ensure output is JSON-serializable

--- a/packages/ai-parrot/src/parrot/models/outputs.py
+++ b/packages/ai-parrot/src/parrot/models/outputs.py
@@ -68,6 +68,7 @@ class OutputMode(str, Enum):
     WHATSAPP = "whatsapp"
     SLACK = "slack"
     INFOGRAPHIC = "infographic"
+    SQL_ANALYSIS = "sql_analysis"  # DBA helper: QueryResponse with explanation + SQL artifact
 
 @dataclass
 class StructuredOutputConfig:


### PR DESCRIPTION
## Summary

- **Bug**: the HTTP handler at `parrot/handlers/agent.py` was collapsing any output object with an `explanation` attribute down to that single string (the `elif hasattr(output, 'explanation')` branch), which discarded `query`, `data` and other fields from the `QueryResponse` produced by `DatabaseAgent.ask()` post FEAT-164. Downstream consumers therefore never received the structured artifact and had to fall back to regex-extracting SQL from a fenced markdown block in `response`.
- **Fix**: preserve any `pydantic.BaseModel` output via `model_dump(mode="json")` before the `hasattr('explanation')` fallback. `QueryResponse` (and any future structured agent output) now reaches consumers intact.
- **Also**: new `OutputMode.SQL_ANALYSIS` enum value so downstream layers can switch on a stable discriminator; `DatabaseAgent.ask()` sets `response.output_mode = OutputMode.SQL_ANALYSIS` whenever the LLM honours the structured schema.

## Changes

| File | LOC | Purpose |
|---|---|---|
| `models/outputs.py` | +1 | `OutputMode.SQL_ANALYSIS = "sql_analysis"` |
| `bots/database/agent.py` | +5 | Set `response.output_mode` when structured + import `OutputMode` |
| `handlers/agent.py` | +7 | Branch on `isinstance(output, BaseModel) → model_dump(mode="json")` + import `BaseModel` |

Total: 13 lines, 3 files.

## Test plan

- [ ] Existing parrot test suite passes (`pytest`) — no regressions in the agent handler.
- [ ] Run an `sql_analyst` (or any `DatabaseAgent`) instance end-to-end and confirm the HTTP response now carries `output: { explanation, query, data, ... }` rather than `output: "<explanation string>"`.
- [ ] Confirm `output_mode == "sql_analysis"` in the response payload.
- [ ] Verify non-structured agents (free-text fallback path) keep working — `response.output_mode` is left at `DEFAULT` when `qr is None`.
- [ ] Verify other `output` shapes (DataFrame, Panel, plain string) are unaffected by the new `BaseModel` branch.

## Downstream impact

This unblocks the downstream migration of the `sql_analyst` plugin (in `navigator-plugins`) onto the new LLM-driven `DatabaseAgent` base, and a corresponding frontend change to render the structured `QueryResponse` as a dedicated SQL artifact card instead of regex-extracting from markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)