### PR TITLE
Add AgentFactory orchestrator with HITL gates and specialist builders

### DIFF
--- a/docs/agent_factory_handler.md
+++ b/docs/agent_factory_handler.md
@@ -1,0 +1,313 @@
+# AgentFactory HTTP API
+
+Reference for the `AgentFactoryHandler` endpoint and the HITL flow needed
+to drive it from a chat interface.
+
+## Overview
+
+The AgentFactory is a meta-agent that turns a natural-language description
+into a registered, ready-to-use agent. It orchestrates an LLM **router**, one
+of three **specialist builders** (`rag`, `tool_agent`, `clone`), and a final
+**finalize** step that writes the YAML to `agents/<category>/` and reloads
+the `AgentRegistry`.
+
+Every run goes through two human-in-the-loop checkpoints:
+
+- **pre-delegation** — the user approves which specialist will draft the
+  agent before the factory pays for the specialist's LLM tokens.
+- **pre-finalize** — the user reviews the generated YAML before it is
+  persisted and the registry is reloaded.
+
+Both gates can time out (`TimeoutAction.CANCEL`), guaranteeing the factory
+never burns LLM tokens past a checkpoint the user abandoned.
+
+## Base URL
+
+```
+/api/v1/agents/factory
+```
+
+The route is registered automatically by `BotManager`. No host wiring
+required as long as `BotManager.setup_routes(app)` ran at startup.
+
+## Endpoints
+
+### Create a new agent (POST)
+
+Drives the full factory flow synchronously: route → pre-delegation HITL →
+specialist build → pre-finalize HITL → finalize. The HTTP response holds
+the terminal `FactoryResult`.
+
+**Endpoint:** `POST /api/v1/agents/factory`
+
+**Request body**
+
+```jsonc
+{
+  // required — natural-language description of the agent to build
+  "description": "Create an agent that generates and posts LinkedIn content, finding recent news and never duplicating content.",
+
+  // optional — short-circuit the router toward CloneAgentBuilder.
+  // Equivalent to telling the LLM 'clone X then mutate it'.
+  "clone_from": "ATTBot",
+
+  // optional — pin a builder or pass auxiliary info to the router.
+  // 'builder' must be one of: rag | tool_agent | clone.
+  "hints": {
+    "builder": "tool_agent",
+    "integrations": ["linkedin"]
+  },
+
+  // optional — subdirectory under agents/ where the YAML is written
+  // (defaults to "general"). Useful to group agents per tenant/domain.
+  "category": "marketing",
+
+  // optional — LLM provider tag used to back the router & builders.
+  // Falls back to "google" / Gemini Flash.
+  "use_llm": "google",
+  "llm": null,
+
+  // optional — bypass both HITL checkpoints. Returns the agent
+  // unattended. Intended for scripts / CI; DO NOT enable for end-user
+  // chat traffic.
+  "auto_approve": false,
+
+  // optional — only relevant when auto_approve is false. Selects which
+  // registered channel the HumanInteractionManager dispatches gates to.
+  // Defaults to "web" so the WebHumanChannel can stream prompts over
+  // the existing user socket.
+  "human_channel": "web",
+
+  // optional — recipient ids the channel routes to. For the web
+  // channel this is the authenticated user id.
+  "human_targets": ["alice@acme.example"]
+}
+```
+
+**Response — 200 OK (status: success)**
+
+```jsonc
+{
+  "status": "success",
+  "router_decision": {
+    "builder": "tool_agent",
+    "reasoning": "User requested LinkedIn integration with no native toolkit; tool_agent will register an OpenAPI toolkit.",
+    "detected_integrations": ["linkedin"]
+  },
+  "definition": {
+    "name": "LinkedInContentBot",
+    "class_name": "BasicAgent",
+    "module": "parrot.bots.agent",
+    "enabled": true,
+    "system_prompt": "You are a LinkedIn content assistant…",
+    "model": {"provider": "google", "model": "gemini-2.5-flash", "temperature": 0.4, "max_tokens": 4096},
+    "tools": {"tools": [], "toolkits": ["openapi_linkedin"], "mcp_servers": []},
+    "tags": ["requires_approval"]
+  },
+  "yaml_path": "/srv/parrot/agents/marketing/linkedincontentbot.yaml",
+  "provisioning": [
+    {"kind": "openapi_toolkit", "name": "openapi_linkedin", "details": {"service": "linkedin", "operations": 27, "auth_type": "bearer"}}
+  ]
+}
+```
+
+**Response — 202 Accepted (status: cancelled_by_user | timeout)**
+
+The factory ran but the user bailed or did not respond. `cancelled_at`
+tells the chat UI which gate stopped the flow.
+
+```jsonc
+{
+  "status": "cancelled_by_user",     // or "timeout"
+  "cancelled_at": "pre_delegation",  // or "pre_finalize"
+  "router_decision": { /* … */ },
+  "definition": { /* present only when cancelled_at == "pre_finalize" */ }
+}
+```
+
+If the user cancels at `pre_finalize`, the response still carries the
+`definition` and `provisioning` records — the chat UI can offer to keep
+provisioned resources (e.g. the vector-store table) or surface them for
+cleanup.
+
+**Response — 400 Bad Request**
+
+Returned when `description` is missing or the JSON body is invalid.
+
+```json
+{"status": "error", "message": "description is required"}
+```
+
+**Response — 500 Internal Server Error (status: failed)**
+
+The orchestrator raised an unrecoverable error. The body mirrors the
+`FactoryResult` shape with `status: "failed"` and a free-text `error`.
+
+```jsonc
+{
+  "status": "failed",
+  "error": "Specialist tool_agent failed: spec URL returned 404",
+  "router_decision": { /* … */ }
+}
+```
+
+## HITL flow for a chat interface
+
+The factory blocks the HTTP request while it waits for the user to clear
+each gate. For a chat UI this is fine because the WebHumanChannel pushes
+prompts over a WebSocket — the chat UI does not poll, it just renders
+prompts as they arrive and POSTs the user's response.
+
+### Prerequisites
+
+1. `setup_web_hitl(app)` must run at startup. `BotManager` schedules this
+   automatically as an `on_startup` callback, provided
+   `app['user_socket_manager']` is already set when the manager initialises.
+2. The chat client must be connected over the user socket so prompts can
+   reach it. The socket name and authentication are owned by
+   `UserSocketManager`.
+
+### Sequence
+
+```
+chat-ui                  POST /api/v1/agents/factory
+   │   description=…                  ▶ handler
+   │   human_channel="web"
+   │                                  ┌── route (LLM)
+   │                                  │
+   │                                  ▼
+   │   ws: hitl_request               ┌── pre-delegation gate
+   │ ◀────────────────────────────────┤   (HumanInteractionManager
+   │   { interaction_id,              │    via WebHumanChannel)
+   │     question,                    │
+   │     options: [confirm,cancel] }  │
+   │                                  │
+   │   POST /api/v1/agents/hitl/respond
+   │ ─────────────────────────────────▶   { interaction_id, value: "confirm" }
+   │                                  │
+   │                                  ▼
+   │                                  ┌── specialist.build (LLM)
+   │                                  │
+   │                                  ▼
+   │   ws: hitl_request               ┌── pre-finalize gate
+   │ ◀────────────────────────────────┤   (shows the YAML for review)
+   │                                  │
+   │   POST /api/v1/agents/hitl/respond
+   │ ─────────────────────────────────▶   { interaction_id, value: "confirm" }
+   │                                  │
+   │                                  ▼
+   │                                  ┌── finalize_agent_registration
+   │                                  │   (write YAML + reload registry)
+   │                                  │
+   │   HTTP 200                       ▼
+   │ ◀────────────────────────────────  FactoryResult JSON
+```
+
+### Companion endpoint: submit a HITL response
+
+The chat UI uses the **existing** HITL response endpoint to clear gates.
+The factory does not need its own confirm/cancel route.
+
+```
+POST /api/v1/agents/hitl/respond
+```
+
+**Body**
+
+```json
+{
+  "interaction_id": "<uuid from the ws hitl_request payload>",
+  "value": "confirm"
+}
+```
+
+`value` accepts `"confirm" | "approve" | "approved" | "yes" | "y" | true`
+as approval (case-insensitive). Anything else — including `"cancel"` — is
+treated as rejection.
+
+### WebSocket payload the chat UI receives at each gate
+
+```jsonc
+{
+  "type": "hitl_request",
+  "interaction_id": "f4b2…",
+  "source_agent": "agent_factory",
+  "source_node": "pre_delegation",        // or "pre_finalize"
+  "question": "I will use the **tool_agent** specialist…",
+  "interaction_type": "approval",
+  "options": [
+    {"key": "confirm", "label": "Approve"},
+    {"key": "cancel",  "label": "Cancel"}
+  ],
+  "timeout": 120                          // seconds remaining before auto-cancel
+}
+```
+
+`source_node` lets the UI tailor the rendering — at `pre_finalize` the
+`question` body already contains a `yaml`-fenced preview of the generated
+agent definition, which the chat client can render with a YAML highlighter.
+
+### Timeouts
+
+Per-gate timeouts default to:
+
+| Gate            | Default | Override env var                       |
+|-----------------|---------|----------------------------------------|
+| pre_delegation  | 120 s   | `FACTORY_HITL_DELEGATION_TIMEOUT`      |
+| pre_finalize    | 600 s   | `FACTORY_HITL_FINALIZE_TIMEOUT`        |
+
+A timed-out gate resolves the factory run with `status: "timeout"` and the
+HTTP response unblocks immediately. The chat UI should surface this as
+"the factory request expired" and offer to restart.
+
+## Example: minimal chat client (TypeScript)
+
+```ts
+async function createAgent(description: string) {
+  const res = await fetch("/api/v1/agents/factory", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      description,
+      human_channel: "web",
+      human_targets: [currentUserId()],
+    }),
+  });
+  return res.json() as Promise<FactoryResult>;
+}
+
+// Wire the user socket to forward HITL prompts to the chat UI.
+userSocket.on("hitl_request", (payload) => {
+  chatThread.renderPrompt(payload, async (choice) => {
+    await fetch("/api/v1/agents/hitl/respond", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      credentials: "include",                    // session cookie
+      body: JSON.stringify({
+        interaction_id: payload.interaction_id,
+        value: choice,                            // "confirm" | "cancel"
+      }),
+    });
+  });
+});
+```
+
+## Non-interactive usage
+
+For scripts, CI checks, or callers that already approved through their own
+UI (e.g. an internal admin panel), pass `auto_approve: true` and skip the
+HITL plumbing entirely:
+
+```bash
+curl -X POST /api/v1/agents/factory \
+  -H 'content-type: application/json' \
+  -d '{
+    "description": "A RAG bot for product manuals stored in PgVector",
+    "category": "support",
+    "auto_approve": true
+  }'
+```
+
+The handler injects an in-memory channel that resolves both gates with
+`confirm`. The factory still writes the YAML and reloads the registry, but
+nothing is sent over WebSocket and no human ever sees a prompt.

--- a/packages/ai-parrot/src/parrot/bots/factory/__init__.py
+++ b/packages/ai-parrot/src/parrot/bots/factory/__init__.py
@@ -1,0 +1,26 @@
+"""Agent Factory: orchestrator + specialist builders that generate, validate
+and register new agent YAML definitions in the ``AgentRegistry``.
+"""
+from parrot.bots.factory.contracts import (
+    AgentDefinition,
+    BuilderOutput,
+    BuilderType,
+    FactoryRequest,
+    FactoryResult,
+    FactoryStatus,
+    HITLCheckpoint,
+    ProvisioningRecord,
+    RouterDecision,
+)
+
+__all__ = [
+    "AgentDefinition",
+    "BuilderOutput",
+    "BuilderType",
+    "FactoryRequest",
+    "FactoryResult",
+    "FactoryStatus",
+    "HITLCheckpoint",
+    "ProvisioningRecord",
+    "RouterDecision",
+]

--- a/packages/ai-parrot/src/parrot/bots/factory/__init__.py
+++ b/packages/ai-parrot/src/parrot/bots/factory/__init__.py
@@ -12,9 +12,11 @@ from parrot.bots.factory.contracts import (
     ProvisioningRecord,
     RouterDecision,
 )
+from parrot.bots.factory.orchestrator import AgentFactoryOrchestrator
 
 __all__ = [
     "AgentDefinition",
+    "AgentFactoryOrchestrator",
     "BuilderOutput",
     "BuilderType",
     "FactoryRequest",

--- a/packages/ai-parrot/src/parrot/bots/factory/builders/__init__.py
+++ b/packages/ai-parrot/src/parrot/bots/factory/builders/__init__.py
@@ -1,0 +1,12 @@
+"""Specialist builders the orchestrator delegates to."""
+from parrot.bots.factory.builders.base import BaseFactoryBuilder
+from parrot.bots.factory.builders.clone_builder import CloneAgentBuilder
+from parrot.bots.factory.builders.rag_builder import RAGBuilderAgent
+from parrot.bots.factory.builders.tool_agent_builder import ToolAgentBuilderAgent
+
+__all__ = [
+    "BaseFactoryBuilder",
+    "CloneAgentBuilder",
+    "RAGBuilderAgent",
+    "ToolAgentBuilderAgent",
+]

--- a/packages/ai-parrot/src/parrot/bots/factory/builders/base.py
+++ b/packages/ai-parrot/src/parrot/bots/factory/builders/base.py
@@ -1,0 +1,167 @@
+"""Shared base class for specialist builders.
+
+A builder is a thin wrapper over a ``BasicAgent`` with:
+
+- a specialist system prompt embedding the YAML schema and conventions
+- a curated toolset (introspection + builder-specific deterministic tools)
+- a single ``build`` entry point that emits a ``BuilderOutput`` via the
+  LLM's structured-output channel
+
+The orchestrator never speaks to ``BasicAgent`` directly — it only calls
+``builder.build(request, decision)`` and consumes the typed result.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, ClassVar, Dict, List, Optional
+
+from parrot.bots.agent import BasicAgent
+from parrot.bots.factory.contracts import (
+    AgentDefinition,
+    BuilderOutput,
+    BuilderType,
+    FactoryRequest,
+    RouterDecision,
+)
+
+
+COMMON_SCHEMA_NOTES = """\
+The YAML AgentDefinition follows this shape (Pydantic: BotConfig):
+
+  name: str               # PascalCase, unique
+  class_name: str         # implementing class, default "BasicAgent"
+  module: str             # default "parrot.bots.agent"
+  enabled: bool           # default true
+  description: str        # short purpose
+  system_prompt: str|dict # the agent persona / instructions
+  model:
+    provider: str         # openai | anthropic | google | groq | vertex
+    model: str            # provider-specific id
+    temperature: float
+    max_tokens: int
+  tools:
+    tools: list[dict]     # standalone @tool function names
+    toolkits: list[str]   # ToolkitRegistry names (lower-case)
+    mcp_servers: list[dict]
+  vector_store:           # only for RAG agents
+    provider: pgvector
+    table: str
+    schema: str
+    dimension: int
+    embedding_model: str
+  tags: list[str]
+
+Toolkits must match names returned by list_available_toolkits. Do not invent
+toolkit names. If the user needs an integration with no native toolkit, call
+register_openapi_toolkit FIRST and use the returned name."""
+
+
+class BaseFactoryBuilder:
+    """Common machinery for the three specialists."""
+
+    builder_type: ClassVar[BuilderType]
+    system_prompt: ClassVar[str]
+
+    def __init__(
+        self,
+        *,
+        llm: Optional[str] = None,
+        use_llm: str = "google",
+        agent_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.logger = logging.getLogger(f"Parrot.Factory.{self.__class__.__name__}")
+        self._llm = llm
+        self._use_llm = use_llm
+        self._agent_kwargs = agent_kwargs or {}
+
+    # ---- tool wiring --------------------------------------------------------
+
+    def _tools(self) -> List[Any]:
+        """Tools available to this specialist. Override to add more."""
+        from parrot.bots.factory.tools.introspection import (
+            _list_available_toolkits_tool,
+            _list_available_tools_tool,
+        )
+
+        return [_list_available_toolkits_tool, _list_available_tools_tool]
+
+    def _make_agent(self) -> BasicAgent:
+        return BasicAgent(
+            name=f"{self.builder_type.value}_builder",
+            agent_id=f"factory_{self.builder_type.value}_builder",
+            use_llm=self._use_llm,
+            llm=self._llm,
+            tools=self._tools(),
+            system_prompt=self.system_prompt,
+            **self._agent_kwargs,
+        )
+
+    # ---- prompt rendering ---------------------------------------------------
+
+    def _render_user_prompt(
+        self,
+        request: FactoryRequest,
+        decision: RouterDecision,
+    ) -> str:
+        return (
+            f"User request:\n{request.description}\n\n"
+            f"Router reasoning: {decision.reasoning}\n"
+            f"Detected integrations: {decision.detected_integrations or 'none'}\n\n"
+            "Produce a BuilderOutput. The 'definition' field MUST be a valid "
+            "AgentDefinition with all required keys filled in. Use the tools "
+            "to discover capabilities; do not invent toolkit names."
+        )
+
+    # ---- main entry point ---------------------------------------------------
+
+    async def build(
+        self,
+        request: FactoryRequest,
+        decision: RouterDecision,
+    ) -> BuilderOutput:
+        agent = self._make_agent()
+        prompt = self._render_user_prompt(request, decision)
+
+        self.logger.info("Building %s agent for: %s",
+                         self.builder_type.value, request.description[:80])
+
+        result = await agent.ask(prompt, response_model=BuilderOutput)
+        return self._coerce_output(result)
+
+    # ---- result normalisation ----------------------------------------------
+
+    def _coerce_output(self, result: Any) -> BuilderOutput:
+        """Normalise ``BasicAgent.ask`` return shape to a ``BuilderOutput``.
+
+        ``ask`` returns either a ``ChatResponse``-ish object whose ``output``
+        is the parsed Pydantic model, or the model itself depending on the
+        client. Accept both, plus the JSON-string fallback when the client
+        cannot natively bind structured output.
+        """
+        candidate = getattr(result, "output", result)
+        if isinstance(candidate, BuilderOutput):
+            return candidate
+        if isinstance(candidate, AgentDefinition):
+            return BuilderOutput(
+                builder=self.builder_type, definition=candidate, provisioning=[]
+            )
+        if isinstance(candidate, dict):
+            if "definition" in candidate:
+                return BuilderOutput(**candidate)
+            return BuilderOutput(
+                builder=self.builder_type,
+                definition=AgentDefinition(**candidate),
+            )
+        if isinstance(candidate, str):
+            data = json.loads(candidate)
+            if "definition" in data:
+                return BuilderOutput(**data)
+            return BuilderOutput(
+                builder=self.builder_type,
+                definition=AgentDefinition(**data),
+            )
+        raise TypeError(
+            f"Specialist {self.builder_type.value} returned unsupported "
+            f"output type: {type(result).__name__}"
+        )

--- a/packages/ai-parrot/src/parrot/bots/factory/builders/clone_builder.py
+++ b/packages/ai-parrot/src/parrot/bots/factory/builders/clone_builder.py
@@ -1,0 +1,76 @@
+"""Specialist that clones an existing agent definition with mutations."""
+from __future__ import annotations
+
+from typing import Any, ClassVar, List
+
+from parrot.bots.factory.builders.base import COMMON_SCHEMA_NOTES, BaseFactoryBuilder
+from parrot.bots.factory.contracts import (
+    BuilderOutput,
+    BuilderType,
+    FactoryRequest,
+    RouterDecision,
+)
+
+
+_CLONE_PROMPT = f"""\
+You are CloneAgentBuilder, a specialist that clones an existing ai-parrot
+agent definition and applies the user's requested mutations.
+
+Decision flow:
+1. Call `list_registered_agents` to confirm the source agent exists.
+2. Call `load_agent_definition` with the source agent's name to obtain its
+   current YAML payload as a dict.
+3. Produce a BuilderOutput whose `definition` mirrors the source EXCEPT for
+   the fields the user wants changed (typical: name, system_prompt, tags,
+   vector_store.table). Keep model + toolkits unless told otherwise.
+4. Generate a new unique `name`. Do not reuse the source name.
+5. Add a ProvisioningRecord(kind="other", name="cloned_from:<source>") so
+   the orchestrator can surface the lineage.
+
+{COMMON_SCHEMA_NOTES}
+"""
+
+
+class CloneAgentBuilder(BaseFactoryBuilder):
+    """Specialist that produces cloned agent definitions."""
+
+    builder_type: ClassVar[BuilderType] = BuilderType.CLONE
+    system_prompt: ClassVar[str] = _CLONE_PROMPT
+
+    def _tools(self) -> List[Any]:
+        from parrot.bots.factory.tools.introspection import (
+            _list_registered_agents_tool,
+            _load_agent_definition_tool,
+        )
+
+        return [
+            *super()._tools(),
+            _list_registered_agents_tool,
+            _load_agent_definition_tool,
+        ]
+
+    def _render_user_prompt(
+        self,
+        request: FactoryRequest,
+        decision: RouterDecision,
+    ) -> str:
+        clone_hint = ""
+        if request.clone_from:
+            clone_hint = (
+                f"\nSource agent to clone from: {request.clone_from}\n"
+                "Load it with `load_agent_definition` before producing the "
+                "BuilderOutput.\n"
+            )
+        return super()._render_user_prompt(request, decision) + clone_hint
+
+    async def build(
+        self,
+        request: FactoryRequest,
+        decision: RouterDecision,
+    ) -> BuilderOutput:
+        if not request.clone_from:
+            raise ValueError(
+                "CloneAgentBuilder requires FactoryRequest.clone_from to be "
+                "set — the router should have populated it before delegating."
+            )
+        return await super().build(request, decision)

--- a/packages/ai-parrot/src/parrot/bots/factory/builders/rag_builder.py
+++ b/packages/ai-parrot/src/parrot/bots/factory/builders/rag_builder.py
@@ -1,0 +1,47 @@
+"""Specialist that designs RAG chatbots backed by PgVector."""
+from __future__ import annotations
+
+from typing import Any, ClassVar, List
+
+from parrot.bots.factory.builders.base import COMMON_SCHEMA_NOTES, BaseFactoryBuilder
+from parrot.bots.factory.contracts import BuilderType
+
+
+_RAG_PROMPT = f"""\
+You are RAGBuilderAgent, a specialist that designs RAG (retrieval-augmented
+generation) chatbots inside ai-parrot.
+
+Your single responsibility is to produce a BuilderOutput whose `definition`
+configures a RAG-capable BasicAgent with a PgVector vector_store.
+
+Rules:
+- Always call `provision_vector_store` to create the backing table before
+  emitting the definition. Record the result in the `vector_store` block of
+  the definition AND in the BuilderOutput.provisioning list.
+- Pick a sensible `table` name from the user's domain (snake_case, prefixed
+  with `rag_`). Default `schema` is `public`. Default `dimension` is 768
+  unless the user specified an embedding model that implies otherwise.
+- Pick `class_name = "BasicAgent"` and `module = "parrot.bots.agent"` unless
+  the user explicitly asked for a different bot class.
+- The `system_prompt` must describe the bot's persona, the corpus it can
+  retrieve from, and explicit instructions to ground answers on retrieved
+  context.
+- Default model: provider=`google`, model=`gemini-2.5-flash`,
+  temperature=0.2, max_tokens=4096 — override only if the user said so.
+- tools.toolkits stays empty unless the user mentioned an extra integration
+  on top of retrieval.
+
+{COMMON_SCHEMA_NOTES}
+"""
+
+
+class RAGBuilderAgent(BaseFactoryBuilder):
+    """Specialist that produces RAG chatbot definitions."""
+
+    builder_type: ClassVar[BuilderType] = BuilderType.RAG
+    system_prompt: ClassVar[str] = _RAG_PROMPT
+
+    def _tools(self) -> List[Any]:
+        from parrot.bots.factory.tools.vector_store import _provision_vector_store_tool
+
+        return [*super()._tools(), _provision_vector_store_tool]

--- a/packages/ai-parrot/src/parrot/bots/factory/builders/tool_agent_builder.py
+++ b/packages/ai-parrot/src/parrot/bots/factory/builders/tool_agent_builder.py
@@ -1,0 +1,51 @@
+"""Specialist that designs tool-using agents backed by toolkits / MCP servers."""
+from __future__ import annotations
+
+from typing import Any, ClassVar, List
+
+from parrot.bots.factory.builders.base import COMMON_SCHEMA_NOTES, BaseFactoryBuilder
+from parrot.bots.factory.contracts import BuilderType
+
+
+_TOOL_AGENT_PROMPT = f"""\
+You are ToolAgentBuilderAgent, a specialist that designs tool-using agents
+inside ai-parrot.
+
+Your single responsibility is to produce a BuilderOutput whose `definition`
+configures a BasicAgent with the right mix of toolkits and standalone
+tools to satisfy the user's request.
+
+Decision flow:
+1. Call `list_available_toolkits` and `list_available_tools` to see what is
+   already shipped. ONLY reference these names in the definition.
+2. If the user needs an integration with NO matching toolkit (LinkedIn,
+   Notion, custom REST API, …), call `register_openapi_toolkit` with a
+   public OpenAPI spec URL. Use the returned `toolkit_name` in
+   `definition.toolkits`. Add a ProvisioningRecord(kind="openapi_toolkit").
+3. If the agent will write to / publish on an external service, set the
+   definition tag `requires_approval` and mention in `system_prompt` that
+   destructive actions need explicit user confirmation. Never silently
+   enable autonomous posting/sending.
+4. Pick `class_name = "BasicAgent"` and `module = "parrot.bots.agent"`
+   unless the user explicitly wants another bot class.
+5. Default model: provider=`google`, model=`gemini-2.5-flash`,
+   temperature=0.4, max_tokens=4096 — override only if the user said so.
+6. `vector_store` stays null. If the user asked for retrieval, switch to
+   RAGBuilderAgent territory (note it and refuse).
+
+{COMMON_SCHEMA_NOTES}
+"""
+
+
+class ToolAgentBuilderAgent(BaseFactoryBuilder):
+    """Specialist that produces tool-using agent definitions."""
+
+    builder_type: ClassVar[BuilderType] = BuilderType.TOOL_AGENT
+    system_prompt: ClassVar[str] = _TOOL_AGENT_PROMPT
+
+    def _tools(self) -> List[Any]:
+        from parrot.bots.factory.tools.openapi_register import (
+            _register_openapi_toolkit_tool,
+        )
+
+        return [*super()._tools(), _register_openapi_toolkit_tool]

--- a/packages/ai-parrot/src/parrot/bots/factory/contracts.py
+++ b/packages/ai-parrot/src/parrot/bots/factory/contracts.py
@@ -1,0 +1,135 @@
+"""Pydantic contracts for the Agent Factory subsystem.
+
+The factory orchestrates several specialist builder agents (RAG, tool-agent,
+clone). Every specialist produces the same end-shape: a ``BotConfig`` ready to
+be persisted as YAML and registered with the ``AgentRegistry``. The wrapper
+types below carry orchestrator-level state (routing decisions, provisioning
+side-effects, HITL outcomes) around that shared payload.
+
+The ``AgentDefinition`` alias points at ``BotConfig`` deliberately — there is
+exactly one source of truth for the registry schema and the factory consumes
+it directly to avoid drift.
+"""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+from parrot.registry.registry import BotConfig
+
+AgentDefinition = BotConfig
+
+
+class BuilderType(str, Enum):
+    """Specialist builders the orchestrator can delegate to."""
+
+    RAG = "rag"
+    TOOL_AGENT = "tool_agent"
+    CLONE = "clone"
+
+
+class HITLCheckpoint(str, Enum):
+    """Named human-in-the-loop checkpoints in the factory flow."""
+
+    PRE_DELEGATION = "pre_delegation"
+    PRE_FINALIZE = "pre_finalize"
+
+
+class FactoryStatus(str, Enum):
+    """Terminal states for a factory run."""
+
+    SUCCESS = "success"
+    CANCELLED_BY_USER = "cancelled_by_user"
+    TIMEOUT = "timeout"
+    FAILED = "failed"
+
+
+class FactoryRequest(BaseModel):
+    """User-facing input to the orchestrator.
+
+    ``description`` is the natural-language ask. ``clone_from`` short-circuits
+    the router toward the CloneBuilder. ``hints`` lets callers pin choices the
+    LLM would otherwise infer (useful for the HTTP handler when the caller
+    already knows the desired builder).
+    """
+
+    description: str = Field(..., min_length=1)
+    clone_from: Optional[str] = Field(
+        default=None,
+        description="Name of an existing agent in the registry to clone from.",
+    )
+    hints: Dict[str, Any] = Field(default_factory=dict)
+
+
+class RouterDecision(BaseModel):
+    """First-stage output: which specialist the orchestrator wants to invoke.
+
+    The LLM emits this via structured output. The orchestrator then surfaces
+    it through ``HITLCheckpoint.PRE_DELEGATION`` for user confirmation before
+    paying for the specialist's tokens.
+    """
+
+    builder: BuilderType
+    reasoning: str = Field(
+        ...,
+        description="One-paragraph justification shown to the user at the "
+        "pre-delegation checkpoint.",
+    )
+    detected_integrations: List[str] = Field(
+        default_factory=list,
+        description="External services the router detected in the request "
+        "(e.g. 'linkedin', 'jira'). The specialist uses this to decide "
+        "whether to register an OpenAPI toolkit on the fly.",
+    )
+
+
+class ProvisioningRecord(BaseModel):
+    """Side-effect produced by a builder while drafting the definition.
+
+    Builders may provision a vector store, register an OpenAPI toolkit, etc.
+    These records let the orchestrator report what was done and, if the user
+    cancels at pre-finalize, surface the items that may need cleanup.
+    """
+
+    kind: Literal["vector_store", "openapi_toolkit", "other"]
+    name: str
+    details: Dict[str, Any] = Field(default_factory=dict)
+
+
+class BuilderOutput(BaseModel):
+    """Specialist-to-orchestrator handoff payload.
+
+    Every builder returns this shape regardless of internal flow.
+    """
+
+    builder: BuilderType
+    definition: AgentDefinition
+    provisioning: List[ProvisioningRecord] = Field(default_factory=list)
+    notes: Optional[str] = Field(
+        default=None,
+        description="Free-form notes the builder wants surfaced at "
+        "pre-finalize (e.g. assumptions, deferred work).",
+    )
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+class FactoryResult(BaseModel):
+    """Terminal output of an orchestrator run.
+
+    ``definition`` and ``yaml_path`` are populated only when ``status`` is
+    ``SUCCESS``. ``cancelled_at`` records which HITL checkpoint the user
+    bailed at, so the handler/CLI can show a meaningful message.
+    """
+
+    status: FactoryStatus
+    definition: Optional[AgentDefinition] = None
+    yaml_path: Optional[str] = None
+    provisioning: List[ProvisioningRecord] = Field(default_factory=list)
+    cancelled_at: Optional[HITLCheckpoint] = None
+    error: Optional[str] = None
+    router_decision: Optional[RouterDecision] = None
+
+    model_config = {"arbitrary_types_allowed": True}

--- a/packages/ai-parrot/src/parrot/bots/factory/orchestrator.py
+++ b/packages/ai-parrot/src/parrot/bots/factory/orchestrator.py
@@ -1,0 +1,326 @@
+"""AgentFactoryOrchestrator — the user-facing entry point of the factory.
+
+The orchestrator runs a small LLM router to pick a specialist, gates that
+choice through a pre-delegation HITL checkpoint, delegates the actual
+drafting to the specialist, gates the resulting ``AgentDefinition`` through a
+pre-finalize HITL checkpoint, and finally writes + registers the YAML.
+
+The two HITL checkpoints are the cost-protection mechanism: if the user
+times out or cancels at either gate, the orchestrator returns immediately
+without invoking the next LLM stage.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict, Mapping, Optional
+
+import yaml
+
+from parrot.bots.agent import BasicAgent
+from parrot.bots.factory.builders import (
+    BaseFactoryBuilder,
+    CloneAgentBuilder,
+    RAGBuilderAgent,
+    ToolAgentBuilderAgent,
+)
+from parrot.bots.factory.contracts import (
+    BuilderOutput,
+    BuilderType,
+    FactoryRequest,
+    FactoryResult,
+    FactoryStatus,
+    HITLCheckpoint,
+    RouterDecision,
+)
+from parrot.bots.factory.tools.finalize import finalize_agent_registration
+from parrot.bots.factory.tools.introspection import _list_registered_agents_tool
+from parrot.human.manager import HumanInteractionManager
+from parrot.human.models import (
+    ChoiceOption,
+    HumanInteraction,
+    InteractionStatus,
+    InteractionType,
+    TimeoutAction,
+)
+
+
+_ROUTER_PROMPT = """\
+You are the AgentFactory router. The user wants to create a new agent.
+Inspect the request and pick exactly one specialist builder.
+
+BuilderType options:
+- "rag": user wants a retrieval-augmented chatbot (mentions corpus,
+  knowledge base, documents, embeddings, "ask questions about X").
+- "tool_agent": user wants an agent that takes actions via APIs / toolkits
+  (mentions integrations, "post to", "search the web", "create a ticket").
+- "clone": user explicitly asks to clone, copy, or replicate an existing
+  agent ("a partir de X crea otro Bot para Y"). Call list_registered_agents
+  first to confirm the source exists; populate detected_integrations with
+  the source agent name.
+
+Always emit a RouterDecision via structured output. Keep reasoning under 4
+sentences — it goes to the user verbatim at the pre-delegation gate."""
+
+
+def _default_timeouts() -> Dict[HITLCheckpoint, float]:
+    return {
+        HITLCheckpoint.PRE_DELEGATION: float(
+            os.getenv("FACTORY_HITL_DELEGATION_TIMEOUT", "120")
+        ),
+        HITLCheckpoint.PRE_FINALIZE: float(
+            os.getenv("FACTORY_HITL_FINALIZE_TIMEOUT", "600")
+        ),
+    }
+
+
+class AgentFactoryOrchestrator:
+    """Orchestrate router → specialist → finalize with HITL gates."""
+
+    def __init__(
+        self,
+        *,
+        human_manager: HumanInteractionManager,
+        human_channel: str = "cli",
+        human_targets: Optional[list] = None,
+        llm: Optional[str] = None,
+        use_llm: str = "google",
+        builders: Optional[Mapping[BuilderType, BaseFactoryBuilder]] = None,
+        category: str = "general",
+        timeouts: Optional[Mapping[HITLCheckpoint, float]] = None,
+    ) -> None:
+        self.logger = logging.getLogger("Parrot.Factory.Orchestrator")
+        self.human_manager = human_manager
+        self.human_channel = human_channel
+        self.human_targets = human_targets or ["local"]
+        self.category = category
+        self.timeouts = {**_default_timeouts(), **(timeouts or {})}
+
+        self.builders: Dict[BuilderType, BaseFactoryBuilder] = dict(
+            builders
+            or {
+                BuilderType.RAG: RAGBuilderAgent(llm=llm, use_llm=use_llm),
+                BuilderType.TOOL_AGENT: ToolAgentBuilderAgent(llm=llm, use_llm=use_llm),
+                BuilderType.CLONE: CloneAgentBuilder(llm=llm, use_llm=use_llm),
+            }
+        )
+
+        self._llm = llm
+        self._use_llm = use_llm
+
+    # ---- public entry point -------------------------------------------------
+
+    async def run(self, request: FactoryRequest) -> FactoryResult:
+        """Drive the full factory flow for a single user request."""
+        # Phase 1: route
+        decision = await self._route(request)
+        self.logger.info("Router picked %s — %s", decision.builder.value,
+                         decision.reasoning[:120])
+
+        # Phase 2: HITL pre-delegation
+        delegation_ok = await self._confirm_delegation(decision)
+        if not delegation_ok.approved:
+            return FactoryResult(
+                status=delegation_ok.status,
+                router_decision=decision,
+                cancelled_at=HITLCheckpoint.PRE_DELEGATION,
+            )
+
+        # Phase 3: specialist build
+        builder = self.builders[decision.builder]
+        try:
+            output = await builder.build(request, decision)
+        except Exception as exc:  # noqa: BLE001 — surface as FAILED to caller
+            self.logger.exception("Specialist %s failed", decision.builder.value)
+            return FactoryResult(
+                status=FactoryStatus.FAILED,
+                router_decision=decision,
+                error=str(exc),
+            )
+
+        # Phase 4: HITL pre-finalize
+        finalize_ok = await self._confirm_finalize(output)
+        if not finalize_ok.approved:
+            return FactoryResult(
+                status=finalize_ok.status,
+                router_decision=decision,
+                cancelled_at=HITLCheckpoint.PRE_FINALIZE,
+                definition=output.definition,
+                provisioning=output.provisioning,
+            )
+
+        # Phase 5: persist + reload
+        try:
+            registration = await finalize_agent_registration(
+                output.definition, category=self.category
+            )
+        except Exception as exc:  # noqa: BLE001
+            self.logger.exception("Finalize failed for %s", output.definition.name)
+            return FactoryResult(
+                status=FactoryStatus.FAILED,
+                router_decision=decision,
+                definition=output.definition,
+                provisioning=output.provisioning,
+                error=str(exc),
+            )
+
+        return FactoryResult(
+            status=FactoryStatus.SUCCESS,
+            router_decision=decision,
+            definition=output.definition,
+            yaml_path=registration["yaml_path"],
+            provisioning=output.provisioning,
+        )
+
+    # ---- phase 1: routing ---------------------------------------------------
+
+    async def _route(self, request: FactoryRequest) -> RouterDecision:
+        if request.clone_from:
+            # User explicitly asked to clone — skip the LLM, the answer is
+            # already known.
+            return RouterDecision(
+                builder=BuilderType.CLONE,
+                reasoning=(
+                    f"User asked to clone from '{request.clone_from}'. "
+                    f"Delegating to CloneAgentBuilder."
+                ),
+                detected_integrations=[request.clone_from],
+            )
+
+        hinted = request.hints.get("builder")
+        if hinted:
+            try:
+                builder_type = BuilderType(hinted)
+            except ValueError:
+                pass
+            else:
+                return RouterDecision(
+                    builder=builder_type,
+                    reasoning=f"Caller pinned builder={builder_type.value} via hints.",
+                    detected_integrations=request.hints.get("integrations", []) or [],
+                )
+
+        router_agent = BasicAgent(
+            name="factory_router",
+            agent_id="factory_router",
+            use_llm=self._use_llm,
+            llm=self._llm,
+            tools=[_list_registered_agents_tool],
+            system_prompt=_ROUTER_PROMPT,
+        )
+
+        result = await router_agent.ask(
+            request.description, response_model=RouterDecision
+        )
+        candidate = getattr(result, "output", result)
+        if isinstance(candidate, RouterDecision):
+            return candidate
+        if isinstance(candidate, dict):
+            return RouterDecision(**candidate)
+        if isinstance(candidate, str):
+            return RouterDecision(**json.loads(candidate))
+        raise TypeError(
+            f"Router returned unsupported type: {type(result).__name__}"
+        )
+
+    # ---- HITL helpers -------------------------------------------------------
+
+    async def _confirm_delegation(self, decision: RouterDecision) -> "_GateResult":
+        question = (
+            f"I will use the **{decision.builder.value}** specialist to draft "
+            f"this agent.\n\nReasoning: {decision.reasoning}"
+        )
+        if decision.detected_integrations:
+            question += (
+                f"\n\nDetected integrations: "
+                f"{', '.join(decision.detected_integrations)}"
+            )
+        return await self._gate(
+            checkpoint=HITLCheckpoint.PRE_DELEGATION,
+            question=question,
+        )
+
+    async def _confirm_finalize(self, output: BuilderOutput) -> "_GateResult":
+        yaml_preview = yaml.safe_dump(
+            output.definition.model_dump(mode="json", exclude_none=True),
+            sort_keys=False,
+            allow_unicode=True,
+        )
+        provisioning_note = ""
+        if output.provisioning:
+            items = ", ".join(
+                f"{p.kind}:{p.name}" for p in output.provisioning
+            )
+            provisioning_note = f"\nSide-effects already applied: {items}\n"
+        question = (
+            f"Review the generated agent definition.{provisioning_note}\n"
+            f"```yaml\n{yaml_preview}```\n\n"
+            f"Approve to write `agents/{self.category}/"
+            f"{output.definition.name.lower()}.yaml` and reload the registry."
+        )
+        return await self._gate(
+            checkpoint=HITLCheckpoint.PRE_FINALIZE,
+            question=question,
+            notes=output.notes,
+        )
+
+    async def _gate(
+        self,
+        *,
+        checkpoint: HITLCheckpoint,
+        question: str,
+        notes: Optional[str] = None,
+    ) -> "_GateResult":
+        interaction = HumanInteraction(
+            question=question,
+            context=notes,
+            interaction_type=InteractionType.APPROVAL,
+            options=[
+                ChoiceOption(key="confirm", label="Approve"),
+                ChoiceOption(key="cancel", label="Cancel"),
+            ],
+            timeout=self.timeouts[checkpoint],
+            timeout_action=TimeoutAction.CANCEL,
+            target_humans=list(self.human_targets),
+            source_agent="agent_factory",
+            source_node=checkpoint.value,
+        )
+
+        result = await self.human_manager.request_human_input(
+            interaction, channel=self.human_channel
+        )
+        return _GateResult.from_interaction_result(result)
+
+
+class _GateResult:
+    """Internal helper — normalises an InteractionResult to (approved, status)."""
+
+    __slots__ = ("approved", "status")
+
+    def __init__(self, approved: bool, status: FactoryStatus) -> None:
+        self.approved = approved
+        self.status = status
+
+    @classmethod
+    def from_interaction_result(cls, result: Any) -> "_GateResult":
+        status = getattr(result, "status", None)
+        value = getattr(result, "consolidated_value", None)
+
+        if status == InteractionStatus.COMPLETED and _is_approval(value):
+            return cls(True, FactoryStatus.SUCCESS)
+        if status == InteractionStatus.TIMEOUT:
+            return cls(False, FactoryStatus.TIMEOUT)
+        return cls(False, FactoryStatus.CANCELLED_BY_USER)
+
+
+def _is_approval(value: Any) -> bool:
+    """Accept 'confirm', 'approve', True, or first-option behaviour."""
+    if value is True:
+        return True
+    if isinstance(value, str):
+        return value.lower() in {"confirm", "approve", "approved", "yes", "y"}
+    if isinstance(value, dict):
+        key = value.get("key") or value.get("value") or value.get("response")
+        return _is_approval(key)
+    return False

--- a/packages/ai-parrot/src/parrot/bots/factory/tools/__init__.py
+++ b/packages/ai-parrot/src/parrot/bots/factory/tools/__init__.py
@@ -1,0 +1,29 @@
+"""Deterministic tools the Agent Factory builders invoke.
+
+These are plain async helpers. They are also exposed as ``@tool``-decorated
+callables so the orchestrator/specialist LLMs can invoke them directly when
+that is more natural than calling them from Python.
+"""
+from parrot.bots.factory.tools.finalize import (
+    finalize_agent_registration,
+    write_agent_yaml,
+)
+from parrot.bots.factory.tools.introspection import (
+    list_available_toolkits,
+    list_available_tools,
+    list_registered_agents,
+    load_agent_definition,
+)
+from parrot.bots.factory.tools.openapi_register import register_openapi_toolkit
+from parrot.bots.factory.tools.vector_store import provision_vector_store
+
+__all__ = [
+    "finalize_agent_registration",
+    "list_available_toolkits",
+    "list_available_tools",
+    "list_registered_agents",
+    "load_agent_definition",
+    "provision_vector_store",
+    "register_openapi_toolkit",
+    "write_agent_yaml",
+]

--- a/packages/ai-parrot/src/parrot/bots/factory/tools/finalize.py
+++ b/packages/ai-parrot/src/parrot/bots/factory/tools/finalize.py
@@ -1,0 +1,68 @@
+"""Finalize step — write the YAML and reload the registry.
+
+This is the only tool that mutates the registry on disk. It is invoked at the
+very end of the factory flow, **after** the user has approved the
+``AgentDefinition`` at the pre-finalize HITL checkpoint.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+from parrot.bots.factory.contracts import AgentDefinition
+from parrot.registry import agent_registry
+from parrot.registry.registry import BotConfig
+from parrot.tools.decorators import tool
+
+
+async def write_agent_yaml(
+    definition: AgentDefinition,
+    category: str = "general",
+) -> Path:
+    """Persist an ``AgentDefinition`` as a YAML file under ``agents/<category>/``.
+
+    Delegates to ``AgentRegistry.create_agent_definition`` so the on-disk
+    layout matches what the registry's YAML loader expects.
+    """
+    if not isinstance(definition, BotConfig):
+        definition = BotConfig(**definition.model_dump())
+    return agent_registry.create_agent_definition(definition, category=category)
+
+
+async def finalize_agent_registration(
+    definition: AgentDefinition,
+    category: str = "general",
+) -> Dict[str, Any]:
+    """Write the YAML, reload the registry, and return the registration result.
+
+    Returns a dict with the YAML path and whether the registry picked up the
+    new definition (the registry skips ``enabled=False`` configs silently).
+    """
+    yaml_path = await write_agent_yaml(definition, category=category)
+
+    # Reload only the directory we just wrote to — avoids redundant rescans.
+    loaded = agent_registry.load_agent_definitions(yaml_path.parent)
+
+    is_registered = definition.name in agent_registry._registered_agents
+    return {
+        "yaml_path": str(yaml_path),
+        "registered": is_registered,
+        "definitions_loaded_in_directory": loaded,
+        "agent_name": definition.name,
+    }
+
+
+# --- LLM-facing wrapper ------------------------------------------------------
+
+
+@tool(name="finalize_agent_registration",
+      description="Persist the AgentDefinition to YAML and reload the "
+                  "AgentRegistry so the new agent is immediately available. "
+                  "ONLY call this after the user has approved the definition "
+                  "at the pre-finalize checkpoint.")
+async def _finalize_agent_registration_tool(
+    definition: Dict[str, Any],
+    category: str = "general",
+) -> Dict[str, Any]:
+    config = BotConfig(**definition)
+    return await finalize_agent_registration(config, category=category)

--- a/packages/ai-parrot/src/parrot/bots/factory/tools/introspection.py
+++ b/packages/ai-parrot/src/parrot/bots/factory/tools/introspection.py
@@ -1,0 +1,116 @@
+"""Introspection helpers — the catalog the builders show to their LLM.
+
+Every helper has a plain async function (callable from builder code) and a
+``@tool``-decorated wrapper of the same name suffix for LLM invocation.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from parrot.registry import agent_registry
+from parrot.tools.decorators import tool
+from parrot.tools.registry import ToolkitRegistry
+
+
+async def list_available_toolkits() -> List[Dict[str, str]]:
+    """Return the registered toolkit catalog: name + class docstring summary."""
+    catalog: List[Dict[str, str]] = []
+    for name, cls in ToolkitRegistry.get_registry().items():
+        doc = (cls.__doc__ or "").strip().splitlines()
+        summary = doc[0] if doc else ""
+        catalog.append(
+            {
+                "name": name,
+                "class_name": cls.__name__,
+                "module": cls.__module__,
+                "summary": summary,
+            }
+        )
+    return sorted(catalog, key=lambda item: item["name"])
+
+
+async def list_available_tools() -> List[Dict[str, str]]:
+    """Return the catalog of standalone ``@tool`` functions discovered.
+
+    The factory currently relies on the toolkit catalog for capability
+    discovery; standalone tools surface here so builders can reference them
+    by name in ``tools.tools`` of an ``AgentDefinition``.
+    """
+    from parrot.tools import _imports  # noqa: F401 — triggers @tool registration
+
+    import parrot.tools as parrot_tools
+
+    catalog: List[Dict[str, str]] = []
+    for attr in dir(parrot_tools):
+        obj = getattr(parrot_tools, attr, None)
+        meta = getattr(obj, "_tool_metadata", None)
+        if meta is None:
+            continue
+        catalog.append(
+            {
+                "name": meta.get("name", attr),
+                "description": (meta.get("description") or "").strip(),
+            }
+        )
+    return sorted(catalog, key=lambda item: item["name"])
+
+
+async def list_registered_agents() -> List[Dict[str, Any]]:
+    """List agents currently known to ``AgentRegistry`` (YAML + decorator)."""
+    agents: List[Dict[str, Any]] = []
+    for name, meta in agent_registry._registered_agents.items():
+        cfg = meta.bot_config
+        agents.append(
+            {
+                "name": name,
+                "class_name": cfg.class_name if cfg else None,
+                "module": cfg.module if cfg else meta.module_path,
+                "tags": sorted(cfg.tags) if cfg and cfg.tags else [],
+                "has_vector_store": bool(cfg and cfg.vector_store),
+                "toolkits": list(cfg.toolkits) if cfg else [],
+            }
+        )
+    return sorted(agents, key=lambda item: item["name"])
+
+
+async def load_agent_definition(name: str) -> Optional[Dict[str, Any]]:
+    """Return the ``BotConfig`` of a registered agent as a dict (for cloning).
+
+    Returns ``None`` if the agent is not registered or has no config (i.e. was
+    registered programmatically without YAML metadata).
+    """
+    meta = agent_registry._registered_agents.get(name)
+    if meta is None or meta.bot_config is None:
+        return None
+    return meta.bot_config.model_dump(mode="json", exclude_none=True)
+
+
+# --- LLM-facing wrappers -----------------------------------------------------
+
+
+@tool(name="list_available_toolkits",
+      description="List every toolkit registered in the ToolkitRegistry "
+                  "(JIRA, GitHub, GoogleSearch, OpenAPI, …). Use this to pick "
+                  "toolkits when drafting an agent definition.")
+async def _list_available_toolkits_tool() -> List[Dict[str, str]]:
+    return await list_available_toolkits()
+
+
+@tool(name="list_available_tools",
+      description="List standalone @tool functions discovered in parrot.tools.")
+async def _list_available_tools_tool() -> List[Dict[str, str]]:
+    return await list_available_tools()
+
+
+@tool(name="list_registered_agents",
+      description="List agents currently registered in the AgentRegistry. "
+                  "Use this when the user asks to clone an existing agent.")
+async def _list_registered_agents_tool() -> List[Dict[str, Any]]:
+    return await list_registered_agents()
+
+
+@tool(name="load_agent_definition",
+      description="Return the full YAML definition of a registered agent as "
+                  "a dict, ready to be mutated for a clone.")
+async def _load_agent_definition_tool(name: str) -> Optional[Dict[str, Any]]:
+    return await load_agent_definition(name)

--- a/packages/ai-parrot/src/parrot/bots/factory/tools/openapi_register.py
+++ b/packages/ai-parrot/src/parrot/bots/factory/tools/openapi_register.py
@@ -1,0 +1,115 @@
+"""Register a third-party OpenAPI spec as a runtime-discoverable toolkit.
+
+This is how the factory turns "create an agent for LinkedIn" into a working
+agent without a hand-written ``LinkedInToolkit``: download the OpenAPI spec,
+materialise an ``OpenAPIToolkit`` subclass scoped to that service, register
+it under a stable name in ``ToolkitRegistry`` and reference it by name in
+the generated ``AgentDefinition.toolkits`` list.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from parrot.tools.decorators import tool
+from parrot.tools.openapitoolkit import OpenAPIToolkit
+from parrot.tools.registry import ToolkitRegistry
+
+
+def _build_toolkit_subclass(service: str, spec: Any, **defaults: Any) -> type:
+    """Create a thin OpenAPIToolkit subclass bound to a specific spec.
+
+    The subclass is what gets registered: ``ToolkitRegistry`` indexes by name
+    and instantiates the class with defaults (``service``, ``spec``) baked in
+    so the YAML loader does not have to know the spec URL.
+    """
+    bound_spec = spec
+    bound_service = service
+    bound_defaults = defaults
+
+    class _BoundOpenAPIToolkit(OpenAPIToolkit):
+        __qualname__ = f"OpenAPIToolkit_{service}"
+
+        def __init__(self, **kwargs: Any) -> None:
+            merged = {**bound_defaults, **kwargs}
+            super().__init__(
+                spec=bound_spec,
+                service=bound_service,
+                **merged,
+            )
+
+    _BoundOpenAPIToolkit.__name__ = f"OpenAPIToolkit_{service}"
+    return _BoundOpenAPIToolkit
+
+
+async def register_openapi_toolkit(
+    spec: str,
+    service: str,
+    *,
+    base_url: Optional[str] = None,
+    auth_type: str = "bearer",
+    api_key_env: Optional[str] = None,
+    toolkit_name: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Materialise + register an OpenAPI toolkit.
+
+    Args:
+        spec: URL, file path, JSON/YAML string, or dict containing the
+            OpenAPI document.
+        service: Logical service name used as tool-name prefix
+            (e.g. ``"linkedin"``).
+        base_url: Override the ``servers`` entry from the spec.
+        auth_type: ``"bearer"``, ``"apikey"`` or ``"basic"``.
+        api_key_env: Optional env var name to surface in the registration
+            metadata so the YAML can reference it via interpolation.
+        toolkit_name: Override the registry name (defaults to
+            ``"openapi_<service>"``).
+
+    Returns:
+        Dict with ``toolkit_name`` (what to put in ``AgentDefinition.toolkits``)
+        and a ``metadata`` block describing the registration.
+    """
+    name = toolkit_name or f"openapi_{service.lower()}"
+
+    defaults: Dict[str, Any] = {"auth_type": auth_type}
+    if base_url:
+        defaults["base_url"] = base_url
+
+    # Smoke-test the spec by instantiating once — prance will raise if invalid.
+    probe = OpenAPIToolkit(spec=spec, service=service, base_url=base_url)
+    operations = len(getattr(probe, "operations", {}) or {})
+
+    toolkit_cls = _build_toolkit_subclass(service=service, spec=spec, **defaults)
+    ToolkitRegistry.register(name, toolkit_cls)
+
+    return {
+        "toolkit_name": name,
+        "metadata": {
+            "service": service,
+            "base_url": probe.base_url,
+            "operations": operations,
+            "auth_type": auth_type,
+            "api_key_env": api_key_env,
+        },
+    }
+
+
+@tool(name="register_openapi_toolkit",
+      description="Download an OpenAPI spec and register a dynamic toolkit "
+                  "for that service so the new agent can call it. Use this "
+                  "when the user asks for an integration to a REST API that "
+                  "has no native toolkit (e.g. LinkedIn, Notion). Returns "
+                  "the toolkit name to add to AgentDefinition.toolkits.")
+async def _register_openapi_toolkit_tool(
+    spec: str,
+    service: str,
+    base_url: Optional[str] = None,
+    auth_type: str = "bearer",
+    api_key_env: Optional[str] = None,
+) -> Dict[str, Any]:
+    return await register_openapi_toolkit(
+        spec=spec,
+        service=service,
+        base_url=base_url,
+        auth_type=auth_type,
+        api_key_env=api_key_env,
+    )

--- a/packages/ai-parrot/src/parrot/bots/factory/tools/vector_store.py
+++ b/packages/ai-parrot/src/parrot/bots/factory/tools/vector_store.py
@@ -1,0 +1,84 @@
+"""Provision a PgVector table for a RAG agent.
+
+Builders call ``provision_vector_store`` after the LLM has chosen a table
+name, schema and embedding dimension. The function creates the table via
+``PgVectorStore.create_embedding_table`` and returns a ``StoreConfig`` block
+ready to embed in the resulting ``AgentDefinition``.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from parrot.tools.decorators import tool
+
+
+async def provision_vector_store(
+    table: str,
+    *,
+    schema: str = "public",
+    dimension: int = 768,
+    embedding_model: str = "sentence-transformers/all-mpnet-base-v2",
+    extra_columns: Optional[List[str]] = None,
+    dsn: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create a PgVector table and return a ``StoreConfig``-shaped dict.
+
+    Args:
+        table: Target table name.
+        schema: Postgres schema (defaults to ``public``).
+        dimension: Embedding vector dimension. Match it to ``embedding_model``.
+        embedding_model: HuggingFace / sentence-transformers identifier.
+        extra_columns: Additional non-vector columns to add to the table.
+        dsn: Optional Postgres DSN override; falls back to PgVector defaults
+            (driven by env vars: ``PG_HOST``, ``PG_USER``, …).
+
+    Returns:
+        Dict with ``provider``, ``table``, ``schema``, ``dimension``,
+        ``embedding_model`` ready to use as the ``vector_store`` block of an
+        ``AgentDefinition``.
+    """
+    from parrot.stores.postgres import PgVectorStore  # local import: heavy deps
+
+    store_kwargs: Dict[str, Any] = {
+        "table": table,
+        "schema": schema,
+        "embedding_model": embedding_model,
+        "auto_initialize": True,
+    }
+    if dsn:
+        store_kwargs["dsn"] = dsn
+
+    store = PgVectorStore(**store_kwargs)
+    await store.create_embedding_table(
+        table=table,
+        columns=list(extra_columns or []),
+        schema=schema,
+        dimension=dimension,
+    )
+
+    return {
+        "provider": "pgvector",
+        "table": table,
+        "schema": schema,
+        "dimension": dimension,
+        "embedding_model": embedding_model,
+    }
+
+
+@tool(name="provision_vector_store",
+      description="Create a PgVector table for a RAG agent. Call this when the "
+                  "user wants a RAG bot and after you have picked a table name "
+                  "and embedding model. Returns a vector_store block to embed "
+                  "in the AgentDefinition.")
+async def _provision_vector_store_tool(
+    table: str,
+    schema: str = "public",
+    dimension: int = 768,
+    embedding_model: str = "sentence-transformers/all-mpnet-base-v2",
+) -> Dict[str, Any]:
+    return await provision_vector_store(
+        table=table,
+        schema=schema,
+        dimension=dimension,
+        embedding_model=embedding_model,
+    )

--- a/packages/ai-parrot/src/parrot/cli/commands.py
+++ b/packages/ai-parrot/src/parrot/cli/commands.py
@@ -151,6 +151,13 @@ class SlashCommandDispatcher:
                 _cmd_export,
             ),
             SlashCommand("stream", "Toggle streaming mode on/off.", _cmd_stream),
+            SlashCommand(
+                "create_agent",
+                "Run the AgentFactory to create a new agent. "
+                "Usage: /create_agent <natural-language description> "
+                "[--clone-from <name>] [--category <dir>]",
+                _cmd_create_agent,
+            ),
             SlashCommand("help", "List all available slash commands.", _cmd_help),
             SlashCommand("quit", "Exit the REPL.", _cmd_quit),
         ]
@@ -310,3 +317,92 @@ async def _cmd_quit(repl: "AgentREPL", args: str) -> None:  # noqa: ARG001
     """
     repl.renderer.print("[dim]Goodbye.[/dim]")
     raise SystemExit(0)
+
+
+def _parse_create_agent_args(args: str) -> Dict[str, Any]:
+    """Parse ``--clone-from X`` and ``--category Y`` flags out of ``args``.
+
+    The remaining text is the natural-language description.
+    """
+    tokens = args.strip().split()
+    parsed: Dict[str, Any] = {"description": "", "clone_from": None, "category": "general"}
+    description: List[str] = []
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok == "--clone-from" and i + 1 < len(tokens):
+            parsed["clone_from"] = tokens[i + 1]
+            i += 2
+            continue
+        if tok == "--category" and i + 1 < len(tokens):
+            parsed["category"] = tokens[i + 1]
+            i += 2
+            continue
+        description.append(tok)
+        i += 1
+    parsed["description"] = " ".join(description)
+    return parsed
+
+
+async def _cmd_create_agent(repl: "AgentREPL", args: str) -> None:
+    """Handle /create_agent — drive the AgentFactoryOrchestrator from the REPL.
+
+    Builds a CLI-channel HumanInteractionManager on the fly, runs the
+    orchestrator, and prints the FactoryResult. Both HITL checkpoints are
+    delivered through the same CLI prompt the REPL already uses.
+    """
+    parsed = _parse_create_agent_args(args)
+    if not parsed["description"]:
+        repl.renderer.print(
+            "[yellow]Usage:[/yellow] /create_agent <description> "
+            "[--clone-from <name>] [--category <dir>]"
+        )
+        return
+
+    # Local imports keep REPL startup snappy — factory pulls in pydantic +
+    # the registry graph, which we do not want to pay for unless the user
+    # actually invokes this command.
+    from parrot.bots.factory import (
+        AgentFactoryOrchestrator,
+        FactoryRequest,
+        FactoryStatus,
+    )
+    from parrot.human.channels import CLIHumanChannel
+    from parrot.human.manager import HumanInteractionManager
+
+    channel = CLIHumanChannel(console=getattr(repl.renderer, "console", None))
+    manager = HumanInteractionManager(channels={"cli": channel})
+    await manager.startup()
+
+    use_llm = getattr(repl.bot, "_use_llm", None) or "google"
+    orchestrator = AgentFactoryOrchestrator(
+        human_manager=manager,
+        human_channel="cli",
+        human_targets=[repl.config.user_id or "cli_user"],
+        use_llm=use_llm,
+        category=parsed["category"],
+    )
+
+    request = FactoryRequest(
+        description=parsed["description"],
+        clone_from=parsed["clone_from"],
+    )
+
+    repl.renderer.print("[cyan]Routing your request to the factory…[/cyan]")
+    result = await orchestrator.run(request)
+
+    if result.status == FactoryStatus.SUCCESS:
+        repl.renderer.print(
+            f"[green]Agent created:[/green] "
+            f"[bold]{result.definition.name}[/bold] → {result.yaml_path}"
+        )
+    elif result.status == FactoryStatus.CANCELLED_BY_USER:
+        repl.renderer.print(
+            f"[yellow]Cancelled at {result.cancelled_at.value}.[/yellow]"
+        )
+    elif result.status == FactoryStatus.TIMEOUT:
+        repl.renderer.print(
+            f"[yellow]Timed out at {result.cancelled_at.value}.[/yellow]"
+        )
+    else:
+        repl.renderer.print(f"[red]Factory failed:[/red] {result.error or 'unknown'}")

--- a/packages/ai-parrot/src/parrot/handlers/agents/factory.py
+++ b/packages/ai-parrot/src/parrot/handlers/agents/factory.py
@@ -1,0 +1,162 @@
+"""HTTP handler for the AgentFactoryOrchestrator.
+
+Endpoint shape:
+
+    POST /api/v1/agents/factory
+        body: {description, clone_from?, hints?, category?, auto_approve?}
+        returns: FactoryResult-as-JSON
+
+The handler picks up the ``HumanInteractionManager`` from
+``request.app["human_manager"]``. If absent OR ``auto_approve=true`` is
+supplied, a stub manager that auto-approves every gate is used — handy for
+scripted / CI runs where there is no human at the other end.
+
+For real interactive flows the host application must register the manager
+beforehand (typically wiring a ``WebHumanChannel`` or telegram channel).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from aiohttp import web
+from navigator.responses import JSONResponse
+from navigator.views import BaseView
+
+from parrot.bots.factory import (
+    AgentFactoryOrchestrator,
+    FactoryRequest,
+    FactoryResult,
+)
+from parrot.human.channels import HumanChannel
+from parrot.human.manager import HumanInteractionManager
+from parrot.human.models import (
+    HumanInteraction,
+    HumanResponse,
+    InteractionType,
+)
+
+
+logger = logging.getLogger("Parrot.Handlers.AgentFactory")
+
+
+class _AutoApproveChannel(HumanChannel):
+    """Channel that resolves every interaction inline with ``value="confirm"``.
+
+    Used for headless / scripted factory runs (CI, tests, API clients that
+    pre-approved through their own UI). Not meant for production HITL.
+    """
+
+    channel_type = "auto_approve"
+
+    def __init__(self) -> None:
+        self._on_response = None
+        self._on_cancel = None
+
+    async def register_response_handler(self, callback) -> None:
+        self._on_response = callback
+
+    async def register_cancel_handler(self, callback) -> None:
+        self._on_cancel = callback
+
+    async def send_interaction(
+        self,
+        interaction: HumanInteraction,
+        recipient: str,
+    ) -> bool:
+        if self._on_response is None:
+            return False
+        await self._on_response(
+            HumanResponse(
+                interaction_id=interaction.interaction_id,
+                respondent=recipient,
+                response_type=interaction.interaction_type,
+                value=(
+                    True
+                    if interaction.interaction_type == InteractionType.APPROVAL
+                    else "confirm"
+                ),
+            )
+        )
+        return True
+
+    async def send_notification(self, recipient: str, message: str) -> None:  # noqa: ARG002
+        return None
+
+    async def cancel_interaction(
+        self,
+        interaction_id: str,
+        recipient: str,
+    ) -> None:  # noqa: ARG002
+        return None
+
+
+def build_auto_approve_manager() -> HumanInteractionManager:
+    """Construct a manager whose only channel auto-approves every gate."""
+    channel = _AutoApproveChannel()
+    manager = HumanInteractionManager(channels={"auto_approve": channel})
+    return manager
+
+
+class AgentFactoryHandler(BaseView):
+    """POST /api/v1/agents/factory — create a new agent via the factory."""
+
+    async def post(self, request: web.Request) -> web.Response:
+        try:
+            payload: Dict[str, Any] = await request.json()
+        except Exception:
+            payload = {}
+
+        if "description" not in payload:
+            return JSONResponse(
+                {"status": "error", "message": "description is required"},
+                status=400,
+            )
+
+        try:
+            factory_request = FactoryRequest(**{
+                k: v
+                for k, v in payload.items()
+                if k in {"description", "clone_from", "hints"}
+            })
+        except Exception as exc:  # noqa: BLE001
+            return JSONResponse(
+                {"status": "error", "message": f"invalid request: {exc}"},
+                status=400,
+            )
+
+        category = payload.get("category", "general")
+        auto_approve = bool(payload.get("auto_approve", False))
+        use_llm = payload.get("use_llm", "google")
+        llm = payload.get("llm")
+
+        human_manager: HumanInteractionManager | None = request.app.get("human_manager")
+        if auto_approve or human_manager is None:
+            human_manager = build_auto_approve_manager()
+            await human_manager.startup()
+            human_channel = "auto_approve"
+        else:
+            human_channel = payload.get("human_channel", "web")
+
+        orchestrator = AgentFactoryOrchestrator(
+            human_manager=human_manager,
+            human_channel=human_channel,
+            human_targets=payload.get("human_targets") or ["api_user"],
+            use_llm=use_llm,
+            llm=llm,
+            category=category,
+        )
+
+        try:
+            result: FactoryResult = await orchestrator.run(factory_request)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("AgentFactory run failed")
+            return JSONResponse(
+                {"status": "error", "message": str(exc)},
+                status=500,
+            )
+
+        return JSONResponse(
+            result.model_dump(mode="json", exclude_none=True),
+            status=200 if result.status.value == "success" else 202,
+        )

--- a/packages/ai-parrot/src/parrot/manager/manager.py
+++ b/packages/ai-parrot/src/parrot/manager/manager.py
@@ -29,6 +29,7 @@ from ..handlers.agent import AgentTalk
 from ..handlers.integrations import IntegrationsHandler
 from ..handlers.infographic import InfographicTalk
 from ..handlers.agents.data import DataAnalystHandler
+from ..handlers.agents.factory import AgentFactoryHandler
 from ..handlers.print_pdf import PrintPDFHandler
 from ..handlers.datasets import DatasetManagerHandler
 from ..handlers.database import (
@@ -1436,6 +1437,12 @@ class BotManager:
         router.add_view(
             '/api/v1/agents/analyst',
             DataAnalystHandler
+        )
+        # AgentFactory: meta-agent that drafts and registers new agents
+        # from a natural-language description (RAG / tool-agent / clone).
+        router.add_view(
+            '/api/v1/agents/factory',
+            AgentFactoryHandler
         )
         # InfographicTalk routes (FEAT-095) — literal resource routes MUST
         # come before the {agent_id} catch-all so aiohttp resolves

--- a/packages/ai-parrot/tests/bots/factory/test_argparser.py
+++ b/packages/ai-parrot/tests/bots/factory/test_argparser.py
@@ -1,0 +1,47 @@
+"""Unit tests for the /create_agent CLI argument parser."""
+from parrot.cli.commands import _parse_create_agent_args
+
+
+def test_pure_description():
+    parsed = _parse_create_agent_args("Build a RAG bot for product docs")
+    assert parsed["description"] == "Build a RAG bot for product docs"
+    assert parsed["clone_from"] is None
+    assert parsed["category"] == "general"
+
+
+def test_clone_from_flag():
+    parsed = _parse_create_agent_args(
+        "Clone the AT&T bot for Hisense --clone-from ATTBot"
+    )
+    assert parsed["clone_from"] == "ATTBot"
+    assert "ATTBot" not in parsed["description"]
+    assert parsed["description"].startswith("Clone the AT&T bot")
+
+
+def test_category_flag():
+    parsed = _parse_create_agent_args(
+        "A finance assistant --category finance"
+    )
+    assert parsed["category"] == "finance"
+    assert "finance" not in parsed["description"].split()[-1:]
+
+
+def test_combined_flags():
+    parsed = _parse_create_agent_args(
+        "Variant agent --clone-from BaseBot --category support"
+    )
+    assert parsed["clone_from"] == "BaseBot"
+    assert parsed["category"] == "support"
+    assert parsed["description"] == "Variant agent"
+
+
+def test_empty_description():
+    parsed = _parse_create_agent_args("")
+    assert parsed["description"] == ""
+
+
+def test_flag_without_value_keeps_token_in_description():
+    parsed = _parse_create_agent_args("Build a bot --clone-from")
+    # The flag without a value should be ignored gracefully.
+    assert parsed["clone_from"] is None
+    assert "--clone-from" in parsed["description"]

--- a/packages/ai-parrot/tests/bots/factory/test_contracts.py
+++ b/packages/ai-parrot/tests/bots/factory/test_contracts.py
@@ -1,0 +1,124 @@
+"""Unit tests for parrot.bots.factory.contracts."""
+import pytest
+
+from parrot.bots.factory.contracts import (
+    AgentDefinition,
+    BuilderOutput,
+    BuilderType,
+    FactoryRequest,
+    FactoryResult,
+    FactoryStatus,
+    HITLCheckpoint,
+    ProvisioningRecord,
+    RouterDecision,
+)
+from parrot.registry.registry import BotConfig
+
+
+class TestAgentDefinition:
+    def test_alias_points_at_bot_config(self):
+        assert AgentDefinition is BotConfig
+
+
+class TestBuilderType:
+    def test_three_members(self):
+        assert {b.value for b in BuilderType} == {"rag", "tool_agent", "clone"}
+
+
+class TestHITLCheckpoint:
+    def test_two_members(self):
+        assert {c.value for c in HITLCheckpoint} == {
+            "pre_delegation",
+            "pre_finalize",
+        }
+
+
+class TestFactoryStatus:
+    def test_four_members(self):
+        assert {s.value for s in FactoryStatus} == {
+            "success",
+            "cancelled_by_user",
+            "timeout",
+            "failed",
+        }
+
+
+class TestFactoryRequest:
+    def test_minimal_request_is_valid(self):
+        req = FactoryRequest(description="Build a Jira agent.")
+        assert req.description == "Build a Jira agent."
+        assert req.clone_from is None
+        assert req.hints == {}
+
+    def test_empty_description_rejected(self):
+        with pytest.raises(ValueError):
+            FactoryRequest(description="")
+
+    def test_clone_from_carries_through(self):
+        req = FactoryRequest(description="Variant", clone_from="ATTBot")
+        assert req.clone_from == "ATTBot"
+
+
+class TestRouterDecision:
+    def test_basic_decision_round_trip(self):
+        decision = RouterDecision(
+            builder=BuilderType.RAG,
+            reasoning="User asked for a knowledge base.",
+        )
+        assert decision.builder == BuilderType.RAG
+        assert decision.detected_integrations == []
+
+    def test_serialises_via_model_dump(self):
+        decision = RouterDecision(
+            builder=BuilderType.TOOL_AGENT,
+            reasoning="LinkedIn integration requested",
+            detected_integrations=["linkedin"],
+        )
+        dumped = decision.model_dump()
+        assert dumped["builder"] == "tool_agent"
+        assert dumped["detected_integrations"] == ["linkedin"]
+
+
+class TestBuilderOutput:
+    def test_wraps_an_agent_definition(self):
+        defn = BotConfig(
+            name="Demo",
+            class_name="BasicAgent",
+            module="parrot.bots.agent",
+        )
+        output = BuilderOutput(builder=BuilderType.RAG, definition=defn)
+        assert output.builder == BuilderType.RAG
+        assert output.definition.name == "Demo"
+        assert output.provisioning == []
+
+
+class TestProvisioningRecord:
+    def test_kind_constrained_to_known_set(self):
+        rec = ProvisioningRecord(kind="vector_store", name="rag_demo")
+        assert rec.kind == "vector_store"
+        with pytest.raises(ValueError):
+            ProvisioningRecord(kind="invalid", name="x")
+
+
+class TestFactoryResult:
+    def test_success_carries_definition(self):
+        defn = BotConfig(
+            name="Demo",
+            class_name="BasicAgent",
+            module="parrot.bots.agent",
+        )
+        result = FactoryResult(
+            status=FactoryStatus.SUCCESS,
+            definition=defn,
+            yaml_path="/tmp/demo.yaml",
+        )
+        assert result.status == FactoryStatus.SUCCESS
+        assert result.yaml_path.endswith("demo.yaml")
+
+    def test_cancelled_marks_checkpoint(self):
+        result = FactoryResult(
+            status=FactoryStatus.CANCELLED_BY_USER,
+            cancelled_at=HITLCheckpoint.PRE_DELEGATION,
+        )
+        assert result.cancelled_at == HITLCheckpoint.PRE_DELEGATION
+        assert result.definition is None

--- a/packages/ai-parrot/tests/bots/factory/test_gate_result.py
+++ b/packages/ai-parrot/tests/bots/factory/test_gate_result.py
@@ -1,0 +1,64 @@
+"""Unit tests for the orchestrator's HITL gate-result normalisation."""
+from types import SimpleNamespace
+
+import pytest
+
+from parrot.bots.factory.contracts import FactoryStatus
+from parrot.bots.factory.orchestrator import _GateResult, _is_approval
+from parrot.human.models import InteractionStatus
+
+
+class TestIsApproval:
+    @pytest.mark.parametrize(
+        "value",
+        [True, "confirm", "approve", "approved", "YES", "y", {"key": "confirm"}],
+    )
+    def test_truthy_inputs(self, value):
+        assert _is_approval(value) is True
+
+    @pytest.mark.parametrize(
+        "value", [False, None, "cancel", "no", {"key": "cancel"}, 42]
+    )
+    def test_falsy_inputs(self, value):
+        assert _is_approval(value) is False
+
+
+class TestGateResult:
+    def test_completed_with_confirm_is_approved(self):
+        result = SimpleNamespace(
+            status=InteractionStatus.COMPLETED, consolidated_value="confirm"
+        )
+        gate = _GateResult.from_interaction_result(result)
+        assert gate.approved is True
+        assert gate.status == FactoryStatus.SUCCESS
+
+    def test_completed_with_cancel_is_rejected(self):
+        result = SimpleNamespace(
+            status=InteractionStatus.COMPLETED, consolidated_value="cancel"
+        )
+        gate = _GateResult.from_interaction_result(result)
+        assert gate.approved is False
+        assert gate.status == FactoryStatus.CANCELLED_BY_USER
+
+    def test_timeout_maps_to_factory_timeout(self):
+        result = SimpleNamespace(
+            status=InteractionStatus.TIMEOUT, consolidated_value=None
+        )
+        gate = _GateResult.from_interaction_result(result)
+        assert gate.approved is False
+        assert gate.status == FactoryStatus.TIMEOUT
+
+    def test_cancelled_status_maps_to_cancel(self):
+        result = SimpleNamespace(
+            status=InteractionStatus.CANCELLED, consolidated_value=None
+        )
+        gate = _GateResult.from_interaction_result(result)
+        assert gate.approved is False
+        assert gate.status == FactoryStatus.CANCELLED_BY_USER
+
+    def test_approval_interaction_returns_bool_true(self):
+        result = SimpleNamespace(
+            status=InteractionStatus.COMPLETED, consolidated_value=True
+        )
+        gate = _GateResult.from_interaction_result(result)
+        assert gate.approved is True


### PR DESCRIPTION
## Summary

Introduces the **AgentFactory** subsystem — a meta-agent framework that transforms natural-language descriptions into registered, ready-to-use agent YAML definitions. The factory orchestrates an LLM router, three specialist builders (RAG, tool-agent, clone), and a finalize step, with two human-in-the-loop checkpoints to control LLM token spend.

## Key Changes

### Core Orchestrator & Contracts
- **`AgentFactoryOrchestrator`** (`orchestrator.py`): Main entry point driving the full factory flow:
  - Phase 1: Route request to appropriate specialist via LLM
  - Phase 2: Pre-delegation HITL gate (user approves specialist choice)
  - Phase 3: Specialist builds the agent definition
  - Phase 4: Pre-finalize HITL gate (user reviews generated YAML)
  - Phase 5: Persist YAML and reload registry
  
- **Factory contracts** (`contracts.py`): Pydantic models for type-safe data flow:
  - `FactoryRequest`, `RouterDecision`, `BuilderOutput`, `FactoryResult`
  - `BuilderType` enum (rag, tool_agent, clone)
  - `HITLCheckpoint` enum (pre_delegation, pre_finalize)
  - `FactoryStatus` enum (success, cancelled_by_user, timeout, failed)

### Specialist Builders
- **`BaseFactoryBuilder`** (`builders/base.py`): Shared base class with:
  - Specialist system prompts embedding YAML schema conventions
  - Curated toolset (introspection + builder-specific tools)
  - Single `build()` entry point returning typed `BuilderOutput`

- **`RAGBuilderAgent`** (`builders/rag_builder.py`): Designs RAG chatbots backed by PgVector
- **`ToolAgentBuilderAgent`** (`builders/tool_agent_builder.py`): Designs tool-using agents with toolkits/MCP
- **`CloneAgentBuilder`** (`builders/clone_builder.py`): Clones existing agents with mutations

### Factory Tools
- **Introspection** (`tools/introspection.py`): Catalog discovery for builders
  - `list_available_toolkits()`, `list_available_tools()`, `list_registered_agents()`
  - `load_agent_definition()` for cloning
  
- **OpenAPI Registration** (`tools/openapi_register.py`): Dynamic toolkit provisioning
  - `register_openapi_toolkit()` materializes OpenAPI specs as runtime-discoverable toolkits
  
- **Vector Store Provisioning** (`tools/vector_store.py`): PgVector table creation
  - `provision_vector_store()` creates embedding tables for RAG agents
  
- **Finalization** (`tools/finalize.py`): Persist and register
  - `write_agent_yaml()`, `finalize_agent_registration()`

### HTTP Handler & CLI Integration
- **`AgentFactoryHandler`** (`handlers/agents/factory.py`): REST endpoint
  - `POST /api/v1/agents/factory` drives full factory flow synchronously
  - Supports `auto_approve` mode for headless/scripted runs
  - Integrates with `HumanInteractionManager` for HITL gates
  - Includes `_AutoApproveChannel` for unattended execution

- **CLI Command** (`cli/commands.py`): `/create_agent` slash command
  - Parses natural-language description with optional `--clone-from` and `--category` flags
  - Drives orchestrator from REPL with CLI-based HITL prompts

### Tests
- **Contract tests** (`tests/bots/factory/test_contracts.py`): Validates all Pydantic models
- **Gate result tests** (`tests/bots/factory/test_gate_result.py`): HITL gate normalization logic
- **CLI argument parser tests** (`tests/bots/factory/test_argparser.py`): Flag parsing for `/create_agent

https://claude.ai/code/session_0141AkMNmJSFKXmRgXv79hDg