### PR TITLE
feat: color de marcadores por capa en STRUCTURED_MAP (piggyback)

### DIFF
--- a/packages/ai-parrot-visualizations/src/parrot/outputs/formats/structured_map.py
+++ b/packages/ai-parrot-visualizations/src/parrot/outputs/formats/structured_map.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
@@ -51,6 +52,31 @@ _HARD_TYPES: frozenset[str] = frozenset({"number", "datetime", "boolean"})
 #: Allowed finer format hints the LLM may add to ambiguous columns.
 _ALLOWED_FORMATS: frozenset[str] = frozenset(
     {"currency", "percent", "email", "uri", "enum", "id", "code"}
+)
+
+#: Closed set of canonical marker color names accepted from the LLM (FEAT-221
+#: piggyback). Anything outside this set (or a valid hex string) is dropped —
+#: the frontend then falls back to its default marker color (fail-open).
+_NAMED_COLORS: frozenset[str] = frozenset(
+    {
+        "red", "blue", "green", "orange", "purple", "yellow", "pink", "brown",
+        "black", "white", "gray", "grey", "cyan", "magenta", "teal", "navy",
+        "lime", "olive", "maroon", "gold", "violet", "indigo", "turquoise",
+        "darkred", "darkblue", "darkgreen", "lightblue", "lightgreen",
+    }
+)
+
+#: 3- or 6-digit hex color, e.g. ``#f00`` or ``#1f77b4``.
+_HEX_COLOR_RE = re.compile(r"^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$")
+
+#: Keys the LLM may use to apply a single color to every layer.
+_DEFAULT_COLOR_KEYS: Tuple[str, ...] = ("default", "all", "*")
+
+#: Fenced block the LLM appends to its explanation to carry marker colors.
+#: Distinct tag (``mapcolors``) so it never collides with other code/JSON blocks.
+_MAPCOLORS_BLOCK_RE = re.compile(
+    r"```mapcolors\s*(?P<body>\{.*?\})\s*```",
+    re.DOTALL | re.IGNORECASE,
 )
 
 # ── System Prompt ─────────────────────────────────────────────────────────────
@@ -90,6 +116,23 @@ BOTH PATHS:
 - Do NOT render HTML, do NOT return GeoJSON inline, do NOT retype the rows in your
   answer — the backend builds the map from the tool output (Path A) or the named
   DataFrame (Path B).
+
+MARKER COLORS (optional — only when the user asks for one):
+- If, and ONLY if, the user's question specifies a color for the map markers/pins
+  (e.g. "show the stores in red", "pinta las escuelas de azul y los centros
+  comerciales de verde"), append ONE fenced block to the END of your explanation:
+
+      ```mapcolors
+      {"default": "red"}
+      ```
+
+  - Use the key "default" to color ALL markers with a single color.
+  - To color per dataset/layer, key the color by the dataset name, e.g.
+    {"schools": "blue", "malls": "green"}.
+  - Values MUST be a basic CSS color name (red, blue, green, orange, purple,
+    yellow, pink, gray, black, teal, navy, ...) or a hex string ("#1f77b4").
+- If the user does NOT mention any color, OMIT the block entirely — never invent
+  colors. The frontend will use its default marker styling.
 """
 
 # Column-format-hint refine contract (FEAT-221). Distinct from the generation
@@ -195,6 +238,12 @@ class StructuredMapRenderer(StructuredOutputBase, BaseChart):
             # Step 1: Capture explanation from the producing agent.
             explanation: Optional[str] = getattr(response, "response", None) or None
 
+            # Step 1b: Extract optional marker colors the LLM emitted in the same
+            # generation call (piggyback — no extra LLM call). Strips the fenced
+            # ```mapcolors``` block from the explanation so it never leaks to the
+            # user. Fail-open: no block / malformed → empty mapping.
+            marker_colors, explanation = self._extract_marker_colors(explanation)
+
             # Step 2: Read the SpatialResult from response.data.
             spatial_result = getattr(response, "data", None)
             if spatial_result is None:
@@ -289,6 +338,12 @@ class StructuredMapRenderer(StructuredOutputBase, BaseChart):
                     )
                     label_field = profile.label_col
 
+                # Resolve the per-layer marker color from the LLM-supplied mapping
+                # (matches by dataset name, layer id, or a "default"/"all"/"*" key).
+                marker_color = self._resolve_layer_color(
+                    marker_colors, dataset_name, layer_result.layer
+                )
+
                 map_layer = MapLayer(
                     layer=layer_result.layer,
                     columns=columns,
@@ -298,6 +353,7 @@ class StructuredMapRenderer(StructuredOutputBase, BaseChart):
                     total_count=layer_result.total_count,
                     capped=layer_result.capped,
                     geodesic=layer_result.geodesic,
+                    marker_color=marker_color,
                 )
                 layers.append(map_layer)
                 all_payloads.append(
@@ -557,6 +613,124 @@ class StructuredMapRenderer(StructuredOutputBase, BaseChart):
             )
         except Exception:
             return None
+
+    # ── Marker color extraction (piggyback) ──────────────────────────────────────
+
+    def _extract_marker_colors(
+        self, explanation: Optional[str]
+    ) -> Tuple[Dict[str, str], Optional[str]]:
+        """Extract LLM-supplied marker colors from the explanation text.
+
+        The map system prompt instructs the LLM to append a single fenced
+        ``​```mapcolors {...}```​`` block to its explanation **only** when the
+        user requested marker colors.  This rides on the same generation call —
+        no extra LLM round-trip.  The block is parsed into a
+        ``{layer_or_default: canonical_color}`` mapping and stripped from the
+        explanation so it never reaches the user.
+
+        Color values are validated against a closed set of CSS color names plus
+        hex strings; unknown values are dropped (fail-open).
+
+        Args:
+            explanation: The producing agent's explanation text (may be None).
+
+        Returns:
+            Tuple of ``(colors, cleaned_explanation)``.  ``colors`` is possibly
+            empty; ``cleaned_explanation`` has the block removed (or the original
+            text unchanged when no block was present).  Never raises.
+        """
+        if not isinstance(explanation, str) or "```mapcolors" not in explanation.lower():
+            return {}, explanation
+
+        match = _MAPCOLORS_BLOCK_RE.search(explanation)
+        if match is None:
+            return {}, explanation
+
+        cleaned = _MAPCOLORS_BLOCK_RE.sub("", explanation).strip() or None
+
+        try:
+            raw = json.loads(match.group("body"))
+        except (json.JSONDecodeError, ValueError) as exc:
+            logger.debug(
+                "StructuredMapRenderer: malformed ```mapcolors``` block — ignored (%s)",
+                exc,
+            )
+            return {}, cleaned
+
+        # Accept either a bare mapping or {"marker_colors": {...}}.
+        if isinstance(raw, dict) and isinstance(raw.get("marker_colors"), dict):
+            raw = raw["marker_colors"]
+        if not isinstance(raw, dict):
+            return {}, cleaned
+
+        colors: Dict[str, str] = {}
+        for key, value in raw.items():
+            normalized = self._normalize_color(value)
+            if normalized is not None:
+                colors[str(key)] = normalized
+            else:
+                logger.debug(
+                    "StructuredMapRenderer: dropped unsupported marker color %r "
+                    "for key %r",
+                    value, key,
+                )
+        return colors, cleaned
+
+    @staticmethod
+    def _normalize_color(value: Any) -> Optional[str]:
+        """Normalize a single color value to a canonical form, or None.
+
+        Accepts a closed set of CSS color names (case-insensitive) or a 3-/6-digit
+        hex string.  Anything else returns ``None`` (the layer then has no color
+        and the frontend uses its default).
+
+        Args:
+            value: The raw color value from the LLM (any type).
+
+        Returns:
+            A lowercased color name / hex string, or ``None`` when unsupported.
+        """
+        if not isinstance(value, str):
+            return None
+        candidate = value.strip()
+        if not candidate:
+            return None
+        if _HEX_COLOR_RE.match(candidate):
+            return candidate.lower()
+        lowered = candidate.lower()
+        if lowered in _NAMED_COLORS:
+            return lowered
+        return None
+
+    @staticmethod
+    def _resolve_layer_color(
+        colors: Dict[str, str],
+        dataset_name: str,
+        layer_id: str,
+    ) -> Optional[str]:
+        """Pick the color for one layer from the parsed color mapping.
+
+        Resolution order: exact dataset name → layer id → a ``default``/``all``/``*``
+        key → the single value when the mapping has exactly one entry.  Matching
+        is case-insensitive.
+
+        Args:
+            colors: Parsed ``{key: canonical_color}`` mapping (may be empty).
+            dataset_name: The dataset key from the ``SpatialResult.layers`` dict.
+            layer_id: The ``SpatialLayerResult.layer`` discriminator.
+
+        Returns:
+            A canonical color string, or ``None`` when nothing matches.
+        """
+        if not colors:
+            return None
+        lookup = {str(k).lower(): v for k, v in colors.items()}
+        for key in (dataset_name, layer_id, *_DEFAULT_COLOR_KEYS):
+            if key is not None and str(key).lower() in lookup:
+                return lookup[str(key).lower()]
+        if len(colors) == 1:
+            return next(iter(colors.values()))
+        return None
 
     # ── LLM-refine pass ────────────────────────────────────────────────────────
 

--- a/packages/ai-parrot/src/parrot/models/outputs.py
+++ b/packages/ai-parrot/src/parrot/models/outputs.py
@@ -656,6 +656,11 @@ class MapLayer(BaseModel):
         capped: True when the per-dataset result was truncated at the hard cap.
         geodesic: Whether the executed path was geodesic (True) or
             spherical-approximate (False). Sourced from ``SpatialLayerResult``.
+        marker_color: Optional marker/pin color for every feature in this layer,
+            derived from the user's request (piggyback — no extra LLM call). A
+            canonical CSS color name (e.g. ``"red"``, ``"blue"``) or a hex string
+            (e.g. ``"#1f77b4"``). ``None`` = the frontend uses its default marker
+            color.
     """
 
     model_config = ConfigDict(populate_by_name=True)
@@ -691,6 +696,14 @@ class MapLayer(BaseModel):
     geodesic: Optional[bool] = Field(
         default=None,
         description="True = geodesic path; False = spherical-approx. From SpatialLayerResult.",
+    )
+    marker_color: Optional[str] = Field(
+        default=None,
+        alias="markerColor",
+        description=(
+            "Optional marker/pin color for this layer (CSS color name or hex). "
+            "Derived from the user's request; None = frontend default."
+        ),
     )
 
 

--- a/packages/ai-parrot/tests/models/test_structured_map_config.py
+++ b/packages/ai-parrot/tests/models/test_structured_map_config.py
@@ -98,6 +98,38 @@ def test_map_layer_alias_fields():
     assert dumped["capped"] is True
 
 
+def test_map_layer_marker_color_default_none():
+    """MapLayer.marker_color defaults to None."""
+    from parrot.models.outputs import MapLayer, MapColumn
+
+    layer = MapLayer(
+        layer="schools",
+        columns=[MapColumn(name="name", type="string", title="Name")],
+    )
+    assert layer.marker_color is None
+
+
+def test_map_layer_marker_color_alias():
+    """MapLayer.marker_color round-trips via the camelCase alias."""
+    from parrot.models.outputs import MapLayer, MapColumn
+
+    layer = MapLayer(
+        layer="schools",
+        columns=[MapColumn(name="name", type="string", title="Name")],
+        marker_color="red",
+    )
+    dumped = layer.model_dump(mode="json", by_alias=True)
+    assert dumped["markerColor"] == "red"
+
+    # Accepts the alias on input too (populate_by_name).
+    from_alias = MapLayer(
+        layer="schools",
+        columns=[MapColumn(name="name", type="string", title="Name")],
+        markerColor="#1f77b4",
+    )
+    assert from_alias.marker_color == "#1f77b4"
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # TASK-1445 — MapViewport model
 # ─────────────────────────────────────────────────────────────────────────────

--- a/packages/ai-parrot/tests/outputs/formats/test_structured_map_renderer.py
+++ b/packages/ai-parrot/tests/outputs/formats/test_structured_map_renderer.py
@@ -209,6 +209,125 @@ async def test_render_viewport_bbox(two_layer_result):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Marker colors (piggyback — FEAT-221)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _layers_by_id(out):
+    return {layer["layer"]: layer for layer in out["layers"]}
+
+
+@pytest.mark.asyncio
+async def test_marker_color_default_applies_to_all_layers(two_layer_result):
+    """A 'default' color is applied to every layer."""
+    from parrot.outputs.formats import get_renderer
+    from parrot.models.outputs import OutputMode
+
+    r = get_renderer(OutputMode.STRUCTURED_MAP)()
+    text = 'Here is your map.\n```mapcolors\n{"default": "red"}\n```'
+    resp = make_response(data=two_layer_result, response_text=text)
+    out, explanation = await r.render(resp)
+
+    layers = _layers_by_id(out)
+    assert layers["schools"]["markerColor"] == "red"
+    assert layers["malls"]["markerColor"] == "red"
+    # The fenced block is stripped from the explanation shown to the user.
+    assert "mapcolors" not in (explanation or "")
+    assert explanation == "Here is your map."
+
+
+@pytest.mark.asyncio
+async def test_marker_color_per_layer(two_layer_result):
+    """Per-dataset colors are matched by dataset name."""
+    from parrot.outputs.formats import get_renderer
+    from parrot.models.outputs import OutputMode
+
+    r = get_renderer(OutputMode.STRUCTURED_MAP)()
+    text = '```mapcolors\n{"schools": "blue", "malls": "green"}\n```'
+    resp = make_response(data=two_layer_result, response_text=text)
+    out, _ = await r.render(resp)
+
+    layers = _layers_by_id(out)
+    assert layers["schools"]["markerColor"] == "blue"
+    assert layers["malls"]["markerColor"] == "green"
+
+
+@pytest.mark.asyncio
+async def test_marker_color_hex_accepted(two_layer_result):
+    """Hex color values are accepted and lowercased."""
+    from parrot.outputs.formats import get_renderer
+    from parrot.models.outputs import OutputMode
+
+    r = get_renderer(OutputMode.STRUCTURED_MAP)()
+    text = '```mapcolors\n{"default": "#1F77B4"}\n```'
+    resp = make_response(data=two_layer_result, response_text=text)
+    out, _ = await r.render(resp)
+
+    assert all(layer["markerColor"] == "#1f77b4" for layer in out["layers"])
+
+
+@pytest.mark.asyncio
+async def test_marker_color_invalid_dropped(two_layer_result):
+    """Unsupported color names are dropped (fail-open → no color)."""
+    from parrot.outputs.formats import get_renderer
+    from parrot.models.outputs import OutputMode
+
+    r = get_renderer(OutputMode.STRUCTURED_MAP)()
+    text = '```mapcolors\n{"schools": "definitely-not-a-color"}\n```'
+    resp = make_response(data=two_layer_result, response_text=text)
+    out, _ = await r.render(resp)
+
+    layers = _layers_by_id(out)
+    assert layers["schools"]["markerColor"] is None
+    assert layers["malls"]["markerColor"] is None
+
+
+@pytest.mark.asyncio
+async def test_marker_color_absent_when_no_block(two_layer_result):
+    """No fenced block → no marker color (default behaviour preserved)."""
+    from parrot.outputs.formats import get_renderer
+    from parrot.models.outputs import OutputMode
+
+    r = get_renderer(OutputMode.STRUCTURED_MAP)()
+    resp = make_response(data=two_layer_result, response_text="A plain map.")
+    out, explanation = await r.render(resp)
+
+    assert all(layer["markerColor"] is None for layer in out["layers"])
+    assert explanation == "A plain map."
+
+
+@pytest.mark.asyncio
+async def test_marker_color_malformed_block_ignored(two_layer_result):
+    """A malformed JSON block is ignored without raising."""
+    from parrot.outputs.formats import get_renderer
+    from parrot.models.outputs import OutputMode
+
+    r = get_renderer(OutputMode.STRUCTURED_MAP)()
+    text = '```mapcolors\n{not valid json}\n```'
+    resp = make_response(data=two_layer_result, response_text=text)
+    out, explanation = await r.render(resp)
+
+    assert out is not None
+    assert all(layer["markerColor"] is None for layer in out["layers"])
+    # Block is still stripped even when its body fails to parse.
+    assert "mapcolors" not in (explanation or "")
+
+
+@pytest.mark.asyncio
+async def test_marker_color_marker_colors_wrapper(two_layer_result):
+    """A {"marker_colors": {...}} wrapper object is unwrapped."""
+    from parrot.outputs.formats import get_renderer
+    from parrot.models.outputs import OutputMode
+
+    r = get_renderer(OutputMode.STRUCTURED_MAP)()
+    text = '```mapcolors\n{"marker_colors": {"default": "purple"}}\n```'
+    resp = make_response(data=two_layer_result, response_text=text)
+    out, _ = await r.render(resp)
+
+    assert all(layer["markerColor"] == "purple" for layer in out["layers"])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # data_shape support
 # ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Qué hace

Agrega **color de marcadores/chinchetas por capa** al modo de salida `STRUCTURED_MAP`, tomando el color desde la pregunta del usuario **sin agregar ninguna llamada extra al LLM** (piggyback sobre la llamada de generación que ya ocurre).

## Cómo funciona

El system prompt del mapa instruye al LLM a anexar un bloque cercado a su explicación **solo cuando el usuario pide color**:

```mapcolors
{"default": "red"}          // o por capa: {"schools": "blue", "malls": "green"}
```

`StructuredMapRenderer` lo extrae desde `response.response`, lo **quita** de la explicación (no llega al usuario), normaliza el color (lista cerrada de nombres CSS + hex, fail-open) y resuelve un color por capa (match por dataset → layer id → clave `default`/`all`/`*`).

El canal es la explicación del LLM → funciona en **ambos paths** (tool espacial y DataFrame), es agnóstico de proveedor y **no toca `data.py`** ni el binding de structured-output.

## Cambios

- `packages/ai-parrot/src/parrot/models/outputs.py` — nuevo `MapLayer.marker_color` (alias `markerColor`).
- `packages/ai-parrot-visualizations/.../formats/structured_map.py` — sección del prompt, `_extract_marker_colors`, `_normalize_color`, `_resolve_layer_color`, cableado en `render()`.
- Tests (modelo + renderer): default / por capa / hex / inválido / ausente / malformado / wrapper.

## Contrato para el front

Cada capa puede traer `markerColor` (`"red"`, `"#1f77b4"`, o `null` = estilo por defecto).

## Tests

9 tests nuevos en verde. El único fallo del suite es preexistente y ajeno (falta la dependencia opcional `aioquic`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)