### PR TITLE
FEAT-115: Route Telegram reminders through originating bot

### DIFF
--- a/packages/ai-parrot-integrations/src/parrot/integrations/telegram/wrapper.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/telegram/wrapper.py
@@ -2934,6 +2934,13 @@ class TelegramAgentWrapper:
 
     async def close(self) -> None:
         """Release resources held by the wrapper (call on shutdown)."""
+        if self._bot_id:
+            try:
+                from parrot.tools.reminder import unregister_telegram_bot
+
+                unregister_telegram_bot(self._bot_id)
+            except Exception:  # noqa: BLE001 - reminders are optional
+                pass
         if self._transcriber is not None:
             await self._transcriber.close()
             self._transcriber = None

--- a/packages/ai-parrot-integrations/src/parrot/integrations/telegram/wrapper.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/telegram/wrapper.py
@@ -96,6 +96,24 @@ class TelegramAgentWrapper:
         self.conversations: Dict[int, "ConversationMemory"] = {}
         self.logger = logging.getLogger(f"TelegramWrapper.{config.name}")
 
+        # Cache the bot's non-secret numeric id (token prefix before ``:``) and
+        # register the full token with the reminder module so a scheduled
+        # ``deliver_reminder`` can deliver through THIS bot instead of the
+        # global TELEGRAM_BOT_TOKEN env default. Only the numeric id is ever
+        # persisted in the APScheduler job; the token stays in process memory.
+        self._bot_id: Optional[str] = self._resolve_bot_id(bot, config)
+        _bot_token = getattr(config, "bot_token", None)
+        if self._bot_id and isinstance(_bot_token, str):
+            try:
+                from parrot.tools.reminder import register_telegram_bot
+
+                register_telegram_bot(self._bot_id, _bot_token)
+            except Exception:  # noqa: BLE001 - reminders are optional
+                self.logger.debug(
+                    "Could not register Telegram bot token for reminders",
+                    exc_info=True,
+                )
+
         # Agent-declared commands (from @telegram_command decorator).
         # TelegramBotManager passes these explicitly, but IntegrationManager
         # constructs wrappers directly, so discover here as a fallback.
@@ -1071,9 +1089,32 @@ class TelegramAgentWrapper:
         return f"<reply_context>{original_text}</reply_context>\n"
 
     @staticmethod
+    def _resolve_bot_id(bot: Bot, config: "TelegramAgentConfig") -> Optional[str]:
+        """Return the bot's non-secret numeric id (token prefix before ``:``).
+
+        Prefers aiogram's :pyattr:`Bot.id` (parsed from the token, no network
+        call) and falls back to parsing ``config.bot_token``. Returns ``None``
+        when neither is available so callers degrade to the env default.
+        """
+        try:
+            bot_id = getattr(bot, "id", None)
+            # aiogram's Bot.id is always an int (parsed from the token). The
+            # int check also rejects MagicMock attributes in tests so we fall
+            # through to parsing config.bot_token instead.
+            if isinstance(bot_id, int):
+                return str(bot_id)
+        except Exception:  # noqa: BLE001 - id may raise if token is malformed
+            pass
+        token = getattr(config, "bot_token", None)
+        if isinstance(token, str) and ":" in token:
+            return token.split(":", 1)[0]
+        return None
+
+    @staticmethod
     def _build_permission_context(
         session: TelegramUserSession,
         chat_id: Optional[int] = None,
+        bot_id: Optional[str] = None,
     ) -> Any:
         """Construct a ``PermissionContext`` scoped to this Telegram user.
 
@@ -1092,6 +1133,12 @@ class TelegramAgentWrapper:
         is in — not the user's DM, which is unreachable for groups or for
         users who never opened a private chat with the bot.
 
+        When *bot_id* is supplied it is added to ``extra['telegram_bot_id']``
+        so a scheduled reminder is later delivered through the *same* bot the
+        user talked to, rather than the global ``TELEGRAM_BOT_TOKEN`` env
+        default (which, in a multi-bot deployment, is the wrong bot and lands
+        the message on a default channel).
+
         Imported lazily to keep the Telegram wrapper importable without
         ``parrot.auth.permission`` on the path (older deployments).
         """
@@ -1109,6 +1156,10 @@ class TelegramAgentWrapper:
         }
         if chat_id is not None:
             extra["chat_id"] = chat_id
+        if bot_id is not None:
+            # Non-secret bot id so ReminderToolkit can persist it and
+            # deliver_reminder can resolve the originating bot's token.
+            extra["telegram_bot_id"] = bot_id
         if session.nav_user_id:
             extra["nav_user_id"] = session.nav_user_id
         if session.jira_account_id:
@@ -1286,7 +1337,9 @@ class TelegramAgentWrapper:
 
         agent, user_tm = await self._resolve_agent_for_request(session, message=message)
         chat_id = message.chat.id if message is not None else None
-        permission_context = self._build_permission_context(session, chat_id=chat_id)
+        permission_context = self._build_permission_context(
+            session, chat_id=chat_id, bot_id=self._bot_id
+        )
         enriched = self._enrich_question(question, session)
 
         timeout = self.config.agent_timeout

--- a/packages/ai-parrot/src/parrot/notifications/__init__.py
+++ b/packages/ai-parrot/src/parrot/notifications/__init__.py
@@ -137,6 +137,7 @@ class NotificationMixin:
         report: Optional[Any] = None,
         template: Optional[str] = None,
         with_attachments: bool = True,
+        provider_options: Optional[Dict[str, Any]] = None,
         **kwargs
     ) -> Dict[str, Any]:
         """
@@ -150,6 +151,12 @@ class NotificationMixin:
             report: Optional AgentResponse or AIMessage containing output/files
             template: Email template name
             with_attachments: Whether to include file attachments
+            provider_options: Connection-level keyword arguments forwarded to
+                the provider's constructor (NOT the per-message ``send`` call).
+                For Telegram this carries ``{"bot_token": "..."}`` so the
+                notification is delivered through a specific bot rather than the
+                global ``TELEGRAM_BOT_TOKEN`` env default — essential when
+                several agents each run their own Telegram bot.
             **kwargs: Additional provider-specific arguments
 
         Returns:
@@ -222,7 +229,8 @@ class NotificationMixin:
             result = await self._send_with_provider(
                 provider=provider,
                 notify_args=notify_args,
-                files=files if with_attachments else None
+                files=files if with_attachments else None,
+                provider_options=provider_options,
             )
 
             self.logger.info(
@@ -468,7 +476,8 @@ class NotificationMixin:
         self,
         provider: NotificationProvider,
         notify_args: Dict[str, Any],
-        files: Optional[List[Path]] = None
+        files: Optional[List[Path]] = None,
+        provider_options: Optional[Dict[str, Any]] = None,
     ) -> Any:
         """
         Send notification using the specified provider with smart file handling.
@@ -477,6 +486,9 @@ class NotificationMixin:
             provider: Notification provider to use
             notify_args: Arguments for the notification
             files: Optional list of file attachments
+            provider_options: Connection-level kwargs for the provider
+                constructor (currently honoured by the Telegram provider to
+                select a specific bot token).
 
         Returns:
             Provider-specific result
@@ -488,7 +500,9 @@ class NotificationMixin:
             return await self._send_slack(notify_args)
 
         elif provider == NotificationProvider.TELEGRAM:
-            return await self._send_telegram(notify_args, files)
+            return await self._send_telegram(
+                notify_args, files, provider_options=provider_options
+            )
 
         elif provider == NotificationProvider.TEAMS:
             return await self._send_teams(notify_args, files)
@@ -519,15 +533,26 @@ class NotificationMixin:
     async def _send_telegram(
         self,
         notify_args: Dict[str, Any],
-        files: Optional[List[Path]] = None
+        files: Optional[List[Path]] = None,
+        provider_options: Optional[Dict[str, Any]] = None,
     ) -> Any:
         """
         Send Telegram notification with smart file handling.
 
         Images are sent as photos, documents as documents, videos as videos.
+
+        Args:
+            notify_args: Per-message arguments forwarded to the provider's
+                ``send``/``send_*`` calls (message text, recipient, …).
+            files: Optional attachments classified and sent by type.
+            provider_options: Connection-level kwargs for the ``Telegram``
+                constructor. When it carries ``bot_token`` the message is
+                delivered through that specific bot instead of the global
+                ``TELEGRAM_BOT_TOKEN`` env default — required so a scheduled
+                reminder reaches the user via the same bot that scheduled it.
         """
         from notify.providers.telegram import Telegram
-        telegram = Telegram()
+        telegram = Telegram(**(provider_options or {}))
         results = []
 
         async with telegram as conn:

--- a/packages/ai-parrot/src/parrot/tools/reminder.py
+++ b/packages/ai-parrot/src/parrot/tools/reminder.py
@@ -35,6 +35,56 @@ _notifier = NotificationMixin()
 
 
 # ---------------------------------------------------------------------------
+# Per-bot token registry (FEAT-115 hardening)
+# ---------------------------------------------------------------------------
+# ``deliver_reminder`` runs at module scope (APScheduler serialises only a
+# dotted-path reference), so it cannot capture the live aiogram ``Bot`` the
+# user talked to. Without a token it builds a generic ``notify.Telegram()``
+# that falls back to the global ``TELEGRAM_BOT_TOKEN`` env var — the *wrong*
+# bot in a multi-agent deployment, which is why reminders surfaced on a
+# default channel instead of the originating chat.
+#
+# The integration layer registers each bot's token here, keyed by the bot's
+# **non-secret** numeric id (the part of the token before ``:``). Only that id
+# is persisted inside the APScheduler job, never the token itself, so secrets
+# stay out of the Redis jobstore. On process restart the integration
+# re-registers its bots at startup, so reminders armed before the restart
+# still resolve the correct token when they fire.
+_TELEGRAM_BOT_TOKENS: dict[str, str] = {}
+
+
+def register_telegram_bot(bot_id: str | int, bot_token: str) -> None:
+    """Register a Telegram bot token under its non-secret numeric id.
+
+    Called by the Telegram integration when a bot starts so that
+    :func:`deliver_reminder` can deliver through the same bot the user
+    interacted with.
+
+    Args:
+        bot_id: The bot's Telegram numeric id (token prefix before ``:``).
+        bot_token: The full ``<id>:<secret>`` bot token.
+    """
+    if bot_id and bot_token:
+        _TELEGRAM_BOT_TOKENS[str(bot_id)] = bot_token
+
+
+def unregister_telegram_bot(bot_id: str | int) -> None:
+    """Remove a previously registered Telegram bot token.
+
+    Args:
+        bot_id: The bot's Telegram numeric id used at registration time.
+    """
+    _TELEGRAM_BOT_TOKENS.pop(str(bot_id), None)
+
+
+def _resolve_telegram_token(bot_id: str | None) -> str | None:
+    """Return the registered token for *bot_id*, or ``None`` if unknown."""
+    if not bot_id:
+        return None
+    return _TELEGRAM_BOT_TOKENS.get(str(bot_id))
+
+
+# ---------------------------------------------------------------------------
 # Top-level coroutine — MUST NOT be a method, closure, or lambda.
 # ---------------------------------------------------------------------------
 async def deliver_reminder(
@@ -44,6 +94,7 @@ async def deliver_reminder(
     message: str,
     requested_by: str,
     requested_at: str,
+    bot_id: str | None = None,
 ) -> None:
     """Fire a reminder by delivering it through the requested notification channel.
 
@@ -62,18 +113,42 @@ async def deliver_reminder(
             Stored for audit purposes; not used for delivery logic here.
         requested_at: ISO-8601 UTC timestamp of when the reminder was
             scheduled.  Included in the delivered message prefix.
+        bot_id: For Telegram reminders, the non-secret numeric id of the bot
+            that scheduled the reminder. Used to resolve the matching token
+            from :data:`_TELEGRAM_BOT_TOKENS` so delivery goes through the
+            originating bot. When ``None`` or unregistered, the provider falls
+            back to the global ``TELEGRAM_BOT_TOKEN`` env default (legacy
+            behaviour).
     """
     prefix = f"⏰ <b>Reminder</b> (scheduled {requested_at}):\n\n"
+
+    provider_options: dict | None = None
+    if provider == "telegram" and bot_id:
+        token = _resolve_telegram_token(bot_id)
+        if token:
+            provider_options = {"bot_token": token}
+        else:
+            logger.warning(
+                "No registered Telegram bot for bot_id=%s; delivering reminder "
+                "for user=%s via the TELEGRAM_BOT_TOKEN env default. The "
+                "reminder may reach the wrong chat if the env bot differs from "
+                "the originating bot.",
+                bot_id,
+                requested_by,
+            )
+
     logger.info(
-        "Delivering reminder for user=%s via provider=%s recipients=%s",
+        "Delivering reminder for user=%s via provider=%s recipients=%s bot_id=%s",
         requested_by,
         provider,
         recipients,
+        bot_id,
     )
     await _notifier.send_notification(
         message=prefix + message,
         recipients=recipients,
         provider=provider,
+        provider_options=provider_options,
     )
 
 
@@ -191,17 +266,36 @@ class ReminderToolkit(AbstractToolkit):
         reminder_id = f"reminder-{uuid.uuid4()}"
         requested_at = datetime.now(timezone.utc).isoformat()
 
+        # For Telegram, persist the originating bot's *non-secret* numeric id
+        # so ``deliver_reminder`` can resolve the matching token at fire time
+        # and deliver through the same bot the user talked to (never the global
+        # env default). The token itself is never persisted in the jobstore.
+        job_kwargs: dict[str, Any] = {
+            "provider": channel,
+            "recipients": recipients,
+            "message": message,
+            "requested_by": str(pctx.user_id),
+            "requested_at": requested_at,
+        }
+        if channel == "telegram":
+            extra: dict = pctx.extra or {}
+            bot_id = extra.get("telegram_bot_id")
+            if bot_id is not None:
+                job_kwargs["bot_id"] = str(bot_id)
+            else:
+                self.logger.warning(
+                    "schedule_reminder: no 'telegram_bot_id' in "
+                    "PermissionContext.extra; the reminder will be delivered "
+                    "via the TELEGRAM_BOT_TOKEN env default and may reach the "
+                    "wrong bot. Ensure the Telegram integration populates "
+                    "extra['telegram_bot_id']."
+                )
+
         self._sm.scheduler.add_job(
             deliver_reminder,
             trigger="date",
             run_date=run_at,
-            kwargs={
-                "provider": channel,
-                "recipients": recipients,
-                "message": message,
-                "requested_by": str(pctx.user_id),
-                "requested_at": requested_at,
-            },
+            kwargs=job_kwargs,
             id=reminder_id,
             jobstore="redis",
             replace_existing=False,

--- a/packages/ai-parrot/tests/tools/test_deliver_reminder.py
+++ b/packages/ai-parrot/tests/tools/test_deliver_reminder.py
@@ -9,7 +9,11 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from parrot.tools.reminder import deliver_reminder
+from parrot.tools.reminder import (
+    deliver_reminder,
+    register_telegram_bot,
+    unregister_telegram_bot,
+)
 
 
 async def test_deliver_reminder_forwards_to_send_notification():
@@ -30,9 +34,11 @@ async def test_deliver_reminder_forwards_to_send_notification():
         mock_notifier.send_notification.assert_awaited_once()
         call_kwargs = mock_notifier.send_notification.call_args.kwargs
 
-        # Message must start with the ⏰ prefix
+        # Message must start with the ⏰ prefix. Telegram is rendered by the
+        # notify provider with parse_mode=html, so the prefix uses HTML tags
+        # (matching parrot.tools.reminder.deliver_reminder's shipped format).
         assert call_kwargs["message"].startswith(
-            f"⏰ *Recordatorio* (programado {requested_at}):\n\n"
+            f"⏰ <b>Reminder</b> (scheduled {requested_at}):\n\n"
         )
         # Message must end with the original text
         assert call_kwargs["message"].endswith("call the developer")
@@ -60,3 +66,66 @@ async def test_deliver_reminder_prefix_contains_requested_at():
         msg = mock_notifier.send_notification.call_args.kwargs["message"]
         assert ts in msg
         assert "year-end check" in msg
+
+
+async def test_deliver_reminder_routes_to_registered_bot_token():
+    """A telegram reminder whose bot_id is registered delivers through that
+    bot's token (passed as provider_options) — not the env default bot."""
+    register_telegram_bot("123456", "123456:SECRET-TOKEN")
+    try:
+        with patch("parrot.tools.reminder._notifier") as mock_notifier:
+            mock_notifier.send_notification = AsyncMock(return_value={})
+
+            await deliver_reminder(
+                provider="telegram",
+                recipients=[-1001234567],
+                message="standup in 5",
+                requested_by="user-123",
+                requested_at="2026-04-22T12:00:00+00:00",
+                bot_id="123456",
+            )
+
+            call_kwargs = mock_notifier.send_notification.call_args.kwargs
+            assert call_kwargs["provider_options"] == {
+                "bot_token": "123456:SECRET-TOKEN"
+            }
+            assert call_kwargs["recipients"] == [-1001234567]
+    finally:
+        unregister_telegram_bot("123456")
+
+
+async def test_deliver_reminder_unregistered_bot_falls_back_to_env():
+    """When bot_id is not registered, provider_options is None so the notify
+    provider uses the TELEGRAM_BOT_TOKEN env default (legacy behaviour)."""
+    unregister_telegram_bot("999999")  # ensure absent
+    with patch("parrot.tools.reminder._notifier") as mock_notifier:
+        mock_notifier.send_notification = AsyncMock(return_value={})
+
+        await deliver_reminder(
+            provider="telegram",
+            recipients=[987654321],
+            message="ping",
+            requested_by="user-123",
+            requested_at="2026-04-22T12:00:00+00:00",
+            bot_id="999999",
+        )
+
+        call_kwargs = mock_notifier.send_notification.call_args.kwargs
+        assert call_kwargs["provider_options"] is None
+
+
+async def test_deliver_reminder_without_bot_id_is_backward_compatible():
+    """Omitting bot_id (pre-existing jobs) → provider_options is None."""
+    with patch("parrot.tools.reminder._notifier") as mock_notifier:
+        mock_notifier.send_notification = AsyncMock(return_value={})
+
+        await deliver_reminder(
+            provider="telegram",
+            recipients=[987654321],
+            message="legacy",
+            requested_by="user-123",
+            requested_at="2026-04-22T12:00:00+00:00",
+        )
+
+        call_kwargs = mock_notifier.send_notification.call_args.kwargs
+        assert call_kwargs["provider_options"] is None

--- a/packages/ai-parrot/tests/tools/test_reminder_toolkit.py
+++ b/packages/ai-parrot/tests/tools/test_reminder_toolkit.py
@@ -155,6 +155,32 @@ async def test_schedule_telegram_prefers_chat_id_over_telegram_id(toolkit, mock_
     assert call_kwargs["kwargs"]["recipients"] == [-1001234567]
 
 
+async def test_schedule_telegram_persists_bot_id(toolkit, mock_sm):
+    """When extra carries telegram_bot_id, it is persisted in the job kwargs
+    as the (non-secret) bot_id so deliver_reminder can route through the
+    originating bot instead of the TELEGRAM_BOT_TOKEN env default."""
+    pctx = _pctx(extra={"chat_id": -1001234567, "telegram_bot_id": "123456"})
+    await _run(
+        toolkit, pctx,
+        lambda: toolkit.schedule_reminder(message="x", delay_seconds=60, channel="telegram"),
+    )
+    payload = mock_sm.scheduler.add_job.call_args.kwargs["kwargs"]
+    assert payload["bot_id"] == "123456"
+    # The secret token must never be persisted in the jobstore payload.
+    assert "bot_token" not in payload
+
+
+async def test_schedule_telegram_without_bot_id_omits_key(toolkit, mock_sm):
+    """No telegram_bot_id in extra → bot_id key is absent (legacy fallback)."""
+    pctx = _pctx(extra={"chat_id": 987654321})
+    await _run(
+        toolkit, pctx,
+        lambda: toolkit.schedule_reminder(message="x", delay_seconds=60, channel="telegram"),
+    )
+    payload = mock_sm.scheduler.add_job.call_args.kwargs["kwargs"]
+    assert "bot_id" not in payload
+
+
 async def test_schedule_email_requires_email_in_pctx(toolkit):
     """Missing email in pctx + channel='email' → clear ValueError."""
     pctx = _pctx(extra={})  # no email field


### PR DESCRIPTION
## Summary

Fixes multi-bot Telegram deployments where reminders were incorrectly delivered through the global `TELEGRAM_BOT_TOKEN` env default instead of the bot that scheduled them. Introduces a per-bot token registry so scheduled reminders can resolve and use the correct bot at delivery time.

## Key Changes

- **Reminder token registry** (`parrot/tools/reminder.py`):
  - Added `_TELEGRAM_BOT_TOKENS` dict to store bot tokens keyed by non-secret numeric bot id
  - Added `register_telegram_bot()` and `unregister_telegram_bot()` functions for the Telegram integration to manage registrations
  - Added `_resolve_telegram_token()` helper to look up tokens at reminder delivery time
  - Modified `deliver_reminder()` to accept optional `bot_id` parameter and pass resolved token via `provider_options` to the notification provider
  - Updated `schedule_reminder()` to extract `telegram_bot_id` from `PermissionContext.extra` and persist it (never the secret token) in the APScheduler job kwargs

- **Telegram integration** (`parrot/integrations/telegram/wrapper.py`):
  - Added `_bot_id` instance variable to cache the bot's numeric id (token prefix before `:`)
  - Added `_resolve_bot_id()` static method to extract numeric id from aiogram `Bot.id` or by parsing `config.bot_token`
  - Registers the bot token with the reminder module on initialization so reminders armed before process restart still resolve correctly
  - Modified `_build_permission_context()` to accept and populate `bot_id` parameter in `extra['telegram_bot_id']`
  - Updated `_invoke_agent()` to pass `bot_id` when building permission context

- **Notification provider** (`parrot/notifications/__init__.py`):
  - Added `provider_options` parameter to `send_notification()` to forward connection-level kwargs to provider constructors
  - Updated `_send_with_provider()` and `_send_telegram()` to accept and use `provider_options`
  - Telegram provider now instantiated with `bot_token` when supplied, allowing per-message bot selection

- **Tests**:
  - Added comprehensive test coverage for registered bot token routing, unregistered bot fallback, and backward compatibility with pre-existing jobs
  - Updated existing tests to reflect HTML tag format in reminder prefix

## Implementation Details

- **Secret safety**: Only the non-secret numeric bot id is persisted in the Redis jobstore; the full token stays in process memory and is re-registered on startup
- **Backward compatibility**: Omitting `bot_id` (pre-existing scheduled jobs) falls back to the global `TELEGRAM_BOT_TOKEN` env default
- **Graceful degradation**: When a bot_id is not registered at delivery time, a warning is logged and the env default is used
- **Multi-bot support**: Each bot registers its token independently; reminders scheduled by different bots route through their respective bots

https://claude.ai/code/session_012QGU5HKrGxuto2xzQWy35P