### PR TITLE
fix(embeddings): drop unused google-cloud-aiplatform from `google` extra (+ infographic sign coloring)

### DIFF
--- a/packages/ai-parrot-embeddings/pyproject.toml
+++ b/packages/ai-parrot-embeddings/pyproject.toml
@@ -45,8 +45,14 @@ huggingface = [
     "sentencepiece==0.2.1",
 ]
 google = [
+    # The embeddings backend (parrot/embeddings/google.py) uses only the
+    # google-genai SDK (`from google import genai`). google-cloud-aiplatform is
+    # NOT imported anywhere in this package; declaring it dragged in
+    # google-cloud-storage>=3.10.0, conflicting with consumers that pin
+    # google-cloud-storage<=3.1.0 (e.g. navigator-api[google]). Keep this extra
+    # to google-genai only; add a dedicated `vertex` extra if Vertex SDK use is
+    # ever introduced.
     "google-genai>=2.6.0",
-    "google-cloud-aiplatform>=1.153.0",
 ]
 openai = [
     "openai==2.8.1",

--- a/packages/ai-parrot-embeddings/src/parrot/embeddings/version.py
+++ b/packages/ai-parrot-embeddings/src/parrot/embeddings/version.py
@@ -4,7 +4,7 @@ __title__ = "ai-parrot-embeddings"
 __description__ = (
     "Concrete embedding, vector-store, and reranker backends for AI-Parrot."
 )
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 __author__ = "Jesus Lara"
 __author_email__ = "jesuslara@phenobarbital.info"
 __license__ = "MIT"

--- a/packages/ai-parrot/src/parrot/models/infographic.py
+++ b/packages/ai-parrot/src/parrot/models/infographic.py
@@ -427,6 +427,39 @@ class ChartBlock(BaseModel):
             "a 2-column grid. Omit or set to 'full' for full-width rendering."
         ),
     )
+    color_by_sign: Optional[bool] = Field(
+        False,
+        description=(
+            "When True, the frontend colors each data point by the sign of its "
+            "value (positive vs negative) instead of by series. Intended for "
+            "variance/delta charts (e.g. bar or waterfall) where positive and "
+            "negative figures should read differently. The actual colors come "
+            "from the frontend theme unless overridden via 'positive_color' / "
+            "'negative_color'."
+        ),
+    )
+    positive_color: Optional[str] = Field(
+        None,
+        description=(
+            "Optional override color for positive values when 'color_by_sign' is "
+            "enabled. CSS color value. When omitted, the frontend falls back to "
+            "its theme's positive/success color."
+        ),
+    )
+    negative_color: Optional[str] = Field(
+        None,
+        description=(
+            "Optional override color for negative values when 'color_by_sign' is "
+            "enabled. CSS color value. When omitted, the frontend falls back to "
+            "its theme's negative/danger color."
+        ),
+    )
+
+    @field_validator("positive_color", "negative_color", mode="before")
+    @classmethod
+    def _validate_sign_colors(cls, v: Any) -> Any:
+        """Validate CSS color value — silently drops invalid values."""
+        return _validate_css_color(v)
 
 
 class BulletListBlock(BaseModel):

--- a/packages/ai-parrot/src/parrot/models/infographic_templates.py
+++ b/packages/ai-parrot/src/parrot/models/infographic_templates.py
@@ -405,17 +405,19 @@ TEMPLATE_FINANCIAL_VARIANCE = InfographicTemplate(
             block_type=BlockType.CHART,
             description=(
                 "Bar chart — day-over-day change of the headline metric. "
-                "MUST set layout='half'."
+                "MUST set layout='half'. Set color_by_sign=true so positive and "
+                "negative deltas render in different colors."
             ),
-            constraints={"chart_type": "bar", "layout": "half"},
+            constraints={"chart_type": "bar", "layout": "half", "color_by_sign": "true"},
         ),
         BlockSpec(
             block_type=BlockType.CHART,
             description=(
                 "Bar chart — day-over-day change of the secondary metric. "
-                "MUST set layout='half'."
+                "MUST set layout='half'. Set color_by_sign=true so positive and "
+                "negative deltas render in different colors."
             ),
-            constraints={"chart_type": "bar", "layout": "half"},
+            constraints={"chart_type": "bar", "layout": "half", "color_by_sign": "true"},
         ),
         BlockSpec(
             block_type=BlockType.CHART,
@@ -431,6 +433,17 @@ TEMPLATE_FINANCIAL_VARIANCE = InfographicTemplate(
                 "Executive summary (2–4 sentences) tying the 4 KPIs and the "
                 "trend together."
             ),
+        ),
+    ],
+    js_bundles=[
+        JSBundle(
+            name="echarts",
+            scope="cdn",
+            url="https://cdn.jsdelivr.net/npm/echarts@5.4.3/dist/echarts.min.js",
+            # Hash computed via:
+            #   curl -sL "https://cdn.jsdelivr.net/npm/echarts@5.4.3/dist/echarts.min.js" | \
+            #     openssl dgst -sha384 -binary | base64 | tr -d '\n'
+            sri_hash="sha384-BQKzmHvQLMCAnL3UtDBA1Al5tFjsCz1wrMlIUA1wkzo14DYkRWjywW+p9pCj0cwd",
         ),
     ],
 )
@@ -544,53 +557,3 @@ class InfographicTemplateRegistry:
 
 # Module-level singleton registry
 infographic_registry = InfographicTemplateRegistry()
-
-
-# ── FEAT-197: financial_projection_variance template ─────────────────────────
-# Registered outside the _register_builtins() block so it can reference
-# JSBundle (added by FEAT-197) without touching the seven built-in definitions.
-
-TEMPLATE_FINANCIAL_PROJECTION_VARIANCE = InfographicTemplate(
-    name="financial_projection_variance",
-    description=(
-        "4 hero cards (total revenue, total EBITDA, EBITDA margin, largest swing) "
-        "+ 2 DoD bar charts (revenue, EBITDA) + 1 cumulative line chart."
-    ),
-    block_specs=[
-        BlockSpec(
-            block_type=BlockType.HERO_CARD,
-            min_items=4,
-            max_items=4,
-            description="4 KPI cards: total revenue, total EBITDA, EBITDA margin, largest daily swing.",
-        ),
-        BlockSpec(
-            block_type=BlockType.CHART,
-            required=True,
-            description="Day-over-day revenue bar chart (uses rev_daily DataFrame).",
-        ),
-        BlockSpec(
-            block_type=BlockType.CHART,
-            required=True,
-            description="Day-over-day EBITDA bar chart (uses ebitda_daily DataFrame).",
-        ),
-        BlockSpec(
-            block_type=BlockType.CHART,
-            required=True,
-            description="Cumulative revenue line chart (uses rev_cumulative DataFrame).",
-        ),
-    ],
-    default_theme="dark",
-    js_bundles=[
-        JSBundle(
-            name="echarts",
-            scope="cdn",
-            url="https://cdn.jsdelivr.net/npm/echarts@5.4.3/dist/echarts.min.js",
-            # Hash computed via:
-            #   curl -sL "https://cdn.jsdelivr.net/npm/echarts@5.4.3/dist/echarts.min.js" | \
-            #     openssl dgst -sha384 -binary | base64 | tr -d '\n'
-            sri_hash="sha384-BQKzmHvQLMCAnL3UtDBA1Al5tFjsCz1wrMlIUA1wkzo14DYkRWjywW+p9pCj0cwd",
-        ),
-    ],
-)
-
-infographic_registry.register(TEMPLATE_FINANCIAL_PROJECTION_VARIANCE)

--- a/packages/ai-parrot/tests/integration/test_infographic_e2e.py
+++ b/packages/ai-parrot/tests/integration/test_infographic_e2e.py
@@ -246,22 +246,24 @@ def test_e2e_csp_headers_from_js_bundles():
 
 
 # ---------------------------------------------------------------------------
-# E2E: financial_projection_variance template is registered
+# E2E: financial_variance template is registered
 # ---------------------------------------------------------------------------
 
 def test_e2e_financial_variance_template_registered():
-    """infographic_registry must have financial_projection_variance."""
+    """infographic_registry must have the consolidated financial_variance template."""
     # The template is registered at module load time in infographic_templates.py
     # We need to reimport to pick it up (since we cleared the module cache above).
     sys.modules.pop("parrot.models.infographic_templates", None)
     import parrot.models.infographic_templates as _fresh
     sys.modules["parrot.models.infographic_templates"] = _fresh
 
-    assert "financial_projection_variance" in _fresh.infographic_registry.list_templates()
-    tpl = _fresh.infographic_registry.get("financial_projection_variance")
-    assert len(tpl.block_specs) == 4
+    names = _fresh.infographic_registry.list_templates()
+    assert "financial_variance" in names
+    # The legacy duplicate was consolidated into financial_variance.
+    assert "financial_projection_variance" not in names
+    tpl = _fresh.infographic_registry.get("financial_variance")
+    assert len(tpl.block_specs) == 9
     assert tpl.js_bundles is not None and len(tpl.js_bundles) >= 1
-    assert tpl.default_theme == "dark"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/ai-parrot/tests/unit/tools/test_infographic_financial_variance.py
+++ b/packages/ai-parrot/tests/unit/tools/test_infographic_financial_variance.py
@@ -127,10 +127,14 @@ def test_financial_variance_chart_constraints():
     """Positions 5,6 carry bar/half constraints; position 7 carries line/full."""
     tpl = infographic_registry.get("financial_variance")
     specs = tpl.block_specs
-    assert specs[5].constraints == {"chart_type": "bar", "layout": "half"}, (
+    assert specs[5].constraints == {
+        "chart_type": "bar", "layout": "half", "color_by_sign": "true"
+    }, (
         f"Slot 5 constraints wrong: {specs[5].constraints}"
     )
-    assert specs[6].constraints == {"chart_type": "bar", "layout": "half"}, (
+    assert specs[6].constraints == {
+        "chart_type": "bar", "layout": "half", "color_by_sign": "true"
+    }, (
         f"Slot 6 constraints wrong: {specs[6].constraints}"
     )
     assert specs[7].constraints == {"chart_type": "line", "layout": "full"}, (


### PR DESCRIPTION
## Summary

Two independent changes on this branch (separate commits):

### 1. `fix(embeddings)` — drop unused `google-cloud-aiplatform` from the `google` extra
The `ai-parrot-embeddings` `google` backend (`parrot/embeddings/google.py`) only uses the **google-genai** SDK (`from google import genai`). `google-cloud-aiplatform` is **never imported** anywhere in the package, yet declaring it forced `google-cloud-storage>=3.10.0`.

That transitively conflicts with consumers pinning `google-cloud-storage<=3.1.0` — e.g. `navigator-api[google]` — making `uv lock` unresolvable for downstream projects (navapi). Keeping the extra to `google-genai` only resolves the conflict while preserving the Google embeddings backend.

A dedicated `vertex` extra can be added later if the Vertex AI SDK is ever introduced.

Version bumped `0.1.3 → 0.1.4` so downstreams can pin `ai-parrot-embeddings>=0.1.4` from the index.

### 2. `feat(infographic)` — sign-based chart coloring for variance charts
- Add `color_by_sign` / `positive_color` / `negative_color` fields to `ChartBlock` (with CSS color validation).
- Enable `color_by_sign` on the `financial_variance` template's day-over-day bar charts and attach the echarts CDN `JSBundle`.
- Remove the now-redundant `financial_projection_variance` template.

## Validation
- Downstream (navapi) `uv lock` now resolves with `ai-parrot-embeddings[huggingface,google,openai,pgvector,arango,bigquery]` and the Google embeddings backend imports cleanly; `google-cloud-aiplatform` is no longer pulled and `google-cloud-storage` stays at 3.1.0 (within the navigator-api pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)