### PR TITLE
Add form submission metadata enrichment system

### DIFF
--- a/packages/parrot-formdesigner/src/parrot_formdesigner/api/handlers.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/api/handlers.py
@@ -520,6 +520,10 @@ class FormAPIHandler:
         import uuid
         from datetime import datetime, timezone
 
+        from ..services.metadata_enricher import (
+            MetadataResolutionError,
+            enrich_submission,
+        )
         from ..services.submissions import FormSubmission
 
         form_id = request.match_info["form_id"]
@@ -551,6 +555,27 @@ class FormAPIHandler:
             is_valid=True,
             created_at=datetime.now(timezone.utc),
         )
+
+        # Metadata enrichment runs between validation and storage so the
+        # resolved values are persisted alongside the answers.
+        if form.metadata:
+            try:
+                core_overrides, extra_flat = await enrich_submission(
+                    request=request,
+                    form=form,
+                    submission=submission,
+                    answers=result.sanitized_data,
+                    auth_context=self._build_auth_context(request),
+                )
+            except MetadataResolutionError as exc:
+                return web.json_response(
+                    {"is_valid": False, "errors": {"_metadata": str(exc)}},
+                    status=422,
+                )
+            if core_overrides:
+                submission = submission.model_copy(update=core_overrides)
+            if extra_flat:
+                submission.data = {**submission.data, **extra_flat}
 
         # Store locally (if storage configured)
         if self._submission_storage is not None:

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/core/__init__.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/core/__init__.py
@@ -13,10 +13,13 @@ from .constraints import (
 )
 from .options import FieldOption, OptionsSource
 from .schema import (
+    BUILTIN_METADATA_SOURCE_NAMES,
     FormField,
+    FormMetadataField,
     FormSchema,
     FormSection,
     FormSubsection,
+    MetadataSource,
     RenderedForm,
     SectionItem,
     SubmitAction,
@@ -54,6 +57,9 @@ __all__ = [
     "FormSection",
     "SubmitAction",
     "FormSchema",
+    "FormMetadataField",
+    "MetadataSource",
+    "BUILTIN_METADATA_SOURCE_NAMES",
     "RenderedForm",
     # Style
     "LayoutType",

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/core/schema.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/core/schema.py
@@ -12,7 +12,7 @@ from collections.abc import Iterator
 from datetime import datetime
 from typing import Any, Literal, Union
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from .auth import AuthConfig
 from .constraints import DependencyRule, FieldConstraints
@@ -150,6 +150,94 @@ class SubmitAction(BaseModel):
     auth: AuthConfig | None = None
 
 
+MetadataSource = Literal[
+    "user_id",
+    "username",
+    "org_id",
+    "submitted_at",
+    "submission_id",
+    "tenant",
+    "programs",
+    "ip",
+    "user_agent",
+    "locale",
+    "callback",
+    "constant",
+]
+
+
+BUILTIN_METADATA_SOURCE_NAMES: frozenset[str] = frozenset(
+    {
+        "user_id",
+        "username",
+        "org_id",
+        "submitted_at",
+        "submission_id",
+        "tenant",
+        "programs",
+        "ip",
+        "user_agent",
+        "locale",
+    }
+)
+
+
+class FormMetadataField(BaseModel):
+    """Declared contextual metadata captured on every form submission.
+
+    Metadata fields are computed in a before-save enrichment step on the
+    submit handler. Each declaration produces one or more ``key`` / value
+    pairs that are either promoted to a real ``form_data`` column (for
+    reserved core keys) or flat-merged into the submission ``data`` JSONB
+    alongside the user's answers (no ``"metadata"`` sub-object).
+
+    Attributes:
+        key: Identifier under which the value is stored. Must be a valid
+            Postgres identifier (``[A-Za-z_][A-Za-z0-9_]{0,62}``) so it
+            is safe to promote to a column name and stable as a JSONB
+            key. Validated at FormSchema construction.
+        source: Where the value comes from. Built-in sources resolve
+            against the inbound request / session; ``"callback"`` invokes
+            a coroutine registered with ``register_form_callback``;
+            ``"constant"`` returns ``default`` verbatim.
+        label: Optional human-readable label (i18n supported).
+        callback_ref: Required when ``source == "callback"``. Logical
+            callback name looked up in the shared tenant-scoped form
+            callback registry.
+        default: Value substituted when the resolver returns ``None`` or
+            a non-required callback fails. Also the source of truth for
+            ``source == "constant"``.
+        required: When ``True``, an unresolved value (resolver returns
+            ``None`` after ``default`` substitution) fails the
+            submission with HTTP 422.
+        options: Free-form per-source options bag (e.g.
+            ``{"header": "Accept-Language"}`` for ``locale``). Kept loose
+            on purpose to avoid a discriminated union per built-in.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    key: str
+    source: MetadataSource
+    label: LocalizedString | None = None
+    callback_ref: str | None = None
+    default: Any = None
+    required: bool = False
+    options: dict[str, Any] | None = None
+
+    @model_validator(mode="after")
+    def _validate_callback_ref(self) -> "FormMetadataField":
+        if self.source == "callback" and not self.callback_ref:
+            raise ValueError(
+                "callback_ref is required when source='callback'"
+            )
+        if self.source != "callback" and self.callback_ref:
+            raise ValueError(
+                "callback_ref is only valid when source='callback'"
+            )
+        return self
+
+
 class FormSchema(BaseModel):
     """The canonical representation of a complete form.
 
@@ -185,6 +273,58 @@ class FormSchema(BaseModel):
     meta: dict[str, Any] | None = None
     created_at: datetime | None = None
     tenant: str | None = None
+    metadata: list[FormMetadataField] | None = None
+
+    def iter_all_fields(self) -> Iterator[FormField]:
+        """Yield every ``FormField`` across all sections, flattening subsections."""
+        for section in self.sections:
+            yield from section.iter_fields()
+
+    @model_validator(mode="after")
+    def _validate_metadata(self) -> "FormSchema":
+        if not self.metadata:
+            return self
+
+        # Lazy import to avoid a hard dependency from core/ to services/.
+        from ..services._identifiers import validate_identifier
+
+        seen_keys: set[str] = set()
+        field_ids = {f.field_id for f in self.iter_all_fields()}
+
+        for entry in self.metadata:
+            try:
+                validate_identifier(entry.key, kind="metadata key")
+            except ValueError as exc:
+                raise ValueError(
+                    f"FormMetadataField.key {entry.key!r} is not a valid "
+                    f"identifier: {exc}"
+                ) from exc
+
+            if entry.key in seen_keys:
+                raise ValueError(
+                    f"Duplicate metadata key {entry.key!r} in FormSchema "
+                    f"{self.form_id!r}."
+                )
+            seen_keys.add(entry.key)
+
+            if entry.key in field_ids:
+                raise ValueError(
+                    f"Metadata key {entry.key!r} collides with a form "
+                    f"field_id in FormSchema {self.form_id!r}."
+                )
+
+            if (
+                entry.source == "callback"
+                and entry.key in BUILTIN_METADATA_SOURCE_NAMES
+            ):
+                raise ValueError(
+                    f"Metadata key {entry.key!r} is a reserved built-in "
+                    "source name and cannot be overridden with "
+                    "source='callback'. Use a different key (e.g. "
+                    f"'{entry.key}_ext')."
+                )
+
+        return self
 
 
 class RenderWarning(BaseModel):

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/__init__.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/__init__.py
@@ -5,12 +5,19 @@ Provides validation, registry, caching, and storage for FormSchema objects.
 
 from .cache import FormCache
 from .forwarder import ForwardResult, SubmissionForwarder
+from .metadata_callbacks import MetadataCallbackInput, MetadataCallbackOutput
+from .metadata_enricher import MetadataResolutionError, enrich_submission
 from .registry import FormRegistry, FormStorage
 from .storage import PostgresFormStorage
-from .submissions import FormSubmission, FormSubmissionStorage
+from .submissions import (
+    CORE_METADATA_COLUMNS,
+    FormSubmission,
+    FormSubmissionStorage,
+)
 from .validators import FormValidator, ValidationResult
 
 __all__ = [
+    "CORE_METADATA_COLUMNS",
     "FormCache",
     "ForwardResult",
     "FormRegistry",
@@ -18,7 +25,11 @@ __all__ = [
     "FormSubmission",
     "FormSubmissionStorage",
     "FormValidator",
+    "MetadataCallbackInput",
+    "MetadataCallbackOutput",
+    "MetadataResolutionError",
     "PostgresFormStorage",
     "SubmissionForwarder",
     "ValidationResult",
+    "enrich_submission",
 ]

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/metadata_callbacks.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/metadata_callbacks.py
@@ -1,0 +1,82 @@
+"""Pydantic I/O models for submission metadata callbacks.
+
+A *metadata callback* is an async coroutine registered with
+``register_form_callback`` (in :mod:`.callback_registry`) and referenced
+from a ``FormMetadataField`` with ``source='callback'``. The submit
+handler invokes the callback in the enrichment step (after validation,
+before storage) and merges its output into the persisted submission.
+
+These models intentionally live in their own module — separate from
+``rest_field_resolver`` — because the input payload is shaped around
+form *answers* rather than uploaded file content.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ..core.schema import FormMetadataField
+
+
+class MetadataCallbackInput(BaseModel):
+    """Payload delivered to a registered metadata-callback coroutine.
+
+    Attributes:
+        form_id: ID of the form being submitted.
+        submission_id: UUID of the in-flight submission (not yet stored).
+        user_id: Authenticated user ID (may be ``None``).
+        username: Authenticated username (may be ``None``).
+        org_id: Authenticated organization ID (may be ``None``).
+        tenant: Tenant slug (may be ``None``).
+        programs: Tenant programs list (may be empty).
+        submitted_at: UTC timestamp of the submission.
+        answers: Sanitized form answers as produced by the validator.
+            The callback MUST treat this dict as read-only.
+        field: The ``FormMetadataField`` declaration that triggered this
+            invocation. Carries ``options`` / ``default`` for the
+            callback to honour.
+    """
+
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    form_id: str
+    submission_id: str
+    user_id: str | None = None
+    username: str | None = None
+    org_id: int | None = None
+    tenant: str | None = None
+    programs: list[str] = Field(default_factory=list)
+    submitted_at: datetime
+    answers: dict[str, Any]
+    field: FormMetadataField
+
+
+class MetadataCallbackOutput(BaseModel):
+    """Return value from a registered metadata-callback coroutine.
+
+    A callback MAY return either a single value (stored under the
+    declaring field's ``key``) OR a fan-out dict of additional keys
+    merged into the submission. When ``values`` is set it takes
+    precedence over ``value``.
+
+    Attributes:
+        success: Whether the callback completed successfully. ``False``
+            triggers either the ``default`` substitution (when the
+            field is not required) or a 422 (when it is).
+        value: Single computed value, stored under the field's ``key``.
+            Used only when ``values`` is ``None``.
+        values: Optional fan-out dict merged flat into the submission.
+            Every key must be a valid identifier — keys are checked at
+            merge time by the enricher.
+        error: Human-readable error message on failure (logged).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    success: bool
+    value: Any | None = None
+    values: dict[str, Any] | None = None
+    error: str | None = None

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/metadata_enricher.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/metadata_enricher.py
@@ -1,0 +1,239 @@
+"""Before-save submission metadata enrichment.
+
+Given a validated submission, a form schema with declared
+``metadata`` entries, and the inbound aiohttp request, this module
+resolves every declared field, splits the resulting keys into the
+"core" set (promoted to typed ``FormSubmission`` columns) and the
+"extra" set (flat-merged into the submission ``data`` JSONB).
+
+The enricher is intentionally a pure function — no HTTP, no DB —
+so it is trivial to unit-test against stubbed requests.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from .callback_registry import get_form_callback
+from .metadata_callbacks import MetadataCallbackInput, MetadataCallbackOutput
+from .metadata_sources import (
+    BUILTIN_METADATA_SOURCES,
+    _extract_org_id,
+    _extract_programs,
+    _user_attr,
+)
+from .submissions import CORE_METADATA_COLUMNS
+
+if TYPE_CHECKING:
+    from aiohttp import web
+
+    from ..core.schema import FormMetadataField, FormSchema
+    from .auth_context import AuthContext
+    from .submissions import FormSubmission
+
+
+logger = logging.getLogger(__name__)
+
+
+class MetadataResolutionError(Exception):
+    """Raised when a required metadata field cannot be resolved.
+
+    The handler maps this to HTTP 422 with the message in
+    ``errors._metadata``.
+    """
+
+
+async def enrich_submission(
+    *,
+    request: "web.Request",
+    form: "FormSchema",
+    submission: "FormSubmission",
+    answers: dict[str, Any],
+    auth_context: "AuthContext",
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Resolve declared metadata for a pending submission.
+
+    Iterates ``form.metadata`` in declaration order, dispatching each
+    entry to either the built-in source resolver
+    (:data:`BUILTIN_METADATA_SOURCES`) or a registered async callback
+    looked up via :func:`get_form_callback` with tenant fallback.
+
+    Args:
+        request: Inbound aiohttp request, used by built-in resolvers
+            to read session / user / headers.
+        form: The form definition; its ``tenant`` field drives callback
+            lookup.
+        submission: The in-flight ``FormSubmission`` (constructed but
+            not yet stored). Resolvers may read its existing fields
+            (e.g. ``submission_id``, ``created_at``).
+        answers: Sanitized form answers from the validator.
+        auth_context: Runtime auth context forwarded to callbacks.
+
+    Returns:
+        Tuple ``(core_overrides, extra_flat)`` where ``core_overrides``
+        is a dict whose keys are a subset of ``CORE_METADATA_COLUMNS``
+        (to be applied via ``submission.model_copy(update=...)``) and
+        ``extra_flat`` is a dict of remaining keys to merge into
+        ``submission.data``.
+
+    Raises:
+        MetadataResolutionError: When a ``required=True`` entry cannot
+            be resolved, or when a callback fan-out returns an invalid
+            identifier as a key, or when a resolved key would collide
+            with an existing answer in ``answers``.
+    """
+    core_overrides: dict[str, Any] = {}
+    extra_flat: dict[str, Any] = {}
+
+    if not form.metadata:
+        return core_overrides, extra_flat
+
+    # Pre-compute identity fields so callbacks see consistent context.
+    base_user_id = _user_attr(request, "user_id") or _user_attr(request, "id")
+    base_user_id = None if base_user_id is None else str(base_user_id)
+    base_username = _user_attr(request, "username") or _user_attr(
+        request, "email"
+    )
+    base_username = None if base_username is None else str(base_username)
+    base_org_id = _extract_org_id(request)
+    base_programs = _extract_programs(request)
+    base_tenant = submission.tenant or form.tenant
+
+    for entry in form.metadata:
+        resolved: dict[str, Any] = {}
+
+        try:
+            if entry.source == "callback":
+                output = await _invoke_callback(
+                    entry=entry,
+                    submission=submission,
+                    form=form,
+                    answers=answers,
+                    auth_context=auth_context,
+                    base_user_id=base_user_id,
+                    base_username=base_username,
+                    base_org_id=base_org_id,
+                    base_tenant=base_tenant,
+                    base_programs=base_programs,
+                )
+                if not output.success:
+                    if entry.required:
+                        raise MetadataResolutionError(
+                            f"required metadata {entry.key!r} failed: "
+                            f"{output.error or 'callback returned success=False'}"
+                        )
+                    logger.warning(
+                        "metadata callback %r failed (key=%r): %s — using default",
+                        entry.callback_ref,
+                        entry.key,
+                        output.error,
+                    )
+                    resolved = {entry.key: entry.default}
+                elif output.values is not None:
+                    resolved = dict(output.values)
+                else:
+                    resolved = {entry.key: output.value}
+            else:
+                resolver = BUILTIN_METADATA_SOURCES.get(entry.source)
+                if resolver is None:
+                    # Should be unreachable given MetadataSource Literal.
+                    raise MetadataResolutionError(
+                        f"unknown metadata source {entry.source!r}"
+                    )
+                value = await resolver(request, submission, form, entry)
+                resolved = {entry.key: value}
+        except MetadataResolutionError:
+            raise
+        except Exception as exc:
+            if entry.required:
+                raise MetadataResolutionError(
+                    f"required metadata {entry.key!r} raised: {exc}"
+                ) from exc
+            logger.warning(
+                "metadata resolver for %r raised %s — using default",
+                entry.key,
+                exc,
+                exc_info=True,
+            )
+            resolved = {entry.key: entry.default}
+
+        # Default substitution + required enforcement happens per key so
+        # callback fan-out works the same way as single-value resolvers.
+        for key, value in list(resolved.items()):
+            if value is None:
+                value = entry.default
+                resolved[key] = value
+            if value is None and entry.required and key == entry.key:
+                raise MetadataResolutionError(
+                    f"required metadata {entry.key!r} resolved to None"
+                )
+
+        for key, value in resolved.items():
+            if key in CORE_METADATA_COLUMNS and key == entry.key:
+                core_overrides[key] = value
+            else:
+                if key in answers:
+                    raise MetadataResolutionError(
+                        f"metadata key {key!r} collides with form answer"
+                    )
+                extra_flat[key] = value
+
+    return core_overrides, extra_flat
+
+
+async def _invoke_callback(
+    *,
+    entry: "FormMetadataField",
+    submission: "FormSubmission",
+    form: "FormSchema",
+    answers: dict[str, Any],
+    auth_context: "AuthContext",
+    base_user_id: str | None,
+    base_username: str | None,
+    base_org_id: int | None,
+    base_tenant: str | None,
+    base_programs: list[str],
+) -> MetadataCallbackOutput:
+    """Invoke a registered metadata callback and normalise its output.
+
+    Always returns a ``MetadataCallbackOutput``: callbacks that raise or
+    return a plain value are wrapped so the caller has a uniform
+    surface to interrogate.
+    """
+    callback_ref = entry.callback_ref or ""
+    try:
+        callback = get_form_callback(
+            callback_ref, tenant=base_tenant
+        )
+    except KeyError:
+        return MetadataCallbackOutput(
+            success=False,
+            error=f"callback {callback_ref!r} is not registered",
+        )
+
+    payload = MetadataCallbackInput(
+        form_id=form.form_id,
+        submission_id=submission.submission_id,
+        user_id=base_user_id,
+        username=base_username,
+        org_id=base_org_id,
+        tenant=base_tenant,
+        programs=list(base_programs),
+        submitted_at=submission.created_at,
+        answers=dict(answers),
+        field=entry,
+    )
+
+    try:
+        result = await callback(payload, auth_context)
+    except Exception as exc:
+        return MetadataCallbackOutput(
+            success=False,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+
+    if isinstance(result, MetadataCallbackOutput):
+        return result
+    # Lenient: a bare value is treated as a successful single-value return.
+    return MetadataCallbackOutput(success=True, value=result)

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/metadata_sources.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/metadata_sources.py
@@ -1,0 +1,211 @@
+"""Built-in resolvers for ``FormMetadataField`` sources.
+
+This module owns the dispatch table that maps a ``MetadataSource``
+literal (e.g. ``"user_id"``, ``"locale"``) to an async resolver that
+extracts the corresponding value from the inbound aiohttp request,
+the in-flight ``FormSubmission`` record, and the parent ``FormSchema``.
+
+The resolvers deliberately stay tolerant of missing context (returning
+``None`` rather than raising) so the enricher can apply the field's
+``default`` substitution and ``required`` semantics uniformly.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+from aiohttp import web
+
+if TYPE_CHECKING:
+    from ..core.schema import FormMetadataField, FormSchema
+    from .submissions import FormSubmission
+
+
+BuiltinResolver = Callable[
+    [web.Request, "FormSubmission", "FormSchema", "FormMetadataField"],
+    Awaitable[Any],
+]
+
+
+def _extract_org_id(request: web.Request) -> int | None:
+    """Read ``org_id`` from the navigator-auth user session as an integer.
+
+    Mirrors the original logic in ``FormAPIHandler._get_org_id`` so the
+    handler and the metadata-source resolver share a single
+    implementation.
+
+    Args:
+        request: Incoming aiohttp request with ``user`` attribute set by
+            the navigator-auth ``user_session`` decorator.
+
+    Returns:
+        The first organization's ``org_id`` coerced to ``int``, or
+        ``None`` if the user has no organizations, ``user`` is missing,
+        or the value cannot be coerced.
+    """
+    user = getattr(request, "user", None)
+    if not user:
+        return None
+    orgs = getattr(user, "organizations", None) or []
+    if not orgs:
+        return None
+    try:
+        return int(orgs[0].org_id)
+    except (AttributeError, TypeError, ValueError):
+        return None
+
+
+def _extract_programs(request: web.Request) -> list[str]:
+    """Read the programs list from the navigator-auth session."""
+    session = getattr(request, "session", None)
+    if session is None:
+        return []
+    try:
+        userinfo = session.get("session", {}) or {}
+    except AttributeError:
+        return []
+    programs = userinfo.get("programs", []) or []
+    return [str(p) for p in programs]
+
+
+def _user_attr(request: web.Request, name: str) -> Any:
+    user = getattr(request, "user", None)
+    if user is None:
+        return None
+    return getattr(user, name, None)
+
+
+async def _resolve_user_id(
+    request: web.Request,
+    submission: "FormSubmission",
+    form: "FormSchema",
+    field: "FormMetadataField",
+) -> Any:
+    raw = _user_attr(request, "user_id")
+    if raw is None:
+        raw = _user_attr(request, "id")
+    return None if raw is None else str(raw)
+
+
+async def _resolve_username(
+    request: web.Request,
+    submission: "FormSubmission",
+    form: "FormSchema",
+    field: "FormMetadataField",
+) -> Any:
+    raw = _user_attr(request, "username")
+    if raw is None:
+        raw = _user_attr(request, "email")
+    return None if raw is None else str(raw)
+
+
+async def _resolve_org_id(
+    request: web.Request,
+    submission: "FormSubmission",
+    form: "FormSchema",
+    field: "FormMetadataField",
+) -> Any:
+    return _extract_org_id(request)
+
+
+async def _resolve_submitted_at(
+    request: web.Request,
+    submission: "FormSubmission",
+    form: "FormSchema",
+    field: "FormMetadataField",
+) -> Any:
+    return submission.created_at
+
+
+async def _resolve_submission_id(
+    request: web.Request,
+    submission: "FormSubmission",
+    form: "FormSchema",
+    field: "FormMetadataField",
+) -> Any:
+    return submission.submission_id
+
+
+async def _resolve_tenant(
+    request: web.Request,
+    submission: "FormSubmission",
+    form: "FormSchema",
+    field: "FormMetadataField",
+) -> Any:
+    if submission.tenant is not None:
+        return submission.tenant
+    if form.tenant is not None:
+        return form.tenant
+    header = request.headers.get("X-Parrot-Tenant")
+    return header or None
+
+
+async def _resolve_programs(
+    request: web.Request,
+    submission: "FormSubmission",
+    form: "FormSchema",
+    field: "FormMetadataField",
+) -> Any:
+    return _extract_programs(request)
+
+
+async def _resolve_ip(
+    request: web.Request,
+    submission: "FormSubmission",
+    form: "FormSchema",
+    field: "FormMetadataField",
+) -> Any:
+    forwarded = request.headers.get("X-Forwarded-For")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.remote
+
+
+async def _resolve_user_agent(
+    request: web.Request,
+    submission: "FormSubmission",
+    form: "FormSchema",
+    field: "FormMetadataField",
+) -> Any:
+    return request.headers.get("User-Agent")
+
+
+async def _resolve_locale(
+    request: web.Request,
+    submission: "FormSubmission",
+    form: "FormSchema",
+    field: "FormMetadataField",
+) -> Any:
+    opts = field.options or {}
+    header_name = opts.get("header", "Accept-Language")
+    value = request.headers.get(header_name)
+    if not value:
+        return None
+    # Strip quality params: "en-US,en;q=0.9" -> "en-US".
+    primary = value.split(",")[0].strip()
+    return primary or None
+
+
+async def _resolve_constant(
+    request: web.Request,
+    submission: "FormSubmission",
+    form: "FormSchema",
+    field: "FormMetadataField",
+) -> Any:
+    return field.default
+
+
+BUILTIN_METADATA_SOURCES: dict[str, BuiltinResolver] = {
+    "user_id": _resolve_user_id,
+    "username": _resolve_username,
+    "org_id": _resolve_org_id,
+    "submitted_at": _resolve_submitted_at,
+    "submission_id": _resolve_submission_id,
+    "tenant": _resolve_tenant,
+    "programs": _resolve_programs,
+    "ip": _resolve_ip,
+    "user_agent": _resolve_user_agent,
+    "locale": _resolve_locale,
+    "constant": _resolve_constant,
+}

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/submissions.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/submissions.py
@@ -32,6 +32,21 @@ DEFAULT_SCHEMA = "navigator"
 DEFAULT_TABLE = "form_data"
 
 
+# Reserved keys that, when produced by metadata enrichment, are promoted
+# from the JSONB ``data`` blob to dedicated columns on ``form_data``.
+# Order is meaningful — it matches the INSERT column order in
+# :meth:`FormSubmissionStorage._insert_sql`.
+CORE_METADATA_COLUMNS: tuple[str, ...] = (
+    "user_id",
+    "username",
+    "org_id",
+    "submitted_at",
+    "ip",
+    "user_agent",
+    "locale",
+)
+
+
 class FormSubmission(BaseModel):
     """Record of a single form data submission.
 
@@ -49,6 +64,15 @@ class FormSubmission(BaseModel):
             uses it to resolve the Postgres schema where the submission
             is stored. ``None`` falls back to the storage's default
             schema.
+        user_id: Promoted metadata column — authenticated user identifier.
+        username: Promoted metadata column — authenticated username.
+        org_id: Promoted metadata column — authenticated organization ID.
+        submitted_at: Promoted metadata column — wall-clock moment the
+            form left the client. Distinct from ``created_at`` (which is
+            the DB-insert moment).
+        ip: Promoted metadata column — submitter IP address.
+        user_agent: Promoted metadata column — submitter User-Agent header.
+        locale: Promoted metadata column — BCP-47 locale (e.g. ``en-US``).
     """
 
     submission_id: str = Field(
@@ -66,6 +90,13 @@ class FormSubmission(BaseModel):
         default_factory=lambda: datetime.now(timezone.utc),
     )
     tenant: str | None = None
+    user_id: str | None = None
+    username: str | None = None
+    org_id: int | None = None
+    submitted_at: datetime | None = None
+    ip: str | None = None
+    user_agent: str | None = None
+    locale: str | None = None
 
 
 class FormSubmissionStorage:
@@ -141,10 +172,36 @@ class FormSubmissionStorage:
             forward_status INTEGER,
             forward_error TEXT,
             tenant VARCHAR(63),
+            user_id VARCHAR(255),
+            username VARCHAR(255),
+            org_id INTEGER,
+            submitted_at TIMESTAMPTZ,
+            ip INET,
+            user_agent TEXT,
+            locale VARCHAR(35),
             created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
         );
         CREATE INDEX IF NOT EXISTS "{idx_name}"
             ON "{schema}"."{self._table}"(form_id);
+        """
+
+    def _alter_table_sql(self, tenant: str | None) -> str:
+        """Idempotent ``ADD COLUMN IF NOT EXISTS`` block for legacy tables.
+
+        Postgres >= 11 makes ``ADD COLUMN IF NOT EXISTS`` a metadata-only
+        operation when the column is nullable with no default, so this
+        is cheap on existing rows.
+        """
+        qt = self._qualified(tenant)
+        return f"""
+        ALTER TABLE {qt}
+            ADD COLUMN IF NOT EXISTS user_id VARCHAR(255),
+            ADD COLUMN IF NOT EXISTS username VARCHAR(255),
+            ADD COLUMN IF NOT EXISTS org_id INTEGER,
+            ADD COLUMN IF NOT EXISTS submitted_at TIMESTAMPTZ,
+            ADD COLUMN IF NOT EXISTS ip INET,
+            ADD COLUMN IF NOT EXISTS user_agent TEXT,
+            ADD COLUMN IF NOT EXISTS locale VARCHAR(35);
         """
 
     def _insert_sql(self, tenant: str | None) -> str:
@@ -153,8 +210,12 @@ class FormSubmissionStorage:
         INSERT INTO {qt} (
             submission_id, form_id, form_version, data,
             is_valid, forwarded, forward_status, forward_error,
-            tenant, created_at
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            tenant, created_at,
+            user_id, username, org_id, submitted_at, ip, user_agent, locale
+        ) VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+            $11, $12, $13, $14, $15, $16, $17
+        )
         """
 
     # ------------------------------------------------------------------
@@ -167,9 +228,14 @@ class FormSubmissionStorage:
         Idempotent. Targets the default schema unless a ``tenant`` is
         provided (or the instance has a default tenant configured). The
         schema itself MUST already exist.
+
+        Runs the metadata-column ``ALTER TABLE ... ADD COLUMN IF NOT
+        EXISTS`` block immediately after the ``CREATE TABLE`` so legacy
+        ``form_data`` tables pick up the new columns on startup.
         """
         async with self._pool.acquire() as conn:
             await conn.execute(self._create_table_sql(tenant))
+            await conn.execute(self._alter_table_sql(tenant))
         self.logger.info(
             "FormSubmissionStorage: %s ensured", self._qualified(tenant)
         )
@@ -207,6 +273,13 @@ class FormSubmissionStorage:
                 submission.forward_error,
                 effective_tenant,
                 submission.created_at,
+                submission.user_id,
+                submission.username,
+                submission.org_id,
+                submission.submitted_at,
+                submission.ip,
+                submission.user_agent,
+                submission.locale,
             )
         self.logger.debug(
             "Stored submission %s for form %s in %s",

--- a/packages/parrot-formdesigner/tests/unit/test_submission_metadata.py
+++ b/packages/parrot-formdesigner/tests/unit/test_submission_metadata.py
@@ -1,0 +1,510 @@
+"""Tests for form submission metadata (FormMetadataField + enricher)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from parrot_formdesigner.core.schema import (
+    FormField,
+    FormMetadataField,
+    FormSchema,
+    FormSection,
+)
+from parrot_formdesigner.core.types import FieldType
+from parrot_formdesigner.services.auth_context import AuthContext
+from parrot_formdesigner.services.callback_registry import (
+    _clear_registry_for_tests,
+    register_form_callback,
+)
+from parrot_formdesigner.services.metadata_callbacks import (
+    MetadataCallbackInput,
+    MetadataCallbackOutput,
+)
+from parrot_formdesigner.services.metadata_enricher import (
+    MetadataResolutionError,
+    enrich_submission,
+)
+from parrot_formdesigner.services.submissions import FormSubmission
+
+
+# ---------------------------------------------------------------------------
+# Stubs that mimic aiohttp / navigator-auth shape just enough for resolvers.
+# ---------------------------------------------------------------------------
+
+
+class _StubOrg:
+    def __init__(self, org_id: Any) -> None:
+        self.org_id = org_id
+
+
+class _StubUser:
+    def __init__(
+        self,
+        *,
+        user_id: Any = None,
+        username: str | None = None,
+        organizations: list[_StubOrg] | None = None,
+    ) -> None:
+        self.user_id = user_id
+        self.username = username
+        self.organizations = organizations or []
+
+
+class _StubRequest:
+    """Minimal stand-in for aiohttp.web.Request used by resolvers."""
+
+    def __init__(
+        self,
+        *,
+        user: _StubUser | None = None,
+        session: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        remote: str | None = None,
+    ) -> None:
+        self.user = user
+        self.session = session
+        self.headers = headers or {}
+        self.remote = remote
+
+
+def _form(
+    *,
+    metadata: list[FormMetadataField] | None = None,
+    fields: list[FormField] | None = None,
+    tenant: str | None = None,
+) -> FormSchema:
+    return FormSchema(
+        form_id="form-1",
+        title="t",
+        sections=[FormSection(section_id="s", fields=fields or [])],
+        metadata=metadata,
+        tenant=tenant,
+    )
+
+
+def _submission(tenant: str | None = None) -> FormSubmission:
+    return FormSubmission(
+        submission_id="sub-1",
+        form_id="form-1",
+        form_version="1.0",
+        data={},
+        is_valid=True,
+        created_at=datetime(2026, 5, 18, 12, 0, tzinfo=timezone.utc),
+        tenant=tenant,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_callbacks():
+    """Ensure each test starts with a clean callback registry."""
+    _clear_registry_for_tests()
+    yield
+    _clear_registry_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# FormMetadataField + FormSchema validation
+# ---------------------------------------------------------------------------
+
+
+class TestFormMetadataFieldValidation:
+    def test_callback_source_requires_callback_ref(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            FormMetadataField(key="x", source="callback")
+        assert "callback_ref" in str(exc.value)
+
+    def test_non_callback_source_forbids_callback_ref(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            FormMetadataField(
+                key="x", source="user_id", callback_ref="oops"
+            )
+        assert "callback_ref" in str(exc.value)
+
+    def test_builtin_source_constructs_cleanly(self) -> None:
+        mf = FormMetadataField(key="user_id", source="user_id")
+        assert mf.source == "user_id"
+        assert mf.callback_ref is None
+
+
+class TestFormSchemaMetadataValidator:
+    def test_metadata_defaults_none(self) -> None:
+        f = _form()
+        assert f.metadata is None
+
+    def test_collision_with_field_id_is_rejected(self) -> None:
+        field = FormField(
+            field_id="email", field_type=FieldType.EMAIL, label="Email"
+        )
+        with pytest.raises(ValidationError) as exc:
+            _form(
+                fields=[field],
+                metadata=[FormMetadataField(key="email", source="username")],
+            )
+        assert "collides" in str(exc.value)
+
+    def test_duplicate_metadata_keys_rejected(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            _form(
+                metadata=[
+                    FormMetadataField(key="user_id", source="user_id"),
+                    FormMetadataField(key="user_id", source="username"),
+                ]
+            )
+        assert "Duplicate" in str(exc.value)
+
+    def test_callback_shadowing_builtin_key_rejected(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            _form(
+                metadata=[
+                    FormMetadataField(
+                        key="user_id",
+                        source="callback",
+                        callback_ref="custom_user",
+                    )
+                ]
+            )
+        assert "reserved" in str(exc.value)
+
+    def test_invalid_key_identifier_rejected(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            _form(
+                metadata=[
+                    FormMetadataField(key="has space", source="username")
+                ]
+            )
+        assert "identifier" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# enrich_submission
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichSubmissionBuiltins:
+    async def test_resolves_request_context(self) -> None:
+        form = _form(
+            metadata=[
+                FormMetadataField(key="user_id", source="user_id"),
+                FormMetadataField(key="username", source="username"),
+                FormMetadataField(key="org_id", source="org_id"),
+                FormMetadataField(key="ip", source="ip"),
+                FormMetadataField(key="user_agent", source="user_agent"),
+                FormMetadataField(key="locale", source="locale"),
+                FormMetadataField(
+                    key="submitted_at", source="submitted_at"
+                ),
+                FormMetadataField(key="programs", source="programs"),
+            ],
+            tenant="acme",
+        )
+        request = _StubRequest(
+            user=_StubUser(
+                user_id=42,
+                username="alice",
+                organizations=[_StubOrg(7)],
+            ),
+            session={"session": {"programs": ["sales", "ops"]}},
+            headers={
+                "User-Agent": "ParrotTest/1.0",
+                "X-Forwarded-For": "203.0.113.5, 10.0.0.1",
+                "Accept-Language": "en-US,en;q=0.8",
+            },
+            remote="10.0.0.99",
+        )
+        submission = _submission()
+
+        core, extra = await enrich_submission(
+            request=request,
+            form=form,
+            submission=submission,
+            answers={"q1": "yes"},
+            auth_context=AuthContext(scheme="none"),
+        )
+
+        assert core["user_id"] == "42"
+        assert core["username"] == "alice"
+        assert core["org_id"] == 7
+        assert core["ip"] == "203.0.113.5"
+        assert core["user_agent"] == "ParrotTest/1.0"
+        assert core["locale"] == "en-US"
+        assert core["submitted_at"] == submission.created_at
+        # programs is NOT a core column; lives in extra_flat.
+        assert extra == {"programs": ["sales", "ops"]}
+
+    async def test_ip_falls_back_to_remote(self) -> None:
+        form = _form(
+            metadata=[FormMetadataField(key="ip", source="ip")]
+        )
+        request = _StubRequest(remote="198.51.100.4")
+        core, _ = await enrich_submission(
+            request=request,
+            form=form,
+            submission=_submission(),
+            answers={},
+            auth_context=AuthContext(scheme="none"),
+        )
+        assert core["ip"] == "198.51.100.4"
+
+    async def test_missing_optional_value_uses_default(self) -> None:
+        form = _form(
+            metadata=[
+                FormMetadataField(
+                    key="locale", source="locale", default="en-GB"
+                )
+            ]
+        )
+        core, _ = await enrich_submission(
+            request=_StubRequest(),
+            form=form,
+            submission=_submission(),
+            answers={},
+            auth_context=AuthContext(scheme="none"),
+        )
+        assert core["locale"] == "en-GB"
+
+    async def test_required_missing_raises(self) -> None:
+        form = _form(
+            metadata=[
+                FormMetadataField(
+                    key="user_id", source="user_id", required=True
+                )
+            ]
+        )
+        with pytest.raises(MetadataResolutionError):
+            await enrich_submission(
+                request=_StubRequest(),
+                form=form,
+                submission=_submission(),
+                answers={},
+                auth_context=AuthContext(scheme="none"),
+            )
+
+
+class TestEnrichSubmissionCallbacks:
+    async def test_single_value_callback(self) -> None:
+        @register_form_callback("store_lookup")
+        async def _cb(
+            payload: MetadataCallbackInput, auth: AuthContext
+        ) -> MetadataCallbackOutput:
+            assert payload.field.key == "store_id"
+            return MetadataCallbackOutput(success=True, value="S-77")
+
+        form = _form(
+            metadata=[
+                FormMetadataField(
+                    key="store_id",
+                    source="callback",
+                    callback_ref="store_lookup",
+                )
+            ]
+        )
+        core, extra = await enrich_submission(
+            request=_StubRequest(),
+            form=form,
+            submission=_submission(),
+            answers={},
+            auth_context=AuthContext(scheme="none"),
+        )
+        assert core == {}
+        assert extra == {"store_id": "S-77"}
+
+    async def test_fan_out_callback(self) -> None:
+        @register_form_callback("geo_lookup")
+        async def _cb(
+            payload: MetadataCallbackInput, auth: AuthContext
+        ) -> MetadataCallbackOutput:
+            return MetadataCallbackOutput(
+                success=True,
+                values={"lat": 1.23, "lng": 4.56, "accuracy": 9.0},
+            )
+
+        form = _form(
+            metadata=[
+                FormMetadataField(
+                    key="lat",
+                    source="callback",
+                    callback_ref="geo_lookup",
+                )
+            ]
+        )
+        _, extra = await enrich_submission(
+            request=_StubRequest(),
+            form=form,
+            submission=_submission(),
+            answers={},
+            auth_context=AuthContext(scheme="none"),
+        )
+        assert extra == {"lat": 1.23, "lng": 4.56, "accuracy": 9.0}
+
+    async def test_callback_failure_non_required_uses_default(self) -> None:
+        @register_form_callback("flaky")
+        async def _cb(
+            payload: MetadataCallbackInput, auth: AuthContext
+        ) -> MetadataCallbackOutput:
+            return MetadataCallbackOutput(success=False, error="boom")
+
+        form = _form(
+            metadata=[
+                FormMetadataField(
+                    key="store_id",
+                    source="callback",
+                    callback_ref="flaky",
+                    default="UNKNOWN",
+                )
+            ]
+        )
+        _, extra = await enrich_submission(
+            request=_StubRequest(),
+            form=form,
+            submission=_submission(),
+            answers={},
+            auth_context=AuthContext(scheme="none"),
+        )
+        assert extra == {"store_id": "UNKNOWN"}
+
+    async def test_callback_failure_required_raises(self) -> None:
+        @register_form_callback("flaky")
+        async def _cb(
+            payload: MetadataCallbackInput, auth: AuthContext
+        ) -> MetadataCallbackOutput:
+            return MetadataCallbackOutput(success=False, error="boom")
+
+        form = _form(
+            metadata=[
+                FormMetadataField(
+                    key="store_id",
+                    source="callback",
+                    callback_ref="flaky",
+                    required=True,
+                )
+            ]
+        )
+        with pytest.raises(MetadataResolutionError):
+            await enrich_submission(
+                request=_StubRequest(),
+                form=form,
+                submission=_submission(),
+                answers={},
+                auth_context=AuthContext(scheme="none"),
+            )
+
+    async def test_callback_raises_non_required_uses_default(self) -> None:
+        @register_form_callback("explosive")
+        async def _cb(
+            payload: MetadataCallbackInput, auth: AuthContext
+        ) -> MetadataCallbackOutput:
+            raise RuntimeError("kaboom")
+
+        form = _form(
+            metadata=[
+                FormMetadataField(
+                    key="store_id",
+                    source="callback",
+                    callback_ref="explosive",
+                    default="UNKNOWN",
+                )
+            ]
+        )
+        _, extra = await enrich_submission(
+            request=_StubRequest(),
+            form=form,
+            submission=_submission(),
+            answers={},
+            auth_context=AuthContext(scheme="none"),
+        )
+        assert extra == {"store_id": "UNKNOWN"}
+
+    async def test_callback_unregistered_with_required_raises(self) -> None:
+        form = _form(
+            metadata=[
+                FormMetadataField(
+                    key="store_id",
+                    source="callback",
+                    callback_ref="ghost",
+                    required=True,
+                )
+            ]
+        )
+        with pytest.raises(MetadataResolutionError):
+            await enrich_submission(
+                request=_StubRequest(),
+                form=form,
+                submission=_submission(),
+                answers={},
+                auth_context=AuthContext(scheme="none"),
+            )
+
+    async def test_tenant_scoped_callback_overrides_global(self) -> None:
+        @register_form_callback("role")
+        async def _global(
+            payload: MetadataCallbackInput, auth: AuthContext
+        ) -> MetadataCallbackOutput:
+            return MetadataCallbackOutput(success=True, value="default")
+
+        @register_form_callback("role", tenant="acme")
+        async def _acme(
+            payload: MetadataCallbackInput, auth: AuthContext
+        ) -> MetadataCallbackOutput:
+            return MetadataCallbackOutput(success=True, value="acme-role")
+
+        form = _form(
+            metadata=[
+                FormMetadataField(
+                    key="role",
+                    source="callback",
+                    callback_ref="role",
+                )
+            ],
+            tenant="acme",
+        )
+        _, extra = await enrich_submission(
+            request=_StubRequest(),
+            form=form,
+            submission=_submission(tenant="acme"),
+            answers={},
+            auth_context=AuthContext(scheme="none"),
+        )
+        assert extra == {"role": "acme-role"}
+
+
+class TestEnrichSubmissionEdgeCases:
+    async def test_no_metadata_returns_empty(self) -> None:
+        core, extra = await enrich_submission(
+            request=_StubRequest(),
+            form=_form(),
+            submission=_submission(),
+            answers={"a": 1},
+            auth_context=AuthContext(scheme="none"),
+        )
+        assert core == {}
+        assert extra == {}
+
+    async def test_collision_with_answer_raises(self) -> None:
+        @register_form_callback("custom")
+        async def _cb(
+            payload: MetadataCallbackInput, auth: AuthContext
+        ) -> MetadataCallbackOutput:
+            return MetadataCallbackOutput(success=True, value="x")
+
+        form = _form(
+            metadata=[
+                FormMetadataField(
+                    key="store_id",
+                    source="callback",
+                    callback_ref="custom",
+                )
+            ]
+        )
+        with pytest.raises(MetadataResolutionError):
+            await enrich_submission(
+                request=_StubRequest(),
+                form=form,
+                submission=_submission(),
+                # answer key already contains "store_id" — collision.
+                answers={"store_id": "user-supplied"},
+                auth_context=AuthContext(scheme="none"),
+            )

--- a/packages/parrot-formdesigner/tests/unit/test_submission_metadata_storage.py
+++ b/packages/parrot-formdesigner/tests/unit/test_submission_metadata_storage.py
@@ -1,0 +1,150 @@
+"""Tests for FormSubmissionStorage DDL + INSERT with metadata columns."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from parrot_formdesigner.services.submissions import (
+    CORE_METADATA_COLUMNS,
+    FormSubmission,
+    FormSubmissionStorage,
+)
+
+from .test_storage_schema_tenant import _RecordingPool
+
+
+class TestInitializeDDL:
+    @pytest.mark.asyncio
+    async def test_initialize_emits_create_then_alter(self) -> None:
+        """initialize() runs the CREATE block followed by the ALTER block."""
+        pool = _RecordingPool()
+        storage = FormSubmissionStorage(pool=pool)
+        await storage.initialize()
+        assert len(pool.conn.executed) == 2
+        create_sql, _ = pool.conn.executed[0]
+        alter_sql, _ = pool.conn.executed[1]
+        assert "CREATE TABLE IF NOT EXISTS" in create_sql
+        assert "ALTER TABLE" in alter_sql
+        assert "ADD COLUMN IF NOT EXISTS user_id" in alter_sql
+
+    @pytest.mark.asyncio
+    async def test_create_table_declares_all_core_columns(self) -> None:
+        pool = _RecordingPool()
+        await FormSubmissionStorage(pool=pool).initialize()
+        create_sql = pool.conn.executed[0][0]
+        for col in CORE_METADATA_COLUMNS:
+            assert col in create_sql, f"missing column {col!r} in CREATE"
+
+    @pytest.mark.asyncio
+    async def test_alter_table_declares_all_core_columns(self) -> None:
+        pool = _RecordingPool()
+        await FormSubmissionStorage(pool=pool).initialize()
+        alter_sql = pool.conn.executed[1][0]
+        for col in CORE_METADATA_COLUMNS:
+            assert (
+                f"ADD COLUMN IF NOT EXISTS {col}" in alter_sql
+            ), f"alter does not add {col!r}"
+
+
+class TestStoreInsertsMetadata:
+    @pytest.mark.asyncio
+    async def test_insert_has_seventeen_placeholders(self) -> None:
+        pool = _RecordingPool()
+        storage = FormSubmissionStorage(pool=pool)
+        await storage.store(
+            FormSubmission(
+                form_id="f", form_version="1.0", data={}, is_valid=True
+            )
+        )
+        sql, args = pool.conn.executed[0]
+        assert "$17" in sql
+        assert "$18" not in sql
+        assert len(args) == 17
+
+    @pytest.mark.asyncio
+    async def test_insert_carries_metadata_values_in_order(self) -> None:
+        ts = datetime(2026, 5, 18, 10, 0, tzinfo=timezone.utc)
+        sub = FormSubmission(
+            form_id="f",
+            form_version="1.0",
+            data={"q1": "yes"},
+            is_valid=True,
+            created_at=ts,
+            user_id="u-42",
+            username="alice",
+            org_id=7,
+            submitted_at=ts,
+            ip="203.0.113.5",
+            user_agent="ParrotTest/1.0",
+            locale="en-US",
+        )
+        pool = _RecordingPool()
+        await FormSubmissionStorage(pool=pool).store(sub)
+        _, args = pool.conn.executed[0]
+        # Args layout (1-indexed):
+        # 1 submission_id, 2 form_id, 3 form_version, 4 data,
+        # 5 is_valid, 6 forwarded, 7 forward_status, 8 forward_error,
+        # 9 tenant, 10 created_at,
+        # 11 user_id, 12 username, 13 org_id, 14 submitted_at,
+        # 15 ip, 16 user_agent, 17 locale
+        assert args[10] == "u-42"
+        assert args[11] == "alice"
+        assert args[12] == 7
+        assert args[13] == ts
+        assert args[14] == "203.0.113.5"
+        assert args[15] == "ParrotTest/1.0"
+        assert args[16] == "en-US"
+
+    @pytest.mark.asyncio
+    async def test_insert_nulls_metadata_when_unset(self) -> None:
+        """Submissions without metadata still insert NULLs for the new columns."""
+        pool = _RecordingPool()
+        await FormSubmissionStorage(pool=pool).store(
+            FormSubmission(
+                form_id="f", form_version="1.0", data={}, is_valid=True
+            )
+        )
+        _, args = pool.conn.executed[0]
+        for idx in range(10, 17):
+            assert args[idx] is None, f"arg ${idx + 1} should be NULL"
+
+
+class TestFormSubmissionBackCompat:
+    def test_minimal_construction_still_works(self) -> None:
+        """Pre-metadata callers (no extra kwargs) must keep constructing."""
+        sub = FormSubmission(
+            form_id="f", form_version="1.0", data={}, is_valid=True
+        )
+        assert sub.user_id is None
+        assert sub.username is None
+        assert sub.org_id is None
+        assert sub.submitted_at is None
+        assert sub.ip is None
+        assert sub.user_agent is None
+        assert sub.locale is None
+
+    def test_serialization_roundtrip_with_metadata(self) -> None:
+        ts = datetime(2026, 5, 18, tzinfo=timezone.utc)
+        sub = FormSubmission(
+            form_id="f",
+            form_version="1.0",
+            data={},
+            is_valid=True,
+            user_id="u-1",
+            username="bob",
+            org_id=3,
+            submitted_at=ts,
+            ip="1.2.3.4",
+            user_agent="ua",
+            locale="es-MX",
+        )
+        restored = FormSubmission.model_validate(sub.model_dump())
+        assert restored.user_id == "u-1"
+        assert restored.username == "bob"
+        assert restored.org_id == 3
+        assert restored.submitted_at == ts
+        assert restored.ip == "1.2.3.4"
+        assert restored.user_agent == "ua"
+        assert restored.locale == "es-MX"


### PR DESCRIPTION
## Summary

Implements a complete metadata enrichment system for form submissions, allowing forms to declare contextual fields (user ID, IP address, locale, etc.) that are automatically captured and stored alongside submission data. This includes schema validation, built-in resolvers, callback support, and database schema updates.

## Key Changes

- **FormMetadataField schema** (`core/schema.py`): New Pydantic model for declaring metadata fields with sources (built-in, callback, or constant), validation for identifier format, collision detection with form fields, and callback reference requirements.

- **Metadata enrichment service** (`services/metadata_enricher.py`): Core async function that resolves all declared metadata fields, dispatches to built-in resolvers or registered callbacks, applies defaults and required semantics, and splits results into core columns (promoted to `FormSubmission` fields) and extra data (merged into JSONB).

- **Built-in metadata sources** (`services/metadata_sources.py`): Resolver implementations for 11 built-in sources including `user_id`, `username`, `org_id`, `ip`, `user_agent`, `locale`, `submitted_at`, `submission_id`, `tenant`, `programs`, and `constant`. Handles request header parsing, session extraction, and fallback logic (e.g., IP from X-Forwarded-For or remote address).

- **Metadata callback system** (`services/metadata_callbacks.py`): Pydantic I/O models (`MetadataCallbackInput` / `MetadataCallbackOutput`) for async callbacks registered via `register_form_callback`. Supports single-value returns or fan-out dicts for multi-key results.

- **FormSubmission model updates** (`services/submissions.py`): Added 7 new optional fields (`user_id`, `username`, `org_id`, `submitted_at`, `ip`, `user_agent`, `locale`) as promoted metadata columns. Updated DDL to create and alter table with these columns, and INSERT statement to bind metadata values in correct order.

- **Submit handler integration** (`api/handlers.py`): Calls `enrich_submission()` after validation but before storage, applies core overrides to submission, merges extra metadata into answers dict, and catches `MetadataResolutionError` to return HTTP 422 with error details.

- **Comprehensive test suite** (`tests/unit/test_submission_metadata.py`): 510 lines covering FormMetadataField validation, FormSchema metadata validators, built-in resolver behavior, callback invocation (success/failure/exception), tenant-scoped callback overrides, and edge cases (collisions, missing required fields).

- **Storage tests** (`tests/unit/test_submission_metadata_storage.py`): Validates DDL generation, INSERT statement structure, metadata column ordering, NULL handling for unset fields, and backward compatibility.

## Implementation Details

- **Validation**: FormMetadataField enforces that `callback_ref` is required when `source='callback'` and forbidden otherwise. FormSchema validates metadata keys don't collide with field IDs, aren't duplicated, don't shadow reserved built-in names, and are valid identifiers.

- **Resolution order**: Built-in sources are resolved first with pre-computed identity fields (user_id, username, org_id, programs, tenant) passed to callbacks for consistency. Callbacks receive full context via `MetadataCallbackInput` including form_id, submission_id, answers, and the field declaration.

- **Error handling**: Required fields that resolve to None or fail raise `MetadataResolutionError` (HTTP 422). Non-required fields fall back to `default` on resolver failure or exception. Unregistered callbacks with `required=True` also raise.

- **Core vs. extra split**: Keys in `CORE_METADATA_COLUMNS` tuple are promoted to `FormSubmission` fields; all others are merged into the submission's `data` JSONB alongside user answers (no nested `"metadata"` object).

- **Tenant scoping**: Callbacks can be registered globally or per-tenant; tenant-scoped registrations override global ones during lookup.

https://claude.ai/code/session_014vjpsABSMdEbfBTcnD7cae