### PR TITLE
feat(parrot-loaders): cache WhisperX, alignment and diarization pipelines across files

### DIFF
--- a/packages/ai-parrot-loaders/src/parrot_loaders/basevideo.py
+++ b/packages/ai-parrot-loaders/src/parrot_loaders/basevideo.py
@@ -90,6 +90,16 @@ class BaseVideoLoader(AbstractLoader):
         self._summarizer_device = None
         self._summarizer_dtype = None
 
+        # Cached WhisperX pipelines — loaded on first use, reused across files.
+        # Keyed by (model_id, device, compute_type) so a config change forces reload.
+        self._whisperx_model = None
+        self._whisperx_model_key: tuple = ()   # (model_id, device, compute_type)
+        self._align_model = None
+        self._align_meta = None
+        self._align_model_key: tuple = ()      # (language_code, device)
+        self._diarizer = None
+        self._diarizer_key: tuple = ()         # (token, device)
+
         # Store device info for lazy loading
         device, _, dtype = self._get_device()
         self._summarizer_device = device
@@ -445,22 +455,27 @@ class BaseVideoLoader(AbstractLoader):
                 "Missing PYANNOTE token. Set PYANNOTE_AUDIO_AUTH or pass pyannote_token=..."
             )
 
-        # 1) Run WhisperX diarization on the file
-        try:
-            diarizer = whisperx.diarize.DiarizationPipeline(
-                token=token,
-                device=device
-            )
-        except Exception as e:
-            if "mps" in str(e).lower() and device == "mps":
-                print(f"[WhisperX] MPS diarization failed ({e}), falling back to CPU")
-                device = "cpu"
-                diarizer = whisperx.diarize.DiarizationPipeline(
+        # 1) Run WhisperX diarization on the file — reuse cached pipeline when possible
+        diarizer_key = (token, device)
+        if self._diarizer is None or self._diarizer_key != diarizer_key:
+            try:
+                self._diarizer = whisperx.diarize.DiarizationPipeline(
                     token=token,
-                    device=device
+                    device=device,
                 )
-            else:
-                raise
+                self._diarizer_key = diarizer_key
+            except Exception as e:
+                if "mps" in str(e).lower() and device == "mps":
+                    print(f"[WhisperX] MPS diarization failed ({e}), falling back to CPU")
+                    device = "cpu"
+                    self._diarizer = whisperx.diarize.DiarizationPipeline(
+                        token=token,
+                        device=device,
+                    )
+                    self._diarizer_key = (token, device)
+                else:
+                    raise
+        diarizer = self._diarizer
 
         if speaker_names and len(speaker_names) > 1:
             min_speakers = max(2, len(speaker_names) - 1)
@@ -1041,29 +1056,36 @@ class BaseVideoLoader(AbstractLoader):
         else:
             model_id = self._get_whisperx_name(lang, self._model_size)
 
-        # 1) ASR
-        model = whisperx.load_model(
-            model_id,
-            device=device,
-            compute_type=compute_type,
-            language=language
-        )
+        # 1) ASR — reuse cached model when config matches
+        asr_key = (model_id, device, compute_type)
+        if self._whisperx_model is None or self._whisperx_model_key != asr_key:
+            self._whisperx_model = whisperx.load_model(
+                model_id,
+                device=device,
+                compute_type=compute_type,
+                language=language,
+            )
+            self._whisperx_model_key = asr_key
         audio = whisperx.load_audio(str(audio_path))
-        asr_result = model.transcribe(audio, batch_size=batch_size)
+        asr_result = self._whisperx_model.transcribe(audio, batch_size=batch_size)
         lang = asr_result.get("language", language)
         segs = asr_result.get("segments", []) or []
 
-        # 2) Alignment → precise word times
-        align_model, align_meta = whisperx.load_align_model(
-            language_code=asr_result.get("language", language), device=device
-        )
+        # 2) Alignment — reuse cached align model when language+device match
+        detected_lang = asr_result.get("language", language)
+        align_key = (detected_lang, device)
+        if self._align_model is None or self._align_model_key != align_key:
+            self._align_model, self._align_meta = whisperx.load_align_model(
+                language_code=detected_lang, device=device
+            )
+            self._align_model_key = align_key
         aligned = whisperx.align(
             segs,
-            align_model,
-            align_meta,
+            self._align_model,
+            self._align_meta,
             audio,
             device=device,
-            return_char_alignments=False
+            return_char_alignments=False,
         )
 
         # build the return payload in your existing schema
@@ -1086,16 +1108,6 @@ class BaseVideoLoader(AbstractLoader):
             chunks.append({"text": text, "timestamp": (s, e), "words": words_out})
             if text:
                 full_text_parts.append(text)
-
-        # Cleanup
-        del model
-        del align_model
-        gc.collect()
-        try:
-            if device.startswith("cuda"):
-                torch.cuda.empty_cache()
-        except Exception:
-            pass
 
         return {"text": " ".join(full_text_parts).strip(), "chunks": chunks, "language": lang}
 
@@ -1618,6 +1630,24 @@ class BaseVideoLoader(AbstractLoader):
         Call this method when done processing to free VRAM for other tasks.
         """
         freed_items = []
+
+        # Free cached WhisperX pipelines
+        if self._whisperx_model is not None:
+            del self._whisperx_model
+            self._whisperx_model = None
+            self._whisperx_model_key = ()
+            freed_items.append("whisperx_model")
+        if self._align_model is not None:
+            del self._align_model
+            self._align_model = None
+            self._align_meta = None
+            self._align_model_key = ()
+            freed_items.append("align_model")
+        if self._diarizer is not None:
+            del self._diarizer
+            self._diarizer = None
+            self._diarizer_key = ()
+            freed_items.append("diarizer")
 
         # Free summarizer if it was loaded
         if self._summarizer is not None:

--- a/sdd/tasks/completed/TASK-1164-builtin-metadata-rest.md
+++ b/sdd/tasks/completed/TASK-1164-builtin-metadata-rest.md
@@ -2,7 +2,7 @@
 
 **Feature**: FEAT-170 — FormDesigner `FieldType.REST`
 **Spec**: `sdd/specs/new-formdesigner-field-rest.spec.md` (Module 5)
-**Status**: pending
+**Status**: done
 **Priority**: medium
 **Estimated effort**: S (< 2h)
 **Depends-on**: TASK-1163
@@ -102,4 +102,9 @@ def test_rest_metadata_present():
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+Added `FieldType.REST` entry to `_BUILTIN_METADATA` in `controls/builtin.py` with
+`category="advanced"`, `label="REST"`, `render_hint="upload"`, `supports_constraints=True`,
+`icon="rest"`, `is_container=False`. The snippet will be `{}` until TASK-1165 adds it.
+Created `tests/unit/controls/test_builtin.py` with `test_rest_metadata_present` and
+`test_rest_metadata_full_shape`. Both tests pass. `ruff` clean. Committed on branch
+`feat-170-new-formdesigner-field-rest`.

--- a/sdd/tasks/completed/TASK-1165-field-helper-snippet.md
+++ b/sdd/tasks/completed/TASK-1165-field-helper-snippet.md
@@ -2,7 +2,7 @@
 
 **Feature**: FEAT-170 — FormDesigner `FieldType.REST`
 **Spec**: `sdd/specs/new-formdesigner-field-rest.spec.md` (Module 6)
-**Status**: pending
+**Status**: done
 **Priority**: medium
 **Estimated effort**: S (< 2h)
 **Depends-on**: TASK-1163
@@ -109,4 +109,9 @@ def test_rest_snippet_roundtrips():
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+Added `FieldType.REST.value` entry to `_FIELD_SCHEMA_SNIPPETS` in `tools/field_helpers.py`
+using the planogram callback example from spec §1. Added `test_rest_snippet_roundtrips` to
+the existing `tests/unit/test_field_helpers.py` — all 4 tests pass. The snippet validates via
+`FormField.model_validate` and `RestFieldSpec.model_validate` yields a `CallbackRestFieldSpec`
+with `callback_ref="planogram_compliance"`. `ruff` clean. Committed on branch
+`feat-170-new-formdesigner-field-rest`.

--- a/sdd/tasks/completed/TASK-1166-validator-rest-branch.md
+++ b/sdd/tasks/completed/TASK-1166-validator-rest-branch.md
@@ -2,7 +2,7 @@
 
 **Feature**: FEAT-170 — FormDesigner `FieldType.REST`
 **Spec**: `sdd/specs/new-formdesigner-field-rest.spec.md` (Module 7)
-**Status**: pending
+**Status**: done
 **Priority**: high
 **Estimated effort**: M (2-4h)
 **Depends-on**: TASK-1162, TASK-1163
@@ -181,4 +181,12 @@ def test_design_time_parse_catches_typo():
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+Added `FieldType.REST` branch in `services/validators.py`:
+- Early-return via `_validate_rest_field()` (sync helper): rejects non-dict, `status="in_progress"`,
+  and required+null-answer; returns structured error strings matching existing conventions.
+- `_coerce_value()` REST case returns dict with `status` key stripped.
+- `validate_field_schema(field)` design-time method: parses `field.meta["rest"]` via
+  `RestFieldSpec.model_validate()` and surfaces `ValidationError` as designer-facing errors.
+- Created `tests/unit/services/test_validators_rest.py` with 9 tests (all pass).
+- `ruff` clean. No regressions in existing `test_services.py` (8 pass, 4 pre-existing errors
+  unrelated to this task). Committed on branch `feat-170-new-formdesigner-field-rest`.

--- a/sdd/tasks/completed/TASK-1167-renderer-entries.md
+++ b/sdd/tasks/completed/TASK-1167-renderer-entries.md
@@ -2,7 +2,7 @@
 
 **Feature**: FEAT-170 — FormDesigner `FieldType.REST`
 **Spec**: `sdd/specs/new-formdesigner-field-rest.spec.md` (Module 8)
-**Status**: pending
+**Status**: done
 **Priority**: medium
 **Estimated effort**: L (4-8h)
 **Depends-on**: TASK-1163, TASK-1164
@@ -195,4 +195,11 @@ def test_pdf_fallback_warns(rest_callback_field):
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+Added `FieldType.REST` to all 6 renderers:
+- **html5.py**: `_RestUploaderRenderer` + `_render_rest()` (native: `<input type="file">` + hidden answer/blob_ref). 
+- **jsonschema.py**: `_TYPE_MAP["rest"]="object"` + `x-parrot-rest` extension with mode/response_path/display_template/upload_url_template.
+- **adaptive_card.py**: added to `_AC_FALLBACK_TYPES` → emits `RenderWarning(renderer="adaptive_card")`.
+- **pdf.py**: added to `_PDF_FALLBACK_NEW_TYPES` → emits `RenderWarning(renderer="pdf")`.
+- **xforms.py**: added `("input", "string")` fallback entry to `_XFORMS_TYPE_MAP`.
+- **telegram/renderer.py**: added to `_WEBAPP_FIELD_TYPES` → WebApp redirect mode.
+Created `tests/unit/renderers/test_rest_renderers.py` with 6 tests (all pass). 28 existing renderer tests pass (no regressions). Ruff: no new errors introduced. Committed on `feat-170-new-formdesigner-field-rest`.

--- a/sdd/tasks/index/new-formdesigner-field-rest.json
+++ b/sdd/tasks/index/new-formdesigner-field-rest.json
@@ -129,7 +129,7 @@
       "feature_id": "FEAT-170",
       "feature": "new-formdesigner-field-rest",
       "spec": "sdd/specs/new-formdesigner-field-rest.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -140,8 +140,8 @@
       "parallelism_notes": "Imports RestFieldSpec and edits central validators.py.",
       "assigned_to": null,
       "started_at": "2026-05-15T02:25:39+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-1166-validator-rest-branch.md"
+      "completed_at": "2026-05-15T02:33:06+00:00",
+      "file": "sdd/tasks/completed/TASK-1166-validator-rest-branch.md"
     },
     {
       "id": "TASK-1167",

--- a/sdd/tasks/index/new-formdesigner-field-rest.json
+++ b/sdd/tasks/index/new-formdesigner-field-rest.json
@@ -109,7 +109,7 @@
       "feature_id": "FEAT-170",
       "feature": "new-formdesigner-field-rest",
       "spec": "sdd/specs/new-formdesigner-field-rest.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "S",
       "depends_on": [
@@ -119,8 +119,8 @@
       "parallelism_notes": "Touches a different file from TASK-1164; can run in parallel after TASK-1163.",
       "assigned_to": null,
       "started_at": "2026-05-15T02:13:42+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-1165-field-helper-snippet.md"
+      "completed_at": "2026-05-15T02:23:59+00:00",
+      "file": "sdd/tasks/completed/TASK-1165-field-helper-snippet.md"
     },
     {
       "id": "TASK-1166",

--- a/sdd/tasks/index/new-formdesigner-field-rest.json
+++ b/sdd/tasks/index/new-formdesigner-field-rest.json
@@ -150,7 +150,7 @@
       "feature_id": "FEAT-170",
       "feature": "new-formdesigner-field-rest",
       "spec": "sdd/specs/new-formdesigner-field-rest.spec.md",
-      "status": "pending",
+      "status": "in-progress",
       "priority": "medium",
       "effort": "L",
       "depends_on": [
@@ -160,7 +160,7 @@
       "parallel": false,
       "parallelism_notes": "Six renderer files share a similar pattern; could split per-renderer but stays as one task since they all consume the same FieldType.REST contract.",
       "assigned_to": null,
-      "started_at": null,
+      "started_at": "2026-05-15T02:34:41+00:00",
       "completed_at": null,
       "file": "sdd/tasks/active/TASK-1167-renderer-entries.md"
     },

--- a/sdd/tasks/index/new-formdesigner-field-rest.json
+++ b/sdd/tasks/index/new-formdesigner-field-rest.json
@@ -109,7 +109,7 @@
       "feature_id": "FEAT-170",
       "feature": "new-formdesigner-field-rest",
       "spec": "sdd/specs/new-formdesigner-field-rest.spec.md",
-      "status": "pending",
+      "status": "in-progress",
       "priority": "medium",
       "effort": "S",
       "depends_on": [
@@ -118,7 +118,7 @@
       "parallel": true,
       "parallelism_notes": "Touches a different file from TASK-1164; can run in parallel after TASK-1163.",
       "assigned_to": null,
-      "started_at": null,
+      "started_at": "2026-05-15T02:13:42+00:00",
       "completed_at": null,
       "file": "sdd/tasks/active/TASK-1165-field-helper-snippet.md"
     },

--- a/sdd/tasks/index/new-formdesigner-field-rest.json
+++ b/sdd/tasks/index/new-formdesigner-field-rest.json
@@ -129,7 +129,7 @@
       "feature_id": "FEAT-170",
       "feature": "new-formdesigner-field-rest",
       "spec": "sdd/specs/new-formdesigner-field-rest.spec.md",
-      "status": "pending",
+      "status": "in-progress",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -139,7 +139,7 @@
       "parallel": false,
       "parallelism_notes": "Imports RestFieldSpec and edits central validators.py.",
       "assigned_to": null,
-      "started_at": null,
+      "started_at": "2026-05-15T02:25:39+00:00",
       "completed_at": null,
       "file": "sdd/tasks/active/TASK-1166-validator-rest-branch.md"
     },

--- a/sdd/tasks/index/new-formdesigner-field-rest.json
+++ b/sdd/tasks/index/new-formdesigner-field-rest.json
@@ -150,7 +150,7 @@
       "feature_id": "FEAT-170",
       "feature": "new-formdesigner-field-rest",
       "spec": "sdd/specs/new-formdesigner-field-rest.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "L",
       "depends_on": [
@@ -161,8 +161,8 @@
       "parallelism_notes": "Six renderer files share a similar pattern; could split per-renderer but stays as one task since they all consume the same FieldType.REST contract.",
       "assigned_to": null,
       "started_at": "2026-05-15T02:34:41+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-1167-renderer-entries.md"
+      "completed_at": "2026-05-15T02:50:49+00:00",
+      "file": "sdd/tasks/completed/TASK-1167-renderer-entries.md"
     },
     {
       "id": "TASK-1168",

--- a/sdd/tasks/index/new-formdesigner-field-rest.json
+++ b/sdd/tasks/index/new-formdesigner-field-rest.json
@@ -53,7 +53,10 @@
       "status": "pending",
       "priority": "high",
       "effort": "L",
-      "depends_on": ["TASK-1160", "TASK-1161"],
+      "depends_on": [
+        "TASK-1160",
+        "TASK-1161"
+      ],
       "parallel": false,
       "parallelism_notes": "Depends on blob_storage and callback_registry interfaces.",
       "assigned_to": null,
@@ -86,16 +89,18 @@
       "feature_id": "FEAT-170",
       "feature": "new-formdesigner-field-rest",
       "spec": "sdd/specs/new-formdesigner-field-rest.spec.md",
-      "status": "pending",
+      "status": "done",
       "priority": "medium",
       "effort": "S",
-      "depends_on": ["TASK-1163"],
+      "depends_on": [
+        "TASK-1163"
+      ],
       "parallel": false,
       "parallelism_notes": "Single-file edit on central registry; sequential after enum.",
       "assigned_to": null,
       "started_at": null,
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-1164-builtin-metadata-rest.md"
+      "completed_at": "2026-05-15T02:12:10+00:00",
+      "file": "sdd/tasks/completed/TASK-1164-builtin-metadata-rest.md"
     },
     {
       "id": "TASK-1165",
@@ -107,7 +112,9 @@
       "status": "pending",
       "priority": "medium",
       "effort": "S",
-      "depends_on": ["TASK-1163"],
+      "depends_on": [
+        "TASK-1163"
+      ],
       "parallel": true,
       "parallelism_notes": "Touches a different file from TASK-1164; can run in parallel after TASK-1163.",
       "assigned_to": null,
@@ -125,7 +132,10 @@
       "status": "pending",
       "priority": "high",
       "effort": "M",
-      "depends_on": ["TASK-1162", "TASK-1163"],
+      "depends_on": [
+        "TASK-1162",
+        "TASK-1163"
+      ],
       "parallel": false,
       "parallelism_notes": "Imports RestFieldSpec and edits central validators.py.",
       "assigned_to": null,
@@ -143,7 +153,10 @@
       "status": "pending",
       "priority": "medium",
       "effort": "L",
-      "depends_on": ["TASK-1163", "TASK-1164"],
+      "depends_on": [
+        "TASK-1163",
+        "TASK-1164"
+      ],
       "parallel": false,
       "parallelism_notes": "Six renderer files share a similar pattern; could split per-renderer but stays as one task since they all consume the same FieldType.REST contract.",
       "assigned_to": null,
@@ -161,7 +174,9 @@
       "status": "pending",
       "priority": "medium",
       "effort": "S",
-      "depends_on": ["TASK-1163"],
+      "depends_on": [
+        "TASK-1163"
+      ],
       "parallel": true,
       "parallelism_notes": "Independent of renderers and validator; touches only extractor files.",
       "assigned_to": null,
@@ -197,7 +212,14 @@
       "status": "pending",
       "priority": "high",
       "effort": "L",
-      "depends_on": ["TASK-1160", "TASK-1161", "TASK-1162", "TASK-1163", "TASK-1164", "TASK-1166"],
+      "depends_on": [
+        "TASK-1160",
+        "TASK-1161",
+        "TASK-1162",
+        "TASK-1163",
+        "TASK-1164",
+        "TASK-1166"
+      ],
       "parallel": false,
       "parallelism_notes": "Full pipeline integration; must run after Phase 1 + the validator branch.",
       "assigned_to": null,
@@ -215,9 +237,12 @@
       "status": "pending",
       "priority": "medium",
       "effort": "M",
-      "depends_on": ["TASK-1160", "TASK-1162"],
+      "depends_on": [
+        "TASK-1160",
+        "TASK-1162"
+      ],
       "parallel": false,
-      "parallelism_notes": "Edits api/routes.py — same file TASK-1170 touches; must serialize to avoid merge friction.",
+      "parallelism_notes": "Edits api/routes.py \u2014 same file TASK-1170 touches; must serialize to avoid merge friction.",
       "assigned_to": null,
       "started_at": null,
       "completed_at": null,
@@ -233,7 +258,11 @@
       "status": "pending",
       "priority": "medium",
       "effort": "M",
-      "depends_on": ["TASK-1162", "TASK-1167", "TASK-1170"],
+      "depends_on": [
+        "TASK-1162",
+        "TASK-1167",
+        "TASK-1170"
+      ],
       "parallel": false,
       "parallelism_notes": "Terminal task; reads finished models and renderer extension.",
       "assigned_to": null,


### PR DESCRIPTION
## Summary

- `BaseVideoLoader` now caches `_whisperx_model`, `_align_model`/`_align_meta`, and `_diarizer` as instance attributes
- `get_whisperx_transcript()`: reuses the cached ASR + alignment models when `(model_id, device, compute_type)` key matches — no reload per file
- `audio_to_srt()`: reuses the cached `DiarizationPipeline` when `(token, device)` key matches
- `clear_cuda()`: extended to release the three new cached pipelines alongside the existing summarizer

## Benchmark (CPU, tiny.en model, 5s audio)

| Call | Time | Notes |
|---|---|---|
| 1st (cold) | 54.83s | model download + load |
| 2nd (warm) | 0.61s | reuse cached model |
| **Speedup** | **~90x** | |

## Test plan

- [x] Smoke test passed: `whisperx_model reused: YES`, `align_model reused: YES`, `clear_cuda() releases all: YES`
- [ ] Integration test with real GPU workload (Assurant pipeline) — validate heartbeat survives + VRAM freed on `clear_cuda()`
- [ ] Verify diarizer caching with `audio_to_srt()` on a real diarized call

## Related

Complements flowtask FEAT-020 (`extract-transcript-event-loop-blocking-fix`): the executor offloading (TASK-055) + pre-warm (TASK-056) fix the event-loop blocking; this PR eliminates the per-file cold model reload cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)