### PR TITLE
Add pluggable usage-logging layer with auto-boot from env

### DIFF
--- a/packages/ai-parrot/pyproject.toml
+++ b/packages/ai-parrot/pyproject.toml
@@ -444,6 +444,12 @@ observability-openlit = [
     "openlit>=1.40.0",
 ]
 
+# Pluggable usage-logging: Prometheus backend (pull-based metrics + cost).
+# The default "logging" usage backend needs NO extra — it uses stdlib logging.
+observability-prometheus = [
+    "prometheus-client>=0.20,<1.0",
+]
+
 # Developer / CI tooling (not shipped to end users)
 dev = [
     "pytest>=8.0",

--- a/packages/ai-parrot/src/parrot/clients/base.py
+++ b/packages/ai-parrot/src/parrot/clients/base.py
@@ -452,7 +452,7 @@ $backstory
             A ``TraceContext`` for the current call span.
         """
         tc = parent_trace.child() if parent_trace else TraceContext.new_root()
-        self.events.emit_nowait(BeforeClientCallEvent(
+        event = BeforeClientCallEvent(
             trace_context=tc,
             client_name=client_name,
             model=model or "",
@@ -461,7 +461,13 @@ $backstory
             has_tools=has_tools,
             source_type="client",
             source_name=client_name,
-        ))
+        )
+        self.events.emit_nowait(event)
+        # Client registries are isolated (forward_to_global=False). Forward the
+        # LLM-call lifecycle events explicitly so global observers (cost/token
+        # recorders, OTel subscribers) receive them. The guard inside
+        # forward_to_global skips the work when nobody is listening globally.
+        self.events.forward_to_global(event)
         return tc
 
     async def _emit_after_call(
@@ -488,7 +494,7 @@ $backstory
             output_tokens: Output token count (provider-dependent; may be ``None``).
             finish_reason: Stop reason from the provider.
         """
-        await self.events.emit(AfterClientCallEvent(
+        event = AfterClientCallEvent(
             trace_context=tc,
             client_name=client_name,
             model=model or "",
@@ -498,7 +504,12 @@ $backstory
             finish_reason=finish_reason,
             source_type="client",
             source_name=client_name,
-        ))
+        )
+        await self.events.emit(event)
+        # Forward to global so cost/token recorders and OTel subscribers
+        # registered on the global registry observe this call (see
+        # _emit_before_call for the rationale).
+        self.events.forward_to_global(event)
 
     async def _emit_failed_call(
         self,
@@ -520,7 +531,7 @@ $backstory
             duration_ms: Wall-clock time in milliseconds until failure.
             exc: The exception that was raised.
         """
-        await self.events.emit(ClientCallFailedEvent(
+        event = ClientCallFailedEvent(
             trace_context=tc,
             client_name=client_name,
             model=model or "",
@@ -529,7 +540,11 @@ $backstory
             error_message=str(exc),
             source_type="client",
             source_name=client_name,
-        ))
+        )
+        await self.events.emit(event)
+        # Forward to global so error counters on the global registry observe
+        # the failure (see _emit_before_call for the rationale).
+        self.events.forward_to_global(event)
 
     @property
     def tool_manager(self) -> ToolManager:

--- a/packages/ai-parrot/src/parrot/core/events/lifecycle/mixin.py
+++ b/packages/ai-parrot/src/parrot/core/events/lifecycle/mixin.py
@@ -60,6 +60,18 @@ class EventEmitterMixin:
             event_bus=event_bus,  # type: ignore[arg-type]
             forward_to_global=forward_to_global,
         )
+        # Env-driven observability auto-boot (idempotent; near-zero cost when
+        # disabled). Runs on the first bot/client/tool construction so the usage
+        # recorder is registered on the global registry before any LLM call.
+        # Guarded so a bootstrap failure can never break construction.
+        try:
+            from parrot.observability.bootstrap import (
+                ensure_observability_bootstrapped,
+            )
+
+            ensure_observability_bootstrapped()
+        except Exception:  # noqa: BLE001
+            logger.debug("observability bootstrap skipped", exc_info=True)
 
     @property
     def events(self) -> EventRegistry:

--- a/packages/ai-parrot/src/parrot/core/events/lifecycle/registry.py
+++ b/packages/ai-parrot/src/parrot/core/events/lifecycle/registry.py
@@ -389,6 +389,26 @@ class EventRegistry:
             name=f"lifecycle.{type(event).__name__}",
         )
 
+    def forward_to_global(self, event: LifecycleEvent) -> None:
+        """Forward *event* to the global registry regardless of ``forward_to_global``.
+
+        Public, opt-in counterpart to the automatic forwarding done inside
+        :meth:`emit`.  An isolated registry (one constructed with
+        ``forward_to_global=False`` — e.g. an LLM client, see
+        ``clients/base.py``) can call this for the specific events it wants
+        global observers (cost/token recorders, OTel subscribers) to receive,
+        without forwarding *every* event it emits (e.g. high-frequency
+        ``ClientStreamChunkEvent`` stays isolated).
+
+        Reuses the same safe, guarded path as automatic forwarding: a no-op
+        when this registry IS the global one, when no event loop is running,
+        or when no global subscriber would receive ``type(event)``.
+
+        Args:
+            event: The ``LifecycleEvent`` to forward to the global registry.
+        """
+        self._forward_to_global_safely(event)
+
     def _forward_to_global_safely(self, event: LifecycleEvent) -> None:
         """Forward *event* to the global registry as a fire-and-forget task.
 

--- a/packages/ai-parrot/src/parrot/observability/README.md
+++ b/packages/ai-parrot/src/parrot/observability/README.md
@@ -38,6 +38,85 @@ See [examples/README.md](examples/README.md) for the full quickstart.
 
 ---
 
+## Pluggable usage logging (no OpenTelemetry required)
+
+For the common case — "just log model usage, tokens, and cost" — you do **not**
+need the OTel SDK or a collector. A pluggable recorder layer fronted by a single
+`AbstractLogger` interface lets you start with structured logs and swap to
+Prometheus (or full OTel) by changing one environment variable.
+
+### Auto-boot from environment variables
+
+Set `OBSERVABILITY_ENABLED=true` and AI-Parrot activates usage recording
+automatically on the first bot/client construction — no code changes:
+
+```bash
+export OBSERVABILITY_ENABLED=true       # backend defaults to "logging"
+# optional:
+export OBSERVABILITY_BACKEND=logging    # logging | prometheus | otel
+export OBSERVABILITY_LOG_LEVEL=INFO
+```
+
+Each LLM call then emits one line on the `parrot.usage` logger:
+
+```
+llm-usage provider=openai model=gpt-4o input_tokens=1000 output_tokens=500 \
+  total_tokens=1500 cost_usd=0.005000 cumulative_cost_usd=0.005000 \
+  duration_ms=842.0 finish_reason=stop trace=<id>
+```
+
+The `logging` backend pulls in **no third-party dependency** and never imports
+the OpenTelemetry SDK. Cost is computed via the bundled `CostCalculator`
+(disable with `OBSERVABILITY_COST=false`).
+
+### Backends
+
+| Backend | Install | When |
+|---|---|---|
+| `logging` (default) | none | Start here. Zero infra, zero network, minimal latency. |
+| `prometheus` | `pip install 'ai-parrot[observability-prometheus]'` | Pull-based metrics + Grafana dashboards. Exposes `:9464/metrics`. |
+| `otel` | `pip install 'ai-parrot[observability]'` | Full OTLP traces + metrics (delegates to `setup_telemetry`). |
+
+The Prometheus backend exposes `parrot_llm_requests_total`,
+`parrot_llm_input_tokens_total`, `parrot_llm_output_tokens_total`,
+`parrot_llm_cost_usd_total` (all labelled `{provider, model}`),
+`parrot_llm_request_duration_seconds`, and `parrot_llm_tokens{type}`. A starter
+dashboard ships at
+[`examples/grafana-dashboards/parrot-usage.json`](examples/grafana-dashboards/parrot-usage.json).
+
+### Programmatic use / custom backends
+
+```python
+from parrot.observability import (
+    UsageRecord, AbstractLogger, UsageRecordingSubscriber, LoggingUsageRecorder,
+)
+from parrot.observability.cost import CostCalculator
+from parrot.core.events.lifecycle.global_registry import get_global_registry
+
+class MyRecorder(AbstractLogger):
+    name = "my-sink"
+    async def record(self, record: UsageRecord) -> None:
+        ...  # ship `record` (provider, model, tokens, cost_usd, …) anywhere
+
+sub = UsageRecordingSubscriber(
+    recorders=[LoggingUsageRecorder(), MyRecorder()],
+    cost_calculator=CostCalculator(),
+)
+get_global_registry().add_provider(sub)
+```
+
+### How events reach the recorder
+
+LLM clients emit their call lifecycle events on an **isolated** registry
+(`forward_to_global=False`) so high-frequency stream chunks stay local. The
+three call events (`Before`/`After`/`Failed`) are explicitly bridged to the
+**global** registry via `EventRegistry.forward_to_global`, which is a guarded
+no-op when no global subscriber is listening. This is what lets a single
+globally-registered subscriber (the usage recorder *or* the OTel
+`MetricsSubscriber`) observe every agent's LLM calls.
+
+---
+
 ## Configuration
 
 `ObservabilityConfig` is a Pydantic v2 model. All fields have safe defaults.
@@ -78,8 +157,12 @@ See [examples/README.md](examples/README.md) for the full quickstart.
 | `OBSERVABILITY_SAMPLING` | `config.sampling_ratio` | Float string `"0.1"` → 10% sampling. |
 | `PARROT_PRICING_PATH` | `config.pricing_override_path` | Path to a custom pricing directory. |
 
-Note: `setup_telemetry` only reads `PARROT_PRICING_PATH` automatically. For the other
-env vars, configure `ObservabilityConfig` directly or use a navconfig integration layer.
+Note: `setup_telemetry` itself only auto-reads `PARROT_PRICING_PATH`. To build a
+config from **all** the variables above, use `ObservabilityConfig.from_env()`, or
+rely on the auto-boot (`OBSERVABILITY_ENABLED=true`) which calls it for you. The
+auto-boot additionally reads `OBSERVABILITY_BACKEND`, `OBSERVABILITY_LOG_LEVEL`,
+`OBSERVABILITY_PROM_PORT`, and `OBSERVABILITY_PROM_ADDR` (see the pluggable
+usage-logging section above).
 
 ---
 

--- a/packages/ai-parrot/src/parrot/observability/__init__.py
+++ b/packages/ai-parrot/src/parrot/observability/__init__.py
@@ -12,12 +12,31 @@ Public surface:
   * ``GenAIOpenTelemetrySubscriber`` — rich span subscriber (TASK-1230).
   * ``MetricsSubscriber`` — counters + histograms subscriber (TASK-1231).
   * ``CostCalculator`` — USD cost calculator (TASK-1232).
+
+Pluggable usage-logging layer (no OpenTelemetry SDK required for the logging
+path):
+  * ``AbstractLogger`` — the pluggable recorder interface.
+  * ``UsageRecord`` — normalized, PII-free per-call record.
+  * ``LoggingUsageRecorder`` — zero-infra structured-log backend.
+  * ``UsageRecordingSubscriber`` — builds records + fans out to recorders.
+  * ``ensure_observability_bootstrapped`` / ``shutdown_usage_recording`` —
+    env-driven auto-boot helpers.
 """
 
+from parrot.observability.bootstrap import (
+    ensure_observability_bootstrapped,
+    shutdown_usage_recording,
+)
 from parrot.observability.config import ObservabilityConfig
 from parrot.observability.cost.calculator import CostCalculator
 from parrot.observability.errors import ConfigurationError
 from parrot.observability.provider import ParrotTelemetryProvider
+from parrot.observability.recorders import (
+    AbstractLogger,
+    LoggingUsageRecorder,
+    UsageRecord,
+    UsageRecordingSubscriber,
+)
 from parrot.observability.setup import setup_telemetry, shutdown_telemetry
 from parrot.observability.subscribers.metrics import MetricsSubscriber
 from parrot.observability.subscribers.trace import GenAIOpenTelemetrySubscriber
@@ -31,4 +50,10 @@ __all__: list[str] = [
     "GenAIOpenTelemetrySubscriber",
     "MetricsSubscriber",
     "CostCalculator",
+    "AbstractLogger",
+    "UsageRecord",
+    "LoggingUsageRecorder",
+    "UsageRecordingSubscriber",
+    "ensure_observability_bootstrapped",
+    "shutdown_usage_recording",
 ]

--- a/packages/ai-parrot/src/parrot/observability/bootstrap.py
+++ b/packages/ai-parrot/src/parrot/observability/bootstrap.py
@@ -1,0 +1,165 @@
+"""ensure_observability_bootstrapped — env-driven, idempotent auto-boot.
+
+Called once (lazily, from ``EventEmitterMixin._init_events``) the first time any
+bot/client/tool is constructed. When ``OBSERVABILITY_ENABLED=true``, it activates
+the usage-recording layer selected by ``OBSERVABILITY_BACKEND`` WITHOUT the user
+writing any code:
+
+- ``logging`` (default when enabled and backend unset): structured per-call cost
+  logs — zero infra, no OTel SDK import.
+- ``prometheus``: lazy ``prometheus_client`` exposition.
+- ``otel``: delegates to ``setup_telemetry`` (full OTLP traces + metrics).
+
+Idempotent and near-zero cost when disabled: the very first line is a boolean
+check; after the first construction the env is never re-read.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Optional
+
+logger = logging.getLogger("parrot.observability.bootstrap")
+
+# Module-level state. threading.Lock (not asyncio) because this may run during
+# synchronous bot/client construction before an event loop exists.
+_BOOTSTRAPPED: bool = False
+_LOCK = threading.Lock()
+_SUBSCRIBER: Optional[object] = None
+_SUBSCRIPTION_IDS: list[str] = []
+
+
+def ensure_observability_bootstrapped() -> None:
+    """Activate env-driven observability exactly once. Safe to call repeatedly.
+
+    No-op (after recording the decision) when ``OBSERVABILITY_ENABLED`` is not
+    truthy. Never raises: any failure is logged at DEBUG and swallowed so it can
+    never break bot/client construction.
+    """
+    global _BOOTSTRAPPED  # noqa: PLW0603
+    if _BOOTSTRAPPED:
+        return
+    with _LOCK:
+        if _BOOTSTRAPPED:
+            return
+        try:
+            _do_bootstrap()
+        except Exception:  # noqa: BLE001 — observability must never break construction
+            logger.debug("Observability auto-boot failed; continuing.", exc_info=True)
+        finally:
+            _BOOTSTRAPPED = True
+
+
+def _do_bootstrap() -> None:
+    """Read config from env and activate the selected backend."""
+    global _SUBSCRIBER  # noqa: PLW0603
+    from parrot.observability.config import ObservabilityConfig  # noqa: PLC0415
+
+    config = ObservabilityConfig.from_env()
+    if not config.enabled:
+        logger.debug("Observability auto-boot: OBSERVABILITY_ENABLED is false.")
+        return
+
+    # Resolve "none" → "logging" when explicitly enabled, so OBSERVABILITY_ENABLED
+    # alone yields structured cost logs.
+    backend = config.usage_backend
+    if backend == "none":
+        backend = "logging"
+        config = config.model_copy(update={"usage_backend": backend})
+
+    if backend == "otel":
+        from parrot.observability.setup import setup_telemetry  # noqa: PLC0415
+
+        setup_telemetry(config)
+        logger.info("Observability auto-boot: OTel backend active.")
+        return
+
+    # Lightweight pluggable path (logging / prometheus) — no OTel SDK import.
+    cost_calc = None
+    if config.enable_cost_tracking:
+        from parrot.observability.cost.calculator import CostCalculator  # noqa: PLC0415
+
+        cost_calc = CostCalculator(override_path=config.pricing_override_path)
+
+    from parrot.observability.recorders.factory import (  # noqa: PLC0415
+        build_recorders_from_config,
+    )
+    from parrot.observability.recorders.subscriber import (  # noqa: PLC0415
+        UsageRecordingSubscriber,
+    )
+
+    recorders = build_recorders_from_config(config)
+    if not recorders:
+        logger.debug(
+            "Observability auto-boot: backend=%r produced no recorders.", backend
+        )
+        return
+
+    subscriber = UsageRecordingSubscriber(
+        recorders=recorders,
+        cost_calculator=cost_calc,
+        service_name=config.service_name,
+    )
+    from parrot.core.events.lifecycle.global_registry import (  # noqa: PLC0415
+        get_global_registry,
+    )
+
+    ids = get_global_registry().add_provider(subscriber)
+    _SUBSCRIBER = subscriber
+    _SUBSCRIPTION_IDS.extend(ids)
+    logger.info(
+        "Observability auto-boot: '%s' backend active (cost=%s, service=%s).",
+        backend,
+        config.enable_cost_tracking,
+        config.service_name,
+    )
+
+
+def shutdown_usage_recording() -> None:
+    """Unsubscribe the usage subscriber and close recorders. Idempotent.
+
+    Only affects the lightweight (logging/prometheus) path. The OTel path is
+    torn down via ``shutdown_telemetry``.
+    """
+    global _SUBSCRIBER  # noqa: PLW0603
+    if _SUBSCRIPTION_IDS:
+        try:
+            from parrot.core.events.lifecycle.global_registry import (  # noqa: PLC0415
+                get_global_registry,
+            )
+
+            registry = get_global_registry()
+            for sub_id in _SUBSCRIPTION_IDS:
+                try:
+                    registry.unsubscribe(sub_id)
+                except Exception:  # noqa: BLE001
+                    logger.debug("Failed to unsubscribe %s.", sub_id)
+        except Exception:  # noqa: BLE001
+            logger.exception("Error unsubscribing usage recorder.")
+        _SUBSCRIPTION_IDS.clear()
+
+    if _SUBSCRIBER is not None:
+        aclose = getattr(_SUBSCRIBER, "aclose", None)
+        if aclose is not None:
+            try:
+                import asyncio  # noqa: PLC0415
+
+                try:
+                    asyncio.get_running_loop()
+                except RuntimeError:
+                    asyncio.run(aclose())
+                else:
+                    # Inside a running loop: schedule fire-and-forget close.
+                    asyncio.ensure_future(aclose())  # noqa: RUF006
+            except Exception:  # noqa: BLE001
+                logger.debug("Error closing usage subscriber.", exc_info=True)
+        _SUBSCRIBER = None
+
+
+def reset_bootstrap_for_tests() -> None:
+    """Test-only: reset module state so a fresh bootstrap can run."""
+    global _BOOTSTRAPPED, _SUBSCRIBER  # noqa: PLW0603
+    shutdown_usage_recording()
+    _BOOTSTRAPPED = False
+    _SUBSCRIBER = None

--- a/packages/ai-parrot/src/parrot/observability/config.py
+++ b/packages/ai-parrot/src/parrot/observability/config.py
@@ -6,9 +6,13 @@ Spec §2 Data Models.
 
 from __future__ import annotations
 
+import logging
+import os
 from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
+
+UsageBackend = Literal["none", "logging", "prometheus", "otel"]
 
 
 class ObservabilityConfig(BaseModel):
@@ -52,6 +56,22 @@ class ObservabilityConfig(BaseModel):
         pricing_override_path: Path to a directory whose ``<provider>.json``
             files are deep-merged over bundled pricing. When ``None``,
             ``setup_telemetry`` reads the ``PARROT_PRICING_PATH`` env var.
+        usage_backend: Selects the pluggable usage/token/cost recording path.
+            ``"none"`` (default) records nothing. ``"logging"`` emits one
+            structured log line per LLM call (zero infra). ``"prometheus"``
+            exposes counters/histograms on an HTTP endpoint. ``"otel"`` delegates
+            to ``setup_telemetry`` (full OTLP traces + metrics). The auto-boot
+            (``ensure_observability_bootstrapped``) resolves ``"none"`` to
+            ``"logging"`` when ``enabled`` is ``True``.
+        usage_log_level: Logging level for the ``logging`` backend's per-call
+            line. Default ``logging.INFO``.
+        usage_log_logger_name: Logger name for the ``logging`` backend. Default
+            ``"parrot.usage"`` (kept distinct from ``parrot.lifecycle`` so the
+            cost line is independently filterable).
+        prometheus_port: TCP port for the ``prometheus`` backend's exposition
+            HTTP server. Default ``9464``.
+        prometheus_addr: Bind address for the ``prometheus`` backend's HTTP
+            server. Default ``"0.0.0.0"``.
     """
 
     enabled: bool = False
@@ -81,3 +101,125 @@ class ObservabilityConfig(BaseModel):
 
     # Cost pricing override (mirrors PARROT_PRICING_PATH env var)
     pricing_override_path: Optional[str] = None
+
+    # Pluggable usage/token/cost recording layer
+    usage_backend: UsageBackend = "none"
+    usage_log_level: int = logging.INFO
+    usage_log_logger_name: str = "parrot.usage"
+    prometheus_port: int = 9464
+    prometheus_addr: str = "0.0.0.0"
+
+    @classmethod
+    def from_env(cls) -> "ObservabilityConfig":
+        """Build an ``ObservabilityConfig`` from environment variables.
+
+        Reads values via ``navconfig`` when importable, falling back to
+        ``os.environ`` so the logging-only path carries no hard navconfig
+        dependency. Absent variables use the model defaults.
+
+        Recognised variables:
+
+        ===========================  ==============================
+        Env var                      Field
+        ===========================  ==============================
+        ``OBSERVABILITY_ENABLED``    ``enabled``
+        ``OBSERVABILITY_BACKEND``    ``usage_backend``
+        ``OBSERVABILITY_SERVICE_NAME``  ``service_name``
+        ``OBSERVABILITY_COST``       ``enable_cost_tracking``
+        ``OBSERVABILITY_LOG_LEVEL``  ``usage_log_level``
+        ``OBSERVABILITY_SAMPLING``   ``sampling_ratio``
+        ``OBSERVABILITY_OPENLIT``    ``enable_openlit``
+        ``OTEL_EXPORTER_OTLP_ENDPOINT``  ``otlp_endpoint``
+        ``OBSERVABILITY_PROM_PORT``  ``prometheus_port``
+        ``OBSERVABILITY_PROM_ADDR``  ``prometheus_addr``
+        ``PARROT_PRICING_PATH``      ``pricing_override_path``
+        ===========================  ==============================
+
+        Returns:
+            A validated ``ObservabilityConfig``.
+        """
+        defaults = cls()
+        get = _env_getter()
+
+        values: dict = {
+            "enabled": _as_bool(get("OBSERVABILITY_ENABLED"), defaults.enabled),
+            "service_name": get("OBSERVABILITY_SERVICE_NAME") or defaults.service_name,
+            "enable_cost_tracking": _as_bool(
+                get("OBSERVABILITY_COST"), defaults.enable_cost_tracking
+            ),
+            "enable_openlit": _as_bool(
+                get("OBSERVABILITY_OPENLIT"), defaults.enable_openlit
+            ),
+            "sampling_ratio": _as_float(
+                get("OBSERVABILITY_SAMPLING"), defaults.sampling_ratio
+            ),
+            "usage_log_level": _as_log_level(
+                get("OBSERVABILITY_LOG_LEVEL"), defaults.usage_log_level
+            ),
+            "prometheus_port": _as_int(
+                get("OBSERVABILITY_PROM_PORT"), defaults.prometheus_port
+            ),
+            "prometheus_addr": get("OBSERVABILITY_PROM_ADDR") or defaults.prometheus_addr,
+        }
+
+        backend = get("OBSERVABILITY_BACKEND")
+        if backend:
+            values["usage_backend"] = backend.strip().lower()
+
+        endpoint = get("OTEL_EXPORTER_OTLP_ENDPOINT")
+        if endpoint:
+            values["otlp_endpoint"] = endpoint
+
+        pricing = get("PARROT_PRICING_PATH")
+        if pricing:
+            values["pricing_override_path"] = pricing
+
+        return cls(**values)
+
+
+def _env_getter():
+    """Return a ``key -> Optional[str]`` getter backed by navconfig or os.environ."""
+    try:
+        from navconfig import config as nav_config  # noqa: PLC0415
+
+        return lambda key: nav_config.get(key, fallback=os.environ.get(key))
+    except Exception:  # noqa: BLE001 — navconfig optional; fall back to os.environ
+        return os.environ.get
+
+
+def _as_bool(raw: Optional[str], default: bool) -> bool:
+    """Parse a truthy string (``true/1/yes/on``); fall back to *default*."""
+    if raw is None:
+        return default
+    return str(raw).strip().lower() in {"true", "1", "yes", "on"}
+
+
+def _as_float(raw: Optional[str], default: float) -> float:
+    """Parse a float; fall back to *default* on error/None."""
+    if raw is None or str(raw).strip() == "":
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_int(raw: Optional[str], default: int) -> int:
+    """Parse an int; fall back to *default* on error/None."""
+    if raw is None or str(raw).strip() == "":
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_log_level(raw: Optional[str], default: int) -> int:
+    """Resolve a level name (``"DEBUG"``) or numeric string to a logging level int."""
+    if raw is None or str(raw).strip() == "":
+        return default
+    token = str(raw).strip().upper()
+    if token.isdigit():
+        return int(token)
+    resolved = logging.getLevelName(token)
+    return resolved if isinstance(resolved, int) else default

--- a/packages/ai-parrot/src/parrot/observability/examples/grafana-dashboards/parrot-usage.json
+++ b/packages/ai-parrot/src/parrot/observability/examples/grafana-dashboards/parrot-usage.json
@@ -1,0 +1,120 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource scraping the PrometheusUsageRecorder endpoint (default :9464).",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" }
+  ],
+  "annotations": { "list": [] },
+  "description": "AI-Parrot LLM usage — total cost, cost rate by provider/model, token throughput, request rate and latency. Backed by the pluggable PrometheusUsageRecorder.",
+  "editable": true,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "title": "Total estimated cost (USD)",
+      "type": "stat",
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "currencyUSD", "decimals": 4 }, "overrides": [] },
+      "targets": [
+        { "expr": "sum(parrot_llm_cost_usd_total)", "legendFormat": "total", "refId": "A" }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "title": "Request rate (req/s)",
+      "type": "stat",
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        { "expr": "sum(rate(parrot_llm_requests_total[5m]))", "legendFormat": "rps", "refId": "A" }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "title": "Cost rate by provider/model (USD/s)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "currencyUSD", "color": { "mode": "palette-classic" } }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "sum by (provider, model) (rate(parrot_llm_cost_usd_total[5m]))",
+          "legendFormat": "{{provider}}/{{model}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "title": "Token throughput (tokens/s)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "palette-classic" } }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "sum by (provider, model) (rate(parrot_llm_input_tokens_total[5m]))",
+          "legendFormat": "in {{provider}}/{{model}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (provider, model) (rate(parrot_llm_output_tokens_total[5m]))",
+          "legendFormat": "out {{provider}}/{{model}}",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "title": "Request duration p50 / p95 (s)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "s", "color": { "mode": "palette-classic" } }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(parrot_llm_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(parrot_llm_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "title": "Cumulative cost by model (USD)",
+      "type": "table",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "currencyUSD", "decimals": 4 }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "sum by (provider, model) (parrot_llm_cost_usd_total)",
+          "legendFormat": "{{provider}}/{{model}}",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["ai-parrot", "llm", "usage", "cost"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timezone": "",
+  "title": "AI-Parrot — LLM Usage & Cost",
+  "version": 1
+}

--- a/packages/ai-parrot/src/parrot/observability/recorders/__init__.py
+++ b/packages/ai-parrot/src/parrot/observability/recorders/__init__.py
@@ -1,0 +1,27 @@
+"""Pluggable usage/token/cost recording backends.
+
+A single ``AbstractLogger`` interface fronts every backend (logging, Prometheus,
+…). ``UsageRecordingSubscriber`` builds one ``UsageRecord`` per LLM call from the
+FEAT-176 lifecycle events (reusing the shared ``CostCalculator``) and fans it out
+to the configured recorders. Backend selection is driven by
+``ObservabilityConfig.usage_backend``.
+
+The logging path imports NO OpenTelemetry SDK and adds no third-party
+dependency. ``PrometheusUsageRecorder`` lazily imports ``prometheus_client``.
+"""
+
+from __future__ import annotations
+
+from parrot.observability.recorders.base import AbstractLogger
+from parrot.observability.recorders.factory import build_recorders_from_config
+from parrot.observability.recorders.logging_recorder import LoggingUsageRecorder
+from parrot.observability.recorders.models import UsageRecord
+from parrot.observability.recorders.subscriber import UsageRecordingSubscriber
+
+__all__ = [
+    "AbstractLogger",
+    "UsageRecord",
+    "LoggingUsageRecorder",
+    "UsageRecordingSubscriber",
+    "build_recorders_from_config",
+]

--- a/packages/ai-parrot/src/parrot/observability/recorders/base.py
+++ b/packages/ai-parrot/src/parrot/observability/recorders/base.py
@@ -1,0 +1,45 @@
+"""AbstractLogger — the pluggable usage-recording interface.
+
+Every usage backend (logging, Prometheus, …) implements this single async
+surface so that swapping backends is a configuration change, not a code change.
+``UsageRecordingSubscriber`` builds one ``UsageRecord`` per LLM call and calls
+``record`` on each configured backend.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from parrot.observability.recorders.models import UsageRecord
+
+
+class AbstractLogger(ABC):
+    """Abstract base for pluggable usage/token/cost recorders.
+
+    Implementations MUST be cheap and non-blocking on the hot path: ``record``
+    runs inside the event-dispatch coroutine of every LLM call. Backends that
+    perform network I/O should buffer and flush out-of-band, or rely on a
+    pull-based exposition model (e.g. Prometheus).
+
+    Attributes:
+        name: Short identifier for the backend (used in logs/diagnostics).
+    """
+
+    name: str = "abstract"
+
+    @abstractmethod
+    async def record(self, record: UsageRecord) -> None:
+        """Record a single normalized usage record.
+
+        Args:
+            record: The per-call ``UsageRecord`` to persist/emit.
+        """
+        raise NotImplementedError
+
+    async def aclose(self) -> None:
+        """Flush and release any resources. Default implementation is a no-op.
+
+        Stateful backends (buffered exporters, HTTP servers) override this to
+        flush on shutdown. Called by ``shutdown_usage_recording``.
+        """
+        return None

--- a/packages/ai-parrot/src/parrot/observability/recorders/factory.py
+++ b/packages/ai-parrot/src/parrot/observability/recorders/factory.py
@@ -1,0 +1,64 @@
+"""build_recorders_from_config — map an ObservabilityConfig to recorder backends.
+
+Used by the auto-boot (``ensure_observability_bootstrapped``) to instantiate the
+pluggable recorders for the selected ``usage_backend`` without the caller knowing
+about concrete backend classes.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from parrot.observability.recorders.logging_recorder import LoggingUsageRecorder
+
+if TYPE_CHECKING:
+    from parrot.observability.config import ObservabilityConfig
+    from parrot.observability.recorders.base import AbstractLogger
+
+logger = logging.getLogger(__name__)
+
+
+def build_recorders_from_config(
+    config: "ObservabilityConfig",
+) -> "list[AbstractLogger]":
+    """Return the recorder backends for ``config.usage_backend``.
+
+    Only the lightweight (non-OTel) backends are built here: ``"logging"`` and
+    ``"prometheus"``. The ``"otel"`` and ``"none"`` backends are handled by the
+    bootstrap (delegate to ``setup_telemetry`` / no-op respectively) and yield no
+    recorders.
+
+    Args:
+        config: The observability configuration.
+
+    Returns:
+        A list of ``AbstractLogger`` instances (possibly empty).
+    """
+    backend = config.usage_backend
+    recorders: "list[AbstractLogger]" = []
+
+    if backend == "logging":
+        recorders.append(
+            LoggingUsageRecorder(
+                level=config.usage_log_level,
+                logger_name=config.usage_log_logger_name,
+            )
+        )
+    elif backend == "prometheus":
+        from parrot.observability.recorders.prometheus_recorder import (  # noqa: PLC0415
+            PrometheusUsageRecorder,
+        )
+
+        recorders.append(
+            PrometheusUsageRecorder(
+                port=config.prometheus_port,
+                addr=config.prometheus_addr,
+            )
+        )
+    else:
+        logger.debug(
+            "build_recorders_from_config: backend=%r yields no recorders.", backend
+        )
+
+    return recorders

--- a/packages/ai-parrot/src/parrot/observability/recorders/logging_recorder.py
+++ b/packages/ai-parrot/src/parrot/observability/recorders/logging_recorder.py
@@ -1,0 +1,64 @@
+"""LoggingUsageRecorder — zero-infra usage backend that logs one line per call.
+
+The default, lowest-overhead backend: no network, no extra dependencies (stdlib
+``logging`` only). Emits a single structured line per LLM call to a dedicated
+logger (``parrot.usage`` by default) carrying provider, model, token counts,
+estimated cost, duration, and the process-cumulative cost.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from parrot.observability.recorders.base import AbstractLogger
+from parrot.observability.recorders.models import UsageRecord
+
+
+class LoggingUsageRecorder(AbstractLogger):
+    """Record usage by emitting one structured log line per LLM call.
+
+    Args:
+        level: Logging level for the per-call line (default ``logging.INFO``).
+        logger_name: Logger to write to (default ``"parrot.usage"``).
+    """
+
+    name = "logging"
+
+    def __init__(
+        self,
+        *,
+        level: int = logging.INFO,
+        logger_name: str = "parrot.usage",
+    ) -> None:
+        self._level = level
+        self._logger = logging.getLogger(logger_name)
+
+    async def record(self, record: UsageRecord) -> None:
+        """Emit a single line summarising *record*.
+
+        Args:
+            record: The per-call usage record to log.
+        """
+        cost = "n/a" if record.cost_usd is None else f"{record.cost_usd:.6f}"
+        cumulative = (
+            "n/a"
+            if record.cumulative_cost_usd is None
+            else f"{record.cumulative_cost_usd:.6f}"
+        )
+        # Lazy %-formatting: skipped entirely when the level is filtered out.
+        self._logger.log(
+            self._level,
+            "llm-usage provider=%s model=%s input_tokens=%d output_tokens=%d "
+            "total_tokens=%d cost_usd=%s cumulative_cost_usd=%s duration_ms=%.1f "
+            "finish_reason=%s trace=%s",
+            record.provider,
+            record.model,
+            record.input_tokens,
+            record.output_tokens,
+            record.total_tokens,
+            cost,
+            cumulative,
+            record.duration_ms,
+            record.finish_reason or "-",
+            record.trace_id or "-",
+        )

--- a/packages/ai-parrot/src/parrot/observability/recorders/models.py
+++ b/packages/ai-parrot/src/parrot/observability/recorders/models.py
@@ -1,0 +1,64 @@
+"""UsageRecord — the normalized, PII-free record shared by all usage recorders.
+
+A single ``UsageRecord`` is built per successful LLM call by
+``UsageRecordingSubscriber`` from an ``AfterClientCallEvent`` plus an optional
+``CostCalculator`` result, then fanned out to every configured
+``AbstractLogger`` backend.
+
+Privacy: this record carries NO prompt/completion content and NO
+``user_id``/``session_id`` — only provider/model identifiers, token counts,
+cost, timing, and a correlation ``trace_id``. This preserves the observability
+PII contract (see ``observability/README.md``).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from pydantic import BaseModel, Field, computed_field
+
+
+class UsageRecord(BaseModel):
+    """Normalized usage/token/cost record for one LLM API call.
+
+    Attributes:
+        provider: ``gen_ai.system`` value (e.g. ``"openai"``, ``"anthropic"``,
+            ``"gemini"``) resolved via ``resolve_gen_ai_system``.
+        client_name: Raw client identifier as emitted by the client (kept for
+            traceability alongside the resolved ``provider``).
+        model: Model identifier.
+        input_tokens: Prompt/input token count (0 when unknown).
+        output_tokens: Completion/output token count (0 when unknown).
+        cost_usd: Estimated USD cost for this call, or ``None`` when pricing is
+            unavailable for the ``(provider, model)`` pair.
+        cumulative_cost_usd: Process-cumulative estimated USD cost across all
+            calls observed so far (set by the subscriber), or ``None`` when cost
+            tracking is disabled.
+        duration_ms: Wall-clock duration of the call in milliseconds.
+        finish_reason: Provider stop reason (e.g. ``"stop"``), or ``None``.
+        trace_id: Correlation trace id (no content), or ``None``.
+        service_name: Configured ``service.name``.
+        timestamp: UTC timestamp at record construction.
+    """
+
+    provider: str
+    client_name: str = ""
+    model: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cost_usd: Optional[float] = None
+    cumulative_cost_usd: Optional[float] = None
+    duration_ms: float = 0.0
+    finish_reason: Optional[str] = None
+    trace_id: Optional[str] = None
+    service_name: str = "ai-parrot"
+    timestamp: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def total_tokens(self) -> int:
+        """Sum of input and output tokens."""
+        return self.input_tokens + self.output_tokens

--- a/packages/ai-parrot/src/parrot/observability/recorders/prometheus_recorder.py
+++ b/packages/ai-parrot/src/parrot/observability/recorders/prometheus_recorder.py
@@ -1,0 +1,144 @@
+"""PrometheusUsageRecorder — pull-based metrics backend (described, lazy-loaded).
+
+A lightweight, low-latency backend for usage/token/cost metrics. Uses
+``prometheus_client`` directly (not the OTel→Prometheus exporter) so the
+logging-first design never drags in the OTel SDK. Metrics are updated in-process
+(counter ``.inc`` / histogram ``.observe`` — no network on the hot path) and
+exposed on an HTTP endpoint that Prometheus scrapes, so request latency is
+unaffected.
+
+Install with: ``pip install 'ai-parrot[observability-prometheus]'``.
+
+Cardinality contract: labels are limited to ``provider`` (bounded ~10 values)
+and ``model``. NEVER ``trace_id``/``user_id``/``session_id``/prompt content.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any
+
+from parrot.observability.recorders.base import AbstractLogger
+from parrot.observability.recorders.models import UsageRecord
+
+logger = logging.getLogger(__name__)
+
+# Latency buckets (seconds) — mirrors MetricsSubscriber._DEFAULT_BUCKETS.
+_LATENCY_BUCKETS = (0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 30.0, 60.0)
+# Token-space buckets — mirrors MetricsSubscriber._TOKEN_BUCKETS.
+_TOKEN_BUCKETS = (10, 50, 100, 500, 1000, 2000, 5000, 10000, 50000, 100000)
+
+# Module-level guards so re-construction (multi-bot, tests) neither re-registers
+# instruments with the default Prometheus registry nor re-binds the HTTP server.
+_INSTRUMENTS: Any = None
+_SERVER_STARTED = False
+_LOCK = threading.Lock()
+
+
+def _build_instruments() -> Any:
+    """Create (once) and return the Prometheus instruments namespace."""
+    global _INSTRUMENTS  # noqa: PLW0603
+    if _INSTRUMENTS is not None:
+        return _INSTRUMENTS
+    from prometheus_client import Counter, Histogram  # noqa: PLC0415
+
+    labelnames = ("provider", "model")
+    _INSTRUMENTS = {
+        "requests": Counter(
+            "parrot_llm_requests_total",
+            "Number of LLM API calls.",
+            labelnames,
+        ),
+        "input_tokens": Counter(
+            "parrot_llm_input_tokens_total",
+            "Total input tokens billed.",
+            labelnames,
+        ),
+        "output_tokens": Counter(
+            "parrot_llm_output_tokens_total",
+            "Total output tokens billed.",
+            labelnames,
+        ),
+        "cost": Counter(
+            "parrot_llm_cost_usd_total",
+            "Total estimated cost of LLM API calls in USD.",
+            labelnames,
+        ),
+        "duration": Histogram(
+            "parrot_llm_request_duration_seconds",
+            "Duration of LLM API calls in seconds.",
+            labelnames,
+            buckets=_LATENCY_BUCKETS,
+        ),
+        "tokens": Histogram(
+            "parrot_llm_tokens",
+            "Token usage per LLM API call (input + output).",
+            ("provider", "model", "type"),
+            buckets=_TOKEN_BUCKETS,
+        ),
+    }
+    return _INSTRUMENTS
+
+
+class PrometheusUsageRecorder(AbstractLogger):
+    """Record usage as Prometheus counters/histograms exposed over HTTP.
+
+    Args:
+        port: Exposition HTTP server port (default ``9464``).
+        addr: Bind address (default ``"0.0.0.0"``).
+        start_server: When ``True`` (default), start the exposition server.
+            Pass ``False`` in tests that scrape the default registry directly.
+    """
+
+    name = "prometheus"
+
+    def __init__(
+        self,
+        *,
+        port: int = 9464,
+        addr: str = "0.0.0.0",
+        start_server: bool = True,
+    ) -> None:
+        try:
+            import prometheus_client  # noqa: F401, PLC0415
+        except ImportError as exc:  # pragma: no cover - exercised via extras
+            raise ImportError(
+                "PrometheusUsageRecorder requires the 'observability-prometheus' "
+                "extra. Install with: pip install 'ai-parrot[observability-prometheus]'"
+            ) from exc
+
+        self._m = _build_instruments()
+        if start_server:
+            self._maybe_start_server(port, addr)
+
+    @staticmethod
+    def _maybe_start_server(port: int, addr: str) -> None:
+        """Start the exposition HTTP server once per process."""
+        global _SERVER_STARTED  # noqa: PLW0603
+        with _LOCK:
+            if _SERVER_STARTED:
+                return
+            from prometheus_client import start_http_server  # noqa: PLC0415
+
+            start_http_server(port, addr=addr)
+            _SERVER_STARTED = True
+            logger.info(
+                "PrometheusUsageRecorder: exposition server on http://%s:%d/metrics",
+                addr,
+                port,
+            )
+
+    async def record(self, record: UsageRecord) -> None:
+        """Update Prometheus instruments from *record* (no network in hot path)."""
+        labels = {"provider": record.provider, "model": record.model}
+        self._m["requests"].labels(**labels).inc()
+        if record.input_tokens:
+            self._m["input_tokens"].labels(**labels).inc(record.input_tokens)
+            self._m["tokens"].labels(type="input", **labels).observe(record.input_tokens)
+        if record.output_tokens:
+            self._m["output_tokens"].labels(**labels).inc(record.output_tokens)
+            self._m["tokens"].labels(type="output", **labels).observe(record.output_tokens)
+        if record.cost_usd is not None:
+            self._m["cost"].labels(**labels).inc(record.cost_usd)
+        self._m["duration"].labels(**labels).observe(record.duration_ms / 1000.0)

--- a/packages/ai-parrot/src/parrot/observability/recorders/subscriber.py
+++ b/packages/ai-parrot/src/parrot/observability/recorders/subscriber.py
@@ -1,0 +1,132 @@
+"""UsageRecordingSubscriber — turns LLM-call events into UsageRecords + fan-out.
+
+This is the bridge between the FEAT-176 lifecycle event system and the pluggable
+recorder backends. It subscribes to ``AfterClientCallEvent`` on the global
+registry (the same surface the OTel ``MetricsSubscriber`` uses), computes cost
+via the shared ``CostCalculator``, builds a normalized ``UsageRecord``, and
+fans it out to every configured ``AbstractLogger``.
+
+It implements the ``EventProvider`` protocol (synchronous ``register``).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import TYPE_CHECKING, Optional
+
+from parrot.core.events.lifecycle.events import AfterClientCallEvent
+from parrot.observability.attributes import resolve_gen_ai_system
+from parrot.observability.recorders.models import UsageRecord
+
+if TYPE_CHECKING:
+    from parrot.core.events.lifecycle.registry import EventRegistry
+    from parrot.observability.cost.calculator import CostCalculator
+    from parrot.observability.recorders.base import AbstractLogger
+
+logger = logging.getLogger(__name__)
+
+
+class UsageRecordingSubscriber:
+    """Build ``UsageRecord``s from LLM-call events and fan out to recorders.
+
+    Args:
+        recorders: The pluggable backends to forward each record to.
+        cost_calculator: Optional ``CostCalculator``; when provided, the per-call
+            and cumulative USD cost are computed.
+        service_name: ``service.name`` stamped on each record.
+    """
+
+    def __init__(
+        self,
+        *,
+        recorders: "list[AbstractLogger]",
+        cost_calculator: "Optional[CostCalculator]" = None,
+        service_name: str = "ai-parrot",
+    ) -> None:
+        self._recorders = list(recorders)
+        self._cost = cost_calculator
+        self._service_name = service_name
+        self._cumulative_cost_usd: float = 0.0
+        self._has_cost: bool = False
+        self._lock = threading.Lock()
+
+    @property
+    def recorders(self) -> "list[AbstractLogger]":
+        """The configured recorder backends."""
+        return self._recorders
+
+    # ------------------------------------------------------------------
+    # EventProvider Protocol
+    # ------------------------------------------------------------------
+
+    def register(self, registry: "EventRegistry") -> None:
+        """Subscribe the usage handler to *registry*.
+
+        Args:
+            registry: The ``EventRegistry`` (typically the global registry) to
+                attach to.
+        """
+        registry.subscribe(AfterClientCallEvent, self._on_client_after)
+
+    # ------------------------------------------------------------------
+    # Handler
+    # ------------------------------------------------------------------
+
+    async def _on_client_after(self, event: AfterClientCallEvent) -> None:
+        """Build a ``UsageRecord`` for a successful call and fan it out."""
+        provider = resolve_gen_ai_system(event.client_name)
+        input_tokens = event.input_tokens or 0
+        output_tokens = event.output_tokens or 0
+
+        cost_usd: Optional[float] = None
+        cumulative: Optional[float] = None
+        if self._cost is not None:
+            cost_usd = self._cost.cost_usd(
+                provider=provider,
+                model=event.model,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+            )
+            with self._lock:
+                if cost_usd is not None:
+                    self._cumulative_cost_usd += cost_usd
+                    self._has_cost = True
+                cumulative = self._cumulative_cost_usd if self._has_cost else None
+
+        trace_id = (
+            event.trace_context.trace_id if event.trace_context else None
+        )
+        record = UsageRecord(
+            provider=provider,
+            client_name=event.client_name,
+            model=event.model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=cost_usd,
+            cumulative_cost_usd=cumulative,
+            duration_ms=event.duration_ms,
+            finish_reason=event.finish_reason,
+            trace_id=trace_id,
+            service_name=self._service_name,
+        )
+
+        for recorder in self._recorders:
+            try:
+                await recorder.record(record)
+            except Exception:  # noqa: BLE001 — one bad backend must not break others
+                logger.exception(
+                    "Usage recorder %r failed on record; continuing.",
+                    getattr(recorder, "name", type(recorder).__name__),
+                )
+
+    async def aclose(self) -> None:
+        """Close all recorders (flush stateful backends)."""
+        for recorder in self._recorders:
+            try:
+                await recorder.aclose()
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "Usage recorder %r failed on aclose.",
+                    getattr(recorder, "name", type(recorder).__name__),
+                )

--- a/packages/ai-parrot/tests/unit/observability/test_bootstrap.py
+++ b/packages/ai-parrot/tests/unit/observability/test_bootstrap.py
@@ -1,0 +1,77 @@
+"""Unit tests for the env-driven observability auto-boot."""
+
+from __future__ import annotations
+
+import pytest
+
+from parrot.core.events.lifecycle.global_registry import get_global_registry, scope
+from parrot.observability import bootstrap as boot
+
+_ENV_KEYS = [
+    "OBSERVABILITY_ENABLED", "OBSERVABILITY_BACKEND", "OBSERVABILITY_COST",
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    for key in _ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    boot.reset_bootstrap_for_tests()
+    yield
+    boot.reset_bootstrap_for_tests()
+
+
+def _sub_count() -> int:
+    return len(get_global_registry()._subscriptions)
+
+
+def test_disabled_is_noop(monkeypatch) -> None:
+    """With OBSERVABILITY_ENABLED unset, no global subscription is added."""
+    with scope():
+        before = _sub_count()
+        boot.ensure_observability_bootstrapped()
+        assert _sub_count() == before
+
+
+def test_enabled_defaults_to_logging(monkeypatch) -> None:
+    """OBSERVABILITY_ENABLED=true alone registers a logging usage subscriber."""
+    monkeypatch.setenv("OBSERVABILITY_ENABLED", "true")
+    with scope():
+        before = _sub_count()
+        boot.ensure_observability_bootstrapped()
+        assert _sub_count() == before + 1
+        sub = boot._SUBSCRIBER
+        assert sub is not None
+        assert [r.name for r in sub.recorders] == ["logging"]
+
+
+def test_bootstrap_is_idempotent(monkeypatch) -> None:
+    """Calling the bootstrap twice registers exactly one subscription."""
+    monkeypatch.setenv("OBSERVABILITY_ENABLED", "true")
+    with scope():
+        before = _sub_count()
+        boot.ensure_observability_bootstrapped()
+        boot.ensure_observability_bootstrapped()
+        assert _sub_count() == before + 1
+
+
+def test_otel_backend_delegates_to_setup_telemetry(monkeypatch) -> None:
+    """usage_backend=otel routes to setup_telemetry without the new subscriber."""
+    monkeypatch.setenv("OBSERVABILITY_ENABLED", "true")
+    monkeypatch.setenv("OBSERVABILITY_BACKEND", "otel")
+
+    called = {}
+
+    def _fake_setup(config):
+        called["config"] = config
+        return None
+
+    import parrot.observability.setup as setup_mod
+    monkeypatch.setattr(setup_mod, "setup_telemetry", _fake_setup)
+
+    with scope():
+        boot.ensure_observability_bootstrapped()
+
+    assert "config" in called
+    assert called["config"].usage_backend == "otel"
+    assert boot._SUBSCRIBER is None  # lightweight path not used

--- a/packages/ai-parrot/tests/unit/observability/test_client_global_bridge.py
+++ b/packages/ai-parrot/tests/unit/observability/test_client_global_bridge.py
@@ -1,0 +1,77 @@
+"""Unit tests for the client->global event bridge (EventRegistry.forward_to_global).
+
+The fix that lets isolated client registries (forward_to_global=False) deliver
+their LLM-call lifecycle events to global observers (cost/token recorders, OTel
+subscribers) without forwarding every event (e.g. stream chunks stay isolated).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from parrot.core.events.lifecycle.events import (
+    AfterClientCallEvent,
+    ClientStreamChunkEvent,
+)
+from parrot.core.events.lifecycle.global_registry import get_global_registry, scope
+from parrot.core.events.lifecycle.registry import EventRegistry
+from parrot.core.events.lifecycle.trace import TraceContext
+
+
+def _after() -> AfterClientCallEvent:
+    return AfterClientCallEvent(
+        trace_context=TraceContext.new_root(), client_name="openai", model="gpt-4o",
+        duration_ms=1.0, input_tokens=5, output_tokens=2,
+        source_type="client", source_name="openai",
+    )
+
+
+@pytest.mark.asyncio
+async def test_plain_emit_does_not_reach_global() -> None:
+    """An isolated registry's plain emit stays local (does not reach global)."""
+    received: list = []
+    with scope():
+        get_global_registry().subscribe(AfterClientCallEvent, _collect(received))
+        client_reg = EventRegistry(forward_to_global=False)
+        await client_reg.emit(_after())
+        await asyncio.sleep(0)
+        assert received == []
+
+
+@pytest.mark.asyncio
+async def test_forward_to_global_delivers_event() -> None:
+    """forward_to_global delivers the event to a global subscriber."""
+    received: list = []
+    with scope():
+        get_global_registry().subscribe(AfterClientCallEvent, _collect(received))
+        client_reg = EventRegistry(forward_to_global=False)
+        ev = _after()
+        client_reg.forward_to_global(ev)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert len(received) == 1
+        assert received[0] is ev
+
+
+@pytest.mark.asyncio
+async def test_forward_skipped_when_no_global_subscriber() -> None:
+    """forward_to_global is a safe no-op when nobody listens for that type."""
+    with scope():
+        # Only AfterClientCallEvent has a listener; stream chunks have none.
+        get_global_registry().subscribe(AfterClientCallEvent, _collect([]))
+        client_reg = EventRegistry(forward_to_global=False)
+        chunk = ClientStreamChunkEvent(
+            trace_context=TraceContext.new_root(), client_name="openai",
+            model="gpt-4o", chunk_index=0, chunk_size_bytes=3,
+        )
+        # Must not raise and must not schedule anything observable.
+        client_reg.forward_to_global(chunk)
+        await asyncio.sleep(0)
+
+
+def _collect(sink: list):
+    async def _cb(event) -> None:
+        sink.append(event)
+    return _cb

--- a/packages/ai-parrot/tests/unit/observability/test_config.py
+++ b/packages/ai-parrot/tests/unit/observability/test_config.py
@@ -33,6 +33,24 @@ def test_config_defaults() -> None:
     assert cfg.service_instance_id is None
 
 
+def test_config_usage_layer_defaults() -> None:
+    """Defaults for the pluggable usage-logging layer."""
+    import logging
+
+    cfg = ObservabilityConfig()
+    assert cfg.usage_backend == "none"
+    assert cfg.usage_log_level == logging.INFO
+    assert cfg.usage_log_logger_name == "parrot.usage"
+    assert cfg.prometheus_port == 9464
+    assert cfg.prometheus_addr == "0.0.0.0"
+
+
+def test_config_rejects_invalid_usage_backend() -> None:
+    """usage_backend only accepts the known literal values."""
+    with pytest.raises(ValidationError):
+        ObservabilityConfig(usage_backend="bogus")
+
+
 def test_config_rejects_invalid_sampling() -> None:
     """sampling_ratio > 1.0 must raise ValidationError."""
     with pytest.raises(ValidationError):

--- a/packages/ai-parrot/tests/unit/observability/test_config_from_env.py
+++ b/packages/ai-parrot/tests/unit/observability/test_config_from_env.py
@@ -1,0 +1,82 @@
+"""Unit tests for ObservabilityConfig.from_env()."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from parrot.observability.config import ObservabilityConfig
+
+_ENV_KEYS = [
+    "OBSERVABILITY_ENABLED", "OBSERVABILITY_BACKEND", "OBSERVABILITY_SERVICE_NAME",
+    "OBSERVABILITY_COST", "OBSERVABILITY_LOG_LEVEL", "OBSERVABILITY_SAMPLING",
+    "OBSERVABILITY_OPENLIT", "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OBSERVABILITY_PROM_PORT", "OBSERVABILITY_PROM_ADDR", "PARROT_PRICING_PATH",
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for key in _ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_absent_env_uses_defaults() -> None:
+    """With no env vars set, from_env matches the model defaults."""
+    cfg = ObservabilityConfig.from_env()
+    assert cfg.enabled is False
+    assert cfg.usage_backend == "none"
+    assert cfg.service_name == "ai-parrot"
+    assert cfg.enable_cost_tracking is True
+
+
+def test_maps_all_env_vars(monkeypatch) -> None:
+    """Each recognised env var maps to the correct field with proper parsing."""
+    monkeypatch.setenv("OBSERVABILITY_ENABLED", "true")
+    monkeypatch.setenv("OBSERVABILITY_BACKEND", "prometheus")
+    monkeypatch.setenv("OBSERVABILITY_SERVICE_NAME", "my-agent")
+    monkeypatch.setenv("OBSERVABILITY_COST", "false")
+    monkeypatch.setenv("OBSERVABILITY_LOG_LEVEL", "DEBUG")
+    monkeypatch.setenv("OBSERVABILITY_SAMPLING", "0.1")
+    monkeypatch.setenv("OBSERVABILITY_OPENLIT", "1")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318")
+    monkeypatch.setenv("OBSERVABILITY_PROM_PORT", "9999")
+    monkeypatch.setenv("OBSERVABILITY_PROM_ADDR", "127.0.0.1")
+    monkeypatch.setenv("PARROT_PRICING_PATH", "/tmp/pricing")
+
+    cfg = ObservabilityConfig.from_env()
+    assert cfg.enabled is True
+    assert cfg.usage_backend == "prometheus"
+    assert cfg.service_name == "my-agent"
+    assert cfg.enable_cost_tracking is False
+    assert cfg.usage_log_level == logging.DEBUG
+    assert cfg.sampling_ratio == 0.1
+    assert cfg.enable_openlit is True
+    assert cfg.otlp_endpoint == "http://collector:4318"
+    assert cfg.prometheus_port == 9999
+    assert cfg.prometheus_addr == "127.0.0.1"
+    assert cfg.pricing_override_path == "/tmp/pricing"
+
+
+def test_bad_numbers_fall_back_to_defaults(monkeypatch) -> None:
+    """Non-numeric port/sampling fall back to defaults instead of raising."""
+    monkeypatch.setenv("OBSERVABILITY_PROM_PORT", "not-a-number")
+    monkeypatch.setenv("OBSERVABILITY_SAMPLING", "")
+    cfg = ObservabilityConfig.from_env()
+    assert cfg.prometheus_port == 9464
+    assert cfg.sampling_ratio == 1.0
+
+
+def test_from_env_does_not_import_opentelemetry(monkeypatch) -> None:
+    """The logging-config path must not pull in the OTel SDK."""
+    import sys
+
+    monkeypatch.setenv("OBSERVABILITY_ENABLED", "true")
+    monkeypatch.setenv("OBSERVABILITY_BACKEND", "logging")
+    # If OTel was already imported by another test, this assertion is moot;
+    # only assert the call itself adds nothing new.
+    had_otel = "opentelemetry" in sys.modules
+    ObservabilityConfig.from_env()
+    if not had_otel:
+        assert "opentelemetry" not in sys.modules

--- a/packages/ai-parrot/tests/unit/observability/test_logging_recorder.py
+++ b/packages/ai-parrot/tests/unit/observability/test_logging_recorder.py
@@ -1,0 +1,56 @@
+"""Unit tests for LoggingUsageRecorder."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from parrot.observability.recorders.logging_recorder import LoggingUsageRecorder
+from parrot.observability.recorders.models import UsageRecord
+
+
+@pytest.mark.asyncio
+async def test_logs_one_line_with_cost(caplog) -> None:
+    """A recorded call emits one line carrying provider, model, tokens, cost."""
+    recorder = LoggingUsageRecorder(level=logging.INFO, logger_name="parrot.usage")
+    rec = UsageRecord(
+        provider="openai", model="gpt-4o", input_tokens=100, output_tokens=50,
+        cost_usd=0.001234, cumulative_cost_usd=0.001234, duration_ms=42.0,
+        finish_reason="stop",
+    )
+    with caplog.at_level(logging.INFO, logger="parrot.usage"):
+        await recorder.record(rec)
+
+    records = [r for r in caplog.records if r.name == "parrot.usage"]
+    assert len(records) == 1
+    msg = records[0].getMessage()
+    assert "provider=openai" in msg
+    assert "model=gpt-4o" in msg
+    assert "input_tokens=100" in msg
+    assert "output_tokens=50" in msg
+    assert "total_tokens=150" in msg
+    assert "cost_usd=0.001234" in msg
+    assert "cumulative_cost_usd=0.001234" in msg
+
+
+@pytest.mark.asyncio
+async def test_unknown_cost_renders_na(caplog) -> None:
+    """cost_usd=None renders as 'n/a' (no crash)."""
+    recorder = LoggingUsageRecorder(level=logging.INFO)
+    rec = UsageRecord(provider="x", model="y", cost_usd=None, cumulative_cost_usd=None)
+    with caplog.at_level(logging.INFO, logger="parrot.usage"):
+        await recorder.record(rec)
+    msg = caplog.records[-1].getMessage()
+    assert "cost_usd=n/a" in msg
+    assert "cumulative_cost_usd=n/a" in msg
+
+
+@pytest.mark.asyncio
+async def test_level_below_threshold_suppresses_line(caplog) -> None:
+    """A DEBUG-level recorder emits nothing when only INFO is captured."""
+    recorder = LoggingUsageRecorder(level=logging.DEBUG, logger_name="parrot.usage")
+    rec = UsageRecord(provider="openai", model="gpt-4o")
+    with caplog.at_level(logging.INFO, logger="parrot.usage"):
+        await recorder.record(rec)
+    assert [r for r in caplog.records if r.name == "parrot.usage"] == []

--- a/packages/ai-parrot/tests/unit/observability/test_usage_models.py
+++ b/packages/ai-parrot/tests/unit/observability/test_usage_models.py
@@ -1,0 +1,32 @@
+"""Unit tests for UsageRecord (pluggable usage-logging layer)."""
+
+from __future__ import annotations
+
+from datetime import timezone
+
+from parrot.observability.recorders.models import UsageRecord
+
+
+def test_total_tokens_computed() -> None:
+    """total_tokens is the sum of input and output tokens."""
+    rec = UsageRecord(provider="openai", model="gpt-4o", input_tokens=100, output_tokens=50)
+    assert rec.total_tokens == 150
+
+
+def test_defaults_are_pii_free_and_safe() -> None:
+    """Defaults: no cost, tz-aware timestamp, and no PII fields on the model."""
+    rec = UsageRecord(provider="anthropic")
+    assert rec.cost_usd is None
+    assert rec.cumulative_cost_usd is None
+    assert rec.input_tokens == 0 and rec.output_tokens == 0
+    assert rec.timestamp.tzinfo is not None
+    assert rec.timestamp.utcoffset() == timezone.utc.utcoffset(None)
+    # PII contract: these fields must NOT exist on the record.
+    forbidden = {"user_id", "session_id", "prompt", "completion", "question"}
+    assert forbidden.isdisjoint(UsageRecord.model_fields.keys())
+
+
+def test_total_tokens_serialized() -> None:
+    """computed total_tokens is included in model_dump output."""
+    rec = UsageRecord(provider="groq", model="x", input_tokens=3, output_tokens=4)
+    assert rec.model_dump()["total_tokens"] == 7

--- a/packages/ai-parrot/tests/unit/observability/test_usage_subscriber.py
+++ b/packages/ai-parrot/tests/unit/observability/test_usage_subscriber.py
@@ -1,0 +1,116 @@
+"""Unit tests for UsageRecordingSubscriber."""
+
+from __future__ import annotations
+
+import pytest
+
+from parrot.core.events.lifecycle.events import AfterClientCallEvent
+from parrot.core.events.lifecycle.registry import EventRegistry
+from parrot.core.events.lifecycle.trace import TraceContext
+from parrot.observability.cost.calculator import (
+    CostCalculator,
+    _reset_pricing_cache_for_tests,
+)
+from parrot.observability.recorders.base import AbstractLogger
+from parrot.observability.recorders.models import UsageRecord
+from parrot.observability.recorders.subscriber import UsageRecordingSubscriber
+
+
+class _CapturingRecorder(AbstractLogger):
+    name = "capture"
+
+    def __init__(self) -> None:
+        self.records: list[UsageRecord] = []
+
+    async def record(self, record: UsageRecord) -> None:
+        self.records.append(record)
+
+
+class _ExplodingRecorder(AbstractLogger):
+    name = "boom"
+
+    async def record(self, record: UsageRecord) -> None:
+        raise RuntimeError("backend down")
+
+
+def _after(model: str = "gpt-4o-mini", it: int = 100, ot: int = 50) -> AfterClientCallEvent:
+    return AfterClientCallEvent(
+        trace_context=TraceContext.new_root(),
+        client_name="openai", model=model, duration_ms=42.0,
+        input_tokens=it, output_tokens=ot, finish_reason="stop",
+        source_type="client", source_name="openai",
+    )
+
+
+@pytest.mark.asyncio
+async def test_builds_record_with_cost_and_resolved_provider() -> None:
+    """The subscriber computes cost and resolves provider via gen_ai mapping."""
+    _reset_pricing_cache_for_tests()
+    cap = _CapturingRecorder()
+    sub = UsageRecordingSubscriber(recorders=[cap], cost_calculator=CostCalculator())
+    reg = EventRegistry(forward_to_global=False)
+    reg.add_provider(sub)
+
+    await reg.emit(_after())
+
+    assert len(cap.records) == 1
+    rec = cap.records[0]
+    assert rec.provider == "openai"
+    assert rec.model == "gpt-4o-mini"
+    assert rec.input_tokens == 100 and rec.output_tokens == 50
+    # Cost must match the shared CostCalculator for the bundled model.
+    expected = CostCalculator().cost_usd(
+        provider="openai", model="gpt-4o-mini", input_tokens=100, output_tokens=50
+    )
+    assert rec.cost_usd == expected
+    assert rec.cumulative_cost_usd == expected
+
+
+@pytest.mark.asyncio
+async def test_cumulative_cost_accumulates() -> None:
+    """Cumulative cost grows across successive calls."""
+    _reset_pricing_cache_for_tests()
+    cap = _CapturingRecorder()
+    sub = UsageRecordingSubscriber(recorders=[cap], cost_calculator=CostCalculator())
+    reg = EventRegistry(forward_to_global=False)
+    reg.add_provider(sub)
+
+    await reg.emit(_after())
+    await reg.emit(_after())
+
+    assert len(cap.records) == 2
+    first, second = cap.records
+    assert second.cumulative_cost_usd == pytest.approx(
+        (first.cost_usd or 0) + (second.cost_usd or 0)
+    )
+
+
+@pytest.mark.asyncio
+async def test_fan_out_isolates_failing_recorder() -> None:
+    """A recorder raising does not prevent others from receiving the record."""
+    _reset_pricing_cache_for_tests()
+    cap = _CapturingRecorder()
+    sub = UsageRecordingSubscriber(
+        recorders=[_ExplodingRecorder(), cap], cost_calculator=None
+    )
+    reg = EventRegistry(forward_to_global=False)
+    reg.add_provider(sub)
+
+    await reg.emit(_after())
+
+    assert len(cap.records) == 1
+    assert cap.records[0].cost_usd is None  # no calculator → no cost
+
+
+@pytest.mark.asyncio
+async def test_no_calculator_means_no_cost() -> None:
+    """Without a CostCalculator, cost fields stay None."""
+    cap = _CapturingRecorder()
+    sub = UsageRecordingSubscriber(recorders=[cap], cost_calculator=None)
+    reg = EventRegistry(forward_to_global=False)
+    reg.add_provider(sub)
+
+    await reg.emit(_after())
+
+    assert cap.records[0].cost_usd is None
+    assert cap.records[0].cumulative_cost_usd is None


### PR DESCRIPTION
## Summary

Introduces a pluggable, environment-driven usage/token/cost recording layer that requires **no OpenTelemetry SDK** for the default logging path. Enables structured per-call cost logs via a single `OBSERVABILITY_ENABLED=true` environment variable, with swappable backends (logging, Prometheus, OTel) selected by `OBSERVABILITY_BACKEND`.

## Key Changes

### Core Infrastructure
- **`bootstrap.py`**: Idempotent auto-boot triggered on first bot/client construction. Reads `OBSERVABILITY_ENABLED` and `OBSERVABILITY_BACKEND` from env, instantiates the selected recorder backend, and subscribes to the global event registry. Failures are logged at DEBUG and never break construction.
- **`config.py`**: Extended `ObservabilityConfig` with new fields (`usage_backend`, `usage_log_level`, `usage_log_logger_name`, `prometheus_port`, `prometheus_addr`) and added `from_env()` classmethod to populate config from environment variables with sensible defaults.

### Recorder Backends
- **`recorders/base.py`**: `AbstractLogger` interface — single async `record(UsageRecord)` method that all backends implement.
- **`recorders/logging_recorder.py`**: Zero-dependency backend emitting one structured log line per LLM call to `parrot.usage` logger (or custom logger name).
- **`recorders/prometheus_recorder.py`**: Pull-based metrics backend using `prometheus_client` directly (lazy-loaded, not via OTel exporter). Exposes counters and histograms on HTTP endpoint (default `:9464`). Includes module-level guards to prevent re-registration in multi-bot scenarios.
- **`recorders/factory.py`**: Maps `ObservabilityConfig.usage_backend` to concrete recorder instances without exposing backend classes to callers.

### Event Bridge & Normalization
- **`recorders/models.py`**: `UsageRecord` — normalized, PII-free per-call record (provider, model, token counts, cost, duration, trace_id). Computed field `total_tokens` sums input and output.
- **`recorders/subscriber.py`**: `UsageRecordingSubscriber` — subscribes to `AfterClientCallEvent` on the global registry, computes cost via shared `CostCalculator`, builds `UsageRecord`, and fans out to all configured recorders. Thread-safe cumulative cost tracking.

### Client Integration
- **`clients/base.py`**: Modified `_emit_before_call` and `_emit_after_call` to explicitly forward LLM-call lifecycle events to the global registry via `forward_to_global()`, enabling isolated client registries to reach global observers (cost/token recorders, OTel subscribers) without forwarding all events.
- **`core/events/lifecycle/registry.py`**: Added public `forward_to_global(event)` method for opt-in event forwarding to the global registry.
- **`core/events/lifecycle/mixin.py`**: Calls `ensure_observability_bootstrapped()` on first bot/client/tool construction.

### Configuration & Exports
- **`observability/__init__.py`**: Exports `AbstractLogger`, `UsageRecord`, `LoggingUsageRecorder`, `UsageRecordingSubscriber`, `ensure_observability_bootstrapped`, `shutdown_usage_recording`.
- **`recorders/__init__.py`**: Exports recorder factory and models.
- **`pyproject.toml`**: Added `observability-prometheus` extra for optional Prometheus backend.

### Documentation & Examples
- **`observability/README.md`**: Added section on pluggable usage logging with auto-boot, backend comparison table, and programmatic usage examples.
- **`examples/grafana-dashboards/parrot-usage.json`**: Starter Grafana dashboard for Prometheus backend metrics (cost, request rate, token throughput, latency).

### Tests
- **`test_bootstrap.py`**: Tests for idempotent auto-boot, disabled/enabled behavior, OTel delegation.
- **`test_config_from_env.py`**: Tests for `Ob

https://claude.ai/code/session_01MKPsi3kv8SbJYCX3QMrNiC