### PR TITLE
fix(structured_map): mapas multi-capa — coerción de spec + multi-dataset → SpatialResult

### DIFF
--- a/packages/ai-parrot/src/parrot/bots/data.py
+++ b/packages/ai-parrot/src/parrot/bots/data.py
@@ -1195,6 +1195,95 @@ class PandasAgent(IntentRouterMixin, BasicAgent):
             return None
         return result
 
+    def _spatial_result_from_datasets(
+        self, datasets: List[Dict[str, Any]],
+    ) -> Optional[Any]:
+        """Build a MULTI-layer ``SpatialResult`` from a multi-dataset payload.
+
+        FEAT-221: :meth:`_spatial_result_from_dataframe` converts a single result
+        DataFrame for the STRUCTURED_MAP fallback, but when the agent produces
+        SEVERAL DataFrames in one turn (e.g. one layer per category so each can
+        be colored differently), ``_inject_multi_data_from_variables`` sets
+        ``response.data`` to a list of ``DatasetResult`` dicts. The map renderer
+        then rejects the list (``response.data must be a SpatialResult``).
+
+        This converts each dataset entry into its own layer and merges them into
+        one multi-layer ``SpatialResult`` so the map renders. Entries with no
+        resolvable geometry/lat-lon are skipped (not every layer in a multi-
+        dataset turn need be mappable). As a fallback, a flat list of row dicts
+        (not wrapped in ``DatasetResult``) is treated as a single layer.
+
+        Args:
+            datasets: ``response.data`` as a list — either ``DatasetResult``
+                dicts (each with a ``data`` list of record dicts and a
+                ``name``/``variable``) or a flat list of row dicts.
+
+        Returns:
+            A multi-layer ``SpatialResult`` with at least one feature, or
+            ``None`` when no entry yields a mappable layer.
+        """
+        try:
+            from ..tools.dataset_manager.spatial.contracts import SpatialResult
+        except ImportError:
+            self.logger.debug(
+                "SpatialResult unavailable; skipping multi-dataset STRUCTURED_MAP "
+                "conversion."
+            )
+            return None
+
+        if not datasets:
+            return None
+
+        # Dataset-shaped entries carry a nested ``data`` list; a flat list of row
+        # dicts does not. Treat the latter as a single anonymous layer.
+        dataset_shaped = [
+            e for e in datasets if isinstance(e, dict) and isinstance(e.get("data"), list)
+        ]
+        if not dataset_shaped:
+            if all(isinstance(e, dict) for e in datasets):
+                return self._spatial_result_from_dataframe(pd.DataFrame(datasets))
+            return None
+
+        merged_layers: Dict[str, Any] = {}
+        for entry in dataset_shaped:
+            rows = entry.get("data")
+            if not rows:
+                continue
+            name = str(
+                entry.get("name") or entry.get("variable") or f"layer_{len(merged_layers)}"
+            )
+            try:
+                df = pd.DataFrame(rows)
+            except Exception:  # noqa: BLE001
+                continue
+            if df.empty:
+                continue
+            try:
+                layer_result = SpatialResult.from_dataframe(
+                    df, dataset=name, layer=name,
+                )
+            except ValueError:
+                # This dataset has no geometry/lat-lon pair — skip its layer.
+                self.logger.debug(
+                    "Multi-dataset STRUCTURED_MAP: dataset '%s' has no resolvable "
+                    "coordinates/geometry — skipping layer.", name,
+                )
+                continue
+            for layer_key, layer_val in layer_result.layers.items():
+                # Guard against key collisions across datasets.
+                key = (
+                    layer_key
+                    if layer_key not in merged_layers
+                    else f"{layer_key}_{len(merged_layers)}"
+                )
+                merged_layers[key] = layer_val
+
+        if not merged_layers:
+            return None
+        if not any(layer.features for layer in merged_layers.values()):
+            return None
+        return SpatialResult(version=2, layers=merged_layers)
+
     @staticmethod
     def _client_uses_split_structured_with_tools(client: Any) -> bool:
         """Return True when the LLM client splits a tool-using call and a
@@ -1920,6 +2009,40 @@ class PandasAgent(IntentRouterMixin, BasicAgent):
                     else:
                         self.logger.warning(
                             "STRUCTURED_MAP: result DataFrame has no resolvable "
+                            "coordinates/geometry; map cannot be rendered."
+                        )
+                # Multi-layer fallback: when the agent produced SEVERAL DataFrames
+                # (e.g. one layer per category to color them separately),
+                # response.data is the list of DatasetResult dicts assembled by
+                # _inject_multi_data_from_variables. Merge them into one
+                # multi-layer SpatialResult so the renderer accepts it instead of
+                # rejecting the list ("response.data must be a SpatialResult").
+                elif (
+                    output_mode == OutputMode.STRUCTURED_MAP
+                    and isinstance(response.data, list)
+                    and response.data
+                ):
+                    spatial_result = self._spatial_result_from_datasets(
+                        response.data
+                    )
+                    if spatial_result is not None:
+                        feature_count = sum(
+                            len(lyr.features)
+                            for lyr in spatial_result.layers.values()
+                        )
+                        self.logger.info(
+                            "STRUCTURED_MAP: converted %d dataset(s) to a "
+                            "multi-layer SpatialResult (%d layer(s), %d feature(s)) "
+                            "— agent returned multiple DataFrames instead of "
+                            "calling the spatial_filter tool.",
+                            len(response.data),
+                            len(spatial_result.layers),
+                            feature_count,
+                        )
+                        response.data = spatial_result
+                    else:
+                        self.logger.warning(
+                            "STRUCTURED_MAP: multi-dataset result has no resolvable "
                             "coordinates/geometry; map cannot be rendered."
                         )
 

--- a/packages/ai-parrot/src/parrot/tools/dataset_manager/tool.py
+++ b/packages/ai-parrot/src/parrot/tools/dataset_manager/tool.py
@@ -5028,9 +5028,22 @@ class DatasetManager(AbstractToolkit):
                 in this ``DatasetManager`` instance OR lacks a spatial profile.
         """
         import asyncio
-        from .spatial.contracts import SpatialResult, SpatialLayerResult
+        from .spatial.contracts import (
+            SpatialResult,
+            SpatialLayerResult,
+            SpatialFilterSpec,
+        )
         from .spatial.registry import get_spatial_profile, validate_profiles_exist
         from .spatial.compiler import SpatialCompiler
+
+        # Coerce a dict spec into the Pydantic model. The tool framework may pass
+        # ``spec`` as a raw dict (e.g. the LLM emits JSON args like
+        # {"point": [...], "radius": 100, "unit": "km", "datasets": [...]})
+        # rather than a constructed SpatialFilterSpec; without this, the
+        # ``spec.datasets`` access below raises AttributeError and the spatial
+        # query (Path A) fails for the map renderer.
+        if isinstance(spec, dict):
+            spec = SpatialFilterSpec(**spec)
 
         compiler = SpatialCompiler()
 

--- a/packages/ai-parrot/tests/unit/bots/test_pandasagent_multilayer_map.py
+++ b/packages/ai-parrot/tests/unit/bots/test_pandasagent_multilayer_map.py
@@ -1,0 +1,134 @@
+"""Unit tests for PandasAgent's multi-layer STRUCTURED_MAP fallback.
+
+Regression coverage for the bug where the agent produced SEVERAL result
+DataFrames in one turn (e.g. one layer per distance band so each could be
+colored differently). ``_inject_multi_data_from_variables`` then sets
+``response.data`` to a list of ``DatasetResult`` dicts, and the single-DataFrame
+STRUCTURED_MAP fallback skipped it — leaving the renderer to reject the list
+("response.data must be a SpatialResult, got list").
+
+These tests exercise the pure helper ``_spatial_result_from_datasets``, which
+merges the per-dataset payloads into one multi-layer ``SpatialResult``.
+"""
+import logging
+import types
+
+import pytest
+
+try:
+    from parrot.bots.data import PandasAgent
+except Exception:  # pragma: no cover - env-dependent
+    PandasAgent = None
+
+
+pytestmark = pytest.mark.skipif(
+    PandasAgent is None, reason="parrot.bots.data not importable in this environment"
+)
+
+
+def _bind():
+    """Bind the multi-layer helpers to a minimal object with a logger.
+
+    ``_spatial_result_from_datasets`` only touches ``self.logger`` and (for the
+    flat-list fallback) ``self._spatial_result_from_dataframe``.
+    """
+    ns = types.SimpleNamespace()
+    ns.logger = logging.getLogger("test_multilayer_map")
+    ns._spatial_result_from_dataframe = types.MethodType(
+        PandasAgent._spatial_result_from_dataframe, ns
+    )
+    ns._spatial_result_from_datasets = types.MethodType(
+        PandasAgent._spatial_result_from_datasets, ns
+    )
+    return ns
+
+
+def _dataset(name, rows):
+    """Build a DatasetResult-shaped dict (the shape _inject_multi produces)."""
+    return {
+        "name": name,
+        "variable": name,
+        "data": rows,
+        "shape": (len(rows), len(rows[0]) if rows else 0),
+        "columns": list(rows[0].keys()) if rows else [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Happy path — multiple mappable datasets become multiple layers
+# ---------------------------------------------------------------------------
+
+def test_multi_dataset_builds_multilayer_result():
+    ns = _bind()
+    datasets = [
+        _dataset("band_0_20", [
+            {"name": "K1", "latitude": 33.4, "longitude": -112.0, "dist": 5},
+            {"name": "K2", "latitude": 33.5, "longitude": -112.1, "dist": 12},
+        ]),
+        _dataset("band_20_40", [
+            {"name": "K3", "latitude": 33.7, "longitude": -112.3, "dist": 30},
+        ]),
+    ]
+
+    result = ns._spatial_result_from_datasets(datasets)
+
+    assert result is not None
+    assert set(result.layers.keys()) == {"band_0_20", "band_20_40"}
+    assert len(result.layers["band_0_20"].features) == 2
+    assert len(result.layers["band_20_40"].features) == 1
+    # Layer discriminator is preserved.
+    assert result.layers["band_0_20"].layer == "band_0_20"
+
+
+def test_unmappable_dataset_is_skipped_others_kept():
+    """A dataset without coordinates is dropped; mappable ones survive."""
+    ns = _bind()
+    datasets = [
+        _dataset("geo", [{"name": "K1", "latitude": 33.4, "longitude": -112.0}]),
+        _dataset("no_geo", [{"name": "X", "revenue": 100}]),  # no lat/lon
+    ]
+
+    result = ns._spatial_result_from_datasets(datasets)
+
+    assert result is not None
+    assert set(result.layers.keys()) == {"geo"}
+    assert len(result.layers["geo"].features) == 1
+
+
+# ---------------------------------------------------------------------------
+# Flat list fallback — a list of plain row dicts becomes a single layer
+# ---------------------------------------------------------------------------
+
+def test_flat_row_list_becomes_single_layer():
+    ns = _bind()
+    rows = [
+        {"name": "K1", "latitude": 33.4, "longitude": -112.0},
+        {"name": "K2", "latitude": 33.5, "longitude": -112.1},
+    ]
+
+    result = ns._spatial_result_from_datasets(rows)
+
+    assert result is not None
+    total = sum(len(lyr.features) for lyr in result.layers.values())
+    assert total == 2
+
+
+# ---------------------------------------------------------------------------
+# Degenerate inputs — never raise, return None
+# ---------------------------------------------------------------------------
+
+def test_empty_list_returns_none():
+    ns = _bind()
+    assert ns._spatial_result_from_datasets([]) is None
+
+
+def test_no_mappable_dataset_returns_none():
+    ns = _bind()
+    datasets = [_dataset("no_geo", [{"name": "X", "revenue": 100}])]
+    assert ns._spatial_result_from_datasets(datasets) is None
+
+
+def test_dataset_with_empty_rows_returns_none():
+    ns = _bind()
+    datasets = [_dataset("empty", [])]
+    assert ns._spatial_result_from_datasets(datasets) is None


### PR DESCRIPTION
## Contexto

Al pedir un mapa que agrupa marcadores por categoría (ej. kioscos por banda de distancia, para colorearlos por capa), el mapa **no renderizaba**. Dos bugs distintos lo impedían, ambos en el flujo STRUCTURED_MAP multi-capa.

## Bug A — lista multi-dataset rechazada por el renderer

Cuando el agente produce **varias** DataFrames en un turno, `_inject_multi_data_from_variables` deja `response.data` como una **lista** de `DatasetResult`. El fallback de STRUCTURED_MAP solo convertía un DataFrame único, así que el renderer rechazaba la lista:

```
StructuredMapRenderer: response.data must be a SpatialResult, got list
```

**Fix:** nuevo `PandasAgent._spatial_result_from_datasets` — convierte cada entrada en su propia capa (vía `SpatialResult.from_dataframe`) y las fusiona en un `SpatialResult` **multi-capa**. Salta entradas sin geometría resoluble y trata una lista plana de filas como una sola capa. Se cablea como rama `elif` en el fallback cuando `response.data` es una lista.

## Bug B — `spatial_filter` crashea con `spec` dict

El agente (Path A, el preferido) llama `dataset_spatial_filter` con `spec` como **dict** JSON; el framework de tools no lo coercionaba al modelo Pydantic, así que `spec.datasets` reventaba:

```
AttributeError: 'dict' object has no attribute 'datasets'  (tool.py:5038)
```

**Fix:** coerción `spec → SpatialFilterSpec(**spec)` al inicio de `DatasetManager.spatial_filter`, antes de cualquier acceso a atributos.

## Impacto

Juntos desbloquean los mapas **multi-capa** (y por tanto multi-color con `markerColor`) de punta a punta: ya sea por Path A (spatial_filter sobre varias datasets) o por el fallback multi-DataFrame.

## Tests

- `tests/unit/bots/test_pandasagent_multilayer_map.py`: cobertura del helper multi-dataset (multi-capa, dataset sin geo saltado, lista plana, casos vacíos). *(corren en CI; se saltan local por dependencias del entorno)*.
- Verificado en vivo por el usuario: la pregunta que antes fallaba ahora renderiza el mapa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)