### PR TITLE
Add GraphIndexLoader and PageIndexLoader for knowledge graph ingestion

### DIFF
--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/__init__.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/__init__.py
@@ -36,6 +36,7 @@ from parrot.knowledge.graphindex.communities import (
     cohesion_for_community,
     detect_communities,
 )
+from parrot.knowledge.graphindex.loader import GraphIndexLoader
 
 __all__ = [
     "Provenance",
@@ -55,4 +56,5 @@ __all__ = [
     "CommunitiesResult",
     "cohesion_for_community",
     "detect_communities",
+    "GraphIndexLoader",
 ]

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/loader.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/loader.py
@@ -1,0 +1,410 @@
+"""GraphIndexLoader — :class:`AbstractLoader` wrapper around GraphIndex.
+
+This loader accepts a list of files and runs the **full**
+:class:`~parrot.knowledge.graphindex.builder.GraphIndexBuilder` pipeline
+(extract → embed → assemble → cross-domain resolve → analytics) over them,
+emitting ``UniversalNode`` / ``UniversalEdge`` that are compatible with the rest
+of the GraphIndex subsystem.
+
+ArangoDB persistence is **optional**:
+
+* When ArangoDB credentials are supplied (explicit kwargs or an ``arango``
+  dict; missing fields are filled from ``ARANGODB_*`` env vars via
+  ``navconfig``), the graph is persisted through
+  :class:`~parrot.knowledge.graphindex.persist.GraphIndexPersistence` backed by
+  an :class:`~parrot.knowledge.ontology.graph_store.OntologyGraphStore`.
+* When no credentials are given, an in-process no-op persistence is used: the
+  full pipeline still runs and the assembled graph is exposed in memory, but
+  nothing is written to a database.
+
+As with :class:`PageIndexLoader`, two views are offered: ``load()`` returns one
+:class:`~parrot.stores.models.Document` per graph node, while
+:meth:`build_graph` / the :pyattr:`nodes`, :pyattr:`edges`, :pyattr:`build_result`
+attributes expose the native artifacts.
+"""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any, List, Optional, Union
+
+from parrot.loaders.abstract import AbstractLoader
+from parrot.stores.models import Document
+
+from parrot.knowledge.ontology.graph_store import OntologyGraphStore
+from parrot.knowledge.ontology.schema import TenantContext
+
+from .builder import GraphIndexBuilder
+from .embed import GraphIndexEmbedder
+from .meta_ontology import build_graphindex_ontology
+from .persist import GraphIndexPersistence
+from .schema import BuildResult, SourceConfig, UniversalEdge, UniversalNode
+
+
+class _NullPersistence:
+    """No-op persistence used when no ArangoDB credentials are supplied.
+
+    Mirrors the :class:`GraphIndexPersistence` surface the builder calls so the
+    full pipeline runs end-to-end without a database. Nothing is written.
+    """
+
+    async def persist_graph(
+        self,
+        ctx: TenantContext,
+        nodes: list,
+        edges: list,
+    ) -> dict:
+        return {"nodes_persisted": 0, "edges_persisted": 0}
+
+    async def replace_document_slice(
+        self,
+        ctx: TenantContext,
+        document_uri: str,
+        nodes: list,
+        edges: list,
+    ) -> dict:
+        return {"nodes_replaced": 0, "edges_replaced": 0}
+
+
+class _CapturingPersistence:
+    """Decorator that records the assembled nodes/edges then delegates.
+
+    The builder hands the fully-resolved node/edge lists (including inferred
+    edges) to ``persist_graph``. Wrapping the real or null persistence lets the
+    loader recover those lists from a single ``build()`` run — without
+    re-extracting — to project them into :class:`Document` objects.
+    """
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+        self.nodes: list[UniversalNode] = []
+        self.edges: list[UniversalEdge] = []
+
+    async def persist_graph(self, ctx, nodes, edges):  # noqa: ANN001
+        self.nodes = list(nodes)
+        self.edges = list(edges)
+        return await self._inner.persist_graph(ctx, nodes, edges)
+
+    async def replace_document_slice(self, ctx, document_uri, nodes, edges):  # noqa: ANN001
+        self.nodes = list(nodes)
+        self.edges = list(edges)
+        return await self._inner.replace_document_slice(
+            ctx, document_uri, nodes, edges
+        )
+
+
+class GraphIndexLoader(AbstractLoader):
+    """Build a GraphIndex graph from a list of files.
+
+    Args:
+        source: Path, directory, or list of paths to index.
+        tenant_id: Tenant identifier used for graph isolation and the default
+            ArangoDB database / pgvector schema names.
+        client: An ``AbstractClient`` for the optional PageIndex adapter used
+            when ``storage_dir`` is set (hierarchical content → sidecars). When
+            ``None`` and an adapter is needed, a default client is created.
+        model: Model id for that adapter.
+        adapter: A pre-built ``PageIndexLLMAdapter`` (overrides ``client``).
+        output_dir: Directory for the generated ``GRAPH_REPORT.md``. A temp
+            directory is used when omitted.
+        embedding_model: Embedding model name (via ``EmbeddingRegistry``).
+        embedding_dim: Embedding dimension (must match the model output).
+        pgvector_dsn: Optional DSN for durable pgvector embedding storage. When
+            ``None`` only the in-memory FAISS index is built.
+        detect_communities: Enable Louvain community detection.
+        arango: ArangoDB connection dict (alternative to discrete kwargs).
+        arango_host / arango_port / arango_protocol / arango_user /
+        arango_password / arango_database: Discrete ArangoDB credentials.
+            Supplying ``arango`` or **any** of these enables persistence; the
+            rest are filled from ``ARANGODB_*`` env vars.
+        storage_dir: When set (and an adapter is available), a
+            :class:`PageIndexToolkit` is attached so hierarchical documents are
+            persisted as PageIndex trees with per-node sidecars.
+        **kwargs: Forwarded to :class:`AbstractLoader`.
+    """
+
+    extensions: List[str] = [
+        '.pdf', '.md', '.markdown', '.txt', '.text', '.html', '.htm', '.docx',
+    ]
+
+    def __init__(
+        self,
+        source: Optional[Union[str, Path, List[Union[str, Path]]]] = None,
+        *,
+        tenant_id: str = "default",
+        client: Any = None,
+        model: Optional[str] = None,
+        adapter: Any = None,
+        output_dir: Optional[Union[str, Path]] = None,
+        embedding_model: str = "default",
+        embedding_dim: int = 384,
+        pgvector_dsn: Optional[str] = None,
+        detect_communities: bool = False,
+        arango: Optional[dict] = None,
+        arango_host: Optional[str] = None,
+        arango_port: Optional[int] = None,
+        arango_protocol: Optional[str] = None,
+        arango_user: Optional[str] = None,
+        arango_password: Optional[str] = None,
+        arango_database: Optional[str] = None,
+        storage_dir: Optional[Union[str, Path]] = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(source, **kwargs)
+        self.doctype = 'graphindex_node'
+        self.tenant_id = tenant_id
+        self.detect_communities = detect_communities
+        self._output_dir = Path(output_dir) if output_dir is not None else None
+
+        # Optional PageIndex adapter + toolkit (only for hierarchical content).
+        self._pageindex_toolkit = None
+        self._adapter = adapter
+        if storage_dir is not None:
+            from parrot.knowledge.pageindex.llm_adapter import PageIndexLLMAdapter
+            from parrot.knowledge.pageindex.toolkit import PageIndexToolkit
+
+            if self._adapter is None:
+                if client is None:
+                    client = self.get_default_llm(model=model)
+                self._adapter = PageIndexLLMAdapter(client=client, model=model)
+            self._pageindex_toolkit = PageIndexToolkit(self._adapter, storage_dir)
+
+        self.embedder = GraphIndexEmbedder(
+            model_name=embedding_model,
+            dimension=embedding_dim,
+            pgvector_dsn=pgvector_dsn,
+        )
+
+        # Resolve ArangoDB credentials → persistence enabled iff explicit.
+        self._arango_params = self._resolve_arango(
+            arango,
+            arango_host,
+            arango_port,
+            arango_protocol,
+            arango_user,
+            arango_password,
+            arango_database,
+        )
+        self.persist_enabled = self._arango_params is not None
+        self.arango_db = (
+            arango_database
+            or (self._arango_params or {}).get("database")
+            or f"db_{tenant_id}"
+        )
+
+        # The GraphIndex meta-ontology defines the ``gi_*`` vertex/edge
+        # collections; using it as the tenant ontology means
+        # ``initialize_tenant`` provisions exactly the collections persistence
+        # routes into.
+        self._ontology = build_graphindex_ontology()
+        self.ctx = TenantContext(
+            tenant_id=tenant_id,
+            arango_db=self.arango_db,
+            pgvector_schema=f"schema_{tenant_id}",
+            ontology=self._ontology,
+        )
+
+        # Native artifacts populated by build_graph()/load().
+        self.build_result: Optional[BuildResult] = None
+        self.nodes: List[UniversalNode] = []
+        self.edges: List[UniversalEdge] = []
+        self.graph_store: Optional[OntologyGraphStore] = None
+        self.builder: Optional[GraphIndexBuilder] = None
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    async def load(  # type: ignore[override]
+        self,
+        source: Optional[Any] = None,
+        split_documents: bool = False,
+        **kwargs: Any,
+    ) -> List[Document]:
+        """Run the pipeline and return one Document per graph node.
+
+        Args:
+            source: Override for the construction-time source.
+            split_documents: Re-chunk node Documents. Off by default — graph
+                nodes already carry summaries.
+            **kwargs: Accepted for signature compatibility; ignored.
+
+        Returns:
+            One :class:`Document` per :class:`UniversalNode`.
+        """
+        await self.build_graph(source)
+        return [self._node_to_document(node) for node in self.nodes]
+
+    async def build_graph(self, source: Optional[Any] = None) -> BuildResult:
+        """Run the full GraphIndex pipeline and return the :class:`BuildResult`.
+
+        Side effects: persists to ArangoDB when credentials were supplied, and
+        populates :pyattr:`nodes`, :pyattr:`edges`, :pyattr:`build_result`.
+
+        Args:
+            source: Optional override for the construction-time source.
+
+        Returns:
+            The pipeline :class:`BuildResult` (persisted counts + report path).
+        """
+        files = self._resolve_files(source)
+        inner = await self._make_persistence()
+        capture = _CapturingPersistence(inner)
+        output_dir = self._output_dir or Path(
+            tempfile.mkdtemp(prefix="graphindex_")
+        )
+        self.builder = GraphIndexBuilder(
+            persistence=capture,
+            embedder=self.embedder,
+            output_dir=output_dir,
+            pageindex_toolkit=self._pageindex_toolkit,
+            detect_communities_enabled=self.detect_communities,
+        )
+        sources = SourceConfig(
+            tenant_id=self.tenant_id,
+            loader_sources=[str(f) for f in files],
+        )
+        result = await self.builder.build(sources, self.ctx)
+        self.build_result = result
+        self.nodes = capture.nodes
+        self.edges = capture.edges
+        return result
+
+    # ------------------------------------------------------------------
+    # AbstractLoader hook (single file) — kept for ABC + base-class reuse
+    # ------------------------------------------------------------------
+
+    async def _load(self, source: Union[str, Path], **kwargs: Any) -> List[Document]:
+        """Build a single-file graph and return its node Documents."""
+        await self.build_graph([source])
+        return [self._node_to_document(node) for node in self.nodes]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _make_persistence(self) -> Any:
+        """Build the persistence target (real ArangoDB or in-memory no-op)."""
+        if not self.persist_enabled:
+            return _NullPersistence()
+
+        from asyncdb import AsyncDB
+
+        db = AsyncDB("arangodb", params=self._arango_params)
+        try:
+            await db.connection()
+        except Exception as exc:  # pragma: no cover - needs a live server
+            self.logger.error("ArangoDB connection failed: %s", exc)
+            raise
+        self.graph_store = OntologyGraphStore(arango_client=db)
+        try:
+            await self.graph_store.initialize_tenant(self.ctx)
+        except Exception as exc:  # pragma: no cover - needs a live server
+            self.logger.warning(
+                "initialize_tenant failed (collections may already exist): %s",
+                exc,
+            )
+        return GraphIndexPersistence(self.graph_store)
+
+    def _resolve_arango(
+        self,
+        arango: Optional[dict],
+        host: Optional[str],
+        port: Optional[int],
+        protocol: Optional[str],
+        user: Optional[str],
+        password: Optional[str],
+        database: Optional[str],
+    ) -> Optional[dict]:
+        """Resolve ArangoDB connection params, or ``None`` when not requested.
+
+        Persistence is enabled only when the caller explicitly passed an
+        ``arango`` dict or any discrete credential. Missing fields fall back to
+        ``ARANGODB_*`` environment variables.
+        """
+        explicit = arango is not None or any(
+            v is not None for v in (host, user, password, database)
+        )
+        if not explicit:
+            return None
+
+        from navconfig import config  # local import: optional dependency
+
+        def _cfg(key: str, default: Any) -> Any:
+            # navconfig's config.get may return None for a missing key even
+            # when a fallback is passed, so coalesce explicitly.
+            val = config.get(key)
+            return val if val is not None else default
+
+        base = dict(arango) if isinstance(arango, dict) else {}
+        return {
+            "host": base.get("host") or host or _cfg("ARANGODB_HOST", "127.0.0.1"),
+            "port": int(
+                base.get("port") or port or _cfg("ARANGODB_PORT", 8529)
+            ),
+            "protocol": base.get("protocol")
+            or protocol
+            or _cfg("ARANGODB_PROTOCOL", "http"),
+            "username": base.get("username")
+            or user
+            or _cfg("ARANGODB_USERNAME", "root"),
+            "password": (
+                base.get("password")
+                if base.get("password") is not None
+                else (
+                    password
+                    if password is not None
+                    else _cfg("ARANGODB_PASSWORD", "")
+                )
+            ),
+            "database": base.get("database")
+            or database
+            or _cfg("ARANGODB_DATABASE", f"db_{self.tenant_id}"),
+        }
+
+    def _resolve_files(self, source: Optional[Any]) -> List[Path]:
+        """Expand ``source`` / ``self.path`` into a de-duplicated file list."""
+        src = source if source is not None else self.path
+        if src is None:
+            raise ValueError(
+                "No source provided and self.path is not set. Pass a source to "
+                "load() or set it during initialization."
+            )
+        items = list(src) if isinstance(src, list) else [src]
+        files: List[Path] = []
+        for item in items:
+            p = Path(item)
+            if p.is_dir():
+                for ext in self.extensions:
+                    globber = p.rglob if self._recursive else p.glob
+                    files.extend(sorted(globber(f"*{ext}")))
+            elif p.is_file():
+                files.append(p)
+            else:
+                self.logger.warning("Path %s is not a valid file or directory.", p)
+        seen: set[Path] = set()
+        ordered: List[Path] = []
+        for f in files:
+            if f not in seen:
+                seen.add(f)
+                ordered.append(f)
+        return ordered
+
+    def _node_to_document(self, node: UniversalNode) -> Document:
+        """Convert a :class:`UniversalNode` into a canonical :class:`Document`."""
+        domain_tags = node.domain_tags or {}
+        metadata = self.create_metadata(
+            path=node.source_uri
+            or f"graphindex://{self.tenant_id}/{node.node_id}",
+            doctype='graphindex_node',
+            source_type=self._source_type,
+            title=node.title,
+            node_id=node.node_id,
+            kind=node.kind.value,
+            parent_id=node.parent_id,
+            provenance=node.provenance.value,
+            content_ref=node.content_ref,
+            community_id=domain_tags.get("community_id"),
+        )
+        content = node.summary or node.title or ""
+        return Document(page_content=content, metadata=metadata)

--- a/packages/ai-parrot/src/parrot/knowledge/pageindex/__init__.py
+++ b/packages/ai-parrot/src/parrot/knowledge/pageindex/__init__.py
@@ -19,6 +19,7 @@ from .tree_ops import splice_subtree, delete_node, reindex_node_ids
 from .hybrid_search import HybridPageIndexSearch
 from .ingest import TwoStepIngester, IngestedMarkdown
 from .toolkit import PageIndexToolkit
+from .loader import PageIndexLoader
 
 __all__ = [
     "build_page_index",
@@ -38,4 +39,5 @@ __all__ = [
     "TwoStepIngester",
     "IngestedMarkdown",
     "PageIndexToolkit",
+    "PageIndexLoader",
 ]

--- a/packages/ai-parrot/src/parrot/knowledge/pageindex/loader.py
+++ b/packages/ai-parrot/src/parrot/knowledge/pageindex/loader.py
@@ -1,0 +1,310 @@
+"""PageIndexLoader — :class:`AbstractLoader` wrapper around PageIndex.
+
+This loader accepts a list of files (PDF / Markdown / plain text), drives the
+existing :class:`~parrot.knowledge.pageindex.toolkit.PageIndexToolkit` to build a
+single hierarchical **PageIndex tree** (a lean ToC tree plus per-node markdown
+sidecars persisted under ``storage_dir``), and exposes the result through the
+familiar loader contract.
+
+Two complementary views of the same build are offered:
+
+* ``load()`` returns **one** :class:`~parrot.stores.models.Document` **per tree
+  node** so the output flows straight into the existing RAG / vector-store
+  pipeline. Re-chunking is disabled by default because tree nodes are already
+  bounded retrieval units.
+* :meth:`build_tree` / the :pyattr:`tree` property return the **native** tree
+  dict (validated against :class:`PageIndexTree`), and :pyattr:`toolkit`
+  exposes the underlying toolkit for downstream hybrid search / retrieval.
+
+Persistence is mandatory (decision recorded in the feature plan): a
+``storage_dir`` must be supplied and every tree is written to disk via the
+toolkit so it is immediately searchable afterwards.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, List, Optional, Union
+
+from parrot.loaders.abstract import AbstractLoader
+from parrot.stores.models import Document
+
+from .content_store import NodeContentStore
+from .llm_adapter import PageIndexLLMAdapter
+from .schemas import PageIndexTree
+from .toolkit import PageIndexToolkit
+from .utils import find_node_by_id
+
+
+class PageIndexLoader(AbstractLoader):
+    """Build a PageIndex tree from a list of files.
+
+    Args:
+        source: Path, directory, or list of paths/directories to ingest.
+            Resolved the same way :class:`AbstractLoader` resolves sources,
+            filtered by :pyattr:`extensions`.
+        storage_dir: **Required.** Directory where the tree JSON and per-node
+            markdown sidecars are persisted (via :class:`PageIndexToolkit`).
+        tree_name: Name of the single aggregate tree all files are imported
+            into. Must match ``[A-Za-z0-9_-]{1,128}``.
+        client: An ``AbstractClient`` used to drive the PageIndex LLM calls.
+            Ignored when ``adapter`` is supplied. When both ``client`` and
+            ``adapter`` are ``None`` a default client is created via
+            :meth:`AbstractLoader.get_default_llm`.
+        model: Heavy model id for the adapter (tree-walk, summaries, Step-2
+            markdown generation).
+        lightweight_model: Optional cheaper model id for the toolkit's helper
+            calls (TOC detection, Step-1 analysis, summaries).
+        adapter: A pre-built :class:`PageIndexLLMAdapter`. Takes precedence over
+            ``client`` / ``model``.
+        with_summaries: Generate per-node LLM summaries when importing PDFs.
+        with_doc_description: Generate a one-sentence document description when
+            importing PDFs.
+        reset_tree: When ``True`` (default) an existing tree with the same name
+            is deleted before ingestion so each ``load()`` is reproducible.
+            Set ``False`` to append to an existing tree.
+        **kwargs: Forwarded to :class:`AbstractLoader`.
+
+    Raises:
+        ValueError: If ``storage_dir`` is not provided.
+    """
+
+    extensions: List[str] = ['.pdf', '.md', '.markdown', '.txt', '.text']
+
+    def __init__(
+        self,
+        source: Optional[Union[str, Path, List[Union[str, Path]]]] = None,
+        *,
+        storage_dir: Optional[Union[str, Path]] = None,
+        tree_name: str = "pageindex",
+        client: Any = None,
+        model: Optional[str] = None,
+        lightweight_model: Optional[str] = None,
+        adapter: Optional[PageIndexLLMAdapter] = None,
+        with_summaries: bool = True,
+        with_doc_description: bool = True,
+        reset_tree: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(source, **kwargs)
+        if storage_dir is None:
+            raise ValueError(
+                "PageIndexLoader requires a 'storage_dir' — trees are always "
+                "persisted via PageIndexToolkit."
+            )
+
+        self.doctype = 'pageindex_node'
+        self.storage_dir = Path(storage_dir)
+        self.tree_name = tree_name
+        self.with_summaries = with_summaries
+        self.with_doc_description = with_doc_description
+        self.reset_tree = reset_tree
+
+        # Resolve / build the LLM adapter.
+        if adapter is not None:
+            self._adapter = adapter
+        else:
+            if client is None:
+                client = self.get_default_llm(model=model)
+            self._adapter = PageIndexLLMAdapter(client=client, model=model)
+
+        self.toolkit = PageIndexToolkit(
+            adapter=self._adapter,
+            storage_dir=self.storage_dir,
+            lightweight_model=lightweight_model,
+        )
+        # Independent reader over the same sidecar directory (public API).
+        self._content_store = NodeContentStore(self.storage_dir)
+        self._tree: Optional[dict] = None
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    async def load(  # type: ignore[override]
+        self,
+        source: Optional[Any] = None,
+        split_documents: bool = False,
+        **kwargs: Any,
+    ) -> List[Document]:
+        """Import every file into one tree and return per-node Documents.
+
+        Unlike the base loader this runs ingestion **sequentially** (the
+        toolkit performs read-modify-write on a shared tree JSON, so concurrent
+        splices would race) and leaves ``split_documents`` ``False`` by default.
+
+        Args:
+            source: Override for the source provided at construction time.
+            split_documents: Re-chunk node Documents. Off by default — tree
+                nodes are already bounded retrieval units.
+            **kwargs: Accepted for signature compatibility; ignored.
+
+        Returns:
+            One :class:`Document` per node in the resulting tree.
+        """
+        files = self._resolve_files(source)
+        await self._ensure_tree(reset=self.reset_tree)
+        for path in files:
+            await self._import_one(path)
+        self._tree = await self.toolkit.get_tree(self.tree_name)
+        return self._tree_to_documents(self._tree)
+
+    async def build_tree(self, source: Optional[Any] = None) -> dict:
+        """Build the tree and return the native tree dict.
+
+        Args:
+            source: Optional override for the construction-time source.
+
+        Returns:
+            The raw tree dict (``{"doc_name", "structure": [...]}``). It is also
+            validated into a :class:`PageIndexTree` to surface schema errors
+            early; the dict (not the model) is returned for direct toolkit use.
+        """
+        await self.load(source)
+        # Validate shape — raises if the tree drifts from the schema.
+        PageIndexTree.model_validate(
+            {
+                "doc_name": (self._tree or {}).get("doc_name", self.tree_name),
+                "doc_description": (self._tree or {}).get("doc_description"),
+                "structure": (self._tree or {}).get("structure", []),
+            }
+        )
+        return self._tree or {}
+
+    @property
+    def tree(self) -> Optional[dict]:
+        """The most recently built tree dict, or ``None`` before ``load()``."""
+        return self._tree
+
+    # ------------------------------------------------------------------
+    # AbstractLoader hook (single file) — kept for ABC + base-class reuse
+    # ------------------------------------------------------------------
+
+    async def _load(self, source: Union[str, Path], **kwargs: Any) -> List[Document]:
+        """Import a single file into the tree and return its node Documents."""
+        path = Path(source)
+        await self._ensure_tree(reset=False)
+        new_ids = await self._import_one(path)
+        self._tree = await self.toolkit.get_tree(self.tree_name)
+        structure = self._tree.get("structure", [])
+        docs: List[Document] = []
+        seen: set[str] = set()
+        for node_id in new_ids:
+            node = find_node_by_id(structure, node_id)
+            if node is None:
+                continue
+            for sub in self._iter_subtree(node):
+                sid = sub.get("node_id")
+                if sid and sid not in seen:
+                    seen.add(sid)
+                    docs.append(self._node_to_document(sub, path))
+        return docs
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _ensure_tree(self, reset: bool) -> None:
+        """Ensure the target tree exists, optionally resetting it first."""
+        existing = await self.toolkit.list_trees()
+        if self.tree_name in existing:
+            if reset:
+                await self.toolkit.delete_tree(self.tree_name)
+                await self.toolkit.create_tree(self.tree_name)
+        else:
+            await self.toolkit.create_tree(self.tree_name)
+
+    async def _import_one(self, path: Path) -> List[str]:
+        """Import a single file into the tree; return the new node ids."""
+        if path.suffix.lower() == '.pdf':
+            result = await self.toolkit.import_pdf(
+                self.tree_name,
+                str(path),
+                with_summaries=self.with_summaries,
+                with_doc_description=self.with_doc_description,
+            )
+        else:
+            result = await self.toolkit.import_file(self.tree_name, str(path))
+        return list(result.get("new_node_ids", []) or [])
+
+    def _resolve_files(self, source: Optional[Any]) -> List[Path]:
+        """Expand ``source`` / ``self.path`` into a de-duplicated file list."""
+        src = source if source is not None else self.path
+        if src is None:
+            raise ValueError(
+                "No source provided and self.path is not set. Pass a source to "
+                "load() or set it during initialization."
+            )
+        items = list(src) if isinstance(src, list) else [src]
+        files: List[Path] = []
+        for item in items:
+            p = Path(item)
+            if p.is_dir():
+                for ext in self.extensions:
+                    globber = p.rglob if self._recursive else p.glob
+                    files.extend(sorted(globber(f"*{ext}")))
+            elif p.is_file():
+                files.append(p)
+            else:
+                self.logger.warning("Path %s is not a valid file or directory.", p)
+        seen: set[Path] = set()
+        ordered: List[Path] = []
+        for f in files:
+            if f not in seen:
+                seen.add(f)
+                ordered.append(f)
+        return ordered
+
+    def _iter_subtree(self, node: dict):
+        """Yield ``node`` and every descendant (depth-first)."""
+        yield node
+        for child in node.get("nodes") or []:
+            yield from self._iter_subtree(child)
+
+    def _tree_to_documents(self, tree: dict) -> List[Document]:
+        """Flatten a tree into one Document per node (depth-first)."""
+        docs: List[Document] = []
+
+        def _walk(nodes: list, parent_id: Optional[str]) -> None:
+            for node in nodes:
+                docs.append(self._node_to_document(node, parent_id=parent_id))
+                _walk(node.get("nodes") or [], node.get("node_id"))
+
+        _walk(tree.get("structure", []), None)
+        return docs
+
+    def _node_to_document(
+        self,
+        node: dict,
+        source_path: Optional[Path] = None,
+        parent_id: Optional[str] = None,
+    ) -> Document:
+        """Convert a single tree node into a canonical :class:`Document`."""
+        node_id = node.get("node_id")
+        body: Optional[str] = None
+        if node_id:
+            body = self._content_store.load(self.tree_name, node_id)
+        content = (
+            body
+            or node.get("text")
+            or node.get("summary")
+            or node.get("prefix_summary")
+            or node.get("title")
+            or ""
+        )
+        origin = (
+            str(source_path)
+            if source_path is not None
+            else f"pageindex://{self.tree_name}/{node_id or ''}"
+        )
+        metadata = self.create_metadata(
+            path=origin,
+            doctype='pageindex_node',
+            source_type=self._source_type,
+            title=node.get("title"),
+            node_id=node_id,
+            parent_id=parent_id if parent_id is not None else node.get("parent_id"),
+            tree_name=self.tree_name,
+            doc_name=(self._tree or {}).get("doc_name"),
+            summary=node.get("summary"),
+        )
+        return Document(page_content=content, metadata=metadata)

--- a/packages/ai-parrot/tests/knowledge/graphindex/test_loader.py
+++ b/packages/ai-parrot/tests/knowledge/graphindex/test_loader.py
@@ -1,0 +1,176 @@
+"""Unit tests for parrot.knowledge.graphindex.loader.GraphIndexLoader.
+
+The heavy pipeline pieces (embedder, builder, ArangoDB) are replaced with
+fakes so the loader's wiring is exercised without models or a live database:
+
+* a fake ``GraphIndexBuilder`` whose ``build`` feeds canned nodes/edges through
+  the persistence object the loader supplied (so the capturing wrapper records
+  them), then returns a ``BuildResult``;
+* the no-credentials path is asserted to use the in-memory ``_NullPersistence``;
+* the credentials path is asserted to construct an ``OntologyGraphStore`` +
+  ``GraphIndexPersistence`` against a mocked asyncdb client.
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import parrot.knowledge.graphindex.loader as loader_mod
+from parrot.knowledge.graphindex.loader import (
+    GraphIndexLoader,
+    _NullPersistence,
+)
+from parrot.knowledge.graphindex.schema import (
+    BuildResult,
+    NodeKind,
+    UniversalNode,
+)
+from parrot.loaders.abstract import AbstractLoader
+from parrot.stores.models import Document
+
+
+_FAKE_NODES = [
+    UniversalNode(
+        node_id="n1",
+        kind=NodeKind.DOCUMENT,
+        title="Doc One",
+        source_uri="a.md",
+        summary="summary one",
+    ),
+    UniversalNode(
+        node_id="n2",
+        kind=NodeKind.SECTION,
+        title="Section Two",
+        source_uri="a.md",
+        parent_id="n1",
+    ),
+]
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    """Patch the embedder and builder used inside the loader module."""
+    captured: dict = {}
+
+    monkeypatch.setattr(loader_mod, "GraphIndexEmbedder", MagicMock())
+
+    class _FakeBuilder:
+        def __init__(self, persistence, embedder, output_dir, **kwargs):
+            self.persistence = persistence
+            captured["persistence"] = persistence
+            captured["output_dir"] = output_dir
+            captured["kwargs"] = kwargs
+
+        async def build(self, sources, ctx):
+            captured["sources"] = sources
+            await self.persistence.persist_graph(ctx, _FAKE_NODES, [])
+            return BuildResult(
+                tenant_id=ctx.tenant_id,
+                node_count=len(_FAKE_NODES),
+                edge_count=0,
+                inferred_edge_count=0,
+                report_path=None,
+                errors=[],
+            )
+
+    monkeypatch.setattr(loader_mod, "GraphIndexBuilder", _FakeBuilder)
+    return captured
+
+
+class TestConstruction:
+    def test_is_abstract_loader_subclass(self, patched):
+        assert issubclass(GraphIndexLoader, AbstractLoader)
+
+    def test_no_creds_disables_persistence(self, patched):
+        loader = GraphIndexLoader(tenant_id="t")
+        assert loader.persist_enabled is False
+
+    def test_explicit_creds_enable_persistence(self, patched):
+        loader = GraphIndexLoader(
+            tenant_id="t",
+            arango_host="127.0.0.1",
+            arango_user="root",
+            arango_password="secret",
+            arango_database="kg",
+        )
+        assert loader.persist_enabled is True
+        assert loader.arango_db == "kg"
+        assert loader._arango_params["host"] == "127.0.0.1"
+
+
+class TestLoad:
+    @pytest.mark.asyncio
+    async def test_load_returns_document_per_node(self, patched, tmp_path):
+        loader = GraphIndexLoader(tenant_id="t", output_dir=tmp_path)
+        (tmp_path / "a.md").write_text("x", encoding="utf-8")
+
+        docs = await loader.load([tmp_path / "a.md"])
+
+        assert len(docs) == 2
+        assert all(isinstance(d, Document) for d in docs)
+        assert {d.metadata["node_id"] for d in docs} == {"n1", "n2"}
+        assert loader.build_result.node_count == 2
+
+    @pytest.mark.asyncio
+    async def test_no_creds_uses_null_persistence(self, patched, tmp_path):
+        loader = GraphIndexLoader(tenant_id="t", output_dir=tmp_path)
+        await loader.load([tmp_path])
+        inner = patched["persistence"]._inner
+        assert isinstance(inner, _NullPersistence)
+
+    @pytest.mark.asyncio
+    async def test_node_metadata_mapping(self, patched, tmp_path):
+        loader = GraphIndexLoader(tenant_id="t", output_dir=tmp_path)
+        docs = await loader.load([tmp_path])
+        by_id = {d.metadata["node_id"]: d for d in docs}
+        assert by_id["n1"].page_content == "summary one"
+        assert by_id["n1"].metadata["kind"] == "document"
+        assert by_id["n2"].metadata["parent_id"] == "n1"
+        # Falls back to title when no summary.
+        assert by_id["n2"].page_content == "Section Two"
+
+    @pytest.mark.asyncio
+    async def test_build_graph_exposes_nodes_edges(self, patched, tmp_path):
+        loader = GraphIndexLoader(tenant_id="t", output_dir=tmp_path)
+        result = await loader.build_graph([tmp_path])
+        assert isinstance(result, BuildResult)
+        assert len(loader.nodes) == 2
+        assert loader.edges == []
+
+
+class TestCredsPersistence:
+    @pytest.mark.asyncio
+    async def test_creds_path_builds_real_persistence(
+        self, patched, monkeypatch, tmp_path
+    ):
+        # Mock asyncdb so no live server is touched.
+        fake_db = MagicMock()
+        fake_db.connection = AsyncMock()
+        fake_asyncdb = MagicMock()
+        fake_asyncdb.AsyncDB = MagicMock(return_value=fake_db)
+        monkeypatch.setitem(__import__("sys").modules, "asyncdb", fake_asyncdb)
+
+        fake_store = MagicMock()
+        fake_store.initialize_tenant = AsyncMock()
+        store_cls = MagicMock(return_value=fake_store)
+        fake_persistence = MagicMock()
+        fake_persistence.persist_graph = AsyncMock(
+            return_value={"nodes_persisted": 2, "edges_persisted": 0}
+        )
+        persistence_cls = MagicMock(return_value=fake_persistence)
+        monkeypatch.setattr(loader_mod, "OntologyGraphStore", store_cls)
+        monkeypatch.setattr(loader_mod, "GraphIndexPersistence", persistence_cls)
+
+        loader = GraphIndexLoader(
+            tenant_id="t",
+            output_dir=tmp_path,
+            arango_host="127.0.0.1",
+            arango_user="root",
+            arango_password="secret",
+            arango_database="kg",
+        )
+        await loader.build_graph([tmp_path])
+
+        fake_asyncdb.AsyncDB.assert_called_once()
+        store_cls.assert_called_once_with(arango_client=fake_db)
+        fake_store.initialize_tenant.assert_awaited_once()
+        persistence_cls.assert_called_once_with(fake_store)

--- a/packages/ai-parrot/tests/knowledge/pageindex/test_loader.py
+++ b/packages/ai-parrot/tests/knowledge/pageindex/test_loader.py
@@ -1,0 +1,156 @@
+"""Unit tests for parrot.knowledge.pageindex.loader.PageIndexLoader.
+
+The toolkit (and its LLM adapter) are replaced with an in-memory fake so the
+loader's orchestration — tree creation, per-file import dispatch, and the
+tree → Document projection — is exercised without any real LLM calls.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from parrot.knowledge.pageindex.loader import PageIndexLoader
+from parrot.loaders.abstract import AbstractLoader
+from parrot.stores.models import Document
+
+
+class _FakeToolkit:
+    """Minimal stand-in for PageIndexToolkit recording imports."""
+
+    def __init__(self) -> None:
+        self.created: list[str] = []
+        self.deleted: list[str] = []
+        self.imported: list[str] = []
+        self.pdf_imported: list[str] = []
+        self._existing: list[str] = []
+        self._tree = {
+            "doc_name": "doc",
+            "structure": [
+                {
+                    "node_id": "0000",
+                    "title": "Root",
+                    "summary": "root summary",
+                    "nodes": [
+                        {
+                            "node_id": "0001",
+                            "title": "Child",
+                            "summary": "child summary",
+                            "nodes": [],
+                        }
+                    ],
+                }
+            ],
+        }
+
+    async def list_trees(self) -> list[str]:
+        return list(self._existing)
+
+    async def create_tree(self, tree_name: str, doc_name=None) -> dict:
+        self.created.append(tree_name)
+        self._existing.append(tree_name)
+        return {"tree_name": tree_name}
+
+    async def delete_tree(self, tree_name: str) -> dict:
+        self.deleted.append(tree_name)
+        if tree_name in self._existing:
+            self._existing.remove(tree_name)
+        return {"tree_name": tree_name}
+
+    async def import_file(self, tree_name, file_path, **kwargs) -> dict:
+        self.imported.append(str(file_path))
+        return {"new_node_ids": ["0000", "0001"]}
+
+    async def import_pdf(self, tree_name, pdf_path, **kwargs) -> dict:
+        self.pdf_imported.append(str(pdf_path))
+        return {"new_node_ids": ["0000", "0001"]}
+
+    async def get_tree(self, tree_name) -> dict:
+        return self._tree
+
+
+def _make_loader(tmp_path, **kwargs) -> PageIndexLoader:
+    loader = PageIndexLoader(
+        storage_dir=tmp_path,
+        adapter=MagicMock(),
+        **kwargs,
+    )
+    loader.toolkit = _FakeToolkit()
+    # Sidecars are empty in the fake → content falls back to node summary.
+    loader._content_store = MagicMock()
+    loader._content_store.load.return_value = None
+    return loader
+
+
+class TestConstruction:
+    def test_is_abstract_loader_subclass(self):
+        assert issubclass(PageIndexLoader, AbstractLoader)
+
+    def test_storage_dir_required(self):
+        with pytest.raises(ValueError, match="storage_dir"):
+            PageIndexLoader(adapter=MagicMock())
+
+
+class TestLoad:
+    @pytest.mark.asyncio
+    async def test_load_returns_document_per_node(self, tmp_path):
+        loader = _make_loader(tmp_path)
+        (tmp_path / "a.md").write_text("# hello", encoding="utf-8")
+
+        docs = await loader.load([tmp_path / "a.md"])
+
+        assert len(docs) == 2  # root + child
+        assert all(isinstance(d, Document) for d in docs)
+        node_ids = {d.metadata["node_id"] for d in docs}
+        assert node_ids == {"0000", "0001"}
+
+    @pytest.mark.asyncio
+    async def test_load_uses_summary_when_no_sidecar(self, tmp_path):
+        loader = _make_loader(tmp_path)
+        (tmp_path / "a.md").write_text("# hello", encoding="utf-8")
+
+        docs = await loader.load([tmp_path / "a.md"])
+
+        by_id = {d.metadata["node_id"]: d for d in docs}
+        assert by_id["0000"].page_content == "root summary"
+        assert by_id["0001"].page_content == "child summary"
+
+    @pytest.mark.asyncio
+    async def test_child_metadata_records_parent(self, tmp_path):
+        loader = _make_loader(tmp_path)
+        (tmp_path / "a.md").write_text("x", encoding="utf-8")
+
+        docs = await loader.load([tmp_path / "a.md"])
+        child = next(d for d in docs if d.metadata["node_id"] == "0001")
+        assert child.metadata["parent_id"] == "0000"
+        assert child.metadata["tree_name"] == loader.tree_name
+
+    @pytest.mark.asyncio
+    async def test_pdf_routes_to_import_pdf(self, tmp_path):
+        loader = _make_loader(tmp_path)
+        pdf = tmp_path / "doc.pdf"
+        pdf.write_bytes(b"%PDF-1.4 fake")
+
+        await loader.load([pdf])
+
+        assert loader.toolkit.pdf_imported == [str(pdf)]
+        assert loader.toolkit.imported == []
+
+    @pytest.mark.asyncio
+    async def test_reset_tree_deletes_existing(self, tmp_path):
+        loader = _make_loader(tmp_path)
+        loader.toolkit._existing = [loader.tree_name]
+        (tmp_path / "a.md").write_text("x", encoding="utf-8")
+
+        await loader.load([tmp_path / "a.md"])
+
+        assert loader.tree_name in loader.toolkit.deleted
+
+    @pytest.mark.asyncio
+    async def test_build_tree_returns_native_tree(self, tmp_path):
+        loader = _make_loader(tmp_path)
+        (tmp_path / "a.md").write_text("x", encoding="utf-8")
+
+        tree = await loader.build_tree([tmp_path / "a.md"])
+
+        assert tree["doc_name"] == "doc"
+        assert tree["structure"][0]["node_id"] == "0000"
+        assert loader.tree is tree


### PR DESCRIPTION
## Summary

Introduces two new loader classes that wrap the existing GraphIndex and PageIndex subsystems, exposing them through the familiar `AbstractLoader` interface for seamless integration into the RAG pipeline.

## Key Changes

### GraphIndexLoader (`packages/ai-parrot/src/parrot/knowledge/graphindex/loader.py`)
- New `AbstractLoader` subclass that runs the full GraphIndex pipeline (extract → embed → assemble → cross-domain resolve → analytics) over a list of files
- Supports optional ArangoDB persistence via explicit credentials or environment variables; falls back to in-memory no-op persistence when no credentials supplied
- Exposes two complementary views:
  - `load()` returns one `Document` per graph node for RAG integration
  - `build_graph()` / native attributes (`nodes`, `edges`, `build_result`) expose raw GraphIndex artifacts
- Includes helper classes:
  - `_NullPersistence`: no-op persistence for in-memory-only builds
  - `_CapturingPersistence`: decorator that records assembled nodes/edges for projection into Documents
- Handles optional PageIndex adapter integration for hierarchical content with per-node sidecars
- Comprehensive credential resolution with fallback to `ARANGODB_*` environment variables via `navconfig`

### PageIndexLoader (`packages/ai-parrot/src/parrot/knowledge/pageindex/loader.py`)
- New `AbstractLoader` subclass that builds a single hierarchical PageIndex tree from a list of files
- Mandatory `storage_dir` parameter ensures trees are persisted via `PageIndexToolkit` and immediately searchable
- Exposes two complementary views:
  - `load()` returns one `Document` per tree node (depth-first traversal)
  - `build_tree()` / `tree` property expose the native tree dict validated against `PageIndexTree` schema
- Handles sequential file import (read-modify-write on shared tree JSON prevents race conditions)
- Routes PDF files to `import_pdf()` with optional summaries and document descriptions; other formats to `import_file()`
- Supports tree reset on each load for reproducibility or append mode for incremental ingestion
- Falls back to node title/summary when per-node markdown sidecars are unavailable

### Module Exports
- Updated `parrot/knowledge/graphindex/__init__.py` to export `GraphIndexLoader`
- Updated `parrot/knowledge/pageindex/__init__.py` to export `PageIndexLoader`

### Test Coverage
- `tests/knowledge/graphindex/test_loader.py`: Unit tests for GraphIndexLoader with mocked embedder, builder, and asyncdb; validates credential handling, persistence wiring, and node-to-document projection
- `tests/knowledge/pageindex/test_loader.py`: Unit tests for PageIndexLoader with mocked toolkit; validates tree creation, file routing (PDF vs. other formats), reset behavior, and tree-to-document flattening

## Notable Implementation Details

- Both loaders inherit from `AbstractLoader` and reuse its file resolution logic (`_resolve_files`), supporting paths, directories, and lists with recursive globbing
- GraphIndexLoader uses a `_CapturingPersistence` wrapper to intercept the fully-resolved node/edge lists from the builder's `persist_graph` call, enabling single-pass projection to Documents without re-extraction
- PageIndexLoader's `_node_to_document` method prioritizes sidecar content, then falls back to node summary, prefix_summary, and title in order
- Both loaders set `doctype` to their respective node types (`'graphindex_node'` / `'pageindex_node'`) for downstream filtering and routing
- Metadata projection includes source URIs, node IDs, parent relationships, and domain-specific fields (community_id for GraphIndex, tree_name for PageIndex)

https://claude.ai/code/session_01FMuxH4wGtuYtyPxgvruFm3