### PR TITLE
fix(structured-chart): robust data delivery, column reconciliation & rendering

### DIFF
--- a/packages/ai-parrot-visualizations/src/parrot/outputs/formats/structured_chart.py
+++ b/packages/ai-parrot-visualizations/src/parrot/outputs/formats/structured_chart.py
@@ -34,10 +34,29 @@ REQUIREMENTS:
    - First, fetch the data using the appropriate tool.
    - Then map the fetched column names to x/y in the config.
 2. Emit ONLY a single JSON object matching the schema below — no prose, no markdown, no code fences.
-3. Put the data rows inside the JSON under "data" (a list of flat row dicts).
+3. CRITICAL — column names: set "x" and "y" to the EXACT column names of the
+   DataFrame you computed with your tools (the column headers shown in your tool
+   output). These names are matched against the real data, which the system takes
+   directly from the DataFrame you computed. Do NOT invent semantic names such as
+   "category", "metric" or "value" unless those are the actual column headers —
+   a name that is not a real column produces an empty chart. The "data" field is
+   OPTIONAL: you may leave it as an empty list [], because the system uses the
+   DataFrame you computed as the data source (you do not need to retype the rows).
+   MANDATORY data-delivery convention: your LAST tool call before emitting the
+   JSON MUST be a `python_repl_pandas` step that assigns the exact, final chart
+   rows to a flat pandas DataFrame named EXACTLY `chart_data`, and you MUST set
+   "dataVariable": "chart_data". If you obtained the data with
+   `dataset_fetch_dataset`, `database_query` or SQL, load/rebuild it into
+   `chart_data` in that final step (e.g. `chart_data = <your_dataframe>`). This is
+   what guarantees the rows reach the chart — data fetched only via
+   `dataset_fetch_dataset` and NOT placed into `chart_data` may not render. The
+   columns of `chart_data` MUST include your x and y.
 4. For xAxisMode="time", the x column values MUST be ISO 8601 date strings (e.g. "2024-01-15").
 5. For type="map", mapName is required.
 6. The y field is a list — include all series columns.
+7. ALWAYS include a short "title" (≤1 line, no trailing punctuation) and a one-paragraph
+   "description" in natural language summarizing the chart's key takeaway (this is the text
+   shown to the user next to the chart).
 
 SCHEMA (your output must match this exactly):
 {json.dumps(_SCHEMA, indent=2)}
@@ -160,31 +179,135 @@ class StructuredChartRenderer(BaseChart):
             # 3. Build output — camelCase, data key excluded
             out = cfg.model_dump(mode="json", by_alias=True, exclude={"data"})
 
-            # 4. Route chart rows to response.data.
-            #    cfg.data contains the rows the LLM selected and matched to
-            #    x/y — they take priority over any raw DataFrame the agent
-            #    placed in response.data before the renderer ran.
-            #    Explicit None/empty check avoids DataFrame truthiness crash:
-            #    `not response.data` raises "truth value of a DataFrame is
-            #    ambiguous" when the agent pre-populated response.data with a
-            #    pd.DataFrame.
-            if cfg.data:
-                # cfg.data rows always win — they match the chart config.
-                response.data = cfg.data
-            # else: leave response.data as-is (e.g. aggregated DataFrame from
-            # agent — data.py will serialise it to records if still a DataFrame)
+            # 4. Resolve the data rows and reconcile the config's x/y columns.
+            #    Reality (FEAT-215): the LLM does NOT reliably embed rows — it
+            #    emits a placeholder like `[{}]` even when asked. The
+            #    authoritative data is the DataFrame the agent computed, which
+            #    PandasAgent injects into ``response.data`` *before* the renderer
+            #    runs. We pick the best available rows, then ensure out["x"] /
+            #    out["y"] name columns that actually exist in those rows —
+            #    otherwise the frontend (LayerChart) builds a scale over
+            #    `undefined` and renders nothing.
+            rows = self._resolve_rows(cfg, getattr(response, "data", None))
+            if rows:
+                self._reconcile_columns(out, cfg, rows)
+                response.data = rows
+            # else: no usable rows — leave response.data as-is (the frontend
+            # shows a graceful "no data" fallback).
+
+            # Diagnostic: log the FINAL config axes vs the actual data columns so
+            # a config/data mismatch (the frontend "columns don't match" guard)
+            # can be pinpointed from the server log without guesswork.
+            logger.info(
+                "structured_chart render: type=%s x=%r y=%r data_cols=%s rows=%d",
+                out.get("type"),
+                out.get("x"),
+                out.get("y"),
+                list(rows[0].keys()) if rows else None,
+                len(rows) if rows else 0,
+            )
 
             # response.code is left untouched (renderer never sets it)
-            # Return the explanation as `wrapped` so that data.py's
+            # Return the natural-language text as `wrapped` so that data.py's
             #   response.response = wrapped
-            # preserves the LLM's natural-language text instead of setting it
-            # to None (the previous behaviour when render returned (out, None)).
-            return out, explanation
+            # surfaces it as the message body. Prefer the config's own
+            # `description` (the LLM's chart summary); fall back to any
+            # pre-existing explanation the agent set before the renderer ran.
+            return out, (cfg.description or explanation)
 
         except Exception as exc:  # noqa: BLE001
             msg = f"Unexpected error in StructuredChartRenderer: {exc}"
             logger.exception(msg)
             return None, msg
+
+    # ── Data resolution + column reconciliation ──────────────────────────────
+
+    @staticmethod
+    def _resolve_rows(cfg: StructuredChartConfig, existing: Any) -> Optional[list]:
+        """Pick the authoritative data rows for the chart.
+
+        Priority:
+            1. Real rows the LLM embedded in ``cfg.data`` (non-empty first row).
+            2. The agent-injected pandas DataFrame in ``response.data``
+               (converted to records). Duck-typed (``to_dict`` + ``empty``) so
+               this module doesn't need to import pandas.
+            3. A pre-existing plain ``list[dict]`` with a non-empty first row.
+
+        Args:
+            cfg: The validated chart configuration.
+            existing: The current ``response.data`` (may be a DataFrame, list,
+                or None).
+
+        Returns:
+            A list of row dicts, or ``None`` when nothing usable is available.
+        """
+        # 1. LLM embedded real rows
+        if cfg.data and cfg.data[0]:
+            return cfg.data
+        # 2. Agent-injected pandas DataFrame (duck-typed)
+        if existing is not None and hasattr(existing, "to_dict") and hasattr(existing, "empty"):
+            return None if existing.empty else existing.to_dict("records")
+        # 3. Pre-existing list of non-empty dicts
+        if isinstance(existing, list) and existing and existing[0]:
+            return existing
+        return None
+
+    @staticmethod
+    def _reconcile_columns(
+        out: dict, cfg: StructuredChartConfig, rows: list
+    ) -> None:
+        """Ensure ``out['x']`` and ``out['y']`` reference columns present in rows.
+
+        The LLM frequently names semantic axes (e.g. ``x="category"``) that do
+        not match the real DataFrame columns. When a configured column is absent
+        we infer a sensible replacement from the data: the first non-numeric
+        column becomes ``x`` and the numeric columns become ``y``. This mutates
+        ``out`` in place so the frontend receives a config whose x/y exist in
+        ``response.data``.
+
+        Index-like columns (``index``, ``level_0``, ``Unnamed: 0``) — typically
+        the pandas row index that leaked in via ``reset_index`` or dataset
+        materialization — are never used as a ``y`` series: they are row counters,
+        not metrics, and would otherwise show up as a meaningless extra series in
+        the legend (e.g. an "index" entry alongside "total_amount").
+
+        Args:
+            out: The camelCase config dict (mutated in place).
+            cfg: The validated chart configuration (source x/y).
+            rows: The resolved data rows (first row used for column inference).
+        """
+        first = rows[0]
+        cols = list(first.keys())
+        col_set = set(cols)
+
+        def _is_number(v: Any) -> bool:
+            return isinstance(v, (int, float)) and not isinstance(v, bool)
+
+        def _is_index_like(c: Any) -> bool:
+            return str(c).strip().lower() in {"index", "level_0", "unnamed: 0", ""}
+
+        # x: keep when present, else first non-numeric column, else first column.
+        if cfg.x not in col_set:
+            categorical = next(
+                (c for c in cols if not _is_number(first.get(c))), None
+            )
+            out["x"] = categorical or cols[0]
+
+        # y: keep the configured columns that exist and are real metrics (drop
+        # index-like columns); otherwise infer from the numeric columns. Either
+        # way, never emit an index column as a series.
+        present_y = [
+            c for c in cfg.y if c in col_set and not _is_index_like(c)
+        ]
+        if not present_y:
+            x_col = out.get("x")
+            present_y = [
+                c
+                for c in cols
+                if c != x_col and _is_number(first.get(c)) and not _is_index_like(c)
+            ]
+        if present_y:
+            out["y"] = present_y
 
     # ── JSON extraction helper (mirrors EChartsRenderer._extract_json_code) ──
 

--- a/packages/ai-parrot/src/parrot/bots/data.py
+++ b/packages/ai-parrot/src/parrot/bots/data.py
@@ -25,7 +25,7 @@ from ..tools.pythonpandas import PythonPandasTool
 from ..tools.json_tool import ToJsonTool
 from .agent import BasicAgent
 from ..models.responses import AIMessage, AgentResponse
-from ..models.outputs import OutputMode, StructuredOutputConfig
+from ..models.outputs import OutputMode, StructuredOutputConfig, StructuredChartConfig
 from ..memory.abstract import ConversationTurn
 from ..conf import STATIC_DIR
 from ..bots.prompts import OUTPUT_SYSTEM_PROMPT
@@ -1496,8 +1496,20 @@ class PandasAgent(BasicAgent):
                     elif isinstance(structured_output, StructuredOutputConfig):
                         llm_kwargs["structured_output"] = structured_output
                 elif return_structured:
+                    # FEAT-215: for STRUCTURED_CHART the structured output IS the
+                    # chart config (mirrors the frontend AppChartConfig), not the
+                    # generic PandasAgentResponse. Forcing PandasAgentResponse here
+                    # made the model emit a prose-only {explanation} and omit the
+                    # chart config; advertising StructuredChartConfig (incl. the
+                    # fast-path JSON addendum below) makes it reliably emit the
+                    # config + embedded data rows.
+                    _forced_output_type = (
+                        StructuredChartConfig
+                        if output_mode == OutputMode.STRUCTURED_CHART
+                        else PandasAgentResponse
+                    )
                     llm_kwargs["structured_output"] = StructuredOutputConfig(
-                        output_type=PandasAgentResponse
+                        output_type=_forced_output_type
                     )
 
                 # Fast-path optimization for clients that split tools +
@@ -1539,6 +1551,31 @@ class PandasAgent(BasicAgent):
                 response.turn_id = getattr(response, 'turn_id', None) or turn_id
                 data_response: Optional[PandasAgentResponse] = response.output \
                     if isinstance(response.output, PandasAgentResponse) else None
+
+                # FEAT-215: in STRUCTURED_CHART mode the structured output IS the
+                # chart config (StructuredChartConfig), not a PandasAgentResponse, so
+                # the branch below is skipped. Route the config to response.code where
+                # StructuredChartRenderer reads and validates it (it accepts a dict).
+                if output_mode == OutputMode.STRUCTURED_CHART and data_response is None:
+                    _cfg_out = response.output
+                    _chart_data_var: Optional[str] = None
+                    if isinstance(_cfg_out, StructuredChartConfig):
+                        response.code = _cfg_out.model_dump(mode="json", by_alias=True)
+                        _chart_data_var = _cfg_out.data_variable
+                    elif isinstance(_cfg_out, dict):
+                        response.code = _cfg_out
+                        _chart_data_var = (
+                            _cfg_out.get("data_variable")
+                            or _cfg_out.get("dataVariable")
+                        )
+                    # The chart config may name the DataFrame variable to chart.
+                    # Inject it explicitly: this disambiguates turns that produced
+                    # multiple DataFrames, where blind inference refuses to guess
+                    # (see _infer_data_variable_from_tools).
+                    if _chart_data_var:
+                        await self._inject_data_from_variable(
+                            response, _chart_data_var
+                        )
 
                 missing_data_variables: List[str] = []
                 if data_response:
@@ -1600,8 +1637,18 @@ class PandasAgent(BasicAgent):
                     response.tool_calls
                 )
                 if not inferred_var:
+                    # FEAT-215: in STRUCTURED_CHART mode the prompt asks the
+                    # agent to place the final chart rows in a conventionally
+                    # named DataFrame (`chart_data`). Prefer it when present so a
+                    # multi-DataFrame turn still resolves instead of refusing.
+                    _prefer = (
+                        ("chart_data", "chart_df")
+                        if output_mode == OutputMode.STRUCTURED_CHART
+                        else ()
+                    )
                     inferred_var = self._infer_data_variable_from_tools(
-                        response.tool_calls
+                        response.tool_calls,
+                        prefer_names=_prefer,
                     )
 
                 response_data_is_empty = (
@@ -2036,7 +2083,7 @@ class PandasAgent(BasicAgent):
         return None
 
     def _infer_data_variable_from_tools(
-        self, tool_calls: List[Any]
+        self, tool_calls: List[Any], prefer_names: tuple = ()
     ) -> Optional[str]:
         """Strict-mode inference of a ``data_variable`` from the current turn.
 
@@ -2104,6 +2151,15 @@ class PandasAgent(BasicAgent):
             and isinstance(pandas_tool.locals[var], pd.DataFrame)
             and not pandas_tool.locals[var].empty
         ]
+
+        # Convention-aware preference: when the caller passes conventional names
+        # (e.g. the structured_chart `chart_data` DataFrame), prefer the first
+        # one that is live this turn. This breaks a multi-candidate tie WITHOUT
+        # relaxing the anti-stale guard — we still only ever return a DataFrame
+        # created and live in the current turn's REPL context.
+        for name in prefer_names:
+            if name in live_dataframes:
+                return name
 
         # Strict disambiguation: return only when there is exactly one.
         if len(live_dataframes) == 1:

--- a/packages/ai-parrot/src/parrot/conf.py
+++ b/packages/ai-parrot/src/parrot/conf.py
@@ -351,6 +351,16 @@ HUGGINGFACE_EMBEDDING_CACHE_DIR = config.get(
     'HUGGINGFACE_EMBEDDING_CACHE_DIR',
     fallback=BASE_DIR.joinpath('model_cache', 'huggingface')
 )
+# Propagate the app-level cache dir to the *standard* HuggingFace env var so
+# the whole HF stack (huggingface_hub, transformers, sentence-transformers)
+# downloads into this directory — not only the `cache_folder` kwarg we pass to
+# SentenceTransformer. Without this, hub snapshots land in the user's default
+# ~/.cache/huggingface/hub regardless of HUGGINGFACE_EMBEDDING_CACHE_DIR.
+#
+# IMPORTANT: huggingface_hub freezes HF_HUB_CACHE at import time, so this MUST
+# run before any HF library is imported. conf.py loads early enough to satisfy
+# that. `setdefault` lets an explicitly-set HF_HOME in the environment win.
+os.environ.setdefault('HF_HOME', str(HUGGINGFACE_EMBEDDING_CACHE_DIR))
 HUGGINGFACEHUB_API_TOKEN = config.get('HUGGINGFACEHUB_API_TOKEN')
 MAX_VRAM_AVAILABLE = config.get('MAX_VRAM_AVAILABLE', fallback=20000)
 RAM_AVAILABLE = config.get('RAM_AVAILABLE', fallback=819200)

--- a/packages/ai-parrot/src/parrot/models/outputs.py
+++ b/packages/ai-parrot/src/parrot/models/outputs.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass, fields, is_dataclass, MISSING
 import json
 import os
 import uuid
-from pydantic import BaseModel, Field, ConfigDict, model_validator
+from pydantic import BaseModel, Field, ConfigDict, model_validator, field_validator
 from .basic import OutputFormat
 
 
@@ -364,32 +364,105 @@ class StructuredChartConfig(BaseModel):
         default=None, alias="mapName",
         description="GeoJSON map name (frontend-validated, free-form; required for type='map')",
     )
+    title: Optional[str] = Field(
+        default=None,
+        description="Short chart title (≤1 line) shown as the card header.",
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description=(
+            "One short paragraph (natural language) summarizing the chart's key "
+            "takeaway; shown as the message text alongside the chart."
+        ),
+    )
     data: List[dict] = Field(
         default_factory=list,
         description=(
-            "Flat data rows; INPUT-ONLY — excluded from `output`, "
-            "routed to response.data by the renderer."
+            "Optional: the rows to chart, as a list of flat dicts whose keys "
+            "include the x and y column names. When omitted, the renderer uses "
+            "the DataFrame the agent computed (injected into response.data) as "
+            "the data source instead — see StructuredChartRenderer."
+        ),
+    )
+    data_variable: Optional[str] = Field(
+        default=None,
+        alias="dataVariable",
+        description=(
+            "The name of the pandas DataFrame variable you created in a tool "
+            "(e.g. 'expense_breakdown') that holds the rows to chart. ALWAYS set "
+            "this to the variable that contains the chart data. It is REQUIRED "
+            "when the turn produced more than one DataFrame, so the system knows "
+            "which one to use; x and y must be columns of that DataFrame."
         ),
     )
 
+    @field_validator("data", mode="before")
+    @classmethod
+    def _normalize_data_orientation(cls, v):
+        """Accept any pandas-style orientation for ``data`` and coerce to records.
+
+        The LLM serializes the DataFrame inconsistently — sometimes as a list of
+        row dicts (``records``), sometimes as ``split`` orientation
+        ``{"columns": [...], "data": [[...], ...]}``, sometimes as the default
+        ``{col: {idx: val}}``. Only ``records`` matches ``List[dict]``; the others
+        used to fail validation and trigger a slow (~13s) reformat call. Normalize
+        them here so the chart pipeline is resilient to the serialization shape.
+
+        Args:
+            v: The raw ``data`` value from the LLM (list or dict orientation).
+
+        Returns:
+            A list of row dicts, or the value unchanged when already a list / not
+            a recognized orientation (lets normal validation handle it).
+        """
+        if not isinstance(v, dict):
+            return v
+        # 'split'/'tight' orientation: {"columns": [...], "data"|"rows"|"values": [[...]]}.
+        # The values key varies by serializer/LLM ('data' is pandas-canonical, but
+        # models also emit 'rows' or 'values'); accept any of them.
+        cols = v.get("columns")
+        rows = v.get("data")
+        if rows is None:
+            rows = v.get("rows")
+        if rows is None:
+            rows = v.get("values")
+        if isinstance(cols, list) and isinstance(rows, list):
+            return [
+                dict(zip(cols, r)) if isinstance(r, (list, tuple)) else r
+                for r in rows
+            ]
+        # pandas default 'dict' orientation: {col: {row_idx: value}}
+        if v and all(isinstance(col_vals, dict) for col_vals in v.values()):
+            indices = list(next(iter(v.values())).keys())
+            return [
+                {col: col_vals.get(idx) for col, col_vals in v.items()}
+                for idx in indices
+            ]
+        # A single row dict → wrap as one-row list
+        return [v]
+
     @model_validator(mode="after")
     def _validate_chart_constraints(self) -> "StructuredChartConfig":
-        """Validate map-name requirement and column presence.
+        """Validate the map-name requirement only.
+
+        We deliberately do NOT reject configs whose ``x``/``y`` don't match the
+        embedded data columns. The LLM frequently names semantic axes
+        (``x="expense_category"``) that differ from the keys it actually embeds,
+        and it delivers data through several paths (embedded rows, a python
+        variable, or a materialized dataset). Raising here forced a slow
+        reformat call and — worse — pre-empted ``StructuredChartRenderer``, which
+        is responsible for reconciling x/y against whatever rows are available.
+        So the only hard constraint left is the map-name requirement; column
+        alignment is handled downstream by the renderer.
 
         Returns:
             The validated StructuredChartConfig instance.
 
         Raises:
-            ValueError: When type='map' and mapName is absent, or when x/y
-                columns are missing from non-empty data rows.
+            ValueError: When type='map' and mapName is absent.
         """
         if self.type == "map" and not self.map_name:
             raise ValueError("type='map' requires 'mapName'")
-        if self.data:
-            cols = set(self.data[0].keys())
-            missing = [c for c in [self.x, *self.y] if c not in cols]
-            if missing:
-                raise ValueError(f"columns not present in data rows: {missing}")
         return self
 
 

--- a/packages/ai-parrot/tests/outputs/formats/test_structured_chart.py
+++ b/packages/ai-parrot/tests/outputs/formats/test_structured_chart.py
@@ -48,13 +48,16 @@ def test_structured_chart_config_alias_roundtrip():
     """camelCase aliases serialize correctly; snake_case input also accepted."""
     from parrot.models.outputs import StructuredChartConfig
 
-    cfg = StructuredChartConfig(type="bar", x="m", y=["v"], splitSeries=True, xAxisMode="time")
+    rows = [{"m": "Jan", "v": 1}]
+    cfg = StructuredChartConfig(
+        type="bar", x="m", y=["v"], splitSeries=True, xAxisMode="time", data=rows
+    )
     dumped = cfg.model_dump(by_alias=True)
     assert "splitSeries" in dumped and "xAxisMode" in dumped
     assert "split_series" not in dumped
 
     # snake_case input also accepted (populate_by_name=True)
-    cfg2 = StructuredChartConfig(type="bar", x="m", y=["v"], split_series=True)
+    cfg2 = StructuredChartConfig(type="bar", x="m", y=["v"], split_series=True, data=rows)
     assert cfg2.split_series is True
 
 
@@ -72,6 +75,7 @@ def test_structured_chart_config_all_aliases_in_dump():
         colorBySign=True,
         negativeColor="#ff0000",
         mapName="world",
+        data=[{"country": "US", "sales": 1}],
     )
     dumped = cfg.model_dump(by_alias=True)
     for alias in ("splitSeries", "showLegend", "xAxisMode", "colorBySign", "negativeColor", "mapName"):
@@ -91,36 +95,96 @@ def test_structured_chart_config_map_with_mapname_ok():
     """type='map' with mapName does NOT raise."""
     from parrot.models.outputs import StructuredChartConfig
 
-    cfg = StructuredChartConfig(type="map", x="country", y=["sales"], mapName="world")
+    cfg = StructuredChartConfig(
+        type="map", x="country", y=["sales"], mapName="world",
+        data=[{"country": "US", "sales": 1}],
+    )
     assert cfg.map_name == "world"
 
 
-def test_structured_chart_config_y_columns_present():
-    """y referencing absent column raises ValidationError when data is non-empty."""
-    from pydantic import ValidationError
+def test_structured_chart_config_mismatched_columns_accepted():
+    """x/y not matching the embedded data is ACCEPTED (renderer reconciles).
+
+    The model_validator no longer rejects column mismatches: the LLM often names
+    semantic axes that differ from the embedded keys, and StructuredChartRenderer
+    reconciles x/y downstream. Raising here would force a slow reformat and
+    pre-empt that reconciliation.
+    """
     from parrot.models.outputs import StructuredChartConfig
 
-    with pytest.raises(ValidationError):
-        StructuredChartConfig(type="bar", x="m", y=["missing"],
-                              data=[{"m": "Jan", "v": 1}])
+    cfg = StructuredChartConfig(type="bar", x="m", y=["missing"],
+                                data=[{"m": "Jan", "v": 1}])
+    assert cfg.y == ["missing"]  # kept as-is; renderer reconciles at render time
 
-
-def test_structured_chart_config_x_column_present():
-    """x referencing absent column raises ValidationError when data is non-empty."""
-    from pydantic import ValidationError
-    from parrot.models.outputs import StructuredChartConfig
-
-    with pytest.raises(ValidationError):
-        StructuredChartConfig(type="bar", x="bad_col", y=["v"],
-                              data=[{"m": "Jan", "v": 1}])
+    cfg2 = StructuredChartConfig(type="bar", x="bad_col", y=["v"],
+                                 data=[{"m": "Jan", "v": 1}])
+    assert cfg2.x == "bad_col"
 
 
 def test_structured_chart_config_empty_data_skips_column_check():
-    """Empty data list does not trigger column-check validation."""
+    """Empty/placeholder data does not trigger column-check validation.
+
+    The LLM does not reliably embed rows (emits [{}]); the renderer reconciles
+    columns against the agent-injected DataFrame, so an empty/placeholder data
+    list is accepted at the model level.
+    """
     from parrot.models.outputs import StructuredChartConfig
 
     cfg = StructuredChartConfig(type="bar", x="anything", y=["whatever"], data=[])
     assert cfg.data == []
+
+    cfg2 = StructuredChartConfig(type="bar", x="anything", y=["whatever"], data=[{}])
+    assert cfg2.data == [{}]
+
+
+def test_structured_chart_config_data_split_orientation_normalized():
+    """data in pandas 'split' orientation ({columns, data}) is coerced to records."""
+    from parrot.models.outputs import StructuredChartConfig
+
+    cfg = StructuredChartConfig(
+        type="radar",
+        x="cat",
+        y=["val"],
+        data={
+            "columns": ["cat", "val"],
+            "data": [["A", 1], ["B", 2]],
+        },
+    )
+    assert cfg.data == [
+        {"cat": "A", "val": 1},
+        {"cat": "B", "val": 2},
+    ]
+
+
+def test_structured_chart_config_data_split_rows_key_normalized():
+    """split orientation with the 'rows' key (not 'data') is also coerced.
+
+    Replays the exact radar failure: the model emitted
+    {"columns": [...], "rows": [[...]]} which previously got wrapped as one bogus
+    row with columns ['columns','rows'].
+    """
+    from parrot.models.outputs import StructuredChartConfig
+
+    cfg = StructuredChartConfig(
+        type="radar",
+        x="cat",
+        y=["val"],
+        data={"columns": ["cat", "val"], "rows": [["A", 1], ["B", 2]]},
+    )
+    assert cfg.data == [{"cat": "A", "val": 1}, {"cat": "B", "val": 2}]
+
+
+def test_structured_chart_config_data_dict_orientation_normalized():
+    """data in pandas default 'dict' orientation ({col: {idx: val}}) → records."""
+    from parrot.models.outputs import StructuredChartConfig
+
+    cfg = StructuredChartConfig(
+        type="bar",
+        x="m",
+        y=["v"],
+        data={"m": {0: "Jan", 1: "Feb"}, "v": {0: 1, 1: 2}},
+    )
+    assert cfg.data == [{"m": "Jan", "v": 1}, {"m": "Feb", "v": 2}]
 
 
 def test_structured_chart_config_data_excluded_from_output_dump():
@@ -267,25 +331,147 @@ async def test_renderer_cfg_data_wins_over_dataframe(bar_config_json):
 
 @satellite_available
 @pytest.mark.asyncio
-async def test_renderer_preserves_data_when_cfg_data_empty():
-    """When cfg.data is empty, existing response.data is left untouched."""
+async def test_renderer_uses_existing_data_when_cfg_data_empty():
+    """When cfg.data is empty, the renderer uses the pre-existing response.data.
+
+    The LLM does not embed rows reliably; the agent-injected data is the source.
+    When the config's x/y already match the existing rows, they are kept as-is.
+    """
     import json
     from types import SimpleNamespace
     from parrot.models.outputs import OutputMode
     from parrot.outputs.formats import get_renderer
 
-    # A valid config with no data rows
     config_no_data = json.dumps({"type": "bar", "x": "m", "y": ["v"]})
     pre_existing = [{"m": "Jan", "v": 1}]
     r = get_renderer(OutputMode.STRUCTURED_CHART)()
     resp = SimpleNamespace(code=config_no_data, data=pre_existing, output=None, response=None)
     output, wrapped = await r.render(resp)
 
-    # wrapped = explanation (None since resp.response is None)
     assert wrapped is None
+    assert output is not None
     assert "data" not in output
-    # No cfg.data → existing data must be preserved
+    assert output["x"] == "m" and output["y"] == ["v"]  # already valid → unchanged
     assert resp.data is pre_existing
+
+
+@satellite_available
+@pytest.mark.asyncio
+async def test_renderer_reconciles_mismatched_columns():
+    """LLM names x/y that don't exist → renderer infers them from the data.
+
+    Mirrors the real failure shape: the config says x="category" but the injected
+    DataFrame has columns grp / sub / amount. The renderer rewrites x to the
+    first non-numeric column and y to the numeric columns so the frontend can
+    actually render. (Placeholder column names/values only.)
+    """
+    import json
+    from types import SimpleNamespace
+    from parrot.models.outputs import OutputMode
+    from parrot.outputs.formats import get_renderer
+
+    config = json.dumps({"type": "pie", "x": "category", "y": ["amount"]})
+    injected = [
+        {"grp": "X", "sub": "A", "amount": 10},
+        {"grp": "X", "sub": "B", "amount": 20},
+    ]
+    r = get_renderer(OutputMode.STRUCTURED_CHART)()
+    resp = SimpleNamespace(code=config, data=injected, output=None, response=None)
+    output, wrapped = await r.render(resp)
+
+    assert wrapped is None
+    assert output is not None
+    # x was "category" (absent) → first non-numeric column
+    assert output["x"] == "grp"
+    # y "amount" exists → kept
+    assert output["y"] == ["amount"]
+    assert resp.data is injected
+
+
+@satellite_available
+@pytest.mark.asyncio
+async def test_renderer_reconciles_from_dataframe():
+    """A pandas DataFrame in response.data is converted to records + reconciled."""
+    import json
+    import pandas as pd
+    from types import SimpleNamespace
+    from parrot.models.outputs import OutputMode
+    from parrot.outputs.formats import get_renderer
+
+    # config invents x/y that don't match the DataFrame columns
+    config = json.dumps({"type": "bar", "x": "metric", "y": ["value"]})
+    df = pd.DataFrame({"region": ["N", "S"], "sales": [100, 200]})
+    r = get_renderer(OutputMode.STRUCTURED_CHART)()
+    resp = SimpleNamespace(code=config, data=df, output=None, response=None)
+    output, wrapped = await r.render(resp)
+
+    assert wrapped is None
+    assert output is not None
+    assert output["x"] == "region"      # first non-numeric column
+    assert output["y"] == ["sales"]     # numeric column
+    assert isinstance(resp.data, list) and len(resp.data) == 2
+
+
+@satellite_available
+@pytest.mark.asyncio
+async def test_renderer_output_columns_always_match_data():
+    """INVARIANT: after render, config.x and every config.y exist in response.data.
+
+    This is exactly what the frontend guard checks before rendering. We exercise
+    several shapes the radar/finance agent produced (matching cols, mismatched
+    cols, index column, DataFrame source) and assert the config/data stay aligned
+    so the frontend never shows "columns don't match".
+    """
+    import json
+    import pandas as pd
+    from types import SimpleNamespace
+    from parrot.models.outputs import OutputMode
+    from parrot.outputs.formats import get_renderer
+
+    cases = [
+        # radar: config matches the injected DataFrame columns
+        (json.dumps({"type": "radar", "x": "cat", "y": ["amount"]}),
+         pd.DataFrame({"cat": ["A", "B"], "amount": [10, 20]})),
+        # config invents x/y; data has different real columns
+        (json.dumps({"type": "radar", "x": "expense_category", "y": ["total_amount"]}),
+         pd.DataFrame({"grp": ["A", "B"], "amt": [1, 2]})),
+        # data carries a leaked pandas index column
+        (json.dumps({"type": "bar", "x": "cat", "y": ["amount"]}),
+         [{"index": 0, "cat": "A", "amount": 10}, {"index": 1, "cat": "B", "amount": 20}]),
+    ]
+    r = get_renderer(OutputMode.STRUCTURED_CHART)()
+    for code, data in cases:
+        resp = SimpleNamespace(code=code, data=data, output=None, response=None)
+        output, wrapped = await r.render(resp)
+        assert output is not None, f"render failed for {code}"
+        rows = resp.data
+        assert isinstance(rows, list) and rows, "response.data must be non-empty rows"
+        cols = set(rows[0].keys())
+        # The exact invariant the frontend's hasValidColumns enforces:
+        assert output["x"] in cols, f"x={output['x']} not in {cols}"
+        assert all(y in cols for y in output["y"]), f"y={output['y']} not all in {cols}"
+        assert "index" not in output["y"], "index must never be a y series"
+
+
+@satellite_available
+@pytest.mark.asyncio
+async def test_renderer_drops_index_column_from_y():
+    """An 'index' column (pandas row index) is never emitted as a y series."""
+    import json
+    from types import SimpleNamespace
+    from parrot.models.outputs import OutputMode
+    from parrot.outputs.formats import get_renderer
+
+    # Model named both an index column and the real metric in y.
+    config = json.dumps({"type": "radar", "x": "cat", "y": ["index", "val"]})
+    rows = [{"index": 0, "cat": "A", "val": 10}, {"index": 1, "cat": "B", "val": 20}]
+    r = get_renderer(OutputMode.STRUCTURED_CHART)()
+    resp = SimpleNamespace(code=config, data=rows, output=None, response=None)
+    output, wrapped = await r.render(resp)
+
+    assert wrapped is None
+    assert output["x"] == "cat"
+    assert output["y"] == ["val"]  # "index" dropped → single meaningful series
 
 
 @satellite_available


### PR DESCRIPTION
Follow-up to #920 (already merged). Hardens the `STRUCTURED_CHART` output mode end-to-end based on real agent behavior, validated against **pie, bar, horizontalBar, radar and line** charts (positive and negative values) with the `troc_finance` agent.

## What & why

The LLM/agents deliver chart data in many shapes; the original pipeline broke on several of them ("No data", empty charts, columns-don't-match). This makes the path resilient without touching the anti-stale data guard.

**`models/outputs.py`**
- Normalize the `data` field from any orientation → list of records: split `{columns, data|rows|values}`, pandas `dict` orientation, single-row dict.
- Add `data_variable` (alias `dataVariable`) so turns with multiple DataFrames can disambiguate.
- Lenient validator: keep only the `mapName` rule. Column alignment is delegated to the renderer — raising on a mismatch forced a slow reformat call **and** pre-empted reconciliation.

**`ai-parrot-visualizations/.../structured_chart.py` (renderer)**
- `_resolve_rows`: prefer embedded rows, else the agent-injected DataFrame.
- `_reconcile_columns`: align `x`/`y` to the real data columns; never emit an index-like column (`index`, `level_0`, `Unnamed: 0`) as a `y` series.
- System prompt: mandate a final `chart_data` DataFrame + `dataVariable` convention so data reliably reaches the chart.
- Diagnostic log of final `x`/`y` vs actual data columns.

**`bots/data.py`**
- Inject the DataFrame named by `dataVariable`.
- On inference, prefer a conventional live `chart_data`/`chart_df` variable (STRUCTURED_CHART only) to break multi-DataFrame ties — without relaxing the anti-stale guard (only this turn's live REPL vars are ever returned).

**`conf.py`** (unrelated small config): propagate `HUGGINGFACE_EMBEDDING_CACHE_DIR` → `HF_HOME` so the whole HF stack downloads into the app cache dir.

## Tests
- `tests/outputs/formats/test_structured_chart.py`: **32 passing** (added: orientation normalization incl. `{columns, rows}`, column reconciliation, index-column drop, config/data invariant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)