### PR TITLE
STRUCTURED_MAP: Separate tabular rows from GeoJSON payloads

### DIFF
--- a/packages/ai-parrot-visualizations/src/parrot/outputs/formats/structured_map.py
+++ b/packages/ai-parrot-visualizations/src/parrot/outputs/formats/structured_map.py
@@ -1,9 +1,12 @@
 """FEAT-221: Structured Map Output Mode renderer.
 
 Deterministically converts a per-dataset ``SpatialResult`` (in ``response.data``)
-into a :class:`~parrot.models.outputs.StructuredMapConfig`, sets ``response.data``
-to the per-layer payload, and returns ``(out_without_data, explanation)`` so the
-HTTP envelope mirrors the STRUCTURED_TABLE / STRUCTURED_CHART shape.
+into a :class:`~parrot.models.outputs.StructuredMapConfig` whose ``datasets`` key
+carries the per-layer GeoJSON/rows payloads, sets ``response.data`` to the flat
+tabular rows the payloads were built from, and returns
+``(out_without_data, explanation)`` so the HTTP envelope mirrors the
+STRUCTURED_TABLE / STRUCTURED_CHART shape (``data`` = tabular rows,
+``output`` = full presentation spec including the GeoJSON).
 
 Key design decisions (mirroring StructuredTableRenderer):
 - The **deterministic layer owns data + base schema** — no LLM involvement for
@@ -141,7 +144,11 @@ class StructuredMapRenderer(StructuredOutputBase, BaseChart):
 
     The renderer always:
 
-    - Sets ``response.data`` to the per-layer payload list.
+    - Sets ``response.data`` to the flat tabular rows (feature properties plus
+      ``latitude``/``longitude`` for Point geometries, ``_geometry`` otherwise,
+      and a ``layer`` discriminator when the result has multiple layers).
+    - Includes the per-layer payload list in the config's ``datasets`` key, so
+      the GeoJSON travels in ``output``.
     - Returns ``(out_without_data, explanation)`` — the structured-map config
       dict with the ``data`` key excluded, paired with the prose explanation.
     - Returns ``(None, error_message)`` on any unrecoverable error — never raises.
@@ -172,8 +179,9 @@ class StructuredMapRenderer(StructuredOutputBase, BaseChart):
         4. Optional LLM-refine pass for ambiguous column format hints.
         5. Compute ``MapViewport`` from feature bounds.
         6. Build ``MapQuery`` from originating ``SpatialFilterSpec`` (if present).
-        7. Build ``StructuredMapConfig``; exclude ``data`` from output.
-        8. Set ``response.data`` to the per-layer payload list; return ``(out, explanation)``.
+        7. Build ``StructuredMapConfig`` with the per-layer payloads in
+           ``datasets``; exclude ``data`` from output.
+        8. Set ``response.data`` to the flat tabular rows; return ``(out, explanation)``.
 
         On any error: return ``(None, error_message)`` — never raise.
 
@@ -315,11 +323,15 @@ class StructuredMapRenderer(StructuredOutputBase, BaseChart):
             # Step 6: Build MapQuery from SpatialFilterSpec (if present in response).
             query = self._extract_map_query(response)
 
-            # Step 7: Build StructuredMapConfig (with data list for potential validation skip).
+            # Step 7: Build StructuredMapConfig. The per-layer GeoJSON/rows
+            # payloads travel in `datasets` (serialized into output); `data`
+            # stays [] to skip the column-name validator (multi-layer footgun —
+            # see StructuredMapConfig._validate_column_names).
             try:
                 cfg = StructuredMapConfig(
                     layers=layers,
-                    data=[],  # data is in all_payloads; skip column-name validator
+                    data=[],
+                    datasets=all_payloads,
                     viewport=viewport,
                     query=query,
                     explanation=explanation,
@@ -331,10 +343,12 @@ class StructuredMapRenderer(StructuredOutputBase, BaseChart):
 
             # Step 8: Route envelope via shared base (data excluded; explanation wrapped).
             # cfg.data is [] by design so _route_envelope skips data routing; we
-            # route all_payloads explicitly below.
+            # route the flat tabular rows explicitly below.
             out, wrapped = self._route_envelope(response, cfg, explanation)
-            if all_payloads:
-                response.data = all_payloads
+            if spatial_result.layers:
+                response.data = self._build_tabular_rows(
+                    spatial_result, row_limit=effective_row_limit,
+                )
             return out, wrapped
 
         except Exception as exc:  # noqa: BLE001
@@ -462,6 +476,50 @@ class StructuredMapRenderer(StructuredOutputBase, BaseChart):
             "rows": rows,
             "truncated": len(features) > row_limit,
         }
+
+    # ── Tabular rows builder ───────────────────────────────────────────────────
+
+    @staticmethod
+    def _build_tabular_rows(
+        spatial_result: Any,
+        *,
+        row_limit: int,
+    ) -> List[Dict]:
+        """Flatten all layers' features into the tabular rows for ``response.data``.
+
+        Each row carries the feature's ``properties`` plus the geometry it was
+        built from: ``latitude``/``longitude`` columns for Point geometries, or
+        a ``_geometry`` key with the raw GeoJSON geometry otherwise. When the
+        result has more than one layer, a ``layer`` discriminator column is
+        added. Existing property keys are never overwritten.
+
+        Args:
+            spatial_result: A ``SpatialResult`` instance.
+            row_limit: Maximum rows to include per layer.
+
+        Returns:
+            Flat list of row dicts across all layers.
+        """
+        multi_layer = len(spatial_result.layers) > 1
+        rows: List[Dict] = []
+        for layer_result in spatial_result.layers.values():
+            for feat in layer_result.features[:row_limit]:
+                row = dict(feat.get("properties") or {})
+                geometry = feat.get("geometry")
+                if (
+                    isinstance(geometry, dict)
+                    and geometry.get("type") == "Point"
+                    and isinstance(geometry.get("coordinates"), (list, tuple))
+                    and len(geometry["coordinates"]) >= 2
+                ):
+                    row.setdefault("latitude", geometry["coordinates"][1])
+                    row.setdefault("longitude", geometry["coordinates"][0])
+                else:
+                    row.setdefault("_geometry", geometry)
+                if multi_layer:
+                    row.setdefault("layer", layer_result.layer)
+                rows.append(row)
+        return rows
 
     # ── Viewport computation ───────────────────────────────────────────────────
 

--- a/packages/ai-parrot/src/parrot/bots/data.py
+++ b/packages/ai-parrot/src/parrot/bots/data.py
@@ -1978,8 +1978,11 @@ class PandasAgent(IntentRouterMixin, BasicAgent):
                     # G2 safety net: the renderer already excludes rows, but strip
                     # any stray `data` key defensively so the envelope definition
                     # never carries rows (rows live in response.data only).
+                    # `datasets` (STRUCTURED_MAP per-layer GeoJSON payloads) is
+                    # also stripped to keep the stored artifact lean.
                     _definition = {
-                        _k: _v for _k, _v in content.items() if _k != "data"
+                        _k: _v for _k, _v in content.items()
+                        if _k not in ("data", "datasets")
                     }
                     response.artifacts.append({
                         "type": _art_type,

--- a/packages/ai-parrot/src/parrot/models/outputs.py
+++ b/packages/ai-parrot/src/parrot/models/outputs.py
@@ -744,8 +744,11 @@ class StructuredMapConfig(BaseModel):
 
     Attributes:
         layers: One ``MapLayer`` per dataset with data-schema + presentation hints.
-        data: Flat data rows or per-layer payloads — INPUT-ONLY; excluded from
-            ``output``, routed to ``response.data`` by the renderer.
+        data: Flat tabular rows — INPUT-ONLY; excluded from ``output``,
+            routed to ``response.data`` by the renderer.
+        datasets: Per-layer GeoJSON/rows payloads — INCLUDED in ``output``
+            (unlike ``data``); stripped from the FEAT-224 artifact definition
+            to keep chat storage lean.
         viewport: Viewport hints (bbox + optional center/zoom).
         query: Echoed ``SpatialFilterSpec`` parameters (point / radius / unit).
         base_layer: Optional base-tile/style hint for the frontend (e.g. an OSM
@@ -763,8 +766,16 @@ class StructuredMapConfig(BaseModel):
     data: List[dict] = Field(
         default_factory=list,
         description=(
-            "Per-layer payloads; INPUT-ONLY — excluded from ``output``, "
+            "Flat tabular rows; INPUT-ONLY — excluded from ``output``, "
             "routed to response.data by the renderer."
+        ),
+    )
+    datasets: List[dict] = Field(
+        default_factory=list,
+        description=(
+            "Per-layer GeoJSON/rows payloads [{dataset, layer, data_shape, payload}]; "
+            "INCLUDED in output (unlike ``data``). Stripped from the FEAT-224 "
+            "artifact definition to keep chat storage lean."
         ),
     )
     viewport: Optional[MapViewport] = Field(

--- a/packages/ai-parrot/tests/integration/test_structured_artifact_envelope_e2e.py
+++ b/packages/ai-parrot/tests/integration/test_structured_artifact_envelope_e2e.py
@@ -49,10 +49,13 @@ def _attach_envelope(response: Any, output_mode: str, content: Any) -> None:
     art_type = _STRUCTURED_ARTIFACT_TYPE.get(output_mode)
     if art_type and isinstance(content, dict) and content:
         art_id = f"{output_mode}-{uuid.uuid4().hex[:8]}"
+        # Mirror data.py: strip `data` (rows) and `datasets` (STRUCTURED_MAP
+        # per-layer GeoJSON payloads) so the stored definition stays lean.
+        definition = {k: v for k, v in content.items() if k not in ("data", "datasets")}
         response.artifacts.append({
             "type": art_type,
             "artifactId": art_id,
-            "definition": content,
+            "definition": definition,
         })
         response.artifact_id = art_id
         response.output = content  # G6 mirror
@@ -192,7 +195,7 @@ async def test_e2e_table_envelope_end_to_end() -> None:
 @satellite_available
 @pytest.mark.asyncio
 async def test_e2e_map_envelope_end_to_end() -> None:
-    """E2E: STRUCTURED_MAP produces artifacts[].definition + per-layer payloads in data."""
+    """E2E: STRUCTURED_MAP — payloads in output.datasets, tabular rows in data."""
     from parrot.models.outputs import OutputMode
     from parrot.outputs.formats import get_renderer
     from parrot.tools.dataset_manager.spatial import SpatialResult, SpatialLayerResult
@@ -219,14 +222,22 @@ async def test_e2e_map_envelope_end_to_end() -> None:
 
     assert content is not None, "renderer must return a config dict"
     assert "data" not in content, "definition must exclude data key"
+    # Per-layer GeoJSON payloads travel in output.datasets
+    assert isinstance(content["datasets"], list) and len(content["datasets"]) == 1
+    assert content["datasets"][0]["payload"]["type"] == "FeatureCollection"
 
     _attach_envelope(resp, "structured_map", content)
 
     _assert_artifact_envelope(resp, "map")
+    # The stored artifact definition stays lean — no GeoJSON payloads
+    assert "datasets" not in resp.artifacts[0]["definition"]
 
-    # G2: per-layer payloads in response.data
+    # Tabular rows (properties + coordinates) in response.data
     assert resp.data is not None
-    assert isinstance(resp.data, list) and len(resp.data) >= 1
+    assert isinstance(resp.data, list) and len(resp.data) == 1
+    assert resp.data[0]["name"] == "Place A"
+    assert resp.data[0]["latitude"] == 40.7
+    assert resp.data[0]["longitude"] == -74.0
 
 
 # ── Parametrized contract test ────────────────────────────────────────────────

--- a/packages/ai-parrot/tests/integration/test_structured_map_e2e.py
+++ b/packages/ai-parrot/tests/integration/test_structured_map_e2e.py
@@ -129,7 +129,8 @@ async def test_structured_map_e2e_llm_mode(two_dataset_spatial_result):
     Verifies:
     - out is not None and 'data' is not in out.
     - out['layers'] has correct layer names.
-    - response.data is set (per-layer payloads).
+    - out['datasets'] carries the per-layer GeoJSON payloads.
+    - response.data is set (flat tabular rows).
     - explanation is passed through.
     """
     from parrot.outputs.formats import get_renderer
@@ -152,8 +153,14 @@ async def test_structured_map_e2e_llm_mode(two_dataset_spatial_result):
     assert "schools" in layer_names
     assert "malls" in layer_names
 
-    # response.data set
+    # GeoJSON payloads in output.datasets — one entry per layer
+    assert {entry["layer"] for entry in out["datasets"]} == layer_names
+    for entry in out["datasets"]:
+        assert isinstance(entry["payload"], dict)
+
+    # response.data set (flat tabular rows, not per-layer payloads)
     assert resp.data is not None
+    assert all("payload" not in row for row in resp.data)
 
     # Explanation
     assert explanation == "Found schools and malls within 5 miles."

--- a/packages/ai-parrot/tests/models/test_structured_map_config.py
+++ b/packages/ai-parrot/tests/models/test_structured_map_config.py
@@ -167,6 +167,27 @@ def test_config_data_accessible_on_model():
     assert len(cfg.data) == 2
 
 
+def test_config_datasets_included_in_dump():
+    """datasets (per-layer GeoJSON payloads) defaults to [] and survives the dump."""
+    from parrot.models.outputs import StructuredMapConfig, MapLayer, MapColumn
+
+    layer = MapLayer(layer="schools", columns=[MapColumn(name="name", type="string", title="Name")])
+
+    cfg = StructuredMapConfig(layers=[layer])
+    assert cfg.datasets == []
+
+    payload = {
+        "dataset": "schools",
+        "layer": "schools",
+        "data_shape": "geojson",
+        "payload": {"type": "FeatureCollection", "features": []},
+    }
+    cfg = StructuredMapConfig(layers=[layer], data=[], datasets=[payload])
+    out = cfg.model_dump(mode="json", by_alias=True, exclude={"data"})
+    assert "data" not in out
+    assert out["datasets"] == [payload]
+
+
 def test_config_defaults():
     """viewport, query, base_layer, title, description, explanation default to None."""
     from parrot.models.outputs import StructuredMapConfig, MapLayer, MapColumn

--- a/packages/ai-parrot/tests/outputs/formats/test_structured_map_renderer.py
+++ b/packages/ai-parrot/tests/outputs/formats/test_structured_map_renderer.py
@@ -179,7 +179,7 @@ async def test_render_data_excluded(two_layer_result):
 
 @pytest.mark.asyncio
 async def test_render_sets_response_data(two_layer_result):
-    """render() sets response.data to the per-layer payloads."""
+    """render() sets response.data to the flat tabular rows."""
     from parrot.outputs.formats import get_renderer
     from parrot.models.outputs import OutputMode
 
@@ -189,7 +189,11 @@ async def test_render_sets_response_data(two_layer_result):
 
     assert resp.data is not None
     assert isinstance(resp.data, list)
-    assert len(resp.data) > 0
+    # 2 school features + 1 mall feature = 3 flat rows
+    assert len(resp.data) == 3
+    for row in resp.data:
+        assert isinstance(row, dict)
+        assert "payload" not in row, "rows must be tabular, not per-layer payloads"
 
 
 @pytest.mark.asyncio
@@ -215,21 +219,22 @@ async def test_render_viewport_bbox(two_layer_result):
 
 @pytest.mark.asyncio
 async def test_render_geojson_data_shape(two_layer_result):
-    """data_shape=geojson passes features through as FeatureCollection."""
+    """data_shape=geojson passes features through as FeatureCollection in output.datasets."""
     from parrot.outputs.formats import get_renderer
     from parrot.models.outputs import OutputMode
 
     r = get_renderer(OutputMode.STRUCTURED_MAP)()
     resp = make_response(data=two_layer_result)
-    await r.render(resp)
+    out, _ = await r.render(resp)
 
     # Default data_shape is geojson (no profile in test)
-    payloads = resp.data
+    payloads = out["datasets"]
+    assert len(payloads) == 2
     for entry in payloads:
         assert "payload" in entry
         payload = entry["payload"]
-        # Should be FeatureCollection or rows dict
         assert isinstance(payload, dict)
+        assert payload["type"] == "FeatureCollection"
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -415,8 +420,8 @@ class TestMapEnvelopeConformance:
         assert "data" not in out, "data key must be excluded from output via _route_envelope"
 
     @pytest.mark.asyncio
-    async def test_payloads_routed_to_response_data(self, two_layer_result):
-        """Per-layer payloads are routed to response.data after the retrofit."""
+    async def test_payloads_routed_to_output_datasets(self, two_layer_result):
+        """Per-layer payloads live in output.datasets; response.data is tabular rows."""
         from parrot.outputs.formats import get_renderer
         from parrot.models.outputs import OutputMode
 
@@ -425,11 +430,16 @@ class TestMapEnvelopeConformance:
         out, _ = await r.render(resp)
 
         assert out is not None
-        assert isinstance(resp.data, list) and len(resp.data) > 0
-        # Each entry is a per-layer payload dict
-        for entry in resp.data:
+        # GeoJSON payloads travel in output.datasets
+        assert isinstance(out["datasets"], list) and len(out["datasets"]) == 2
+        for entry in out["datasets"]:
             assert "dataset" in entry
             assert "payload" in entry
+        # response.data carries the flat tabular rows the payloads were built from
+        assert isinstance(resp.data, list) and len(resp.data) == 3
+        for row in resp.data:
+            assert "dataset" not in row
+            assert "payload" not in row
 
     @pytest.mark.asyncio
     async def test_existing_behavior_preserved(self, two_layer_result):
@@ -452,8 +462,9 @@ class TestMapEnvelopeConformance:
         # Layers present
         assert "layers" in out
         assert len(out["layers"]) == 2
-        # Payload entries available on response.data
-        assert isinstance(resp.data, list) and len(resp.data) == 2
+        # Payload entries available on output.datasets; tabular rows on response.data
+        assert isinstance(out["datasets"], list) and len(out["datasets"]) == 2
+        assert isinstance(resp.data, list) and len(resp.data) == 3
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -499,3 +510,133 @@ async def test_render_accepts_dataframe_converted_warehouses():
     assert out is not None
     assert "layers" in out and len(out["layers"]) == 1
     assert explanation == "3 warehouses."
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tabular rows contract — response.data carries the data the GeoJSON was built
+# from (properties + coordinates), NOT the GeoJSON itself.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tabular_rows_point_coordinates(two_layer_result):
+    """Point features yield latitude/longitude columns in response.data rows."""
+    from parrot.outputs.formats import get_renderer
+    from parrot.models.outputs import OutputMode
+
+    r = get_renderer(OutputMode.STRUCTURED_MAP)()
+    resp = make_response(data=two_layer_result)
+    await r.render(resp)
+
+    school_row = next(row for row in resp.data if row.get("name") == "PS 1")
+    assert school_row["latitude"] == 40.7
+    assert school_row["longitude"] == -74.0
+    assert school_row["enrollment"] == 500
+    assert "_geometry" not in school_row
+
+
+@pytest.mark.asyncio
+async def test_tabular_rows_layer_discriminator(two_layer_result):
+    """Multi-layer results add a 'layer' column to every row."""
+    from parrot.outputs.formats import get_renderer
+    from parrot.models.outputs import OutputMode
+
+    r = get_renderer(OutputMode.STRUCTURED_MAP)()
+    resp = make_response(data=two_layer_result)
+    await r.render(resp)
+
+    assert {row["layer"] for row in resp.data} == {"schools", "malls"}
+
+
+@pytest.mark.asyncio
+async def test_tabular_rows_single_layer_no_discriminator():
+    """Single-layer results do NOT add a 'layer' column."""
+    from parrot.outputs.formats import get_renderer
+    from parrot.models.outputs import OutputMode
+    from parrot.tools.dataset_manager.spatial import SpatialResult, SpatialLayerResult
+
+    spatial = SpatialResult(
+        layers={
+            "stores": SpatialLayerResult(
+                layer="stores",
+                features=[
+                    {
+                        "type": "Feature",
+                        "geometry": {"type": "Point", "coordinates": [-73.9, 40.8]},
+                        "properties": {"name": "Store A"},
+                    },
+                ],
+                total_count=1,
+            ),
+        }
+    )
+    r = get_renderer(OutputMode.STRUCTURED_MAP)()
+    resp = make_response(data=spatial)
+    await r.render(resp)
+
+    assert len(resp.data) == 1
+    assert "layer" not in resp.data[0]
+
+
+@pytest.mark.asyncio
+async def test_tabular_rows_non_point_geometry():
+    """Non-Point geometries are preserved under a '_geometry' key (no lat/lon)."""
+    from parrot.outputs.formats import get_renderer
+    from parrot.models.outputs import OutputMode
+    from parrot.tools.dataset_manager.spatial import SpatialResult, SpatialLayerResult
+
+    polygon = {
+        "type": "Polygon",
+        "coordinates": [[[-74.0, 40.7], [-74.0, 40.8], [-73.9, 40.8], [-74.0, 40.7]]],
+    }
+    spatial = SpatialResult(
+        layers={
+            "zones": SpatialLayerResult(
+                layer="zones",
+                features=[
+                    {
+                        "type": "Feature",
+                        "geometry": polygon,
+                        "properties": {"name": "Zone 1"},
+                    },
+                ],
+                total_count=1,
+            ),
+        }
+    )
+    r = get_renderer(OutputMode.STRUCTURED_MAP)()
+    resp = make_response(data=spatial)
+    await r.render(resp)
+
+    row = resp.data[0]
+    assert row["_geometry"] == polygon
+    assert "latitude" not in row
+    assert "longitude" not in row
+
+
+def test_tabular_rows_property_keys_win():
+    """Existing property keys (latitude/longitude/layer) are never overwritten."""
+    from parrot.outputs.formats.structured_map import StructuredMapRenderer
+    from parrot.tools.dataset_manager.spatial import SpatialResult, SpatialLayerResult
+
+    spatial = SpatialResult(
+        layers={
+            "a": SpatialLayerResult(
+                layer="a",
+                features=[
+                    {
+                        "type": "Feature",
+                        "geometry": {"type": "Point", "coordinates": [-74.0, 40.7]},
+                        "properties": {"latitude": "original", "layer": "custom"},
+                    },
+                ],
+                total_count=1,
+            ),
+            "b": SpatialLayerResult(layer="b", features=[], total_count=0),
+        }
+    )
+    rows = StructuredMapRenderer._build_tabular_rows(spatial, row_limit=1000)
+
+    assert rows[0]["latitude"] == "original"
+    assert rows[0]["layer"] == "custom"
+    assert rows[0]["longitude"] == -74.0


### PR DESCRIPTION
## Summary

Refactors the STRUCTURED_MAP renderer to cleanly separate concerns: `response.data` now carries flat tabular rows (feature properties + coordinates), while per-layer GeoJSON payloads travel in `output.datasets`. This mirrors the STRUCTURED_TABLE/STRUCTURED_CHART pattern where `data` = rows and `output` = full presentation spec.

## Key Changes

- **Tabular rows contract**: Added `_build_tabular_rows()` static method that flattens all layers' features into a single list of dicts, extracting:
  - Feature properties as row columns
  - `latitude`/`longitude` for Point geometries (or `_geometry` key for other types)
  - `layer` discriminator column when result has multiple layers
  - Respects existing property keys (never overwrites)

- **StructuredMapConfig model**: 
  - Added `datasets` field to hold per-layer GeoJSON/rows payloads
  - Updated `data` field docstring to clarify it's for tabular rows (input-only)
  - `datasets` is included in output (unlike `data`) but stripped from FEAT-224 artifact definitions to keep chat storage lean

- **Renderer behavior**:
  - Step 8 now calls `_build_tabular_rows()` and sets `response.data` to the result
  - Per-layer payloads are routed to `cfg.datasets` instead of `response.data`
  - Artifact envelope and data.py updated to strip both `data` and `datasets` from stored definitions

- **Test coverage**: Added comprehensive test suite for tabular rows contract:
  - Point coordinate extraction (latitude/longitude)
  - Layer discriminator column behavior
  - Non-Point geometry handling (_geometry key)
  - Property key precedence (existing keys never overwritten)
  - Updated existing tests to verify new routing behavior

## Implementation Details

- The `_build_tabular_rows()` method is static and reusable, accepting a `SpatialResult` and row limit
- Multi-layer detection is automatic: discriminator column only added when `len(spatial_result.layers) > 1`
- Geometry handling is defensive: Point coordinates must be a list/tuple with ≥2 elements
- All existing property keys are preserved via `setdefault()` — no silent overwrites

https://claude.ai/code/session_01D2KMoR71hh9ansFvWGS4fP