### PR TITLE
Add list_skill_commands tool to SkillFileToolkit

### DIFF
--- a/.agent/CONTEXT.md
+++ b/.agent/CONTEXT.md
@@ -59,10 +59,11 @@ each initialized once with its shared registry — never instantiate skill tools
 individually:
 
 - **`SkillFileToolkit`** — file-based skills, shares a `SkillFileRegistry`.
-  Tools: `load_skill` (body + asset manifest), `read_skill_asset` (sandboxed
-  reader for a composite skill's bundled asset; path-traversal rejected,
-  `SKILL.md` reserved for `load_skill`), `save_learned_skill` (only when a
-  `learned_dir` is configured).
+  Tools: `list_skill_commands` (live listing of skills with descriptions and
+  `/trigger` commands), `load_skill` (body + asset manifest),
+  `read_skill_asset` (sandboxed reader for a composite skill's bundled asset;
+  path-traversal rejected, `SKILL.md` reserved for `load_skill`),
+  `save_learned_skill` (only when a `learned_dir` is configured).
 - **`SkillRegistryToolkit`** — DB-backed skill registry, shares a
   `SkillRegistry` store + `agent_id`. Tools: `search_skills`, `read_skill`,
   `list_skills`, and the write tools `document_skill` / `update_skill` (exposed

--- a/packages/ai-parrot/src/parrot/skills/mixin.py
+++ b/packages/ai-parrot/src/parrot/skills/mixin.py
@@ -41,8 +41,9 @@ class SkillRegistryMixin:
       :func:`~parrot.skills.prompt.render_skills_prompt_layer` when
       :attr:`inject_skills_into_prompt` is ``True`` (FEAT-188).
     - :class:`~parrot.skills.tools.SkillFileToolkit` registration exposing
-      ``load_skill`` / ``read_skill_asset`` / ``save_learned_skill`` for
-      on-demand skill body and asset retrieval (FEAT-188).
+      ``list_skill_commands`` / ``load_skill`` / ``read_skill_asset`` /
+      ``save_learned_skill`` for skill discovery, on-demand body and asset
+      retrieval (FEAT-188).
 
     Usage::
 
@@ -234,14 +235,14 @@ class SkillRegistryMixin:
                     )
 
         # --- FEAT-188: file-based skill tools registration ---
-        # Register the SkillFileToolkit (load_skill / read_skill_asset /
-        # save_learned_skill) whenever file-based skills were discovered —
-        # whether via the agents_dir convention OR explicit skill_paths.
-        # Gating this on skill_paths alone left agents_dir-based agents with a
-        # <available_skills> prompt index promising load_skill() but no tool to
-        # honour it, so the model fell back to the DB-backed read_skill/
-        # list_skills (empty registry) and failed to load the skill body.
-        if self._skill_file_registry is not None and self._skill_file_registry.list_skills():
+        # Register the SkillFileToolkit (list_skill_commands / load_skill /
+        # read_skill_asset / save_learned_skill) whenever a file registry
+        # exists — whether populated via the agents_dir convention, explicit
+        # skill_paths, or still empty. An empty registry must still expose the
+        # tools: save_learned_skill can hot-add skills mid-session and
+        # list_skill_commands reads the live registry, so gating on a
+        # non-empty registry at configure() time would hide them forever.
+        if self._skill_file_registry is not None:
             from .tools import SkillFileToolkit
             toolkit = SkillFileToolkit(
                 file_registry=self._skill_file_registry,

--- a/packages/ai-parrot/src/parrot/skills/tools.py
+++ b/packages/ai-parrot/src/parrot/skills/tools.py
@@ -13,8 +13,9 @@ dependency:
 
 - :class:`SkillRegistryToolkit` — DB-backed registry (search/read/list/
   document/update), sharing a :class:`~parrot.skills.store.SkillRegistry`.
-- :class:`SkillFileToolkit` — file-based skills (load/read_asset/save_learned),
-  sharing a :class:`~parrot.skills.file_registry.SkillFileRegistry`.
+- :class:`SkillFileToolkit` — file-based skills (list_commands/load/read_asset/
+  save_learned), sharing a
+  :class:`~parrot.skills.file_registry.SkillFileRegistry`.
 """
 import asyncio
 from typing import Dict, List, Optional, Type
@@ -378,6 +379,8 @@ class SkillFileToolkit(AbstractToolkit):
 
     Tiers:
 
+    - ``list_skill_commands`` (Tier 1): live listing of every registered skill
+      with its description and ``/trigger`` commands.
     - ``load_skill`` (Tier 2): full skill body + asset manifest for composite
       skills.
     - ``read_skill_asset`` (Tier 2): sandboxed reader for a bundled asset.
@@ -406,6 +409,46 @@ class SkillFileToolkit(AbstractToolkit):
         # Only expose save_learned_skill when we have somewhere to write.
         if learned_dir is None:
             self.exclude_tools = ("save_learned_skill",)
+
+    async def list_skill_commands(self) -> ToolResult:
+        """List all available skills with their descriptions and /trigger
+        commands. Use to tell the user which skills and slash-commands are
+        available. Reads the live registry, so skills learned during the
+        current session are included.
+        """
+        skills = self._file_registry.list_skills()
+        if not skills:
+            return ToolResult(
+                status="done",
+                result="No skills available.",
+                metadata={"count": 0, "skills": []},
+            )
+
+        lines = [f"**{len(skills)} skills available:**"]
+        for skill in skills:
+            triggers = (
+                ", ".join(skill.triggers)
+                if skill.triggers
+                else "(no trigger — load with load_skill)"
+            )
+            lines.append(f"- {skill.name}: {skill.description} — {triggers}")
+
+        return ToolResult(
+            status="done",
+            result="\n".join(lines),
+            metadata={
+                "count": len(skills),
+                "skills": [
+                    {
+                        "name": s.name,
+                        "description": s.description,
+                        "triggers": list(s.triggers),
+                        "category": s.category,
+                    }
+                    for s in skills
+                ],
+            },
+        )
 
     @tool_schema(LoadSkillArgs)
     async def load_skill(self, name: str) -> ToolResult:

--- a/tests/integration/test_skill_registry_mixin.py
+++ b/tests/integration/test_skill_registry_mixin.py
@@ -93,6 +93,42 @@ async def test_skill_paths_discovers_and_registers(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_skill_paths_registers_list_skill_commands(tmp_path):
+    """Non-empty skill_paths: list_skill_commands tool is registered and
+    reports the discovered skills with their triggers."""
+    (tmp_path / "resumen.md").write_text(
+        "---\nname: resumen\ndescription: Summarize text\n"
+        "triggers:\n  - /resumen\n---\nSummarize the input text."
+    )
+    bot = MockBot(skill_paths=[tmp_path])
+    await bot._configure_skill_file_registry()
+
+    list_tool = next(
+        t for t in bot._tools
+        if hasattr(t, "name") and t.name == "list_skill_commands"
+    )
+    result = await list_tool._execute()
+    assert result.status == "done"
+    assert result.metadata["count"] == 1
+    assert "/resumen" in result.result
+
+
+@pytest.mark.asyncio
+async def test_empty_skill_dir_still_registers_tools(tmp_path):
+    """A registry with zero skills at configure() time still registers the
+    SkillFileToolkit so list_skill_commands and save_learned_skill remain
+    available for skills hot-added mid-session."""
+    empty_dir = tmp_path / "skills"
+    empty_dir.mkdir()
+    bot = MockBot(skill_paths=[empty_dir])
+    await bot._configure_skill_file_registry()
+
+    tool_names = [t.name for t in bot._tools if hasattr(t, "name")]
+    assert "list_skill_commands" in tool_names
+    assert "load_skill" in tool_names
+
+
+@pytest.mark.asyncio
 async def test_skill_paths_injects_prompt_layer(tmp_path):
     """Non-empty skill_paths with inject=True: prompt layer added."""
     (tmp_path / "test-skill.md").write_text(

--- a/tests/unit/test_list_skill_commands_tool.py
+++ b/tests/unit/test_list_skill_commands_tool.py
@@ -1,0 +1,114 @@
+"""
+Unit tests for the ``list_skill_commands`` tool of
+parrot.skills.tools.SkillFileToolkit.
+
+Verifies the live listing of file-based skills with their descriptions and
+/trigger commands, including skills hot-added after toolkit creation.
+"""
+from pathlib import Path
+
+import pytest
+
+from parrot.skills.file_registry import SkillFileRegistry
+from parrot.skills.models import SkillDefinition, SkillSource
+from parrot.skills.tools import SkillFileToolkit
+
+
+@pytest.fixture
+def registry(tmp_path):
+    """Empty SkillFileRegistry backed by a temp directory."""
+    return SkillFileRegistry(skills_dir=tmp_path)
+
+
+@pytest.fixture
+def registry_with_skills(registry, tmp_path):
+    """Registry with one triggered skill and one trigger-less skill."""
+    registry.add(SkillDefinition(
+        name="summarize",
+        description="Summarize text",
+        triggers=["/resumen", "/summary"],
+        source=SkillSource.AUTHORED,
+        template_body="Summarize the input text concisely.",
+        token_count=8,
+        file_path=tmp_path / "summarize.md",
+    ))
+    registry.add(SkillDefinition(
+        name="extract-pdf",
+        description="Extract tables",
+        triggers=[],
+        source=SkillSource.AUTHORED,
+        template_body="Use camelot to extract tables.",
+        token_count=7,
+        file_path=tmp_path / "extract-pdf.md",
+    ))
+    return registry
+
+
+@pytest.mark.asyncio
+async def test_list_skill_commands_empty_registry(registry):
+    """Empty registry returns status='done' with count=0."""
+    toolkit = SkillFileToolkit(file_registry=registry)
+    result = await toolkit.list_skill_commands()
+    assert result.status == "done"
+    assert result.metadata["count"] == 0
+    assert result.metadata["skills"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_skill_commands_lists_triggers(registry_with_skills):
+    """Listing includes skill names, descriptions and /trigger commands."""
+    toolkit = SkillFileToolkit(file_registry=registry_with_skills)
+    result = await toolkit.list_skill_commands()
+    assert result.status == "done"
+    assert result.metadata["count"] == 2
+    assert "summarize" in result.result
+    assert "/resumen" in result.result
+    assert "/summary" in result.result
+
+
+@pytest.mark.asyncio
+async def test_list_skill_commands_triggerless_skill_hint(registry_with_skills):
+    """Skills without triggers point to load_skill instead."""
+    toolkit = SkillFileToolkit(file_registry=registry_with_skills)
+    result = await toolkit.list_skill_commands()
+    assert "extract-pdf" in result.result
+    assert "load_skill" in result.result
+
+
+@pytest.mark.asyncio
+async def test_list_skill_commands_structured_metadata(registry_with_skills):
+    """Metadata carries a machine-readable skills list with triggers."""
+    toolkit = SkillFileToolkit(file_registry=registry_with_skills)
+    result = await toolkit.list_skill_commands()
+    by_name = {s["name"]: s for s in result.metadata["skills"]}
+    assert by_name["summarize"]["triggers"] == ["/resumen", "/summary"]
+    assert by_name["summarize"]["description"] == "Summarize text"
+    assert by_name["extract-pdf"]["triggers"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_skill_commands_sees_hot_added_skills(registry, tmp_path):
+    """Skills added after toolkit creation appear in the listing (live read)."""
+    toolkit = SkillFileToolkit(file_registry=registry)
+    result = await toolkit.list_skill_commands()
+    assert result.metadata["count"] == 0
+
+    registry.add(SkillDefinition(
+        name="learned-skill",
+        description="A learned skill",
+        triggers=["/aprendido"],
+        source=SkillSource.LEARNED,
+        template_body="Learned body.",
+        token_count=3,
+        file_path=tmp_path / "learned" / "learned-skill.md",
+    ))
+    result = await toolkit.list_skill_commands()
+    assert result.metadata["count"] == 1
+    assert "/aprendido" in result.result
+
+
+def test_list_skill_commands_registered_as_tool(registry):
+    """The toolkit exposes a tool named 'list_skill_commands'."""
+    toolkit = SkillFileToolkit(file_registry=registry)
+    names = {t.name for t in toolkit.get_tools()}
+    assert "list_skill_commands" in names


### PR DESCRIPTION
## Summary

Adds a new `list_skill_commands` tool to `SkillFileToolkit` that provides live discovery of available file-based skills with their descriptions and `/trigger` commands. This enables agents to dynamically report which skills are available, including skills learned during the current session.

## Key Changes

- **New `list_skill_commands()` method** in `SkillFileToolkit`:
  - Returns a formatted list of all registered skills with descriptions and trigger commands
  - Reads the live registry, so hot-added skills (learned mid-session) are immediately visible
  - Provides both human-readable output and structured metadata for tool consumption
  - Handles skills without triggers by suggesting `load_skill` as the alternative

- **Updated toolkit registration logic** in `SkillRegistryMixin._configure_skill_file_registry()`:
  - Changed gating condition from "registry exists AND has skills" to "registry exists"
  - Ensures `SkillFileToolkit` is always registered when a file registry is configured, even if empty at startup
  - Allows `save_learned_skill` and `list_skill_commands` to remain available for skills added mid-session

- **Comprehensive unit tests** (`test_list_skill_commands_tool.py`):
  - Empty registry behavior
  - Trigger listing and formatting
  - Trigger-less skill handling
  - Structured metadata format
  - Hot-added skill visibility (live registry reads)
  - Tool registration verification

- **Integration tests** in `test_skill_registry_mixin.py`:
  - Verifies `list_skill_commands` is registered and functional when skills are discovered
  - Confirms tools remain available even with empty skill directories at configure time

- **Documentation updates**:
  - Updated module docstrings and class docstrings to reflect the new tool
  - Updated `.agent/CONTEXT.md` to document the new capability

## Implementation Details

The tool returns a `ToolResult` with:
- **Status**: Always "done"
- **Result**: Human-readable markdown list of skills with triggers
- **Metadata**: Structured list of skills with name, description, triggers, and category for programmatic use

The implementation reads directly from the live registry on each call, ensuring newly learned skills are immediately discoverable without requiring toolkit recreation.

https://claude.ai/code/session_01JJg8AaS2UcyRi95YyV1x3X