### PR TITLE
docs: add MkDocs Material site with API reference and chapter guides

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,56 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'requirements-docs.txt'
+      - 'packages/ai-parrot/src/parrot/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install doc tooling
+        run: pip install -r requirements-docs.txt
+
+      - name: Install ai-parrot (for mkdocstrings imports)
+        run: pip install -e packages/ai-parrot || echo "Editable install failed; mkdocstrings will degrade gracefully"
+        continue-on-error: true
+
+      - name: Build site
+        run: mkdocs build
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/api-reference/a2a.md
+++ b/docs/api-reference/a2a.md
@@ -1,0 +1,6 @@
+# A2A (Agent-to-Agent)
+
+::: parrot.a2a
+    options:
+      show_root_heading: false
+      heading_level: 2

--- a/docs/api-reference/bots.md
+++ b/docs/api-reference/bots.md
@@ -1,0 +1,6 @@
+# Bots
+
+::: parrot.bots
+    options:
+      show_root_heading: false
+      heading_level: 2

--- a/docs/api-reference/clients.md
+++ b/docs/api-reference/clients.md
@@ -1,0 +1,6 @@
+# Clients
+
+::: parrot.clients
+    options:
+      show_root_heading: false
+      heading_level: 2

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -1,0 +1,27 @@
+# API Reference
+
+This section is generated automatically from the docstrings of the
+`parrot` package by
+[mkdocstrings](https://mkdocstrings.github.io/). The pages mirror the
+top-level subpackages most users interact with.
+
+| Module | What's there |
+|---|---|
+| [Clients](./clients.md) | `AbstractClient`, provider wrappers, presets |
+| [Bots](./bots.md) | `AbstractBot`, `Chatbot`, `Agent`, crews |
+| [Tools](./tools.md) | `@tool`, `AbstractToolkit`, `OpenAPIToolkit` |
+| [Memory](./memory.md) | Conversation memory, episodic memory |
+| [Stores](./stores.md) | Vector store back-ends |
+| [Loaders](./loaders.md) | Document loaders for RAG |
+| [Integrations](./integrations.md) | Messaging platform adapters |
+| [MCP](./mcp.md) | Model Context Protocol clients & servers |
+| [A2A](./a2a.md) | Agent-to-Agent protocol |
+
+!!! note "Coverage"
+
+    Some modules have richer docstrings than others. If a page looks
+    sparse, that's an invitation to improve the docstrings upstream
+    in `packages/ai-parrot/src/parrot/` — not to rewrite the page.
+
+For conceptual narratives, jump into the chapter pages on the left
+sidebar.

--- a/docs/api-reference/integrations.md
+++ b/docs/api-reference/integrations.md
@@ -1,0 +1,6 @@
+# Integrations
+
+::: parrot.integrations
+    options:
+      show_root_heading: false
+      heading_level: 2

--- a/docs/api-reference/loaders.md
+++ b/docs/api-reference/loaders.md
@@ -1,0 +1,6 @@
+# Loaders
+
+::: parrot.loaders
+    options:
+      show_root_heading: false
+      heading_level: 2

--- a/docs/api-reference/mcp.md
+++ b/docs/api-reference/mcp.md
@@ -1,0 +1,6 @@
+# MCP (Model Context Protocol)
+
+::: parrot.mcp
+    options:
+      show_root_heading: false
+      heading_level: 2

--- a/docs/api-reference/memory.md
+++ b/docs/api-reference/memory.md
@@ -1,0 +1,6 @@
+# Memory
+
+::: parrot.memory
+    options:
+      show_root_heading: false
+      heading_level: 2

--- a/docs/api-reference/stores.md
+++ b/docs/api-reference/stores.md
@@ -1,0 +1,6 @@
+# Stores
+
+::: parrot.stores
+    options:
+      show_root_heading: false
+      heading_level: 2

--- a/docs/api-reference/tools.md
+++ b/docs/api-reference/tools.md
@@ -1,0 +1,6 @@
+# Tools
+
+::: parrot.tools
+    options:
+      show_root_heading: false
+      heading_level: 2

--- a/docs/chapters/bots-agents.md
+++ b/docs/chapters/bots-agents.md
@@ -1,0 +1,40 @@
+# Bots & Agents
+
+A **bot** in AI-Parrot is a stateful conversational entity wrapped
+around an `AbstractClient`. An **agent** extends that with tool calling
+and a ReAct-style reasoning loop. A **crew** orchestrates several
+agents together via sequential, parallel or DAG-based execution.
+
+## What lives here
+
+- **`AbstractBot`** — base class for everything conversational.
+- **`Chatbot`** — single-LLM, single-turn-aware, stateful chat.
+- **`Agent` / `BasicAgent`** — tool-using ReAct agents.
+- **`AgentCrew`** — orchestrator with three execution modes:
+  - `run_sequential()` — output of agent _n_ feeds agent _n+1_
+  - `run_parallel()` — agents run concurrently, results merged
+  - `run_flow()` — DAG defined with `task_flow()`
+- **Plugin agents** — see `parrot.agents` for the dynamic-import
+  registry that resolves agents by name.
+
+## Picking the right primitive
+
+| You need… | Use |
+|---|---|
+| A single-LLM conversation, no tools | `Chatbot` |
+| One agent + a set of tools | `Agent` / `BasicAgent` |
+| Several agents in a pipeline | `AgentCrew.run_sequential` |
+| Independent agents fanning out | `AgentCrew.run_parallel` |
+| Branching dependencies between agents | `AgentCrew.run_flow` |
+
+## Read next
+
+- [Agents](../agent.md), [Agent Mesh](../agent_mesh.md)
+- [Crews](../crew.md), [Crew Handler](../crew_handler.md),
+  [Crew Summary](../crew_summary.md)
+- [Orchestration](../orchestration.md) and
+  [Advanced Orchestration](../ORCHESTRATION.md)
+
+## API reference
+
+[API Reference → Bots](../api-reference/bots.md)

--- a/docs/chapters/foundations.md
+++ b/docs/chapters/foundations.md
@@ -1,0 +1,38 @@
+# Foundations
+
+The foundations layer holds the core abstractions every other module in
+AI-Parrot is built on: the hook/event bus, the data models shared between
+clients, bots and tools, and the architectural decisions that keep the
+framework vendor-agnostic and fully async.
+
+## What lives here
+
+- **Core hooks & event bus** — the cross-cutting infrastructure agents
+  use to publish lifecycle events, attach observers and compose
+  middleware. Source: `parrot.core.hooks`.
+- **Pydantic data models** — `AIMessage`, `SourceDocument`,
+  `MessageResponse`, `ToolCall` and friends. These are the lingua franca
+  between clients, bots and integrations. Source: `parrot.models`.
+- **Helpers & utils** — small reusable building blocks (string
+  normalisation, async runners, retry decorators).
+
+## Read next
+
+For the long-form architectural reasoning behind these pieces, see the
+nine-part architecture series in this section's sidebar:
+
+- [Architecture — MCP Server](../architecture/01-mcp-server.md)
+- [Architecture — A2A](../architecture/02-a2a.md)
+- [Architecture — Toolkits](../architecture/03-toolkits.md)
+- [Architecture — Interaction Surface](../architecture/04-interaction-surface.md)
+- [Architecture — Hardening](../architecture/05-hardening.md)
+- [Architecture — Cross-cutting Concerns](../architecture/06-cross-cutting.md)
+- [Architecture — AgentCrew](../architecture/07-agentcrew.md)
+- [Architecture — AgentsFlow DAG](../architecture/08-agentsflow-dag.md)
+- [Architecture — Ontologic RAG](../architecture/09-ontologic-rag.md)
+
+## API reference
+
+The auto-generated API for these modules is in
+[API Reference → Clients](../api-reference/clients.md) and the per-module
+pages that follow it.

--- a/docs/chapters/integrations.md
+++ b/docs/chapters/integrations.md
@@ -1,0 +1,60 @@
+# Integrations & Transport
+
+AI-Parrot ships first-class integrations with messaging platforms
+(Telegram, MS Teams, Slack, WhatsApp), voice (WhisperX, voice chat)
+and the open protocols that let agents talk to each other and to the
+outside world: **MCP** (Model Context Protocol) and **A2A**
+(Agent-to-Agent).
+
+## What lives here
+
+### Platform integrations (`parrot.integrations`)
+
+- **`IntegrationBotManager`** — the entry point that wires a bot into
+  one or more platforms.
+- **Per-platform configs** — `TelegramAgentConfig`,
+  `MSTeamsAgentConfig`, etc., with Pydantic-validated credentials.
+
+### MCP (`parrot.mcp`)
+
+- **As a server**: expose any AI-Parrot agent as an MCP server so
+  other tools (Claude Desktop, Cursor, …) can call it.
+- **As a client**: consume external MCP servers and surface their
+  tools to your agent.
+- **Auth**: built-in OAuth2 flow for MCP endpoints that require it.
+
+### A2A (`parrot.a2a`)
+
+The native AI-Parrot protocol for agent discovery and inter-agent
+communication. Lets two agents — possibly on different hosts —
+negotiate capabilities and route tasks.
+
+### REST surface (`parrot.handlers`)
+
+Aiohttp-based HTTP handlers for chat, MCP, config, datasets and
+threads. This is what your frontend talks to.
+
+## Decision matrix
+
+| You want… | Use |
+|---|---|
+| Agent in a messaging app | `parrot.integrations.<platform>` |
+| Expose agent to Claude Desktop / Cursor | MCP server |
+| Consume tools from a third party | MCP client |
+| Multi-agent across processes/hosts | A2A |
+| Web/mobile frontend | `parrot.handlers` REST API |
+
+## Read next
+
+- [A2A Communication](../a2a_communication.md)
+- [MCP Sessions](../mcp_session.md),
+  [Simple MCP Server](../simple_mcp_server.md)
+- [Telegram](../telegram_integration.md), [MS Teams](../msteams.md),
+  [WhatsApp Orchestrator](../WHATSAPP_AUTONOMOUS_ORCHESTRATOR.md)
+- [Office 365 OAuth](../integrations/office365-oauth2.md)
+
+## API reference
+
+- [API Reference → Integrations](../api-reference/integrations.md)
+- [API Reference → MCP](../api-reference/mcp.md)
+- [API Reference → A2A](../api-reference/a2a.md)

--- a/docs/chapters/llm-clients.md
+++ b/docs/chapters/llm-clients.md
@@ -1,0 +1,49 @@
+# LLM Clients
+
+AI-Parrot talks to every LLM provider through a single
+`AbstractClient` interface, so the same agent code can run on OpenAI,
+Anthropic, Google GenAI, Groq, VertexAI or HuggingFace without changes.
+
+## What lives here
+
+- **`AbstractClient`** — async base class with `completion()`,
+  `stream()` and `embed()`. Every provider wrapper inherits from it.
+- **Provider clients** — concrete implementations under
+  `parrot.clients.*` (one module per vendor).
+- **`LLM_PRESETS`** — opinionated configurations for the most common
+  models (temperature, max tokens, retry budget).
+- **`StreamingRetryConfig`** — retry policy applied around streaming
+  completions, including back-off and partial-response handling.
+- **Embeddings** — `parrot.embeddings` covers dense and sparse
+  embedding back-ends used by the RAG pipeline.
+
+```mermaid
+flowchart LR
+    Agent --> AbstractClient
+    AbstractClient --> OpenAI
+    AbstractClient --> Anthropic
+    AbstractClient --> Groq
+    AbstractClient --> VertexAI
+    AbstractClient --> HuggingFace
+```
+
+## Golden rules
+
+1. **Never call a provider SDK directly** — always go through
+   `AbstractClient`. This is the seam that keeps the framework vendor
+   agnostic.
+2. **`await` everything** — clients are async only. Wrapping them with
+   `asyncio.run` inside another coroutine will block the event loop.
+3. **Don't subclass `AbstractClient` lightly** — discuss the change
+   first; it's the foundation that all bots and crews assume.
+
+## Read next
+
+- [Per-loop Caching](../clients/per-loop-cache.md) — how the client
+  layer caches completions inside a single agent turn.
+- [Contextual Embedding](../contextual-embedding.md)
+- [Matryoshka Embeddings](../matryoshka-embeddings.md)
+
+## API reference
+
+[API Reference → Clients](../api-reference/clients.md)

--- a/docs/chapters/memory-knowledge.md
+++ b/docs/chapters/memory-knowledge.md
@@ -1,0 +1,47 @@
+# Memory & Knowledge
+
+AI-Parrot separates two concerns that often get confused: **memory**
+(conversation state for a given session) and **knowledge** (long-lived
+facts, documents, embeddings used by RAG).
+
+## What lives here
+
+### Memory
+
+- **`ConversationMemory`** — abstract base for per-session histories.
+- **`InMemoryConversation`** — process-local store, ideal for tests.
+- **`RedisConversation`** — production-grade, multi-process safe,
+  TTL-aware.
+- **`EpisodicMemoryStore`** — FAISS-backed long-term episodic memory
+  for agents that need to remember across sessions.
+- **`AnswerMemory`** — cache of (question → answer) pairs for repeat
+  queries.
+
+### Knowledge
+
+- **Vector stores** — `AbstractStore` plus concrete back-ends:
+  `PgVectorStore`, `FaissStore`, `MilvusStore`, `ArangoStore`,
+  `BigQueryStore`. PgVector is the recommended default.
+- **`parrot.knowledge`** — context assembly: takes a user query and
+  returns ranked, deduplicated, citation-ready chunks.
+
+## Decision matrix
+
+| Use case | Component |
+|---|---|
+| Track the last N user turns | `RedisConversation` |
+| Remember a user across sessions | `EpisodicMemoryStore` |
+| Avoid recomputing identical queries | `AnswerMemory` |
+| Semantic retrieval over documents | `PgVectorStore` + `knowledge` |
+
+## Read next
+
+- [Execution Memory](../EXECUTION_MEMORY.md)
+- [Local Knowledge Base](../local_kb.md)
+- [Parent-Child Retrieval](../parent-child-retrieval.md)
+- [DocumentDB](../documentdb.md), [Storage Backends](../storage-backends.md)
+
+## API reference
+
+- [API Reference → Memory](../api-reference/memory.md)
+- [API Reference → Stores](../api-reference/stores.md)

--- a/docs/chapters/tools-rag.md
+++ b/docs/chapters/tools-rag.md
@@ -1,0 +1,61 @@
+# Tools, Loaders & RAG
+
+Agents are useful only as far as their tools let them act on the world.
+AI-Parrot treats tools as first-class citizens: a docstring becomes
+the LLM-facing description, a Pydantic model becomes the schema.
+
+## What lives here
+
+### Tools
+
+- **`@tool` decorator** — the fast path. Annotate any async function
+  and it becomes callable by any agent.
+- **`AbstractToolkit`** — group related tools that share state
+  (auth, clients, rate-limit budget).
+- **`OpenAPIToolkit`** — turn any OpenAPI spec into a dynamic toolkit.
+
+### Loaders
+
+`parrot.loaders` turns documents — PDFs, HTML, DOCX, audio transcripts,
+database rows, web pages — into chunks ready for the vector store.
+Every loader subclasses `BaseLoader` and implements
+`async def load() -> list[Document]`.
+
+### RAG pipeline
+
+Loaders → chunkers → embeddings (see [LLM Clients](./llm-clients.md))
+→ vector store (see [Memory & Knowledge](./memory-knowledge.md)) →
+`parrot.knowledge` retrieves and assembles context → agent uses it
+in its system prompt or as a tool result.
+
+```mermaid
+flowchart LR
+    Doc[Documents] --> L[Loader]
+    L --> C[Chunker]
+    C --> E[Embeddings]
+    E --> VS[(Vector Store)]
+    Q[User Query] --> R[Retriever]
+    VS --> R
+    R --> A[Agent]
+```
+
+## Golden rules
+
+1. **Docstrings are the API for the LLM** — write them with the model
+   as your audience, not your colleagues.
+2. **Use Pydantic for tool inputs** — the schema becomes the function
+   spec sent to the model. `Field(description=...)` matters.
+3. **Tools must be async** — blocking I/O inside a tool stalls every
+   other agent on the loop.
+
+## Read next
+
+- [Tools Reference](../tools.md), [Sandbox Tool](../sandbox_tool.md),
+  [What-If Tool](../whatif_tool.md), [Hierarchy Tool](../hierarchy_tool.md)
+- [Charts & Visualization](../charts_samples.md)
+- [Loaders Metadata](../loaders-metadata.md)
+
+## API reference
+
+- [API Reference → Tools](../api-reference/tools.md)
+- [API Reference → Loaders](../api-reference/loaders.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,107 +1,141 @@
-# 🦜 AI-Parrot Documentation
-
-Welcome to the AI-Parrot documentation. This is your comprehensive guide to building intelligent agents, chatbots, and LLM-powered applications.
-
-## 📚 Table of Contents
-
-### 🚀 Getting Started
-
-- [Installation Guide](INSTALL.md) - Set up AI-Parrot in your environment
-- [Configuration](config.md) - Configure AI-Parrot for your needs
-- [Quick Start Guide](tools_quick.md) - Get up and running quickly
-
-### 🤖 Core Concepts
-
-- [Agents](agent.md) - Understanding AI agents in AI-Parrot
-- [Agent Mesh](agent_mesh.md) - Multi-agent systems and coordination
-- [Crews](crew.md) - Organizing agents into teams
-- [Crew Handler](crew_handler.md) - Managing crew operations
-- [Crew Summary](crew_summary.md) - Summarizing crew activities
-- [Orchestration](orchestration.md) - Orchestrating complex workflows
-- [Advanced Orchestration](ORCHESTRATION.md) - Advanced orchestration patterns
-
-### 🛠️ Tools & Capabilities
-
-- [Tools Overview](tools.md) - Comprehensive guide to tools
-- [What-If Tool](whatif_tool.md) - Scenario analysis and optimization
-- [Sandbox Tool](sandbox_tool.md) - Safe code execution environment
-- [Hierarchy Tool](hierarchy_tool.md) - Working with hierarchical data
-- [Tool Clone](tool_clone.md) - Cloning and replicating tools
-- [ArXiv Tool](ARXIV_TOOL_README.md) - Research paper integration
-- [Charts & Visualization](charts_samples.md) - Creating visualizations
-
-### 💬 Communication & Integration
-
-- [Agent-to-Agent Communication](a2a_communication.md) - Inter-agent messaging
-- [MCP Sessions](mcp_session.md) - Model Context Protocol sessions
-- [Telegram Integration](telegram_integration.md) - Building Telegram bots
-- [Microsoft Teams Integration](msteams.md) - Teams bot integration
-- [Voice Chat](voice_chat.md) - Voice-enabled conversations
-- [WhisperX Integration](whisperx.md) - Speech recognition
-
-### 🗄️ Knowledge & Data
-
-- [Local Knowledge Base](local_kb.md) - Building local knowledge bases
-- [Outputs](outputs.md) - Managing agent outputs
-- [Company Info](company_info.md) - Company information tools
-
-### 🌐 API & Development
-
-- [API Endpoints](API_ENDPOINTS.md) - REST API reference
-- [Jupyter Mode](jupyter_mode.md) - Using AI-Parrot in Jupyter notebooks
-- [Job Manager](jobmanager.md) - Managing background jobs
-
-### 📖 Reference
-
-- [Classes Reference](CLASSES.md) - Class documentation
-- [Functions Reference](FUNCTIONS.md) - Function documentation
-- [Style Guide](STYLE_GUIDE.md) - Code style and conventions
-
-### 🔧 Advanced Topics
-
-- [MCP GenMedia Installation](install-mcp-genmedia.md) - Installing GenMedia for MCP
+---
+hide:
+  - navigation
+  - toc
 ---
 
-## 🎯 Quick Navigation by Use Case
+# AI-Parrot
 
-### Building a Chatbot
-1. Start with [Installation](INSTALL.md)
-2. Read [Agents](agent.md) to understand the basics
-3. Check [Tools Overview](tools.md) for available capabilities
-4. Review [Configuration](config.md) for setup
+**Async-first Python framework for building AI Agents and Chatbots.**
 
-### Creating Multi-Agent Systems
-1. Learn about [Agent Mesh](agent_mesh.md)
-2. Understand [Crews](crew.md) and [Crew Handler](crew_handler.md)
-3. Explore [Orchestration](orchestration.md) patterns
-4. Review [A2A Communication](a2a_communication.md)
+AI-Parrot is a vendor-agnostic framework that lets you build conversational
+agents, tool-using assistants and multi-agent crews on top of any major LLM
+provider — OpenAI, Anthropic, Google GenAI, Groq, VertexAI, HuggingFace —
+through a single async interface.
 
-### Integrating with External Services
-1. [Telegram Integration](telegram_integration.md)
-2. [Microsoft Teams Integration](msteams.md)
-3. [Voice Chat](voice_chat.md)
-4. [API Endpoints](API_ENDPOINTS.md)
-
-### Working with Data & Analysis
-1. [What-If Tool](whatif_tool.md) for scenario analysis
-2. [Charts & Visualization](charts_samples.md)
-3. [Local Knowledge Base](local_kb.md)
-4. [Sandbox Tool](sandbox_tool.md) for safe execution
+[Get started →](INSTALL.md){ .md-button .md-button--primary }
+[Browse the API →](api-reference/index.md){ .md-button }
 
 ---
 
-## 📝 Contributing
+## Documentation by chapter
 
-When contributing to the documentation, please follow the [Style Guide](STYLE_GUIDE.md) to maintain consistency.
+<div class="grid cards" markdown>
+
+-   :material-cube-outline:{ .lg .middle } **Foundations**
+
+    ---
+
+    Core abstractions, data models and the architectural decisions that
+    keep AI-Parrot async and vendor-agnostic.
+
+    [→ Open chapter](chapters/foundations.md)
+
+-   :material-brain:{ .lg .middle } **LLM Clients**
+
+    ---
+
+    One `AbstractClient` interface for every provider. Streaming,
+    retries, presets and embeddings.
+
+    [→ Open chapter](chapters/llm-clients.md)
+
+-   :material-robot-outline:{ .lg .middle } **Bots & Agents**
+
+    ---
+
+    `Chatbot`, `Agent`, `AgentCrew` — single agents and multi-agent
+    orchestration with sequential, parallel and DAG execution.
+
+    [→ Open chapter](chapters/bots-agents.md)
+
+-   :material-database-search:{ .lg .middle } **Memory & Knowledge**
+
+    ---
+
+    Conversation memory, episodic memory and RAG over PgVector,
+    FAISS, Milvus, Arango or BigQuery.
+
+    [→ Open chapter](chapters/memory-knowledge.md)
+
+-   :material-tools:{ .lg .middle } **Tools, Loaders & RAG**
+
+    ---
+
+    The `@tool` decorator, toolkits, OpenAPI ingestion and document
+    loaders for the RAG pipeline.
+
+    [→ Open chapter](chapters/tools-rag.md)
+
+-   :material-connection:{ .lg .middle } **Integrations & Transport**
+
+    ---
+
+    Telegram, MS Teams, WhatsApp, voice. MCP servers/clients and the
+    A2A inter-agent protocol.
+
+    [→ Open chapter](chapters/integrations.md)
+
+</div>
 
 ---
 
-## 🔗 External Resources
+## Quick navigation by use case
+
+=== "Build a chatbot"
+
+    1. [Install AI-Parrot](INSTALL.md)
+    2. Read the [Bots & Agents overview](chapters/bots-agents.md)
+    3. Pick the tools you need in [Tools, Loaders & RAG](chapters/tools-rag.md)
+    4. Tune behaviour via [Configuration](config.md)
+
+=== "Build a multi-agent system"
+
+    1. Read [Bots & Agents](chapters/bots-agents.md) and pick the
+       right execution mode (sequential / parallel / DAG).
+    2. For cross-host or cross-process agents, jump to
+       [A2A Communication](a2a_communication.md).
+    3. Production patterns live in
+       [Advanced Orchestration](ORCHESTRATION.md).
+
+=== "RAG over your documents"
+
+    1. Pick a vector store —
+       [Storage Backends](storage-backends.md).
+    2. Wire loaders →
+       [Local Knowledge Base](local_kb.md),
+       [Loaders Metadata](loaders-metadata.md).
+    3. Tune retrieval with
+       [Parent-Child Retrieval](parent-child-retrieval.md).
+
+=== "Expose an agent as a service"
+
+    1. Decide the surface — REST? MCP? Messaging?
+    2. REST: [API Endpoints](API_ENDPOINTS.md).
+    3. MCP: [MCP Sessions](mcp_session.md) and
+       [Simple MCP Server](simple_mcp_server.md).
+    4. Telegram / Teams / WhatsApp: see the
+       [Integrations chapter](chapters/integrations.md).
+
+---
+
+## Contributing
+
+Documentation lives in `docs/` and follows the
+[Style Guide](STYLE_GUIDE.md). The site is built with
+[MkDocs Material](https://squidfunk.github.io/mkdocs-material/) and the
+API reference is generated by
+[mkdocstrings](https://mkdocstrings.github.io/) from the docstrings in
+`packages/ai-parrot/src/parrot/`.
+
+Run the site locally:
+
+```bash
+pip install -r requirements-docs.txt
+pip install -e packages/ai-parrot
+mkdocs serve
+```
+
+## External resources
 
 - [GitHub Repository](https://github.com/phenobarbital/ai-parrot)
-- [Project README](../README.md)
-
----
-
-
-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,226 @@
+site_name: AI-Parrot
+site_description: Async-first Python framework for building AI Agents and Chatbots
+site_url: https://phenobarbital.github.io/ai-parrot/
+repo_url: https://github.com/phenobarbital/ai-parrot
+repo_name: phenobarbital/ai-parrot
+edit_uri: edit/main/docs/
+
+docs_dir: docs
+site_dir: site
+
+validation:
+  omitted_files: warn
+  absolute_links: warn
+  unrecognized_links: warn
+  anchors: warn
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - navigation.indexes
+    - navigation.tracking
+    - toc.follow
+    - search.suggest
+    - search.highlight
+    - search.share
+    - content.code.copy
+    - content.code.annotate
+    - content.tabs.link
+  palette:
+    - scheme: default
+      primary: green
+      accent: light green
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: green
+      accent: light green
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  icon:
+    logo: material/robot-happy-outline
+    repo: fontawesome/brands/github
+
+plugins:
+  - search
+  - glightbox
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          paths:
+            - packages/ai-parrot/src
+          options:
+            show_source: true
+            show_root_heading: true
+            show_root_full_path: false
+            show_signature_annotations: true
+            separate_signature: true
+            merge_init_into_class: true
+            docstring_style: google
+            docstring_section_style: spacy
+            members_order: source
+            filters:
+              - "!^_"
+            heading_level: 2
+
+markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.caret
+  - pymdownx.tilde
+  - pymdownx.mark
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/phenobarbital/ai-parrot
+    - icon: fontawesome/brands/python
+      link: https://pypi.org/project/ai-parrot/
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Installation: INSTALL.md
+      - Configuration: config.md
+      - Quick Start (Tools): tools_quick.md
+  - Foundations:
+      - Overview: chapters/foundations.md
+      - Architecture - MCP Server: architecture/01-mcp-server.md
+      - Architecture - A2A: architecture/02-a2a.md
+      - Architecture - Toolkits: architecture/03-toolkits.md
+      - Architecture - Interaction Surface: architecture/04-interaction-surface.md
+      - Architecture - Hardening: architecture/05-hardening.md
+      - Architecture - Cross-cutting: architecture/06-cross-cutting.md
+      - Architecture - AgentCrew: architecture/07-agentcrew.md
+      - Architecture - AgentsFlow DAG: architecture/08-agentsflow-dag.md
+      - Architecture - Ontologic RAG: architecture/09-ontologic-rag.md
+  - LLM Clients:
+      - Overview: chapters/llm-clients.md
+      - Per-loop Caching: clients/per-loop-cache.md
+      - Contextual Embedding: contextual-embedding.md
+      - Matryoshka Embeddings: matryoshka-embeddings.md
+  - Bots & Agents:
+      - Overview: chapters/bots-agents.md
+      - Agents: agent.md
+      - Agent Mesh: agent_mesh.md
+      - Agent Service: agent_service.md
+      - Agent Factory Handler: agent_factory_handler.md
+      - Agent Config Creation: agent_config_creation.md
+      - Crews: crew.md
+      - Crew Handler: crew_handler.md
+      - Crew Summary: crew_summary.md
+      - Orchestration: orchestration.md
+      - Advanced Orchestration: ORCHESTRATION.md
+      - Test Agent: testagent.md
+      - UI Agent: uiagent.md
+  - Memory & Knowledge:
+      - Overview: chapters/memory-knowledge.md
+      - Execution Memory: EXECUTION_MEMORY.md
+      - Local Knowledge Base: local_kb.md
+      - Parent-Child Retrieval: parent-child-retrieval.md
+      - Loaders Metadata: loaders-metadata.md
+      - DocumentDB: documentdb.md
+      - DocumentDB Interface: documentdb_interface.md
+      - Storage Backends: storage-backends.md
+      - DynamoDB Local: dynamodb-local.md
+      - Database Agent: database-agent.md
+      - Dataset Manager Design: datasetmanager_design.md
+      - Company Info: company_info.md
+      - User Profile: user-profile.md
+  - Tools, Loaders & RAG:
+      - Overview: chapters/tools-rag.md
+      - Tools Reference: tools.md
+      - What-If Tool: whatif_tool.md
+      - Sandbox Tool: sandbox_tool.md
+      - Hierarchy Tool: hierarchy_tool.md
+      - Tool Clone: tool_clone.md
+      - ArXiv Tool: ARXIV_TOOL_README.md
+      - FRED API Tool: fred_api_tool.md
+      - Odoo Toolkit: odoo_toolkit_capabilities.md
+      - GitHub Reviewer: github-reviewer.md
+      - Charts & Visualization: charts_samples.md
+      - Toolbar API: toolbar-api.md
+  - Integrations & Transport:
+      - Overview: chapters/integrations.md
+      - A2A Communication: a2a_communication.md
+      - MCP Sessions: mcp_session.md
+      - Simple MCP Server: simple_mcp_server.md
+      - MCP Server Config: simple_mcp_server_config.md
+      - Install GitHub MCP: install_github_mcp.md
+      - Install MCP GenMedia: install-mcp-genmedia.md
+      - Telegram: telegram_integration.md
+      - MS Teams: msteams.md
+      - WhatsApp Orchestrator: WHATSAPP_AUTONOMOUS_ORCHESTRATOR.md
+      - WhatsApp Spec: messaging/whatsapp.md
+      - WhatsApp Implementation: messaging/implement-whatsapp.md
+      - Office 365 OAuth: integrations/office365-oauth2.md
+      - Voice Chat: voice_chat.md
+      - WhisperX: whisperx.md
+  - Orchestration & Flows:
+      - Decision Nodes: DECISION_NODE_USAGE.md
+      - Bot Cleanup Lifecycle: bot-cleanup-lifecycle.md
+      - Infographic Handler API: infographic_handler_api.md
+      - VectorStore Handler API: vectorstore_handler_api.md
+      - Jira Specialist Prompt Layers: jira-specialist-prompt-layers.md
+  - Advanced:
+      - API Endpoints (REST): API_ENDPOINTS.md
+      - Ephemeral Agents API: api/feat-149-ephemeral-agents-api.md
+      - Jupyter Mode: jupyter_mode.md
+      - Job Manager: jobmanager.md
+      - Outputs: outputs.md
+      - AWS Deployment: aws_deployment.md
+      - 2026 Roadmap: parrot_roadmap_2026.md
+      - PR Review Setup: pr-review-setup.md
+      - Web HITL Frontend Brainstorm: web-hitl-frontend-brainstorm.md
+  - API Reference:
+      - Overview: api-reference/index.md
+      - Clients: api-reference/clients.md
+      - Bots: api-reference/bots.md
+      - Tools: api-reference/tools.md
+      - Memory: api-reference/memory.md
+      - Stores: api-reference/stores.md
+      - Loaders: api-reference/loaders.md
+      - Integrations: api-reference/integrations.md
+      - MCP: api-reference/mcp.md
+      - A2A: api-reference/a2a.md
+  - Reference:
+      - Classes: CLASSES.md
+      - Functions: FUNCTIONS.md
+  - Development:
+      - Style Guide: STYLE_GUIDE.md
+      - SDD Workflow: sdd/WORKFLOW.md
+      - SDD Guide: sdd/GUIDE.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,5 @@
+mkdocs>=1.6
+mkdocs-material>=9.5
+mkdocstrings[python]>=0.27
+pymdown-extensions>=10.11
+mkdocs-glightbox>=0.4


### PR DESCRIPTION
## Summary

This PR establishes a comprehensive documentation site for AI-Parrot using MkDocs Material. It introduces a structured navigation hierarchy, auto-generated API reference via mkdocstrings, and six conceptual chapter guides that organize the framework by concern (Foundations, LLM Clients, Bots & Agents, Memory & Knowledge, Tools & RAG, Integrations & Transport).

## Key Changes

- **`mkdocs.yml`** — Complete site configuration with Material theme, plugins (search, glightbox, mkdocstrings), markdown extensions, and hierarchical navigation structure
- **`docs/index.md`** — Redesigned landing page with chapter cards, quick-start tabs by use case, and contribution guidelines
- **`docs/chapters/`** — Six new chapter overview pages:
  - `foundations.md` — Core abstractions, hooks, data models, and architectural decisions
  - `llm-clients.md` — `AbstractClient` interface, provider wrappers, presets, embeddings
  - `bots-agents.md` — `Chatbot`, `Agent`, `AgentCrew` primitives and execution modes
  - `memory-knowledge.md` — Conversation memory, episodic memory, vector stores, RAG pipeline
  - `tools-rag.md` — `@tool` decorator, toolkits, loaders, and RAG golden rules
  - `integrations.md` — MCP, A2A, platform integrations, REST surface
- **`docs/api-reference/`** — Eight auto-generated API reference pages (clients, bots, tools, memory, stores, loaders, integrations, mcp, a2a) using mkdocstrings
- **`.github/workflows/docs.yml`** — CI/CD workflow to build and deploy docs to GitHub Pages on push to main
- **`requirements-docs.txt`** — Documentation tooling dependencies (mkdocs, mkdocs-material, mkdocstrings, pymdown-extensions, mkdocs-glightbox)

## Implementation Details

- **Chapter structure** mirrors the framework's module organization and serves as conceptual entry points before diving into API reference
- **API reference** is auto-generated from docstrings in `packages/ai-parrot/src/parrot/` using mkdocstrings with Google-style docstring parsing
- **Navigation** uses Material's sticky tabs and section expansion for intuitive browsing across 200+ pages
- **Quick-start tabs** on the landing page guide users by use case (chatbot, multi-agent, RAG, service exposure)
- **Workflow** includes local development instructions (`mkdocs serve`) and GitHub Pages deployment automation

https://claude.ai/code/session_0157h65M3wedK1ySu8jghDQH