### PR TITLE
Add voice/audio transcription support for HITL free-text interactions

### DIFF
--- a/packages/ai-parrot-integrations/src/parrot/human/channels/telegram.py
+++ b/packages/ai-parrot-integrations/src/parrot/human/channels/telegram.py
@@ -21,9 +21,12 @@ Usage:
     channel = TelegramHumanChannel(bot=bot, redis=redis_client)
     await channel.register_response_handler(manager.receive_response)
 """
+import asyncio
 import json
 import secrets
+import tempfile
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
 
 from navconfig.logging import logging
@@ -41,6 +44,7 @@ try:
     from aiogram.filters import Command
     from aiogram.types import (
         CallbackQuery,
+        ContentType,
         InlineKeyboardMarkup,
         InlineKeyboardButton,
         Message,
@@ -81,6 +85,7 @@ class TelegramHumanChannel(HumanChannel):
         redis: Any,
         token_ttl: int = 86400,
         parse_mode: str = "Markdown",
+        voice_config: Optional[Any] = None,  # VoiceTranscriberConfig | None
     ) -> None:
         if not HAS_AIOGRAM:
             raise ImportError(
@@ -92,6 +97,7 @@ class TelegramHumanChannel(HumanChannel):
         self.redis = redis
         self.token_ttl = token_ttl
         self.parse_mode = parse_mode
+        self.voice_config = voice_config
         self.logger = logging.getLogger("parrot.human.channels.telegram")
 
         # Router for handling callback queries
@@ -111,6 +117,9 @@ class TelegramHumanChannel(HumanChannel):
         # abort them. Callback interactions live in Redis tokens; this is the
         # in-memory index to reverse-lookup them by chat.
         self._pending_by_chat: Dict[int, Set[str]] = {}
+
+        # Lazy-initialized voice transcriber (shared VoiceTranscriber instance)
+        self._transcriber: Optional[Any] = None
 
         # Register handlers
         self._register_handlers()
@@ -154,6 +163,19 @@ class TelegramHumanChannel(HumanChannel):
             self._handle_text_reply,
             F.chat.type == "private",
             F.text,
+            self._awaiting_text_filter,
+        )
+
+        # Voice / audio replies during HITL free-text interactions.
+        # Registered AFTER the text handler so F.text wins when present.
+        # When the user sends a voice note while we're awaiting a free-text
+        # response, transcribe it here and route to the same finalization
+        # logic — rather than letting it fall through to the wrapper and
+        # being treated as a fresh agent query.
+        self.router.message.register(
+            self._handle_voice_reply,
+            F.chat.type == "private",
+            F.content_type.in_({ContentType.VOICE, ContentType.AUDIO}),
             self._awaiting_text_filter,
         )
 
@@ -832,16 +854,25 @@ class TelegramHumanChannel(HumanChannel):
         Only processes messages from chats where we're actively
         waiting for a text response.
         """
+        if message.chat.id not in self._awaiting_text:
+            return  # Not waiting for input from this chat — ignore
+
+        await self._finalize_text_response(message, message.text.strip())
+
+    async def _finalize_text_response(self, message: Message, text: str) -> None:
+        """Complete a HITL free-text interaction with the provided text.
+
+        Shared by ``_handle_text_reply`` (typed input) and
+        ``_handle_voice_reply`` (transcribed voice input).
+        """
         chat_id = message.chat.id
 
         if chat_id not in self._awaiting_text:
-            return  # Not waiting for input from this chat — ignore
+            return
 
         interaction_id = self._awaiting_text.pop(chat_id)
         telegram_user_id = str(message.from_user.id)
 
-        # Check if this is a form response (key: value format)
-        text = message.text.strip()
         interaction_meta = await self._get_interaction_meta(interaction_id)
 
         value: Any = text
@@ -872,6 +903,110 @@ class TelegramHumanChannel(HumanChannel):
 
         if self._response_callback:
             await self._response_callback(response)
+
+    def _get_transcriber(self) -> Any:
+        """Lazily create the VoiceTranscriber from the configured voice_config."""
+        if self._transcriber is None:
+            from ...voice.transcriber import VoiceTranscriber
+
+            self._transcriber = VoiceTranscriber(self.voice_config)
+        return self._transcriber
+
+    async def _handle_voice_reply(self, message: Message) -> None:
+        """Handle voice/audio messages during HITL free-text interactions.
+
+        When voice_config is set: downloads, transcribes, then routes to
+        ``_finalize_text_response`` exactly like a typed reply.
+        When voice_config is absent: informs the user to type instead.
+        """
+        chat_id = message.chat.id
+
+        if chat_id not in self._awaiting_text:
+            return
+
+        if not self.voice_config:
+            await message.reply(
+                "🎙 Voice notes aren't supported for this interaction. "
+                "Please type your response as text."
+            )
+            return
+
+        # Extract file_id and choose a temporary file suffix
+        if message.voice:
+            file_id = message.voice.file_id
+            suffix = ".ogg"
+        elif message.audio:
+            file_id = message.audio.file_id
+            mt = (message.audio.mime_type or "").lower()
+            if "ogg" in mt:
+                suffix = ".ogg"
+            elif "wav" in mt:
+                suffix = ".wav"
+            elif "m4a" in mt or "mp4" in mt:
+                suffix = ".m4a"
+            else:
+                suffix = ".mp3"
+        else:
+            return
+
+        tmp_path: Optional[Path] = None
+        try:
+            file = await self.bot.get_file(file_id)
+            if file.file_path:
+                tg_ext = Path(file.file_path).suffix
+                if tg_ext:
+                    suffix = tg_ext
+
+            tmp = tempfile.NamedTemporaryFile(
+                suffix=suffix, prefix="hitl_voice_", delete=False
+            )
+            await self.bot.download_file(file.file_path, tmp)
+            tmp.close()
+            tmp_path = Path(tmp.name)
+
+            transcriber = self._get_transcriber()
+            result = await transcriber.transcribe_file(
+                tmp_path, language=self.voice_config.language
+            )
+
+            if not result.text.strip():
+                await message.reply(
+                    "❓ Sorry, I couldn't understand the voice note. "
+                    "Please try again or type your response."
+                )
+                return
+
+            if self.voice_config.show_transcription:
+                await message.answer(
+                    f"🎙 _{result.text}_", parse_mode="Markdown"
+                )
+
+            await self._finalize_text_response(message, result.text.strip())
+
+        except Exception as exc:
+            self.logger.error(
+                "Error transcribing HITL voice reply (chat %d): %s",
+                chat_id,
+                exc,
+                exc_info=True,
+            )
+            await message.reply(
+                "❌ Couldn't process the voice note. Please type your response."
+            )
+        finally:
+            if tmp_path is not None and tmp_path.exists():
+                try:
+                    tmp_path.unlink()
+                except OSError as exc:
+                    self.logger.debug(
+                        "Could not delete HITL temp file %s: %s", tmp_path, exc
+                    )
+
+    async def close(self) -> None:
+        """Release transcriber resources (call on bot shutdown)."""
+        if self._transcriber is not None:
+            await self._transcriber.close()
+            self._transcriber = None
 
     # ─── User-initiated cancellation ──────────────────────────────────────
 

--- a/packages/ai-parrot-integrations/src/parrot/integrations/manager.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/manager.py
@@ -193,6 +193,7 @@ class IntegrationBotManager:
         human_channel = TelegramHumanChannel(
             bot=bot,
             redis=self._human_redis,
+            voice_config=config.voice_config,
         )
         human_manager.register_channel(name, human_channel)
         await human_channel.register_response_handler(

--- a/packages/ai-parrot-integrations/tests/test_hitl_telegram_voice.py
+++ b/packages/ai-parrot-integrations/tests/test_hitl_telegram_voice.py
@@ -1,0 +1,379 @@
+"""
+Unit tests for TelegramHumanChannel voice-note reply support.
+
+Covers:
+- Voice note during HITL free-text: transcribed and routed correctly
+- Audio file during HITL free-text: transcribed and routed correctly
+- voice_config=None during HITL: user told to type instead
+- Empty transcription: user prompted to retry
+- show_transcription=True: italic preview sent before finalizing
+- Transcription error: graceful error reply, temp file cleaned up
+- Voice note NOT during HITL (no awaiting state): handler returns immediately
+- _finalize_text_response: creates correct HumanResponse and invokes callback
+- close(): releases transcriber resources
+"""
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+import pytest
+
+from parrot.voice.transcriber import TranscriptionResult, VoiceTranscriberConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_voice_config(**kwargs) -> VoiceTranscriberConfig:
+    defaults = dict(
+        enabled=True,
+        max_audio_duration_seconds=60,
+        show_transcription=False,
+        language=None,
+    )
+    defaults.update(kwargs)
+    return VoiceTranscriberConfig(**defaults)
+
+
+def _make_transcription(text: str = "Hello from voice") -> TranscriptionResult:
+    return TranscriptionResult(
+        text=text,
+        language="en",
+        duration_seconds=2.5,
+        processing_time_ms=800,
+    )
+
+
+def _make_channel(voice_config=None):
+    """Return a TelegramHumanChannel with mocked Bot and Redis."""
+    bot = MagicMock()
+    bot.get_file = AsyncMock()
+    bot.download_file = AsyncMock()
+    bot.send_message = AsyncMock()
+
+    redis = AsyncMock()
+
+    with patch(
+        "parrot.human.channels.telegram.HAS_AIOGRAM", True
+    ), patch(
+        "parrot.human.channels.telegram.Router"
+    ) as mock_router_cls:
+        mock_router = MagicMock()
+        mock_router.message = MagicMock()
+        mock_router.message.register = MagicMock()
+        mock_router.callback_query = MagicMock()
+        mock_router.callback_query.register = MagicMock()
+        mock_router_cls.return_value = mock_router
+
+        from parrot.human.channels.telegram import TelegramHumanChannel
+
+        channel = TelegramHumanChannel(bot=bot, redis=redis, voice_config=voice_config)
+        channel.router = mock_router
+        return channel, bot
+
+
+def _make_voice_message(
+    chat_id: int = 42,
+    user_id: int = 99,
+    message_id: int = 7,
+    file_id: str = "voice_file_001",
+    duration: int = 5,
+) -> MagicMock:
+    message = MagicMock()
+    message.chat.id = chat_id
+    message.chat.type = "private"
+    message.message_id = message_id
+
+    user = MagicMock()
+    user.id = user_id
+    message.from_user = user
+
+    voice = MagicMock()
+    voice.file_id = file_id
+    voice.duration = duration
+    message.voice = voice
+    message.audio = None
+    message.text = None
+
+    message.reply = AsyncMock()
+    message.answer = AsyncMock()
+    return message
+
+
+def _make_audio_message(
+    chat_id: int = 42,
+    user_id: int = 99,
+    message_id: int = 8,
+    file_id: str = "audio_file_001",
+    mime_type: str = "audio/mpeg",
+) -> MagicMock:
+    message = MagicMock()
+    message.chat.id = chat_id
+    message.chat.type = "private"
+    message.message_id = message_id
+
+    user = MagicMock()
+    user.id = user_id
+    message.from_user = user
+
+    audio = MagicMock()
+    audio.file_id = file_id
+    audio.mime_type = mime_type
+    audio.duration = 4
+    message.audio = audio
+    message.voice = None
+    message.text = None
+
+    message.reply = AsyncMock()
+    message.answer = AsyncMock()
+    return message
+
+
+def _make_file_info(file_path: str = "voice/abc.ogg") -> MagicMock:
+    fi = MagicMock()
+    fi.file_path = file_path
+    return fi
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestHITLVoiceReply:
+
+    @pytest.mark.asyncio
+    async def test_voice_reply_transcribed_and_finalized(self):
+        """Voice note during HITL free-text interaction is transcribed + processed."""
+        voice_config = _make_voice_config(show_transcription=False)
+        channel, bot = _make_channel(voice_config=voice_config)
+
+        interaction_id = "iid-001"
+        channel._awaiting_text[42] = interaction_id
+
+        response_cb = AsyncMock()
+        channel._response_callback = response_cb
+        channel._pending_by_chat[42] = {interaction_id}
+
+        message = _make_voice_message(chat_id=42, user_id=99)
+        file_info = _make_file_info("voice/abc.ogg")
+        bot.get_file.return_value = file_info
+
+        transcription = _make_transcription("Approve this request")
+        mock_transcriber = AsyncMock()
+        mock_transcriber.transcribe_file = AsyncMock(return_value=transcription)
+
+        with patch.object(channel, "_get_transcriber", return_value=mock_transcriber):
+            await channel._handle_voice_reply(message)
+
+        # Should confirm receipt
+        message.reply.assert_called()
+        reply_text = message.reply.call_args[0][0]
+        assert "Got it" in reply_text
+
+        # Callback should be invoked
+        response_cb.assert_awaited_once()
+        hr = response_cb.call_args[0][0]
+        assert hr.value == "Approve this request"
+        assert hr.interaction_id == interaction_id
+        assert hr.respondent == "99"
+
+        # HITL state should be cleared
+        assert 42 not in channel._awaiting_text
+
+    @pytest.mark.asyncio
+    async def test_voice_reply_not_awaiting_returns_immediately(self):
+        """Voice note handler is a no-op when chat is not in HITL state."""
+        voice_config = _make_voice_config()
+        channel, bot = _make_channel(voice_config=voice_config)
+        # No entry in _awaiting_text
+
+        message = _make_voice_message(chat_id=42)
+        await channel._handle_voice_reply(message)
+
+        # No bot interaction
+        bot.get_file.assert_not_called()
+        message.reply.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_voice_reply_no_voice_config_tells_user_to_type(self):
+        """When voice_config is absent, user is instructed to type."""
+        channel, bot = _make_channel(voice_config=None)
+        channel._awaiting_text[42] = "iid-002"
+
+        message = _make_voice_message(chat_id=42)
+        await channel._handle_voice_reply(message)
+
+        # Should NOT attempt download
+        bot.get_file.assert_not_called()
+        # Should inform user
+        message.reply.assert_awaited_once()
+        reply_text = message.reply.call_args[0][0]
+        assert "type" in reply_text.lower() or "text" in reply_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_voice_reply_empty_transcription_prompts_retry(self):
+        """Empty transcription → user is asked to retry or type."""
+        voice_config = _make_voice_config()
+        channel, bot = _make_channel(voice_config=voice_config)
+        channel._awaiting_text[42] = "iid-003"
+        channel._pending_by_chat[42] = {"iid-003"}
+
+        message = _make_voice_message(chat_id=42)
+        file_info = _make_file_info()
+        bot.get_file.return_value = file_info
+
+        empty_result = _make_transcription(text="   ")
+        mock_transcriber = AsyncMock()
+        mock_transcriber.transcribe_file = AsyncMock(return_value=empty_result)
+
+        with patch.object(channel, "_get_transcriber", return_value=mock_transcriber):
+            await channel._handle_voice_reply(message)
+
+        message.reply.assert_awaited_once()
+        reply_text = message.reply.call_args[0][0]
+        assert "understand" in reply_text.lower() or "try" in reply_text.lower()
+        # HITL state NOT cleared (user can retry)
+        assert 42 in channel._awaiting_text
+
+    @pytest.mark.asyncio
+    async def test_voice_reply_show_transcription_sends_preview(self):
+        """show_transcription=True sends italic preview before finalizing."""
+        voice_config = _make_voice_config(show_transcription=True)
+        channel, bot = _make_channel(voice_config=voice_config)
+        channel._awaiting_text[42] = "iid-004"
+        channel._pending_by_chat[42] = {"iid-004"}
+        channel._response_callback = AsyncMock()
+
+        message = _make_voice_message(chat_id=42)
+        bot.get_file.return_value = _make_file_info()
+
+        transcription = _make_transcription("Please proceed")
+        mock_transcriber = AsyncMock()
+        mock_transcriber.transcribe_file = AsyncMock(return_value=transcription)
+
+        with patch.object(channel, "_get_transcriber", return_value=mock_transcriber):
+            await channel._handle_voice_reply(message)
+
+        # answer() called with italic transcription
+        message.answer.assert_awaited_once()
+        preview = message.answer.call_args[0][0]
+        assert "Please proceed" in preview
+
+    @pytest.mark.asyncio
+    async def test_voice_reply_error_sends_error_message(self):
+        """Transcription error results in graceful error reply, not an exception."""
+        voice_config = _make_voice_config()
+        channel, bot = _make_channel(voice_config=voice_config)
+        channel._awaiting_text[42] = "iid-005"
+
+        message = _make_voice_message(chat_id=42)
+        bot.get_file.return_value = _make_file_info()
+
+        mock_transcriber = AsyncMock()
+        mock_transcriber.transcribe_file = AsyncMock(
+            side_effect=RuntimeError("whisper error")
+        )
+
+        with patch.object(channel, "_get_transcriber", return_value=mock_transcriber):
+            await channel._handle_voice_reply(message)
+
+        message.reply.assert_awaited()
+        reply_text = message.reply.call_args[0][0]
+        assert "❌" in reply_text or "type" in reply_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_audio_file_reply_works(self):
+        """ContentType.AUDIO (forwarded audio) also transcribes correctly."""
+        voice_config = _make_voice_config(show_transcription=False)
+        channel, bot = _make_channel(voice_config=voice_config)
+        channel._awaiting_text[42] = "iid-006"
+        channel._pending_by_chat[42] = {"iid-006"}
+        channel._response_callback = AsyncMock()
+
+        message = _make_audio_message(chat_id=42, mime_type="audio/mpeg")
+        bot.get_file.return_value = _make_file_info("audio/abc.mp3")
+
+        transcription = _make_transcription("Audio reply text")
+        mock_transcriber = AsyncMock()
+        mock_transcriber.transcribe_file = AsyncMock(return_value=transcription)
+
+        with patch.object(channel, "_get_transcriber", return_value=mock_transcriber):
+            await channel._handle_voice_reply(message)
+
+        channel._response_callback.assert_awaited_once()
+        hr = channel._response_callback.call_args[0][0]
+        assert hr.value == "Audio reply text"
+
+    @pytest.mark.asyncio
+    async def test_close_releases_transcriber(self):
+        """close() closes the transcriber and clears the reference."""
+        voice_config = _make_voice_config()
+        channel, _ = _make_channel(voice_config=voice_config)
+
+        mock_transcriber = AsyncMock()
+        mock_transcriber.close = AsyncMock()
+        channel._transcriber = mock_transcriber
+
+        await channel.close()
+
+        mock_transcriber.close.assert_awaited_once()
+        assert channel._transcriber is None
+
+    @pytest.mark.asyncio
+    async def test_close_noop_when_no_transcriber(self):
+        """close() is a no-op when no transcriber has been initialized."""
+        channel, _ = _make_channel()
+        await channel.close()  # must not raise
+
+
+class TestFinalizeTextResponse:
+
+    @pytest.mark.asyncio
+    async def test_creates_correct_human_response(self):
+        """_finalize_text_response creates a HumanResponse with the given text."""
+        channel, _ = _make_channel()
+        interaction_id = "iid-fin-001"
+        channel._awaiting_text[10] = interaction_id
+        channel._pending_by_chat[10] = {interaction_id}
+
+        response_cb = AsyncMock()
+        channel._response_callback = response_cb
+
+        # Stub Redis so _get_interaction_meta returns None (no form)
+        channel.redis.get = AsyncMock(return_value=None)
+
+        message = MagicMock()
+        message.chat.id = 10
+        message.message_id = 55
+        message.from_user = MagicMock()
+        message.from_user.id = 77
+        message.reply = AsyncMock()
+
+        await channel._finalize_text_response(message, "My typed answer")
+
+        response_cb.assert_awaited_once()
+        hr = response_cb.call_args[0][0]
+        assert hr.value == "My typed answer"
+        assert hr.respondent == "77"
+        assert hr.interaction_id == interaction_id
+        assert hr.metadata["channel"] == "telegram"
+        assert 10 not in channel._awaiting_text
+
+    @pytest.mark.asyncio
+    async def test_noop_when_not_awaiting(self):
+        """_finalize_text_response is a no-op if chat is not in awaiting state."""
+        channel, _ = _make_channel()
+        response_cb = AsyncMock()
+        channel._response_callback = response_cb
+
+        message = MagicMock()
+        message.chat.id = 99  # not in _awaiting_text
+        message.reply = AsyncMock()
+
+        await channel._finalize_text_response(message, "irrelevant")
+
+        response_cb.assert_not_awaited()


### PR DESCRIPTION
## Summary

Adds voice note and audio file transcription support to `TelegramHumanChannel` for HITL (Human-in-the-Loop) free-text interactions. When a user sends a voice message or audio file while awaiting a text response, the message is automatically transcribed and routed through the same finalization logic as typed responses.

## Key Changes

- **Voice message handler** (`_handle_voice_reply`): Intercepts voice/audio messages during HITL interactions, downloads the file, transcribes it using a configurable `VoiceTranscriber`, and routes the result to `_finalize_text_response`
- **Lazy transcriber initialization** (`_get_transcriber`): Creates a shared `VoiceTranscriber` instance on first use, avoiding unnecessary resource allocation when voice is not configured
- **Refactored text finalization** (`_finalize_text_response`): Extracted common response finalization logic from `_handle_text_reply` to support both typed and transcribed inputs
- **Voice configuration** (`voice_config` parameter): Optional `VoiceTranscriberConfig` passed to the channel; when absent, users are instructed to type instead
- **Graceful error handling**: Transcription failures, empty results, and missing configuration all result in user-friendly error messages without raising exceptions
- **Resource cleanup** (`close` method): Properly releases transcriber resources on bot shutdown
- **Temporary file management**: Downloads audio to a temporary file with appropriate suffix detection, cleaned up in a finally block
- **Transcription preview** (`show_transcription` flag): When enabled, sends an italic preview of the transcribed text before finalizing the response
- **Router registration**: Voice/audio handler registered after text handler so typed messages take precedence

## Implementation Details

- Voice messages (`.voice`) and audio files (`.audio`) are both supported with appropriate MIME type detection for file suffix selection
- The handler is only active when the chat is in the `_awaiting_text` state (HITL interaction in progress)
- Transcription errors are logged but do not propagate; users receive a fallback message asking them to type instead
- Temporary files are cleaned up even if transcription fails, with debug logging for any OS-level cleanup errors
- The transcriber is shared across all chats to avoid repeated initialization overhead

## Tests

Comprehensive test suite (`test_hitl_telegram_voice.py`) covers:
- Successful voice/audio transcription and finalization
- No-op behavior when not in HITL state
- Fallback messaging when `voice_config` is absent
- Empty transcription retry prompts
- Transcription preview when `show_transcription=True`
- Graceful error handling and recovery
- Resource cleanup on channel close

https://claude.ai/code/session_01PTtvu4qp94RaUMonj75aXm