### PR TITLE
Add Z.ai LLM client (ZaiClient) with thinking, streaming, tool-calling and model enum

### DIFF
--- a/packages/ai-parrot/pyproject.toml
+++ b/packages/ai-parrot/pyproject.toml
@@ -352,6 +352,10 @@ groq = [
     "groq==0.33.0"
 ]
 
+zai = [
+    "zai-sdk>=0.2.2"
+]
+
 llms = [
     "google-genai>=2.6.0",
     "openai==2.8.1",
@@ -359,6 +363,7 @@ llms = [
     "anthropic[aiohttp]>=0.105.0,<1.0.0",
     "claude-agent-sdk>=0.1.68",
     "xai-sdk>=0.1.0",
+    "zai-sdk>=0.2.2",
 ]
 
 integrations = [

--- a/packages/ai-parrot/src/parrot/clients/__init__.py
+++ b/packages/ai-parrot/src/parrot/clients/__init__.py
@@ -13,4 +13,7 @@ __all__ = (
     "AbstractClient",
     "LLM_PRESETS",
     "StreamingRetryConfig",
+    "ZaiClient",
 )
+
+from .zai import ZaiClient

--- a/packages/ai-parrot/src/parrot/clients/factory.py
+++ b/packages/ai-parrot/src/parrot/clients/factory.py
@@ -9,6 +9,7 @@ from .openrouter import OpenRouterClient
 from .localllm import LocalLLMClient
 from .vllm import vLLMClient
 from .nvidia import NvidiaClient
+from .zai import ZaiClient
 
 
 def _lazy_gemma4():
@@ -52,6 +53,8 @@ SUPPORTED_CLIENTS = {
     "groq": GroqClient,
     "grok": GrokClient,
     "xai": GrokClient,
+    "zai": ZaiClient,
+    "z.ai": ZaiClient,
     "openrouter": OpenRouterClient,
     "nvidia": NvidiaClient,
     "local": LocalLLMClient,

--- a/packages/ai-parrot/src/parrot/clients/zai.py
+++ b/packages/ai-parrot/src/parrot/clients/zai.py
@@ -1,0 +1,668 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+import uuid
+from dataclasses import is_dataclass
+from pathlib import Path
+from typing import Any, AsyncIterator, Dict, List, Optional, Union
+
+from datamodel.exceptions import ParserError  # pylint: disable=E0611 # noqa
+from datamodel.parsers.json import json_decoder  # pylint: disable=E0611 # noqa
+from navconfig import config
+
+from ..models import AIMessage, CompletionUsage, OutputFormat, StructuredOutputConfig, ToolCall
+from ..models.zai import THINKING_CAPABLE_ZAI_MODELS, ZaiModel
+from .base import AbstractClient
+
+
+class ZaiClient(AbstractClient):
+    """Client for Z.ai chat completions using the official ``zai-sdk`` package."""
+
+    client_type: str = "zai"
+    client_name: str = "zai"
+    model: str = ZaiModel.GLM_5_1.value
+    _default_model: str = ZaiModel.GLM_5_1.value
+    _lightweight_model: str = ZaiModel.GLM_4_5_FLASH_FREE.value
+    _min_cache_tokens: int = 1
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: str = "https://api.z.ai/api/paas/v4/",
+        timeout: Optional[float] = None,
+        max_retries: Optional[int] = None,
+        **kwargs: Any,
+    ) -> None:
+        self.api_key = api_key or config.get("ZAI_API_KEY")
+        self.base_url = base_url or config.get("ZAI_BASE_URL") or "https://api.z.ai/api/paas/v4/"
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.base_headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+        }
+        super().__init__(**kwargs)
+
+    async def get_client(self) -> Any:
+        """Create the official Z.ai SDK client for the current event loop."""
+        from zai import ZaiClient as OfficialZaiClient
+
+        kwargs: Dict[str, Any] = {
+            "api_key": self.api_key,
+            "base_url": self.base_url,
+        }
+        if self.timeout is not None:
+            kwargs["timeout"] = self.timeout
+        if self.max_retries is not None:
+            kwargs["max_retries"] = self.max_retries
+        return OfficialZaiClient(**kwargs)
+
+    def _model_value(self, model: Union[str, ZaiModel, None]) -> str:
+        if isinstance(model, ZaiModel):
+            return model.value
+        return model or self.model or self._default_model
+
+    def _normalize_content(self, content: Any) -> Any:
+        if not isinstance(content, list):
+            return content
+
+        text_parts: List[str] = []
+        normalized: List[Dict[str, Any]] = []
+        for part in content:
+            if not isinstance(part, dict):
+                normalized.append(part)
+                continue
+            if part.get("type") == "text":
+                text = part.get("text", "")
+                if text:
+                    text_parts.append(text)
+                continue
+            normalized.append(part)
+
+        if normalized:
+            return [
+                *({"type": "text", "text": text} for text in text_parts),
+                *normalized,
+            ]
+        return "\n".join(text_parts)
+
+    def _normalize_messages(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        normalized: List[Dict[str, Any]] = []
+        for message in messages:
+            msg = dict(message)
+            if "content" in msg:
+                msg["content"] = self._normalize_content(msg["content"])
+            normalized.append(msg)
+        return normalized
+
+    async def _build_messages(
+        self,
+        prompt: str,
+        files: Optional[List[Union[str, Path]]],
+        user_id: Optional[str],
+        session_id: Optional[str],
+        system_prompt: Optional[Union[str, list]],
+    ) -> tuple[List[Dict[str, Any]], Any, Optional[str]]:
+        resolved_system_prompt = self._resolve_system_prompt(system_prompt)
+        messages, conversation_history, _ = await self._prepare_conversation_context(
+            prompt,
+            files,
+            user_id,
+            session_id,
+            resolved_system_prompt,
+        )
+        if resolved_system_prompt:
+            messages.insert(
+                0,
+                {
+                    "role": "system",
+                    "content": resolved_system_prompt,
+                },
+            )
+        return self._normalize_messages(messages), conversation_history, resolved_system_prompt
+
+    def _prepare_zai_tools(self) -> List[Dict[str, Any]]:
+        tools: List[Dict[str, Any]] = []
+        for tool in self.tool_manager.all_tools():
+            tool_name = tool.name if hasattr(tool, "name") else tool.__class__.__name__
+            if hasattr(tool, "input_schema") and tool.input_schema:
+                parameters = tool.input_schema
+            elif hasattr(tool, "get_schema"):
+                schema = tool.get_schema()
+                parameters = schema.get("parameters", schema)
+            else:
+                parameters = {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": False,
+                }
+
+            tools.append(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": tool_name,
+                        "description": getattr(tool, "description", "") or "",
+                        "parameters": parameters,
+                    },
+                }
+            )
+        return tools
+
+    def _prepare_structured_output_format(self, output_type: Optional[type]) -> Dict[str, Any]:
+        if output_type is None:
+            return {"response_format": {"type": "json_object"}}
+
+        if hasattr(output_type, "model_json_schema"):
+            schema = output_type.model_json_schema()
+        elif hasattr(output_type, "schema"):
+            schema = output_type.schema()
+        elif is_dataclass(output_type):
+            schema = StructuredOutputConfig(output_type=output_type).get_schema()
+        else:
+            return {"response_format": {"type": "json_object"}}
+
+        name = getattr(output_type, "__name__", "structured_output")
+        return {
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": name.lower(),
+                    "schema": self._oai_normalize_schema(schema, force_required_all=False),
+                },
+            }
+        }
+
+    def _thinking_payload(
+        self,
+        model: str,
+        thinking: Optional[Union[bool, str, Dict[str, Any]]],
+        deep_thinking: bool,
+    ) -> Optional[Dict[str, Any]]:
+        if thinking is None and not deep_thinking:
+            return None
+        if model not in THINKING_CAPABLE_ZAI_MODELS:
+            self.logger.warning(
+                "Z.ai thinking requested for model %s, which is not in the known thinking-capable set.",
+                model,
+            )
+        if isinstance(thinking, dict):
+            return thinking
+        if isinstance(thinking, str):
+            return {"type": thinking}
+        enabled = bool(thinking) or deep_thinking
+        return {"type": "enabled" if enabled else "disabled"}
+
+    def _usage_from_response(self, response: Any) -> CompletionUsage:
+        usage = getattr(response, "usage", None)
+        prompt_details = getattr(usage, "prompt_tokens_details", None)
+        completion_details = getattr(usage, "completion_tokens_details", None)
+        extra_usage: Dict[str, Any] = {}
+        cached_tokens = getattr(prompt_details, "cached_tokens", None)
+        reasoning_tokens = getattr(completion_details, "reasoning_tokens", None)
+        if cached_tokens is not None:
+            extra_usage["cached_tokens"] = cached_tokens
+        if reasoning_tokens is not None:
+            extra_usage["reasoning_tokens"] = reasoning_tokens
+        return CompletionUsage(
+            prompt_tokens=getattr(usage, "prompt_tokens", 0),
+            completion_tokens=getattr(usage, "completion_tokens", 0),
+            total_tokens=getattr(usage, "total_tokens", 0),
+            extra_usage=extra_usage,
+        )
+
+    def _response_to_dict(self, response: Any) -> Dict[str, Any]:
+        if hasattr(response, "model_dump"):
+            return response.model_dump()
+        if hasattr(response, "dict"):
+            return response.dict()
+        if isinstance(response, dict):
+            return response
+        return getattr(response, "__dict__", {})
+
+    def _message_to_dict(self, message: Any) -> Dict[str, Any]:
+        if hasattr(message, "model_dump"):
+            return message.model_dump()
+        if hasattr(message, "dict"):
+            return message.dict()
+        if isinstance(message, dict):
+            return message
+        return getattr(message, "__dict__", {})
+
+    def _create_ai_message(
+        self,
+        *,
+        response: Any,
+        input_text: str,
+        model: str,
+        user_id: Optional[str],
+        session_id: Optional[str],
+        turn_id: str,
+        structured_output: Any = None,
+        tool_calls: Optional[List[ToolCall]] = None,
+        response_time: Optional[float] = None,
+    ) -> AIMessage:
+        choice = response.choices[0]
+        message = choice.message
+        content = getattr(message, "content", None) or ""
+        reasoning_content = getattr(message, "reasoning_content", None)
+        usage = self._usage_from_response(response)
+        metadata: Dict[str, Any] = {}
+        if reasoning_content:
+            metadata["reasoning_content"] = reasoning_content
+        if usage.extra_usage.get("cached_tokens") is not None:
+            metadata["cached_tokens"] = usage.extra_usage["cached_tokens"]
+
+        return AIMessage(
+            input=input_text,
+            output=structured_output if structured_output is not None else content,
+            response=content,
+            is_structured=structured_output is not None,
+            structured_output=structured_output,
+            model=model,
+            provider="zai",
+            usage=usage,
+            stop_reason=getattr(choice, "finish_reason", None),
+            finish_reason=getattr(choice, "finish_reason", None),
+            tool_calls=tool_calls or [],
+            user_id=user_id,
+            session_id=session_id,
+            turn_id=turn_id,
+            response_time=response_time,
+            raw_response=self._response_to_dict(response),
+            metadata=metadata,
+        )
+
+    async def _create_completion(self, **request_args: Any) -> Any:
+        client = await self._ensure_client()
+        return await asyncio.to_thread(client.chat.completions.create, **request_args)
+
+    def _parse_tool_arguments(self, raw_arguments: Any) -> Dict[str, Any]:
+        if isinstance(raw_arguments, dict):
+            return raw_arguments
+        if not raw_arguments:
+            return {}
+        try:
+            return json.loads(raw_arguments)
+        except json.JSONDecodeError:
+            try:
+                return json_decoder(raw_arguments)
+            except ParserError:
+                return {}
+
+    async def _run_tool_loop(
+        self,
+        *,
+        messages: List[Dict[str, Any]],
+        response: Any,
+        request_args: Dict[str, Any],
+        max_turns: int = 10,
+    ) -> tuple[Any, List[ToolCall]]:
+        all_tool_calls: List[ToolCall] = []
+        result = response.choices[0].message
+        turns = 0
+        while getattr(result, "tool_calls", None) and turns < max_turns:
+            turns += 1
+            messages.append(self._message_to_dict(result))
+            for provider_tool_call in result.tool_calls:
+                function = provider_tool_call.function
+                tool_name = function.name
+                tool_args = self._parse_tool_arguments(function.arguments)
+                tool_call = ToolCall(
+                    id=provider_tool_call.id,
+                    name=tool_name,
+                    arguments=tool_args,
+                )
+                try:
+                    started = time.perf_counter()
+                    tool_result = await self._execute_tool(tool_name, tool_args)
+                    tool_call.execution_time = time.perf_counter() - started
+                    tool_call.result = tool_result
+                    content = json.dumps(tool_result, default=str)
+                except Exception as exc:
+                    tool_call.error = str(exc)
+                    content = f"Error: {exc}"
+
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": provider_tool_call.id,
+                        "name": tool_name,
+                        "content": content,
+                    }
+                )
+                all_tool_calls.append(tool_call)
+
+            follow_up_args = dict(request_args)
+            follow_up_args["messages"] = messages
+            response = await self._create_completion(**follow_up_args)
+            result = response.choices[0].message
+        return response, all_tool_calls
+
+    async def ask(
+        self,
+        prompt: str,
+        model: Union[str, ZaiModel, None] = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        files: Optional[List[Union[str, Path]]] = None,
+        system_prompt: Optional[Union[str, list]] = None,
+        structured_output: Union[type, StructuredOutputConfig, None] = None,
+        user_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        use_tools: Optional[bool] = None,
+        thinking: Optional[Union[bool, str, Dict[str, Any]]] = None,
+        deep_thinking: bool = False,
+        **_: Any,
+    ) -> AIMessage:
+        """Send a non-streaming chat request to Z.ai."""
+        resolved_model = self._model_value(model)
+        turn_id = str(uuid.uuid4())
+        started = time.perf_counter()
+        messages, conversation_history, resolved_system_prompt = await self._build_messages(
+            prompt,
+            files,
+            user_id,
+            session_id,
+            system_prompt,
+        )
+
+        _use_tools = use_tools if use_tools is not None else self.enable_tools
+        if tools:
+            for tool in tools:
+                self.register_tool(tool)
+
+        output_config = self._get_structured_config(structured_output)
+        request_args: Dict[str, Any] = {
+            "model": resolved_model,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "top_p": top_p,
+            "stream": False,
+        }
+
+        if thinking_payload := self._thinking_payload(resolved_model, thinking, deep_thinking):
+            request_args["thinking"] = thinking_payload
+
+        if _use_tools:
+            request_args["tools"] = self._prepare_zai_tools()
+            request_args["tool_choice"] = "auto"
+        elif output_config:
+            self._ensure_json_instruction(
+                messages,
+                "Please respond with a valid JSON object that matches the requested schema.",
+            )
+            request_args.update(
+                self._prepare_structured_output_format(output_config.output_type)
+                if output_config.format == OutputFormat.JSON
+                else {}
+            )
+
+        response = await self._create_completion(**request_args)
+        all_tool_calls: List[ToolCall] = []
+        if _use_tools:
+            response, all_tool_calls = await self._run_tool_loop(
+                messages=messages,
+                response=response,
+                request_args=request_args,
+            )
+
+        content = getattr(response.choices[0].message, "content", None) or ""
+        parsed_output = None
+        if output_config:
+            parsed_output = await self._parse_structured_output(content, output_config)
+
+        response_time = time.perf_counter() - started
+        ai_message = self._create_ai_message(
+            response=response,
+            input_text=prompt,
+            model=resolved_model,
+            user_id=user_id,
+            session_id=session_id,
+            turn_id=turn_id,
+            structured_output=parsed_output,
+            tool_calls=all_tool_calls,
+            response_time=response_time,
+        )
+        await self._update_conversation_memory(
+            user_id,
+            session_id,
+            conversation_history,
+            messages,
+            resolved_system_prompt,
+            turn_id,
+            prompt,
+            ai_message.response or "",
+            tools_used=[tool_call.name for tool_call in all_tool_calls],
+        )
+        return ai_message
+
+    def _next_stream_item(self, iterator: Any) -> tuple[bool, Any]:
+        try:
+            return True, next(iterator)
+        except StopIteration:
+            return False, None
+
+    def _accumulate_stream_tool_calls(
+        self,
+        accumulator: Dict[int, Dict[str, Any]],
+        tool_call_deltas: Optional[List[Any]],
+    ) -> None:
+        if not tool_call_deltas:
+            return
+        for delta in tool_call_deltas:
+            index = getattr(delta, "index", 0)
+            current = accumulator.setdefault(
+                index,
+                {"id": "", "type": "function", "function": {"name": "", "arguments": ""}},
+            )
+            if getattr(delta, "id", None):
+                current["id"] = delta.id
+            if getattr(delta, "type", None):
+                current["type"] = delta.type
+            function = getattr(delta, "function", None)
+            if function is None:
+                continue
+            if getattr(function, "name", None):
+                current["function"]["name"] += function.name
+            if getattr(function, "arguments", None):
+                current["function"]["arguments"] += function.arguments
+
+    async def _stream_completion(self, **request_args: Any) -> AsyncIterator[Any]:
+        client = await self._ensure_client()
+        stream = await asyncio.to_thread(client.chat.completions.create, **request_args)
+        iterator = iter(stream)
+        while True:
+            has_item, item = await asyncio.to_thread(self._next_stream_item, iterator)
+            if not has_item:
+                break
+            yield item
+
+    async def ask_stream(
+        self,
+        prompt: str,
+        model: Union[str, ZaiModel, None] = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        files: Optional[List[Union[str, Path]]] = None,
+        system_prompt: Optional[Union[str, list]] = None,
+        user_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        use_tools: Optional[bool] = None,
+        thinking: Optional[Union[bool, str, Dict[str, Any]]] = None,
+        deep_thinking: bool = False,
+        stream_reasoning: bool = False,
+        **_: Any,
+    ) -> AsyncIterator[Union[str, AIMessage]]:
+        """Stream a Z.ai response and finish with an ``AIMessage`` sentinel."""
+        resolved_model = self._model_value(model)
+        turn_id = str(uuid.uuid4())
+        started = time.perf_counter()
+        messages, conversation_history, resolved_system_prompt = await self._build_messages(
+            prompt,
+            files,
+            user_id,
+            session_id,
+            system_prompt,
+        )
+
+        _use_tools = use_tools if use_tools is not None else self.enable_tools
+        if tools:
+            for tool in tools:
+                self.register_tool(tool)
+
+        request_args: Dict[str, Any] = {
+            "model": resolved_model,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "top_p": top_p,
+            "stream": True,
+        }
+        if thinking_payload := self._thinking_payload(resolved_model, thinking, deep_thinking):
+            request_args["thinking"] = thinking_payload
+        if _use_tools:
+            request_args["tools"] = self._prepare_zai_tools()
+            request_args["tool_choice"] = "auto"
+            request_args["tool_stream"] = True
+
+        content_parts: List[str] = []
+        reasoning_parts: List[str] = []
+        usage = CompletionUsage()
+        finish_reason: Optional[str] = None
+        last_raw_chunk: Dict[str, Any] = {}
+        tool_call_accumulator: Dict[int, Dict[str, Any]] = {}
+
+        async for chunk in self._stream_completion(**request_args):
+            last_raw_chunk = self._response_to_dict(chunk)
+            if getattr(chunk, "usage", None):
+                usage = self._usage_from_response(chunk)
+            if not getattr(chunk, "choices", None):
+                continue
+            choice = chunk.choices[0]
+            finish_reason = getattr(choice, "finish_reason", None) or finish_reason
+            delta = getattr(choice, "delta", None)
+            if delta is None:
+                continue
+            reasoning = getattr(delta, "reasoning_content", None)
+            if reasoning:
+                reasoning_parts.append(reasoning)
+                if stream_reasoning:
+                    yield reasoning
+            content = getattr(delta, "content", None)
+            if content:
+                content_parts.append(content)
+                yield content
+            self._accumulate_stream_tool_calls(
+                tool_call_accumulator,
+                getattr(delta, "tool_calls", None),
+            )
+
+        all_tool_calls: List[ToolCall] = []
+        if tool_call_accumulator:
+            assistant_tool_calls = [tool_call_accumulator[index] for index in sorted(tool_call_accumulator)]
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": "".join(content_parts),
+                    "tool_calls": assistant_tool_calls,
+                }
+            )
+            for provider_tool_call in assistant_tool_calls:
+                function = provider_tool_call["function"]
+                tool_name = function["name"]
+                tool_args = self._parse_tool_arguments(function["arguments"])
+                tool_call = ToolCall(
+                    id=provider_tool_call.get("id") or str(uuid.uuid4()),
+                    name=tool_name,
+                    arguments=tool_args,
+                )
+                try:
+                    tool_started = time.perf_counter()
+                    tool_result = await self._execute_tool(tool_name, tool_args)
+                    tool_call.execution_time = time.perf_counter() - tool_started
+                    tool_call.result = tool_result
+                    tool_content = json.dumps(tool_result, default=str)
+                except Exception as exc:
+                    tool_call.error = str(exc)
+                    tool_content = f"Error: {exc}"
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call.id,
+                        "name": tool_name,
+                        "content": tool_content,
+                    }
+                )
+                all_tool_calls.append(tool_call)
+
+            follow_up_args = dict(request_args)
+            follow_up_args["messages"] = messages
+            follow_up_args.pop("tool_stream", None)
+            async for chunk in self._stream_completion(**follow_up_args):
+                last_raw_chunk = self._response_to_dict(chunk)
+                if getattr(chunk, "usage", None):
+                    usage = self._usage_from_response(chunk)
+                if not getattr(chunk, "choices", None):
+                    continue
+                choice = chunk.choices[0]
+                finish_reason = getattr(choice, "finish_reason", None) or finish_reason
+                delta = getattr(choice, "delta", None)
+                if delta is None:
+                    continue
+                content = getattr(delta, "content", None)
+                if content:
+                    content_parts.append(content)
+                    yield content
+
+        content_text = "".join(content_parts)
+        if not content_text:
+            yield ""
+
+        metadata: Dict[str, Any] = {}
+        reasoning_text = "".join(reasoning_parts)
+        if reasoning_text:
+            metadata["reasoning_content"] = reasoning_text
+        if usage.extra_usage.get("cached_tokens") is not None:
+            metadata["cached_tokens"] = usage.extra_usage["cached_tokens"]
+
+        ai_message = AIMessage(
+            input=prompt,
+            output=content_text,
+            response=content_text,
+            model=resolved_model,
+            provider="zai",
+            usage=usage,
+            stop_reason=finish_reason,
+            finish_reason=finish_reason,
+            tool_calls=all_tool_calls,
+            user_id=user_id,
+            session_id=session_id,
+            turn_id=turn_id,
+            response_time=time.perf_counter() - started,
+            raw_response=last_raw_chunk,
+            metadata=metadata,
+        )
+        await self._update_conversation_memory(
+            user_id,
+            session_id,
+            conversation_history,
+            messages,
+            resolved_system_prompt,
+            turn_id,
+            prompt,
+            content_text,
+            tools_used=[tool_call.name for tool_call in all_tool_calls],
+        )
+        yield ai_message
+
+    async def embed(self, *args: Any, **kwargs: Any) -> Any:
+        """Embeddings are not implemented by this chat client yet."""
+        raise NotImplementedError("ZaiClient embed() is not implemented.")

--- a/packages/ai-parrot/src/parrot/models/__init__.py
+++ b/packages/ai-parrot/src/parrot/models/__init__.py
@@ -89,6 +89,7 @@ from .vllm import (
     pydantic_to_guided_json,
 )
 from .nvidia import NvidiaModel
+from .zai import ZaiModel
 from .crew_definition import (
     ExecutionMode,
     AgentDefinition,
@@ -105,6 +106,7 @@ __all__ = (
     "OutputFormat",
     "ToolCall",
     "CompletionUsage",
+    "ZaiModel",
     "ToolConfig",
     "AIMessage",
     "AIMessageFactory",

--- a/packages/ai-parrot/src/parrot/models/zai.py
+++ b/packages/ai-parrot/src/parrot/models/zai.py
@@ -1,0 +1,54 @@
+from enum import Enum
+
+
+class ZaiModel(str, Enum):
+    """Z.ai GLM chat model identifiers.
+
+    The ``*_FREE`` variants use Z.ai's documented ``:free`` model suffix for
+    free-tier text/vision models.
+    """
+
+    GLM_5_1 = "glm-5.1"
+    GLM_5 = "glm-5"
+    GLM_5_TURBO = "glm-5-turbo"
+    GLM_5V_TURBO = "glm-5v-turbo"
+    GLM_4_7 = "glm-4.7"
+    GLM_4_7_FLASHX = "glm-4.7-flashx"
+    GLM_4_6 = "glm-4.6"
+    GLM_4_6V = "glm-4.6v"
+    GLM_4_6V_FLASHX = "glm-4.6v-flashx"
+    GLM_4_6V_FLASH = "glm-4.6v-flash"
+    GLM_4_5 = "glm-4.5"
+    GLM_4_5_X = "glm-4.5-x"
+    GLM_4_5_AIR = "glm-4.5-air"
+    GLM_4_5_AIRX = "glm-4.5-airx"
+    GLM_4_5_FLASH = "glm-4.5-flash"
+    GLM_4_5V = "glm-4.5v"
+    GLM_4_32B_0414_128K = "glm-4-32b-0414-128k"
+
+    GLM_4_7_FLASH_FREE = "glm-4.7-flash:free"
+    GLM_4_5_FLASH_FREE = "glm-4.5-flash:free"
+    GLM_4_6V_FLASH_FREE = "glm-4.6v-flash:free"
+
+
+THINKING_CAPABLE_ZAI_MODELS = frozenset(
+    {
+        ZaiModel.GLM_5_1.value,
+        ZaiModel.GLM_5.value,
+        ZaiModel.GLM_5_TURBO.value,
+        ZaiModel.GLM_5V_TURBO.value,
+        ZaiModel.GLM_4_7.value,
+        ZaiModel.GLM_4_6.value,
+        ZaiModel.GLM_4_6V.value,
+        ZaiModel.GLM_4_6V_FLASHX.value,
+        ZaiModel.GLM_4_6V_FLASH.value,
+        ZaiModel.GLM_4_5.value,
+        ZaiModel.GLM_4_5_X.value,
+        ZaiModel.GLM_4_5_AIR.value,
+        ZaiModel.GLM_4_5_AIRX.value,
+        ZaiModel.GLM_4_5_FLASH.value,
+        ZaiModel.GLM_4_5V.value,
+        ZaiModel.GLM_4_5_FLASH_FREE.value,
+        ZaiModel.GLM_4_6V_FLASH_FREE.value,
+    }
+)

--- a/packages/ai-parrot/tests/test_zai_client.py
+++ b/packages/ai-parrot/tests/test_zai_client.py
@@ -1,0 +1,174 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from parrot.clients.factory import LLMFactory
+from parrot.clients.zai import ZaiClient
+from parrot.models import AIMessage, ZaiModel
+from pydantic import BaseModel
+
+
+class Answer(BaseModel):
+    answer: str
+
+
+def completion_response(content="Hello Z.ai", tool_calls=None, usage=None):
+    message = SimpleNamespace(
+        content=content,
+        role="assistant",
+        reasoning_content="reasoning",
+        tool_calls=tool_calls,
+    )
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(
+        choices=[choice],
+        usage=usage
+        or SimpleNamespace(
+            prompt_tokens=10,
+            completion_tokens=5,
+            total_tokens=15,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=3),
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=2),
+        ),
+        model="glm-5.1",
+        id="resp_1",
+    )
+
+
+def stream_chunk(content=None, reasoning=None, tool_calls=None, finish_reason=None, usage=None):
+    delta = SimpleNamespace(
+        content=content,
+        reasoning_content=reasoning,
+        tool_calls=tool_calls,
+    )
+    choice = SimpleNamespace(delta=delta, finish_reason=finish_reason, index=0)
+    return SimpleNamespace(choices=[choice], usage=usage, model="glm-5.1")
+
+
+@pytest.mark.asyncio
+async def test_zai_ask_sends_thinking_and_structured_output():
+    fake_sdk = MagicMock()
+    fake_sdk.chat.completions.create.return_value = completion_response('{"answer": "42"}')
+
+    client = ZaiClient(api_key="fake")
+    client._ensure_client = AsyncMock(return_value=fake_sdk)
+
+    response = await client.ask(
+        "answer exactly",
+        model=ZaiModel.GLM_5_1,
+        structured_output=Answer,
+        thinking=True,
+    )
+
+    assert isinstance(response, AIMessage)
+    assert response.is_structured is True
+    assert response.structured_output.answer == "42"
+    assert response.metadata["reasoning_content"] == "reasoning"
+    assert response.metadata["cached_tokens"] == 3
+
+    call_kwargs = fake_sdk.chat.completions.create.call_args.kwargs
+    assert call_kwargs["model"] == "glm-5.1"
+    assert call_kwargs["thinking"] == {"type": "enabled"}
+    assert call_kwargs["response_format"]["type"] == "json_schema"
+
+
+@pytest.mark.asyncio
+async def test_zai_ask_executes_current_tool_infrastructure():
+    provider_tool_call = SimpleNamespace(
+        id="call_1",
+        function=SimpleNamespace(name="lookup", arguments='{"query": "zai"}'),
+    )
+    fake_sdk = MagicMock()
+    fake_sdk.chat.completions.create.side_effect = [
+        completion_response("", tool_calls=[provider_tool_call]),
+        completion_response("tool complete", tool_calls=None),
+    ]
+
+    client = ZaiClient(api_key="fake", use_tools=True)
+    client._ensure_client = AsyncMock(return_value=fake_sdk)
+    client._execute_tool = AsyncMock(return_value={"ok": True})
+    client.register_tool(
+        name="lookup",
+        description="Lookup a value.",
+        input_schema={
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        },
+        function=lambda query: {"query": query},
+    )
+
+    response = await client.ask("use lookup")
+
+    assert response.response == "tool complete"
+    assert response.tool_calls[0].name == "lookup"
+    assert response.tool_calls[0].arguments == {"query": "zai"}
+    assert response.tool_calls[0].result == {"ok": True}
+    assert fake_sdk.chat.completions.create.call_args_list[0].kwargs["tool_choice"] == "auto"
+
+
+@pytest.mark.asyncio
+async def test_zai_ask_stream_supports_reasoning_tool_stream_and_final_message():
+    tool_delta = SimpleNamespace(
+        index=0,
+        id="call_1",
+        type="function",
+        function=SimpleNamespace(name="lookup", arguments='{"query":"zai"}'),
+    )
+    final_usage = SimpleNamespace(
+        prompt_tokens=4,
+        completion_tokens=6,
+        total_tokens=10,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=1),
+        completion_tokens_details=None,
+    )
+    fake_sdk = MagicMock()
+    fake_sdk.chat.completions.create.side_effect = [
+        iter(
+            [
+                stream_chunk(reasoning="think ", tool_calls=[tool_delta]),
+                stream_chunk(finish_reason="tool_calls"),
+            ]
+        ),
+        iter(
+            [
+                stream_chunk(content="done", finish_reason="stop", usage=final_usage),
+            ]
+        ),
+    ]
+
+    client = ZaiClient(api_key="fake", use_tools=True)
+    client._ensure_client = AsyncMock(return_value=fake_sdk)
+    client._execute_tool = AsyncMock(return_value="tool result")
+    client.register_tool(
+        name="lookup",
+        description="Lookup a value.",
+        input_schema={
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        },
+        function=lambda query: query,
+    )
+
+    chunks = []
+    async for chunk in client.ask_stream("stream tool", thinking=True, stream_reasoning=True):
+        chunks.append(chunk)
+
+    assert chunks[0] == "think "
+    assert chunks[1] == "done"
+    assert isinstance(chunks[-1], AIMessage)
+    assert chunks[-1].response == "done"
+    assert chunks[-1].tool_calls[0].name == "lookup"
+    first_call = fake_sdk.chat.completions.create.call_args_list[0].kwargs
+    assert first_call["stream"] is True
+    assert first_call["tool_stream"] is True
+
+
+def test_zai_factory_and_models():
+    client = LLMFactory.create("zai:glm-4.5-flash:free", api_key="fake")
+
+    assert isinstance(client, ZaiClient)
+    assert client.model == "glm-4.5-flash:free"
+    assert ZaiModel.GLM_5_1.value == "glm-5.1"
+    assert ZaiModel.GLM_4_7_FLASH_FREE.value.endswith(":free")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ anthropic = ["ai-parrot[anthropic]"]
 claude-agent = ["ai-parrot[claude-agent]"]
 groq = ["ai-parrot[groq]"]
 xai = ["ai-parrot[xai]"]
+zai = ["ai-parrot[zai]"]
 llms = ["ai-parrot[llms]"]
 # embeddings extra moved from core to the ai-parrot-embeddings satellite
 # package (FEAT-201); re-export the package directly (like `pipelines`).


### PR DESCRIPTION
### Motivation
- Provide a first-class Z.ai (zai-sdk) integration exposing reasoning-capable GLM models and free-tier `:free` variants so the framework can use Z.ai as an LLM provider.
- Support Z.ai-specific capabilities: `thinking` / deep-thinking payloads, streaming (including reasoning deltas), streaming tool-call deltas (`tool_stream`) and provider-compatible function/tool calling.
- Reuse existing project conventions (per-loop SDK client cache, ToolManager, `StructuredOutputConfig`) so the new client interoperates with current tools, caching, and structured-output plumbing.

### Description
- Added `parrot.models.zai.ZaiModel` enum with GLM model identifiers and `:free` variants and a `THINKING_CAPABLE_ZAI_MODELS` set for capability checks.
- Implemented `parrot.clients.zai.ZaiClient` (subclass of `AbstractClient`) that:
  - Constructs the official SDK client via `get_client()` (lazy import of `zai.ZaiClient`) and runs blocking SDK calls in `asyncio.to_thread` to avoid event-loop blocking.
  - Implements `ask()` and `ask_stream()` with support for `thinking` / `deep_thinking` payloads, streaming reasoning (`stream_reasoning`) and `tool_stream` handling for streaming tool-call deltas.
  - Converts framework tools into provider function descriptors and loops tool-calls via `_run_tool_loop()` and stream post-processing to execute tools using the existing `_execute_tool()` infrastructure.
  - Integrates structured output by producing provider `response_format` (JSON schema) via `_prepare_structured_output_format()` and parsing responses with existing `_parse_structured_output()` logic.
  - Extracts and surfaces caching/reasoning usage metadata (e.g. `cached_tokens`, `reasoning_tokens`) into `AIMessage.metadata` and unified `CompletionUsage.extra_usage`.
  - Provides helpers for normalizing message content, parsing tool arguments and robust conversion of provider responses to `AIMessage`.
- Wired the client into the codebase: exported `ZaiClient` from `parrot.clients`, added `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26c68c92dc8330ab83c918a8403590)