### PR TITLE
Add multi-repository credentials registry to GitToolkit

### DIFF
--- a/packages/ai-parrot-tools/src/parrot_tools/gittoolkit.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/gittoolkit.py
@@ -28,7 +28,7 @@ import os
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 
 import difflib
 
@@ -96,16 +96,11 @@ class RepositoryCredential(BaseModel):
 
     @model_validator(mode="after")
     def _validate_auth(self) -> "RepositoryCredential":  # pragma: no cover - pydantic hook
-        """Validate that App-mode entries carry the required fields.
-
-        Returns:
-            The validated model instance.
-
-        Raises:
-            ValueError: When auth_type='github_app' is missing required fields
-                or violates the private_key/private_key_path mutual exclusion.
-        """
-        if self.auth_type == "github_app":
+        """Validate auth fields for both pat and github_app modes."""
+        if self.auth_type == "pat":
+            if not self.github_token:
+                raise ValueError("auth_type='pat' requires github_token")
+        elif self.auth_type == "github_app":
             if not self.app_id:
                 raise ValueError("auth_type='github_app' requires app_id")
             if not self.installation_id:
@@ -721,23 +716,7 @@ def _load_pem(
     private_key: Optional[str],
     private_key_path: Optional[str],
 ) -> str:
-    """Resolve a GitHub App private key PEM from inline contents or a file path.
-
-    Exactly one of ``private_key`` / ``private_key_path`` must be supplied.
-    Env-injected PEMs sometimes carry literal ``\\n`` escape sequences, which
-    are normalised back to real newlines.
-
-    Args:
-        private_key: Inline PEM contents, or None.
-        private_key_path: Filesystem path to a PEM file, or None.
-
-    Returns:
-        The PEM contents as a string with real newlines.
-
-    Raises:
-        GitToolkitError: When neither or both inputs are supplied, or when the
-            file cannot be read.
-    """
+    """Resolve a PEM from inline contents or file path (exactly one must be set)."""
     if private_key and private_key_path:
         raise GitToolkitError(
             "auth_type='github_app': set EITHER private_key OR "
@@ -762,32 +741,7 @@ def _load_pem(
 
 
 class _RepoConnection:
-    """A resolved connection to one repository: slug, branch default + token.
-
-    One instance per registered alias (and one per ad-hoc ``owner/name`` slug
-    that is resolved at call time). Each connection owns its own
-    :class:`_GitHubAppTokenProvider` in App mode, so installation tokens are
-    minted and cached independently per repository. :meth:`token` re-resolves
-    the bearer token on every call — that is the "re-connect per operation"
-    semantic.
-
-    Args:
-        repository: Repository in ``owner/name`` format.
-        default_branch: Fallback branch for pull requests.
-        auth_type: ``'pat'`` or ``'github_app'``.
-        github_token: PAT (pat mode).
-        token_provider: Pre-built App token provider to reuse. When supplied in
-            App mode, it takes precedence over the ``app_id``/``private_key``
-            arguments (used so the ``"default"`` connection shares the toolkit's
-            already-built provider).
-        app_id: GitHub App ID (App mode, when no ``token_provider`` is given).
-        installation_id: Installation ID (App mode).
-        private_key: Inline PEM (App mode).
-        private_key_path: PEM file path (App mode).
-
-    Raises:
-        GitToolkitError: When App-mode configuration is incomplete/invalid.
-    """
+    """Resolved connection to one repository: slug, branch default, and token provider."""
 
     def __init__(
         self,
@@ -827,15 +781,7 @@ class _RepoConnection:
                 )
 
     def token(self) -> str:
-        """Return the bearer token for the next GitHub API call to this repo.
-
-        Returns:
-            A valid bearer token string.
-
-        Raises:
-            GitToolkitError: When no token is available (pat mode without a
-                token) or the App provider fails to mint one.
-        """
+        """Return the bearer token for the next API call to this repo."""
         if self.auth_type == "github_app":
             if self._token_provider is None:
                 raise GitToolkitError(
@@ -1037,7 +983,7 @@ class GitToolkit(AbstractToolkit):
         installation_id: Optional[int] = None,
         private_key: Optional[str] = None,
         private_key_path: Optional[str] = None,
-        repositories: Optional[Dict[str, "RepositoryCredential | dict"]] = None,
+        repositories: Optional[Dict[str, Union[RepositoryCredential, dict]]] = None,
         **kwargs: Any,
     ) -> None:
         """Initialise the Git/GitHub toolkit.
@@ -1163,18 +1109,7 @@ class GitToolkit(AbstractToolkit):
     # Connection / bearer token resolution
     # ------------------------------------------------------------------
     def _default_token(self) -> str:
-        """Return the bearer token for the global/default credentials.
-
-        Independent of the repository registry, so it works even when no
-        ``default_repository`` is configured (only a bare token/App is set).
-
-        Returns:
-            A valid bearer token string.
-
-        Raises:
-            GitToolkitError: When no token is available (PAT mode with no token
-                set) or when the App token provider fails to mint a token.
-        """
+        """Return the bearer token for the global/default credentials."""
         if self.auth_type == "github_app":
             if self._token_provider is None:
                 raise GitToolkitError(
@@ -1189,28 +1124,7 @@ class GitToolkit(AbstractToolkit):
         return self.github_token
 
     def _resolve_connection(self, repository: Optional[str]) -> _RepoConnection:
-        """Resolve ``repository`` (None | alias | 'owner/name') to a connection.
-
-        Resolution order:
-        1. ``None`` -> the ``"default"`` registry entry (raises when absent).
-        2. A registered alias -> that connection.
-        3. A raw ``owner/name`` slug matching a registered connection's
-           ``.repository`` -> that connection (so callers can pass the slug of
-           a registered repo and still use its dedicated credentials).
-        4. An unknown ``owner/name`` slug -> an ad-hoc connection built from the
-           global/default credentials, cached under the slug for reuse.
-
-        Args:
-            repository: An alias, an ``owner/name`` slug, or None for default.
-
-        Returns:
-            The resolved :class:`_RepoConnection`.
-
-        Raises:
-            GitToolkitError: When no repository can be resolved (no default and
-                none supplied) or when no global credentials exist for an
-                ad-hoc slug.
-        """
+        """Map None / alias / ``owner/name`` slug to a ``_RepoConnection``."""
         if repository is None:
             conn = self._connections.get("default")
             if conn is None:
@@ -1220,21 +1134,24 @@ class GitToolkit(AbstractToolkit):
                 )
             return conn
 
-        # Alias hit.
+        # Fast path (no lock): alias hit from the pre-built registry.
         conn = self._connections.get(repository)
         if conn is not None:
             return conn
 
-        # Raw slug matching a registered connection's repository.
-        for existing in self._connections.values():
-            if existing.repository == repository:
-                return existing
-
-        # Unknown slug -> ad-hoc connection from global/default creds (cached).
+        # Slug scan + ad-hoc creation under lock (safe for free-threaded Python).
         with self._connections_lock:
+            # Re-check after acquiring lock.
             conn = self._connections.get(repository)
             if conn is not None:
                 return conn
+
+            # Raw slug matching a registered connection's repository field.
+            for existing in self._connections.values():
+                if existing.repository == repository:
+                    return existing
+
+            # Unknown slug -> ad-hoc connection from global/default creds.
             if self.auth_type == "github_app":
                 if self._token_provider is None:
                     raise GitToolkitError(
@@ -1257,19 +1174,7 @@ class GitToolkit(AbstractToolkit):
             return conn
 
     def _bearer_token(self) -> str:
-        """Return the bearer token for the next GitHub API call.
-
-        In ``pat`` mode, returns ``self.github_token`` and raises when it is
-        absent. In ``github_app`` mode, delegates to the token provider which
-        mints / caches installation access tokens transparently.
-
-        Returns:
-            A valid bearer token string.
-
-        Raises:
-            GitToolkitError: When no token is available (PAT mode with no token
-                set) or when the App token provider fails to mint a token.
-        """
+        """Legacy shim — delegates to ``_default_token``."""
         return self._default_token()
 
     # ------------------------------------------------------------------

--- a/packages/ai-parrot-tools/src/parrot_tools/gittoolkit.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/gittoolkit.py
@@ -44,6 +44,84 @@ class GitToolkitError(RuntimeError):
     """Raised when the toolkit cannot satisfy a request."""
 
 
+class RepositoryCredential(BaseModel):
+    """Credentials + defaults for a single named repository in a registry.
+
+    Each entry in :attr:`GitToolkit.repositories` is one of these. The alias
+    (the dict key) is how tools reference the repository by name; the
+    ``repository`` field is the underlying ``owner/name`` slug used to build
+    GitHub API URLs.
+    """
+
+    repository: str = Field(
+        description="GitHub repository in 'owner/name' format.",
+    )
+    default_branch: str = Field(
+        default="main",
+        description="Fallback branch used for pull requests against this repo.",
+    )
+    auth_type: Literal["pat", "github_app"] = Field(
+        default="pat",
+        description=(
+            "Authentication backend. 'pat' uses github_token; 'github_app' "
+            "uses app_id + installation_id + private key."
+        ),
+    )
+    github_token: Optional[str] = Field(
+        default=None,
+        description="Personal access token with repo scope (pat mode).",
+    )
+    app_id: Optional[int] = Field(
+        default=None,
+        description="GitHub App ID (required when auth_type='github_app').",
+    )
+    installation_id: Optional[int] = Field(
+        default=None,
+        description="Installation ID (required when auth_type='github_app').",
+    )
+    private_key: Optional[str] = Field(
+        default=None,
+        description=(
+            "PEM contents of the App's private key. Mutually exclusive with "
+            "private_key_path."
+        ),
+    )
+    private_key_path: Optional[str] = Field(
+        default=None,
+        description=(
+            "Filesystem path to the App's private key PEM. Mutually exclusive "
+            "with private_key."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_auth(self) -> "RepositoryCredential":  # pragma: no cover - pydantic hook
+        """Validate that App-mode entries carry the required fields.
+
+        Returns:
+            The validated model instance.
+
+        Raises:
+            ValueError: When auth_type='github_app' is missing required fields
+                or violates the private_key/private_key_path mutual exclusion.
+        """
+        if self.auth_type == "github_app":
+            if not self.app_id:
+                raise ValueError("auth_type='github_app' requires app_id")
+            if not self.installation_id:
+                raise ValueError("auth_type='github_app' requires installation_id")
+            if self.private_key and self.private_key_path:
+                raise ValueError(
+                    "auth_type='github_app': set EITHER private_key OR "
+                    "private_key_path, not both."
+                )
+            if not self.private_key and not self.private_key_path:
+                raise ValueError(
+                    "auth_type='github_app' requires private_key or private_key_path"
+                )
+        return self
+
+
 class GitToolkitInput(BaseModel):
     """Default configuration shared by all tools in the toolkit."""
 
@@ -88,6 +166,15 @@ class GitToolkitInput(BaseModel):
         description=(
             "Filesystem path to the App's private key PEM. Mutually "
             "exclusive with private_key."
+        ),
+    )
+    repositories: Optional[Dict[str, RepositoryCredential]] = Field(
+        default=None,
+        description=(
+            "Named registry mapping an alias to that repository's credentials "
+            "and defaults. Registry entries are explicit-config only and do NOT "
+            "inherit GITHUB_* environment variables (those feed only the default "
+            "and ad-hoc fallback paths)."
         ),
     )
 
@@ -184,7 +271,12 @@ class CreatePullRequestInput(BaseModel):
     """Input payload for ``create_pull_request``."""
 
     repository: Optional[str] = Field(
-        default=None, description="Target GitHub repository in 'owner/name' format."
+        default=None,
+        description=(
+            "Target repository: a registered alias from the toolkit's "
+            "repositories registry, or a raw 'owner/name' slug. Uses the "
+            "default repository when omitted."
+        ),
     )
     title: str = Field(description="Pull request title")
     body: Optional[str] = Field(default=None, description="Pull request description")
@@ -215,7 +307,7 @@ class GetPullRequestInput(BaseModel):
     pr_number: int = Field(description="Pull request number on the repository.")
     repository: Optional[str] = Field(
         default=None,
-        description="Target GitHub repository in 'owner/name' format. Uses default when omitted.",
+        description="Target repository: a registered alias from the toolkit's repositories registry, or a raw 'owner/name' slug. Uses the default repository when omitted.",
     )
 
 
@@ -224,7 +316,7 @@ class ListPullRequestsInput(BaseModel):
 
     repository: Optional[str] = Field(
         default=None,
-        description="Target GitHub repository in 'owner/name' format. Uses default when omitted.",
+        description="Target repository: a registered alias from the toolkit's repositories registry, or a raw 'owner/name' slug. Uses the default repository when omitted.",
     )
     state: Literal["open", "closed", "all"] = Field(
         default="open",
@@ -244,7 +336,7 @@ class GetPullRequestDiffInput(BaseModel):
     pr_number: int = Field(description="Pull request number on the repository.")
     repository: Optional[str] = Field(
         default=None,
-        description="Target GitHub repository in 'owner/name' format. Uses default when omitted.",
+        description="Target repository: a registered alias from the toolkit's repositories registry, or a raw 'owner/name' slug. Uses the default repository when omitted.",
     )
     max_bytes: int = Field(
         default=50_000,
@@ -260,7 +352,7 @@ class AddPRCommentInput(BaseModel):
     body: str = Field(description="Comment body in Markdown.")
     repository: Optional[str] = Field(
         default=None,
-        description="Target GitHub repository in 'owner/name' format. Uses default when omitted.",
+        description="Target repository: a registered alias from the toolkit's repositories registry, or a raw 'owner/name' slug. Uses the default repository when omitted.",
     )
 
 
@@ -274,7 +366,7 @@ class SubmitPRReviewInput(BaseModel):
     body: str = Field(description="Review body in Markdown (required for REQUEST_CHANGES).")
     repository: Optional[str] = Field(
         default=None,
-        description="Target GitHub repository in 'owner/name' format. Uses default when omitted.",
+        description="Target repository: a registered alias from the toolkit's repositories registry, or a raw 'owner/name' slug. Uses the default repository when omitted.",
     )
 
 
@@ -294,7 +386,7 @@ class GetFileContentInput(BaseModel):
     )
     repository: Optional[str] = Field(
         default=None,
-        description="Target GitHub repository in 'owner/name' format. Uses default when omitted.",
+        description="Target repository: a registered alias from the toolkit's repositories registry, or a raw 'owner/name' slug. Uses the default repository when omitted.",
     )
     start_line: Optional[int] = Field(
         default=None,
@@ -342,7 +434,7 @@ class ComparePRVersionsInput(BaseModel):
     )
     repository: Optional[str] = Field(
         default=None,
-        description="Target GitHub repository in 'owner/name' format. Uses default when omitted.",
+        description="Target repository: a registered alias from the toolkit's repositories registry, or a raw 'owner/name' slug. Uses the default repository when omitted.",
     )
 
 
@@ -357,7 +449,7 @@ class SearchRepoCodeInput(BaseModel):
     )
     repository: Optional[str] = Field(
         default=None,
-        description="Target GitHub repository in 'owner/name' format. Uses default when omitted.",
+        description="Target repository: a registered alias from the toolkit's repositories registry, or a raw 'owner/name' slug. Uses the default repository when omitted.",
     )
     max_results: int = Field(
         default=20,
@@ -522,7 +614,7 @@ class GetContributorStatsInput(BaseModel):
 
     repository: Optional[str] = Field(
         default=None,
-        description="Target GitHub repository in 'owner/name' format. Uses default when omitted.",
+        description="Target repository: a registered alias from the toolkit's repositories registry, or a raw 'owner/name' slug. Uses the default repository when omitted.",
     )
 
 
@@ -531,7 +623,7 @@ class GetCommitActivityInput(BaseModel):
 
     repository: Optional[str] = Field(
         default=None,
-        description="Target GitHub repository in 'owner/name' format. Uses default when omitted.",
+        description="Target repository: a registered alias from the toolkit's repositories registry, or a raw 'owner/name' slug. Uses the default repository when omitted.",
     )
 
 
@@ -540,7 +632,7 @@ class GetCodeFrequencyInput(BaseModel):
 
     repository: Optional[str] = Field(
         default=None,
-        description="Target GitHub repository in 'owner/name' format. Uses default when omitted.",
+        description="Target repository: a registered alias from the toolkit's repositories registry, or a raw 'owner/name' slug. Uses the default repository when omitted.",
     )
 
 
@@ -623,6 +715,138 @@ class _GitHubAppTokenProvider:
         if self._expires_at is not None and self._expires_at.tzinfo is None:
             # Defensive: PyGithub returns tz-aware UTC, but normalise just in case.
             self._expires_at = self._expires_at.replace(tzinfo=_dt.timezone.utc)
+
+
+def _load_pem(
+    private_key: Optional[str],
+    private_key_path: Optional[str],
+) -> str:
+    """Resolve a GitHub App private key PEM from inline contents or a file path.
+
+    Exactly one of ``private_key`` / ``private_key_path`` must be supplied.
+    Env-injected PEMs sometimes carry literal ``\\n`` escape sequences, which
+    are normalised back to real newlines.
+
+    Args:
+        private_key: Inline PEM contents, or None.
+        private_key_path: Filesystem path to a PEM file, or None.
+
+    Returns:
+        The PEM contents as a string with real newlines.
+
+    Raises:
+        GitToolkitError: When neither or both inputs are supplied, or when the
+            file cannot be read.
+    """
+    if private_key and private_key_path:
+        raise GitToolkitError(
+            "auth_type='github_app': set EITHER private_key OR "
+            "private_key_path, not both."
+        )
+    if not private_key and not private_key_path:
+        raise GitToolkitError(
+            "auth_type='github_app' requires private_key or private_key_path "
+            "(or GITHUB_APP_PRIVATE_KEY[_PATH] env)."
+        )
+    pem = private_key
+    if private_key_path:
+        try:
+            with open(private_key_path, "r", encoding="utf-8") as fh:
+                pem = fh.read()
+        except OSError as exc:
+            raise GitToolkitError(
+                f"Could not read GitHub App private key from {private_key_path}: {exc}"
+            ) from exc
+    # Defensive: env-injected PEMs sometimes carry literal "\n" escape sequences.
+    return pem.replace("\\n", "\n")  # type: ignore[union-attr]
+
+
+class _RepoConnection:
+    """A resolved connection to one repository: slug, branch default + token.
+
+    One instance per registered alias (and one per ad-hoc ``owner/name`` slug
+    that is resolved at call time). Each connection owns its own
+    :class:`_GitHubAppTokenProvider` in App mode, so installation tokens are
+    minted and cached independently per repository. :meth:`token` re-resolves
+    the bearer token on every call — that is the "re-connect per operation"
+    semantic.
+
+    Args:
+        repository: Repository in ``owner/name`` format.
+        default_branch: Fallback branch for pull requests.
+        auth_type: ``'pat'`` or ``'github_app'``.
+        github_token: PAT (pat mode).
+        token_provider: Pre-built App token provider to reuse. When supplied in
+            App mode, it takes precedence over the ``app_id``/``private_key``
+            arguments (used so the ``"default"`` connection shares the toolkit's
+            already-built provider).
+        app_id: GitHub App ID (App mode, when no ``token_provider`` is given).
+        installation_id: Installation ID (App mode).
+        private_key: Inline PEM (App mode).
+        private_key_path: PEM file path (App mode).
+
+    Raises:
+        GitToolkitError: When App-mode configuration is incomplete/invalid.
+    """
+
+    def __init__(
+        self,
+        repository: str,
+        default_branch: str,
+        auth_type: Literal["pat", "github_app"],
+        *,
+        github_token: Optional[str] = None,
+        token_provider: Optional[_GitHubAppTokenProvider] = None,
+        app_id: Optional[int] = None,
+        installation_id: Optional[int] = None,
+        private_key: Optional[str] = None,
+        private_key_path: Optional[str] = None,
+    ) -> None:
+        self.repository = repository
+        self.default_branch = default_branch
+        self.auth_type = auth_type
+        self._github_token = github_token
+        self._token_provider: Optional[_GitHubAppTokenProvider] = None
+        if auth_type == "github_app":
+            if token_provider is not None:
+                self._token_provider = token_provider
+            else:
+                if not app_id:
+                    raise GitToolkitError(
+                        "auth_type='github_app' requires app_id."
+                    )
+                if not installation_id:
+                    raise GitToolkitError(
+                        "auth_type='github_app' requires installation_id."
+                    )
+                pem = _load_pem(private_key, private_key_path)
+                self._token_provider = _GitHubAppTokenProvider(
+                    app_id=app_id,
+                    installation_id=installation_id,
+                    private_key_pem=pem,
+                )
+
+    def token(self) -> str:
+        """Return the bearer token for the next GitHub API call to this repo.
+
+        Returns:
+            A valid bearer token string.
+
+        Raises:
+            GitToolkitError: When no token is available (pat mode without a
+                token) or the App provider fails to mint one.
+        """
+        if self.auth_type == "github_app":
+            if self._token_provider is None:
+                raise GitToolkitError(
+                    "BUG: _token_provider is None in github_app mode; internal error."
+                )
+            return self._token_provider.get_token()
+        if not self._github_token:
+            raise GitToolkitError(
+                "A GitHub personal access token is required via init argument or GITHUB_TOKEN."
+            )
+        return self._github_token
 
 
 class _FileBlobCache:
@@ -813,6 +1037,7 @@ class GitToolkit(AbstractToolkit):
         installation_id: Optional[int] = None,
         private_key: Optional[str] = None,
         private_key_path: Optional[str] = None,
+        repositories: Optional[Dict[str, "RepositoryCredential | dict"]] = None,
         **kwargs: Any,
     ) -> None:
         """Initialise the Git/GitHub toolkit.
@@ -830,11 +1055,21 @@ class GitToolkit(AbstractToolkit):
                 exclusive with ``private_key_path``.
             private_key_path: Filesystem path to the App's private key PEM.
                 Mutually exclusive with ``private_key``.
+            repositories: Optional named registry mapping an alias to that
+                repository's credentials (``RepositoryCredential`` or an
+                equivalent dict). Tools may reference a repository by its alias
+                or by its raw ``owner/name`` slug. Registry entries are
+                explicit-config only — they do NOT inherit ``GITHUB_*`` env
+                vars. Passing a ``"default"`` alias here while the legacy
+                ``default_repository`` argument is also set raises, to avoid
+                ambiguity.
             **kwargs: Forwarded to the base class.
 
         Raises:
             GitToolkitError: When ``auth_type`` is invalid or required App-mode
-                fields are missing / mutually exclusive constraints are violated.
+                fields are missing / mutually exclusive constraints are violated,
+                or when a ``"default"`` registry alias collides with the legacy
+                default-repository arguments.
         """
         super().__init__(**kwargs)
 
@@ -875,27 +1110,7 @@ class GitToolkit(AbstractToolkit):
 
             inline_pem = private_key or os.getenv("GITHUB_APP_PRIVATE_KEY")
             pem_path = private_key_path or os.getenv("GITHUB_APP_PRIVATE_KEY_PATH")
-            if inline_pem and pem_path:
-                raise GitToolkitError(
-                    "auth_type='github_app': set EITHER private_key OR "
-                    "private_key_path, not both."
-                )
-            if not inline_pem and not pem_path:
-                raise GitToolkitError(
-                    "auth_type='github_app' requires private_key or private_key_path "
-                    "(or GITHUB_APP_PRIVATE_KEY[_PATH] env)."
-                )
-            if pem_path:
-                try:
-                    with open(pem_path, "r", encoding="utf-8") as fh:
-                        inline_pem = fh.read()
-                except OSError as exc:
-                    raise GitToolkitError(
-                        f"Could not read GitHub App private key from {pem_path}: {exc}"
-                    ) from exc
-
-            # Defensive: env-injected PEMs sometimes carry literal "\n" escape sequences.
-            inline_pem = inline_pem.replace("\\n", "\n")  # type: ignore[union-attr]
+            inline_pem = _load_pem(inline_pem, pem_path)
 
             self._token_provider = _GitHubAppTokenProvider(
                 app_id=self.app_id,
@@ -903,15 +1118,55 @@ class GitToolkit(AbstractToolkit):
                 private_key_pem=inline_pem,
             )
 
-    # ------------------------------------------------------------------
-    # Bearer token resolution
-    # ------------------------------------------------------------------
-    def _bearer_token(self) -> str:
-        """Return the bearer token for the next GitHub API call.
+        # ------------------------------------------------------------------
+        # Multi-repository registry (alias -> _RepoConnection)
+        # ------------------------------------------------------------------
+        self._connections: Dict[str, _RepoConnection] = {}
+        self._connections_lock = threading.Lock()
 
-        In ``pat`` mode, returns ``self.github_token`` and raises when it is
-        absent. In ``github_app`` mode, delegates to the token provider which
-        mints / caches installation access tokens transparently.
+        # Build the "default" connection from the legacy fields, reusing the
+        # already-built token provider so it shares the cached App token.
+        if self.default_repository:
+            self._connections["default"] = _RepoConnection(
+                repository=self.default_repository,
+                default_branch=self.default_branch,
+                auth_type=self.auth_type,
+                github_token=self.github_token,
+                token_provider=self._token_provider,
+            )
+
+        # Register explicit named repositories.
+        if repositories:
+            if "default" in repositories and self.default_repository:
+                raise GitToolkitError(
+                    "A 'default' alias in repositories collides with the legacy "
+                    "default_repository argument; use one or the other."
+                )
+            for alias, value in repositories.items():
+                cred = (
+                    value
+                    if isinstance(value, RepositoryCredential)
+                    else RepositoryCredential.model_validate(value)
+                )
+                self._connections[alias] = _RepoConnection(
+                    repository=cred.repository,
+                    default_branch=cred.default_branch,
+                    auth_type=cred.auth_type,
+                    github_token=cred.github_token,
+                    app_id=cred.app_id,
+                    installation_id=cred.installation_id,
+                    private_key=cred.private_key,
+                    private_key_path=cred.private_key_path,
+                )
+
+    # ------------------------------------------------------------------
+    # Connection / bearer token resolution
+    # ------------------------------------------------------------------
+    def _default_token(self) -> str:
+        """Return the bearer token for the global/default credentials.
+
+        Independent of the repository registry, so it works even when no
+        ``default_repository`` is configured (only a bare token/App is set).
 
         Returns:
             A valid bearer token string.
@@ -932,6 +1187,90 @@ class GitToolkit(AbstractToolkit):
                 "A GitHub personal access token is required via init argument or GITHUB_TOKEN."
             )
         return self.github_token
+
+    def _resolve_connection(self, repository: Optional[str]) -> _RepoConnection:
+        """Resolve ``repository`` (None | alias | 'owner/name') to a connection.
+
+        Resolution order:
+        1. ``None`` -> the ``"default"`` registry entry (raises when absent).
+        2. A registered alias -> that connection.
+        3. A raw ``owner/name`` slug matching a registered connection's
+           ``.repository`` -> that connection (so callers can pass the slug of
+           a registered repo and still use its dedicated credentials).
+        4. An unknown ``owner/name`` slug -> an ad-hoc connection built from the
+           global/default credentials, cached under the slug for reuse.
+
+        Args:
+            repository: An alias, an ``owner/name`` slug, or None for default.
+
+        Returns:
+            The resolved :class:`_RepoConnection`.
+
+        Raises:
+            GitToolkitError: When no repository can be resolved (no default and
+                none supplied) or when no global credentials exist for an
+                ad-hoc slug.
+        """
+        if repository is None:
+            conn = self._connections.get("default")
+            if conn is None:
+                raise GitToolkitError(
+                    "A target repository is required (pass repository or "
+                    "configure default)."
+                )
+            return conn
+
+        # Alias hit.
+        conn = self._connections.get(repository)
+        if conn is not None:
+            return conn
+
+        # Raw slug matching a registered connection's repository.
+        for existing in self._connections.values():
+            if existing.repository == repository:
+                return existing
+
+        # Unknown slug -> ad-hoc connection from global/default creds (cached).
+        with self._connections_lock:
+            conn = self._connections.get(repository)
+            if conn is not None:
+                return conn
+            if self.auth_type == "github_app":
+                if self._token_provider is None:
+                    raise GitToolkitError(
+                        "No GitHub App credentials configured to access "
+                        f"{repository!r}."
+                    )
+            elif not self.github_token:
+                raise GitToolkitError(
+                    "A GitHub personal access token is required via init "
+                    "argument or GITHUB_TOKEN."
+                )
+            conn = _RepoConnection(
+                repository=repository,
+                default_branch=self.default_branch,
+                auth_type=self.auth_type,
+                github_token=self.github_token,
+                token_provider=self._token_provider,
+            )
+            self._connections[repository] = conn
+            return conn
+
+    def _bearer_token(self) -> str:
+        """Return the bearer token for the next GitHub API call.
+
+        In ``pat`` mode, returns ``self.github_token`` and raises when it is
+        absent. In ``github_app`` mode, delegates to the token provider which
+        mints / caches installation access tokens transparently.
+
+        Returns:
+            A valid bearer token string.
+
+        Raises:
+            GitToolkitError: When no token is available (PAT mode with no token
+                set) or when the App token provider fails to mint a token.
+        """
+        return self._default_token()
 
     # ------------------------------------------------------------------
     # Patch generation helpers
@@ -1035,16 +1374,11 @@ class GitToolkit(AbstractToolkit):
     def _prepare_github_context(
         self, repository: Optional[str], base_branch: Optional[str]
     ) -> _GitHubContext:
-        repo = repository or self.default_repository
-        if not repo:
-            raise GitToolkitError(
-                "A target repository is required (pass repository or configure default)."
-            )
-
-        token = self._bearer_token()
-
-        branch = base_branch or self.default_branch
-        return _GitHubContext(repository=repo, base_branch=branch, token=token)
+        conn = self._resolve_connection(repository)
+        branch = base_branch or conn.default_branch
+        return _GitHubContext(
+            repository=conn.repository, base_branch=branch, token=conn.token()
+        )
 
     @staticmethod
     def _request(
@@ -1277,19 +1611,16 @@ class GitToolkit(AbstractToolkit):
     # Pull request read / review helpers (FEAT: github-pr-review-agent)
     # ------------------------------------------------------------------
     def _resolve_repository(self, repository: Optional[str]) -> str:
-        repo = repository or self.default_repository
-        if not repo:
-            raise GitToolkitError(
-                "A target repository is required (pass repository or set GIT_DEFAULT_REPOSITORY)."
-            )
-        return repo
+        """Resolve ``repository`` (None | alias | slug) to an ``owner/name`` slug."""
+        return self._resolve_connection(repository).repository
 
     def _resolve_token(self) -> str:
-        return self._bearer_token()
+        """Return the bearer token for the global/default credentials."""
+        return self._default_token()
 
     def _get_pull_request_sync(self, repository: Optional[str], pr_number: int) -> Dict[str, Any]:
-        repo = self._resolve_repository(repository)
-        token = self._resolve_token()
+        conn = self._resolve_connection(repository)
+        repo, token = conn.repository, conn.token()
         url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}"
         response = self._request("GET", url, token, expected=200)
         return response.json()
@@ -1312,8 +1643,8 @@ class GitToolkit(AbstractToolkit):
         state: str,
         per_page: int,
     ) -> List[Dict[str, Any]]:
-        repo = self._resolve_repository(repository)
-        token = self._resolve_token()
+        conn = self._resolve_connection(repository)
+        repo, token = conn.repository, conn.token()
         url = f"https://api.github.com/repos/{repo}/pulls"
         params = {"state": state, "per_page": min(max(per_page, 1), 100)}
         response = self._request("GET", url, token, expected=200, params=params)
@@ -1339,8 +1670,8 @@ class GitToolkit(AbstractToolkit):
         pr_number: int,
         max_bytes: int,
     ) -> Dict[str, Any]:
-        repo = self._resolve_repository(repository)
-        token = self._resolve_token()
+        conn = self._resolve_connection(repository)
+        repo, token = conn.repository, conn.token()
         url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}"
         response = self._request(
             "GET",
@@ -1381,8 +1712,8 @@ class GitToolkit(AbstractToolkit):
         pr_number: int,
         body: str,
     ) -> Dict[str, Any]:
-        repo = self._resolve_repository(repository)
-        token = self._resolve_token()
+        conn = self._resolve_connection(repository)
+        repo, token = conn.repository, conn.token()
         url = f"https://api.github.com/repos/{repo}/issues/{pr_number}/comments"
         response = self._request(
             "POST", url, token, expected=201, json={"body": body}
@@ -1410,8 +1741,8 @@ class GitToolkit(AbstractToolkit):
         event: str,
         body: str,
     ) -> Dict[str, Any]:
-        repo = self._resolve_repository(repository)
-        token = self._resolve_token()
+        conn = self._resolve_connection(repository)
+        repo, token = conn.repository, conn.token()
         url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}/reviews"
         payload = {"event": event, "body": body}
         response = self._request("POST", url, token, expected=200, json=payload)
@@ -1448,8 +1779,8 @@ class GitToolkit(AbstractToolkit):
         Returns a dict with ``status`` in {created, already_exists, no_permission, error}
         plus the hook payload when available.
         """
-        repo = self._resolve_repository(repository)
-        token = self._resolve_token()
+        conn = self._resolve_connection(repository)
+        repo, token = conn.repository, conn.token()
         list_url = f"https://api.github.com/repos/{repo}/hooks"
         try:
             response = self._request("GET", list_url, token, expected=200)
@@ -1553,8 +1884,8 @@ class GitToolkit(AbstractToolkit):
             A populated :class:`FileContentResult`. ``exists=False`` on 404;
             ``error='file_too_large'`` when the blob exceeds GitHub's 1 MB limit.
         """
-        repo = self._resolve_repository(repository)
-        token = self._resolve_token()
+        conn = self._resolve_connection(repository)
+        repo, token = conn.repository, conn.token()
 
         url = f"https://api.github.com/repos/{repo}/contents/{path}"
 
@@ -1848,8 +2179,8 @@ class GitToolkit(AbstractToolkit):
             A :class:`SearchCodeResult`. When the search API is rate-limited,
             returns with ``error='rate_limited'`` rather than raising.
         """
-        repo = self._resolve_repository(repository)
-        token = self._resolve_token()
+        conn = self._resolve_connection(repository)
+        repo, token = conn.repository, conn.token()
         q = f"{query} repo:{repo}"
         url = "https://api.github.com/search/code"
         params = {"q": q, "per_page": min(max_results, 100)}
@@ -1957,8 +2288,8 @@ class GitToolkit(AbstractToolkit):
         Returns:
             List of :class:`ContributorStats` models, one per contributor.
         """
-        repo = self._resolve_repository(repository)
-        token = self._resolve_token()
+        conn = self._resolve_connection(repository)
+        repo, token = conn.repository, conn.token()
         url = f"https://api.github.com/repos/{repo}/stats/contributors"
         response = self._get_stats_with_polling(url, token)
         raw = response.json() or []
@@ -2018,8 +2349,8 @@ class GitToolkit(AbstractToolkit):
         Returns:
             Last 52 weeks of commit counts broken down by day-of-week.
         """
-        repo = self._resolve_repository(repository)
-        token = self._resolve_token()
+        conn = self._resolve_connection(repository)
+        repo, token = conn.repository, conn.token()
         url = f"https://api.github.com/repos/{repo}/stats/commit_activity"
         response = self._get_stats_with_polling(url, token)
         raw = response.json() or []
@@ -2060,8 +2391,8 @@ class GitToolkit(AbstractToolkit):
         Returns:
             List of :class:`WeeklyCodeFrequency` models.
         """
-        repo = self._resolve_repository(repository)
-        token = self._resolve_token()
+        conn = self._resolve_connection(repository)
+        repo, token = conn.repository, conn.token()
         url = f"https://api.github.com/repos/{repo}/stats/code_frequency"
         response = self._get_stats_with_polling(url, token)
         raw = response.json() or []
@@ -2104,6 +2435,7 @@ class GitToolkit(AbstractToolkit):
 __all__ = [
     "GitToolkit",
     "GitToolkitInput",
+    "RepositoryCredential",
     "GitPatchFile",
     "GitHubFileChange",
     "GeneratePatchInput",

--- a/packages/ai-parrot-tools/tests/test_gittoolkit_multirepo.py
+++ b/packages/ai-parrot-tools/tests/test_gittoolkit_multirepo.py
@@ -1,17 +1,8 @@
-"""Unit tests for GitToolkit's multi-repository credentials registry.
-
-The registry lets a single ``GitToolkit`` reference several repositories by
-alias, each with its own credentials. Every tool call re-resolves the
-connection for the named repository ("re-connect per operation"), so the
-correct token is used per request.
-
-Network calls are mocked at ``requests.request`` so the tests stay hermetic;
-GitHub App token providers are patched via ``GithubIntegration``.
-"""
+"""Unit tests for GitToolkit's multi-repository credentials registry."""
 from __future__ import annotations
 
-import asyncio
 import datetime as _dt
+import tempfile
 from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 
@@ -22,6 +13,7 @@ from parrot_tools.gittoolkit import (
     GitToolkit,
     GitToolkitError,
     RepositoryCredential,
+    _load_pem,
 )
 
 
@@ -72,7 +64,6 @@ class TestRegistryResolution:
         tk = GitToolkit(
             repositories={"a": {"repository": "org/a", "github_token": "ta"}}
         )
-        # Passing the raw slug of a registered repo uses its dedicated creds.
         assert tk._resolve_connection("org/a") is tk._resolve_connection("a")
         assert tk._resolve_connection("org/a").token() == "ta"
 
@@ -107,7 +98,8 @@ class TestRegistryResolution:
 # ---------------------------------------------------------------------------
 
 class TestPerRepoTokenSelection:
-    def test_authorization_header_per_alias(self):
+    @pytest.mark.asyncio
+    async def test_authorization_header_per_alias(self):
         tk = GitToolkit(
             repositories={
                 "a": {"repository": "org/a", "github_token": "ta"},
@@ -118,11 +110,11 @@ class TestPerRepoTokenSelection:
             "parrot_tools.gittoolkit.requests.request",
             return_value=_make_response(200, json_data={"number": 1}),
         ) as mocked:
-            asyncio.run(tk.get_pull_request(pr_number=1, repository="a"))
+            await tk.get_pull_request(pr_number=1, repository="a")
             assert "/repos/org/a/pulls/1" in mocked.call_args.args[1]
             assert mocked.call_args.kwargs["headers"]["Authorization"] == "Bearer ta"
 
-            asyncio.run(tk.get_pull_request(pr_number=2, repository="b"))
+            await tk.get_pull_request(pr_number=2, repository="b")
             assert "/repos/org/b/pulls/2" in mocked.call_args.args[1]
             assert mocked.call_args.kwargs["headers"]["Authorization"] == "Bearer tb"
 
@@ -171,7 +163,6 @@ class TestPerRepoDefaultBranch:
                 }
             }
         )
-        # base_branch omitted -> fall back to the registered repo's default.
         ctx = tk._prepare_github_context("a", None)
         assert ctx.repository == "org/a"
         assert ctx.base_branch == "develop"
@@ -196,16 +187,16 @@ class TestPerRepoDefaultBranch:
 # ---------------------------------------------------------------------------
 
 class TestAdHocFallback:
-    def test_unknown_slug_uses_global_token_and_caches(self):
+    @pytest.mark.asyncio
+    async def test_unknown_slug_uses_global_token_and_caches(self):
         tk = GitToolkit(default_repository="org/d", github_token="g")
         with patch(
             "parrot_tools.gittoolkit.requests.request",
             return_value=_make_response(200, json_data={"number": 1}),
         ) as mocked:
-            asyncio.run(tk.get_pull_request(pr_number=1, repository="x/y"))
+            await tk.get_pull_request(pr_number=1, repository="x/y")
         assert "/repos/x/y/pulls/1" in mocked.call_args.args[1]
         assert mocked.call_args.kwargs["headers"]["Authorization"] == "Bearer g"
-        # The ad-hoc connection is cached under the slug for reuse.
         assert "x/y" in tk._connections
         first = tk._resolve_connection("x/y")
         second = tk._resolve_connection("x/y")
@@ -224,7 +215,6 @@ class TestAdHocFallback:
                 private_key=PEM,
             )
         conn = tk._resolve_connection("x/y")
-        # Ad-hoc app connection reuses the toolkit's single global provider.
         assert conn._token_provider is tk._token_provider
 
 
@@ -239,6 +229,80 @@ class TestThreadSafety:
             conns = list(
                 pool.map(lambda _: tk._resolve_connection("x/y"), range(32))
             )
-        # All threads observe the same cached connection instance.
         assert all(c is conns[0] for c in conns)
         assert list(tk._connections).count("x/y") == 1
+
+
+# ---------------------------------------------------------------------------
+# "default" alias in repositories (without legacy default_repository)
+# ---------------------------------------------------------------------------
+
+class TestDefaultAliasInRegistry:
+    def test_default_alias_resolves_via_none(self):
+        tk = GitToolkit(
+            repositories={
+                "default": {"repository": "org/main", "github_token": "tok"},
+            }
+        )
+        conn = tk._resolve_connection(None)
+        assert conn.repository == "org/main"
+        assert conn.token() == "tok"
+
+    def test_default_alias_sets_custom_branch(self):
+        tk = GitToolkit(
+            repositories={
+                "default": {
+                    "repository": "org/main",
+                    "github_token": "tok",
+                    "default_branch": "develop",
+                },
+            }
+        )
+        ctx = tk._prepare_github_context(None, None)
+        assert ctx.base_branch == "develop"
+
+
+# ---------------------------------------------------------------------------
+# _load_pem direct tests
+# ---------------------------------------------------------------------------
+
+class TestLoadPem:
+    def test_inline_pem_returned_directly(self):
+        assert _load_pem("INLINE", None) == "INLINE"
+
+    def test_literal_backslash_n_normalised(self):
+        result = _load_pem("line1\\nline2", None)
+        assert result == "line1\nline2"
+
+    def test_file_path_reads_contents(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".pem", delete=False) as f:
+            f.write("FILE_PEM")
+            f.flush()
+            result = _load_pem(None, f.name)
+        assert result == "FILE_PEM"
+
+    def test_both_set_raises(self):
+        with pytest.raises(gt.GitToolkitError, match="EITHER"):
+            _load_pem("inline", "/some/path")
+
+    def test_neither_set_raises(self):
+        with pytest.raises(gt.GitToolkitError, match="requires"):
+            _load_pem(None, None)
+
+    def test_unreadable_path_raises(self):
+        with pytest.raises(gt.GitToolkitError, match="Could not read"):
+            _load_pem(None, "/nonexistent/path.pem")
+
+
+# ---------------------------------------------------------------------------
+# RepositoryCredential pat-mode validation
+# ---------------------------------------------------------------------------
+
+class TestRepositoryCredentialPatValidation:
+    def test_pat_mode_without_token_raises(self):
+        with pytest.raises(ValueError, match="github_token"):
+            RepositoryCredential(repository="org/a", auth_type="pat")
+
+    def test_pat_mode_with_token_succeeds(self):
+        cred = RepositoryCredential(repository="org/a", github_token="tok")
+        assert cred.github_token == "tok"

--- a/packages/ai-parrot-tools/tests/test_gittoolkit_multirepo.py
+++ b/packages/ai-parrot-tools/tests/test_gittoolkit_multirepo.py
@@ -1,0 +1,244 @@
+"""Unit tests for GitToolkit's multi-repository credentials registry.
+
+The registry lets a single ``GitToolkit`` reference several repositories by
+alias, each with its own credentials. Every tool call re-resolves the
+connection for the named repository ("re-connect per operation"), so the
+correct token is used per request.
+
+Network calls are mocked at ``requests.request`` so the tests stay hermetic;
+GitHub App token providers are patched via ``GithubIntegration``.
+"""
+from __future__ import annotations
+
+import asyncio
+import datetime as _dt
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from parrot_tools import gittoolkit as gt
+from parrot_tools.gittoolkit import (
+    GitToolkit,
+    GitToolkitError,
+    RepositoryCredential,
+)
+
+
+def _make_response(status_code: int = 200, json_data=None, text: str = ""):
+    class _Resp:
+        def __init__(self):
+            self.status_code = status_code
+            self._json = json_data
+            self.text = text
+            self.headers = {}
+
+        def json(self):
+            return self._json
+
+    return _Resp()
+
+
+def _mock_installation_auth(token: str, expires_in_seconds: int = 3600) -> MagicMock:
+    inst = MagicMock()
+    inst.token = token
+    inst.expires_at = _dt.datetime.now(_dt.timezone.utc) + _dt.timedelta(
+        seconds=expires_in_seconds
+    )
+    return inst
+
+
+PEM = "-----BEGIN PRIVATE KEY-----\nFAKE\n-----END PRIVATE KEY-----\n"
+
+
+# ---------------------------------------------------------------------------
+# Registry construction + resolution
+# ---------------------------------------------------------------------------
+
+class TestRegistryResolution:
+    def test_build_from_dict_and_model(self):
+        tk = GitToolkit(
+            repositories={
+                "a": {"repository": "org/a", "github_token": "ta"},
+                "b": RepositoryCredential(repository="org/b", github_token="tb"),
+            }
+        )
+        conn_a = tk._resolve_connection("a")
+        conn_b = tk._resolve_connection("b")
+        assert (conn_a.repository, conn_a.token()) == ("org/a", "ta")
+        assert (conn_b.repository, conn_b.token()) == ("org/b", "tb")
+
+    def test_raw_slug_resolves_to_registered_connection(self):
+        tk = GitToolkit(
+            repositories={"a": {"repository": "org/a", "github_token": "ta"}}
+        )
+        # Passing the raw slug of a registered repo uses its dedicated creds.
+        assert tk._resolve_connection("org/a") is tk._resolve_connection("a")
+        assert tk._resolve_connection("org/a").token() == "ta"
+
+    def test_none_resolves_default_entry(self):
+        tk = GitToolkit(default_repository="org/d", github_token="g")
+        conn = tk._resolve_connection(None)
+        assert conn.repository == "org/d"
+        assert conn.token() == "g"
+
+    def test_none_without_default_raises(self):
+        tk = GitToolkit(
+            repositories={"a": {"repository": "org/a", "github_token": "ta"}}
+        )
+        with pytest.raises(GitToolkitError):
+            tk._resolve_connection(None)
+
+    def test_default_alias_collision_raises(self):
+        with pytest.raises(GitToolkitError):
+            GitToolkit(
+                default_repository="org/d",
+                github_token="g",
+                repositories={"default": {"repository": "org/x", "github_token": "tx"}},
+            )
+
+    def test_repository_credential_app_validation(self):
+        with pytest.raises(Exception):
+            RepositoryCredential(repository="org/a", auth_type="github_app")
+
+
+# ---------------------------------------------------------------------------
+# Per-repository token selection at request time
+# ---------------------------------------------------------------------------
+
+class TestPerRepoTokenSelection:
+    def test_authorization_header_per_alias(self):
+        tk = GitToolkit(
+            repositories={
+                "a": {"repository": "org/a", "github_token": "ta"},
+                "b": {"repository": "org/b", "github_token": "tb"},
+            }
+        )
+        with patch(
+            "parrot_tools.gittoolkit.requests.request",
+            return_value=_make_response(200, json_data={"number": 1}),
+        ) as mocked:
+            asyncio.run(tk.get_pull_request(pr_number=1, repository="a"))
+            assert "/repos/org/a/pulls/1" in mocked.call_args.args[1]
+            assert mocked.call_args.kwargs["headers"]["Authorization"] == "Bearer ta"
+
+            asyncio.run(tk.get_pull_request(pr_number=2, repository="b"))
+            assert "/repos/org/b/pulls/2" in mocked.call_args.args[1]
+            assert mocked.call_args.kwargs["headers"]["Authorization"] == "Bearer tb"
+
+    def test_app_mode_providers_are_isolated(self):
+        tk = GitToolkit(
+            repositories={
+                "a": RepositoryCredential(
+                    repository="org/a",
+                    auth_type="github_app",
+                    app_id=1,
+                    installation_id=11,
+                    private_key=PEM,
+                ),
+                "b": RepositoryCredential(
+                    repository="org/b",
+                    auth_type="github_app",
+                    app_id=2,
+                    installation_id=22,
+                    private_key=PEM,
+                ),
+            }
+        )
+        prov_a = tk._connections["a"]._token_provider
+        prov_b = tk._connections["b"]._token_provider
+        assert prov_a is not None and prov_b is not None
+        assert prov_a is not prov_b
+        with patch.object(prov_a, "get_token", return_value="ghs_a"), patch.object(
+            prov_b, "get_token", return_value="ghs_b"
+        ):
+            assert tk._resolve_connection("a").token() == "ghs_a"
+            assert tk._resolve_connection("b").token() == "ghs_b"
+
+
+# ---------------------------------------------------------------------------
+# Per-repository default_branch
+# ---------------------------------------------------------------------------
+
+class TestPerRepoDefaultBranch:
+    def test_context_uses_registered_default_branch_and_token(self):
+        tk = GitToolkit(
+            repositories={
+                "a": {
+                    "repository": "org/a",
+                    "github_token": "ta",
+                    "default_branch": "develop",
+                }
+            }
+        )
+        # base_branch omitted -> fall back to the registered repo's default.
+        ctx = tk._prepare_github_context("a", None)
+        assert ctx.repository == "org/a"
+        assert ctx.base_branch == "develop"
+        assert ctx.token == "ta"
+
+    def test_context_explicit_branch_overrides_default(self):
+        tk = GitToolkit(
+            repositories={
+                "a": {
+                    "repository": "org/a",
+                    "github_token": "ta",
+                    "default_branch": "develop",
+                }
+            }
+        )
+        ctx = tk._prepare_github_context("a", "release")
+        assert ctx.base_branch == "release"
+
+
+# ---------------------------------------------------------------------------
+# Ad-hoc unknown slug uses (and caches) global credentials
+# ---------------------------------------------------------------------------
+
+class TestAdHocFallback:
+    def test_unknown_slug_uses_global_token_and_caches(self):
+        tk = GitToolkit(default_repository="org/d", github_token="g")
+        with patch(
+            "parrot_tools.gittoolkit.requests.request",
+            return_value=_make_response(200, json_data={"number": 1}),
+        ) as mocked:
+            asyncio.run(tk.get_pull_request(pr_number=1, repository="x/y"))
+        assert "/repos/x/y/pulls/1" in mocked.call_args.args[1]
+        assert mocked.call_args.kwargs["headers"]["Authorization"] == "Bearer g"
+        # The ad-hoc connection is cached under the slug for reuse.
+        assert "x/y" in tk._connections
+        first = tk._resolve_connection("x/y")
+        second = tk._resolve_connection("x/y")
+        assert first is second
+
+    def test_ad_hoc_reuses_global_app_provider(self):
+        with patch.object(gt, "GithubIntegration") as gi_cls:
+            gi_cls.return_value.get_access_token.return_value = (
+                _mock_installation_auth("ghs_global")
+            )
+            tk = GitToolkit(
+                default_repository="org/d",
+                auth_type="github_app",
+                app_id=1,
+                installation_id=11,
+                private_key=PEM,
+            )
+        conn = tk._resolve_connection("x/y")
+        # Ad-hoc app connection reuses the toolkit's single global provider.
+        assert conn._token_provider is tk._token_provider
+
+
+# ---------------------------------------------------------------------------
+# Thread-safety smoke test
+# ---------------------------------------------------------------------------
+
+class TestThreadSafety:
+    def test_concurrent_ad_hoc_resolution_single_entry(self):
+        tk = GitToolkit(default_repository="org/d", github_token="g")
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            conns = list(
+                pool.map(lambda _: tk._resolve_connection("x/y"), range(32))
+            )
+        # All threads observe the same cached connection instance.
+        assert all(c is conns[0] for c in conns)
+        assert list(tk._connections).count("x/y") == 1


### PR DESCRIPTION
## Summary

Extends `GitToolkit` with a named repository registry that allows a single toolkit instance to manage credentials and defaults for multiple GitHub repositories. Each repository can have its own PAT or GitHub App credentials, independent of the global/default credentials.

## Key Changes

- **New `RepositoryCredential` model**: Pydantic model for per-repository configuration (repository slug, default branch, auth type, and credentials). Includes validation to ensure GitHub App mode has required fields and enforces mutual exclusion of `private_key` / `private_key_path`.

- **New `_RepoConnection` class**: Internal class that wraps a resolved repository connection, holding the slug, default branch, auth type, and token provider. Provides a `token()` method that re-resolves the bearer token on each call ("re-connect per operation" semantic).

- **New `_load_pem()` helper**: Extracted PEM loading logic (from inline contents or file path) with normalization of literal `\n` escape sequences. Shared by both toolkit initialization and per-repository credential resolution.

- **Repository registry in `GitToolkit.__init__`**: 
  - Added `repositories` parameter accepting a dict of alias → `RepositoryCredential` (or equivalent dict).
  - Builds a `_connections` dict mapping aliases to `_RepoConnection` instances.
  - Registers the legacy `default_repository` as the `"default"` alias, reusing the toolkit's global token provider for App mode.
  - Raises `GitToolkitError` if both a `"default"` registry alias and legacy `default_repository` are supplied (to avoid ambiguity).

- **New `_resolve_connection()` method**: Resolves a repository reference (None | alias | `owner/name` slug) to a `_RepoConnection`:
  1. `None` → the `"default"` registry entry
  2. A registered alias → that connection
  3. A raw slug matching a registered connection's repository → that connection (allows callers to pass the slug of a registered repo and use its dedicated credentials)
  4. An unknown slug → an ad-hoc connection built from global/default credentials, cached for reuse

- **Updated `_prepare_github_context()` and all repository-aware methods**: Changed to use `_resolve_connection()` instead of directly accessing `self.default_repository` and `self._bearer_token()`. Each method now calls `conn.token()` to get the correct token for the resolved repository.

- **Updated field descriptions**: All `repository` parameters in input models now document that they accept either a registered alias or a raw `owner/name` slug.

- **Thread-safe ad-hoc caching**: Uses `_connections_lock` to ensure concurrent calls resolving the same unknown slug create only one cached connection.

## Notable Implementation Details

- **Per-repository token providers in App mode**: Each registered repository with `auth_type='github_app'` gets its own `_GitHubAppTokenProvider` instance, so installation tokens are minted and cached independently per repository.

- **Backward compatibility**: The legacy `default_repository`, `github_token`, `auth_type`, and App-mode fields continue to work as before. The `"default"` connection reuses the toolkit's global token provider to avoid redundant token minting.

- **Validation**: `RepositoryCredential` uses Pydantic's `@model_validator` to enforce App-mode requirements and mutual exclusion constraints at construction time.

- **New test file**: `test_gittoolkit_multirepo.py` covers registry construction, per-repository token selection, per-repository default branches, ad-hoc fallback with caching, and thread-safety.

https://claude.ai/code/session_011RPxv1bFe4M2dmpusJYEBm