### PR TITLE
feat(infographic): add layout field to ChartBlock and financial_variance template

### DIFF
--- a/packages/ai-parrot/src/parrot/models/infographic.py
+++ b/packages/ai-parrot/src/parrot/models/infographic.py
@@ -368,6 +368,14 @@ class ChartBlock(BaseModel):
     y_axis_label: Optional[str] = Field(None, description="Y-axis label")
     stacked: Optional[bool] = Field(False, description="Whether series are stacked")
     show_legend: Optional[bool] = Field(True, description="Whether to show the legend")
+    layout: Optional[Literal["full", "half"]] = Field(
+        None,
+        description=(
+            "Layout hint for the frontend renderer. 'half' marks the chart as "
+            "half-width so consecutive half-width charts render side-by-side in "
+            "a 2-column grid. Omit or set to 'full' for full-width rendering."
+        ),
+    )
 
 
 class BulletListBlock(BaseModel):

--- a/packages/ai-parrot/src/parrot/models/infographic_templates.py
+++ b/packages/ai-parrot/src/parrot/models/infographic_templates.py
@@ -362,6 +362,62 @@ TEMPLATE_MINIMAL = InfographicTemplate(
 )
 
 
+TEMPLATE_FINANCIAL_VARIANCE = InfographicTemplate(
+    name="financial_variance",
+    description=(
+        "Financial projection variance dashboard: 4 KPI hero cards, 2 day-over-day "
+        "bar charts side-by-side, 1 cumulative trend line chart full-width, and an "
+        "executive summary. Ideal for daily/period financial tracking where the "
+        "reader needs both per-period deltas and a cumulative view."
+    ),
+    default_theme="light",
+    block_specs=[
+        BlockSpec(
+            block_type=BlockType.TITLE,
+            description="Report title and the date range covered (e.g. 'May 14 – 27, 2026')",
+        ),
+        BlockSpec(
+            block_type=BlockType.HERO_CARD,
+            description=(
+                "Exactly 4 KPI cards in this order: (1) headline metric current value, "
+                "(2) period variance with trend, (3) secondary metric current value, "
+                "(4) day-over-day delta with trend"
+            ),
+            min_items=4,
+            max_items=4,
+        ),
+        BlockSpec(
+            block_type=BlockType.CHART,
+            description=(
+                "Two bar charts side-by-side showing day-over-day change for the two "
+                "headline metrics. BOTH charts MUST set layout='half' so the frontend "
+                "renders them in a 2-column grid. Use chart_type='bar' and one series each."
+            ),
+            min_items=2,
+            max_items=2,
+            constraints={"chart_type": "bar", "layout": "half"},
+        ),
+        BlockSpec(
+            block_type=BlockType.CHART,
+            description=(
+                "Cumulative trend line chart across the same date range, full width "
+                "(layout='full' or omitted). Single series, smooth line."
+            ),
+            min_items=1,
+            max_items=1,
+            constraints={"chart_type": "line", "layout": "full"},
+        ),
+        BlockSpec(
+            block_type=BlockType.SUMMARY,
+            description=(
+                "Executive summary (2-4 sentences) that ties the 4 KPIs and the trend "
+                "together. Call out the largest delta and its likely driver."
+            ),
+        ),
+    ],
+)
+
+
 TEMPLATE_MULTI_TAB = InfographicTemplate(
     name="multi_tab",
     description=(
@@ -415,6 +471,7 @@ class InfographicTemplateRegistry:
             TEMPLATE_TIMELINE_REPORT,
             TEMPLATE_MINIMAL,
             TEMPLATE_MULTI_TAB,
+            TEMPLATE_FINANCIAL_VARIANCE,
         ):
             self._templates[tpl.name] = tpl
 


### PR DESCRIPTION
## Summary
- Add optional `layout: Literal['full', 'half']` field to `ChartBlock`. Pydantic strips unknown fields by default, so without this the LLM cannot emit a layout hint even when the template prompt instructs it to. `half` marks a chart as half-width so consecutive half-width charts render side-by-side in the frontend's 2-column grid.
- Register a new built-in template `financial_variance` in `infographic_templates.py`: title → exactly four KPI hero cards → two bar charts (`layout='half'`) → one full-width line chart → executive summary. Mirrors the Financial Projection Variance dashboard layout requested by the analytics team.
- Pairs with the frontend PR in `Trocdigital/navigator-frontend-next` that consumes the `layout` field and renders the side-by-side row.

## Test plan
- [ ] `infographic_registry.list_templates()` includes `financial_variance`
- [ ] `GET /api/v1/agents/infographic/templates/financial_variance` returns the expected `block_specs` shape
- [ ] `ChartBlock(chart_type='bar', labels=[...], series=[...], layout='half')` validates and round-trips through `model_dump()`
- [ ] Existing `tests/helpers/test_infographics_helpers.py` and `tests/handlers/test_infographic_handler.py` still pass (they assert *known names are present*, not that the list is exact, so adding a template should not regress)
- [ ] End-to-end smoke: `POST /api/v1/agents/infographic/{agent_id}?format=json` with `template='financial_variance'` returns blocks matching the template ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)