### PR TITLE
feat(formdesigner): port FEAT-300 + FEAT-301 — v0.4.0

### DIFF
--- a/packages/parrot-formdesigner/scripts/backfill_published_versions.py
+++ b/packages/parrot-formdesigner/scripts/backfill_published_versions.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+"""CLI wrapper for ``FormVersionService.backfill_published()``.
+
+Marks all pre-existing forms in a tenant as published at their current
+``version`` value, enabling ``FormVersionService`` for that tenant.
+
+Usage:
+    python scripts/backfill_published_versions.py --tenant navigator
+    python scripts/backfill_published_versions.py --tenant navigator --dry-run
+    python scripts/backfill_published_versions.py --tenant navigator --dsn "postgres://..."
+
+Environment variables:
+    PARROT_DB_DSN — fallback DSN when ``--dsn`` is not passed.
+
+Exit codes:
+    0 — success (including dry-run with 0 changes)
+    1 — error
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+logger = logging.getLogger("backfill_published_versions")
+
+
+async def _run(tenant: str, dsn: str | None, dry_run: bool) -> int:
+    """Run the backfill for the given tenant.
+
+    Args:
+        tenant: Tenant slug to backfill.
+        dsn: Optional Postgres DSN. Falls back to PARROT_DB_DSN env var.
+        dry_run: If True, log what would change without persisting.
+
+    Returns:
+        Number of forms backfilled (or that would be backfilled).
+    """
+    from parrot_formdesigner.services.form_version import FormVersionService
+    from parrot_formdesigner.services.registry import FormRegistry
+    from parrot_formdesigner.services.storage import PostgresFormStorage
+
+    dsn = dsn or os.environ.get("PARROT_DB_DSN")
+    storage = None
+
+    if dsn:
+        logger.info("Connecting to Postgres: %s", dsn[:30] + "…" if len(dsn) > 30 else dsn)
+        try:
+            storage = PostgresFormStorage(dsn=dsn)
+        except Exception as exc:
+            logger.warning("Could not create PostgresFormStorage: %s — using in-memory only", exc)
+
+    registry = FormRegistry(storage=storage)
+
+    if storage is not None:
+        try:
+            await registry.load_from_storage(tenant=tenant)
+            logger.info("Loaded existing forms for tenant '%s' from storage", tenant)
+        except Exception as exc:
+            logger.warning("Could not load forms from storage: %s — proceeding with empty registry", exc)
+
+    svc = FormVersionService(registry, storage=storage)
+    changed = await svc.backfill_published(tenant=tenant, dry_run=dry_run)
+
+    if storage is not None:
+        try:
+            await storage.close()
+        except Exception:
+            pass
+
+    return changed
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Backfill pre-existing forms as published v1.0 snapshots.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--tenant",
+        required=True,
+        help="Tenant slug to backfill (e.g. 'navigator', 'epson').",
+    )
+    parser.add_argument(
+        "--dsn",
+        default=None,
+        help=(
+            "Postgres DSN (e.g. 'postgres://user:pw@host/db'). "
+            "Falls back to PARROT_DB_DSN env var when not provided."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log what would change without persisting anything.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Entry point for the backfill script."""
+    args = _parse_args()
+    if args.dry_run:
+        logger.info("DRY-RUN mode — no data will be modified")
+
+    try:
+        changed = asyncio.run(_run(args.tenant, args.dsn, args.dry_run))
+        action = "[dry-run] would backfill" if args.dry_run else "backfilled"
+        logger.info("Done — %s %d form(s) for tenant '%s'", action, changed, args.tenant)
+        sys.exit(0)
+    except Exception as exc:
+        logger.exception("Backfill failed: %s", exc)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/api/handlers.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/api/handlers.py
@@ -17,6 +17,7 @@ from aiohttp import web
 from pydantic import ValidationError
 from navigator.responses import JSONResponse
 from ..core.events import FormEventAbort, FormEventName
+
 from ..core.schema import FormField, FormSchema, RenderedForm
 from ..renderers.jsonschema import JsonSchemaRenderer
 from ..services.auth_context import AuthContext
@@ -29,9 +30,12 @@ from ._utils import _bump_version, _deep_merge, _loc_to_str
 if TYPE_CHECKING:
     from parrot.clients.base import AbstractClient
 
+    from ..services.form_version import FormVersionService
     from ..services.forwarder import SubmissionForwarder
     from ..services.partial_saves import PartialSaveStore
+    from ..services.question_bank import QuestionBankService
     from ..services.submissions import FormSubmissionStorage
+    from ..tools.services.networkninja import ImportDiffReport
 
 
 class FormAPIHandler:
@@ -81,6 +85,16 @@ class FormAPIHandler:
         self._db_tool = DatabaseFormTool(
             registry=self.registry
         )
+
+        # FEAT-300 — form version service (lazy-init so tests can override)
+        self._version_service: "FormVersionService | None" = None
+
+        # FEAT-300 — per-tenant QuestionBankService cache (one instance per tenant)
+        self._question_banks: "dict[str, QuestionBankService]" = {}
+
+        # FEAT-300 — per-form import diff reports (populated by import flows).
+        # Keyed by (tenant, form_id) to prevent cross-tenant leaks (review M3).
+        self._import_reports: "dict[tuple[str, str], ImportDiffReport]" = {}
 
     def _get_llm_client(self) -> "AbstractClient | None":
         """Return the configured LLM client, lazily creating a GoogleGenAI default.
@@ -896,6 +910,10 @@ class FormAPIHandler:
             )
 
         body["version"] = _bump_version(existing.version)
+        # published_version is immutable from the API surface — only
+        # FormVersionService.publish() may set it (review M1).
+        body.pop("published_version", None)
+        body["published_version"] = existing.published_version
 
         try:
             form = FormSchema.model_validate(body)
@@ -942,6 +960,9 @@ class FormAPIHandler:
         merged["version"] = _bump_version(existing.version)
         # Prevent form_id change via PATCH
         merged["form_id"] = form_id
+        # published_version is immutable from the API surface — only
+        # FormVersionService.publish() may set it (review M1).
+        merged["published_version"] = existing.published_version
 
         try:
             form = FormSchema.model_validate(merged)
@@ -972,6 +993,20 @@ class FormAPIHandler:
         if existing is None:
             return JSONResponse(
                 {"error": f"Form '{form_id}' not found"}, status=404
+            )
+
+        # Spec invariant (FEAT-300 §8, Vision IQ parity): a form with ≥1
+        # response can never be deleted — only deactivated.
+        version_svc = self._get_version_service()
+        if not await version_svc.can_delete(form_id, tenant=tenant):
+            return web.json_response(
+                {
+                    "error": (
+                        f"Form '{form_id}' has responses and cannot be deleted. "
+                        "Deactivate it instead."
+                    )
+                },
+                status=409,
             )
 
         await self.registry.unregister(form_id, tenant=tenant)
@@ -1305,10 +1340,299 @@ class FormAPIHandler:
                 {"error": "Form load succeeded but form_id missing"},
                 status=500,
             )
+
+        # FEAT-300: persist the per-field ImportDiffReport so
+        # GET /forms/{form_id}/import-report can serve it (review H2).
+        report_data = result.metadata.get("import_report")
+        if report_data:
+            from ..tools.services.networkninja import ImportDiffReport
+            self._import_reports[(tenant, form_id)] = (
+                ImportDiffReport.model_validate(report_data)
+            )
+
         title = (result.result or {}).get("title", "")
         prefix = request.app.get("_form_prefix", "")
         return JSONResponse({
             "form_id": form_id,
             "title": title,
             "url": f"{prefix}/forms/{form_id}",
+        })
+
+    # ------------------------------------------------------------------
+    # FEAT-300 helpers — version service + question bank
+    # ------------------------------------------------------------------
+
+    def _get_version_service(self) -> "FormVersionService":
+        """Return the shared FormVersionService, initialising it lazily.
+
+        Returns:
+            Configured ``FormVersionService`` instance.
+        """
+        if self._version_service is None:
+            from ..services.form_version import FormVersionService
+            self._version_service = FormVersionService(self.registry)
+        return self._version_service
+
+    def _make_question_bank(self, tenant: str) -> "QuestionBankService":
+        """Return a tenant-scoped QuestionBankService, creating it on first call.
+
+        One service instance is cached per tenant so in-memory state (and DB
+        connections when a storage backend is configured) is shared across
+        requests within the same handler lifetime.
+
+        Args:
+            tenant: Tenant slug for this request.
+
+        Returns:
+            ``QuestionBankService`` backed by the registry's storage (or
+            in-memory when no storage backend is configured).
+        """
+        if tenant not in self._question_banks:
+            from ..services.question_bank import QuestionBankService
+            self._question_banks[tenant] = QuestionBankService(
+                storage=self.registry.storage,  # type: ignore[arg-type]
+                tenant=tenant,
+            )
+        return self._question_banks[tenant]
+
+    # ------------------------------------------------------------------
+    # FEAT-300 — publish / question-bank / version / import-report endpoints
+    # ------------------------------------------------------------------
+
+    async def publish_form(self, request: web.Request) -> web.Response:
+        """POST /api/v1/forms/{form_id}/publish — Publish current form as immutable snapshot.
+
+        Bumps the form's semver minor tag and freezes the current state as a
+        published snapshot. Returns ``409`` when the computed tag already
+        exists (immutability guard). Returns ``404`` when the form is not found.
+
+        Args:
+            request: Incoming HTTP request (path param: ``form_id``).
+
+        Returns:
+            ``{"form_id": str, "version": str}`` on success (200),
+            ``{"error": str}`` on 404 (not found) or 409 (frozen conflict).
+        """
+        form_id = request.match_info["form_id"]
+        tenant = self._get_tenant(request)
+        svc = self._get_version_service()
+        try:
+            version = await svc.publish(form_id, tenant=tenant)
+        except KeyError as exc:
+            return web.json_response({"error": str(exc)}, status=404)
+        except ValueError as exc:
+            return web.json_response({"error": str(exc)}, status=409)
+        except Exception as exc:
+            self.logger.exception("publish_form failed for '%s': %s", form_id, exc)
+            return web.json_response({"error": str(exc)}, status=500)
+        self.logger.info("Published form '%s' → version '%s'", form_id, version)
+        return web.json_response({"form_id": form_id, "version": version})
+
+    async def list_fields(self, request: web.Request) -> web.Response:
+        """GET /api/v1/fields — List all reusable fields for the current tenant.
+
+        Args:
+            request: Incoming HTTP request.
+
+        Returns:
+            ``{"fields": [<ReusableField>, ...]}`` (200).
+        """
+        tenant = self._get_tenant(request)
+        svc = self._make_question_bank(tenant)
+        fields = await svc.list_fields()
+        return web.json_response(
+            {"fields": [f.model_dump(mode="json") for f in fields]}
+        )
+
+    async def create_field(self, request: web.Request) -> web.Response:
+        """POST /api/v1/fields — Add a field definition to the question bank.
+
+        Args:
+            request: Incoming HTTP request with ``FormField`` JSON body.
+
+        Returns:
+            ``ReusableField`` JSON (201 Created), ``400`` on bad JSON, ``422``
+            on validation errors.
+        """
+        tenant = self._get_tenant(request)
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, ValueError):
+            return web.json_response({"error": "Invalid JSON body"}, status=400)
+
+        from ..core.schema import FormField
+        try:
+            field_def = FormField.model_validate(body)
+        except ValidationError as exc:
+            return web.json_response({"error": exc.errors(include_url=False)}, status=422)
+
+        svc = self._make_question_bank(tenant)
+        entry = await svc.create_field(field_def)
+        return web.json_response(entry.model_dump(mode="json"), status=201)
+
+    async def list_versions(self, request: web.Request) -> web.Response:
+        """GET /api/v1/forms/{form_id}/versions — List published version history.
+
+        Each entry includes ``version``, ``published_at`` (ISO-8601),
+        ``published_by`` (``null`` when not tracked), and ``is_current``
+        (``True`` for the form's active published version).
+
+        Args:
+            request: Incoming HTTP request (path param: ``form_id``).
+
+        Returns:
+            ``{"form_id": str, "versions": [...]}`` (200), ``404`` if not found.
+        """
+        form_id = request.match_info["form_id"]
+        tenant = self._get_tenant(request)
+        form = await self.registry.get(form_id, tenant=tenant)
+        if form is None:
+            return web.json_response({"error": f"Form '{form_id}' not found"}, status=404)
+
+        svc = self._get_version_service()
+        meta_list = await svc.list_versions(form_id, tenant=tenant)
+        current_version = form.published_version or form.version
+
+        return web.json_response({
+            "form_id": form_id,
+            "versions": [
+                {
+                    "version": m.version,
+                    "published_at": m.published_at.isoformat(),
+                    "published_by": None,
+                    "is_current": m.version == current_version,
+                }
+                for m in meta_list
+            ],
+        })
+
+    async def get_version(self, request: web.Request) -> web.Response:
+        """GET /api/v1/forms/{form_id}/versions/{version} — Retrieve a frozen snapshot.
+
+        Returns the immutable ``FormSchema`` snapshot for the requested semver
+        tag. Returns ``404`` when the form or version is not found.
+
+        Args:
+            request: Incoming HTTP request (path params: ``form_id``, ``version``).
+
+        Returns:
+            Full ``FormSchema`` JSON (200) or ``{"error": str}`` (404).
+        """
+        form_id = request.match_info["form_id"]
+        version = request.match_info["version"]
+        tenant = self._get_tenant(request)
+        svc = self._get_version_service()
+        snap = await svc.get_published(form_id, version=version, tenant=tenant)
+        if snap is None:
+            return web.json_response(
+                {"error": f"Version '{version}' of form '{form_id}' not found"},
+                status=404,
+            )
+        return web.json_response(snap.model_dump(mode="json"))
+
+    async def get_import_report(self, request: web.Request) -> web.Response:
+        """GET /api/v1/forms/{form_id}/import-report — Latest ImportDiffReport.
+
+        Returns the per-field mapping report generated when this form was last
+        imported from an external source (e.g. Networkninja). Returns ``404``
+        when no import history exists for this form.
+
+        Args:
+            request: Incoming HTTP request (path param: ``form_id``).
+
+        Returns:
+            ``ImportDiffReport`` JSON (200) or ``{"error": str}`` (404).
+        """
+        form_id = request.match_info["form_id"]
+        tenant = self._get_tenant(request)
+        report = self._import_reports.get((tenant, form_id))
+        if report is None:
+            return web.json_response(
+                {"error": f"No import report found for form '{form_id}'"},
+                status=404,
+            )
+        return web.json_response(report.model_dump(mode="json"))
+
+    async def evaluate_form(self, request: web.Request) -> web.Response:
+        """POST /api/v1/forms/{form_id}/evaluate — Server-side rule evaluation.
+
+        Evaluates all ``DependencyRule`` conditions in the form against the
+        provided context (current answers + location variables + visit context)
+        and returns a per-field visibility/effect map.
+
+        **Intended uses**:
+
+        1. **Thin/server-driven clients** (Adaptive Card / Teams) that cannot
+           run a local rule evaluator and need the server to drive visibility.
+        2. **Authoritative re-validation at submit** — the client sends the
+           final answer set and the server confirms the visibility state used
+           for validation.  Any divergence between client-side and server-side
+           evaluation is surfaced here.
+
+        **Note on ``location_vars``**: In the request body, ``location_vars``
+        is for testing/preview only.  In production, the server injects the
+        location variable snapshot into the form payload when the form is
+        served for a visit (so the client always has a consistent snapshot).
+
+        Body (all keys optional — missing keys default to ``{}``):
+            ``{"answers": {"field_id": <value>, ...},``
+            ``"location_vars": {"key": <value>, ...},``
+            ``"visit_context": {"key": <value>, ...}}``
+
+        Returns:
+            200: ``{"results": {"field_id": {"effect": "show"|"hide"|..., "matched": bool}}}``
+            400: ``{"error": "..."}`` — malformed JSON body or non-dict values.
+            404: ``{"error": "..."}`` — form not found.
+
+        Args:
+            request: Incoming HTTP request (path param: ``form_id``).
+        """
+        from ..services.rule_evaluator import EvaluationContext, DEFAULT_EVALUATOR
+
+        form_id = request.match_info["form_id"]
+        tenant = self._get_tenant(request)
+        form = await self.registry.get(form_id, tenant=tenant)
+        if form is None:
+            return web.json_response(
+                {"error": f"Form '{form_id}' not found"}, status=404
+            )
+
+        # Parse body — all keys optional
+        try:
+            raw_body = await request.json()
+        except (json.JSONDecodeError, ValueError):
+            return web.json_response({"error": "Invalid JSON body"}, status=400)
+
+        if not isinstance(raw_body, dict):
+            return web.json_response(
+                {"error": "Request body must be a JSON object"}, status=400
+            )
+
+        answers = raw_body.get("answers", {})
+        location_vars = raw_body.get("location_vars", {})
+        visit_context = raw_body.get("visit_context", {})
+
+        if not isinstance(answers, dict) or not isinstance(location_vars, dict) or not isinstance(visit_context, dict):
+            return web.json_response(
+                {"error": "answers, location_vars, and visit_context must be objects"},
+                status=400,
+            )
+
+        try:
+            context = EvaluationContext(
+                answers=answers,
+                location_vars=location_vars,
+                visit_context=visit_context,
+            )
+        except Exception as exc:
+            return web.json_response({"error": f"Invalid context: {exc}"}, status=422)
+
+        evaluator = DEFAULT_EVALUATOR
+        results = evaluator.evaluate_form(form, context)
+
+        return web.json_response({
+            "results": {
+                field_id: {"effect": r.effect, "matched": r.matched}
+                for field_id, r in results.items()
+            }
         })

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/api/routes.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/api/routes.py
@@ -262,4 +262,34 @@ def setup_form_api(
         )
         logger.info("setup_form_api: audio WS endpoint mounted at %s/forms/{form_id}/audio/ws", bp)
 
+    # FEAT-301 — server-side rule evaluation endpoint
+    app.router.add_post(
+        f"{bp}/forms/{{form_id}}/evaluate", _wrap_auth(handler.evaluate_form)
+    )
+
+    # FEAT-300 — publish, question-bank, version history, import-report
+    # Note: /versions and /import-report routes are registered BEFORE the
+    # generic /{form_id} catch-all to avoid shadowing issues if the router
+    # were order-sensitive (aiohttp matches on specificity, but belt-and-braces).
+    app.router.add_post(
+        f"{bp}/forms/{{form_id}}/publish", _wrap_auth(handler.publish_form)
+    )
+    app.router.add_get(
+        f"{bp}/fields", _wrap_auth(handler.list_fields)
+    )
+    app.router.add_post(
+        f"{bp}/fields", _wrap_auth(handler.create_field)
+    )
+    app.router.add_get(
+        f"{bp}/forms/{{form_id}}/versions", _wrap_auth(handler.list_versions)
+    )
+    app.router.add_get(
+        f"{bp}/forms/{{form_id}}/versions/{{version}}",
+        _wrap_auth(handler.get_version),
+    )
+    app.router.add_get(
+        f"{bp}/forms/{{form_id}}/import-report",
+        _wrap_auth(handler.get_import_report),
+    )
+
     logger.info("setup_form_api: mounted on %s", bp)

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/controls/builtin.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/controls/builtin.py
@@ -318,6 +318,20 @@ _BUILTIN_METADATA: dict[FieldType, dict[str, Any]] = {
         "supports_constraints": False,
         "is_container": False,
     },
+    # FEAT-300 — formula fields (inert stub; evaluator in FEAT-301)
+    FieldType.FORMULA: {
+        "label": "Formula",
+        "description": (
+            "Computed field — result derived from a BEDMAS expression over "
+            "other field values. Expression evaluation is FEAT-301. "
+            "Renders as a read-only placeholder until the evaluator ships."
+        ),
+        "category": "advanced",
+        "icon": "formula",
+        "render_hint": "readonly",
+        "supports_constraints": False,
+        "is_container": False,
+    },
 }
 
 

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/core/__init__.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/core/__init__.py
@@ -10,6 +10,10 @@ from .constraints import (
     DependencyRule,
     FieldCondition,
     FieldConstraints,
+    FieldRefCondition,
+    LocationVarCondition,
+    LocationVariableBinding,
+    VisitContextCondition,
 )
 from .events import (
     EventResolution,
@@ -27,6 +31,7 @@ from .schema import (
     FormSchema,
     FormSection,
     FormSubsection,
+    FormType,
     MetadataSource,
     RenderedForm,
     SectionItem,
@@ -54,6 +59,10 @@ __all__ = [
     "FieldConstraints",
     "ConditionOperator",
     "FieldCondition",
+    "FieldRefCondition",
+    "LocationVarCondition",
+    "VisitContextCondition",
+    "LocationVariableBinding",
     "DependencyRule",
     # Options
     "FieldOption",
@@ -65,6 +74,7 @@ __all__ = [
     "FormSection",
     "SubmitAction",
     "FormSchema",
+    "FormType",
     "FormMetadataField",
     "MetadataSource",
     "BUILTIN_METADATA_SOURCE_NAMES",

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/core/constraints.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/core/constraints.py
@@ -3,13 +3,23 @@
 This module defines the data models for field-level constraints (min/max,
 patterns, file size limits) and the dependency rule system that controls
 conditional visibility and behavior.
+
+FEAT-301: ``FieldCondition`` is now a **discriminated union** by ``source``:
+- ``FieldRefCondition``       — conditions over another field's answer (legacy path)
+- ``LocationVarCondition``    — conditions over Org Graph location variables
+- ``VisitContextCondition``   — conditions over visit-level metadata
+
+Backward compat: pre-existing serialized forms that have plain
+``{"field_id": ..., "operator": ..., "value": ...}`` dicts (no ``source`` key)
+are automatically upgraded to ``FieldRefCondition`` by the
+``DependencyRule._inject_legacy_source`` validator.
 """
 
 import re
 from enum import Enum
-from typing import Any, Literal
+from typing import Annotated, Any, Literal, Union
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from .types import LocalizedString
 
@@ -141,18 +151,95 @@ class ConditionOperator(str, Enum):
     IS_NOT_EMPTY = "is_not_empty"
 
 
-class FieldCondition(BaseModel):
-    """A single condition referencing another field's value.
+# ---------------------------------------------------------------------------
+# FEAT-301 — FieldCondition discriminated union (RESUELTO §8)
+# ---------------------------------------------------------------------------
+
+class FieldRefCondition(BaseModel):
+    """Condition over another field's answer (the pre-existing behavior).
+
+    This is the backward-compatible variant: ``field_id`` is preserved
+    so existing serialized forms parse without migration.
 
     Attributes:
-        field_id: The ID of the field to evaluate.
+        source: Discriminator, always ``"field"``.
+        field_id: The ID of the field whose answer to evaluate.
         operator: The comparison operator to apply.
         value: The value to compare against (not required for IS_EMPTY/IS_NOT_EMPTY).
     """
 
+    model_config = ConfigDict(extra="forbid")
+
+    source: Literal["field"] = "field"
     field_id: str
     operator: ConditionOperator
     value: Any = None
+
+
+class LocationVarCondition(BaseModel):
+    """Condition over an Org Graph location variable (store > program merge).
+
+    The variable values are pre-fetched from ``ai-parrot`` Org Graph service
+    (FEAT-302) and passed in ``EvaluationContext.location_vars`` at request time.
+
+    Attributes:
+        source: Discriminator, always ``"location_variable"``.
+        key: Location variable key, e.g. ``"store_type"``.
+        operator: The comparison operator to apply.
+        value: The value to compare against.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    source: Literal["location_variable"]
+    key: str
+    operator: ConditionOperator
+    value: Any = None
+
+
+class VisitContextCondition(BaseModel):
+    """Condition over visit-level metadata (date, type, etc.).
+
+    Attributes:
+        source: Discriminator, always ``"visit_context"``.
+        key: Visit context key, e.g. ``"visit_type"`` or ``"visit_date"``.
+        operator: The comparison operator to apply.
+        value: The value to compare against.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    source: Literal["visit_context"]
+    key: str
+    operator: ConditionOperator
+    value: Any = None
+
+
+# The public ``FieldCondition`` type — a discriminated union on ``source``.
+# Legacy dicts without ``source`` are handled by DependencyRule's before-validator.
+FieldCondition = Annotated[
+    Union[FieldRefCondition, LocationVarCondition, VisitContextCondition],
+    Field(discriminator="source"),
+]
+
+
+class LocationVariableBinding(BaseModel):
+    """Immutable key-value pair from the Org Graph for a location/store node.
+
+    These come from the ``ai-parrot`` Org Graph service (FEAT-302) and are
+    passed in ``EvaluationContext.location_vars`` at request time.
+
+    Attributes:
+        key: Variable name, e.g. ``"store_type"``.
+        scope: Org node identifier, e.g. store ID or program ID.
+        value: Resolved value; type depends on the variable definition.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    key: str
+    scope: str
+    value: Any
 
 
 class DependencyRule(BaseModel):
@@ -167,3 +254,25 @@ class DependencyRule(BaseModel):
     conditions: list[FieldCondition]
     logic: Literal["and", "or"] = "and"
     effect: Literal["show", "hide", "require", "disable"] = "show"
+
+    @model_validator(mode="before")
+    @classmethod
+    def _inject_legacy_source(cls, data: Any) -> Any:
+        """Inject ``source="field"`` into legacy condition dicts without a discriminator.
+
+        Backward-compat shim: pre-existing serialized forms store conditions as
+        plain dicts ``{"field_id": ..., "operator": ..., "value": ...}`` without
+        a ``source`` key.  The discriminated union requires ``source`` to dispatch,
+        so we inject it here before Pydantic processes the conditions.
+
+        Args:
+            data: Raw dict or already-validated model instance.
+
+        Returns:
+            The (potentially mutated) data dict.
+        """
+        if isinstance(data, dict):
+            for cond in data.get("conditions") or []:
+                if isinstance(cond, dict) and "source" not in cond:
+                    cond["source"] = "field"
+        return data

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/core/schema.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/core/schema.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from datetime import datetime
+from enum import Enum
 from typing import Any, Literal, Union
 
 from pydantic import BaseModel, ConfigDict, model_validator
@@ -19,6 +20,24 @@ from .constraints import DependencyRule, FieldConstraints
 from .events import FormEventsConfig
 from .options import FieldOption, OptionsSource
 from .types import FieldType, LocalizedString
+
+
+class FormType(str, Enum):
+    """Discriminator for the form's structural type.
+
+    Attributes:
+        SIMPLE: A straightforward form with a linear set of questions
+            (no survey blocks). This is the default.
+        PRODUCT: A form bound to one or more product programmes
+            (activated via FEAT-302 ``product_bindings``).
+        SURVEY: A form composed of survey-style question blocks
+            (imported from ``networkninja.forms.question_blocks`` where
+            ``block_type == "survey"``).
+    """
+
+    SIMPLE = "simple"
+    PRODUCT = "product"
+    SURVEY = "survey"
 
 
 class FormField(BaseModel):
@@ -284,6 +303,10 @@ class FormSchema(BaseModel):
     tenant: str | None = None
     metadata: list[FormMetadataField] | None = None
     events: FormEventsConfig | None = None
+    # FEAT-300 — Form Builder Parity
+    form_type: FormType = FormType.SIMPLE
+    product_bindings: list[str] | None = None
+    published_version: str | None = None
 
     def iter_all_fields(self) -> Iterator[FormField]:
         """Yield every ``FormField`` across all sections, flattening subsections."""

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/core/types.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/core/types.py
@@ -51,3 +51,5 @@ class FieldType(str, Enum):
     REST = "rest"
     # Phase 4 — audio form renderer (FEAT-224)
     AUDIO = "audio"
+    # FEAT-300 — formula fields (inert stub; evaluator in FEAT-301)
+    FORMULA = "formula"

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/extractors/yaml.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/extractors/yaml.py
@@ -9,13 +9,24 @@ Uses yaml_rs (Rust) when available, falls back to PyYAML.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
-from ..core.constraints import ConditionOperator, DependencyRule, FieldCondition, FieldConstraints
+from ..core.constraints import (
+    ConditionOperator,
+    DependencyRule,
+    FieldCondition,
+    FieldConstraints,
+    FieldRefCondition,
+    LocationVarCondition,
+    VisitContextCondition,
+)
 from ..core.options import FieldOption
 from ..core.schema import FormField, FormSchema, FormSection, SubmitAction
 from ..core.types import FieldType, LocalizedString
+
+logger = logging.getLogger(__name__)
 
 # Try yaml_rs first, then PyYAML
 try:
@@ -429,18 +440,51 @@ class YamlExtractor:
         conditions: list[FieldCondition] = []
         for cond in conditions_data:
             if isinstance(cond, dict):
-                field_id = cond.get("field_id", "")
                 op_str = str(cond.get("operator", "eq")).lower()
                 try:
                     operator = ConditionOperator(op_str)
                 except ValueError:
                     operator = ConditionOperator.EQ
                 value = cond.get("value")
-                conditions.append(FieldCondition(
-                    field_id=field_id,
-                    operator=operator,
-                    value=value,
-                ))
+                source = cond.get("source", "field")
+                if source == "field":
+                    field_id = cond.get("field_id", "")
+                    conditions.append(FieldRefCondition(
+                        field_id=field_id,
+                        operator=operator,
+                        value=value,
+                    ))
+                elif source == "location_variable":
+                    key = cond.get("key", "")
+                    if not key:
+                        logger.warning(
+                            "LocationVarCondition in YAML missing 'key' — skipping"
+                        )
+                        continue
+                    conditions.append(LocationVarCondition(
+                        source="location_variable",
+                        key=key,
+                        operator=operator,
+                        value=value,
+                    ))
+                elif source == "visit_context":
+                    key = cond.get("key", "")
+                    if not key:
+                        logger.warning(
+                            "VisitContextCondition in YAML missing 'key' — skipping"
+                        )
+                        continue
+                    conditions.append(VisitContextCondition(
+                        source="visit_context",
+                        key=key,
+                        operator=operator,
+                        value=value,
+                    ))
+                else:
+                    logger.warning(
+                        "Unknown condition source %r in YAML — skipping", source
+                    )
+                    continue
 
         if not conditions:
             return None

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/renderers/adaptive_card.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/renderers/adaptive_card.py
@@ -80,6 +80,8 @@ _AC_FALLBACK_TYPES = frozenset({
     FieldType.AVAILABILITY,
     # Phase 3 — FEAT-170
     FieldType.REST,
+    # FEAT-300 — formula fields (evaluator is FEAT-301)
+    FieldType.FORMULA,
 })
 
 
@@ -150,11 +152,17 @@ class AdaptiveCardRenderer(AbstractFormRenderer):
         locale: str = "en",
         prefilled: dict[str, Any] | None = None,
         errors: dict[str, str] | None = None,
+        evaluation_context: Any | None = None,
     ) -> RenderedForm:
         """Render a complete FormSchema as an Adaptive Card.
 
         In WIZARD layout mode, renders only the first section.
         In all other modes, renders all sections in one card.
+
+        FEAT-301: Pre-resolved visibility state is ALWAYS embedded (not opt-in).
+        The ``data.logic_state`` key on the returned card payload carries the
+        field-level visibility map; individual elements also receive
+        ``isVisible: False`` when their pre-resolved effect is ``"hide"``.
 
         Args:
             form: The form schema.
@@ -162,10 +170,18 @@ class AdaptiveCardRenderer(AbstractFormRenderer):
             locale: Locale for i18n label resolution.
             prefilled: Pre-filled field values.
             errors: Field-level error messages.
+            evaluation_context: Optional :class:`~parrot_formdesigner.services
+                .rule_evaluator.EvaluationContext`.  When ``None``, an empty
+                context is used (all fields visible by default).
 
         Returns:
             RenderedForm with Adaptive Card dict as content.
         """
+        from ..services.rule_evaluator import (
+            DEFAULT_EVALUATOR,
+            EvaluationContext,
+        )
+
         style = style or StyleSchema()
         prefilled = prefilled or {}
         errors = errors or {}
@@ -218,11 +234,64 @@ class AdaptiveCardRenderer(AbstractFormRenderer):
                         ),
                     ))
 
+        # FEAT-301: Pre-resolve visibility state — ALWAYS ON (RESUELTO §8).
+        # Embed the logic state map into the card payload under "data".
+        ctx: EvaluationContext = (
+            evaluation_context
+            if isinstance(evaluation_context, EvaluationContext)
+            else EvaluationContext()
+        )
+        evaluator = DEFAULT_EVALUATOR
+        logic_state = evaluator.evaluate_form(form, ctx)
+        logic_state_map = {
+            fid: {"effect": r.effect, "matched": r.matched}
+            for fid, r in logic_state.items()
+        }
+        # Embed the pre-resolved state in card["data"]["logic_state"].
+        card.setdefault("data", {})["logic_state"] = logic_state_map
+
+        # Apply isVisible: False for fields whose pre-resolved effect is "hide".
+        # This ensures the initial card state is correct on first paint.
+        hidden_ids = {fid for fid, r in logic_state.items() if r.effect == "hide"}
+        if hidden_ids:
+            self._apply_initial_visibility(card, hidden_ids)
+
         return RenderedForm(
             content=card,
             content_type=self.CONTENT_TYPE,
             warnings=warnings,
         )
+
+    def _apply_initial_visibility(
+        self,
+        card: dict[str, Any],
+        hidden_ids: set[str],
+    ) -> None:
+        """Set ``isVisible: False`` on card elements whose field_id is hidden.
+
+        Traverses the card ``body`` recursively to find elements with an
+        ``id`` matching a hidden field ID and sets ``isVisible: False``.
+
+        Args:
+            card: The Adaptive Card dict (mutated in place).
+            hidden_ids: Set of field IDs whose pre-resolved effect is ``"hide"``.
+        """
+        def _walk(elements: list[dict[str, Any]]) -> None:
+            for element in elements:
+                if not isinstance(element, dict):
+                    continue
+                elem_id = element.get("id", "")
+                if elem_id and elem_id in hidden_ids:
+                    element["isVisible"] = False
+                # Recurse into nested containers
+                if "items" in element:
+                    _walk(element["items"])
+                if "columns" in element:
+                    for col in element["columns"]:
+                        if isinstance(col, dict) and "items" in col:
+                            _walk(col["items"])
+
+        _walk(card.get("body", []))
 
     async def render_section(
         self,
@@ -235,6 +304,7 @@ class AdaptiveCardRenderer(AbstractFormRenderer):
         errors: dict[str, str] | None = None,
         show_back: bool = False,
         show_skip: bool = False,
+        evaluation_context: Any | None = None,
     ) -> RenderedForm:
         """Render a single section as a wizard step Adaptive Card.
 
@@ -247,6 +317,9 @@ class AdaptiveCardRenderer(AbstractFormRenderer):
             errors: Field-level error messages.
             show_back: Whether to include a Back button.
             show_skip: Whether to include a Skip button.
+            evaluation_context: Optional EvaluationContext for pre-resolving
+                conditional logic state (defaults to an empty context — the
+                embed is ALWAYS ON, spec FEAT-301 §8).
 
         Returns:
             RenderedForm with wizard step card as content.
@@ -289,6 +362,23 @@ class AdaptiveCardRenderer(AbstractFormRenderer):
         )
 
         card = self._wrap_card(body, actions)
+
+        # Pre-resolved logic state — ALWAYS ON (spec FEAT-301 §8), same as render()
+        from ..services.rule_evaluator import DEFAULT_EVALUATOR, EvaluationContext
+        ctx = (
+            evaluation_context
+            if isinstance(evaluation_context, EvaluationContext)
+            else EvaluationContext()
+        )
+        logic_state = DEFAULT_EVALUATOR.evaluate_form(form, ctx)
+        card.setdefault("data", {})["logic_state"] = {
+            fid: {"effect": r.effect, "matched": r.matched}
+            for fid, r in logic_state.items()
+        }
+        hidden_ids = {fid for fid, r in logic_state.items() if r.effect == "hide"}
+        if hidden_ids:
+            self._apply_initial_visibility(card, hidden_ids)
+
         return RenderedForm(
             content=card,
             content_type=self.CONTENT_TYPE,

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/renderers/html5.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/renderers/html5.py
@@ -75,6 +75,20 @@ def _resolve(value: LocalizedString | None, locale: str = "en") -> str:
     return next(iter(value.values()), "")
 
 
+def _depends_on_attr_json(rule: DependencyRule) -> str:
+    """Serialize a DependencyRule for the ``data-depends-on`` attribute.
+
+    Strips ``source="field"`` from field-ref conditions so the emitted JSON
+    is byte-identical to pre-FEAT-301 output for legacy forms (spec §8
+    invariant: ``data-depends-on`` is preserved unchanged).
+    """
+    data = rule.model_dump()
+    for cond in data.get("conditions", []):
+        if isinstance(cond, dict) and cond.get("source") == "field":
+            cond.pop("source")
+    return json.dumps(data)
+
+
 class HTML5Renderer(AbstractFormRenderer):
     """Renders FormSchema as an HTML5 <form> fragment.
 
@@ -113,7 +127,7 @@ class HTML5Renderer(AbstractFormRenderer):
             autoescape=True,
         )
         # Register tojson filter
-        self._env.filters["tojson"] = lambda v: json.dumps(v)
+        self._env.filters["tojson"] = lambda v: json.dumps(v).replace("</", "<\\/")
         self._fallback = FallbackRenderer()
         self._registry: dict[FieldType, FieldRenderer] = {}
         self._build_registry()
@@ -296,8 +310,14 @@ class HTML5Renderer(AbstractFormRenderer):
         prefilled: dict[str, Any] | None = None,
         errors: dict[str, str] | None = None,
         csrf_token: str | None = None,
+        evaluation_context: Any | None = None,
     ) -> RenderedForm:
         """Render a FormSchema as an HTML5 form fragment.
+
+        FEAT-301: Pre-resolved visibility state is ALWAYS embedded (not opt-in)
+        as a ``<script type="application/json" data-logic-state>`` block at the
+        end of the rendered form.  The existing ``data-depends-on`` attributes
+        are PRESERVED (additive, FE-compatible).
 
         Args:
             form: The form schema.
@@ -309,10 +329,16 @@ class HTML5Renderer(AbstractFormRenderer):
                 bridge. When provided and the form has lifecycle events, a
                 ``<meta name="parrot-csrf-token">`` tag is prepended to the
                 output and the inline lifecycle script reads it.
+            evaluation_context: Optional :class:`~parrot_formdesigner.services
+                .rule_evaluator.EvaluationContext`.  When ``None``, an empty
+                context is used (no answers, no location vars).  The pre-resolved
+                state is always computed and embedded regardless.
 
         Returns:
             RenderedForm with HTML string as content and content_type="text/html".
         """
+        from ..services.rule_evaluator import EvaluationContext, DEFAULT_EVALUATOR
+
         style = style or StyleSchema()
         prefilled = prefilled or {}
         errors = errors or {}
@@ -330,17 +356,19 @@ class HTML5Renderer(AbstractFormRenderer):
             return self._render_field_html(field, prefilled, errors, style, locale)
 
         def depends_on_json(dep: DependencyRule) -> str:
-            return dep.model_dump_json()
+            return _depends_on_attr_json(dep)
 
-        # Collect render warnings for new field types rendered as fallbacks
+        # Collect render warnings for new field types rendered as fallbacks.
+        # FORMULA fields are rendered as read-only placeholders (FEAT-301 evaluator).
         warnings: list[RenderWarning] = []
-        _new_types = {
-            FieldType.SIGNATURE, FieldType.DYNAMIC_SELECT, FieldType.TRANSFER_LIST,
-            FieldType.REMOTE_RESPONSE, FieldType.AVAILABILITY, FieldType.LOCATION,
-            FieldType.TAGS, FieldType.NPS, FieldType.LIKERT, FieldType.RANKING,
-        }
-        # HTML5 renders all new types natively; no warnings needed here.
-        # (warnings are emitted only for renderers that use FallbackRenderer)
+        for _field in form.iter_all_fields():
+            if _field.field_type == FieldType.FORMULA:
+                warnings.append(RenderWarning(
+                    field_id=_field.field_id,
+                    field_type=FieldType.FORMULA.value,
+                    renderer="html5",
+                    reason="formula evaluation not available — rendered as read-only placeholder",
+                ))
 
         template = self._env.get_template("form.html.j2")
         rendered_html = template.render(
@@ -358,6 +386,26 @@ class HTML5Renderer(AbstractFormRenderer):
 
         # lifecycle: inject CSRF meta + lifecycle script when form has events
         rendered_html = self._inject_lifecycle(rendered_html, form, csrf_token)
+
+        # FEAT-301: Pre-resolve visibility state — ALWAYS ON (RESUELTO §8).
+        # One cheap pass of RuleEvaluator; result embedded as a JSON script block.
+        ctx: EvaluationContext = (
+            evaluation_context
+            if isinstance(evaluation_context, EvaluationContext)
+            else EvaluationContext()
+        )
+        evaluator = DEFAULT_EVALUATOR
+        logic_state = evaluator.evaluate_form(form, ctx)
+        # Serialise to JSON — guard against </script> injection.
+        logic_state_json = json.dumps(
+            {fid: {"effect": r.effect, "matched": r.matched} for fid, r in logic_state.items()}
+        ).replace("</", "<\\/")
+        logic_state_block = (
+            f'\n<script type="application/json" data-logic-state>'
+            f"{logic_state_json}"
+            f"</script>"
+        )
+        rendered_html = rendered_html + logic_state_block
 
         return RenderedForm(
             content=rendered_html,
@@ -566,7 +614,7 @@ class HTML5Renderer(AbstractFormRenderer):
         # depends_on data attribute
         depends_attr = ""
         if field.depends_on:
-            safe_json = html.escape(json.dumps(field.depends_on.model_dump()), quote=True)
+            safe_json = html.escape(_depends_on_attr_json(field.depends_on), quote=True)
             depends_attr = f' data-depends-on="{safe_json}"'
 
         # Required asterisk
@@ -743,6 +791,14 @@ class HTML5Renderer(AbstractFormRenderer):
                 # directly to avoid event-loop re-entrancy issues.
                 parts.append(self._render_audio_field(field, value, locale, error))
             # else: fallback — no audio renderer registered, render nothing
+        # FEAT-300 — FORMULA: read-only placeholder (evaluator is FEAT-301)
+        elif ft == FieldType.FORMULA:
+            parts.append(
+                f'<label class="block text-sm font-medium text-gray-700 mb-1">{label_text}</label>'
+            )
+            if description:
+                parts.append(f'<span class="form-field__help text-xs text-gray-500 mb-1 block">{description}</span>')
+            parts.append(self._render_formula_placeholder(field))
 
         else:
             parts.append(
@@ -1236,7 +1292,7 @@ class HTML5Renderer(AbstractFormRenderer):
         depends_attr = ""
         if subsection.depends_on:
             import html as _html
-            safe_json = _html.escape(json.dumps(subsection.depends_on.model_dump()), quote=True)
+            safe_json = _html.escape(_depends_on_attr_json(subsection.depends_on), quote=True)
             depends_attr = f' data-depends-on="{safe_json}"'
 
         parts: list[str] = [
@@ -1473,3 +1529,35 @@ class HTML5Renderer(AbstractFormRenderer):
 
         parts.append("</div>")
         return "\n".join(parts)
+
+    def _render_formula_placeholder(self, field: FormField) -> str:
+        """Render a FORMULA field as a read-only placeholder.
+
+        The formula evaluator ships in FEAT-301; this stub renders a disabled
+        text input so the form remains valid HTML.  A ``RenderWarning`` is
+        emitted at the top-level ``render()`` call.
+
+        Args:
+            field: FORMULA FormField.
+
+        Returns:
+            HTML string for the read-only formula placeholder.
+        """
+        meta = field.meta or {}
+        expression = meta.get("expression")
+        result_type = meta.get("result_type", "")
+        title = "formula field — expression unavailable (FEAT-301)"
+        if expression:
+            # expression will be user-supplied once FEAT-301 lands — escape it
+            title = f"formula: {expression}"
+        result_label = f" ({result_type})" if result_type else ""
+        safe_id = html.escape(str(field.field_id), quote=True)
+        safe_title = html.escape(str(title), quote=True)
+        safe_label = html.escape(str(result_label), quote=True)
+        tw = "block w-full border border-gray-200 bg-gray-50 rounded-md px-3 py-2 text-sm text-gray-500 cursor-not-allowed"
+        return (
+            f'<input type="text" id="{safe_id}" name="{safe_id}" '
+            f'class="{tw}" disabled readonly '
+            f'placeholder="[formula{safe_label}]" title="{safe_title}" '
+            f'data-formula="true">'
+        )

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/renderers/jsonschema.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/renderers/jsonschema.py
@@ -56,6 +56,8 @@ _TYPE_MAP: dict[FieldType, str] = {
     FieldType.RANKING: "integer",
     # Phase 3 — FEAT-170
     FieldType.REST: "object",
+    # FEAT-300 — formula fields (evaluator is FEAT-301)
+    FieldType.FORMULA: "number",
 }
 
 # FieldType → JSON Schema "format" keyword (where applicable)
@@ -78,6 +80,8 @@ _FORMAT_MAP: dict[FieldType, str] = {
     FieldType.RANKING: "ranking",
     # Phase 3 — FEAT-170
     FieldType.REST: "rest",
+    # FEAT-300 — formula fields
+    FieldType.FORMULA: "formula",
 }
 
 

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/renderers/pdf.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/renderers/pdf.py
@@ -55,6 +55,8 @@ _PDF_FALLBACK_NEW_TYPES = frozenset({
     FieldType.DYNAMIC_SELECT,
     # Phase 3 — FEAT-170
     FieldType.REST,
+    # FEAT-300 — formula fields (evaluator is FEAT-301)
+    FieldType.FORMULA,
 })
 
 

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/renderers/telegram/renderer.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/renderers/telegram/renderer.py
@@ -64,6 +64,8 @@ _WEBAPP_FIELD_TYPES = {
     FieldType.TAGS,
     # Phase 3 — FEAT-170
     FieldType.REST,
+    # FEAT-300 — formula fields (evaluator is FEAT-301)
+    FieldType.FORMULA,
 }
 
 # File-type fields that cannot be handled inline even if forced

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/renderers/xforms.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/renderers/xforms.py
@@ -29,6 +29,7 @@ from ..core.constraints import (
     ConditionOperator,
     DependencyRule,
     FieldConstraints,
+    FieldRefCondition,
 )
 from ..core.options import FieldOption
 from ..core.schema import FormField, FormSchema, FormSection, FormSubsection, RenderedForm
@@ -91,6 +92,8 @@ _FIELD_TO_XFORMS: dict[FieldType, tuple[str, str | None]] = {
     FieldType.RANKING: ("range", "integer"),         # <xf:range>
     # Phase 3 — FEAT-170
     FieldType.REST: ("input", "string"),             # fallback: plain text
+    # FEAT-300 — formula fields (evaluator is FEAT-301; render as read-only input)
+    FieldType.FORMULA: ("input", "string"),          # fallback: plain text placeholder
 }
 
 
@@ -134,8 +137,10 @@ def _relevant_xpath(rule: DependencyRule | None) -> str | None:
     """Build the XPath expression for an ``<xf:bind relevant=...>``.
 
     Supports only the simple single-condition equality case
-    (``field_id == value``). Returns ``None`` for anything more complex —
-    a logger.debug message records the skip.
+    (``field_id == value``) for ``FieldRefCondition`` variants. Returns
+    ``None`` for anything more complex — a logger.debug message records the
+    skip. FEAT-301: non-field condition variants (LocationVarCondition,
+    VisitContextCondition) cannot be expressed in XPath and are skipped.
     """
     if rule is None or not rule.conditions:
         return None
@@ -146,6 +151,13 @@ def _relevant_xpath(rule: DependencyRule | None) -> str | None:
         )
         return None
     cond = rule.conditions[0]
+    # FEAT-301: only FieldRefCondition carries field_id; other variants are skipped.
+    if not isinstance(cond, FieldRefCondition):
+        logger.debug(
+            "Skipping `relevant` for non-field condition source: %s",
+            getattr(cond, "source", "unknown"),
+        )
+        return None
     if cond.operator != ConditionOperator.EQ:
         logger.debug(
             "Skipping `relevant` for non-eq operator: %s", cond.operator

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/__init__.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/__init__.py
@@ -1,6 +1,7 @@
 """Form services for parrot-formdesigner.
 
 Provides validation, registry, caching, and storage for FormSchema objects.
+Also exports the FEAT-301 conditional logic evaluation infrastructure.
 """
 
 from .cache import FormCache
@@ -14,10 +15,19 @@ from .event_registry import (
     list_form_events,
     register_form_event,
 )
+from .form_version import FormVersionService, VersionMeta
 from .forwarder import ForwardResult, SubmissionForwarder
+from .logic_graph import CyclicDependencyError, LogicGraph
 from .metadata_callbacks import MetadataCallbackInput, MetadataCallbackOutput
 from .metadata_enricher import MetadataResolutionError, enrich_submission
+from .question_bank import QuestionBankService, ReusableField, ReusableFieldRef
 from .registry import FormRegistry, FormStorage
+from .rule_evaluator import (
+    EffectResult,
+    EvaluationContext,
+    EvaluationResult,
+    RuleEvaluator,
+)
 from .storage import PostgresFormStorage
 from .submissions import (
     CORE_METADATA_COLUMNS,
@@ -28,19 +38,30 @@ from .validators import FormValidator, ValidationResult
 
 __all__ = [
     "CORE_METADATA_COLUMNS",
+    "CyclicDependencyError",
+    "EffectResult",
+    "EvaluationContext",
+    "EvaluationResult",
     "FormCache",
+    "FormVersionService",
     "ForwardResult",
     "FormRegistry",
     "FormStorage",
     "FormSubmission",
     "FormSubmissionStorage",
     "FormValidator",
+    "LogicGraph",
     "MetadataCallbackInput",
     "MetadataCallbackOutput",
     "MetadataResolutionError",
     "PostgresFormStorage",
+    "QuestionBankService",
+    "ReusableField",
+    "ReusableFieldRef",
+    "RuleEvaluator",
     "SubmissionForwarder",
     "ValidationResult",
+    "VersionMeta",
     "enrich_submission",
     # Lifecycle event registry (FEAT-188)
     "register_form_event",

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/form_version.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/form_version.py
@@ -1,0 +1,535 @@
+"""FormVersionService — immutable semver publishing for FormSchema objects.
+
+Implements the form publishing lifecycle described in FEAT-300 §2 (RF-06):
+- Publishing freezes the current form as a semver-tagged snapshot.
+- Published snapshots are immutable — overwriting raises ``ValueError``.
+- In-flight responses resolve against the version they started with.
+- Deletion of a form/version with associated responses is blocked (caller
+  provides a ``has_responses`` hook).
+
+FEAT-300 — Module 4.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timezone
+
+from pydantic import BaseModel, ConfigDict
+
+from ..core.schema import FormSchema
+from .registry import FormRegistry, FormStorage
+
+logger = logging.getLogger(__name__)
+
+#: Upper bound for storage probing when reconstructing version history
+#: (defensive cap — real forms have far fewer published versions).
+_MAX_VERSION_PROBES = 200
+
+
+def _is_unique_violation(exc: Exception) -> bool:
+    """Heuristically detect a UNIQUE(form_id, version) constraint violation.
+
+    Works for asyncpg (``UniqueViolationError``) and for drivers that wrap
+    the original error, without importing driver-specific exception types.
+    """
+    if type(exc).__name__ == "UniqueViolationError":
+        return True
+    text = str(exc).lower()
+    return "duplicate key" in text or "unique constraint" in text
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+class VersionMeta(BaseModel):
+    """Metadata record for a published form version.
+
+    Attributes:
+        form_id: The form's canonical identifier.
+        version: The semver-style ``major.minor`` tag (e.g. ``"1.0"``).
+        published_at: UTC timestamp when this version was published.
+        tenant: Tenant slug.
+        is_frozen: Always ``True`` — published versions are immutable.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    form_id: str
+    version: str
+    published_at: datetime
+    tenant: str
+    is_frozen: bool = True
+
+
+# ---------------------------------------------------------------------------
+# Semver helpers
+# ---------------------------------------------------------------------------
+
+_SEMVER_RE = re.compile(r"^(\d+)\.(\d+)$")
+
+
+def _parse_major_minor(version: str) -> tuple[int, int]:
+    """Parse a ``major.minor`` version string.
+
+    Args:
+        version: Version string, e.g. ``"1.0"`` or ``"2.3"``.
+
+    Returns:
+        ``(major, minor)`` ints. Falls back to ``(1, 0)`` on parse failure.
+    """
+    m = _SEMVER_RE.match(version or "")
+    if m:
+        return int(m.group(1)), int(m.group(2))
+    logger.warning("Could not parse version %r as major.minor — defaulting to (1, 0)", version)
+    return 1, 0
+
+
+def _bump(current: str, bump: str = "minor") -> str:
+    """Bump a ``major.minor`` version string.
+
+    Args:
+        current: Current version (e.g. ``"1.0"``).
+        bump: ``"minor"`` (default) or ``"major"``.
+
+    Returns:
+        New version string. ``"1.0"`` + minor → ``"1.1"``; + major → ``"2.0"``.
+    """
+    major, minor = _parse_major_minor(current)
+    if bump == "major":
+        return f"{major + 1}.0"
+    return f"{major}.{minor + 1}"
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class FormVersionService:
+    """Immutable semver publishing service for ``FormSchema`` objects.
+
+    Each call to :meth:`publish` creates a frozen snapshot identified by a
+    bumped semver tag.  The snapshot is stored via ``storage.save()`` when
+    available; an in-memory fallback (dict) is used otherwise (suitable for
+    tests and development).
+
+    Deletion is guarded by the optional ``has_responses`` async hook: if
+    supplied, the service calls it before any delete to confirm no response
+    data exists.  If the hook returns ``True``, deletion raises ``ValueError``
+    and the form is only deactivated (not deleted).
+
+    Example::
+
+        svc = FormVersionService(registry, storage)
+        tag = await svc.publish("my-form", tenant="navigator")  # → "1.1"
+        snap = await svc.get_published("my-form", version="1.1", tenant="navigator")
+
+    Args:
+        registry: ``FormRegistry`` used to look up the live form state and
+            register snapshots when a ``storage`` backend is not available.
+        storage: ``FormStorage`` used to persist snapshots. When ``None``,
+            the service stores snapshots in an in-memory dict.
+        has_responses: Optional async callback ``(form_id, tenant) -> bool``
+            that returns ``True`` when the form/version has associated
+            responses. When ``True`` is returned, deletion is blocked.
+    """
+
+    def __init__(
+        self,
+        registry: FormRegistry,
+        storage: FormStorage | None = None,
+        *,
+        has_responses: Callable[[str, str], Awaitable[bool]] | None = None,
+    ) -> None:
+        self._registry = registry
+        self._storage = storage
+        self._has_responses = has_responses
+        self.logger = logging.getLogger(__name__)
+
+        # In-memory fallback stores:
+        # _snapshots[tenant][form_id][version] = FormSchema
+        self._snapshots: dict[str, dict[str, dict[str, FormSchema]]] = {}
+        # _meta[tenant][form_id] = list[VersionMeta]
+        self._meta: dict[str, dict[str, list[VersionMeta]]] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def publish(
+        self,
+        form_id: str,
+        *,
+        tenant: str,
+        bump: str = "minor",
+    ) -> str:
+        """Publish the current form as an immutable semver snapshot.
+
+        Steps:
+        1. Load the live form from the registry.
+        2. Compute the next semver tag.
+        3. Raise ``ValueError`` if that tag already exists (immutability).
+        4. Set ``published_version`` on a deep copy.
+        5. Persist the snapshot (storage or in-memory).
+
+        Args:
+            form_id: The form's canonical ID.
+            tenant: Tenant slug.
+            bump: ``"minor"`` (default) or ``"major"``.
+
+        Returns:
+            The new version string (e.g. ``"1.1"``).
+
+        Raises:
+            KeyError: If the form is not found in the registry.
+            ValueError: If the computed version tag already exists (immutable).
+        """
+        form = await self._registry.get(form_id, tenant=tenant)
+        if form is None:
+            raise KeyError(f"Form '{form_id}' not found under tenant '{tenant}'")
+
+        new_version = _bump(form.version, bump=bump)
+
+        # Immutability guard
+        existing = await self.get_published(form_id, version=new_version, tenant=tenant)
+        if existing is not None:
+            raise ValueError(
+                f"Version '{new_version}' of form '{form_id}' already exists and is frozen."
+            )
+
+        published_at = datetime.now(timezone.utc)
+
+        # Build frozen snapshot. ``published_at`` is stamped into ``meta`` so
+        # version history can be reconstructed from storage after a restart.
+        snapshot = form.model_copy(deep=True, update={
+            "version": new_version,
+            "published_version": new_version,
+            "meta": {**(form.meta or {}), "published_at": published_at.isoformat()},
+        })
+
+        # Persist. The database UNIQUE(form_id, version) constraint is the
+        # authoritative immutability guard — two concurrent publishes cannot
+        # both succeed (the pre-check above is a fast path, not the guard).
+        try:
+            await self._save_snapshot(snapshot, tenant=tenant)
+        except Exception as exc:
+            if _is_unique_violation(exc):
+                raise ValueError(
+                    f"Version '{new_version}' of form '{form_id}' already exists and is frozen."
+                ) from exc
+            raise
+
+        # Update the live form's published_version in the registry
+        updated_live = form.model_copy(deep=True, update={
+            "version": new_version,
+            "published_version": new_version,
+        })
+        await self._registry.register(updated_live, persist=False, overwrite=True, tenant=tenant)
+
+        # Record VersionMeta
+        meta = VersionMeta(
+            form_id=form_id,
+            version=new_version,
+            published_at=published_at,
+            tenant=tenant,
+        )
+        self._meta.setdefault(tenant, {}).setdefault(form_id, []).append(meta)
+
+        self.logger.info(
+            "Published form '%s' as version '%s' for tenant '%s'",
+            form_id, new_version, tenant,
+        )
+        return new_version
+
+    async def get_published(
+        self,
+        form_id: str,
+        *,
+        version: str,
+        tenant: str,
+    ) -> FormSchema | None:
+        """Retrieve an immutable published snapshot.
+
+        Always returns the untouched snapshot at ``version`` — subsequent
+        publishes do not affect it (RF-06).
+
+        Args:
+            form_id: The form's canonical ID.
+            version: The semver tag to retrieve (e.g. ``"1.1"``).
+            tenant: Tenant slug.
+
+        Returns:
+            Frozen ``FormSchema`` snapshot, or ``None`` if not found.
+        """
+        if self._storage is not None:
+            snap = await self._storage.load(form_id, version=version, tenant=tenant)
+            if snap is not None and snap.published_version == version:
+                return snap
+        # In-memory fallback
+        return (
+            self._snapshots
+            .get(tenant, {})
+            .get(form_id, {})
+            .get(version)
+        )
+
+    async def list_versions(
+        self,
+        form_id: str,
+        *,
+        tenant: str,
+    ) -> list[VersionMeta]:
+        """List all published version metadata for a form.
+
+        Merges the in-process ``VersionMeta`` cache with a reconstruction
+        from storage, so history survives a process restart (the snapshots
+        live in Postgres under ``UNIQUE(form_id, version)``; ``published_at``
+        is recovered from the stamp written into ``snapshot.meta`` by
+        :meth:`publish`).
+
+        Args:
+            form_id: The form's canonical ID.
+            tenant: Tenant slug.
+
+        Returns:
+            List of ``VersionMeta`` objects ordered by (major, minor).
+        """
+        by_version: dict[str, VersionMeta] = {
+            m.version: m for m in self._meta.get(tenant, {}).get(form_id, [])
+        }
+
+        if self._storage is not None:
+            for version in await self._probe_storage_versions(form_id, tenant=tenant):
+                if version in by_version:
+                    continue
+                snap = await self._storage.load(form_id, version=version, tenant=tenant)
+                if snap is None or snap.published_version != version:
+                    continue
+                by_version[version] = VersionMeta(
+                    form_id=form_id,
+                    version=version,
+                    published_at=self._published_at_from_snapshot(snap),
+                    tenant=tenant,
+                )
+
+        return sorted(by_version.values(), key=lambda m: _parse_major_minor(m.version))
+
+    async def _probe_storage_versions(self, form_id: str, *, tenant: str) -> list[str]:
+        """Enumerate published version tags persisted in storage.
+
+        ``FormStorage`` has no version-listing API, but publish tags form a
+        contiguous semver chain (each publish bumps from the live version),
+        so the history is recoverable by probing minors per major up to the
+        latest stored version. A single leading miss per major is tolerated
+        (the first publish of a form is usually ``X.1``, not ``X.0``).
+        """
+        latest = await self._storage.load(form_id, tenant=tenant)
+        if latest is None:
+            return []
+        latest_major, _ = _parse_major_minor(latest.version)
+
+        found: list[str] = []
+        probes = 0
+        for major in range(1, latest_major + 1):
+            minor = 0
+            misses = 0
+            while misses < 2 and probes < _MAX_VERSION_PROBES:
+                version = f"{major}.{minor}"
+                snap = await self._storage.load(form_id, version=version, tenant=tenant)
+                probes += 1
+                if snap is not None and snap.published_version == version:
+                    found.append(version)
+                    misses = 0
+                else:
+                    misses += 1
+                minor += 1
+        return found
+
+    @staticmethod
+    def _published_at_from_snapshot(snap: FormSchema) -> datetime:
+        """Recover the publish timestamp stamped into ``snapshot.meta``."""
+        stamp = (snap.meta or {}).get("published_at")
+        if isinstance(stamp, str):
+            try:
+                return datetime.fromisoformat(stamp)
+            except ValueError:
+                pass
+        return snap.created_at or datetime.now(timezone.utc)
+
+    async def can_delete(self, form_id: str, *, tenant: str) -> bool:
+        """Return ``True`` if deletion is safe (no responses associated).
+
+        If no ``has_responses`` hook was provided, deletion is always
+        considered safe (returns ``True``).
+
+        Args:
+            form_id: The form's canonical ID.
+            tenant: Tenant slug.
+
+        Returns:
+            ``True`` if deletion is permitted.
+        """
+        if self._has_responses is None:
+            return True
+        has = await self._has_responses(form_id, tenant)
+        return not has
+
+    async def safe_delete(self, form_id: str, *, tenant: str) -> None:
+        """Delete a form only if it has no responses.
+
+        Raises:
+            ValueError: If ``has_responses`` returns ``True`` for this form.
+        """
+        if not await self.can_delete(form_id, tenant=tenant):
+            raise ValueError(
+                f"Form '{form_id}' has responses and cannot be deleted. "
+                "Deactivate it instead."
+            )
+        if self._storage is not None:
+            await self._storage.delete(form_id, tenant=tenant)
+        # Also remove from the registry (public API — never touch _forms)
+        await self._registry.unregister(form_id, tenant=tenant)
+
+    # ------------------------------------------------------------------
+    # Backfill (TASK-005)
+    # ------------------------------------------------------------------
+
+    async def backfill_published(
+        self,
+        *,
+        tenant: str,
+        dry_run: bool = False,
+    ) -> int:
+        """Backfill pre-existing forms as published v1.0 snapshots.
+
+        For every form whose ``published_version`` is ``None``, marks it as
+        published at its current ``version`` value (default ``"1.0"``).
+        Already-backfilled forms (``published_version is not None``) are
+        skipped — the operation is idempotent.
+
+        This resolves decision C3 (spec §8): forms created before FEAT-300 had
+        no version history.  Running this migration once enables
+        ``FormVersionService`` on tenants with pre-existing forms.
+
+        Args:
+            tenant: Tenant slug to backfill.
+            dry_run: If ``True``, logs what would change but persists nothing.
+
+        Returns:
+            Number of forms that were (or would be) backfilled.
+        """
+        changed = 0
+
+        # --- Collect forms needing backfill ---
+        # Strategy: iterate registry forms for this tenant (public API),
+        # then also check storage-persisted forms if a backend is available.
+        forms_to_backfill: list[FormSchema] = []
+
+        # Registry entries (public API — never touch _forms)
+        for form in await self._registry.list_forms(tenant=tenant):
+            if form.published_version is None:
+                forms_to_backfill.append(form)
+
+        # Storage-persisted forms (may not overlap with in-memory).
+        # Storage failures are fatal: silently returning changed=0 would make
+        # operators believe nothing needed backfilling (review M5).
+        if self._storage is not None:
+            try:
+                rows = await self._storage.list_forms(tenant=tenant)
+                seen_ids = {f.form_id for f in forms_to_backfill}
+                for row in rows:
+                    fid = row.get("form_id")
+                    if not fid or fid in seen_ids:
+                        continue
+                    loaded = await self._storage.load(fid, tenant=tenant)
+                    if loaded is not None and loaded.published_version is None:
+                        forms_to_backfill.append(loaded)
+            except Exception:
+                self.logger.error(
+                    "backfill_published: storage unreachable for tenant '%s' — aborting",
+                    tenant,
+                )
+                raise
+
+        # --- Backfill each form ---
+        for form in forms_to_backfill:
+            target_version = form.version or "1.0"
+            self.logger.info(
+                "backfill: %s form '%s' v%s for tenant '%s'",
+                "[dry-run]" if dry_run else "publishing",
+                form.form_id, target_version, tenant,
+            )
+            if not dry_run:
+                published_at = datetime.now(timezone.utc)
+
+                # Build frozen snapshot at the existing version (stamped for
+                # post-restart history reconstruction, same as publish())
+                snapshot = form.model_copy(deep=True, update={
+                    "published_version": target_version,
+                    "meta": {**(form.meta or {}), "published_at": published_at.isoformat()},
+                })
+                await self._save_snapshot(snapshot, tenant=tenant)
+
+                # Update live form in registry
+                updated = form.model_copy(deep=True, update={"published_version": target_version})
+                await self._registry.register(updated, persist=False, overwrite=True, tenant=tenant)
+
+                meta = VersionMeta(
+                    form_id=form.form_id,
+                    version=target_version,
+                    published_at=published_at,
+                    tenant=tenant,
+                )
+                self._meta.setdefault(tenant, {}).setdefault(form.form_id, []).append(meta)
+
+            changed += 1
+
+        self.logger.info(
+            "backfill_published: %s%d form(s) for tenant '%s'",
+            "[dry-run] would change " if dry_run else "changed ",
+            changed, tenant,
+        )
+        return changed
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _save_snapshot(self, snapshot: FormSchema, *, tenant: str) -> None:
+        """Persist a frozen snapshot.
+
+        Uses ``storage.save()`` when a backend is available; the in-memory
+        ``_snapshots`` dict is used ONLY when no backend is configured.
+        Storage failures propagate to the caller — silently falling back to
+        memory would return success for a publish that vanishes on restart
+        (review H3).
+
+        Args:
+            snapshot: Frozen ``FormSchema`` (``published_version`` must be set).
+            tenant: Tenant slug.
+
+        Raises:
+            Exception: Whatever ``storage.save()`` raised (including unique
+                violations, surfaced by :meth:`publish` as ``ValueError``).
+        """
+        if self._storage is not None:
+            try:
+                await self._storage.save(snapshot, tenant=tenant)
+            except Exception as exc:
+                self.logger.error(
+                    "storage.save() failed for snapshot %s v%s: %s",
+                    snapshot.form_id, snapshot.version, exc,
+                )
+                raise
+            return
+        # In-memory store (no backend configured — tests/development)
+        (
+            self._snapshots
+            .setdefault(tenant, {})
+            .setdefault(snapshot.form_id, {})
+        )[snapshot.version] = snapshot

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/logic_graph.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/logic_graph.py
@@ -1,0 +1,258 @@
+"""Shared dependency-graph infrastructure for FEAT-301/FEAT-300.
+
+``LogicGraph`` builds the combined field-dependency graph for a form:
+- Edges from field A → field B when a ``DependencyRule`` on field B references
+  field A via ``FieldRefCondition``.
+- Extensible to formula inputs (FEAT-300 ``ExpressionEvaluator`` follow-up).
+
+Provides:
+- Topological ordering (so chained show/hide resolves deterministically).
+- Cycle detection (reports/raises ``CyclicDependencyError`` but
+  ``evaluate_form`` degrades gracefully — logs warning, never hangs).
+"""
+
+from __future__ import annotations
+
+from collections import deque
+
+import logging
+from typing import TYPE_CHECKING
+
+from ..core.constraints import FieldRefCondition
+
+if TYPE_CHECKING:
+    from ..core.schema import FormSchema
+
+logger = logging.getLogger(__name__)
+
+
+class CyclicDependencyError(ValueError):
+    """Raised when a circular dependency is detected in the logic graph.
+
+    Attributes:
+        cycle: The list of field IDs that form the cycle.
+    """
+
+    def __init__(self, cycle: list[str]) -> None:
+        """Initialize with the cycle path.
+
+        Args:
+            cycle: Ordered list of field IDs forming the cycle.
+        """
+        self.cycle = cycle
+        super().__init__(f"Circular dependency detected: {' -> '.join(cycle)}")
+
+
+class LogicGraph:
+    """Dependency graph for form fields and their condition references.
+
+    The graph is directed: an edge (A → B) means "field B's rule references
+    field A's answer", so A must be evaluated before B.
+
+    Extensible: future formula inputs (FEAT-300) can add edges to the same
+    graph so that the combined topological order is correct for an
+    orchestrator that runs both ``RuleEvaluator`` and ``ExpressionEvaluator``.
+
+    Args:
+        nodes: Set of all field IDs in the graph.
+        edges: Adjacency list: field_id → set of field_ids that depend on it
+               (i.e. "dependents of X", not "dependencies of X").
+    """
+
+    def __init__(
+        self,
+        nodes: set[str],
+        edges: dict[str, set[str]],
+    ) -> None:
+        """Initialize the graph.
+
+        Args:
+            nodes: All field IDs in the form.
+            edges: For each field, the set of fields whose rules reference it
+                   (X → {fields that depend on X}).
+        """
+        self._nodes = nodes
+        # _deps[B] = set of fields that B depends on (reverse of edges above)
+        # For topological sort, we need the "A must come before B" direction.
+        self._deps: dict[str, set[str]] = {n: set() for n in nodes}
+        for src, dependents in edges.items():
+            for dep in dependents:
+                self._deps.setdefault(dep, set()).add(src)
+
+    @classmethod
+    def build(cls, form: "FormSchema") -> "LogicGraph":
+        """Build a LogicGraph from a FormSchema.
+
+        Only ``FieldRefCondition`` variants create intra-form edges.
+        ``LocationVarCondition`` and ``VisitContextCondition`` reference
+        external keys, not form fields.
+
+        Args:
+            form: The form schema to analyze.
+
+        Returns:
+            A ``LogicGraph`` for the form's fields.
+        """
+        all_fields = list(form.iter_all_fields())
+        nodes = {f.field_id for f in all_fields}
+
+        # edges[X] = set of fields whose rules reference X (X is a dependency of those fields)
+        edges: dict[str, set[str]] = {n: set() for n in nodes}
+
+        for field in all_fields:
+            if field.depends_on is None:
+                continue
+            for condition in field.depends_on.conditions:
+                if isinstance(condition, FieldRefCondition):
+                    ref_id = condition.field_id
+                    if ref_id in nodes:
+                        edges.setdefault(ref_id, set()).add(field.field_id)
+
+        return cls(nodes, edges)
+
+    def topological_order(self) -> list[str]:
+        """Return field IDs in topological evaluation order.
+
+        Fields with no dependencies come first; dependents come after.
+        Nodes not connected to the dependency graph appear at the front
+        in their original insertion order (deterministic across Python 3.7+).
+
+        Returns:
+            Ordered list of all field IDs.
+
+        Raises:
+            CyclicDependencyError: If a cycle is detected.
+        """
+        # Kahn's algorithm (BFS-based topological sort)
+        in_degree: dict[str, int] = {n: 0 for n in self._nodes}
+        for n, deps in self._deps.items():
+            in_degree[n] = len(deps)
+
+        # Start with nodes that have no dependencies
+        queue: deque[str] = deque(sorted(n for n, d in in_degree.items() if d == 0))
+        result: list[str] = []
+
+        while queue:
+            node = queue.popleft()
+            result.append(node)
+            # For each node that depends on `node`, reduce its in-degree
+            for dependent in sorted(self._get_dependents(node)):
+                in_degree[dependent] -= 1
+                if in_degree[dependent] == 0:
+                    queue.append(dependent)
+
+        if len(result) != len(self._nodes):
+            # Cycle detected — find one cycle for the error message
+            visited_in_result = set(result)
+            cycle = self._find_cycle(visited_in_result)
+            raise CyclicDependencyError(cycle)
+
+        return result
+
+    def detect_cycles(self) -> list[list[str]]:
+        """Detect all cycles in the graph.
+
+        Returns:
+            List of cycles, each cycle is a list of field IDs. Empty if no cycles.
+        """
+        # Iterative DFS (explicit stack) — avoids RecursionError on deep
+        # dependency chains (Python's default recursion limit is ~1000).
+        UNVISITED, VISITING, VISITED = 0, 1, 2
+        state: dict[str, int] = {n: UNVISITED for n in self._nodes}
+        cycles: list[list[str]] = []
+
+        for root in sorted(self._nodes):
+            if state[root] != UNVISITED:
+                continue
+            path: list[str] = [root]
+            stack = [(root, iter(sorted(self._deps.get(root, set()))))]
+            state[root] = VISITING
+            while stack:
+                node, it = stack[-1]
+                advanced = False
+                for dep in it:
+                    if state.get(dep) == VISITING:
+                        cycle_start = path.index(dep)
+                        cycles.append(path[cycle_start:] + [dep])
+                    elif state.get(dep) == UNVISITED:
+                        state[dep] = VISITING
+                        path.append(dep)
+                        stack.append(
+                            (dep, iter(sorted(self._deps.get(dep, set()))))
+                        )
+                        advanced = True
+                        break
+                if not advanced:
+                    stack.pop()
+                    path.pop()
+                    state[node] = VISITED
+
+        return cycles
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _get_dependents(self, field_id: str) -> set[str]:
+        """Return the set of fields that directly depend on ``field_id``.
+
+        Args:
+            field_id: The field ID to look up.
+
+        Returns:
+            Set of field IDs that have ``field_id`` as a dependency.
+        """
+        dependents: set[str] = set()
+        for n, deps in self._deps.items():
+            if field_id in deps:
+                dependents.add(n)
+        return dependents
+
+    def _find_cycle(self, visited: set[str]) -> list[str]:
+        """Find one cycle among the unvisited nodes (after Kahn failed).
+
+        Args:
+            visited: Set of field IDs that were successfully ordered.
+
+        Returns:
+            A list of field IDs forming one cycle.
+        """
+        remaining = self._nodes - visited
+        if not remaining:
+            return []
+
+        # Iterative DFS (explicit stack) restricted to the remaining nodes —
+        # avoids RecursionError on deep chains (review M-4).
+        UNVISITED, VISITING, VISITED = 0, 1, 2
+        state: dict[str, int] = {n: UNVISITED for n in remaining}
+
+        def _deps_in_remaining(node: str):
+            return iter(
+                d for d in sorted(self._deps.get(node, set())) if d in remaining
+            )
+
+        for root in sorted(remaining):
+            if state.get(root) != UNVISITED:
+                continue
+            path: list[str] = [root]
+            stack = [(root, _deps_in_remaining(root))]
+            state[root] = VISITING
+            while stack:
+                node, it = stack[-1]
+                advanced = False
+                for dep in it:
+                    if state.get(dep) == VISITING:
+                        cycle_start = path.index(dep)
+                        return path[cycle_start:] + [dep]
+                    if state.get(dep) == UNVISITED:
+                        state[dep] = VISITING
+                        path.append(dep)
+                        stack.append((dep, _deps_in_remaining(dep)))
+                        advanced = True
+                        break
+                if not advanced:
+                    stack.pop()
+                    path.pop()
+                    state[node] = VISITED
+
+        return list(remaining)[:2] + [list(remaining)[0]]  # fallback

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/question_bank.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/question_bank.py
@@ -1,0 +1,322 @@
+"""QuestionBankService — tenant-scoped library of reusable field definitions.
+
+Provides CRUD operations on ``ReusableField`` entries stored in a dedicated
+``field_bank`` table (JSONB-backed), mirroring the ``form_schemas`` DDL
+pattern from ``services/storage.py``.  Unit tests use the built-in in-memory
+store; the ``db=`` constructor kwarg plugs in an asyncdb/asyncpg connection
+for production use.
+
+FEAT-300 — Module 3.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+from ..core.schema import FormField
+from ..core.types import FieldType  # noqa: F401 — re-exported for convenience
+from ._identifiers import qualified_table, validate_identifier
+from .registry import FormStorage
+
+
+class ReusableField(BaseModel):
+    """A single entry in the tenant's QuestionBank.
+
+    Attributes:
+        field_id: Unique identifier for this bank entry (UUID string).
+        definition: The canonical ``FormField`` definition.
+        tenant: Tenant slug that owns this entry.
+        usage_forms: Number of forms that reference this entry.
+        usage_responses: Cumulative response count across all referencing forms.
+        created_at: UTC timestamp of creation.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    field_id: str
+    definition: FormField
+    tenant: str
+    usage_forms: int = 0
+    usage_responses: int = 0
+    created_at: datetime | None = None
+
+
+class ReusableFieldRef(BaseModel):
+    """A reference to a ``ReusableField`` with optional field-level overrides.
+
+    When resolved via :meth:`QuestionBankService.resolve_ref`, the returned
+    ``FormField`` is a deep copy of the bank definition with ``overrides``
+    applied on top.
+
+    Attributes:
+        bank_field_id: The ``ReusableField.field_id`` to look up.
+        overrides: Optional dict of ``FormField`` field-level attribute
+            overrides (e.g. ``{"label": "New Label", "required": True}``).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    bank_field_id: str
+    overrides: dict[str, Any] | None = None
+
+
+# ---------------------------------------------------------------------------
+# DDL (for Postgres — used in production via db= constructor kwarg)
+# ---------------------------------------------------------------------------
+
+_CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS {table} (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    field_id VARCHAR(255) NOT NULL,
+    definition_json JSONB NOT NULL,
+    tenant VARCHAR(63) NOT NULL,
+    usage_forms INTEGER NOT NULL DEFAULT 0,
+    usage_responses INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(field_id, tenant)
+);
+"""
+
+_INSERT_SQL = """
+INSERT INTO {table} (field_id, definition_json, tenant)
+VALUES ($1, $2::jsonb, $3)
+ON CONFLICT (field_id, tenant) DO NOTHING
+"""
+
+_SELECT_SQL = "SELECT * FROM {table} WHERE field_id = $1 AND tenant = $2"
+
+_SELECT_ALL_SQL = "SELECT * FROM {table} WHERE tenant = $1 ORDER BY field_id"
+
+_INCREMENT_SQL = """
+UPDATE {table}
+SET usage_forms = usage_forms + $1,
+    usage_responses = usage_responses + $2
+WHERE field_id = $3 AND tenant = $4
+"""
+
+
+class QuestionBankService:
+    """Tenant-scoped service for managing reusable field definitions.
+
+    Backs a ``field_bank`` table (one per tenant schema) that stores
+    ``FormField`` definitions as JSONB, with usage counters.  In tests
+    the in-memory fallback (internal dict) is used automatically when no
+    ``db=`` connection is provided.
+
+    Example::
+
+        svc = QuestionBankService(storage, tenant="navigator")
+        created = await svc.create_field(my_field)
+        await svc.increment_usage(created.field_id, forms=1)
+        ref = ReusableFieldRef(bank_field_id=created.field_id,
+                               overrides={"label": "Custom"})
+        field = await svc.resolve_ref(ref)
+
+    Args:
+        storage: ``FormStorage`` instance (used for tenant-schema resolution
+            in production).  The service uses ``storage`` for context but
+            manages the ``field_bank`` table itself.
+        tenant: Tenant slug scoping all operations.
+        db: Optional asyncdb/asyncpg DB connection.  When ``None``, the
+            service operates in-memory (suitable for tests and development).
+        table: Table name inside the tenant schema. Defaults to
+            ``"field_bank"``.
+    """
+
+    def __init__(
+        self,
+        storage: FormStorage,
+        *,
+        tenant: str,
+        db: Any | None = None,
+        table: str = "field_bank",
+    ) -> None:
+        self._storage = storage
+        # Guard against SQL injection: tenant comes from the auth session and
+        # both names are interpolated into DDL/DML — same pattern as
+        # PostgresFormStorage (storage.py).
+        self._tenant = validate_identifier(tenant, kind="tenant")
+        self._db = db
+        self._table = validate_identifier(table, kind="table")
+        self._qualified = qualified_table(self._tenant, self._table)
+        self.logger = logging.getLogger(__name__)
+
+        # In-memory fallback store: field_id → ReusableField
+        self._mem: dict[str, ReusableField] = {}
+
+    # ------------------------------------------------------------------
+    # DDL helper (production use)
+    # ------------------------------------------------------------------
+
+    async def _ensure_table(self) -> None:
+        """Run ``CREATE TABLE IF NOT EXISTS`` for the field_bank table.
+
+        No-op when operating in-memory (no ``db`` connection).
+        """
+        if self._db is None:
+            return
+        qualified = self._qualified
+        sql = _CREATE_TABLE_SQL.format(table=qualified)
+        await self._db.execute(sql)
+
+    # ------------------------------------------------------------------
+    # Public API (all async)
+    # ------------------------------------------------------------------
+
+    async def create_field(self, field: FormField) -> ReusableField:
+        """Add a field definition to the bank.
+
+        A new ``field_id`` (UUID4) is minted for the bank entry regardless
+        of the source field's ``field_id``.
+
+        Args:
+            field: ``FormField`` definition to store.
+
+        Returns:
+            ``ReusableField`` with the minted ``field_id``.
+        """
+        bank_id = str(uuid.uuid4())
+        entry = ReusableField(
+            field_id=bank_id,
+            definition=field,
+            tenant=self._tenant,
+            created_at=datetime.now(timezone.utc),
+        )
+
+        if self._db is not None:
+            await self._ensure_table()
+            qualified = self._qualified
+            sql = _INSERT_SQL.format(table=qualified)
+            await self._db.execute(
+                sql,
+                bank_id,
+                json.dumps(field.model_dump(mode="json")),
+                self._tenant,
+            )
+        else:
+            self._mem[bank_id] = entry
+
+        self.logger.debug("QuestionBank: created field %s for tenant %s", bank_id, self._tenant)
+        return entry
+
+    async def get_field(self, field_id: str) -> ReusableField | None:
+        """Retrieve a ``ReusableField`` by its bank ID.
+
+        Args:
+            field_id: Bank entry ID (the UUID minted by :meth:`create_field`).
+
+        Returns:
+            ``ReusableField`` if found, ``None`` otherwise.
+        """
+        if self._db is not None:
+            await self._ensure_table()
+            qualified = self._qualified
+            sql = _SELECT_SQL.format(table=qualified)
+            row = await self._db.fetchrow(sql, field_id, self._tenant)
+            if row is None:
+                return None
+            return self._row_to_entry(row)
+        return self._mem.get(field_id)
+
+    async def list_fields(self) -> list[ReusableField]:
+        """List all bank entries for the current tenant.
+
+        Returns:
+            List of ``ReusableField`` sorted by ``field_id``.
+        """
+        if self._db is not None:
+            await self._ensure_table()
+            qualified = self._qualified
+            sql = _SELECT_ALL_SQL.format(table=qualified)
+            rows = await self._db.fetch(sql, self._tenant)
+            return [self._row_to_entry(r) for r in rows]
+        return sorted(self._mem.values(), key=lambda e: e.field_id)
+
+    async def increment_usage(
+        self,
+        field_id: str,
+        *,
+        forms: int = 0,
+        responses: int = 0,
+    ) -> None:
+        """Atomically increment usage counters.
+
+        Uses a single UPDATE (no read-modify-write) to avoid race conditions.
+
+        Args:
+            field_id: Bank entry ID.
+            forms: Number of form references to add.
+            responses: Number of response references to add.
+        """
+        if self._db is not None:
+            await self._ensure_table()
+            qualified = self._qualified
+            sql = _INCREMENT_SQL.format(table=qualified)
+            await self._db.execute(sql, forms, responses, field_id, self._tenant)
+        else:
+            entry = self._mem.get(field_id)
+            if entry is not None:
+                self._mem[field_id] = entry.model_copy(update={
+                    "usage_forms": entry.usage_forms + forms,
+                    "usage_responses": entry.usage_responses + responses,
+                })
+
+    async def resolve_ref(self, ref: ReusableFieldRef) -> FormField:
+        """Resolve a ``ReusableFieldRef`` to a ``FormField``.
+
+        Returns a deep copy of the bank entry's definition, with any
+        ``overrides`` merged on top.  The bank entry is never mutated.
+
+        Args:
+            ref: ``ReusableFieldRef`` with ``bank_field_id`` and optional
+                 ``overrides``.
+
+        Returns:
+            ``FormField`` instance.
+
+        Raises:
+            KeyError: If ``ref.bank_field_id`` is not found in the bank.
+        """
+        entry = await self.get_field(ref.bank_field_id)
+        if entry is None:
+            raise KeyError(f"QuestionBank: field '{ref.bank_field_id}' not found in tenant '{self._tenant}'")
+
+        # Deep copy to avoid mutating the bank entry
+        definition_dict = copy.deepcopy(entry.definition.model_dump())
+
+        if ref.overrides:
+            definition_dict.update(ref.overrides)
+
+        return FormField.model_validate(definition_dict)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _row_to_entry(self, row: Any) -> ReusableField:
+        """Convert a DB row to a ``ReusableField`` instance.
+
+        Args:
+            row: asyncpg Record or dict-like object.
+
+        Returns:
+            ``ReusableField`` instance.
+        """
+        definition_data = row["definition_json"]
+        if isinstance(definition_data, str):
+            definition_data = json.loads(definition_data)
+        return ReusableField(
+            field_id=row["field_id"],
+            definition=FormField.model_validate(definition_data),
+            tenant=row["tenant"],
+            usage_forms=row.get("usage_forms", 0),
+            usage_responses=row.get("usage_responses", 0),
+            created_at=row.get("created_at"),
+        )

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/rule_evaluator.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/rule_evaluator.py
@@ -1,0 +1,423 @@
+"""Server-side authoritative rule evaluator for FEAT-301.
+
+Implements ``RuleEvaluator``: a stateless, synchronous evaluator for
+``DependencyRule`` conditions.  No I/O — safe to call from async handlers
+without ``await``.
+
+Key-missing semantics (RESUELTO §8):
+- Source key absent from ``EvaluationContext`` → key-missing state.
+- ``IS_EMPTY`` evaluates ``True`` on key-missing.
+- All other operators evaluate ``False`` on key-missing.
+- Rules ALWAYS resolve, never raise.
+
+Hidden-field exclusion (RESUELTO §8):
+- ``evaluate_form()`` walks fields in topological order.
+- Values of fields hidden by an upstream rule are excluded from downstream
+  inputs (treated as not-present, not as zero/stale value).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from ..core.constraints import (
+    ConditionOperator,
+    DependencyRule,
+    FieldRefCondition,
+    LocationVarCondition,
+    VisitContextCondition,
+)
+
+if TYPE_CHECKING:
+    from ..core.schema import FormSchema
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public data models
+# ---------------------------------------------------------------------------
+
+class EvaluationContext(BaseModel):
+    """Runtime context fed to RuleEvaluator for a single form evaluation pass.
+
+    Attributes:
+        answers: Map of field_id → current answer value.
+        location_vars: Map of location variable key → resolved value (from
+            the ai-parrot Org Graph, FEAT-302; pre-fetched before evaluation).
+        visit_context: Arbitrary visit metadata (date, type, status, etc.).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    answers: dict[str, Any] = {}
+    location_vars: dict[str, Any] = {}
+    visit_context: dict[str, Any] = {}
+
+
+EffectResult = Literal["show", "hide", "require", "disable"]
+
+_SENTINEL = object()  # Signals key-missing (distinct from None/0/False/"")
+
+
+class EvaluationResult(BaseModel):
+    """Per-field visibility/effect result from a single evaluation pass.
+
+    Attributes:
+        field_id: The field this result applies to.
+        effect: The resolved effect (``"show"`` when no rule fires).
+        matched: ``True`` when the rule's conditions fired and produced the
+            effect; ``False`` when the field gets the default ``"show"`` state.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    field_id: str
+    effect: EffectResult
+    matched: bool
+
+
+# ---------------------------------------------------------------------------
+# RuleEvaluator
+# ---------------------------------------------------------------------------
+
+class RuleEvaluator:
+    """Server-side authoritative evaluator for DependencyRule conditions.
+
+    Stateless — instantiate once (module-level singleton works) and call
+    ``evaluate()`` per field per request.  No external I/O; safe to call
+    synchronously inside async handlers.
+
+    Example::
+
+        evaluator = RuleEvaluator()
+        ctx = EvaluationContext(answers={"q1": "yes"})
+        result = evaluator.evaluate(rule, ctx)
+        # "show" / "hide" / "require" / "disable", or None if no match
+    """
+
+    def __init__(self) -> None:
+        """Initialize the RuleEvaluator."""
+        self.logger = logging.getLogger(__name__)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def evaluate(
+        self,
+        rule: DependencyRule,
+        context: EvaluationContext,
+    ) -> EffectResult | None:
+        """Evaluate a single DependencyRule against the provided context.
+
+        Args:
+            rule: The dependency rule to evaluate.
+            context: The runtime evaluation context (answers + location vars
+                + visit context).
+
+        Returns:
+            The rule's effect string (``"show"``, ``"hide"``, ``"require"``,
+            or ``"disable"``) if conditions are satisfied, else ``None``.
+        """
+        condition_results = [
+            self._evaluate_condition(cond, context)
+            for cond in rule.conditions
+        ]
+        self.logger.debug(
+            "evaluate: effect=%s logic=%s conditions=%s",
+            rule.effect,
+            rule.logic,
+            condition_results,
+        )
+
+        if rule.logic == "and":
+            fires = all(condition_results) if condition_results else False
+        else:  # "or"
+            fires = any(condition_results) if condition_results else False
+
+        if fires:
+            return rule.effect  # type: ignore[return-value]
+        return None
+
+    def evaluate_form(
+        self,
+        form: "FormSchema",
+        context: EvaluationContext,
+    ) -> dict[str, EvaluationResult]:
+        """Evaluate all field rules in the form.
+
+        Walks fields in topological order (so chained show/hide resolves
+        deterministically).  Fields hidden by an upstream rule have their
+        values excluded from downstream inputs (treated as not-present).
+
+        Args:
+            form: The form schema to evaluate.
+            context: The runtime evaluation context.
+
+        Returns:
+            Mapping of field_id → ``EvaluationResult`` for every field
+            that carries a ``DependencyRule``.  Fields without ``depends_on``
+            are omitted.
+        """
+        from .logic_graph import LogicGraph
+
+        graph = LogicGraph.build(form)
+        try:
+            ordered = graph.topological_order()
+        except Exception as exc:  # CyclicDependencyError or unexpected
+            self.logger.warning(
+                "evaluate_form: cycle detected, falling back to form order: %s", exc
+            )
+            ordered = [f.field_id for f in form.iter_all_fields()]
+
+        # Build a field lookup by field_id
+        field_map = {f.field_id: f for f in form.iter_all_fields()}
+
+        # Track which fields are currently hidden so their answers are excluded
+        hidden_fields: set[str] = set()
+
+        results: dict[str, EvaluationResult] = {}
+
+        for field_id in ordered:
+            field = field_map.get(field_id)
+            if field is None or field.depends_on is None:
+                continue
+
+            # Build a context where hidden fields' values are excluded
+            effective_context = self._mask_hidden_answers(context, hidden_fields)
+
+            effect = self.evaluate(field.depends_on, effective_context)
+
+            if effect is not None:
+                results[field_id] = EvaluationResult(
+                    field_id=field_id,
+                    effect=effect,
+                    matched=True,
+                )
+                # Mark as hidden if the effect is "hide"
+                if effect == "hide":
+                    hidden_fields.add(field_id)
+            else:
+                results[field_id] = EvaluationResult(
+                    field_id=field_id,
+                    effect="show",
+                    matched=False,
+                )
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _mask_hidden_answers(
+        self,
+        context: EvaluationContext,
+        hidden_fields: set[str],
+    ) -> EvaluationContext:
+        """Return a new context with hidden fields' answers removed.
+
+        Args:
+            context: Original evaluation context.
+            hidden_fields: Set of field IDs currently hidden.
+
+        Returns:
+            A new ``EvaluationContext`` with hidden field answers excluded.
+        """
+        if not hidden_fields:
+            return context
+        masked_answers = {
+            k: v for k, v in context.answers.items() if k not in hidden_fields
+        }
+        return context.model_copy(update={"answers": masked_answers})
+
+    def _evaluate_condition(
+        self,
+        condition: FieldRefCondition | LocationVarCondition | VisitContextCondition,
+        context: EvaluationContext,
+    ) -> bool:
+        """Evaluate a single condition against the context.
+
+        Args:
+            condition: The condition to evaluate.
+            context: The runtime evaluation context.
+
+        Returns:
+            ``True`` if the condition is satisfied, ``False`` otherwise.
+        """
+        if isinstance(condition, FieldRefCondition):
+            raw = context.answers.get(condition.field_id, _SENTINEL)
+        elif isinstance(condition, LocationVarCondition):
+            raw = context.location_vars.get(condition.key, _SENTINEL)
+        else:  # VisitContextCondition
+            raw = context.visit_context.get(condition.key, _SENTINEL)
+
+        # Key-missing semantics (RESUELTO §8)
+        key_missing = raw is _SENTINEL
+        actual_value = None if key_missing else raw
+
+        return self._apply_operator(condition.operator, actual_value, condition.value, key_missing)
+
+    @staticmethod
+    def _apply_operator(
+        operator: ConditionOperator,
+        actual: Any,
+        expected: Any,
+        key_missing: bool,
+    ) -> bool:
+        """Apply a ConditionOperator to resolve a boolean result.
+
+        Key-missing semantics:
+        - ``IS_EMPTY`` → ``True`` (missing counts as empty).
+        - All other operators → ``False``.
+
+        Args:
+            operator: The condition operator.
+            actual: The resolved value (``None`` if key was missing).
+            expected: The condition's declared comparison value.
+            key_missing: Whether the source key was absent from the context.
+
+        Returns:
+            ``True`` if the condition is satisfied.
+        """
+        # Handle IS_EMPTY / IS_NOT_EMPTY first (no comparison value needed)
+        if operator == ConditionOperator.IS_EMPTY:
+            if key_missing:
+                return True
+            return _is_empty(actual)
+
+        if operator == ConditionOperator.IS_NOT_EMPTY:
+            if key_missing:
+                return False
+            return not _is_empty(actual)
+
+        # For all other operators: key-missing → False
+        if key_missing:
+            return False
+
+        if operator == ConditionOperator.EQ:
+            return _coerce_compare(actual, expected) == 0
+
+        if operator == ConditionOperator.NEQ:
+            return _coerce_compare(actual, expected) != 0
+
+        if operator == ConditionOperator.GT:
+            try:
+                return _coerce_compare(actual, expected) > 0
+            except (TypeError, ValueError):
+                return False
+
+        if operator == ConditionOperator.GTE:
+            try:
+                return _coerce_compare(actual, expected) >= 0
+            except (TypeError, ValueError):
+                return False
+
+        if operator == ConditionOperator.LT:
+            try:
+                return _coerce_compare(actual, expected) < 0
+            except (TypeError, ValueError):
+                return False
+
+        if operator == ConditionOperator.LTE:
+            try:
+                return _coerce_compare(actual, expected) <= 0
+            except (TypeError, ValueError):
+                return False
+
+        if operator == ConditionOperator.IN:
+            if not isinstance(expected, (list, tuple, set)):
+                return False
+            return actual in expected
+
+        if operator == ConditionOperator.NOT_IN:
+            if not isinstance(expected, (list, tuple, set)):
+                logger.warning(
+                    "NOT_IN operator requires a list/tuple/set value; got %s "
+                    "— treating as always-true (rule misconfiguration)",
+                    type(expected).__name__,
+                )
+                return True
+            return actual not in expected
+
+        # Unknown operator — fail safe
+        logger.warning("Unknown ConditionOperator: %s", operator)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _is_empty(value: Any) -> bool:
+    """Return True if value is considered empty.
+
+    Empty: None, empty string, empty list, empty dict, empty set.
+
+    Args:
+        value: The value to check.
+
+    Returns:
+        ``True`` if the value is considered empty.
+    """
+    if value is None:
+        return True
+    if isinstance(value, (str, list, dict, set, tuple)):
+        return len(value) == 0
+    return False
+
+
+def _coerce_compare(actual: Any, expected: Any) -> int:
+    """Compare two values, coercing to comparable types when possible.
+
+    Attempts numeric coercion for string/number comparisons (e.g. "5" vs 5).
+    Falls back to string comparison for EQ/NEQ.
+
+    Args:
+        actual: The runtime value.
+        expected: The condition's declared comparison value.
+
+    Returns:
+        Negative if actual < expected, 0 if equal, positive if actual > expected.
+
+    Raises:
+        TypeError: When the values cannot be compared.
+        ValueError: When numeric coercion fails for ordered operators.
+    """
+    # Both numeric → numeric comparison
+    if isinstance(actual, (int, float)) and isinstance(expected, (int, float)):
+        if actual < expected:
+            return -1
+        if actual > expected:
+            return 1
+        return 0
+
+    # Try numeric coercion (e.g. "5" vs 5 or 5 vs "5")
+    try:
+        a_num = float(actual)  # type: ignore[arg-type]
+        e_num = float(expected)  # type: ignore[arg-type]
+        if a_num < e_num:
+            return -1
+        if a_num > e_num:
+            return 1
+        return 0
+    except (TypeError, ValueError):
+        pass
+
+    # String comparison
+    a_str = str(actual)
+    e_str = str(expected)
+    if a_str < e_str:
+        return -1
+    if a_str > e_str:
+        return 1
+    return 0
+
+
+#: Module-level stateless singleton — RuleEvaluator holds no per-request state,
+#: so renderers and handlers share this instance instead of re-instantiating.
+DEFAULT_EVALUATOR = RuleEvaluator()

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/validators.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/validators.py
@@ -792,11 +792,16 @@ class FormValidator:
             all_fields.extend(self._collect_fields(section))
 
         # Build adjacency list: field_id -> set of referenced field_ids
+        # FEAT-301: Only FieldRefCondition variants carry field_id (the other
+        # variants — LocationVarCondition / VisitContextCondition — reference
+        # external keys, not form fields, so they don't create intra-form edges).
+        from ..core.constraints import FieldRefCondition  # noqa: PLC0415
+
         graph: dict[str, set[str]] = {f.field_id: set() for f in all_fields}
         for field in all_fields:
             if field.depends_on:
                 for condition in field.depends_on.conditions:
-                    if condition.field_id in graph:
+                    if isinstance(condition, FieldRefCondition) and condition.field_id in graph:
                         graph[field.field_id].add(condition.field_id)
 
         # DFS cycle detection

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/tools/database_form.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/tools/database_form.py
@@ -181,7 +181,13 @@ class DatabaseFormTool(AbstractTool):
         try:
             svc = cls(**(service_kwargs or {}))
             raw = await svc.fetch(formid=formid, orgid=orgid, **extra)
-            form = svc.to_form_schema(raw)
+            # FEAT-300: services exposing import_with_report() also produce
+            # a per-field ImportDiffReport consumed by GET .../import-report.
+            import_report = None
+            if hasattr(svc, "import_with_report"):
+                form, import_report = svc.import_with_report(raw)
+            else:
+                form = svc.to_form_schema(raw)
         except json.JSONDecodeError as exc:
             self.logger.error("Malformed JSON for formid=%s: %s", formid, exc)
             msg = str(exc)
@@ -236,5 +242,12 @@ class DatabaseFormTool(AbstractTool):
             success=True,
             status="success",
             result={"form_id": form.form_id, "title": str(form.title)},
-            metadata={"form": form.model_dump()},
+            metadata={
+                "form": form.model_dump(),
+                "import_report": (
+                    import_report.model_dump(mode="json")
+                    if import_report is not None
+                    else None
+                ),
+            },
         )

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/tools/field_helpers.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/tools/field_helpers.py
@@ -244,6 +244,17 @@ _FIELD_SCHEMA_SNIPPETS: dict[str, dict[str, Any]] = {
             }
         },
     },
+    # FEAT-300 — computed fields (expression evaluator in FEAT-301)
+    FieldType.FORMULA.value: {
+        "field_id": "total_price",
+        "field_type": "formula",
+        "label": "Total Price",
+        "required": False,
+        "meta": {
+            "expression": None,  # FEAT-301 will populate the BEDMAS expression
+            "render_as": "readonly",
+        },
+    },
 }
 
 

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/tools/services/networkninja.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/tools/services/networkninja.py
@@ -11,9 +11,13 @@ import logging
 import os
 from typing import Any, Literal, cast
 
-from ...core.constraints import ConditionOperator, DependencyRule, FieldCondition
+from datetime import datetime, timezone
+
+from pydantic import BaseModel, ConfigDict
+
+from ...core.constraints import ConditionOperator, DependencyRule, FieldRefCondition
 from ...core.options import FieldOption
-from ...core.schema import FormField, FormSchema, FormSection
+from ...core.schema import FormField, FormSchema, FormSection, FormType
 from ...core.types import FieldType
 from .abstract import AbstractFormService
 
@@ -41,6 +45,57 @@ GROUP BY f.formid, f.form_name, f.description, f.client_id, f.client_name,
 # ---------------------------------------------------------------------------
 # DB field type → FieldType mapping
 # ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# ImportDiffReport models (FEAT-300 TASK-006)
+# ---------------------------------------------------------------------------
+
+
+class ImportDiffEntry(BaseModel):
+    """Per-field entry in an ImportDiffReport.
+
+    Attributes:
+        column_name: The source ``column_name`` from ``form_metadata``.
+        source_data_type: The raw ``data_type`` string from the source.
+        mapped_field_type: The resolved ``FieldType.value`` string, or
+            ``None`` when mapping failed.
+        status: One of ``"mapeado"`` (fully mapped), ``"aproximado"``
+            (approximate mapping with meta hint), or
+            ``"requiere_intervencion"`` (manual review needed).
+        note: Human-readable note about the mapping decision.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    column_name: str
+    source_data_type: str
+    mapped_field_type: str | None = None
+    status: str  # "mapeado" | "aproximado" | "requiere_intervencion"
+    note: str = ""
+
+
+class ImportDiffReport(BaseModel):
+    """Aggregate report for a single networkninja form import.
+
+    Attributes:
+        form_id: The ``FormSchema.form_id`` produced by the import.
+        source: Always ``"networkninja"``.
+        imported_at: UTC timestamp of the import.
+        fields: One entry per imported field column.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    form_id: str
+    source: str = "networkninja"
+    imported_at: datetime
+    fields: list[ImportDiffEntry] = []
+
+
+# ---------------------------------------------------------------------------
+# Field type mapping table
+# ---------------------------------------------------------------------------
+
 
 #: Maps DB ``data_type`` strings to ``(FieldType, extra_kwargs)`` tuples.
 #: A ``None`` value means "explicitly unsupported — skip with warning".
@@ -74,8 +129,33 @@ _FIELD_TYPE_MAP: dict[str, tuple[FieldType, dict[str, Any]] | None] = {
         FieldType.IMAGE,
         {"read_only": True, "meta": {"render_as": "display_image"}},
     ),
-    # Explicitly unsupported — skip with warning
-    "FIELD_SIGNATURE_CAPTURE": None,
+    # FEAT-300: FIELD_SIGNATURE_CAPTURE now maps to SIGNATURE (was None)
+    "FIELD_SIGNATURE_CAPTURE": (FieldType.SIGNATURE, {}),
+    # FEAT-300: 9 new verified-live data_types
+    "FIELD_FORMULA": (
+        FieldType.FORMULA,
+        {"meta": {"expression": None, "result_type": None}},
+    ),
+    "FIELD_IMAGE_UPLOAD": (
+        FieldType.FILE,
+        {"meta": {"accept": "image/*"}},
+    ),
+    "FIELD_AGREEMENT_CHECKBOX": (
+        FieldType.BOOLEAN,
+        {"meta": {"render_as": "agreement"}},
+    ),
+    "FIELD_DURATION": (
+        FieldType.TEXT,
+        {"meta": {"render_as": "duration"}},
+    ),
+    "FIELD_DATETIME": (FieldType.DATETIME, {}),
+    "FIELD_TIME": (FieldType.TIME, {}),
+    "FIELD_HYPERLINK": (FieldType.URL, {}),
+    "FIELD_PHONENUMBER": (FieldType.PHONE, {}),
+    "FIELD_TOTAL": (
+        FieldType.FORMULA,
+        {"meta": {"render_as": "total", "expression": None, "result_type": None}},
+    ),
 }
 
 # Field types that carry selectable options
@@ -170,7 +250,26 @@ class NetworkninjaFormService(AbstractFormService):
         Returns:
             Fully constructed FormSchema.
         """
-        return self._build_form_schema(raw)
+        schema, _ = self._build_form_schema_with_report(raw)
+        return schema
+
+    def import_with_report(
+        self, raw: dict[str, Any]
+    ) -> tuple[FormSchema, ImportDiffReport]:
+        """Transform a raw row into a FormSchema plus an ImportDiffReport.
+
+        The form is always returned (never aborted).  Unmappable fields are
+        included in the report with ``status="requiere_intervencion"`` and
+        the form is left as draft (``published_version=None``).
+
+        Args:
+            raw: Dict with keys: formid, form_name, description, orgid,
+                 question_blocks (JSON string or list), metadata (list of dicts).
+
+        Returns:
+            Tuple of ``(FormSchema, ImportDiffReport)``.
+        """
+        return self._build_form_schema_with_report(raw)
 
     # ------------------------------------------------------------------
     # DSN resolution
@@ -204,12 +303,41 @@ class NetworkninjaFormService(AbstractFormService):
     # Form building pipeline
     # ------------------------------------------------------------------
 
-    def _build_form_schema(self, row: dict[str, Any]) -> FormSchema:
+    def _build_form_schema_with_report(
+        self, row: dict[str, Any]
+    ) -> tuple[FormSchema, ImportDiffReport]:
+        """Internal pipeline that produces both the FormSchema and the diff report.
+
+        Args:
+            row: DB result row dict.
+
+        Returns:
+            ``(FormSchema, ImportDiffReport)`` pair.
+        """
+        report_entries: list[ImportDiffEntry] = []
+        schema = self._build_form_schema(row, report_entries=report_entries)
+        form_id = schema.form_id
+        report = ImportDiffReport(
+            form_id=form_id,
+            source="networkninja",
+            imported_at=datetime.now(timezone.utc),
+            fields=report_entries,
+        )
+        return schema, report
+
+    def _build_form_schema(
+        self,
+        row: dict[str, Any],
+        report_entries: list[ImportDiffEntry] | None = None,
+    ) -> FormSchema:
         """Transform a DB result row into a FormSchema.
 
         Args:
             row: Dict with keys: formid, form_name, description, orgid,
                  question_blocks (JSON string or list), metadata (list of dicts).
+            report_entries: Optional list to accumulate ``ImportDiffEntry``
+                objects.  When provided, all mapped and unmapped fields are
+                recorded here; the import NEVER aborts.
 
         Returns:
             Fully constructed FormSchema.
@@ -222,12 +350,15 @@ class NetworkninjaFormService(AbstractFormService):
         raw_metadata: list[dict[str, Any]] = row.get("metadata") or []
         meta_index = self._build_metadata_index(raw_metadata)
 
-        # Parse question_blocks — stored as JSON text (not JSONB), must json.loads()
+        # Parse question_blocks — may be:
+        #   a) A JSON string (most rows) — must json.loads()
+        #   b) Already a list (JSONB-native)
+        #   c) Legacy double-encoding: JSON string wrapping a list that uses
+        #      old keys (question_block_id, question_block_type, etc.)
         question_blocks_raw = row.get("question_blocks") or "[]"
-        if isinstance(question_blocks_raw, str):
-            question_blocks: list[dict[str, Any]] = json.loads(question_blocks_raw)
-        else:
-            question_blocks = list(question_blocks_raw)
+        question_blocks: list[dict[str, Any]] = self._normalize_question_blocks(
+            question_blocks_raw
+        )
 
         # Build question_id → column_name reverse index (for conditional resolution)
         question_id_index = self._build_question_id_index(question_blocks, meta_index)
@@ -237,11 +368,21 @@ class NetworkninjaFormService(AbstractFormService):
             question_blocks, question_id_index, meta_index
         )
 
+        # Derive form_type from block_type (FEAT-300):
+        # any block with block_type == "survey" → FormType.SURVEY; else SIMPLE.
+        # PRODUCT is never detected from networkninja (FEAT-302 only).
+        form_type = FormType.SIMPLE
+        for block in question_blocks:
+            if block.get("block_type") == "survey":
+                form_type = FormType.SURVEY
+                break
+
         # Build sections — each question_block → one FormSection
         sections: list[FormSection] = []
         for block in question_blocks:
             section = self._map_block_to_section(
-                block, meta_index, question_id_index, select_options
+                block, meta_index, question_id_index, select_options,
+                report_entries=report_entries,
             )
             if section is not None:
                 sections.append(section)
@@ -251,7 +392,55 @@ class NetworkninjaFormService(AbstractFormService):
             title=form_name,
             description=description,
             sections=sections,
+            form_type=form_type,
         )
+
+    @staticmethod
+    def _normalize_question_blocks(
+        raw: str | list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Normalize legacy and current question_blocks formats.
+
+        Handles:
+        - ``str`` → ``json.loads()``
+        - Legacy keys: ``question_block_id`` → ``block_id``,
+          ``question_block_type`` → ``block_type``,
+          ``question_block_logic_groups`` → ``block_logic_groups``.
+        - Missing/null ``block_type`` → ``"simple"``.
+
+        Args:
+            raw: Raw question_blocks value from the DB row.
+
+        Returns:
+            Normalised list of block dicts.
+        """
+        if isinstance(raw, str):
+            try:
+                blocks = json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                return []
+        else:
+            blocks = list(raw)
+
+        normalised: list[dict[str, Any]] = []
+        for block in blocks:
+            b: dict[str, Any] = dict(block)  # shallow copy for safety
+
+            # Legacy key migration
+            if "block_id" not in b and "question_block_id" in b:
+                b["block_id"] = b.pop("question_block_id")
+            if "block_type" not in b and "question_block_type" in b:
+                b["block_type"] = b.pop("question_block_type")
+            if "block_logic_groups" not in b and "question_block_logic_groups" in b:
+                b["block_logic_groups"] = b.pop("question_block_logic_groups")
+
+            # Default missing/null block_type to "simple"
+            if not b.get("block_type"):
+                b["block_type"] = "simple"
+
+            normalised.append(b)
+
+        return normalised
 
     # ------------------------------------------------------------------
     # Index builders
@@ -414,6 +603,7 @@ class NetworkninjaFormService(AbstractFormService):
         meta_index: dict[str, dict[str, Any]],
         question_id_index: dict[str, str],
         select_options: dict[str, list[FieldOption]],
+        report_entries: list[ImportDiffEntry] | None = None,
     ) -> FormSection | None:
         """Map a question_block dict to a FormSection.
 
@@ -422,11 +612,12 @@ class NetworkninjaFormService(AbstractFormService):
             meta_index: Active metadata lookup.
             question_id_index: question_id → column_name reverse index.
             select_options: Pre-collected options keyed by column_name.
+            report_entries: Optional accumulator for ``ImportDiffEntry`` objects.
 
         Returns:
             FormSection if the block has at least one mappable field, else None.
         """
-        block_id = block.get("question_block_id") or block.get("block_id", "")
+        block_id = block.get("block_id") or block.get("question_block_id", "")
         block_title: str | None = (
             block.get("block_description") or block.get("block_name") or None
         )
@@ -435,7 +626,8 @@ class NetworkninjaFormService(AbstractFormService):
         fields: list[FormField] = []
         for question in block.get("questions") or []:
             field = self._map_question_to_field(
-                question, meta_index, question_id_index, select_options
+                question, meta_index, question_id_index, select_options,
+                report_entries=report_entries,
             )
             if field is not None:
                 fields.append(field)
@@ -455,17 +647,24 @@ class NetworkninjaFormService(AbstractFormService):
         meta_index: dict[str, dict[str, Any]],
         question_id_index: dict[str, str],
         select_options: dict[str, list[FieldOption]],
+        report_entries: list[ImportDiffEntry] | None = None,
     ) -> FormField | None:
         """Map a question dict to a FormField.
 
-        Skips questions whose column is not in active metadata or whose
-        data_type is unsupported.
+        When ``report_entries`` is provided the import NEVER aborts on an
+        unmappable data_type — instead a ``requiere_intervencion`` entry is
+        recorded and the question is skipped (field returns ``None``).
+
+        Formula fields (``FIELD_FORMULA`` / ``FIELD_TOTAL``) always produce a
+        ``requiere_intervencion`` entry because the expression is unavailable
+        at the networkninja source.
 
         Args:
             question: Single question dict from a question block.
             meta_index: Active metadata lookup.
             question_id_index: question_id → column_name reverse index.
             select_options: Pre-collected options keyed by column_name.
+            report_entries: Optional accumulator for ``ImportDiffEntry`` objects.
 
         Returns:
             FormField if mappable, else None.
@@ -486,20 +685,35 @@ class NetworkninjaFormService(AbstractFormService):
         # Resolve field type from mapping table
         if data_type not in _FIELD_TYPE_MAP:
             self.logger.warning(
-                "Skipping question column '%s': unknown data_type '%s'",
-                col_name,
-                data_type,
+                "Unknown data_type '%s' for column '%s'",
+                data_type, col_name,
             )
+            if report_entries is not None:
+                report_entries.append(ImportDiffEntry(
+                    column_name=col_name,
+                    source_data_type=data_type,
+                    mapped_field_type=None,
+                    status="requiere_intervencion",
+                    note=f"data_type '{data_type}' is not in the mapping table — manual review required",
+                ))
             return None
 
         mapping = _FIELD_TYPE_MAP[data_type]
         if mapping is None:
-            # Explicitly unsupported (e.g., FIELD_SIGNATURE_CAPTURE)
+            # Should never happen after FEAT-300 (FIELD_SIGNATURE_CAPTURE now maps),
+            # but kept as a safety net for future explicitly-unsupported entries.
             self.logger.warning(
-                "Skipping question column '%s': unsupported data_type '%s'",
-                col_name,
-                data_type,
+                "Explicitly unsupported data_type '%s' for column '%s'",
+                data_type, col_name,
             )
+            if report_entries is not None:
+                report_entries.append(ImportDiffEntry(
+                    column_name=col_name,
+                    source_data_type=data_type,
+                    mapped_field_type=None,
+                    status="requiere_intervencion",
+                    note=f"data_type '{data_type}' is explicitly unsupported — manual review required",
+                ))
             return None
 
         field_type, extra_kwargs = mapping
@@ -523,6 +737,43 @@ class NetworkninjaFormService(AbstractFormService):
         if data_type in _OPTION_FIELD_TYPES:
             collected = select_options.get(col_name)
             options = collected if collected else None
+
+        # --- ImportDiffReport entry ---
+        if report_entries is not None:
+            is_formula = data_type in ("FIELD_FORMULA", "FIELD_TOTAL")
+            is_approximate = bool(extra_kwargs.get("meta", {}).get("render_as"))
+
+            if is_formula:
+                # Formula expressions are never available from networkninja
+                report_entries.append(ImportDiffEntry(
+                    column_name=col_name,
+                    source_data_type=data_type,
+                    mapped_field_type=field_type.value,
+                    status="requiere_intervencion",
+                    note=(
+                        "formula expression unavailable at networkninja source "
+                        "(options=[]); meta.expression=None; evaluator is FEAT-301"
+                    ),
+                ))
+            elif is_approximate:
+                report_entries.append(ImportDiffEntry(
+                    column_name=col_name,
+                    source_data_type=data_type,
+                    mapped_field_type=field_type.value,
+                    status="aproximado",
+                    note=(
+                        f"mapped to {field_type.value} with render_as hint "
+                        f"{extra_kwargs['meta'].get('render_as')!r}"
+                    ),
+                ))
+            else:
+                report_entries.append(ImportDiffEntry(
+                    column_name=col_name,
+                    source_data_type=data_type,
+                    mapped_field_type=field_type.value,
+                    status="mapeado",
+                    note="",
+                ))
 
         return FormField(
             field_id=field_id,
@@ -566,11 +817,11 @@ class NetworkninjaFormService(AbstractFormService):
         if not logic_groups:
             return None
 
-        all_conditions: list[FieldCondition] = []
+        all_conditions: list[FieldRefCondition] = []
         multi_group = len(logic_groups) > 1
 
         for group in logic_groups:
-            group_conditions: list[FieldCondition] = []
+            group_conditions: list[FieldRefCondition] = []
 
             for cond in group.get("conditions") or []:
                 if cond.get("condition_logic") != "EQUALS":
@@ -592,7 +843,7 @@ class NetworkninjaFormService(AbstractFormService):
                 comparison_value = cond.get("condition_comparison_value")
 
                 group_conditions.append(
-                    FieldCondition(
+                    FieldRefCondition(
                         field_id=ref_field_id,
                         operator=ConditionOperator.EQ,
                         value=comparison_value,

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/version.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/version.py
@@ -2,7 +2,7 @@
 
 __title__ = "parrot-formdesigner"
 __description__ = "Platform-agnostic form design and rendering package for AI-Parrot"
-__version__ = "0.3.17"
+__version__ = "0.4.0"
 __author__ = "Jesus Lara"
 __author_email__ = "jesuslara@phenobarbital.info"
 __license__ = "MIT"

--- a/packages/parrot-formdesigner/tests/integration/test_feat300_integration.py
+++ b/packages/parrot-formdesigner/tests/integration/test_feat300_integration.py
@@ -1,0 +1,379 @@
+"""Integration tests for FEAT-300 — Form Builder Parity (spec §4, Integration table).
+
+Covers the cross-module flows the unit suites do not exercise:
+
+- ``test_recap_survey_round_trip`` — import a survey-type recap (fixture
+  modeled on live formid 71 "Siffron Site Survey") and render it.
+- ``test_epson_recap_product_round_trip`` — a synthetic PRODUCT form renders
+  without error (production has no product blocks; PRODUCT activates via
+  ``product_bindings`` / FEAT-302, never via the importer).
+- ``test_question_bank_reuse_in_two_forms`` — one ReusableField referenced
+  by two forms yields ``usage_forms == 2``.
+- ``test_inflight_response_keeps_version`` — RF-06: a response started on
+  v1.1 keeps resolving against the v1.1 snapshot after v1.2 is published.
+- ``test_epson_validation_set_auto_mapping`` — RF-01 (representative): every
+  live data_type imports without abort; auto-map rate weighted by the live
+  production field counts (verified 2026-06-11) is ≥95%.
+- ``test_render_performance_200_questions`` — NFR: a 200-question form
+  renders via HTML5 in <2s.
+"""
+
+import json
+import time
+
+from parrot_formdesigner.core.schema import (
+    FormField,
+    FormSchema,
+    FormSection,
+    FormType,
+)
+from parrot_formdesigner.core.types import FieldType
+from parrot_formdesigner.renderers.html5 import HTML5Renderer
+from parrot_formdesigner.services.form_version import FormVersionService
+from parrot_formdesigner.services.question_bank import (
+    QuestionBankService,
+    ReusableFieldRef,
+)
+from parrot_formdesigner.services.registry import FormRegistry
+from parrot_formdesigner.tools.services.networkninja import (
+    NetworkninjaFormService,
+)
+
+
+# ---------------------------------------------------------------------------
+# Live production facts (RO replica, verified 2026-06-11) — spec §8
+# ---------------------------------------------------------------------------
+
+#: data_type → live row count in networkninja.form_metadata.
+LIVE_DATA_TYPE_COUNTS: dict[str, int] = {
+    "FIELD_INTEGER": 827,
+    "FIELD_YES_NO": 656,
+    "FIELD_IMAGE_UPLOAD_MULTIPLE": 609,
+    "FIELD_TEXTAREA": 345,
+    "FIELD_TEXT": 320,
+    "FIELD_DISPLAY_TEXT": 244,
+    "FIELD_MULTISELECT": 243,
+    "FIELD_SELECT_RADIO": 227,
+    "FIELD_DISPLAY_IMAGE": 111,
+    "FIELD_SELECT": 111,
+    "FIELD_IMAGE_UPLOAD": 109,
+    "FIELD_SUBSECTION": 56,
+    "FIELD_AGREEMENT_CHECKBOX": 52,
+    "FIELD_FLOAT2": 26,
+    "FIELD_FORMULA": 22,
+    "FIELD_SIGNATURE_CAPTURE": 9,
+    "FIELD_DURATION": 8,
+    "FIELD_DATE": 6,
+    "FIELD_MONEY": 4,
+    "FIELD_DATETIME": 2,
+    "FIELD_TIME": 2,
+    "FIELD_HYPERLINK": 1,
+    "FIELD_PHONENUMBER": 1,
+    "FIELD_TOTAL": 1,
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _service() -> NetworkninjaFormService:
+    return NetworkninjaFormService(dsn="postgres://test")
+
+
+def _row_with_all_live_types() -> dict:
+    """One question per live data_type, single simple block."""
+    questions = []
+    metadata = []
+    for i, data_type in enumerate(LIVE_DATA_TYPE_COUNTS, start=1):
+        col = str(1000 + i)
+        questions.append(
+            {
+                "question_id": i,
+                "question_column_name": col,
+                "question_description": f"Q {data_type}",
+                "question_logic_groups": [],
+                "validations": [],
+            }
+        )
+        metadata.append(
+            {
+                "column_id": i,
+                "column_name": col,
+                "data_type": data_type,
+                "description": f"Q {data_type}",
+                "options": (
+                    [{"option_id": 1, "option_label": "A"}]
+                    if data_type
+                    in ("FIELD_SELECT", "FIELD_SELECT_RADIO", "FIELD_MULTISELECT")
+                    else []
+                ),
+            }
+        )
+    return {
+        "formid": 9000,
+        "orgid": 1,
+        "form_name": "All Live Types",
+        "description": None,
+        "question_blocks": [
+            {
+                "block_id": 1,
+                "block_type": "simple",
+                "block_logic_groups": [],
+                "questions": questions,
+            }
+        ],
+        "metadata": metadata,
+    }
+
+
+def _survey_row() -> dict:
+    """Survey recap modeled on live formid 71 (Siffron Site Survey, FLEXROC)."""
+    return {
+        "formid": 71,
+        "orgid": 1,
+        "form_name": "Siffron Site Survey",
+        "description": None,
+        "question_blocks": [
+            {
+                "block_id": 210,
+                "block_type": "survey",
+                "block_logic_groups": [],
+                "questions": [
+                    {
+                        "question_id": 3328,
+                        "question_column_name": "11095",
+                        "question_description": (
+                            "Enter the aisle or section number you are counting:"
+                        ),
+                        "question_logic_groups": [],
+                        "validations": [
+                            {
+                                "validation_id": 2543,
+                                "validation_type": "responseRequired",
+                                "validation_logic": None,
+                                "validation_comparison_value": None,
+                                "validation_question_reference_id": None,
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+        "metadata": [
+            {
+                "column_id": 1,
+                "column_name": "11095",
+                "data_type": "FIELD_TEXT",
+                "description": "Aisle number",
+                "options": [],
+            }
+        ],
+    }
+
+
+def _form_with_n_questions(n: int, form_id: str = "perf-form") -> FormSchema:
+    fields = [
+        FormField(field_id=f"q{i}", field_type=FieldType.TEXT, label=f"Question {i}")
+        for i in range(n)
+    ]
+    return FormSchema(
+        form_id=form_id,
+        title="Performance Form",
+        sections=[FormSection(section_id="s1", fields=fields)],
+        tenant="t1",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Round trips (import → schema → render)
+# ---------------------------------------------------------------------------
+
+
+async def test_recap_survey_round_trip():
+    """Survey recap imports as FormType.SURVEY and renders without error."""
+    schema, report = _service().import_with_report(_survey_row())
+
+    assert schema.form_type == FormType.SURVEY
+    assert schema.published_version is None  # imported forms stay draft
+    assert report.fields, "report must cover every metadata field"
+
+    rendered = await HTML5Renderer().render(schema)
+    assert rendered.content
+
+
+async def test_epson_recap_product_round_trip():
+    """A PRODUCT form (synthetic — see module docstring) renders without error."""
+    form = FormSchema(
+        form_id="product-form",
+        title="Product Recap",
+        form_type=FormType.PRODUCT,
+        product_bindings=["sku-100", "sku-200"],
+        sections=[
+            FormSection(
+                section_id="s1",
+                fields=[
+                    FormField(
+                        field_id="q1", field_type=FieldType.TEXT, label="Units sold"
+                    )
+                ],
+            )
+        ],
+        tenant="epson",
+    )
+
+    assert form.form_type == FormType.PRODUCT
+    assert form.product_bindings == ["sku-100", "sku-200"]
+
+    rendered = await HTML5Renderer().render(form)
+    assert rendered.content
+
+
+# ---------------------------------------------------------------------------
+# QuestionBank reuse across forms
+# ---------------------------------------------------------------------------
+
+
+async def test_question_bank_reuse_in_two_forms():
+    """One ReusableField referenced in two FormSchemas → usage_forms == 2."""
+    bank = QuestionBankService(None, tenant="t1")
+    base = FormField(field_id="store-id", field_type=FieldType.TEXT, label="Store ID")
+    entry = await bank.create_field(base)
+
+    forms = []
+    for n in (1, 2):
+        resolved = await bank.resolve_ref(ReusableFieldRef(bank_field_id=entry.field_id))
+        forms.append(
+            FormSchema(
+                form_id=f"form-{n}",
+                title=f"Form {n}",
+                sections=[FormSection(section_id="s1", fields=[resolved])],
+                tenant="t1",
+            )
+        )
+        await bank.increment_usage(entry.field_id, forms=1)
+
+    assert len(forms) == 2
+    refreshed = await bank.get_field(entry.field_id)
+    assert refreshed.usage_forms == 2
+
+
+# ---------------------------------------------------------------------------
+# RF-06 — in-flight responses keep their version
+# ---------------------------------------------------------------------------
+
+
+async def test_inflight_response_keeps_version():
+    """RF-06: a response started against v1.1 resolves against the v1.1
+    snapshot even after v1.2 is published mid-capture."""
+    registry = FormRegistry()
+    svc = FormVersionService(registry, storage=None)
+
+    original = FormSchema(
+        form_id="recap",
+        title="Recap v1",
+        sections=[
+            FormSection(
+                section_id="s1",
+                fields=[
+                    FormField(field_id="q1", field_type=FieldType.TEXT, label="Q1")
+                ],
+            )
+        ],
+        tenant="t1",
+    )
+    await registry.register(original, tenant="t1")
+    inflight_version = await svc.publish("recap", tenant="t1")  # "1.1"
+
+    # An in-flight response pins this version.
+    # Meanwhile the form is edited (starting from the CURRENT live form,
+    # whose version was bumped by publish) and re-published (v1.2):
+    live = await registry.get("recap", tenant="t1")
+    edited = live.model_copy(deep=True)
+    edited.title = "Recap v2 — restructured"
+    await registry.register(edited, tenant="t1", overwrite=True)
+    newer_version = await svc.publish("recap", tenant="t1")  # "1.2"
+    assert newer_version != inflight_version
+
+    # The in-flight response still resolves against its pinned snapshot:
+    pinned = await svc.get_published("recap", version=inflight_version, tenant="t1")
+    assert pinned is not None
+    assert str(pinned.title) == "Recap v1"
+    assert pinned.published_version == inflight_version
+
+
+# ---------------------------------------------------------------------------
+# RF-01 (representative) — auto-mapping rate over the live data_type universe
+# ---------------------------------------------------------------------------
+
+
+def test_epson_validation_set_auto_mapping():
+    """RF-01 (representative): all 24 live data_types import without abort and
+    the auto-map rate weighted by live production counts is ≥95%.
+
+    NOTE: the contractual RF-01 check runs over the agreed Epson production
+    form set (list pending — spec §5); this test guards the mapping table
+    against regressions using the verified live distribution instead.
+    """
+    schema, report = _service().import_with_report(_row_with_all_live_types())
+
+    # 100% of fields covered by the report, import never aborts
+    assert len(report.fields) == len(LIVE_DATA_TYPE_COUNTS)
+    by_type = {e.source_data_type: e for e in report.fields}
+
+    # No unknown-type entries: every live data_type is in the mapping table
+    for data_type in LIVE_DATA_TYPE_COUNTS:
+        assert by_type[data_type].mapped_field_type is not None, (
+            f"{data_type} fell out of _FIELD_TYPE_MAP"
+        )
+
+    # Auto-map rate weighted by live counts (mapeado/aproximado = auto)
+    total = sum(LIVE_DATA_TYPE_COUNTS.values())
+    auto = sum(
+        count
+        for data_type, count in LIVE_DATA_TYPE_COUNTS.items()
+        if by_type[data_type].status in ("mapeado", "aproximado")
+    )
+    rate = auto / total
+    assert rate >= 0.95, f"weighted auto-map rate {rate:.2%} < 95%"
+
+
+# ---------------------------------------------------------------------------
+# NFR — render performance
+# ---------------------------------------------------------------------------
+
+
+async def test_render_performance_200_questions():
+    """[PROPUESTA — Review v2.1] A ≥200-question form renders in <2s (HTML5)."""
+    form = _form_with_n_questions(200)
+
+    start = time.perf_counter()
+    rendered = await HTML5Renderer().render(form)
+    elapsed = time.perf_counter() - start
+
+    assert rendered.content
+    assert elapsed < 2.0, f"render took {elapsed:.2f}s (NFR: <2s)"
+
+
+# ---------------------------------------------------------------------------
+# Defensive: legacy double-encoded survey block still detected
+# ---------------------------------------------------------------------------
+
+
+def test_survey_detection_in_legacy_encoded_row():
+    """A double-encoded (legacy) row with a survey block still yields SURVEY."""
+    row = _survey_row()
+    legacy_blocks = [
+        {
+            "question_block_id": b["block_id"],
+            "question_block_type": b["block_type"],
+            "question_block_logic_groups": b["block_logic_groups"],
+            "questions": b["questions"],
+        }
+        for b in row["question_blocks"]
+    ]
+    row["question_blocks"] = json.dumps(legacy_blocks)
+
+    schema, _ = _service().import_with_report(row)
+    assert schema.form_type == FormType.SURVEY

--- a/packages/parrot-formdesigner/tests/parity/README.md
+++ b/packages/parrot-formdesigner/tests/parity/README.md
@@ -1,0 +1,211 @@
+# Parity Suite — Golden Vectors Conformance Contract
+
+This directory contains the **reference conformance suite** for FEAT-301
+(Conditional Logic Engine).  The golden vectors in `vectors/*.json` define
+the authoritative input → output mapping that **every evaluator** (Python,
+JavaScript, native mobile) must produce identically.
+
+---
+
+## Motivation
+
+FEAT-301 ships a server-side `RuleEvaluator` (Python) as the reference
+implementation.  External consumers (the browser SPA's JS evaluator, native
+mobile app evaluators, etc.) must reproduce the same results for the same
+input.  Sharing static JSON vectors — rather than sharing code — ensures
+cross-language conformance without coupling runtimes.
+
+---
+
+## Golden Vector Format
+
+Each file in `vectors/` is a self-contained JSON vector:
+
+```json
+{
+  "name": "short-unique-slug",
+  "description": "Human-readable explanation of what this vector tests",
+  "form": {
+    "form_id": "...",
+    "title": {"en": "..."},
+    "sections": [
+      {
+        "section_id": "s1",
+        "title": {"en": "..."},
+        "fields": [
+          {
+            "field_id": "q1",
+            "field_type": "text",
+            "label": {"en": "..."}
+          },
+          {
+            "field_id": "q2",
+            "field_type": "text",
+            "label": {"en": "..."},
+            "depends_on": {
+              "conditions": [
+                {
+                  "source": "field",
+                  "field_id": "q1",
+                  "operator": "eq",
+                  "value": "yes"
+                }
+              ],
+              "logic": "and",
+              "effect": "show"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "context": {
+    "answers": {"q1": "yes"},
+    "location_vars": {"store_type": "flagship"},
+    "visit_context": {"visit_type": "audit"}
+  },
+  "expected": {
+    "q2": {
+      "effect": "show",
+      "matched": true
+    }
+  }
+}
+```
+
+### Field Descriptions
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | `string` | Unique kebab-case slug identifying this vector |
+| `description` | `string` | Human description of what is being tested |
+| `form` | `FormSchema` | Minimal form with at least one `depends_on` rule |
+| `context.answers` | `object` | Map of `field_id → value` for submitted answers |
+| `context.location_vars` | `object` | Map of Org Graph location variable `key → value` |
+| `context.visit_context` | `object` | Map of visit metadata `key → value` |
+| `expected` | `object` | Map of `field_id → {effect, matched}` for every field with `depends_on` |
+
+### Condition Variants (`source` discriminator)
+
+| `source` | Extra fields | Description |
+|---|---|---|
+| `"field"` | `field_id` | Condition over another field's answer |
+| `"location_variable"` | `key` | Condition over an Org Graph location variable |
+| `"visit_context"` | `key` | Condition over visit metadata |
+
+### Operators (`operator`)
+
+| Operator | Matches when |
+|---|---|
+| `eq` | `actual == value` |
+| `neq` | `actual != value` |
+| `gt` | `actual > value` (numeric) |
+| `gte` | `actual >= value` (numeric) |
+| `lt` | `actual < value` (numeric) |
+| `lte` | `actual <= value` (numeric) |
+| `in` | `actual` in `value` (list) |
+| `not_in` | `actual` not in `value` (list) |
+| `is_empty` | `actual` is `null`, `""`, `[]`, `{}`, or **key missing** |
+| `is_not_empty` | `actual` is non-empty (key must be present and non-empty) |
+
+### Key-Missing Semantics
+
+When the source key is **absent** from the context (not present at all — not
+`null`, not `""`):
+
+- `is_empty` → `true`
+- All other operators → `false` (no exception raised)
+
+### Logic Combinators
+
+| `logic` | Meaning |
+|---|---|
+| `"and"` | All conditions must be true (empty list → false) |
+| `"or"` | At least one condition must be true (empty list → false) |
+
+### Effects
+
+| `effect` | Meaning |
+|---|---|
+| `"show"` | Field becomes visible (default outcome when rule fires) |
+| `"hide"` | Field is hidden |
+| `"require"` | Field becomes required |
+| `"disable"` | Field is disabled (read-only) |
+
+When a rule does **not** fire (conditions not met), the evaluator returns
+`{"effect": "show", "matched": false}` — the field defaults to visible.
+
+### Hidden-Field Exclusion (Downstream Masking)
+
+When a field is resolved as `{"effect": "hide", "matched": true}`, its answer
+is **excluded** from downstream condition evaluation (as if the key were absent).
+This prevents stale values from silently activating downstream rules.
+
+---
+
+## Coverage Map
+
+The 60 vectors cover:
+
+| Category | Count |
+|---|---|
+| FieldRef × 10 operators | 12 |
+| LocationVar × 10+ operators | 13 |
+| VisitContext | 4 |
+| AND / OR logic | 4 |
+| All 4 effects (show/hide/require/disable) | 4 |
+| Chained / nested rules (≥10) | 13 |
+| Key-missing semantics | 5 |
+| Hidden-field downstream exclusion | 2 |
+| Cycle detection (fallback) | 1 |
+| Legacy backward-compat (no source key) | 1 |
+| Networkninja-style realistic vectors (≥5) | 5 |
+| **Total** | **60** |
+
+---
+
+## Running the Suite
+
+```bash
+# From the ai-formdesigner repo root (or worktree):
+source .venv/bin/activate
+PYTHONPATH=$PWD/src python -m pytest tests/parity/ -v
+```
+
+Expected output: all tests pass with two assertions per vector (evaluator +
+HTML5 embed), plus internal-consistency checks.
+
+---
+
+## Adding New Vectors
+
+1. Create a new `tests/parity/vectors/<NN>_<slug>.json` file following the
+   format above.
+2. `expected` must cover **every** field in `form` that has a `depends_on`
+   rule — the runner enforces this.
+3. Re-run the suite to verify.
+4. No changes to `test_golden_vectors.py` required — the runner is fully
+   auto-discovering.
+
+---
+
+## Consuming from External Evaluators
+
+External JS/native evaluators should:
+
+1. Parse the `form` as a `FormSchema` (see schema documentation).
+2. Build an `EvaluationContext` from `context`.
+3. Walk fields in **topological order** (BFS/Kahn's algorithm on `depends_on`
+   edges — see `LogicGraph`).
+4. For each field with `depends_on`, evaluate the rule and record
+   `{effect, matched}`.
+5. **Mask hidden field answers** before evaluating downstream fields.
+6. Assert result matches `expected` for each declared field.
+
+The Python `RuleEvaluator` in `parrot_formdesigner.services.rule_evaluator`
+is the reference implementation.  When in doubt, the Python result is
+authoritative.
+
+---
+
+*Generated by FEAT-301 SDD Worker — 2026-06-11.*

--- a/packages/parrot-formdesigner/tests/parity/test_golden_vectors.py
+++ b/packages/parrot-formdesigner/tests/parity/test_golden_vectors.py
@@ -1,0 +1,249 @@
+"""Parity test suite for FEAT-301 golden vectors.
+
+Validates that the Python ``RuleEvaluator`` (the reference implementation) and
+the HTML5 renderer's embedded ``data-logic-state`` block produce results
+consistent with the statically declared golden vectors in
+``tests/parity/vectors/*.json``.
+
+Purpose
+-------
+These vectors are the **conformance contract** shared between this package and
+all external consumers (JS SPA evaluator, native mobile evaluator, etc.).
+Adding a new vector does *not* require touching this file — the runner
+auto-discovers all ``*.json`` files in ``vectors/``.
+
+Test categories (two assertions per vector)
+-------------------------------------------
+1. ``RuleEvaluator.evaluate_form()`` == ``vector["expected"]``
+2. ``HTML5Renderer.render(..., evaluation_context=...)`` → embedded
+   ``data-logic-state`` JSON == ``vector["expected"]``
+
+Internal consistency check
+---------------------------
+Each vector must declare ``expected`` for every field that carries a
+``depends_on`` rule.  Vectors missing an entry are flagged.
+
+Usage
+-----
+Run from the repo root (worktree):
+    source /path/to/.venv/bin/activate
+    PYTHONPATH=$PWD/src python -m pytest tests/parity/ -v
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from parrot_formdesigner.core.schema import FormSchema
+from parrot_formdesigner.renderers.html5 import HTML5Renderer
+from parrot_formdesigner.services.rule_evaluator import (
+    EvaluationContext,
+    RuleEvaluator,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+VECTORS_DIR = Path(__file__).parent / "vectors"
+
+_DATA_LOGIC_STATE_RE = re.compile(
+    r'<script\s+type="application/json"\s+data-logic-state>(.*?)</script>',
+    re.DOTALL,
+)
+
+
+def _load_vector(path: Path) -> dict[str, Any]:
+    """Load a single golden vector JSON file.
+
+    Args:
+        path: Absolute path to the vector JSON file.
+
+    Returns:
+        Parsed vector dictionary.
+
+    Raises:
+        ValueError: If required top-level keys are missing.
+    """
+    data = json.loads(path.read_text())
+    required = {"name", "form", "context", "expected"}
+    missing = required - set(data.keys())
+    if missing:
+        raise ValueError(f"Vector {path.name} missing keys: {missing}")
+    return data
+
+
+def _all_vectors() -> list[tuple[str, dict[str, Any]]]:
+    """Discover and load all golden vectors.
+
+    Returns:
+        List of (vector_name, vector_dict) tuples sorted by file name.
+    """
+    vectors = []
+    for path in sorted(VECTORS_DIR.glob("*.json")):
+        v = _load_vector(path)
+        vectors.append((v["name"], v))
+    return vectors
+
+
+def _parse_form(raw: dict[str, Any]) -> FormSchema:
+    """Parse a raw form dict into FormSchema.
+
+    Args:
+        raw: Form dict from vector.
+
+    Returns:
+        Parsed FormSchema instance.
+    """
+    return FormSchema.model_validate(raw)
+
+
+def _parse_context(raw: dict[str, Any]) -> EvaluationContext:
+    """Parse a raw context dict into EvaluationContext.
+
+    Args:
+        raw: Context dict from vector.
+
+    Returns:
+        Parsed EvaluationContext instance.
+    """
+    return EvaluationContext(
+        answers=raw.get("answers", {}),
+        location_vars=raw.get("location_vars", {}),
+        visit_context=raw.get("visit_context", {}),
+    )
+
+
+def _extract_logic_state_from_html(html: str) -> dict[str, Any]:
+    """Extract and parse the ``data-logic-state`` JSON block from HTML.
+
+    Args:
+        html: Rendered HTML5 string.
+
+    Returns:
+        Parsed logic state dict.
+
+    Raises:
+        AssertionError: If the block is missing or not valid JSON.
+    """
+    match = _DATA_LOGIC_STATE_RE.search(html)
+    assert match is not None, "data-logic-state block not found in HTML output"
+    raw_json = match.group(1)
+    return json.loads(raw_json)
+
+
+def _fields_with_rules(form: FormSchema) -> set[str]:
+    """Return field_ids that carry a DependencyRule.
+
+    Args:
+        form: The form schema.
+
+    Returns:
+        Set of field_ids with depends_on rules.
+    """
+    return {f.field_id for f in form.iter_all_fields() if f.depends_on is not None}
+
+
+# ---------------------------------------------------------------------------
+# Parametrized fixtures
+# ---------------------------------------------------------------------------
+
+ALL_VECTORS = _all_vectors()
+
+
+@pytest.mark.parametrize("name,vector", ALL_VECTORS, ids=[v[0] for v in ALL_VECTORS])
+class TestGoldenVectors:
+    """Parametrized golden vector conformance suite.
+
+    Each test class instance receives one vector. Two assertions:
+    1.  ``RuleEvaluator.evaluate_form()`` must match ``expected``.
+    2.  ``HTML5Renderer.render(..., evaluation_context=...)`` must embed
+        a ``data-logic-state`` block that matches ``expected``.
+    """
+
+    def test_rule_evaluator_matches_expected(
+        self, name: str, vector: dict[str, Any]
+    ) -> None:
+        """Assert RuleEvaluator.evaluate_form() result equals expected.
+
+        Args:
+            name: Vector name (unused, present for pytest id readability).
+            vector: Full vector dict.
+        """
+        form = _parse_form(vector["form"])
+        ctx = _parse_context(vector["context"])
+        expected: dict[str, dict[str, Any]] = vector["expected"]
+
+        evaluator = RuleEvaluator()
+        results = evaluator.evaluate_form(form, ctx)
+
+        for field_id, exp_entry in expected.items():
+            assert field_id in results, (
+                f"Vector '{name}': field '{field_id}' not in evaluator results. "
+                f"Got: {list(results.keys())}"
+            )
+            result = results[field_id]
+            assert result.effect == exp_entry["effect"], (
+                f"Vector '{name}' field '{field_id}': "
+                f"expected effect={exp_entry['effect']!r}, got {result.effect!r}"
+            )
+            assert result.matched == exp_entry["matched"], (
+                f"Vector '{name}' field '{field_id}': "
+                f"expected matched={exp_entry['matched']}, got {result.matched}"
+            )
+
+    def test_internal_consistency(
+        self, name: str, vector: dict[str, Any]
+    ) -> None:
+        """Assert expected covers every field that has a depends_on rule.
+
+        Args:
+            name: Vector name.
+            vector: Full vector dict.
+        """
+        form = _parse_form(vector["form"])
+        expected: dict[str, dict[str, Any]] = vector["expected"]
+        rule_fields = _fields_with_rules(form)
+
+        for field_id in rule_fields:
+            assert field_id in expected, (
+                f"Vector '{name}': field '{field_id}' has a depends_on rule "
+                f"but is not declared in 'expected'."
+            )
+
+    async def test_html5_embed_matches_expected(
+        self, name: str, vector: dict[str, Any]
+    ) -> None:
+        """Assert HTML5 pre-resolve embed matches expected.
+
+        Args:
+            name: Vector name.
+            vector: Full vector dict.
+        """
+        form = _parse_form(vector["form"])
+        ctx = _parse_context(vector["context"])
+        expected: dict[str, dict[str, Any]] = vector["expected"]
+
+        renderer = HTML5Renderer()
+        rendered = await renderer.render(form, evaluation_context=ctx)
+        logic_state = _extract_logic_state_from_html(rendered.content)
+
+        for field_id, exp_entry in expected.items():
+            assert field_id in logic_state, (
+                f"Vector '{name}': field '{field_id}' not in HTML logic_state. "
+                f"Got: {list(logic_state.keys())}"
+            )
+            state_entry = logic_state[field_id]
+            assert state_entry["effect"] == exp_entry["effect"], (
+                f"Vector '{name}' field '{field_id}' HTML embed: "
+                f"expected effect={exp_entry['effect']!r}, got {state_entry['effect']!r}"
+            )
+            assert state_entry["matched"] == exp_entry["matched"], (
+                f"Vector '{name}' field '{field_id}' HTML embed: "
+                f"expected matched={exp_entry['matched']}, got {state_entry['matched']}"
+            )

--- a/packages/parrot-formdesigner/tests/parity/vectors/01_field_ref_eq.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/01_field_ref_eq.json
@@ -1,0 +1,23 @@
+{
+  "name": "field-ref-eq-match",
+  "description": "FieldRefCondition EQ operator — answer matches",
+  "form": {
+    "form_id": "parity-01",
+    "title": {"en": "Parity 01"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "q2", "field_type": "text", "label": {"en": "Q2"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q1", "operator": "eq", "value": "yes"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"q1": "yes"}, "location_vars": {}, "visit_context": {}},
+  "expected": {"q2": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/02_field_ref_eq_nomatch.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/02_field_ref_eq_nomatch.json
@@ -1,0 +1,23 @@
+{
+  "name": "field-ref-eq-no-match",
+  "description": "FieldRefCondition EQ operator — answer does not match",
+  "form": {
+    "form_id": "parity-02",
+    "title": {"en": "Parity 02"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "q2", "field_type": "text", "label": {"en": "Q2"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q1", "operator": "eq", "value": "yes"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"q1": "no"}, "location_vars": {}, "visit_context": {}},
+  "expected": {"q2": {"effect": "show", "matched": false}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/03_field_ref_neq.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/03_field_ref_neq.json
@@ -1,0 +1,23 @@
+{
+  "name": "field-ref-neq-match",
+  "description": "FieldRefCondition NEQ operator — answer differs from value",
+  "form": {
+    "form_id": "parity-03",
+    "title": {"en": "Parity 03"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "q2", "field_type": "text", "label": {"en": "Q2"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q1", "operator": "neq", "value": "no"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"q1": "yes"}, "location_vars": {}, "visit_context": {}},
+  "expected": {"q2": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/04_field_ref_gt.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/04_field_ref_gt.json
@@ -1,0 +1,23 @@
+{
+  "name": "field-ref-gt-match",
+  "description": "FieldRefCondition GT operator — numeric answer greater than value",
+  "form": {
+    "form_id": "parity-04",
+    "title": {"en": "Parity 04"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "score", "field_type": "number", "label": {"en": "Score"}},
+        {"field_id": "bonus", "field_type": "text", "label": {"en": "Bonus"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "score", "operator": "gt", "value": 80}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"score": 95}, "location_vars": {}, "visit_context": {}},
+  "expected": {"bonus": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/05_field_ref_lt.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/05_field_ref_lt.json
@@ -1,0 +1,23 @@
+{
+  "name": "field-ref-lt-match",
+  "description": "FieldRefCondition LT operator — numeric answer less than value",
+  "form": {
+    "form_id": "parity-05",
+    "title": {"en": "Parity 05"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "age", "field_type": "number", "label": {"en": "Age"}},
+        {"field_id": "minor_consent", "field_type": "text", "label": {"en": "Minor Consent"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "age", "operator": "lt", "value": 18}],
+            "logic": "and", "effect": "require"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"age": 15}, "location_vars": {}, "visit_context": {}},
+  "expected": {"minor_consent": {"effect": "require", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/06_field_ref_gte.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/06_field_ref_gte.json
@@ -1,0 +1,23 @@
+{
+  "name": "field-ref-gte-match",
+  "description": "FieldRefCondition GTE operator — numeric answer >= threshold",
+  "form": {
+    "form_id": "parity-06",
+    "title": {"en": "Parity 06"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "rating", "field_type": "number", "label": {"en": "Rating"}},
+        {"field_id": "review_detail", "field_type": "text_area", "label": {"en": "Review Detail"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "rating", "operator": "gte", "value": 4}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"rating": 4}, "location_vars": {}, "visit_context": {}},
+  "expected": {"review_detail": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/07_field_ref_lte.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/07_field_ref_lte.json
@@ -1,0 +1,23 @@
+{
+  "name": "field-ref-lte-match",
+  "description": "FieldRefCondition LTE operator — numeric answer <= threshold",
+  "form": {
+    "form_id": "parity-07",
+    "title": {"en": "Parity 07"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "items_count", "field_type": "number", "label": {"en": "Items"}},
+        {"field_id": "small_order_msg", "field_type": "text", "label": {"en": "Small Order"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "items_count", "operator": "lte", "value": 5}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"items_count": 5}, "location_vars": {}, "visit_context": {}},
+  "expected": {"small_order_msg": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/08_field_ref_in.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/08_field_ref_in.json
@@ -1,0 +1,23 @@
+{
+  "name": "field-ref-in-match",
+  "description": "FieldRefCondition IN operator — answer in allowed list",
+  "form": {
+    "form_id": "parity-08",
+    "title": {"en": "Parity 08"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "category", "field_type": "select", "label": {"en": "Category"}},
+        {"field_id": "subcategory", "field_type": "select", "label": {"en": "Subcategory"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "category", "operator": "in", "value": ["electronics", "computers", "phones"]}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"category": "computers"}, "location_vars": {}, "visit_context": {}},
+  "expected": {"subcategory": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/09_field_ref_not_in.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/09_field_ref_not_in.json
@@ -1,0 +1,23 @@
+{
+  "name": "field-ref-not-in-match",
+  "description": "FieldRefCondition NOT_IN operator — answer not in excluded list",
+  "form": {
+    "form_id": "parity-09",
+    "title": {"en": "Parity 09"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "payment_method", "field_type": "select", "label": {"en": "Payment"}},
+        {"field_id": "card_number", "field_type": "text", "label": {"en": "Card Number"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "payment_method", "operator": "not_in", "value": ["cash", "check"]}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"payment_method": "credit_card"}, "location_vars": {}, "visit_context": {}},
+  "expected": {"card_number": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/10_field_ref_is_empty.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/10_field_ref_is_empty.json
@@ -1,0 +1,23 @@
+{
+  "name": "field-ref-is-empty-match",
+  "description": "FieldRefCondition IS_EMPTY operator — answer is empty string",
+  "form": {
+    "form_id": "parity-10",
+    "title": {"en": "Parity 10"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "optional_text", "field_type": "text", "label": {"en": "Optional"}},
+        {"field_id": "fill_hint", "field_type": "text", "label": {"en": "Fill Hint"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "optional_text", "operator": "is_empty"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"optional_text": ""}, "location_vars": {}, "visit_context": {}},
+  "expected": {"fill_hint": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/11_field_ref_is_not_empty.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/11_field_ref_is_not_empty.json
@@ -1,0 +1,23 @@
+{
+  "name": "field-ref-is-not-empty-match",
+  "description": "FieldRefCondition IS_NOT_EMPTY operator — answer has content",
+  "form": {
+    "form_id": "parity-11",
+    "title": {"en": "Parity 11"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "company_name", "field_type": "text", "label": {"en": "Company"}},
+        {"field_id": "company_details", "field_type": "text_area", "label": {"en": "Company Details"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "company_name", "operator": "is_not_empty"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"company_name": "Acme Corp"}, "location_vars": {}, "visit_context": {}},
+  "expected": {"company_details": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/12_key_missing_is_empty.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/12_key_missing_is_empty.json
@@ -1,0 +1,23 @@
+{
+  "name": "key-missing-is-empty-true",
+  "description": "Key-missing semantics: absent key + IS_EMPTY → matched=true",
+  "form": {
+    "form_id": "parity-12",
+    "title": {"en": "Parity 12"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "q2", "field_type": "text", "label": {"en": "Q2"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q1", "operator": "is_empty"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {}, "location_vars": {}, "visit_context": {}},
+  "expected": {"q2": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/13_key_missing_eq_false.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/13_key_missing_eq_false.json
@@ -1,0 +1,23 @@
+{
+  "name": "key-missing-eq-false",
+  "description": "Key-missing semantics: absent key + EQ → matched=false (no raise)",
+  "form": {
+    "form_id": "parity-13",
+    "title": {"en": "Parity 13"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "q2", "field_type": "text", "label": {"en": "Q2"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q1", "operator": "eq", "value": "yes"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {}, "location_vars": {}, "visit_context": {}},
+  "expected": {"q2": {"effect": "show", "matched": false}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/14_key_missing_gt_false.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/14_key_missing_gt_false.json
@@ -1,0 +1,23 @@
+{
+  "name": "key-missing-gt-false",
+  "description": "Key-missing semantics: absent key + GT → matched=false",
+  "form": {
+    "form_id": "parity-14",
+    "title": {"en": "Parity 14"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "score", "field_type": "number", "label": {"en": "Score"}},
+        {"field_id": "bonus", "field_type": "text", "label": {"en": "Bonus"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "score", "operator": "gt", "value": 50}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {}, "location_vars": {}, "visit_context": {}},
+  "expected": {"bonus": {"effect": "show", "matched": false}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/15_locvar_eq_match.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/15_locvar_eq_match.json
@@ -1,0 +1,23 @@
+{
+  "name": "locvar-eq-match",
+  "description": "LocationVarCondition EQ — store_type matches flagship",
+  "form": {
+    "form_id": "parity-15",
+    "title": {"en": "Parity 15"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "flagship_promo", "field_type": "text", "label": {"en": "Flagship Promo"},
+          "depends_on": {
+            "conditions": [{"source": "location_variable", "key": "store_type", "operator": "eq", "value": "flagship"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {}, "location_vars": {"store_type": "flagship"}, "visit_context": {}},
+  "expected": {"flagship_promo": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/16_locvar_eq_nomatch.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/16_locvar_eq_nomatch.json
@@ -1,0 +1,23 @@
+{
+  "name": "locvar-eq-no-match",
+  "description": "LocationVarCondition EQ — store_type is not flagship",
+  "form": {
+    "form_id": "parity-16",
+    "title": {"en": "Parity 16"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "flagship_promo", "field_type": "text", "label": {"en": "Flagship Promo"},
+          "depends_on": {
+            "conditions": [{"source": "location_variable", "key": "store_type", "operator": "eq", "value": "flagship"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {}, "location_vars": {"store_type": "standard"}, "visit_context": {}},
+  "expected": {"flagship_promo": {"effect": "show", "matched": false}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/17_locvar_neq.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/17_locvar_neq.json
@@ -1,0 +1,23 @@
+{
+  "name": "locvar-neq-match",
+  "description": "LocationVarCondition NEQ — region is not excluded",
+  "form": {
+    "form_id": "parity-17",
+    "title": {"en": "Parity 17"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "local_section", "field_type": "text", "label": {"en": "Local Section"},
+          "depends_on": {
+            "conditions": [{"source": "location_variable", "key": "region", "operator": "neq", "value": "restricted"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {}, "location_vars": {"region": "north"}, "visit_context": {}},
+  "expected": {"local_section": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/18_locvar_in.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/18_locvar_in.json
@@ -1,0 +1,23 @@
+{
+  "name": "locvar-in-match",
+  "description": "LocationVarCondition IN — store tier in allowed set",
+  "form": {
+    "form_id": "parity-18",
+    "title": {"en": "Parity 18"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "premium_module", "field_type": "text", "label": {"en": "Premium Module"},
+          "depends_on": {
+            "conditions": [{"source": "location_variable", "key": "tier", "operator": "in", "value": ["gold", "platinum", "diamond"]}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {}, "location_vars": {"tier": "platinum"}, "visit_context": {}},
+  "expected": {"premium_module": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/19_locvar_not_in.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/19_locvar_not_in.json
@@ -1,0 +1,23 @@
+{
+  "name": "locvar-not-in-match",
+  "description": "LocationVarCondition NOT_IN — country not in excluded list",
+  "form": {
+    "form_id": "parity-19",
+    "title": {"en": "Parity 19"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "intl_shipping", "field_type": "text", "label": {"en": "International Shipping"},
+          "depends_on": {
+            "conditions": [{"source": "location_variable", "key": "country", "operator": "not_in", "value": ["US", "CA"]}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {}, "location_vars": {"country": "MX"}, "visit_context": {}},
+  "expected": {"intl_shipping": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/20_locvar_gt.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/20_locvar_gt.json
@@ -1,0 +1,23 @@
+{
+  "name": "locvar-gt-match",
+  "description": "LocationVarCondition GT — employee_count greater than threshold",
+  "form": {
+    "form_id": "parity-20",
+    "title": {"en": "Parity 20"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "hr_module", "field_type": "text", "label": {"en": "HR Module"},
+          "depends_on": {
+            "conditions": [{"source": "location_variable", "key": "employee_count", "operator": "gt", "value": 50}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {}, "location_vars": {"employee_count": 120}, "visit_context": {}},
+  "expected": {"hr_module": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/21_locvar_lt.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/21_locvar_lt.json
@@ -1,0 +1,23 @@
+{
+  "name": "locvar-lt-match",
+  "description": "LocationVarCondition LT — capacity_pct less than threshold → show warning",
+  "form": {
+    "form_id": "parity-21",
+    "title": {"en": "Parity 21"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "capacity_warning", "field_type": "text", "label": {"en": "Capacity Warning"},
+          "depends_on": {
+            "conditions": [{"source": "location_variable", "key": "capacity_pct", "operator": "lt", "value": 30}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {}, "location_vars": {"capacity_pct": 15}, "visit_context": {}},
+  "expected": {"capacity_warning": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/22_locvar_is_empty.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/22_locvar_is_empty.json
@@ -1,0 +1,23 @@
+{
+  "name": "locvar-is-empty-match",
+  "description": "LocationVarCondition IS_EMPTY — location var has empty string value",
+  "form": {
+    "form_id": "parity-22",
+    "title": {"en": "Parity 22"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "setup_prompt", "field_type": "text", "label": {"en": "Setup Prompt"},
+          "depends_on": {
+            "conditions": [{"source": "location_variable", "key": "program_code", "operator": "is_empty"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {}, "location_vars": {"program_code": ""}, "visit_context": {}},
+  "expected": {"setup_prompt": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/23_locvar_is_not_empty.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/23_locvar_is_not_empty.json
@@ -1,0 +1,23 @@
+{
+  "name": "locvar-is-not-empty-match",
+  "description": "LocationVarCondition IS_NOT_EMPTY — location var has a value",
+  "form": {
+    "form_id": "parity-23",
+    "title": {"en": "Parity 23"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "program_detail", "field_type": "text", "label": {"en": "Program Detail"},
+          "depends_on": {
+            "conditions": [{"source": "location_variable", "key": "program_code", "operator": "is_not_empty"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {}, "location_vars": {"program_code": "PRG-001"}, "visit_context": {}},
+  "expected": {"program_detail": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/24_locvar_key_missing_is_empty.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/24_locvar_key_missing_is_empty.json
@@ -1,0 +1,23 @@
+{
+  "name": "locvar-key-missing-is-empty",
+  "description": "LocationVarCondition IS_EMPTY with missing key — key-missing → IS_EMPTY=true",
+  "form": {
+    "form_id": "parity-24",
+    "title": {"en": "Parity 24"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "fallback_msg", "field_type": "text", "label": {"en": "Fallback"},
+          "depends_on": {
+            "conditions": [{"source": "location_variable", "key": "store_type", "operator": "is_empty"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {}, "location_vars": {}, "visit_context": {}},
+  "expected": {"fallback_msg": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/25_locvar_key_missing_eq_false.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/25_locvar_key_missing_eq_false.json
@@ -1,0 +1,23 @@
+{
+  "name": "locvar-key-missing-eq-false",
+  "description": "LocationVarCondition EQ with missing key — key-missing → EQ=false (no raise)",
+  "form": {
+    "form_id": "parity-25",
+    "title": {"en": "Parity 25"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "flagship_section", "field_type": "text", "label": {"en": "Flagship"},
+          "depends_on": {
+            "conditions": [{"source": "location_variable", "key": "store_type", "operator": "eq", "value": "flagship"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {}, "location_vars": {}, "visit_context": {}},
+  "expected": {"flagship_section": {"effect": "show", "matched": false}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/26_visitctx_eq_match.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/26_visitctx_eq_match.json
@@ -1,0 +1,23 @@
+{
+  "name": "visit-context-eq-match",
+  "description": "VisitContextCondition EQ — visit_type matches audit",
+  "form": {
+    "form_id": "parity-26",
+    "title": {"en": "Parity 26"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "audit_notes", "field_type": "text_area", "label": {"en": "Audit Notes"},
+          "depends_on": {
+            "conditions": [{"source": "visit_context", "key": "visit_type", "operator": "eq", "value": "audit"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {}, "location_vars": {}, "visit_context": {"visit_type": "audit"}},
+  "expected": {"audit_notes": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/27_visitctx_key_missing_is_empty.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/27_visitctx_key_missing_is_empty.json
@@ -1,0 +1,23 @@
+{
+  "name": "visit-context-key-missing-is-empty",
+  "description": "VisitContextCondition IS_EMPTY with missing key — always true",
+  "form": {
+    "form_id": "parity-27",
+    "title": {"en": "Parity 27"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "visit_date_q", "field_type": "date", "label": {"en": "Visit Date"},
+          "depends_on": {
+            "conditions": [{"source": "visit_context", "key": "visit_date", "operator": "is_empty"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {}, "location_vars": {}, "visit_context": {}},
+  "expected": {"visit_date_q": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/28_visitctx_in_match.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/28_visitctx_in_match.json
@@ -1,0 +1,23 @@
+{
+  "name": "visit-context-in-match",
+  "description": "VisitContextCondition IN — visit status in active states",
+  "form": {
+    "form_id": "parity-28",
+    "title": {"en": "Parity 28"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "active_section", "field_type": "text", "label": {"en": "Active Section"},
+          "depends_on": {
+            "conditions": [{"source": "visit_context", "key": "status", "operator": "in", "value": ["in_progress", "pending", "scheduled"]}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {}, "location_vars": {}, "visit_context": {"status": "pending"}},
+  "expected": {"active_section": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/29_and_logic_all_true.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/29_and_logic_all_true.json
@@ -1,0 +1,27 @@
+{
+  "name": "and-logic-all-conditions-true",
+  "description": "AND logic: both conditions true → matched",
+  "form": {
+    "form_id": "parity-29",
+    "title": {"en": "Parity 29"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "has_insurance", "field_type": "select", "label": {"en": "Has Insurance"}},
+        {"field_id": "age", "field_type": "number", "label": {"en": "Age"}},
+        {"field_id": "coverage_details", "field_type": "text_area", "label": {"en": "Coverage"},
+          "depends_on": {
+            "conditions": [
+              {"source": "field", "field_id": "has_insurance", "operator": "eq", "value": "yes"},
+              {"source": "field", "field_id": "age", "operator": "gte", "value": 18}
+            ],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"has_insurance": "yes", "age": 25}, "location_vars": {}, "visit_context": {}},
+  "expected": {"coverage_details": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/30_and_logic_partial_false.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/30_and_logic_partial_false.json
@@ -1,0 +1,27 @@
+{
+  "name": "and-logic-partial-false",
+  "description": "AND logic: one condition false → not matched",
+  "form": {
+    "form_id": "parity-30",
+    "title": {"en": "Parity 30"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "has_insurance", "field_type": "select", "label": {"en": "Has Insurance"}},
+        {"field_id": "age", "field_type": "number", "label": {"en": "Age"}},
+        {"field_id": "coverage_details", "field_type": "text_area", "label": {"en": "Coverage"},
+          "depends_on": {
+            "conditions": [
+              {"source": "field", "field_id": "has_insurance", "operator": "eq", "value": "yes"},
+              {"source": "field", "field_id": "age", "operator": "gte", "value": 18}
+            ],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"has_insurance": "yes", "age": 15}, "location_vars": {}, "visit_context": {}},
+  "expected": {"coverage_details": {"effect": "show", "matched": false}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/31_or_logic_one_true.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/31_or_logic_one_true.json
@@ -1,0 +1,26 @@
+{
+  "name": "or-logic-one-condition-true",
+  "description": "OR logic: first condition true, second false → matched",
+  "form": {
+    "form_id": "parity-31",
+    "title": {"en": "Parity 31"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "channel", "field_type": "select", "label": {"en": "Channel"}},
+        {"field_id": "extra_info", "field_type": "text_area", "label": {"en": "Extra Info"},
+          "depends_on": {
+            "conditions": [
+              {"source": "field", "field_id": "channel", "operator": "eq", "value": "online"},
+              {"source": "field", "field_id": "channel", "operator": "eq", "value": "mobile"}
+            ],
+            "logic": "or", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"channel": "online"}, "location_vars": {}, "visit_context": {}},
+  "expected": {"extra_info": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/32_or_logic_all_false.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/32_or_logic_all_false.json
@@ -1,0 +1,26 @@
+{
+  "name": "or-logic-all-conditions-false",
+  "description": "OR logic: all conditions false → not matched",
+  "form": {
+    "form_id": "parity-32",
+    "title": {"en": "Parity 32"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "channel", "field_type": "select", "label": {"en": "Channel"}},
+        {"field_id": "extra_info", "field_type": "text_area", "label": {"en": "Extra Info"},
+          "depends_on": {
+            "conditions": [
+              {"source": "field", "field_id": "channel", "operator": "eq", "value": "online"},
+              {"source": "field", "field_id": "channel", "operator": "eq", "value": "mobile"}
+            ],
+            "logic": "or", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"channel": "in_store"}, "location_vars": {}, "visit_context": {}},
+  "expected": {"extra_info": {"effect": "show", "matched": false}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/33_effect_hide.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/33_effect_hide.json
@@ -1,0 +1,23 @@
+{
+  "name": "effect-hide",
+  "description": "effect=hide: when matched, field should be hidden",
+  "form": {
+    "form_id": "parity-33",
+    "title": {"en": "Parity 33"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "user_type", "field_type": "select", "label": {"en": "User Type"}},
+        {"field_id": "admin_panel", "field_type": "text", "label": {"en": "Admin Panel"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "user_type", "operator": "neq", "value": "admin"}],
+            "logic": "and", "effect": "hide"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"user_type": "guest"}, "location_vars": {}, "visit_context": {}},
+  "expected": {"admin_panel": {"effect": "hide", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/34_effect_require.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/34_effect_require.json
@@ -1,0 +1,23 @@
+{
+  "name": "effect-require",
+  "description": "effect=require: when matched, field becomes required",
+  "form": {
+    "form_id": "parity-34",
+    "title": {"en": "Parity 34"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "has_allergy", "field_type": "select", "label": {"en": "Has Allergy"}},
+        {"field_id": "allergy_detail", "field_type": "text_area", "label": {"en": "Allergy Detail"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "has_allergy", "operator": "eq", "value": "yes"}],
+            "logic": "and", "effect": "require"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"has_allergy": "yes"}, "location_vars": {}, "visit_context": {}},
+  "expected": {"allergy_detail": {"effect": "require", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/35_effect_disable.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/35_effect_disable.json
@@ -1,0 +1,23 @@
+{
+  "name": "effect-disable",
+  "description": "effect=disable: when matched, field should be disabled",
+  "form": {
+    "form_id": "parity-35",
+    "title": {"en": "Parity 35"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "locked", "field_type": "select", "label": {"en": "Locked"}},
+        {"field_id": "edit_field", "field_type": "text", "label": {"en": "Edit Field"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "locked", "operator": "eq", "value": "yes"}],
+            "logic": "and", "effect": "disable"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"locked": "yes"}, "location_vars": {}, "visit_context": {}},
+  "expected": {"edit_field": {"effect": "disable", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/36_chained_3level_all_show.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/36_chained_3level_all_show.json
@@ -1,0 +1,32 @@
+{
+  "name": "chained-3level-all-show",
+  "description": "3-field chain: q2 depends on q1, q3 depends on q2 — all conditions met",
+  "form": {
+    "form_id": "parity-36",
+    "title": {"en": "Parity 36"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "select", "label": {"en": "Q1"}},
+        {"field_id": "q2", "field_type": "text", "label": {"en": "Q2"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q1", "operator": "eq", "value": "yes"}],
+            "logic": "and", "effect": "show"
+          }
+        },
+        {"field_id": "q3", "field_type": "text_area", "label": {"en": "Q3"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q2", "operator": "is_not_empty"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"q1": "yes", "q2": "some text"}, "location_vars": {}, "visit_context": {}},
+  "expected": {
+    "q2": {"effect": "show", "matched": true},
+    "q3": {"effect": "show", "matched": true}
+  }
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/37_chained_hidden_excludes_downstream.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/37_chained_hidden_excludes_downstream.json
@@ -1,0 +1,32 @@
+{
+  "name": "chained-hidden-excludes-downstream",
+  "description": "Chain: q2 is hidden → q3 depends on q2 but q2 answer is masked",
+  "form": {
+    "form_id": "parity-37",
+    "title": {"en": "Parity 37"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "select", "label": {"en": "Q1"}},
+        {"field_id": "q2", "field_type": "text", "label": {"en": "Q2"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q1", "operator": "eq", "value": "yes"}],
+            "logic": "and", "effect": "hide"
+          }
+        },
+        {"field_id": "q3", "field_type": "text_area", "label": {"en": "Q3"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q2", "operator": "is_not_empty"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"q1": "yes", "q2": "some text"}, "location_vars": {}, "visit_context": {}},
+  "expected": {
+    "q2": {"effect": "hide", "matched": true},
+    "q3": {"effect": "show", "matched": false}
+  }
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/38_chained_4level.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/38_chained_4level.json
@@ -1,0 +1,39 @@
+{
+  "name": "chained-4level-all-conditions-met",
+  "description": "4-field chain: q4 depends on q3 depends on q2 depends on q1",
+  "form": {
+    "form_id": "parity-38",
+    "title": {"en": "Parity 38"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "select", "label": {"en": "Q1"}},
+        {"field_id": "q2", "field_type": "select", "label": {"en": "Q2"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q1", "operator": "eq", "value": "a"}],
+            "logic": "and", "effect": "show"
+          }
+        },
+        {"field_id": "q3", "field_type": "text", "label": {"en": "Q3"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q2", "operator": "eq", "value": "b"}],
+            "logic": "and", "effect": "show"
+          }
+        },
+        {"field_id": "q4", "field_type": "text_area", "label": {"en": "Q4"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q3", "operator": "is_not_empty"}],
+            "logic": "and", "effect": "require"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"q1": "a", "q2": "b", "q3": "hello"}, "location_vars": {}, "visit_context": {}},
+  "expected": {
+    "q2": {"effect": "show", "matched": true},
+    "q3": {"effect": "show", "matched": true},
+    "q4": {"effect": "require", "matched": true}
+  }
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/39_diamond_dependency.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/39_diamond_dependency.json
@@ -1,0 +1,27 @@
+{
+  "name": "diamond-dependency-both-parents-matched",
+  "description": "Diamond: q3 depends on q1 AND q2, both parents matched",
+  "form": {
+    "form_id": "parity-39",
+    "title": {"en": "Parity 39"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "select", "label": {"en": "Q1"}},
+        {"field_id": "q2", "field_type": "select", "label": {"en": "Q2"}},
+        {"field_id": "q3", "field_type": "text_area", "label": {"en": "Q3"},
+          "depends_on": {
+            "conditions": [
+              {"source": "field", "field_id": "q1", "operator": "eq", "value": "yes"},
+              {"source": "field", "field_id": "q2", "operator": "eq", "value": "yes"}
+            ],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"q1": "yes", "q2": "yes"}, "location_vars": {}, "visit_context": {}},
+  "expected": {"q3": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/40_chained_locvar_and_field.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/40_chained_locvar_and_field.json
@@ -1,0 +1,32 @@
+{
+  "name": "chained-location-var-and-field",
+  "description": "Chain: q2 depends on location_var, q3 depends on q2",
+  "form": {
+    "form_id": "parity-40",
+    "title": {"en": "Parity 40"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "q2", "field_type": "text", "label": {"en": "Q2"},
+          "depends_on": {
+            "conditions": [{"source": "location_variable", "key": "store_type", "operator": "eq", "value": "flagship"}],
+            "logic": "and", "effect": "show"
+          }
+        },
+        {"field_id": "q3", "field_type": "text_area", "label": {"en": "Q3"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q2", "operator": "is_not_empty"}],
+            "logic": "and", "effect": "require"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"q2": "filled value"}, "location_vars": {"store_type": "flagship"}, "visit_context": {}},
+  "expected": {
+    "q2": {"effect": "show", "matched": true},
+    "q3": {"effect": "require", "matched": true}
+  }
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/41_chained_or_logic.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/41_chained_or_logic.json
@@ -1,0 +1,35 @@
+{
+  "name": "chained-with-or-logic",
+  "description": "Chain: q2 uses OR logic, q3 depends on q2",
+  "form": {
+    "form_id": "parity-41",
+    "title": {"en": "Parity 41"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "select", "label": {"en": "Q1"}},
+        {"field_id": "q2", "field_type": "text", "label": {"en": "Q2"},
+          "depends_on": {
+            "conditions": [
+              {"source": "field", "field_id": "q1", "operator": "eq", "value": "a"},
+              {"source": "field", "field_id": "q1", "operator": "eq", "value": "b"}
+            ],
+            "logic": "or", "effect": "show"
+          }
+        },
+        {"field_id": "q3", "field_type": "text_area", "label": {"en": "Q3"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q2", "operator": "is_not_empty"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"q1": "b", "q2": "filled"}, "location_vars": {}, "visit_context": {}},
+  "expected": {
+    "q2": {"effect": "show", "matched": true},
+    "q3": {"effect": "show", "matched": true}
+  }
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/42_multi_section_chain.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/42_multi_section_chain.json
@@ -1,0 +1,40 @@
+{
+  "name": "multi-section-chain",
+  "description": "Chain spanning two sections: q2 in s1, q3 in s2 depends on q2",
+  "form": {
+    "form_id": "parity-42",
+    "title": {"en": "Parity 42"},
+    "sections": [
+      {
+        "section_id": "s1",
+        "title": {"en": "Section 1"},
+        "fields": [
+          {"field_id": "q1", "field_type": "select", "label": {"en": "Q1"}},
+          {"field_id": "q2", "field_type": "text", "label": {"en": "Q2"},
+            "depends_on": {
+              "conditions": [{"source": "field", "field_id": "q1", "operator": "eq", "value": "yes"}],
+              "logic": "and", "effect": "show"
+            }
+          }
+        ]
+      },
+      {
+        "section_id": "s2",
+        "title": {"en": "Section 2"},
+        "fields": [
+          {"field_id": "q3", "field_type": "text_area", "label": {"en": "Q3"},
+            "depends_on": {
+              "conditions": [{"source": "field", "field_id": "q2", "operator": "is_not_empty"}],
+              "logic": "and", "effect": "show"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "context": {"answers": {"q1": "yes", "q2": "detail"}, "location_vars": {}, "visit_context": {}},
+  "expected": {
+    "q2": {"effect": "show", "matched": true},
+    "q3": {"effect": "show", "matched": true}
+  }
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/43_chain_middle_hidden_downstream_masked.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/43_chain_middle_hidden_downstream_masked.json
@@ -1,0 +1,32 @@
+{
+  "name": "chain-middle-hidden-downstream-masked",
+  "description": "Chain: q2 hidden by q1=yes → q3 sees masked (absent) q2 value → IS_NOT_EMPTY false",
+  "form": {
+    "form_id": "parity-43",
+    "title": {"en": "Parity 43"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "select", "label": {"en": "Q1"}},
+        {"field_id": "q2", "field_type": "text", "label": {"en": "Q2"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q1", "operator": "eq", "value": "hide_q2"}],
+            "logic": "and", "effect": "hide"
+          }
+        },
+        {"field_id": "q3", "field_type": "text_area", "label": {"en": "Q3"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q2", "operator": "is_not_empty"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"q1": "hide_q2", "q2": "some_value"}, "location_vars": {}, "visit_context": {}},
+  "expected": {
+    "q2": {"effect": "hide", "matched": true},
+    "q3": {"effect": "show", "matched": false}
+  }
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/44_chain_multiple_effects.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/44_chain_multiple_effects.json
@@ -1,0 +1,32 @@
+{
+  "name": "chain-multiple-effects",
+  "description": "Chain: q2 requires based on q1, q3 disables based on q2",
+  "form": {
+    "form_id": "parity-44",
+    "title": {"en": "Parity 44"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "select", "label": {"en": "Q1"}},
+        {"field_id": "q2", "field_type": "text", "label": {"en": "Q2"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q1", "operator": "eq", "value": "yes"}],
+            "logic": "and", "effect": "require"
+          }
+        },
+        {"field_id": "q3", "field_type": "text_area", "label": {"en": "Q3"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q2", "operator": "eq", "value": "locked"}],
+            "logic": "and", "effect": "disable"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"q1": "yes", "q2": "locked"}, "location_vars": {}, "visit_context": {}},
+  "expected": {
+    "q2": {"effect": "require", "matched": true},
+    "q3": {"effect": "disable", "matched": true}
+  }
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/45_chain_locvar_visitctx.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/45_chain_locvar_visitctx.json
@@ -1,0 +1,39 @@
+{
+  "name": "chain-locvar-visitctx-combined",
+  "description": "Chain: q2 depends on location_var, q3 depends on visit_context AND q2",
+  "form": {
+    "form_id": "parity-45",
+    "title": {"en": "Parity 45"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "q2", "field_type": "text", "label": {"en": "Q2"},
+          "depends_on": {
+            "conditions": [{"source": "location_variable", "key": "tier", "operator": "in", "value": ["gold", "platinum"]}],
+            "logic": "and", "effect": "show"
+          }
+        },
+        {"field_id": "q3", "field_type": "text_area", "label": {"en": "Q3"},
+          "depends_on": {
+            "conditions": [
+              {"source": "visit_context", "key": "visit_type", "operator": "eq", "value": "scheduled"},
+              {"source": "field", "field_id": "q2", "operator": "is_not_empty"}
+            ],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {
+    "answers": {"q2": "gold_detail"},
+    "location_vars": {"tier": "gold"},
+    "visit_context": {"visit_type": "scheduled"}
+  },
+  "expected": {
+    "q2": {"effect": "show", "matched": true},
+    "q3": {"effect": "show", "matched": true}
+  }
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/46_chain_3level_middle_no_match.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/46_chain_3level_middle_no_match.json
@@ -1,0 +1,32 @@
+{
+  "name": "chained-3level-middle-no-match",
+  "description": "3-field chain: q2 condition not met → q2 shows (default) → q3 also shows (default)",
+  "form": {
+    "form_id": "parity-46",
+    "title": {"en": "Parity 46"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "select", "label": {"en": "Q1"}},
+        {"field_id": "q2", "field_type": "text", "label": {"en": "Q2"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q1", "operator": "eq", "value": "yes"}],
+            "logic": "and", "effect": "show"
+          }
+        },
+        {"field_id": "q3", "field_type": "text_area", "label": {"en": "Q3"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q2", "operator": "is_not_empty"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"q1": "no", "q2": "some value"}, "location_vars": {}, "visit_context": {}},
+  "expected": {
+    "q2": {"effect": "show", "matched": false},
+    "q3": {"effect": "show", "matched": true}
+  }
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/47_chain_field_and_locvar_and.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/47_chain_field_and_locvar_and.json
@@ -1,0 +1,39 @@
+{
+  "name": "chain-field-and-locvar-mixed-and",
+  "description": "q2 depends on both field AND location_var (AND logic), q3 depends on q2",
+  "form": {
+    "form_id": "parity-47",
+    "title": {"en": "Parity 47"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "select", "label": {"en": "Q1"}},
+        {"field_id": "q2", "field_type": "text", "label": {"en": "Q2"},
+          "depends_on": {
+            "conditions": [
+              {"source": "field", "field_id": "q1", "operator": "eq", "value": "yes"},
+              {"source": "location_variable", "key": "store_type", "operator": "eq", "value": "flagship"}
+            ],
+            "logic": "and", "effect": "show"
+          }
+        },
+        {"field_id": "q3", "field_type": "text_area", "label": {"en": "Q3"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q2", "operator": "is_not_empty"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {
+    "answers": {"q1": "yes", "q2": "detailed text"},
+    "location_vars": {"store_type": "flagship"},
+    "visit_context": {}
+  },
+  "expected": {
+    "q2": {"effect": "show", "matched": true},
+    "q3": {"effect": "show", "matched": true}
+  }
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/48_hidden_field_excluded_from_or_check.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/48_hidden_field_excluded_from_or_check.json
@@ -1,0 +1,35 @@
+{
+  "name": "hidden-field-excluded-from-or-check",
+  "description": "q2 is hidden → q3 uses OR: q2 OR q1; q2 masked, q1 present → only q1 evaluated",
+  "form": {
+    "form_id": "parity-48",
+    "title": {"en": "Parity 48"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "select", "label": {"en": "Q1"}},
+        {"field_id": "q2", "field_type": "text", "label": {"en": "Q2"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q1", "operator": "eq", "value": "hide_it"}],
+            "logic": "and", "effect": "hide"
+          }
+        },
+        {"field_id": "q3", "field_type": "text_area", "label": {"en": "Q3"},
+          "depends_on": {
+            "conditions": [
+              {"source": "field", "field_id": "q2", "operator": "is_not_empty"},
+              {"source": "field", "field_id": "q1", "operator": "eq", "value": "hide_it"}
+            ],
+            "logic": "or", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"q1": "hide_it", "q2": "some_value"}, "location_vars": {}, "visit_context": {}},
+  "expected": {
+    "q2": {"effect": "hide", "matched": true},
+    "q3": {"effect": "show", "matched": true}
+  }
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/49_cycle_detection_fallback.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/49_cycle_detection_fallback.json
@@ -1,0 +1,32 @@
+{
+  "name": "cycle-detection-fallback-to-form-order",
+  "description": "Cycle: q1 depends on q2 AND q2 depends on q1 → evaluator falls back to form order, no crash",
+  "_cycle_note": "Cycle is detected at LogicGraph.build time; evaluator logs warning and uses form order",
+  "form": {
+    "form_id": "parity-49",
+    "title": {"en": "Parity 49"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "select", "label": {"en": "Q1"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q2", "operator": "eq", "value": "yes"}],
+            "logic": "and", "effect": "show"
+          }
+        },
+        {"field_id": "q2", "field_type": "text", "label": {"en": "Q2"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q1", "operator": "eq", "value": "yes"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"q1": "yes", "q2": "yes"}, "location_vars": {}, "visit_context": {}},
+  "expected": {
+    "q1": {"effect": "show", "matched": true},
+    "q2": {"effect": "show", "matched": true}
+  }
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/50_nn_show_if_yes.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/50_nn_show_if_yes.json
@@ -1,0 +1,48 @@
+{
+  "name": "nn-show-if-yes-answer",
+  "description": "Networkninja-style: show follow-up if main question answered yes (logic_group pattern)",
+  "_nn_source": "Derived from networkninja question_logic_groups show_if pattern",
+  "form": {
+    "form_id": "parity-50",
+    "title": {"en": "Store Audit Form"},
+    "sections": [{
+      "section_id": "main",
+      "title": {"en": "Main Questions"},
+      "fields": [
+        {
+          "field_id": "Q1001",
+          "field_type": "select",
+          "label": {"en": "Is the store display compliant?"},
+          "options": [
+            {"value": "yes", "label": {"en": "Yes"}},
+            {"value": "no", "label": {"en": "No"}},
+            {"value": "na", "label": {"en": "N/A"}}
+          ]
+        },
+        {
+          "field_id": "Q1001_detail",
+          "field_type": "text_area",
+          "label": {"en": "Describe the compliance issue"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "Q1001", "operator": "eq", "value": "no"}],
+            "logic": "and", "effect": "require"
+          }
+        },
+        {
+          "field_id": "Q1001_photo",
+          "field_type": "file",
+          "label": {"en": "Upload evidence photo"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "Q1001", "operator": "eq", "value": "no"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"Q1001": "no"}, "location_vars": {}, "visit_context": {}},
+  "expected": {
+    "Q1001_detail": {"effect": "require", "matched": true},
+    "Q1001_photo": {"effect": "show", "matched": true}
+  }
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/51_nn_require_if_location_type.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/51_nn_require_if_location_type.json
@@ -1,0 +1,45 @@
+{
+  "name": "nn-require-if-location-tier",
+  "description": "Networkninja-style: extra audit fields required for high-tier stores",
+  "_nn_source": "Derived from networkninja location_variable-based logic groups (store tier gating)",
+  "form": {
+    "form_id": "parity-51",
+    "title": {"en": "Premium Store Audit"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "General"},
+      "fields": [
+        {
+          "field_id": "Q2001",
+          "field_type": "select",
+          "label": {"en": "Is the VIP lounge available?"},
+          "depends_on": {
+            "conditions": [{"source": "location_variable", "key": "tier", "operator": "in", "value": ["gold", "platinum"]}],
+            "logic": "and", "effect": "show"
+          }
+        },
+        {
+          "field_id": "Q2001_capacity",
+          "field_type": "number",
+          "label": {"en": "Current lounge capacity"},
+          "depends_on": {
+            "conditions": [
+              {"source": "location_variable", "key": "tier", "operator": "in", "value": ["gold", "platinum"]},
+              {"source": "field", "field_id": "Q2001", "operator": "eq", "value": "yes"}
+            ],
+            "logic": "and", "effect": "require"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {
+    "answers": {"Q2001": "yes"},
+    "location_vars": {"tier": "platinum"},
+    "visit_context": {}
+  },
+  "expected": {
+    "Q2001": {"effect": "show", "matched": true},
+    "Q2001_capacity": {"effect": "require", "matched": true}
+  }
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/52_nn_hide_na_followup.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/52_nn_hide_na_followup.json
@@ -1,0 +1,48 @@
+{
+  "name": "nn-hide-na-followup",
+  "description": "Networkninja-style: hide follow-up when main answer is N/A",
+  "_nn_source": "Derived from networkninja NA-gating pattern in question_logic_groups",
+  "form": {
+    "form_id": "parity-52",
+    "title": {"en": "Product Audit"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "Product Check"},
+      "fields": [
+        {
+          "field_id": "Q3001",
+          "field_type": "select",
+          "label": {"en": "Are product labels compliant?"},
+          "options": [
+            {"value": "yes", "label": {"en": "Yes"}},
+            {"value": "no", "label": {"en": "No"}},
+            {"value": "na", "label": {"en": "N/A"}}
+          ]
+        },
+        {
+          "field_id": "Q3001_comment",
+          "field_type": "text_area",
+          "label": {"en": "Comment"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "Q3001", "operator": "eq", "value": "na"}],
+            "logic": "and", "effect": "hide"
+          }
+        },
+        {
+          "field_id": "Q3001_fix_date",
+          "field_type": "date",
+          "label": {"en": "Target Fix Date"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "Q3001", "operator": "eq", "value": "no"}],
+            "logic": "and", "effect": "require"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"Q3001": "na"}, "location_vars": {}, "visit_context": {}},
+  "expected": {
+    "Q3001_comment": {"effect": "hide", "matched": true},
+    "Q3001_fix_date": {"effect": "show", "matched": false}
+  }
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/53_nn_visit_type_gating.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/53_nn_visit_type_gating.json
@@ -1,0 +1,50 @@
+{
+  "name": "nn-visit-type-gating",
+  "description": "Networkninja-style: different form sections shown based on visit type from context",
+  "_nn_source": "Derived from networkninja visit_context-based form branching",
+  "form": {
+    "form_id": "parity-53",
+    "title": {"en": "Flexible Visit Form"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "Visit Questions"},
+      "fields": [
+        {
+          "field_id": "Q4001",
+          "field_type": "select",
+          "label": {"en": "Was the manager present?"}
+        },
+        {
+          "field_id": "Q4002_manager_signature",
+          "field_type": "file",
+          "label": {"en": "Manager Signature"},
+          "depends_on": {
+            "conditions": [
+              {"source": "visit_context", "key": "visit_type", "operator": "eq", "value": "formal_audit"},
+              {"source": "field", "field_id": "Q4001", "operator": "eq", "value": "yes"}
+            ],
+            "logic": "and", "effect": "require"
+          }
+        },
+        {
+          "field_id": "Q4003_informal_note",
+          "field_type": "text_area",
+          "label": {"en": "Informal Note"},
+          "depends_on": {
+            "conditions": [{"source": "visit_context", "key": "visit_type", "operator": "neq", "value": "formal_audit"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {
+    "answers": {"Q4001": "yes"},
+    "location_vars": {},
+    "visit_context": {"visit_type": "formal_audit"}
+  },
+  "expected": {
+    "Q4002_manager_signature": {"effect": "require", "matched": true},
+    "Q4003_informal_note": {"effect": "show", "matched": false}
+  }
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/54_nn_multi_logic_group.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/54_nn_multi_logic_group.json
@@ -1,0 +1,44 @@
+{
+  "name": "nn-multi-logic-group-combined",
+  "description": "Networkninja-style: multiple independent logic groups on different questions",
+  "_nn_source": "Derived from networkninja question_blocks with multiple question_logic_groups entries",
+  "form": {
+    "form_id": "parity-54",
+    "title": {"en": "Multi-Logic Store Check"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "Questions"},
+      "fields": [
+        {"field_id": "Q5001", "field_type": "select", "label": {"en": "Cleanliness OK?"}},
+        {"field_id": "Q5002", "field_type": "select", "label": {"en": "Stock levels OK?"}},
+        {"field_id": "Q5001_detail", "field_type": "text_area", "label": {"en": "Cleanliness Issue Detail"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "Q5001", "operator": "eq", "value": "no"}],
+            "logic": "and", "effect": "require"
+          }
+        },
+        {"field_id": "Q5002_reorder", "field_type": "number", "label": {"en": "Units to Reorder"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "Q5002", "operator": "eq", "value": "no"}],
+            "logic": "and", "effect": "require"
+          }
+        },
+        {"field_id": "Q5003_escalate", "field_type": "select", "label": {"en": "Escalate to Regional?"},
+          "depends_on": {
+            "conditions": [
+              {"source": "field", "field_id": "Q5001", "operator": "eq", "value": "no"},
+              {"source": "field", "field_id": "Q5002", "operator": "eq", "value": "no"}
+            ],
+            "logic": "or", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"Q5001": "yes", "Q5002": "no"}, "location_vars": {}, "visit_context": {}},
+  "expected": {
+    "Q5001_detail": {"effect": "show", "matched": false},
+    "Q5002_reorder": {"effect": "require", "matched": true},
+    "Q5003_escalate": {"effect": "show", "matched": true}
+  }
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/55_legacy_no_source_field.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/55_legacy_no_source_field.json
@@ -1,0 +1,24 @@
+{
+  "name": "legacy-no-source-field-backward-compat",
+  "description": "Backward compat: condition without 'source' key is auto-upgraded to FieldRefCondition",
+  "_note": "Pre-FEAT-301 serialized forms lack 'source' key; the before-validator injects source='field'",
+  "form": {
+    "form_id": "parity-55",
+    "title": {"en": "Parity 55"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "q2", "field_type": "text", "label": {"en": "Q2"},
+          "depends_on": {
+            "conditions": [{"field_id": "q1", "operator": "eq", "value": "yes"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"q1": "yes"}, "location_vars": {}, "visit_context": {}},
+  "expected": {"q2": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/56_is_empty_null_value.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/56_is_empty_null_value.json
@@ -1,0 +1,23 @@
+{
+  "name": "is-empty-null-value",
+  "description": "IS_EMPTY: explicit null answer → is_empty=true",
+  "form": {
+    "form_id": "parity-56",
+    "title": {"en": "Parity 56"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "q2", "field_type": "text", "label": {"en": "Q2"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "q1", "operator": "is_empty"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"q1": null}, "location_vars": {}, "visit_context": {}},
+  "expected": {"q2": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/57_is_empty_empty_list.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/57_is_empty_empty_list.json
@@ -1,0 +1,23 @@
+{
+  "name": "is-empty-empty-list",
+  "description": "IS_EMPTY: empty list answer → is_empty=true",
+  "form": {
+    "form_id": "parity-57",
+    "title": {"en": "Parity 57"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "selections", "field_type": "multi_select", "label": {"en": "Selections"}},
+        {"field_id": "empty_hint", "field_type": "text", "label": {"en": "Empty Hint"},
+          "depends_on": {
+            "conditions": [{"source": "field", "field_id": "selections", "operator": "is_empty"}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {"selections": []}, "location_vars": {}, "visit_context": {}},
+  "expected": {"empty_hint": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/58_locvar_gte_match.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/58_locvar_gte_match.json
@@ -1,0 +1,23 @@
+{
+  "name": "locvar-gte-match",
+  "description": "LocationVarCondition GTE — opening_year >= threshold",
+  "form": {
+    "form_id": "parity-58",
+    "title": {"en": "Parity 58"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "modern_section", "field_type": "text", "label": {"en": "Modern Section"},
+          "depends_on": {
+            "conditions": [{"source": "location_variable", "key": "opening_year", "operator": "gte", "value": 2020}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {}, "location_vars": {"opening_year": 2022}, "visit_context": {}},
+  "expected": {"modern_section": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/59_locvar_lte_match.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/59_locvar_lte_match.json
@@ -1,0 +1,23 @@
+{
+  "name": "locvar-lte-match",
+  "description": "LocationVarCondition LTE — floor_area_sqm <= threshold → compact form",
+  "form": {
+    "form_id": "parity-59",
+    "title": {"en": "Parity 59"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "compact_layout", "field_type": "text", "label": {"en": "Compact Layout Note"},
+          "depends_on": {
+            "conditions": [{"source": "location_variable", "key": "floor_area_sqm", "operator": "lte", "value": 200}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {}, "location_vars": {"floor_area_sqm": 150}, "visit_context": {}},
+  "expected": {"compact_layout": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/parity/vectors/60_visitctx_not_in.json
+++ b/packages/parrot-formdesigner/tests/parity/vectors/60_visitctx_not_in.json
@@ -1,0 +1,23 @@
+{
+  "name": "visit-context-not-in-match",
+  "description": "VisitContextCondition NOT_IN — visit_type not in completed states",
+  "form": {
+    "form_id": "parity-60",
+    "title": {"en": "Parity 60"},
+    "sections": [{
+      "section_id": "s1",
+      "title": {"en": "S1"},
+      "fields": [
+        {"field_id": "q1", "field_type": "text", "label": {"en": "Q1"}},
+        {"field_id": "action_items", "field_type": "text_area", "label": {"en": "Action Items"},
+          "depends_on": {
+            "conditions": [{"source": "visit_context", "key": "status", "operator": "not_in", "value": ["completed", "cancelled"]}],
+            "logic": "and", "effect": "show"
+          }
+        }
+      ]
+    }]
+  },
+  "context": {"answers": {}, "location_vars": {}, "visit_context": {"status": "in_progress"}},
+  "expected": {"action_items": {"effect": "show", "matched": true}}
+}

--- a/packages/parrot-formdesigner/tests/unit/renderers/test_xforms.py
+++ b/packages/parrot-formdesigner/tests/unit/renderers/test_xforms.py
@@ -10,6 +10,7 @@ from parrot_formdesigner.core.constraints import (
     DependencyRule,
     FieldCondition,
     FieldConstraints,
+    FieldRefCondition,
 )
 from parrot_formdesigner.core.options import FieldOption
 from parrot_formdesigner.core.schema import (
@@ -233,7 +234,7 @@ async def test_relevant_xpath_for_simple_dependency():
                         label={"en": "Child"},
                         depends_on=DependencyRule(
                             conditions=[
-                                FieldCondition(
+                                FieldRefCondition(
                                     field_id="parent",
                                     operator=ConditionOperator.EQ,
                                     value="show",

--- a/packages/parrot-formdesigner/tests/unit/test_api_feat300.py
+++ b/packages/parrot-formdesigner/tests/unit/test_api_feat300.py
@@ -1,0 +1,441 @@
+"""Unit tests for FEAT-300 API endpoints (TASK-007).
+
+Tests the six new handler methods on FormAPIHandler:
+  - publish_form      POST /forms/{form_id}/publish
+  - list_fields       GET  /fields
+  - create_field      POST /fields
+  - list_versions     GET  /forms/{form_id}/versions
+  - get_version       GET  /forms/{form_id}/versions/{version}
+  - get_import_report GET  /forms/{form_id}/import-report
+
+All tests use mocked aiohttp requests — no live HTTP server required.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+from parrot_formdesigner.api.handlers import FormAPIHandler
+from parrot_formdesigner.core.schema import FormField, FormSchema, FormSection
+from parrot_formdesigner.core.types import FieldType
+from parrot_formdesigner.services.registry import FormRegistry
+from parrot_formdesigner.tools.services.networkninja import (
+    ImportDiffEntry,
+    ImportDiffReport,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_form(form_id: str = "f1", tenant: str = "t1") -> FormSchema:
+    """Minimal FormSchema for tests."""
+    return FormSchema(
+        form_id=form_id,
+        title="Test Form",
+        version="1.0",
+        tenant=tenant,
+        sections=[
+            FormSection(
+                section_id="s1",
+                fields=[FormField(field_id="q1", field_type=FieldType.TEXT, label="Q1")],
+            )
+        ],
+    )
+
+
+def _make_request(
+    *,
+    method: str = "GET",
+    form_id: str = "f1",
+    version: str | None = None,
+    body: dict | None = None,
+    session_programs: list[str] | None = None,
+    tenant: str = "t1",
+) -> MagicMock:
+    """Build a mocked aiohttp web.Request.
+
+    Args:
+        method: HTTP method string.
+        form_id: Value for the ``{form_id}`` path parameter.
+        version: Optional value for the ``{version}`` path parameter.
+        body: Optional JSON body dict.
+        session_programs: Programs list for the navigator-auth session.
+            Defaults to ``[tenant]`` so the handler resolves the right tenant.
+        tenant: Convenience param used when ``session_programs`` is omitted.
+    """
+    from aiohttp import web
+
+    req = MagicMock(spec=web.Request)
+    req.method = method
+    match_info: dict[str, str] = {"form_id": form_id}
+    if version is not None:
+        match_info["version"] = version
+    req.match_info = match_info
+
+    # Session / tenant — default to [tenant] so registry lookups resolve.
+    programs = session_programs if session_programs is not None else [tenant]
+    session_obj = {"session": {"programs": programs}}
+    req.session = session_obj
+    req.__contains__ = lambda self, key: False  # no "session" key item access
+
+    # Body
+    if body is not None:
+        req.json = AsyncMock(return_value=body)
+    else:
+        req.json = AsyncMock(side_effect=ValueError("no body"))
+
+    return req
+
+
+def _make_handler(
+    registry: FormRegistry | None = None,
+    *,
+    tenant: str = "t1",
+) -> FormAPIHandler:
+    """Build a FormAPIHandler with a minimal mock registry.
+
+    Args:
+        registry: Optional pre-built ``FormRegistry``. When ``None``, a mock
+            registry is constructed that returns ``None`` for all ``get()``
+            calls (suitable for 404 tests).
+        tenant: Tenant string for the mock registry's ``default_tenant``.
+    """
+    if registry is None:
+        registry = MagicMock(spec=FormRegistry)
+        registry.get = AsyncMock(return_value=None)
+        registry.storage = None
+        registry.default_tenant = tenant
+        registry.register = AsyncMock()
+    return FormAPIHandler(registry=registry)
+
+
+# ---------------------------------------------------------------------------
+# publish_form
+# ---------------------------------------------------------------------------
+
+
+class TestPublishForm:
+    """Tests for FormAPIHandler.publish_form()."""
+
+    async def test_publish_endpoint_200(self):
+        """Publish returns 200 with form_id and version."""
+        registry = FormRegistry()
+        form = _make_form()
+        await registry.register(form, tenant="t1")
+
+        handler = _make_handler(registry)
+        req = _make_request(method="POST", form_id="f1")
+
+        resp = await handler.publish_form(req)
+
+        assert resp.status == 200
+        body = json.loads(resp.body)
+        assert body["form_id"] == "f1"
+        assert "version" in body
+        assert body["version"]  # non-empty version string
+
+    async def test_publish_endpoint_404_unknown_form(self):
+        """Publishing a non-existent form returns 404."""
+        handler = _make_handler()
+        req = _make_request(method="POST", form_id="no-such-form")
+
+        resp = await handler.publish_form(req)
+
+        assert resp.status == 404
+        body = json.loads(resp.body)
+        assert "error" in body
+
+    async def test_publish_endpoint_409_frozen_conflict(self):
+        """Publishing a version that already exists returns 409."""
+        registry = FormRegistry()
+        form = _make_form()
+        await registry.register(form, tenant="t1")
+
+        handler = _make_handler(registry)
+        req = _make_request(method="POST", form_id="f1")
+
+        # First publish succeeds; second publish bumps to 1.2, but if we reset
+        # the form back to 1.0 and the snapshot for 1.1 already exists → 409.
+        await handler.publish_form(req)  # → 1.1
+
+        # Force the live form back to 1.0 so next publish tries to create 1.1 again.
+        form_back = _make_form(form_id="f1")
+        await registry.register(form_back, overwrite=True, tenant="t1")
+
+        resp = await handler.publish_form(req)
+
+        assert resp.status == 409
+        body = json.loads(resp.body)
+        assert "error" in body
+
+
+# ---------------------------------------------------------------------------
+# list_fields
+# ---------------------------------------------------------------------------
+
+
+class TestListFields:
+    """Tests for FormAPIHandler.list_fields()."""
+
+    async def test_list_fields_endpoint(self):
+        """GET /fields returns 200 with a fields list (may be empty)."""
+        handler = _make_handler()
+        req = _make_request(method="GET")
+
+        resp = await handler.list_fields(req)
+
+        assert resp.status == 200
+        body = json.loads(resp.body)
+        assert "fields" in body
+        assert isinstance(body["fields"], list)
+
+    async def test_list_fields_returns_created_field(self):
+        """A field added via create_field appears in list_fields."""
+        handler = _make_handler()
+        field_body = {
+            "field_id": "q1",
+            "field_type": "text",
+            "label": "Question 1",
+        }
+        create_req = _make_request(method="POST", body=field_body)
+        await handler.create_field(create_req)
+
+        list_req = _make_request(method="GET")
+        resp = await handler.list_fields(list_req)
+
+        body = json.loads(resp.body)
+        assert len(body["fields"]) == 1
+        assert body["fields"][0]["definition"]["field_id"] == "q1"
+
+
+# ---------------------------------------------------------------------------
+# create_field
+# ---------------------------------------------------------------------------
+
+
+class TestCreateField:
+    """Tests for FormAPIHandler.create_field()."""
+
+    async def test_create_field_endpoint(self):
+        """POST /fields returns 201 with the created ReusableField."""
+        handler = _make_handler()
+        field_body = {
+            "field_id": "name",
+            "field_type": "text",
+            "label": "Full Name",
+        }
+        req = _make_request(method="POST", body=field_body)
+
+        resp = await handler.create_field(req)
+
+        assert resp.status == 201
+        body = json.loads(resp.body)
+        assert "field_id" in body
+        assert body["definition"]["label"] == "Full Name"
+
+    async def test_create_field_bad_json(self):
+        """Invalid JSON body → 400."""
+        from aiohttp import web
+
+        handler = _make_handler()
+        req = MagicMock(spec=web.Request)
+        req.match_info = {"form_id": "f1"}
+        req.session = {"session": {"programs": []}}
+        req.__contains__ = lambda self, key: False
+        req.json = AsyncMock(side_effect=ValueError("bad json"))
+
+        resp = await handler.create_field(req)
+
+        assert resp.status == 400
+
+    async def test_create_field_invalid_body_422(self):
+        """Body with invalid FormField fields → 422."""
+        handler = _make_handler()
+        req = _make_request(method="POST", body={"field_type": "text"})  # missing field_id
+
+        resp = await handler.create_field(req)
+
+        assert resp.status == 422
+
+
+# ---------------------------------------------------------------------------
+# list_versions
+# ---------------------------------------------------------------------------
+
+
+class TestListVersions:
+    """Tests for FormAPIHandler.list_versions()."""
+
+    async def test_list_versions_endpoint(self):
+        """GET .../versions returns form_id + versions list."""
+        registry = FormRegistry()
+        form = _make_form()
+        await registry.register(form, tenant="t1")
+
+        handler = _make_handler(registry)
+        # Publish once so there's a version in the history
+        pub_req = _make_request(method="POST", form_id="f1")
+        await handler.publish_form(pub_req)
+
+        req = _make_request(method="GET", form_id="f1")
+        resp = await handler.list_versions(req)
+
+        assert resp.status == 200
+        body = json.loads(resp.body)
+        assert body["form_id"] == "f1"
+        assert isinstance(body["versions"], list)
+        assert len(body["versions"]) >= 1
+        v = body["versions"][0]
+        assert "version" in v
+        assert "published_at" in v
+        assert "is_current" in v
+        assert "published_by" in v
+
+    async def test_list_versions_404_unknown_form(self):
+        """Listing versions for an unknown form → 404."""
+        handler = _make_handler()
+        req = _make_request(method="GET", form_id="no-such-form")
+
+        resp = await handler.list_versions(req)
+
+        assert resp.status == 404
+
+    async def test_list_versions_empty_before_publish(self):
+        """A form with no publishes has an empty versions list."""
+        registry = FormRegistry()
+        form = _make_form()
+        await registry.register(form, tenant="t1")
+
+        handler = _make_handler(registry)
+        req = _make_request(method="GET", form_id="f1")
+        resp = await handler.list_versions(req)
+
+        assert resp.status == 200
+        body = json.loads(resp.body)
+        assert body["versions"] == []
+
+
+# ---------------------------------------------------------------------------
+# get_version
+# ---------------------------------------------------------------------------
+
+
+class TestGetVersion:
+    """Tests for FormAPIHandler.get_version()."""
+
+    async def test_get_version_endpoint_200(self):
+        """Known version returns 200 with full FormSchema JSON."""
+        registry = FormRegistry()
+        form = _make_form()
+        await registry.register(form, tenant="t1")
+
+        handler = _make_handler(registry)
+        # Publish first
+        pub_req = _make_request(method="POST", form_id="f1")
+        pub_resp = await handler.publish_form(pub_req)
+        published_version = json.loads(pub_resp.body)["version"]
+
+        req = _make_request(method="GET", form_id="f1", version=published_version)
+        resp = await handler.get_version(req)
+
+        assert resp.status == 200
+        body = json.loads(resp.body)
+        assert body["form_id"] == "f1"
+        assert body["published_version"] == published_version
+
+    async def test_get_version_endpoint_404(self):
+        """Unknown version → 404."""
+        handler = _make_handler()
+        req = _make_request(method="GET", form_id="f1", version="99.0")
+
+        resp = await handler.get_version(req)
+
+        assert resp.status == 404
+        body = json.loads(resp.body)
+        assert "error" in body
+
+    async def test_get_version_unknown_form_404(self):
+        """Unknown form_id → 404 regardless of version."""
+        handler = _make_handler()
+        req = _make_request(method="GET", form_id="ghost-form", version="1.0")
+
+        resp = await handler.get_version(req)
+
+        assert resp.status == 404
+
+
+# ---------------------------------------------------------------------------
+# get_import_report
+# ---------------------------------------------------------------------------
+
+
+class TestGetImportReport:
+    """Tests for FormAPIHandler.get_import_report()."""
+
+    async def test_import_report_endpoint_404_no_report(self):
+        """Form with no import history → 404."""
+        handler = _make_handler()
+        req = _make_request(method="GET", form_id="f1")
+
+        resp = await handler.get_import_report(req)
+
+        assert resp.status == 404
+        body = json.loads(resp.body)
+        assert "error" in body
+
+    async def test_import_report_endpoint(self):
+        """A stored ImportDiffReport is returned as JSON (200)."""
+        handler = _make_handler()
+
+        # Pre-populate the report store (simulates a completed import flow)
+        report = ImportDiffReport(
+            form_id="f1",
+            source="networkninja",
+            imported_at=datetime.now(timezone.utc),
+            fields=[
+                ImportDiffEntry(
+                    column_name="col1",
+                    source_data_type="FIELD_TEXT",
+                    mapped_field_type="text",
+                    status="mapeado",
+                ),
+                ImportDiffEntry(
+                    column_name="col2",
+                    source_data_type="FIELD_FORMULA",
+                    mapped_field_type="formula",
+                    status="requiere_intervencion",
+                    note="expression unavailable (FEAT-301)",
+                ),
+            ],
+        )
+        handler._import_reports[("t1", "f1")] = report
+
+        req = _make_request(method="GET", form_id="f1")
+        resp = await handler.get_import_report(req)
+
+        assert resp.status == 200
+        body = json.loads(resp.body)
+        assert body["source"] == "networkninja"
+        assert all("status" in f for f in body["fields"])
+        assert len(body["fields"]) == 2
+
+    async def test_import_report_correct_form_id_lookup(self):
+        """Import report is scoped per form_id — other form returns 404."""
+        handler = _make_handler()
+        report = ImportDiffReport(
+            form_id="f1",
+            source="networkninja",
+            imported_at=datetime.now(timezone.utc),
+        )
+        handler._import_reports[("t1", "f1")] = report
+
+        # Request for a DIFFERENT form_id
+        req = _make_request(method="GET", form_id="f2")
+        resp = await handler.get_import_report(req)
+
+        assert resp.status == 404

--- a/packages/parrot-formdesigner/tests/unit/test_condition_union.py
+++ b/packages/parrot-formdesigner/tests/unit/test_condition_union.py
@@ -1,0 +1,367 @@
+"""Unit tests for FEAT-301 FieldCondition discriminated union.
+
+Covers:
+- Backward-compat: legacy dicts without ``source`` deserialize as FieldRefCondition.
+- All three variants (FieldRefCondition, LocationVarCondition, VisitContextCondition).
+- Round-trip serialization.
+- LocationVariableBinding value-object.
+- ConfigDict(extra="forbid") enforcement.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from parrot_formdesigner.core.constraints import (
+    ConditionOperator,
+    DependencyRule,
+    FieldRefCondition,
+    LocationVarCondition,
+    LocationVariableBinding,
+    VisitContextCondition,
+)
+
+
+# ---------------------------------------------------------------------------
+# FieldRefCondition
+# ---------------------------------------------------------------------------
+
+class TestFieldRefCondition:
+    """Tests for the FieldRefCondition variant."""
+
+    def test_default_source_is_field(self) -> None:
+        """FieldRefCondition has source='field' by default."""
+        cond = FieldRefCondition(
+            field_id="q1",
+            operator=ConditionOperator.EQ,
+            value=1,
+        )
+        assert cond.source == "field"
+        assert cond.field_id == "q1"
+
+    def test_explicit_source_field(self) -> None:
+        """Explicit source='field' is accepted."""
+        cond = FieldRefCondition(
+            source="field",
+            field_id="q2",
+            operator=ConditionOperator.NEQ,
+            value="no",
+        )
+        assert cond.source == "field"
+
+    def test_value_defaults_to_none(self) -> None:
+        """Value can be omitted (defaults to None)."""
+        cond = FieldRefCondition(
+            field_id="q1",
+            operator=ConditionOperator.IS_EMPTY,
+        )
+        assert cond.value is None
+
+    def test_extra_fields_forbidden(self) -> None:
+        """Extra fields are rejected by ConfigDict(extra='forbid')."""
+        with pytest.raises(ValidationError):
+            FieldRefCondition(
+                field_id="q1",
+                operator=ConditionOperator.EQ,
+                value=1,
+                unknown_field="oops",  # type: ignore[call-arg]
+            )
+
+
+# ---------------------------------------------------------------------------
+# LocationVarCondition
+# ---------------------------------------------------------------------------
+
+class TestLocationVarCondition:
+    """Tests for the LocationVarCondition variant."""
+
+    def test_source_must_be_location_variable(self) -> None:
+        """source must be 'location_variable'."""
+        cond = LocationVarCondition(
+            source="location_variable",
+            key="store_type",
+            operator=ConditionOperator.EQ,
+            value="flagship",
+        )
+        assert cond.source == "location_variable"
+        assert cond.key == "store_type"
+
+    def test_value_none_allowed(self) -> None:
+        """Value defaults to None for IS_EMPTY checks."""
+        cond = LocationVarCondition(
+            source="location_variable",
+            key="feature_flag",
+            operator=ConditionOperator.IS_EMPTY,
+        )
+        assert cond.value is None
+
+    def test_extra_fields_forbidden(self) -> None:
+        """Extra fields are rejected."""
+        with pytest.raises(ValidationError):
+            LocationVarCondition(
+                source="location_variable",
+                key="x",
+                operator=ConditionOperator.EQ,
+                value=1,
+                field_id="should_not_exist",  # type: ignore[call-arg]
+            )
+
+
+# ---------------------------------------------------------------------------
+# VisitContextCondition
+# ---------------------------------------------------------------------------
+
+class TestVisitContextCondition:
+    """Tests for the VisitContextCondition variant."""
+
+    def test_source_is_visit_context(self) -> None:
+        """source must be 'visit_context'."""
+        cond = VisitContextCondition(
+            source="visit_context",
+            key="visit_type",
+            operator=ConditionOperator.IN,
+            value=["audit", "merchandising"],
+        )
+        assert cond.source == "visit_context"
+        assert cond.key == "visit_type"
+
+    def test_value_can_be_string(self) -> None:
+        """Value can be a plain string."""
+        cond = VisitContextCondition(
+            source="visit_context",
+            key="visit_date",
+            operator=ConditionOperator.GT,
+            value="2026-01-01",
+        )
+        assert cond.value == "2026-01-01"
+
+
+# ---------------------------------------------------------------------------
+# DependencyRule — backward compat + legacy source injection
+# ---------------------------------------------------------------------------
+
+class TestDependencyRuleLegacyInjection:
+    """Tests for the backward-compat model_validator on DependencyRule."""
+
+    def test_legacy_dict_backward_compat(self) -> None:
+        """Legacy dict without 'source' deserializes as FieldRefCondition."""
+        rule = DependencyRule.model_validate({
+            "conditions": [{"field_id": "q1", "operator": "eq", "value": 1}],
+            "logic": "and",
+            "effect": "show",
+        })
+        cond = rule.conditions[0]
+        assert isinstance(cond, FieldRefCondition)
+        assert cond.field_id == "q1"
+        assert cond.value == 1
+
+    def test_legacy_multiple_conditions(self) -> None:
+        """Multiple legacy conditions are all injected with source='field'."""
+        rule = DependencyRule.model_validate({
+            "conditions": [
+                {"field_id": "q1", "operator": "eq", "value": "yes"},
+                {"field_id": "q2", "operator": "neq", "value": "no"},
+            ],
+        })
+        for cond in rule.conditions:
+            assert isinstance(cond, FieldRefCondition)
+
+    def test_new_location_var_no_injection(self) -> None:
+        """Dicts with explicit source are NOT overwritten."""
+        rule = DependencyRule.model_validate({
+            "conditions": [
+                {
+                    "source": "location_variable",
+                    "key": "store_type",
+                    "operator": "eq",
+                    "value": "flagship",
+                }
+            ],
+        })
+        cond = rule.conditions[0]
+        assert isinstance(cond, LocationVarCondition)
+        assert cond.key == "store_type"
+
+    def test_empty_conditions_list(self) -> None:
+        """Empty conditions list is valid (DependencyRule allows it)."""
+        rule = DependencyRule.model_validate({"conditions": []})
+        assert rule.conditions == []
+
+    def test_conditions_none_safe(self) -> None:
+        """Missing conditions key defaults gracefully (none = no conditions)."""
+        # The validator must not crash on missing 'conditions'.
+        rule = DependencyRule(conditions=[])
+        assert rule.conditions == []
+
+    def test_default_logic_and_effect(self) -> None:
+        """Default logic='and', effect='show' preserved."""
+        rule = DependencyRule.model_validate({
+            "conditions": [{"field_id": "q1", "operator": "eq", "value": 1}],
+        })
+        assert rule.logic == "and"
+        assert rule.effect == "show"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip serialization
+# ---------------------------------------------------------------------------
+
+class TestRoundTripSerialization:
+    """Tests for model_dump() → model_validate() round-trip correctness."""
+
+    def test_round_trip_field_ref(self) -> None:
+        """FieldRefCondition round-trips through model_dump/model_validate."""
+        rule = DependencyRule(
+            conditions=[
+                FieldRefCondition(
+                    field_id="q1",
+                    operator=ConditionOperator.EQ,
+                    value=1,
+                )
+            ]
+        )
+        reloaded = DependencyRule.model_validate(rule.model_dump())
+        assert reloaded == rule
+
+    def test_round_trip_all_three_variants(self) -> None:
+        """All three condition variants round-trip identically."""
+        rule = DependencyRule(
+            conditions=[
+                FieldRefCondition(
+                    field_id="q1",
+                    operator=ConditionOperator.EQ,
+                    value=1,
+                ),
+                LocationVarCondition(
+                    source="location_variable",
+                    key="store_type",
+                    operator=ConditionOperator.EQ,
+                    value="flagship",
+                ),
+                VisitContextCondition(
+                    source="visit_context",
+                    key="visit_type",
+                    operator=ConditionOperator.IN,
+                    value=["audit"],
+                ),
+            ]
+        )
+        reloaded = DependencyRule.model_validate(rule.model_dump())
+        assert reloaded == rule
+
+    def test_round_trip_preserves_source_key(self) -> None:
+        """model_dump() includes 'source' so the union can be re-parsed."""
+        rule = DependencyRule(
+            conditions=[
+                FieldRefCondition(field_id="q1", operator=ConditionOperator.EQ, value="yes"),
+            ]
+        )
+        dumped = rule.model_dump()
+        cond_dict = dumped["conditions"][0]
+        assert cond_dict["source"] == "field"
+        assert cond_dict["field_id"] == "q1"
+
+    def test_round_trip_from_legacy_to_field_ref(self) -> None:
+        """A rule deserialized from a legacy dict round-trips as FieldRefCondition."""
+        rule = DependencyRule.model_validate({
+            "conditions": [{"field_id": "q2", "operator": "is_empty"}],
+        })
+        reloaded = DependencyRule.model_validate(rule.model_dump())
+        assert isinstance(reloaded.conditions[0], FieldRefCondition)
+        assert reloaded.conditions[0].field_id == "q2"
+
+
+# ---------------------------------------------------------------------------
+# LocationVariableBinding
+# ---------------------------------------------------------------------------
+
+class TestLocationVariableBinding:
+    """Tests for the LocationVariableBinding value-object."""
+
+    def test_basic_creation(self) -> None:
+        """LocationVariableBinding validates key/scope/value."""
+        binding = LocationVariableBinding(
+            key="store_type",
+            scope="store_001",
+            value="flagship",
+        )
+        assert binding.key == "store_type"
+        assert binding.scope == "store_001"
+        assert binding.value == "flagship"
+
+    def test_value_can_be_any_type(self) -> None:
+        """value accepts any JSON-serializable type."""
+        binding_int = LocationVariableBinding(key="k", scope="s", value=42)
+        binding_bool = LocationVariableBinding(key="k", scope="s", value=True)
+        binding_list = LocationVariableBinding(key="k", scope="s", value=["a", "b"])
+        assert binding_int.value == 42
+        assert binding_bool.value is True
+        assert binding_list.value == ["a", "b"]
+
+    def test_extra_fields_forbidden(self) -> None:
+        """Extra fields are rejected."""
+        with pytest.raises(ValidationError):
+            LocationVariableBinding(
+                key="k",
+                scope="s",
+                value="v",
+                extra="not_allowed",  # type: ignore[call-arg]
+            )
+
+    def test_round_trip(self) -> None:
+        """LocationVariableBinding round-trips through model_dump/model_validate."""
+        binding = LocationVariableBinding(key="store_type", scope="store_42", value="flagship")
+        reloaded = LocationVariableBinding.model_validate(binding.model_dump())
+        assert reloaded == binding
+
+
+# ---------------------------------------------------------------------------
+# Discriminated union discrimination
+# ---------------------------------------------------------------------------
+
+class TestUnionDiscrimination:
+    """Tests that the union correctly dispatches by source."""
+
+    def test_discriminates_field(self) -> None:
+        """source='field' → FieldRefCondition."""
+        rule = DependencyRule(conditions=[
+            FieldRefCondition(field_id="q1", operator=ConditionOperator.EQ, value=1),
+        ])
+        assert isinstance(rule.conditions[0], FieldRefCondition)
+
+    def test_discriminates_location_variable(self) -> None:
+        """source='location_variable' → LocationVarCondition."""
+        rule = DependencyRule.model_validate({
+            "conditions": [{
+                "source": "location_variable",
+                "key": "store_type",
+                "operator": "eq",
+                "value": "flagship",
+            }],
+        })
+        assert isinstance(rule.conditions[0], LocationVarCondition)
+
+    def test_discriminates_visit_context(self) -> None:
+        """source='visit_context' → VisitContextCondition."""
+        rule = DependencyRule.model_validate({
+            "conditions": [{
+                "source": "visit_context",
+                "key": "visit_type",
+                "operator": "in",
+                "value": ["audit"],
+            }],
+        })
+        assert isinstance(rule.conditions[0], VisitContextCondition)
+
+    def test_unknown_source_raises(self) -> None:
+        """Unknown source value raises ValidationError."""
+        with pytest.raises(ValidationError):
+            DependencyRule.model_validate({
+                "conditions": [{
+                    "source": "unknown_source",
+                    "key": "x",
+                    "operator": "eq",
+                    "value": 1,
+                }],
+            })

--- a/packages/parrot-formdesigner/tests/unit/test_controls_registry.py
+++ b/packages/parrot-formdesigner/tests/unit/test_controls_registry.py
@@ -163,11 +163,11 @@ def test_builtin_snippets_are_deep_copies():
 
 
 def test_controls_registry_has_all_new_types():
-    """get_controls() returns 31 entries (20 existing + 10 FEAT-167 + 1 FEAT-170 REST)."""
+    """get_controls() returns 32 entries (20 existing + 10 FEAT-167 + 1 FEAT-170 REST + 1 FEAT-300 FORMULA)."""
     sys.modules.pop("parrot_formdesigner.controls.builtin", None)
     importlib.import_module("parrot_formdesigner.controls.builtin")
     controls = get_controls()
-    assert len(controls) == 31, f"Expected 31 controls, got {len(controls)}"
+    assert len(controls) == 32, f"Expected 32 controls, got {len(controls)}"
 
     # Spot-check new types are present
     control_types = {c.type for c in controls}

--- a/packages/parrot-formdesigner/tests/unit/test_core_models.py
+++ b/packages/parrot-formdesigner/tests/unit/test_core_models.py
@@ -197,8 +197,8 @@ def test_field_type_enum_has_new_values():
 
 
 def test_field_type_enum_total_count():
-    """FieldType now has exactly 31 values (20 existing + 10 FEAT-167 + 1 FEAT-170 REST)."""
-    assert len(FieldType) == 31
+    """FieldType now has exactly 32 values (20 existing + 10 FEAT-167 + 1 FEAT-170 REST + 1 FEAT-300 FORMULA)."""
+    assert len(FieldType) == 32
 
 
 def test_field_type_existing_values_unchanged():

--- a/packages/parrot-formdesigner/tests/unit/test_evaluate_endpoint.py
+++ b/packages/parrot-formdesigner/tests/unit/test_evaluate_endpoint.py
@@ -1,0 +1,289 @@
+"""Unit tests for FEAT-301 POST /api/v1/forms/{form_id}/evaluate endpoint.
+
+Uses the same mocked-request pattern as tests/unit/test_api_feat300.py.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+
+from parrot_formdesigner.api.handlers import FormAPIHandler
+from parrot_formdesigner.core.constraints import (
+    ConditionOperator,
+    DependencyRule,
+    FieldRefCondition,
+    LocationVarCondition,
+)
+from parrot_formdesigner.core.schema import FormField, FormSchema, FormSection
+from parrot_formdesigner.core.types import FieldType
+from parrot_formdesigner.services.registry import FormRegistry
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors test_api_feat300.py pattern)
+# ---------------------------------------------------------------------------
+
+def _make_form(form_id: str = "f1", *, with_rule: bool = True) -> FormSchema:
+    """Build a minimal FormSchema, optionally with a DependencyRule on q2."""
+    rule = DependencyRule(
+        conditions=[FieldRefCondition(field_id="q1", operator=ConditionOperator.EQ, value="yes")],
+        effect="show",
+    ) if with_rule else None
+
+    return FormSchema(
+        form_id=form_id,
+        title={"en": "Test Form"},
+        sections=[
+            FormSection(
+                section_id="s1",
+                title={"en": "Section 1"},
+                fields=[
+                    FormField(field_id="q1", field_type=FieldType.TEXT, label={"en": "Q1"}),
+                    FormField(
+                        field_id="q2",
+                        field_type=FieldType.TEXT,
+                        label={"en": "Q2"},
+                        depends_on=rule,
+                    ),
+                ],
+            )
+        ],
+    )
+
+
+def _make_request(
+    *,
+    form_id: str = "f1",
+    body: dict | None = None,
+    bad_body: bool = False,
+    tenant: str = "t1",
+) -> MagicMock:
+    """Build a mocked aiohttp web.Request for the evaluate endpoint.
+
+    Args:
+        form_id: The form_id path parameter.
+        body: Optional JSON body dict.
+        bad_body: If True, simulate a JSON decode error.
+        tenant: Tenant string for session programs.
+    """
+    from aiohttp import web
+
+    req = MagicMock(spec=web.Request)
+    req.method = "POST"
+    req.match_info = {"form_id": form_id}
+    session_obj = {"session": {"programs": [tenant]}}
+    req.session = session_obj
+    req.__contains__ = lambda self, key: False
+
+    if bad_body:
+        req.json = AsyncMock(side_effect=ValueError("bad json"))
+    elif body is not None:
+        req.json = AsyncMock(return_value=body)
+    else:
+        req.json = AsyncMock(return_value={})
+
+    return req
+
+
+def _make_handler(registry: FormRegistry | None = None, *, tenant: str = "t1") -> FormAPIHandler:
+    """Build a FormAPIHandler with a minimal mock registry."""
+    if registry is None:
+        registry = MagicMock(spec=FormRegistry)
+        registry.get = AsyncMock(return_value=None)
+        registry.storage = None
+        registry.default_tenant = tenant
+        registry.register = AsyncMock()
+    return FormAPIHandler(registry=registry)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestEvaluateFormEndpoint:
+    """Tests for FormAPIHandler.evaluate_form() — POST /evaluate."""
+
+    async def test_evaluate_endpoint_200_with_match(self) -> None:
+        """Valid body with matching answer → 200 + results map with effect."""
+        registry = FormRegistry()
+        form = _make_form()
+        await registry.register(form, tenant="t1")
+
+        handler = _make_handler(registry)
+        req = _make_request(body={"answers": {"q1": "yes"}})
+
+        resp = await handler.evaluate_form(req)
+
+        assert resp.status == 200
+        body = json.loads(resp.body)
+        assert "results" in body
+        # q2 has depends_on → should be in results
+        assert "q2" in body["results"]
+        assert body["results"]["q2"]["effect"] == "show"
+        assert body["results"]["q2"]["matched"] is True
+
+    async def test_evaluate_endpoint_200_no_match(self) -> None:
+        """When answer doesn't match, effect=show, matched=False."""
+        registry = FormRegistry()
+        form = _make_form()
+        await registry.register(form, tenant="t1")
+
+        handler = _make_handler(registry)
+        req = _make_request(body={"answers": {"q1": "no"}})
+
+        resp = await handler.evaluate_form(req)
+
+        assert resp.status == 200
+        body = json.loads(resp.body)
+        assert body["results"]["q2"]["effect"] == "show"
+        assert body["results"]["q2"]["matched"] is False
+
+    async def test_evaluate_endpoint_empty_body(self) -> None:
+        """Empty body {} evaluates with empty context → 200."""
+        registry = FormRegistry()
+        form = _make_form()
+        await registry.register(form, tenant="t1")
+
+        handler = _make_handler(registry)
+        req = _make_request(body={})
+
+        resp = await handler.evaluate_form(req)
+
+        assert resp.status == 200
+        body = json.loads(resp.body)
+        assert "results" in body
+
+    async def test_evaluate_endpoint_with_location_vars(self) -> None:
+        """location_vars in body are passed to evaluator."""
+        loc_rule = DependencyRule(
+            conditions=[LocationVarCondition(
+                source="location_variable",
+                key="store_type",
+                operator=ConditionOperator.EQ,
+                value="flagship",
+            )],
+            effect="show",
+        )
+        form = FormSchema(
+            form_id="f2",
+            title={"en": "T"},
+            sections=[FormSection(
+                section_id="s1",
+                title={"en": "S"},
+                fields=[
+                    FormField(field_id="q1", field_type=FieldType.TEXT, label={"en": "Q1"}),
+                    FormField(
+                        field_id="q2", field_type=FieldType.TEXT, label={"en": "Q2"},
+                        depends_on=loc_rule,
+                    ),
+                ],
+            )],
+        )
+        registry = FormRegistry()
+        await registry.register(form, tenant="t1")
+
+        handler = _make_handler(registry)
+        req = _make_request(
+            form_id="f2",
+            body={"answers": {}, "location_vars": {"store_type": "flagship"}},
+        )
+
+        resp = await handler.evaluate_form(req)
+
+        assert resp.status == 200
+        body = json.loads(resp.body)
+        assert body["results"]["q2"]["matched"] is True
+
+    async def test_evaluate_endpoint_form_no_rules(self) -> None:
+        """Form with no DependencyRule fields → empty results dict."""
+        registry = FormRegistry()
+        form = _make_form(with_rule=False)
+        await registry.register(form, tenant="t1")
+
+        handler = _make_handler(registry)
+        req = _make_request(body={"answers": {"q1": "yes"}})
+
+        resp = await handler.evaluate_form(req)
+
+        assert resp.status == 200
+        body = json.loads(resp.body)
+        assert body["results"] == {}
+
+    async def test_evaluate_endpoint_404_unknown_form(self) -> None:
+        """Non-existent form_id → 404."""
+        handler = _make_handler()  # registry returns None for all gets
+        req = _make_request(form_id="no-such-form", body={})
+
+        resp = await handler.evaluate_form(req)
+
+        assert resp.status == 404
+        body = json.loads(resp.body)
+        assert "error" in body
+
+    async def test_evaluate_endpoint_400_bad_json(self) -> None:
+        """Malformed JSON body → 400."""
+        registry = FormRegistry()
+        form = _make_form()
+        await registry.register(form, tenant="t1")
+
+        handler = _make_handler(registry)
+        req = _make_request(bad_body=True)
+
+        resp = await handler.evaluate_form(req)
+
+        assert resp.status == 400
+        body = json.loads(resp.body)
+        assert "error" in body
+
+    async def test_evaluate_endpoint_400_non_dict_body(self) -> None:
+        """Non-dict JSON body (e.g. a list) → 400."""
+        registry = FormRegistry()
+        form = _make_form()
+        await registry.register(form, tenant="t1")
+
+        handler = _make_handler(registry)
+        # Simulate req.json() returning a list instead of a dict
+        req = MagicMock()
+        req.method = "POST"
+        req.match_info = {"form_id": "f1"}
+        req.session = {"session": {"programs": ["t1"]}}
+        req.__contains__ = lambda self, key: False
+        req.json = AsyncMock(return_value=["not", "a", "dict"])
+
+        resp = await handler.evaluate_form(req)
+
+        assert resp.status == 400
+
+    async def test_evaluate_endpoint_400_non_dict_answers(self) -> None:
+        """answers value that's not a dict → 400 (review M-1)."""
+        registry = FormRegistry()
+        form = _make_form()
+        await registry.register(form, tenant="t1")
+
+        handler = _make_handler(registry)
+        req = _make_request(body={"answers": ["not", "a", "dict"]})
+
+        resp = await handler.evaluate_form(req)
+
+        assert resp.status == 400
+
+    async def test_evaluate_endpoint_result_structure(self) -> None:
+        """Result entries contain exactly 'effect' and 'matched' keys."""
+        registry = FormRegistry()
+        form = _make_form()
+        await registry.register(form, tenant="t1")
+
+        handler = _make_handler(registry)
+        req = _make_request(body={"answers": {"q1": "yes"}})
+
+        resp = await handler.evaluate_form(req)
+
+        assert resp.status == 200
+        body = json.loads(resp.body)
+        for field_id, result in body["results"].items():
+            assert "effect" in result
+            assert "matched" in result
+            assert result["effect"] in ("show", "hide", "require", "disable")
+            assert isinstance(result["matched"], bool)

--- a/packages/parrot-formdesigner/tests/unit/test_feat300_review_fixes.py
+++ b/packages/parrot-formdesigner/tests/unit/test_feat300_review_fixes.py
@@ -1,0 +1,298 @@
+"""Regression tests for the FEAT-300 code-review fixes (C1, C2, H1–H5, M1–M3).
+
+Each test class maps to one finding from the pre-merge review:
+
+- C1 — SQL injection guard on QuestionBankService identifiers.
+- C2 — DELETE /forms/{id} blocked (409) when the form has responses.
+- H1 — version history survives a process restart (storage reconstruction).
+- H3 — storage failures during publish propagate (no silent in-memory fallback).
+- H4 — concurrent-publish unique violation surfaces as ValueError.
+- H5 — safe_delete uses the public registry API.
+- M1 — PUT/PATCH cannot clobber published_version.
+- M2 — formula placeholder HTML-escapes field_id and title.
+- M5 — backfill propagates storage errors instead of reporting changed=0.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from parrot_formdesigner.core.schema import FormField, FormSchema
+from parrot_formdesigner.core.types import FieldType
+from parrot_formdesigner.renderers.html5 import HTML5Renderer
+from parrot_formdesigner.services.form_version import FormVersionService
+from parrot_formdesigner.services.question_bank import QuestionBankService
+from parrot_formdesigner.services.registry import FormRegistry, FormStorage
+
+from tests.unit.test_api_feat300 import _make_form, _make_handler, _make_request
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class InMemoryStorage(FormStorage):
+    """Dict-backed FormStorage honoring UNIQUE(form_id, version)."""
+
+    def __init__(self) -> None:
+        # (tenant, form_id) → {version: FormSchema}; insertion order = save order
+        self._rows: dict[tuple[str, str], dict[str, FormSchema]] = {}
+
+    async def save(self, form: FormSchema, style=None, *, tenant=None) -> str:
+        versions = self._rows.setdefault((tenant, form.form_id), {})
+        if form.version in versions:
+            raise RuntimeError(
+                'duplicate key value violates unique constraint "form_schemas_form_id_version_key"'
+            )
+        versions[form.version] = form.model_copy(deep=True)
+        return form.form_id
+
+    async def load(self, form_id, version=None, *, tenant=None):
+        versions = self._rows.get((tenant, form_id), {})
+        if not versions:
+            return None
+        if version is not None:
+            snap = versions.get(version)
+            return snap.model_copy(deep=True) if snap else None
+        latest = list(versions.values())[-1]
+        return latest.model_copy(deep=True)
+
+    async def delete(self, form_id, *, tenant=None) -> bool:
+        return self._rows.pop((tenant, form_id), None) is not None
+
+    async def list_forms(self, *, tenant=None) -> list[dict[str, Any]]:
+        return [
+            {"form_id": fid, "version": list(v.keys())[-1], "tenant": t}
+            for (t, fid), v in self._rows.items()
+            if t == tenant
+        ]
+
+
+class FailingStorage(InMemoryStorage):
+    """Storage whose save/list always fail — simulates an unreachable DB."""
+
+    async def save(self, form, style=None, *, tenant=None) -> str:
+        raise ConnectionError("database unreachable")
+
+    async def list_forms(self, *, tenant=None):
+        raise ConnectionError("database unreachable")
+
+
+async def _registry_with_form(form_id: str = "f1", tenant: str = "t1") -> FormRegistry:
+    registry = FormRegistry()
+    await registry.register(_make_form(form_id, tenant), tenant=tenant)
+    return registry
+
+
+# ---------------------------------------------------------------------------
+# C1 — SQL injection guard
+# ---------------------------------------------------------------------------
+
+
+class TestC1IdentifierValidation:
+    def test_malicious_tenant_rejected(self):
+        with pytest.raises(ValueError, match="Invalid tenant"):
+            QuestionBankService(None, tenant='public"; DROP TABLE epson.field_bank; --')
+
+    def test_malicious_table_rejected(self):
+        with pytest.raises(ValueError, match="Invalid table"):
+            QuestionBankService(None, tenant="t1", table="field_bank; DROP TABLE x")
+
+    def test_valid_identifiers_quoted(self):
+        svc = QuestionBankService(None, tenant="t1", table="field_bank")
+        assert svc._qualified == '"t1"."field_bank"'
+
+
+# ---------------------------------------------------------------------------
+# C2 — delete_form blocked when responses exist
+# ---------------------------------------------------------------------------
+
+
+class TestC2DeleteGuard:
+    async def test_delete_blocked_with_responses(self):
+        registry = await _registry_with_form()
+
+        async def has_responses(form_id: str, tenant: str) -> bool:
+            return True
+
+        handler = _make_handler(registry)
+        handler._version_service = FormVersionService(
+            registry, has_responses=has_responses
+        )
+
+        resp = await handler.delete_form(_make_request(method="DELETE", form_id="f1"))
+        assert resp.status == 409
+        assert await registry.get("f1", tenant="t1") is not None  # untouched
+
+    async def test_delete_allowed_without_responses(self):
+        registry = await _registry_with_form()
+
+        async def has_responses(form_id: str, tenant: str) -> bool:
+            return False
+
+        handler = _make_handler(registry)
+        handler._version_service = FormVersionService(
+            registry, has_responses=has_responses
+        )
+
+        resp = await handler.delete_form(_make_request(method="DELETE", form_id="f1"))
+        assert resp.status == 204
+
+
+# ---------------------------------------------------------------------------
+# H1 — version history survives restart
+# ---------------------------------------------------------------------------
+
+
+class TestH1HistorySurvivesRestart:
+    async def test_list_versions_reconstructed_from_storage(self):
+        storage = InMemoryStorage()
+        registry = await _registry_with_form()
+        svc = FormVersionService(registry, storage=storage)
+
+        v1 = await svc.publish("f1", tenant="t1")  # 1.1
+        v2 = await svc.publish("f1", tenant="t1")  # 1.2
+
+        # Simulate process restart: fresh service, same storage, empty _meta
+        registry2 = await _registry_with_form()
+        svc2 = FormVersionService(registry2, storage=storage)
+
+        versions = [m.version for m in await svc2.list_versions("f1", tenant="t1")]
+        assert versions == [v1, v2]
+
+    async def test_published_at_recovered_from_stamp(self):
+        storage = InMemoryStorage()
+        registry = await _registry_with_form()
+        svc = FormVersionService(registry, storage=storage)
+        await svc.publish("f1", tenant="t1")
+
+        svc2 = FormVersionService(FormRegistry(), storage=storage)
+        metas = await svc2.list_versions("f1", tenant="t1")
+        assert metas and metas[0].published_at is not None
+
+
+# ---------------------------------------------------------------------------
+# H3 / H4 — storage failures during publish
+# ---------------------------------------------------------------------------
+
+
+class TestH3H4PublishStorageFailures:
+    async def test_storage_failure_propagates(self):
+        """H3: a publish that cannot persist must NOT report success."""
+        registry = await _registry_with_form()
+        svc = FormVersionService(registry, storage=FailingStorage())
+
+        with pytest.raises(ConnectionError):
+            await svc.publish("f1", tenant="t1")
+
+    async def test_unique_violation_surfaces_as_frozen_error(self):
+        """H4: the DB unique constraint is the atomic immutability guard."""
+        storage = InMemoryStorage()
+        registry = await _registry_with_form()
+        svc = FormVersionService(registry, storage=storage)
+        await svc.publish("f1", tenant="t1")  # creates 1.1
+
+        # Simulate the TOCTOU race: a second writer saved 1.2 between the
+        # fast-path check and save() — seed 1.2 directly, then reset the
+        # live form version so publish() recomputes 1.2 (stale read).
+        live = await registry.get("f1", tenant="t1")
+        stale = live.model_copy(deep=True, update={"version": "1.1"})
+        racing = stale.model_copy(
+            deep=True, update={"version": "1.2", "published_version": "1.2"}
+        )
+        # bypass published_version check in get_published (no stamp → still frozen row)
+        storage._rows[("t1", "f1")]["1.2"] = racing.model_copy(
+            deep=True, update={"published_version": None}
+        )
+        await registry.register(stale, overwrite=True, tenant="t1")
+
+        with pytest.raises(ValueError, match="already exists and is frozen"):
+            await svc.publish("f1", tenant="t1")
+
+
+# ---------------------------------------------------------------------------
+# H5 — safe_delete via public registry API
+# ---------------------------------------------------------------------------
+
+
+class TestH5PublicRegistryApi:
+    async def test_safe_delete_unregisters_via_public_api(self):
+        registry = await _registry_with_form()
+        svc = FormVersionService(registry)
+
+        await svc.safe_delete("f1", tenant="t1")
+        assert await registry.get("f1", tenant="t1") is None
+
+
+# ---------------------------------------------------------------------------
+# M1 — published_version immutable through PUT/PATCH
+# ---------------------------------------------------------------------------
+
+
+class TestM1PublishedVersionImmutable:
+    async def _published_handler(self):
+        registry = FormRegistry()
+        form = _make_form().model_copy(
+            deep=True, update={"published_version": "1.0"}
+        )
+        await registry.register(form, tenant="t1")
+        return _make_handler(registry), registry
+
+    async def test_put_cannot_clear_published_version(self):
+        handler, registry = await self._published_handler()
+        body = _make_form().model_dump(mode="json")
+        body["published_version"] = None  # attempted unfreeze
+
+        resp = await handler.update_form(
+            _make_request(method="PUT", form_id="f1", body=body)
+        )
+        assert resp.status == 200
+        assert json.loads(resp.body)["published_version"] == "1.0"
+
+    async def test_patch_cannot_clear_published_version(self):
+        handler, registry = await self._published_handler()
+
+        resp = await handler.patch_form(
+            _make_request(
+                method="PATCH", form_id="f1", body={"published_version": None}
+            )
+        )
+        assert resp.status == 200
+        assert json.loads(resp.body)["published_version"] == "1.0"
+
+
+# ---------------------------------------------------------------------------
+# M2 — formula placeholder escapes HTML
+# ---------------------------------------------------------------------------
+
+
+class TestM2FormulaEscaping:
+    def test_field_id_and_expression_escaped(self):
+        field = FormField(
+            field_id='x" onmouseover="alert(1)',
+            field_type=FieldType.FORMULA,
+            label="XSS",
+            meta={"expression": '"><script>alert(1)</script>'},
+        )
+        html_out = HTML5Renderer()._render_formula_placeholder(field)
+        assert "<script>" not in html_out
+        assert 'onmouseover="alert' not in html_out
+        assert "&quot;" in html_out or "&gt;" in html_out
+
+
+# ---------------------------------------------------------------------------
+# M5 — backfill propagates storage errors
+# ---------------------------------------------------------------------------
+
+
+class TestM5BackfillStorageErrors:
+    async def test_backfill_raises_when_storage_unreachable(self):
+        registry = FormRegistry()  # nothing in-memory to backfill
+        svc = FormVersionService(registry, storage=FailingStorage())
+
+        with pytest.raises(ConnectionError):
+            await svc.backfill_published(tenant="t1")

--- a/packages/parrot-formdesigner/tests/unit/test_feat301_review_fixes.py
+++ b/packages/parrot-formdesigner/tests/unit/test_feat301_review_fixes.py
@@ -1,0 +1,221 @@
+"""Regression tests for the FEAT-301 code-review fixes.
+
+- H-1 — data-depends-on stays byte-identical for legacy forms (no "source" key).
+- H-2 — AdaptiveCard render_section (wizard mode) embeds logic_state.
+- M-1 — /evaluate returns 400 (not 422) for non-dict input fields.
+- M-3 — YAML extractor builds explicit models for the new variants.
+- M-4 — cycle detection survives dependency chains deeper than the
+        Python recursion limit.
+"""
+
+from __future__ import annotations
+
+import json
+
+from parrot_formdesigner.core.constraints import (
+    ConditionOperator,
+    DependencyRule,
+    FieldRefCondition,
+    LocationVarCondition,
+)
+from parrot_formdesigner.core.schema import FormField, FormSchema, FormSection
+from parrot_formdesigner.core.types import FieldType
+from parrot_formdesigner.renderers.html5 import HTML5Renderer, _depends_on_attr_json
+from parrot_formdesigner.services.logic_graph import LogicGraph
+from parrot_formdesigner.services.rule_evaluator import EvaluationContext
+
+
+def _legacy_rule() -> DependencyRule:
+    """A rule as a pre-FEAT-301 form would have stored it."""
+    return DependencyRule.model_validate(
+        {
+            "conditions": [{"field_id": "q1", "operator": "eq", "value": "yes"}],
+            "logic": "and",
+            "effect": "show",
+        }
+    )
+
+
+def _conditional_form() -> FormSchema:
+    return FormSchema(
+        form_id="f1",
+        title="F",
+        tenant="t1",
+        sections=[
+            FormSection(
+                section_id="s1",
+                fields=[
+                    FormField(field_id="q1", field_type=FieldType.TEXT, label="Q1"),
+                    FormField(
+                        field_id="q2",
+                        field_type=FieldType.TEXT,
+                        label="Q2",
+                        depends_on=_legacy_rule(),
+                    ),
+                ],
+            )
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# H-1 — byte-identity of data-depends-on for legacy forms
+# ---------------------------------------------------------------------------
+
+
+class TestH1DependsOnByteIdentity:
+    def test_no_source_key_for_field_conditions(self):
+        payload = json.loads(_depends_on_attr_json(_legacy_rule()))
+        assert payload["conditions"][0] == {
+            "field_id": "q1",
+            "operator": "eq",
+            "value": "yes",
+        }
+        assert "source" not in payload["conditions"][0]
+
+    def test_new_variants_keep_source(self):
+        rule = DependencyRule(
+            conditions=[
+                LocationVarCondition(
+                    source="location_variable",
+                    key="store_type",
+                    operator=ConditionOperator.EQ,
+                    value="flagship",
+                )
+            ]
+        )
+        payload = json.loads(_depends_on_attr_json(rule))
+        assert payload["conditions"][0]["source"] == "location_variable"
+
+    async def test_rendered_attribute_has_no_source(self):
+        rendered = await HTML5Renderer().render(_conditional_form())
+        assert "data-depends-on" in rendered.content
+        assert "&quot;source&quot;: &quot;field&quot;" not in rendered.content
+        assert '"source": "field"' not in rendered.content
+
+
+# ---------------------------------------------------------------------------
+# H-2 — wizard render_section embeds logic_state
+# ---------------------------------------------------------------------------
+
+
+class TestH2WizardLogicState:
+    async def test_render_section_embeds_logic_state(self):
+        from parrot_formdesigner.renderers.adaptive_card import AdaptiveCardRenderer
+
+        rendered = await AdaptiveCardRenderer().render_section(
+            _conditional_form(), 0
+        )
+        card = rendered.content
+        assert "logic_state" in card.get("data", {})
+        assert "q2" in card["data"]["logic_state"]
+
+    async def test_render_section_accepts_context(self):
+        from parrot_formdesigner.renderers.adaptive_card import AdaptiveCardRenderer
+
+        ctx = EvaluationContext(answers={"q1": "yes"})
+        rendered = await AdaptiveCardRenderer().render_section(
+            _conditional_form(), 0, evaluation_context=ctx
+        )
+        state = rendered.content["data"]["logic_state"]
+        assert state["q2"]["matched"] is True
+
+
+# ---------------------------------------------------------------------------
+# M-1 — /evaluate 400 for non-dict fields
+# ---------------------------------------------------------------------------
+
+
+class TestM1EvaluateBadTypes:
+    async def test_non_dict_answers_returns_400(self):
+        from tests.unit.test_api_feat300 import _make_handler, _make_request
+        from parrot_formdesigner.services.registry import FormRegistry
+
+        registry = FormRegistry()
+        await registry.register(_conditional_form(), tenant="t1")
+        handler = _make_handler(registry)
+
+        resp = await handler.evaluate_form(
+            _make_request(method="POST", form_id="f1", body={"answers": "nope"})
+        )
+        assert resp.status == 400
+
+
+# ---------------------------------------------------------------------------
+# M-3 — YAML explicit variant dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestM3YamlDispatch:
+    def test_location_variable_from_yaml_dict(self):
+        from parrot_formdesigner.extractors.yaml import YamlExtractor
+
+        rule = YamlExtractor()._parse_dependency_rule(
+            {
+                "conditions": [
+                    {
+                        "source": "location_variable",
+                        "key": "store_type",
+                        "operator": "eq",
+                        "value": "flagship",
+                    }
+                ],
+                "logic": "and",
+                "effect": "show",
+            }
+        )
+        assert isinstance(rule.conditions[0], LocationVarCondition)
+        assert rule.conditions[0].key == "store_type"
+
+    def test_missing_key_skipped_not_crash(self):
+        from parrot_formdesigner.extractors.yaml import YamlExtractor
+
+        rule = YamlExtractor()._parse_dependency_rule(
+            {
+                "conditions": [
+                    {"source": "location_variable", "operator": "eq", "value": "x"},
+                    {"field_id": "q1", "operator": "eq", "value": 1},
+                ],
+            }
+        )
+        assert len(rule.conditions) == 1
+        assert isinstance(rule.conditions[0], FieldRefCondition)
+
+
+# ---------------------------------------------------------------------------
+# M-4 — deep chains do not hit the recursion limit
+# ---------------------------------------------------------------------------
+
+
+class TestM4DeepChains:
+    def _deep_cyclic_form(self, depth: int) -> FormSchema:
+        fields = []
+        for i in range(depth):
+            nxt = (i + 1) % depth  # last points back to first → one big cycle
+            fields.append(
+                FormField(
+                    field_id=f"q{i}",
+                    field_type=FieldType.TEXT,
+                    label=f"Q{i}",
+                    depends_on=DependencyRule(
+                        conditions=[
+                            FieldRefCondition(
+                                field_id=f"q{nxt}",
+                                operator=ConditionOperator.EQ,
+                                value="x",
+                            )
+                        ]
+                    ),
+                )
+            )
+        return FormSchema(
+            form_id="deep",
+            title="Deep",
+            sections=[FormSection(section_id="s1", fields=fields)],
+        )
+
+    def test_cycle_detection_at_depth_2000(self):
+        form = self._deep_cyclic_form(2000)
+        graph = LogicGraph.build(form)
+        cycles = graph.detect_cycles()  # would RecursionError before M-4 fix
+        assert cycles

--- a/packages/parrot-formdesigner/tests/unit/test_form_type.py
+++ b/packages/parrot-formdesigner/tests/unit/test_form_type.py
@@ -1,0 +1,85 @@
+"""Unit tests for FormType enum and FormSchema extensions (FEAT-300 TASK-001)."""
+
+import pytest
+from parrot_formdesigner.core.schema import FormSchema, FormSection, FormField, FormType
+from parrot_formdesigner.core.types import FieldType
+
+
+def _minimal_form(**kw):
+    """Build a minimal valid FormSchema with one section and one field."""
+    return FormSchema(
+        form_id="t1",
+        title="T",
+        sections=[
+            FormSection(
+                section_id="s1",
+                fields=[
+                    FormField(field_id="q1", field_type=FieldType.TEXT, label="Q1")
+                ],
+            )
+        ],
+        **kw,
+    )
+
+
+def test_form_schema_form_type_default():
+    """form_type defaults to FormType.SIMPLE."""
+    assert _minimal_form().form_type == FormType.SIMPLE
+
+
+def test_form_schema_form_type_survey():
+    """form_type can be set to SURVEY."""
+    f = _minimal_form(form_type=FormType.SURVEY)
+    assert f.form_type == FormType.SURVEY
+
+
+def test_form_schema_product_bindings():
+    """product_bindings is stored and returned correctly."""
+    f = _minimal_form(form_type=FormType.PRODUCT, product_bindings=["p1", "p2"])
+    assert f.product_bindings == ["p1", "p2"]
+
+
+def test_form_schema_product_bindings_default():
+    """product_bindings defaults to None."""
+    assert _minimal_form().product_bindings is None
+
+
+def test_form_schema_published_version():
+    """published_version defaults to None."""
+    assert _minimal_form().published_version is None
+
+
+def test_form_schema_published_version_set():
+    """published_version can be set to a semver string."""
+    f = _minimal_form(published_version="2.1")
+    assert f.published_version == "2.1"
+
+
+def test_form_type_values():
+    """FormType enum values match expected strings."""
+    assert FormType.SIMPLE.value == "simple"
+    assert FormType.PRODUCT.value == "product"
+    assert FormType.SURVEY.value == "survey"
+
+
+def test_form_type_importable_from_core():
+    """FormType is importable from the core package."""
+    from parrot_formdesigner.core import FormType as FT  # noqa: PLC0415
+
+    assert FT is FormType
+
+
+def test_backward_compat_existing_fields():
+    """Existing FormSchema construction (without new fields) still validates."""
+    f = _minimal_form()
+    # Core existing fields unchanged
+    assert f.form_id == "t1"
+    assert f.version == "1.0"
+    assert f.title == "T"
+
+
+def test_form_type_str_enum():
+    """FormType is a str enum so values compare equal to plain strings."""
+    assert FormType.SIMPLE == "simple"
+    assert FormType.SURVEY == "survey"
+    assert FormType.PRODUCT == "product"

--- a/packages/parrot-formdesigner/tests/unit/test_form_version.py
+++ b/packages/parrot-formdesigner/tests/unit/test_form_version.py
@@ -1,0 +1,256 @@
+"""Unit tests for FormVersionService (FEAT-300 TASK-004)."""
+
+import pytest
+
+from parrot_formdesigner.core.schema import FormSchema, FormSection, FormField
+from parrot_formdesigner.core.types import FieldType
+from parrot_formdesigner.services.form_version import (
+    FormVersionService,
+    VersionMeta,
+    _bump,
+    _parse_major_minor,
+)
+from parrot_formdesigner.services.registry import FormRegistry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _minimal_form(form_id: str = "form1", version: str = "1.0") -> FormSchema:
+    return FormSchema(
+        form_id=form_id,
+        version=version,
+        title="Test Form",
+        sections=[
+            FormSection(
+                section_id="s1",
+                fields=[FormField(field_id="q1", field_type=FieldType.TEXT, label="Q1")],
+            )
+        ],
+        tenant="t1",
+    )
+
+
+@pytest.fixture
+def registry():
+    """FormRegistry with one in-memory form registered."""
+    reg = FormRegistry()
+    return reg
+
+
+@pytest.fixture
+async def svc(registry):
+    """FormVersionService with no Postgres backend (in-memory)."""
+    form = _minimal_form()
+    await registry.register(form, tenant="t1")
+    return FormVersionService(registry, storage=None)
+
+
+@pytest.fixture
+async def form(registry):
+    """The registered form fixture (matching svc fixture)."""
+    return _minimal_form()
+
+
+# ---------------------------------------------------------------------------
+# Semver helpers
+# ---------------------------------------------------------------------------
+
+
+def test_parse_major_minor_normal():
+    assert _parse_major_minor("1.0") == (1, 0)
+    assert _parse_major_minor("2.5") == (2, 5)
+
+
+def test_parse_major_minor_invalid_falls_back():
+    assert _parse_major_minor("not-semver") == (1, 0)
+    assert _parse_major_minor("") == (1, 0)
+    assert _parse_major_minor(None) == (1, 0)
+
+
+def test_bump_minor():
+    assert _bump("1.0") == "1.1"
+    assert _bump("1.1") == "1.2"
+    assert _bump("2.9") == "2.10"
+
+
+def test_bump_major():
+    assert _bump("1.0", bump="major") == "2.0"
+    assert _bump("1.5", bump="major") == "2.0"
+
+
+def test_bump_twice():
+    assert _bump(_bump("1.0")) == "1.2"
+
+
+# ---------------------------------------------------------------------------
+# Publish
+# ---------------------------------------------------------------------------
+
+
+async def test_form_version_publish_sets_flag(svc, form):
+    """publish() returns the new version tag and sets published_version."""
+    tag = await svc.publish(form.form_id, tenant="t1")
+    assert tag == "1.1"
+
+    published = await svc.get_published(form.form_id, version=tag, tenant="t1")
+    assert published is not None
+    assert published.published_version == tag
+
+
+async def test_form_version_publish_version_tag_correct(svc, form):
+    """First publish of a 1.0 form yields 1.1."""
+    tag = await svc.publish(form.form_id, tenant="t1")
+    assert tag == "1.1"
+
+
+async def test_form_version_publish_twice_increments(svc, form):
+    """Second publish increments minor again: 1.1 → 1.2."""
+    tag1 = await svc.publish(form.form_id, tenant="t1")
+    tag2 = await svc.publish(form.form_id, tenant="t1")
+    assert tag1 == "1.1"
+    assert tag2 == "1.2"
+
+
+async def test_form_version_publish_major_bump(svc, form):
+    """Major bump resets minor to 0."""
+    tag = await svc.publish(form.form_id, tenant="t1", bump="major")
+    assert tag == "2.0"
+
+
+async def test_form_version_publish_unknown_form_raises(svc):
+    """publish() raises KeyError when form_id is not in registry."""
+    with pytest.raises(KeyError):
+        await svc.publish("no-such-form", tenant="t1")
+
+
+# ---------------------------------------------------------------------------
+# Immutability
+# ---------------------------------------------------------------------------
+
+
+async def test_form_version_immutable_on_edit(svc, form):
+    """Attempting to re-publish an already-published version raises ValueError.
+
+    Strategy:
+    1. Publish once → live form bumped to 1.1; snapshot 1.1 stored.
+    2. Force the live form's version back to 1.0 so the next publish
+       would try to create 1.1 again.
+    3. publish() must detect the existing 1.1 snapshot and raise ValueError.
+    """
+    tag = await svc.publish(form.form_id, tenant="t1")
+    assert tag == "1.1"
+
+    # Force live form back to 1.0 to trigger the guard on re-publish
+    live = await svc._registry.get(form.form_id, tenant="t1")
+    rolled_back = live.model_copy(update={"version": "1.0"})
+    await svc._registry.register(rolled_back, overwrite=True, tenant="t1")
+
+    # Now publishing again will try to create 1.1 which already exists
+    with pytest.raises(ValueError, match="frozen"):
+        await svc.publish(form.form_id, tenant="t1")
+
+
+# ---------------------------------------------------------------------------
+# List versions
+# ---------------------------------------------------------------------------
+
+
+async def test_form_version_list_versions(svc, form):
+    """list_versions() returns the published snapshot(s)."""
+    await svc.publish(form.form_id, tenant="t1")
+    versions = await svc.list_versions(form.form_id, tenant="t1")
+    assert len(versions) == 1
+    assert isinstance(versions[0], VersionMeta)
+    assert versions[0].version == "1.1"
+
+
+async def test_form_version_list_versions_empty(svc, form):
+    """list_versions() returns [] when no publishes have been done."""
+    versions = await svc.list_versions(form.form_id, tenant="t1")
+    assert versions == []
+
+
+async def test_form_version_list_versions_multiple(svc, form):
+    """list_versions() accumulates entries across multiple publishes."""
+    await svc.publish(form.form_id, tenant="t1")
+    await svc.publish(form.form_id, tenant="t1")
+    versions = await svc.list_versions(form.form_id, tenant="t1")
+    assert len(versions) == 2
+    assert [v.version for v in versions] == ["1.1", "1.2"]
+
+
+# ---------------------------------------------------------------------------
+# RF-06: snapshot isolation
+# ---------------------------------------------------------------------------
+
+
+async def test_publish_then_edit_isolation(registry):
+    """RF-06: v1 snapshot is unchanged after v2 is published."""
+    form = _minimal_form("form-rf06", version="1.0")
+    await registry.register(form, tenant="t1")
+    svc = FormVersionService(registry, storage=None)
+
+    v1_tag = await svc.publish("form-rf06", tenant="t1")
+    original_title = form.title
+
+    # Simulate editing the live form (changing its title)
+    live = await registry.get("form-rf06", tenant="t1")
+    edited = live.model_copy(update={"title": "Edited Title"})
+    await registry.register(edited, overwrite=True, tenant="t1")
+
+    # Publish a second version
+    v2_tag = await svc.publish("form-rf06", tenant="t1")
+    assert v2_tag != v1_tag
+
+    # v1 snapshot must be unchanged
+    snap_v1 = await svc.get_published("form-rf06", version=v1_tag, tenant="t1")
+    assert snap_v1 is not None
+    assert snap_v1.title == original_title  # untouched
+
+
+# ---------------------------------------------------------------------------
+# Deletion guard
+# ---------------------------------------------------------------------------
+
+
+async def test_form_version_delete_with_responses_blocked():
+    """safe_delete raises ValueError when has_responses returns True."""
+    registry = FormRegistry()
+    form = _minimal_form("form-del")
+    await registry.register(form, tenant="t1")
+
+    async def _has_responses(form_id: str, tenant: str) -> bool:
+        return True
+
+    svc = FormVersionService(registry, has_responses=_has_responses)
+
+    with pytest.raises(ValueError, match="responses"):
+        await svc.safe_delete("form-del", tenant="t1")
+
+
+async def test_form_version_delete_without_responses_allowed():
+    """safe_delete succeeds when has_responses returns False."""
+    registry = FormRegistry()
+    form = _minimal_form("form-del2")
+    await registry.register(form, tenant="t1")
+
+    async def _no_responses(form_id: str, tenant: str) -> bool:
+        return False
+
+    svc = FormVersionService(registry, has_responses=_no_responses)
+    # Should not raise
+    await svc.safe_delete("form-del2", tenant="t1")
+
+
+async def test_form_version_delete_no_hook_allowed():
+    """safe_delete is always allowed when no has_responses hook is provided."""
+    registry = FormRegistry()
+    form = _minimal_form("form-del3")
+    await registry.register(form, tenant="t1")
+
+    svc = FormVersionService(registry)
+    # No hook → deletion is always allowed
+    await svc.safe_delete("form-del3", tenant="t1")

--- a/packages/parrot-formdesigner/tests/unit/test_formula_field.py
+++ b/packages/parrot-formdesigner/tests/unit/test_formula_field.py
@@ -1,0 +1,164 @@
+"""Unit tests for FieldType.FORMULA and renderer fallbacks (FEAT-300 TASK-002)."""
+
+from parrot_formdesigner.core.schema import FormField, FormSchema, FormSection, RenderWarning
+from parrot_formdesigner.core.types import FieldType
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _formula_form(**field_kw):
+    """Build a minimal FormSchema containing one FORMULA field."""
+    return FormSchema(
+        form_id="f1",
+        title="F",
+        sections=[
+            FormSection(
+                section_id="s1",
+                fields=[
+                    FormField(
+                        field_id="total",
+                        field_type=FieldType.FORMULA,
+                        label="Total",
+                        **field_kw,
+                    )
+                ],
+            )
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Enum
+# ---------------------------------------------------------------------------
+
+
+def test_fieldtype_formula_exists():
+    """FieldType.FORMULA resolves to the canonical string 'formula'."""
+    assert FieldType.FORMULA.value == "formula"
+
+
+def test_fieldtype_formula_is_string_enum():
+    """FieldType inherits from str so FieldType.FORMULA == 'formula'."""
+    assert FieldType.FORMULA == "formula"
+
+
+def test_fieldtype_formula_round_trips():
+    """FieldType('formula') round-trips correctly."""
+    assert FieldType("formula") is FieldType.FORMULA
+
+
+# ---------------------------------------------------------------------------
+# HTML5 renderer
+# ---------------------------------------------------------------------------
+
+
+async def test_formula_field_fallback_html5_emits_warning():
+    """Rendering a FORMULA field via HTML5Renderer emits a RenderWarning."""
+    from parrot_formdesigner.renderers.html5 import HTML5Renderer
+
+    form = _formula_form(meta={"expression": None})
+    rendered = await HTML5Renderer().render(form)
+    assert rendered.warnings, "Expected at least one RenderWarning"
+    warning = rendered.warnings[0]
+    assert isinstance(warning, RenderWarning)
+    assert warning.field_id == "total"
+    assert warning.field_type == "formula"
+    assert warning.renderer == "html5"
+
+
+async def test_formula_field_html5_no_exception():
+    """Rendering a FORMULA field via HTML5Renderer must not raise."""
+    from parrot_formdesigner.renderers.html5 import HTML5Renderer
+
+    form = _formula_form()
+    rendered = await HTML5Renderer().render(form)
+    assert rendered.content  # non-empty HTML
+
+
+async def test_formula_field_html5_placeholder_in_output():
+    """HTML5 output for FORMULA contains a disabled input placeholder."""
+    from parrot_formdesigner.renderers.html5 import HTML5Renderer
+
+    form = _formula_form()
+    rendered = await HTML5Renderer().render(form)
+    assert "data-formula" in rendered.content
+
+
+async def test_formula_field_html5_meta_none():
+    """FORMULA field with meta=None must not crash HTML5Renderer."""
+    from parrot_formdesigner.renderers.html5 import HTML5Renderer
+
+    form = _formula_form(meta=None)
+    rendered = await HTML5Renderer().render(form)
+    assert rendered.warnings
+
+
+# ---------------------------------------------------------------------------
+# PDF renderer
+# ---------------------------------------------------------------------------
+
+
+async def test_formula_field_pdf_no_exception():
+    """Rendering a FORMULA field via PdfRenderer must not raise."""
+    from parrot_formdesigner.renderers.pdf import PdfRenderer
+
+    form = _formula_form(meta={"expression": None})
+    rendered = await PdfRenderer().render(form)
+    assert rendered.warnings, "Expected at least one RenderWarning from PDF"
+    warning = rendered.warnings[0]
+    assert warning.field_type == "formula"
+    assert warning.renderer == "pdf"
+
+
+async def test_formula_field_pdf_emits_warning():
+    """PDF rendering of a FORMULA field emits a RenderWarning (not an error)."""
+    from parrot_formdesigner.renderers.pdf import PdfRenderer
+
+    form = _formula_form()
+    rendered = await PdfRenderer().render(form)
+    field_types = [w.field_type for w in rendered.warnings]
+    assert "formula" in field_types
+
+
+# ---------------------------------------------------------------------------
+# AdaptiveCard renderer
+# ---------------------------------------------------------------------------
+
+
+async def test_formula_field_adaptive_card_no_exception():
+    """Rendering a FORMULA field via AdaptiveCardRenderer must not raise."""
+    from parrot_formdesigner.renderers.adaptive_card import AdaptiveCardRenderer
+
+    form = _formula_form()
+    rendered = await AdaptiveCardRenderer().render(form)
+    assert rendered.warnings
+    assert any(w.field_type == "formula" for w in rendered.warnings)
+
+
+# ---------------------------------------------------------------------------
+# JSONSchema renderer
+# ---------------------------------------------------------------------------
+
+
+async def test_formula_field_jsonschema_no_exception():
+    """Rendering a FORMULA field via JsonSchemaRenderer must not raise."""
+    from parrot_formdesigner.renderers.jsonschema import JsonSchemaRenderer
+
+    form = _formula_form()
+    rendered = await JsonSchemaRenderer().render(form)
+    # JSONSchema renderer maps FORMULA to "number" type — no exception expected
+    assert rendered.content
+
+
+async def test_formula_field_jsonschema_has_formula_format():
+    """JSONSchema output for a FORMULA field includes x-parrot-type or format."""
+    from parrot_formdesigner.renderers.jsonschema import JsonSchemaRenderer
+
+    form = _formula_form()
+    rendered = await JsonSchemaRenderer().render(form)
+    schema_str = str(rendered.content)
+    # The format entry for FORMULA should appear somewhere in the schema output
+    assert "formula" in schema_str.lower()

--- a/packages/parrot-formdesigner/tests/unit/test_logic_graph.py
+++ b/packages/parrot-formdesigner/tests/unit/test_logic_graph.py
@@ -1,0 +1,218 @@
+"""Unit tests for FEAT-301 LogicGraph.
+
+Tests cover:
+- Topological ordering (fields in evaluation order).
+- Cycle detection (CyclicDependencyError raised + graceful degradation).
+- Build from FormSchema (only FieldRefCondition creates edges).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from parrot_formdesigner.core.constraints import (
+    ConditionOperator,
+    DependencyRule,
+    FieldRefCondition,
+    LocationVarCondition,
+)
+from parrot_formdesigner.core.schema import FormField, FormSchema, FormSection
+from parrot_formdesigner.core.types import FieldType
+from parrot_formdesigner.services.logic_graph import CyclicDependencyError, LogicGraph
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _field(fid: str, rule: DependencyRule | None = None) -> FormField:
+    """Build a simple text FormField."""
+    return FormField(
+        field_id=fid,
+        field_type=FieldType.TEXT,
+        label={"en": fid},
+        depends_on=rule,
+    )
+
+
+def _form(*fields: FormField) -> FormSchema:
+    """Build a minimal FormSchema."""
+    return FormSchema(
+        form_id="test",
+        title={"en": "T"},
+        sections=[FormSection(section_id="s1", title={"en": "S"}, fields=list(fields))],
+    )
+
+
+def _ref_rule(field_id: str, value: str = "y") -> DependencyRule:
+    """Build a simple EQ DependencyRule referencing another field."""
+    return DependencyRule(
+        conditions=[
+            FieldRefCondition(field_id=field_id, operator=ConditionOperator.EQ, value=value)
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# LogicGraph.build()
+# ---------------------------------------------------------------------------
+
+class TestLogicGraphBuild:
+    """Tests for LogicGraph.build()."""
+
+    def test_build_no_dependencies(self) -> None:
+        """Form with no depends_on → all nodes present, no edges."""
+        form = _form(_field("q1"), _field("q2"), _field("q3"))
+        graph = LogicGraph.build(form)
+        order = graph.topological_order()
+        assert set(order) == {"q1", "q2", "q3"}
+
+    def test_build_simple_dependency(self) -> None:
+        """q2 depends on q1 → q1 must come before q2."""
+        form = _form(_field("q1"), _field("q2", _ref_rule("q1")))
+        graph = LogicGraph.build(form)
+        order = graph.topological_order()
+        assert order.index("q1") < order.index("q2")
+
+    def test_build_location_var_no_edge(self) -> None:
+        """LocationVarCondition does NOT create an intra-form edge."""
+        loc_rule = DependencyRule(
+            conditions=[LocationVarCondition(
+                source="location_variable",
+                key="store_type",
+                operator=ConditionOperator.EQ,
+                value="flagship",
+            )],
+        )
+        form = _form(_field("q1"), _field("q2", loc_rule))
+        graph = LogicGraph.build(form)
+        # q2 has a rule but no intra-form dependency → both in nodes
+        order = graph.topological_order()
+        assert set(order) == {"q1", "q2"}
+        # No ordering constraint between them
+        assert "q1" in order and "q2" in order
+
+    def test_build_chain_q1_q2_q3(self) -> None:
+        """Chain q1 → q2 → q3 evaluates in topological order."""
+        form = _form(
+            _field("q1"),
+            _field("q2", _ref_rule("q1")),
+            _field("q3", _ref_rule("q2")),
+        )
+        graph = LogicGraph.build(form)
+        order = graph.topological_order()
+        assert order.index("q1") < order.index("q2") < order.index("q3")
+
+    def test_external_field_ref_no_crash(self) -> None:
+        """FieldRefCondition referencing a non-existent field is ignored."""
+        rule = DependencyRule(
+            conditions=[FieldRefCondition(field_id="non_existent", operator=ConditionOperator.EQ, value="y")],
+        )
+        form = _form(_field("q1"), _field("q2", rule))
+        graph = LogicGraph.build(form)
+        # Should not crash — external refs are excluded from graph edges
+        order = graph.topological_order()
+        assert set(order) == {"q1", "q2"}
+
+
+# ---------------------------------------------------------------------------
+# LogicGraph.topological_order()
+# ---------------------------------------------------------------------------
+
+class TestTopologicalOrder:
+    """Tests for topological ordering."""
+
+    def test_single_node(self) -> None:
+        """Single-node graph returns that node."""
+        form = _form(_field("q1"))
+        graph = LogicGraph.build(form)
+        assert graph.topological_order() == ["q1"]
+
+    def test_diamond_dependency(self) -> None:
+        """Diamond: q1 → q2,q3 → q4. q4 must come after q2 and q3."""
+        form = _form(
+            _field("q1"),
+            _field("q2", _ref_rule("q1")),
+            _field("q3", _ref_rule("q1")),
+            _field("q4", DependencyRule(conditions=[
+                FieldRefCondition(field_id="q2", operator=ConditionOperator.EQ, value="y"),
+                FieldRefCondition(field_id="q3", operator=ConditionOperator.EQ, value="y"),
+            ])),
+        )
+        graph = LogicGraph.build(form)
+        order = graph.topological_order()
+        assert order.index("q1") < order.index("q2")
+        assert order.index("q1") < order.index("q3")
+        assert order.index("q2") < order.index("q4")
+        assert order.index("q3") < order.index("q4")
+
+    def test_parallel_independent_fields(self) -> None:
+        """Fields with no deps between them can appear in any relative order."""
+        form = _form(_field("a"), _field("b"), _field("c"))
+        graph = LogicGraph.build(form)
+        order = graph.topological_order()
+        assert set(order) == {"a", "b", "c"}
+        assert len(order) == 3
+
+
+# ---------------------------------------------------------------------------
+# Cycle detection
+# ---------------------------------------------------------------------------
+
+class TestCycleDetection:
+    """Tests for cycle detection."""
+
+    def test_simple_cycle_raises(self) -> None:
+        """q1 → q2 → q1 raises CyclicDependencyError."""
+        form = _form(
+            _field("q1", _ref_rule("q2")),
+            _field("q2", _ref_rule("q1")),
+        )
+        graph = LogicGraph.build(form)
+        with pytest.raises(CyclicDependencyError) as exc_info:
+            graph.topological_order()
+        assert "q1" in exc_info.value.cycle or "q2" in exc_info.value.cycle
+
+    def test_detect_cycles_returns_cycles(self) -> None:
+        """detect_cycles() returns cycle list without raising."""
+        form = _form(
+            _field("q1", _ref_rule("q2")),
+            _field("q2", _ref_rule("q1")),
+        )
+        graph = LogicGraph.build(form)
+        cycles = graph.detect_cycles()
+        assert len(cycles) >= 1
+        assert any(len(c) >= 2 for c in cycles)
+
+    def test_no_cycle_detect_cycles_empty(self) -> None:
+        """detect_cycles() returns empty list when no cycles."""
+        form = _form(
+            _field("q1"),
+            _field("q2", _ref_rule("q1")),
+            _field("q3", _ref_rule("q2")),
+        )
+        graph = LogicGraph.build(form)
+        cycles = graph.detect_cycles()
+        assert cycles == []
+
+    def test_cycle_error_message(self) -> None:
+        """CyclicDependencyError message contains the cycle."""
+        form = _form(
+            _field("x", _ref_rule("y")),
+            _field("y", _ref_rule("x")),
+        )
+        graph = LogicGraph.build(form)
+        with pytest.raises(CyclicDependencyError) as exc_info:
+            graph.topological_order()
+        assert " -> " in str(exc_info.value)
+
+    def test_three_node_cycle(self) -> None:
+        """q1 → q2 → q3 → q1 is detected."""
+        form = _form(
+            _field("q1", _ref_rule("q3")),
+            _field("q2", _ref_rule("q1")),
+            _field("q3", _ref_rule("q2")),
+        )
+        graph = LogicGraph.build(form)
+        with pytest.raises(CyclicDependencyError):
+            graph.topological_order()

--- a/packages/parrot-formdesigner/tests/unit/test_networkninja_importer.py
+++ b/packages/parrot-formdesigner/tests/unit/test_networkninja_importer.py
@@ -1,0 +1,441 @@
+"""Unit tests for networkninja importer extensions (FEAT-300 TASK-006)."""
+
+import json
+
+import pytest
+
+from parrot_formdesigner.core.schema import FormType
+from parrot_formdesigner.core.types import FieldType
+from parrot_formdesigner.tools.services.networkninja import (
+    ImportDiffEntry,
+    ImportDiffReport,
+    NetworkninjaFormService,
+)
+
+
+# ---------------------------------------------------------------------------
+# Spec §4 fixtures (verbatim from spec)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def networkninja_formula_row():
+    """Minimal networkninja row with a FIELD_FORMULA column (options=[])."""
+    return {
+        "formid": 999,
+        "orgid": 1,
+        "form_name": "Formula Test",
+        "description": None,
+        "question_blocks": [
+            {
+                "block_id": 1,
+                "block_type": "simple",
+                "block_logic_groups": [],
+                "questions": [
+                    {
+                        "question_id": 1,
+                        "question_column_name": "1",
+                        "question_description": "Total Price",
+                        "question_logic_groups": [],
+                        "validations": [],
+                    }
+                ],
+            }
+        ],
+        "metadata": [
+            {
+                "column_id": 1,
+                "column_name": "1",
+                "data_type": "FIELD_FORMULA",
+                "description": "Total Price",
+                "options": [],
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def networkninja_legacy_double_encoded_row():
+    """Legacy double-encoded row (JSON string with question_block_* keys)."""
+    return {
+        "formid": 998,
+        "orgid": 1,
+        "form_name": "Legacy Encoded Test",
+        "description": None,
+        "question_blocks": (
+            '[{"question_block_id":1,"question_block_type":"simple",'
+            '"question_block_logic_groups":[],'
+            '"questions":[{"question_id":1,"question_column_name":"1",'
+            '"question_description":"Q1"}]}]'
+        ),
+        "metadata": [
+            {
+                "column_id": 1,
+                "column_name": "1",
+                "data_type": "FIELD_TEXT",
+                "description": "Q1",
+                "options": [],
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def networkninja_survey_row():
+    """Survey-type row (block_type='survey'), modeled on live formid 71."""
+    return {
+        "formid": 997,
+        "orgid": 1,
+        "form_name": "Survey Test",
+        "description": None,
+        "question_blocks": [
+            {
+                "block_id": 210,
+                "block_type": "survey",
+                "block_logic_groups": [],
+                "questions": [
+                    {
+                        "question_id": 1,
+                        "question_column_name": "1",
+                        "question_description": "Aisle number",
+                        "question_logic_groups": [],
+                        "validations": [],
+                    }
+                ],
+            }
+        ],
+        "metadata": [
+            {
+                "column_id": 1,
+                "column_name": "1",
+                "data_type": "FIELD_TEXT",
+                "description": "Aisle number",
+                "options": [],
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _svc() -> NetworkninjaFormService:
+    """Return a NetworkninjaFormService with no DB (test-only)."""
+    return NetworkninjaFormService(dsn="postgres://test")
+
+
+def _make_row(data_type: str, col_name: str = "c1") -> dict:
+    """Build a minimal row for a single-field form."""
+    return {
+        "formid": 1,
+        "orgid": 1,
+        "form_name": f"Test {data_type}",
+        "description": None,
+        "question_blocks": [
+            {
+                "block_id": 1,
+                "block_type": "simple",
+                "block_logic_groups": [],
+                "questions": [
+                    {
+                        "question_id": 1,
+                        "question_column_name": col_name,
+                        "question_description": "Q",
+                        "question_logic_groups": [],
+                        "validations": [],
+                    }
+                ],
+            }
+        ],
+        "metadata": [
+            {
+                "column_id": 1,
+                "column_name": col_name,
+                "data_type": data_type,
+                "description": "Q",
+                "options": [],
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# ImportDiffReport model
+# ---------------------------------------------------------------------------
+
+
+def test_import_diff_report_model():
+    """ImportDiffReport is a valid Pydantic v2 model."""
+    from datetime import datetime, timezone
+
+    report = ImportDiffReport(
+        form_id="f1",
+        source="networkninja",
+        imported_at=datetime.now(timezone.utc),
+        fields=[],
+    )
+    assert report.source == "networkninja"
+    assert report.fields == []
+
+
+def test_import_diff_entry_model():
+    """ImportDiffEntry validates correctly."""
+    entry = ImportDiffEntry(
+        column_name="c1",
+        source_data_type="FIELD_FORMULA",
+        mapped_field_type="formula",
+        status="requiere_intervencion",
+        note="expression unavailable",
+    )
+    assert entry.status == "requiere_intervencion"
+
+
+# ---------------------------------------------------------------------------
+# FIELD_FORMULA mapping
+# ---------------------------------------------------------------------------
+
+
+def test_networkninja_formula_mapping(networkninja_formula_row):
+    """FIELD_FORMULA maps to FieldType.FORMULA with meta.expression=None."""
+    svc = _svc()
+    schema = svc.to_form_schema(networkninja_formula_row)
+    fields = list(schema.iter_all_fields())
+    assert any(f.field_type == FieldType.FORMULA for f in fields), (
+        "Expected at least one FORMULA field"
+    )
+    formula_field = next(f for f in fields if f.field_type == FieldType.FORMULA)
+    assert formula_field.meta is not None
+    assert formula_field.meta.get("expression") is None
+
+
+def test_networkninja_formula_no_expression(networkninja_formula_row):
+    """FIELD_FORMULA row yields a requiere_intervencion report entry."""
+    svc = _svc()
+    schema, report = svc.import_with_report(networkninja_formula_row)
+    assert isinstance(report, ImportDiffReport)
+    formula_entries = [e for e in report.fields if e.source_data_type == "FIELD_FORMULA"]
+    assert formula_entries, "Expected at least one FIELD_FORMULA report entry"
+    assert formula_entries[0].status == "requiere_intervencion"
+    assert formula_entries[0].mapped_field_type == "formula"
+
+
+# ---------------------------------------------------------------------------
+# FIELD_SIGNATURE_CAPTURE (no longer skipped)
+# ---------------------------------------------------------------------------
+
+
+def test_networkninja_signature_mapping():
+    """FIELD_SIGNATURE_CAPTURE now maps to FieldType.SIGNATURE (not skipped)."""
+    svc = _svc()
+    schema = svc.to_form_schema(_make_row("FIELD_SIGNATURE_CAPTURE"))
+    fields = list(schema.iter_all_fields())
+    assert any(f.field_type == FieldType.SIGNATURE for f in fields), (
+        "Expected SIGNATURE field; FIELD_SIGNATURE_CAPTURE must not be skipped"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Survey block_type detection
+# ---------------------------------------------------------------------------
+
+
+def test_networkninja_survey_block_type(networkninja_survey_row):
+    """A block with block_type='survey' → FormSchema.form_type == SURVEY."""
+    svc = _svc()
+    schema = svc.to_form_schema(networkninja_survey_row)
+    assert schema.form_type == FormType.SURVEY
+
+
+def test_networkninja_simple_block_type():
+    """A block with block_type='simple' → FormSchema.form_type == SIMPLE."""
+    svc = _svc()
+    schema = svc.to_form_schema(_make_row("FIELD_TEXT"))
+    assert schema.form_type == FormType.SIMPLE
+
+
+# ---------------------------------------------------------------------------
+# Legacy double-encoded blocks
+# ---------------------------------------------------------------------------
+
+
+def test_networkninja_legacy_double_encoded_blocks(networkninja_legacy_double_encoded_row):
+    """Legacy string-encoded blocks (question_block_* keys) decode correctly."""
+    svc = _svc()
+    schema = svc.to_form_schema(networkninja_legacy_double_encoded_row)
+    assert schema.sections, "Expected at least one section after legacy decode"
+    fields = list(schema.iter_all_fields())
+    assert fields, "Expected at least one field from legacy-decoded blocks"
+
+
+def test_networkninja_legacy_null_block_type():
+    """Legacy blocks with null question_block_type default to 'simple'."""
+    row = {
+        "formid": 11,
+        "orgid": 1,
+        "form_name": "Null Type",
+        "description": None,
+        "question_blocks": json.dumps(
+            [
+                {
+                    "question_block_id": 1,
+                    "question_block_type": None,
+                    "question_block_logic_groups": [],
+                    "questions": [
+                        {
+                            "question_id": 1,
+                            "question_column_name": "c1",
+                            "question_description": "Q",
+                        }
+                    ],
+                }
+            ]
+        ),
+        "metadata": [
+            {"column_id": 1, "column_name": "c1", "data_type": "FIELD_TEXT", "description": "Q"}
+        ],
+    }
+    svc = _svc()
+    schema = svc.to_form_schema(row)
+    assert schema.form_type == FormType.SIMPLE
+
+
+# ---------------------------------------------------------------------------
+# Unmappable field — no abort
+# ---------------------------------------------------------------------------
+
+
+def test_networkninja_unmappable_field_no_abort():
+    """Unknown data_type does not abort the import; report entry is generated."""
+    row = _make_row("FIELD_TOTALLY_UNKNOWN")
+    svc = _svc()
+    schema, report = svc.import_with_report(row)
+    # Form is returned (not raised)
+    assert schema is not None
+    # Report entry for the unmappable field
+    entries = [e for e in report.fields if e.source_data_type == "FIELD_TOTALLY_UNKNOWN"]
+    assert entries, "Expected report entry for unknown data_type"
+    assert entries[0].status == "requiere_intervencion"
+    assert entries[0].mapped_field_type is None
+
+
+def test_networkninja_unmappable_field_draft_form():
+    """A form with unmappable fields is left as draft (published_version=None)."""
+    row = _make_row("FIELD_TOTALLY_UNKNOWN")
+    svc = _svc()
+    schema, _ = svc.import_with_report(row)
+    assert schema.published_version is None
+
+
+# ---------------------------------------------------------------------------
+# Formula dangling reference
+# ---------------------------------------------------------------------------
+
+
+def test_networkninja_formula_dangling_reference():
+    """Formula field referencing a deleted source field imports without crash."""
+    row = {
+        "formid": 100,
+        "orgid": 1,
+        "form_name": "Dangling Ref",
+        "description": None,
+        "question_blocks": [
+            {
+                "block_id": 1,
+                "block_type": "simple",
+                "block_logic_groups": [],
+                "questions": [
+                    {
+                        "question_id": 99,
+                        "question_column_name": "formula_col",
+                        "question_description": "Computed",
+                        "question_logic_groups": [],
+                        "validations": [],
+                    }
+                ],
+            }
+        ],
+        "metadata": [
+            {
+                "column_id": 99,
+                "column_name": "formula_col",
+                "data_type": "FIELD_FORMULA",
+                "description": "Computed",
+                "options": [],
+            }
+        ],
+    }
+    svc = _svc()
+    # Must not raise
+    schema, report = svc.import_with_report(row)
+    assert schema is not None
+    entries = [e for e in report.fields if e.source_data_type == "FIELD_FORMULA"]
+    assert entries[0].status == "requiere_intervencion"
+
+
+# ---------------------------------------------------------------------------
+# All 9 new map entries — parametrized
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "data_type, expected_type",
+    [
+        ("FIELD_IMAGE_UPLOAD", FieldType.FILE),
+        ("FIELD_AGREEMENT_CHECKBOX", FieldType.BOOLEAN),
+        ("FIELD_DURATION", FieldType.TEXT),
+        ("FIELD_DATETIME", FieldType.DATETIME),
+        ("FIELD_TIME", FieldType.TIME),
+        ("FIELD_HYPERLINK", FieldType.URL),
+        ("FIELD_PHONENUMBER", FieldType.PHONE),
+        ("FIELD_TOTAL", FieldType.FORMULA),
+        ("FIELD_SIGNATURE_CAPTURE", FieldType.SIGNATURE),
+    ],
+)
+def test_new_map_entries_all_covered(data_type: str, expected_type: FieldType):
+    """Each of the 9 new/fixed map entries maps to the expected FieldType."""
+    svc = _svc()
+    schema = svc.to_form_schema(_make_row(data_type))
+    fields = list(schema.iter_all_fields())
+    assert fields, f"Expected at least one field for data_type '{data_type}'"
+    assert fields[0].field_type == expected_type, (
+        f"data_type '{data_type}' mapped to {fields[0].field_type!r}, expected {expected_type!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# FIELD_TOTAL (approximate mapping — render_as='total')
+# ---------------------------------------------------------------------------
+
+
+def test_networkninja_total_maps_to_formula_with_render_as():
+    """FIELD_TOTAL maps to FORMULA with meta.render_as='total'."""
+    svc = _svc()
+    schema = svc.to_form_schema(_make_row("FIELD_TOTAL"))
+    fields = list(schema.iter_all_fields())
+    total_field = fields[0]
+    assert total_field.field_type == FieldType.FORMULA
+    assert total_field.meta is not None
+    assert total_field.meta.get("render_as") == "total"
+
+
+# ---------------------------------------------------------------------------
+# Report statuses
+# ---------------------------------------------------------------------------
+
+
+def test_report_mapeado_status():
+    """Fully mapped fields have status='mapeado'."""
+    svc = _svc()
+    _, report = svc.import_with_report(_make_row("FIELD_TEXT"))
+    assert report.fields
+    assert report.fields[0].status == "mapeado"
+
+
+def test_report_aproximado_status():
+    """Approximate mappings (e.g. FIELD_MONEY with render_as) have status='aproximado'."""
+    svc = _svc()
+    _, report = svc.import_with_report(_make_row("FIELD_MONEY"))
+    assert report.fields
+    assert report.fields[0].status == "aproximado"

--- a/packages/parrot-formdesigner/tests/unit/test_preresolve_embed.py
+++ b/packages/parrot-formdesigner/tests/unit/test_preresolve_embed.py
@@ -1,0 +1,345 @@
+"""Unit tests for FEAT-301 pre-resolve embed in HTML5 and AdaptiveCard renderers.
+
+Tests that:
+- HTML5: ``data-logic-state`` JSON script block is ALWAYS embedded.
+- HTML5: ``data-depends-on`` attributes are PRESERVED (regression test).
+- HTML5: Fields hidden by pre-resolution are still present in markup.
+- HTML5: Works without evaluation_context (default empty context).
+- AdaptiveCard: ``data.logic_state`` map is embedded in card payload.
+- AdaptiveCard: ``isVisible: False`` applied to hidden fields.
+- Both renderers: no crash on empty-context forms with no rules.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from parrot_formdesigner.core.constraints import (
+    ConditionOperator,
+    DependencyRule,
+    FieldRefCondition,
+    LocationVarCondition,
+)
+from parrot_formdesigner.core.schema import FormField, FormSchema, FormSection
+from parrot_formdesigner.core.types import FieldType
+from parrot_formdesigner.renderers.adaptive_card import AdaptiveCardRenderer
+from parrot_formdesigner.renderers.html5 import HTML5Renderer
+from parrot_formdesigner.services.rule_evaluator import EvaluationContext
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def conditional_form() -> FormSchema:
+    """Form with q2 visible only when q1 == 'yes'."""
+    rule = DependencyRule(
+        conditions=[FieldRefCondition(field_id="q1", operator=ConditionOperator.EQ, value="yes")],
+        effect="show",
+    )
+    return FormSchema(
+        form_id="cond-form",
+        title={"en": "Conditional Form"},
+        sections=[FormSection(
+            section_id="s1",
+            title={"en": "S1"},
+            fields=[
+                FormField(field_id="q1", field_type=FieldType.TEXT, label={"en": "Q1"}),
+                FormField(field_id="q2", field_type=FieldType.TEXT, label={"en": "Q2"},
+                          depends_on=rule),
+            ],
+        )],
+    )
+
+
+@pytest.fixture
+def hide_form() -> FormSchema:
+    """Form with q2 HIDDEN when q1 == 'hide-me'."""
+    rule = DependencyRule(
+        conditions=[FieldRefCondition(field_id="q1", operator=ConditionOperator.EQ, value="hide-me")],
+        effect="hide",
+    )
+    return FormSchema(
+        form_id="hide-form",
+        title={"en": "Hide Form"},
+        sections=[FormSection(
+            section_id="s1",
+            title={"en": "S1"},
+            fields=[
+                FormField(field_id="q1", field_type=FieldType.TEXT, label={"en": "Q1"}),
+                FormField(field_id="q2", field_type=FieldType.TEXT, label={"en": "Q2"},
+                          depends_on=rule),
+            ],
+        )],
+    )
+
+
+@pytest.fixture
+def flagship_context() -> EvaluationContext:
+    """Context with store_type=flagship."""
+    return EvaluationContext(location_vars={"store_type": "flagship"})
+
+
+@pytest.fixture
+def no_rule_form() -> FormSchema:
+    """Form with no DependencyRule fields."""
+    return FormSchema(
+        form_id="no-rule",
+        title={"en": "No Rules"},
+        sections=[FormSection(
+            section_id="s1",
+            title={"en": "S1"},
+            fields=[FormField(field_id="q1", field_type=FieldType.TEXT, label={"en": "Q1"})],
+        )],
+    )
+
+
+# ---------------------------------------------------------------------------
+# HTML5Renderer — data-logic-state embedding
+# ---------------------------------------------------------------------------
+
+class TestHTML5PreResolveEmbed:
+    """Tests for HTML5Renderer pre-resolve embedding."""
+
+    async def test_html5_pre_resolve_embed_with_context(
+        self, conditional_form: FormSchema, flagship_context: EvaluationContext
+    ) -> None:
+        """HTML5 output contains data-logic-state block when context is provided."""
+        rendered = await HTML5Renderer().render(
+            conditional_form,
+            evaluation_context=flagship_context,
+        )
+        assert "data-logic-state" in rendered.content
+
+    async def test_html5_default_empty_context(self, conditional_form: FormSchema) -> None:
+        """HTML5 embeds data-logic-state even with no evaluation_context."""
+        rendered = await HTML5Renderer().render(conditional_form)
+        assert "data-logic-state" in rendered.content
+
+    async def test_html5_data_depends_on_preserved(
+        self, conditional_form: FormSchema
+    ) -> None:
+        """Existing data-depends-on attributes are preserved (regression)."""
+        rendered = await HTML5Renderer().render(conditional_form)
+        assert "data-depends-on" in rendered.content
+
+    async def test_html5_logic_state_json_valid(
+        self, conditional_form: FormSchema
+    ) -> None:
+        """The data-logic-state block contains valid JSON."""
+        rendered = await HTML5Renderer().render(
+            conditional_form,
+            evaluation_context=EvaluationContext(answers={"q1": "yes"}),
+        )
+        # Extract JSON from script block
+        start = rendered.content.find('<script type="application/json" data-logic-state>')
+        end = rendered.content.find("</script>", start)
+        assert start != -1 and end != -1
+        raw_json = rendered.content[start + len('<script type="application/json" data-logic-state>'):end]
+        state = json.loads(raw_json)
+        assert isinstance(state, dict)
+        assert "q2" in state
+        assert state["q2"]["effect"] == "show"
+        assert state["q2"]["matched"] is True
+
+    async def test_html5_logic_state_no_match(
+        self, conditional_form: FormSchema
+    ) -> None:
+        """When conditions don't match, matched=False in embedded state."""
+        rendered = await HTML5Renderer().render(
+            conditional_form,
+            evaluation_context=EvaluationContext(answers={"q1": "no"}),
+        )
+        start = rendered.content.find('<script type="application/json" data-logic-state>')
+        end = rendered.content.find("</script>", start)
+        raw_json = rendered.content[start + len('<script type="application/json" data-logic-state>'):end]
+        state = json.loads(raw_json)
+        assert state["q2"]["matched"] is False
+
+    async def test_html5_no_rule_form_empty_state(
+        self, no_rule_form: FormSchema
+    ) -> None:
+        """Form with no rules → data-logic-state block with empty dict."""
+        rendered = await HTML5Renderer().render(no_rule_form)
+        assert "data-logic-state" in rendered.content
+        start = rendered.content.find('<script type="application/json" data-logic-state>')
+        end = rendered.content.find("</script>", start)
+        raw_json = rendered.content[start + len('<script type="application/json" data-logic-state>'):end]
+        state = json.loads(raw_json)
+        assert state == {}
+
+    async def test_html5_hidden_field_still_present_in_markup(
+        self, hide_form: FormSchema
+    ) -> None:
+        """Fields hidden by pre-resolution are PRESENT in HTML (not omitted).
+
+        The field must remain in the DOM so local evaluators can toggle it.
+        """
+        ctx = EvaluationContext(answers={"q1": "hide-me"})
+        rendered = await HTML5Renderer().render(hide_form, evaluation_context=ctx)
+        # q2 markup must be present
+        assert 'id="q2"' in rendered.content or 'form-field--text' in rendered.content
+        # And the state says it's hidden
+        start = rendered.content.find('<script type="application/json" data-logic-state>')
+        end = rendered.content.find("</script>", start)
+        raw_json = rendered.content[start + len('<script type="application/json" data-logic-state>'):end]
+        state = json.loads(raw_json)
+        assert state["q2"]["effect"] == "hide"
+        assert state["q2"]["matched"] is True
+
+    async def test_html5_location_var_rule(self) -> None:
+        """Location variable conditions work in the embed."""
+        loc_rule = DependencyRule(
+            conditions=[LocationVarCondition(
+                source="location_variable",
+                key="store_type",
+                operator=ConditionOperator.EQ,
+                value="flagship",
+            )],
+            effect="show",
+        )
+        form = FormSchema(
+            form_id="loc-form",
+            title={"en": "Loc Form"},
+            sections=[FormSection(
+                section_id="s1",
+                title={"en": "S1"},
+                fields=[
+                    FormField(field_id="q1", field_type=FieldType.TEXT, label={"en": "Q1"}),
+                    FormField(field_id="q2", field_type=FieldType.TEXT, label={"en": "Q2"},
+                              depends_on=loc_rule),
+                ],
+            )],
+        )
+        ctx = EvaluationContext(location_vars={"store_type": "flagship"})
+        rendered = await HTML5Renderer().render(form, evaluation_context=ctx)
+        start = rendered.content.find('<script type="application/json" data-logic-state>')
+        end = rendered.content.find("</script>", start)
+        raw_json = rendered.content[start + len('<script type="application/json" data-logic-state>'):end]
+        state = json.loads(raw_json)
+        assert state["q2"]["matched"] is True
+
+    async def test_html5_script_injection_guard(self) -> None:
+        """</script> sequences in field data are escaped in the JSON block."""
+        # This is a safety test — values are inside JSON strings, the outer
+        # JSON itself should not contain a literal </script> sequence.
+        rule = DependencyRule(
+            conditions=[FieldRefCondition(
+                field_id="q1",
+                operator=ConditionOperator.EQ,
+                value="</script><script>alert(1)</script>",
+            )],
+        )
+        form = FormSchema(
+            form_id="xss-form",
+            title={"en": "XSS Test"},
+            sections=[FormSection(
+                section_id="s1",
+                title={"en": "S1"},
+                fields=[
+                    FormField(field_id="q1", field_type=FieldType.TEXT, label={"en": "Q1"}),
+                    FormField(field_id="q2", field_type=FieldType.TEXT, label={"en": "Q2"},
+                              depends_on=rule),
+                ],
+            )],
+        )
+        rendered = await HTML5Renderer().render(form)
+        # Count </script> occurrences — should only be the closing tag, not in JSON data
+        script_close_count = rendered.content.count("</script>")
+        # There's exactly one closing </script> per <script> open tag.
+        assert script_close_count >= 1
+        # The JSON block's </script> escaping means no raw </script> inside the block
+        start = rendered.content.find('<script type="application/json" data-logic-state>')
+        end = rendered.content.find("</script>", start)
+        raw_block = rendered.content[start:end]
+        assert "</" not in raw_block or "<\\/script>" not in raw_block  # escape applied
+
+
+# ---------------------------------------------------------------------------
+# AdaptiveCardRenderer — pre-resolve embed
+# ---------------------------------------------------------------------------
+
+class TestAdaptiveCardPreResolveEmbed:
+    """Tests for AdaptiveCardRenderer pre-resolve embedding."""
+
+    async def test_ac_pre_resolve_embed_with_context(
+        self, conditional_form: FormSchema
+    ) -> None:
+        """AdaptiveCard payload includes data.logic_state map."""
+        ctx = EvaluationContext(answers={"q1": "yes"})
+        rendered = await AdaptiveCardRenderer().render(
+            conditional_form, evaluation_context=ctx
+        )
+        card = rendered.content
+        assert isinstance(card, dict)
+        assert "data" in card
+        assert "logic_state" in card["data"]
+        assert "q2" in card["data"]["logic_state"]
+        assert card["data"]["logic_state"]["q2"]["matched"] is True
+
+    async def test_ac_default_empty_context(self, conditional_form: FormSchema) -> None:
+        """AdaptiveCard embeds logic_state even without evaluation_context."""
+        rendered = await AdaptiveCardRenderer().render(conditional_form)
+        card = rendered.content
+        assert "data" in card
+        assert "logic_state" in card["data"]
+
+    async def test_ac_no_rule_form_empty_logic_state(
+        self, no_rule_form: FormSchema
+    ) -> None:
+        """Form with no rules → card.data.logic_state == {}."""
+        rendered = await AdaptiveCardRenderer().render(no_rule_form)
+        card = rendered.content
+        assert card["data"]["logic_state"] == {}
+
+    async def test_ac_hidden_field_isvisible_false(
+        self, hide_form: FormSchema
+    ) -> None:
+        """Input element for hidden field gets isVisible=False."""
+        ctx = EvaluationContext(answers={"q1": "hide-me"})
+        rendered = await AdaptiveCardRenderer().render(hide_form, evaluation_context=ctx)
+        card = rendered.content
+        assert card["data"]["logic_state"]["q2"]["effect"] == "hide"
+
+        # Find the input element with id=q2 and check isVisible
+        def _find_element(elements: list, eid: str) -> dict | None:
+            for elem in elements:
+                if isinstance(elem, dict):
+                    if elem.get("id") == eid:
+                        return elem
+                    found = _find_element(elem.get("items", []), eid)
+                    if found:
+                        return found
+            return None
+
+        q2_elem = _find_element(card.get("body", []), "q2")
+        if q2_elem is not None:
+            assert q2_elem.get("isVisible") is False
+
+    async def test_ac_show_field_no_isvisible_false(
+        self, conditional_form: FormSchema
+    ) -> None:
+        """Fields that are shown do NOT get isVisible=False."""
+        # No match context → q2 matched=False, effect="show"
+        rendered = await AdaptiveCardRenderer().render(
+            conditional_form,
+            evaluation_context=EvaluationContext(),
+        )
+        card = rendered.content
+        # q2's element should NOT have isVisible=False
+        def _find_element(elements: list, eid: str) -> dict | None:
+            for elem in elements:
+                if isinstance(elem, dict):
+                    if elem.get("id") == eid:
+                        return elem
+                    found = _find_element(elem.get("items", []), eid)
+                    if found:
+                        return found
+            return None
+
+        q2_elem = _find_element(card.get("body", []), "q2")
+        if q2_elem is not None:
+            assert q2_elem.get("isVisible") is not False

--- a/packages/parrot-formdesigner/tests/unit/test_question_bank.py
+++ b/packages/parrot-formdesigner/tests/unit/test_question_bank.py
@@ -1,0 +1,198 @@
+"""Unit tests for QuestionBankService (FEAT-300 TASK-003)."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from parrot_formdesigner.core.schema import FormField
+from parrot_formdesigner.core.types import FieldType
+from parrot_formdesigner.services.question_bank import (
+    QuestionBankService,
+    ReusableField,
+    ReusableFieldRef,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_storage():
+    """Return a minimal MagicMock that satisfies FormStorage type checks."""
+    return MagicMock()
+
+
+@pytest.fixture
+def bank(mock_storage):
+    """QuestionBankService using in-memory (db=None) store, tenant='t1'."""
+    return QuestionBankService(mock_storage, tenant="t1")
+
+
+def _text_field(field_id: str = "q1", label: str = "Q1") -> FormField:
+    return FormField(field_id=field_id, field_type=FieldType.TEXT, label=label)
+
+
+# ---------------------------------------------------------------------------
+# Import / basic structure
+# ---------------------------------------------------------------------------
+
+
+def test_import_works():
+    """Public names are importable from services.question_bank."""
+    assert QuestionBankService is not None
+    assert ReusableField is not None
+    assert ReusableFieldRef is not None
+
+
+def test_import_from_services_package():
+    """Names re-exported from services/__init__.py."""
+    from parrot_formdesigner.services import QuestionBankService as QBS
+    from parrot_formdesigner.services import ReusableField as RF
+    from parrot_formdesigner.services import ReusableFieldRef as RFR
+    assert QBS is QuestionBankService
+    assert RF is ReusableField
+    assert RFR is ReusableFieldRef
+
+
+def test_reusable_field_model():
+    """ReusableField is a valid Pydantic v2 model with required fields."""
+    field = _text_field()
+    entry = ReusableField(field_id="uuid-123", definition=field, tenant="t1")
+    assert entry.field_id == "uuid-123"
+    assert entry.definition.field_id == "q1"
+    assert entry.usage_forms == 0
+    assert entry.usage_responses == 0
+
+
+def test_reusable_field_ref_model():
+    """ReusableFieldRef is a valid Pydantic v2 model."""
+    ref = ReusableFieldRef(bank_field_id="uuid-123", overrides={"label": "New"})
+    assert ref.bank_field_id == "uuid-123"
+    assert ref.overrides == {"label": "New"}
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+
+async def test_question_bank_create_and_retrieve(bank):
+    """create_field() mints a UUID; get_field() returns the same definition."""
+    field = _text_field("q1", "Q1")
+    created = await bank.create_field(field)
+
+    assert isinstance(created, ReusableField)
+    assert created.field_id  # minted UUID
+    assert created.tenant == "t1"
+    assert created.definition.field_id == "q1"
+
+    fetched = await bank.get_field(created.field_id)
+    assert fetched is not None
+    assert fetched.definition.field_id == "q1"
+
+
+async def test_question_bank_get_unknown_returns_none(bank):
+    """get_field() returns None for an unknown ID."""
+    result = await bank.get_field("does-not-exist")
+    assert result is None
+
+
+async def test_question_bank_list_fields_empty(bank):
+    """list_fields() returns [] when bank is empty."""
+    assert await bank.list_fields() == []
+
+
+async def test_question_bank_list_fields_populated(bank):
+    """list_fields() returns all created entries."""
+    await bank.create_field(_text_field("q1", "Q1"))
+    await bank.create_field(_text_field("q2", "Q2"))
+    fields = await bank.list_fields()
+    assert len(fields) == 2
+
+
+# ---------------------------------------------------------------------------
+# Usage counters
+# ---------------------------------------------------------------------------
+
+
+async def test_question_bank_usage_counter(bank):
+    """increment_usage() increments both forms and responses counters."""
+    field = _text_field()
+    created = await bank.create_field(field)
+    fid = created.field_id
+
+    await bank.increment_usage(fid, forms=1, responses=2)
+    updated = await bank.get_field(fid)
+    assert updated is not None
+    assert updated.usage_forms == 1
+    assert updated.usage_responses == 2
+
+
+async def test_question_bank_usage_counter_additive(bank):
+    """Multiple increment_usage() calls accumulate."""
+    created = await bank.create_field(_text_field())
+    fid = created.field_id
+
+    await bank.increment_usage(fid, forms=1, responses=0)
+    await bank.increment_usage(fid, forms=0, responses=3)
+    updated = await bank.get_field(fid)
+    assert updated.usage_forms == 1
+    assert updated.usage_responses == 3
+
+
+async def test_question_bank_usage_counter_unknown_noop(bank):
+    """increment_usage() on unknown ID does not raise."""
+    await bank.increment_usage("no-such-id", forms=5, responses=10)  # no exception
+
+
+# ---------------------------------------------------------------------------
+# Resolve ref
+# ---------------------------------------------------------------------------
+
+
+async def test_question_bank_resolve_ref(bank):
+    """resolve_ref() returns a FormField matching the bank definition."""
+    field = _text_field("q1", "Original Label")
+    created = await bank.create_field(field)
+
+    resolved = await bank.resolve_ref(
+        ReusableFieldRef(bank_field_id=created.field_id)
+    )
+    assert isinstance(resolved, FormField)
+    assert resolved.field_id == "q1"
+    assert resolved.label == "Original Label"
+
+
+async def test_question_bank_resolve_ref_with_overrides(bank):
+    """resolve_ref() applies overrides on top of the definition."""
+    field = _text_field("q1", "Original")
+    created = await bank.create_field(field)
+
+    resolved = await bank.resolve_ref(
+        ReusableFieldRef(
+            bank_field_id=created.field_id,
+            overrides={"label": "New Label"},
+        )
+    )
+    assert resolved.label == "New Label"
+    assert resolved.field_id == "q1"  # unchanged
+
+
+async def test_question_bank_resolve_ref_does_not_mutate_bank(bank):
+    """resolve_ref() deep-copies: the bank entry is never mutated."""
+    field = _text_field("q1", "Original")
+    created = await bank.create_field(field)
+    fid = created.field_id
+
+    await bank.resolve_ref(
+        ReusableFieldRef(bank_field_id=fid, overrides={"label": "Mutated?"})
+    )
+    original = await bank.get_field(fid)
+    assert original.definition.label == "Original"
+
+
+async def test_question_bank_resolve_ref_unknown_raises(bank):
+    """resolve_ref() raises KeyError for unknown bank_field_id."""
+    with pytest.raises(KeyError):
+        await bank.resolve_ref(ReusableFieldRef(bank_field_id="no-such-id"))

--- a/packages/parrot-formdesigner/tests/unit/test_rule_evaluator.py
+++ b/packages/parrot-formdesigner/tests/unit/test_rule_evaluator.py
@@ -1,0 +1,541 @@
+"""Unit tests for FEAT-301 RuleEvaluator.
+
+Tests cover:
+- All ConditionOperator values × 3 condition variants.
+- and/or logic combinations.
+- Key-missing semantics (RESUELTO §8).
+- Hidden-field exclusion from downstream inputs.
+- evaluate_form() covers all fields with depends_on; omits those without.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from parrot_formdesigner.core.constraints import (
+    ConditionOperator,
+    DependencyRule,
+    FieldRefCondition,
+    LocationVarCondition,
+    VisitContextCondition,
+)
+from parrot_formdesigner.core.schema import FormField, FormSchema, FormSection
+from parrot_formdesigner.core.types import FieldType
+from parrot_formdesigner.services.rule_evaluator import EvaluationContext, RuleEvaluator
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def evaluator() -> RuleEvaluator:
+    """Return a fresh RuleEvaluator (stateless, reusable)."""
+    return RuleEvaluator()
+
+
+@pytest.fixture
+def location_var_rule() -> DependencyRule:
+    """DependencyRule: show field only when store_type == 'flagship'."""
+    return DependencyRule(
+        conditions=[
+            LocationVarCondition(
+                source="location_variable",
+                key="store_type",
+                operator=ConditionOperator.EQ,
+                value="flagship",
+            )
+        ],
+        logic="and",
+        effect="show",
+    )
+
+
+@pytest.fixture
+def flagship_context() -> EvaluationContext:
+    """Context with store_type=flagship."""
+    return EvaluationContext(
+        answers={},
+        location_vars={"store_type": "flagship"},
+        visit_context={},
+    )
+
+
+@pytest.fixture
+def non_flagship_context() -> EvaluationContext:
+    """Context with store_type=regional (not flagship)."""
+    return EvaluationContext(
+        answers={},
+        location_vars={"store_type": "regional"},
+        visit_context={},
+    )
+
+
+def _simple_form(*fields: FormField) -> FormSchema:
+    """Build a minimal FormSchema with the given fields in a single section."""
+    return FormSchema(
+        form_id="test-form",
+        title={"en": "Test Form"},
+        sections=[FormSection(section_id="s1", title={"en": "S1"}, fields=list(fields))],
+    )
+
+
+def _field(fid: str, rule: DependencyRule | None = None) -> FormField:
+    """Build a simple text FormField."""
+    return FormField(
+        field_id=fid,
+        field_type=FieldType.TEXT,
+        label={"en": fid},
+        depends_on=rule,
+    )
+
+
+# ---------------------------------------------------------------------------
+# FieldRefCondition — basic EQ / NEQ
+# ---------------------------------------------------------------------------
+
+class TestFieldRefEvaluation:
+    """Tests for FieldRefCondition evaluation."""
+
+    def test_eq_match(self, evaluator: RuleEvaluator) -> None:
+        """Rule fires when field answer equals expected value."""
+        rule = DependencyRule(
+            conditions=[FieldRefCondition(field_id="q1", operator=ConditionOperator.EQ, value="yes")],
+        )
+        ctx = EvaluationContext(answers={"q1": "yes"})
+        assert evaluator.evaluate(rule, ctx) == "show"
+
+    def test_eq_no_match(self, evaluator: RuleEvaluator) -> None:
+        """Rule returns None when answer does not match."""
+        rule = DependencyRule(
+            conditions=[FieldRefCondition(field_id="q1", operator=ConditionOperator.EQ, value="yes")],
+        )
+        ctx = EvaluationContext(answers={"q1": "no"})
+        assert evaluator.evaluate(rule, ctx) is None
+
+    def test_neq_match(self, evaluator: RuleEvaluator) -> None:
+        """NEQ fires when values differ."""
+        rule = DependencyRule(
+            conditions=[FieldRefCondition(field_id="q1", operator=ConditionOperator.NEQ, value="yes")],
+        )
+        ctx = EvaluationContext(answers={"q1": "no"})
+        assert evaluator.evaluate(rule, ctx) == "show"
+
+    def test_gt_numeric(self, evaluator: RuleEvaluator) -> None:
+        """GT fires when actual > expected (numeric)."""
+        rule = DependencyRule(
+            conditions=[FieldRefCondition(field_id="q1", operator=ConditionOperator.GT, value=5)],
+        )
+        ctx = EvaluationContext(answers={"q1": 10})
+        assert evaluator.evaluate(rule, ctx) == "show"
+        ctx2 = EvaluationContext(answers={"q1": 3})
+        assert evaluator.evaluate(rule, ctx2) is None
+
+    def test_gte_numeric(self, evaluator: RuleEvaluator) -> None:
+        """GTE fires when actual >= expected."""
+        rule = DependencyRule(
+            conditions=[FieldRefCondition(field_id="q1", operator=ConditionOperator.GTE, value=5)],
+        )
+        assert evaluator.evaluate(rule, EvaluationContext(answers={"q1": 5})) == "show"
+        assert evaluator.evaluate(rule, EvaluationContext(answers={"q1": 6})) == "show"
+        assert evaluator.evaluate(rule, EvaluationContext(answers={"q1": 4})) is None
+
+    def test_lt_numeric(self, evaluator: RuleEvaluator) -> None:
+        """LT fires when actual < expected."""
+        rule = DependencyRule(
+            conditions=[FieldRefCondition(field_id="q1", operator=ConditionOperator.LT, value=5)],
+        )
+        assert evaluator.evaluate(rule, EvaluationContext(answers={"q1": 3})) == "show"
+        assert evaluator.evaluate(rule, EvaluationContext(answers={"q1": 5})) is None
+
+    def test_lte_numeric(self, evaluator: RuleEvaluator) -> None:
+        """LTE fires when actual <= expected."""
+        rule = DependencyRule(
+            conditions=[FieldRefCondition(field_id="q1", operator=ConditionOperator.LTE, value=5)],
+        )
+        assert evaluator.evaluate(rule, EvaluationContext(answers={"q1": 5})) == "show"
+        assert evaluator.evaluate(rule, EvaluationContext(answers={"q1": 4})) == "show"
+        assert evaluator.evaluate(rule, EvaluationContext(answers={"q1": 6})) is None
+
+    def test_in_match(self, evaluator: RuleEvaluator) -> None:
+        """IN fires when actual is in expected list."""
+        rule = DependencyRule(
+            conditions=[FieldRefCondition(field_id="q1", operator=ConditionOperator.IN, value=["a", "b", "c"])],
+        )
+        assert evaluator.evaluate(rule, EvaluationContext(answers={"q1": "b"})) == "show"
+        assert evaluator.evaluate(rule, EvaluationContext(answers={"q1": "d"})) is None
+
+    def test_not_in_match(self, evaluator: RuleEvaluator) -> None:
+        """NOT_IN fires when actual is NOT in expected list."""
+        rule = DependencyRule(
+            conditions=[FieldRefCondition(field_id="q1", operator=ConditionOperator.NOT_IN, value=["a", "b"])],
+        )
+        assert evaluator.evaluate(rule, EvaluationContext(answers={"q1": "c"})) == "show"
+        assert evaluator.evaluate(rule, EvaluationContext(answers={"q1": "a"})) is None
+
+    def test_is_empty_match(self, evaluator: RuleEvaluator) -> None:
+        """IS_EMPTY fires when answer is None, empty string, or empty list."""
+        rule = DependencyRule(
+            conditions=[FieldRefCondition(field_id="q1", operator=ConditionOperator.IS_EMPTY)],
+        )
+        assert evaluator.evaluate(rule, EvaluationContext(answers={"q1": None})) == "show"
+        assert evaluator.evaluate(rule, EvaluationContext(answers={"q1": ""})) == "show"
+        assert evaluator.evaluate(rule, EvaluationContext(answers={"q1": []})) == "show"
+        assert evaluator.evaluate(rule, EvaluationContext(answers={"q1": "text"})) is None
+
+    def test_is_not_empty_match(self, evaluator: RuleEvaluator) -> None:
+        """IS_NOT_EMPTY fires when answer has a value."""
+        rule = DependencyRule(
+            conditions=[FieldRefCondition(field_id="q1", operator=ConditionOperator.IS_NOT_EMPTY)],
+        )
+        assert evaluator.evaluate(rule, EvaluationContext(answers={"q1": "text"})) == "show"
+        assert evaluator.evaluate(rule, EvaluationContext(answers={"q1": ""})) is None
+
+
+# ---------------------------------------------------------------------------
+# LocationVarCondition evaluation
+# ---------------------------------------------------------------------------
+
+class TestLocationVarEvaluation:
+    """Tests for LocationVarCondition evaluation."""
+
+    def test_location_var_eq_match(
+        self, evaluator: RuleEvaluator, location_var_rule: DependencyRule, flagship_context: EvaluationContext
+    ) -> None:
+        """LocationVarCondition fires when location var matches."""
+        assert evaluator.evaluate(location_var_rule, flagship_context) == "show"
+
+    def test_location_var_eq_no_match(
+        self, evaluator: RuleEvaluator, location_var_rule: DependencyRule, non_flagship_context: EvaluationContext
+    ) -> None:
+        """LocationVarCondition returns None when var doesn't match."""
+        assert evaluator.evaluate(location_var_rule, non_flagship_context) is None
+
+    def test_location_var_in_operator(self, evaluator: RuleEvaluator) -> None:
+        """IN operator on location var works correctly."""
+        rule = DependencyRule(
+            conditions=[LocationVarCondition(
+                source="location_variable",
+                key="store_tier",
+                operator=ConditionOperator.IN,
+                value=["gold", "platinum"],
+            )],
+        )
+        assert evaluator.evaluate(rule, EvaluationContext(location_vars={"store_tier": "gold"})) == "show"
+        assert evaluator.evaluate(rule, EvaluationContext(location_vars={"store_tier": "silver"})) is None
+
+    def test_location_var_is_empty(self, evaluator: RuleEvaluator) -> None:
+        """IS_EMPTY on location var works."""
+        rule = DependencyRule(
+            conditions=[LocationVarCondition(
+                source="location_variable",
+                key="optional_flag",
+                operator=ConditionOperator.IS_EMPTY,
+            )],
+        )
+        assert evaluator.evaluate(rule, EvaluationContext(location_vars={"optional_flag": ""})) == "show"
+        assert evaluator.evaluate(rule, EvaluationContext(location_vars={"optional_flag": "set"})) is None
+
+
+# ---------------------------------------------------------------------------
+# VisitContextCondition evaluation
+# ---------------------------------------------------------------------------
+
+class TestVisitContextEvaluation:
+    """Tests for VisitContextCondition evaluation."""
+
+    def test_visit_context_in_match(self, evaluator: RuleEvaluator) -> None:
+        """IN operator fires for visit_context match."""
+        rule = DependencyRule(
+            conditions=[VisitContextCondition(
+                source="visit_context",
+                key="visit_type",
+                operator=ConditionOperator.IN,
+                value=["audit", "merchandising"],
+            )],
+        )
+        ctx = EvaluationContext(visit_context={"visit_type": "audit"})
+        assert evaluator.evaluate(rule, ctx) == "show"
+        ctx2 = EvaluationContext(visit_context={"visit_type": "sales"})
+        assert evaluator.evaluate(rule, ctx2) is None
+
+    def test_visit_context_eq_match(self, evaluator: RuleEvaluator) -> None:
+        """EQ operator fires for visit_context match."""
+        rule = DependencyRule(
+            conditions=[VisitContextCondition(
+                source="visit_context",
+                key="visit_status",
+                operator=ConditionOperator.EQ,
+                value="active",
+            )],
+        )
+        ctx = EvaluationContext(visit_context={"visit_status": "active"})
+        assert evaluator.evaluate(rule, ctx) == "show"
+
+
+# ---------------------------------------------------------------------------
+# Key-missing semantics (RESUELTO §8)
+# ---------------------------------------------------------------------------
+
+class TestKeyMissingSemantics:
+    """Tests for key-missing semantics (RESUELTO §8).
+
+    Absent key → IS_EMPTY evaluates True, other operators evaluate False.
+    Rules ALWAYS resolve, NEVER raise.
+    """
+
+    def test_key_missing_eq_false(
+        self, evaluator: RuleEvaluator, location_var_rule: DependencyRule
+    ) -> None:
+        """EQ operator vs missing key → no match (None/False, not exception)."""
+        ctx = EvaluationContext()  # empty — store_type missing
+        assert evaluator.evaluate(location_var_rule, ctx) is None
+
+    def test_key_missing_is_empty_true(self, evaluator: RuleEvaluator) -> None:
+        """IS_EMPTY vs missing key → True (missing counts as empty)."""
+        rule = DependencyRule(
+            conditions=[LocationVarCondition(
+                source="location_variable",
+                key="absent_key",
+                operator=ConditionOperator.IS_EMPTY,
+            )],
+        )
+        assert evaluator.evaluate(rule, EvaluationContext()) == "show"
+
+    def test_key_missing_is_not_empty_false(self, evaluator: RuleEvaluator) -> None:
+        """IS_NOT_EMPTY vs missing key → False."""
+        rule = DependencyRule(
+            conditions=[LocationVarCondition(
+                source="location_variable",
+                key="absent_key",
+                operator=ConditionOperator.IS_NOT_EMPTY,
+            )],
+        )
+        assert evaluator.evaluate(rule, EvaluationContext()) is None
+
+    def test_key_missing_gt_false(self, evaluator: RuleEvaluator) -> None:
+        """GT vs missing key → False."""
+        rule = DependencyRule(
+            conditions=[FieldRefCondition(
+                field_id="q_missing",
+                operator=ConditionOperator.GT,
+                value=0,
+            )],
+        )
+        assert evaluator.evaluate(rule, EvaluationContext()) is None
+
+    def test_key_missing_field_ref(self, evaluator: RuleEvaluator) -> None:
+        """Missing field answer: EQ returns None, no exception."""
+        rule = DependencyRule(
+            conditions=[FieldRefCondition(
+                field_id="absent_field",
+                operator=ConditionOperator.EQ,
+                value="yes",
+            )],
+        )
+        # No exception — rule degrades gracefully
+        result = evaluator.evaluate(rule, EvaluationContext(answers={}))
+        assert result is None
+
+    def test_key_missing_visit_context(self, evaluator: RuleEvaluator) -> None:
+        """Missing visit_context key: IS_EMPTY → True."""
+        rule = DependencyRule(
+            conditions=[VisitContextCondition(
+                source="visit_context",
+                key="missing_key",
+                operator=ConditionOperator.IS_EMPTY,
+            )],
+        )
+        assert evaluator.evaluate(rule, EvaluationContext()) == "show"
+
+    def test_empty_context_no_match(self, evaluator: RuleEvaluator) -> None:
+        """Empty context: EQ operator always returns None."""
+        rule = DependencyRule(
+            conditions=[
+                FieldRefCondition(field_id="q1", operator=ConditionOperator.EQ, value="yes"),
+                LocationVarCondition(
+                    source="location_variable", key="k", operator=ConditionOperator.EQ, value="v"
+                ),
+            ],
+            logic="or",
+        )
+        assert evaluator.evaluate(rule, EvaluationContext()) is None
+
+
+# ---------------------------------------------------------------------------
+# AND / OR logic
+# ---------------------------------------------------------------------------
+
+class TestAndOrLogic:
+    """Tests for AND/OR condition combining."""
+
+    def test_and_logic_all_must_match(self, evaluator: RuleEvaluator) -> None:
+        """AND: all conditions must fire."""
+        rule = DependencyRule(
+            conditions=[
+                FieldRefCondition(field_id="q1", operator=ConditionOperator.EQ, value="yes"),
+                FieldRefCondition(field_id="q2", operator=ConditionOperator.EQ, value="no"),
+            ],
+            logic="and",
+        )
+        # Both match
+        assert evaluator.evaluate(
+            rule, EvaluationContext(answers={"q1": "yes", "q2": "no"})
+        ) == "show"
+        # Only one matches
+        assert evaluator.evaluate(
+            rule, EvaluationContext(answers={"q1": "yes", "q2": "maybe"})
+        ) is None
+
+    def test_or_logic_one_enough(self, evaluator: RuleEvaluator) -> None:
+        """OR: any one condition firing is sufficient."""
+        rule = DependencyRule(
+            conditions=[
+                FieldRefCondition(field_id="q1", operator=ConditionOperator.EQ, value="yes"),
+                FieldRefCondition(field_id="q2", operator=ConditionOperator.EQ, value="no"),
+            ],
+            logic="or",
+        )
+        # Only first matches
+        assert evaluator.evaluate(
+            rule, EvaluationContext(answers={"q1": "yes", "q2": "maybe"})
+        ) == "show"
+        # None match
+        assert evaluator.evaluate(
+            rule, EvaluationContext(answers={"q1": "nope", "q2": "nope"})
+        ) is None
+
+    def test_effect_is_preserved(self, evaluator: RuleEvaluator) -> None:
+        """effect='hide' is returned when conditions fire."""
+        rule = DependencyRule(
+            conditions=[FieldRefCondition(field_id="q1", operator=ConditionOperator.EQ, value="y")],
+            effect="hide",
+        )
+        assert evaluator.evaluate(rule, EvaluationContext(answers={"q1": "y"})) == "hide"
+
+    def test_effect_require(self, evaluator: RuleEvaluator) -> None:
+        """effect='require' is returned when conditions fire."""
+        rule = DependencyRule(
+            conditions=[FieldRefCondition(field_id="q1", operator=ConditionOperator.IS_NOT_EMPTY)],
+            effect="require",
+        )
+        assert evaluator.evaluate(rule, EvaluationContext(answers={"q1": "something"})) == "require"
+
+    def test_effect_disable(self, evaluator: RuleEvaluator) -> None:
+        """effect='disable' is returned when conditions fire."""
+        rule = DependencyRule(
+            conditions=[FieldRefCondition(field_id="q1", operator=ConditionOperator.EQ, value="lock")],
+            effect="disable",
+        )
+        assert evaluator.evaluate(rule, EvaluationContext(answers={"q1": "lock"})) == "disable"
+
+    def test_empty_conditions_no_fire(self, evaluator: RuleEvaluator) -> None:
+        """Empty conditions list → no fire (AND of nothing = False)."""
+        rule = DependencyRule(conditions=[], logic="and")
+        assert evaluator.evaluate(rule, EvaluationContext()) is None
+
+
+# ---------------------------------------------------------------------------
+# evaluate_form — form-level evaluation
+# ---------------------------------------------------------------------------
+
+class TestEvaluateForm:
+    """Tests for RuleEvaluator.evaluate_form()."""
+
+    def test_returns_all_fields_with_depends_on(self, evaluator: RuleEvaluator) -> None:
+        """evaluate_form covers every field with a depends_on."""
+        rule = DependencyRule(
+            conditions=[FieldRefCondition(field_id="q1", operator=ConditionOperator.EQ, value="y")],
+        )
+        form = _simple_form(
+            _field("q1"),
+            _field("q2", rule),
+            _field("q3", rule),
+        )
+        results = evaluator.evaluate_form(form, EvaluationContext(answers={"q1": "y"}))
+        assert set(results.keys()) == {"q2", "q3"}
+
+    def test_fields_without_depends_on_omitted(self, evaluator: RuleEvaluator) -> None:
+        """Fields without depends_on are NOT in the result."""
+        form = _simple_form(_field("q1"), _field("q2"))
+        results = evaluator.evaluate_form(form, EvaluationContext())
+        assert "q1" not in results
+        assert "q2" not in results
+
+    def test_hidden_field_excluded_from_inputs(self, evaluator: RuleEvaluator) -> None:
+        """Hidden q2's answer is NOT available to q3's rule."""
+        # q1 → q2 (hide when q1="yes")
+        # q3 depends on q2="something" — but if q2 is hidden, its answer is absent.
+        hide_q2_rule = DependencyRule(
+            conditions=[FieldRefCondition(field_id="q1", operator=ConditionOperator.EQ, value="yes")],
+            effect="hide",
+        )
+        show_q3_rule = DependencyRule(
+            conditions=[FieldRefCondition(
+                field_id="q2",
+                operator=ConditionOperator.IS_NOT_EMPTY,
+            )],
+            effect="show",
+        )
+        form = _simple_form(
+            _field("q1"),
+            _field("q2", hide_q2_rule),
+            _field("q3", show_q3_rule),
+        )
+        ctx = EvaluationContext(answers={"q1": "yes", "q2": "something"})
+        results = evaluator.evaluate_form(form, ctx)
+
+        # q2 is hidden
+        assert results["q2"].effect == "hide"
+        assert results["q2"].matched is True
+
+        # q3: q2 is hidden → its answer is excluded → IS_NOT_EMPTY on q2 = False
+        # So q3's rule doesn't fire → effect="show", matched=False
+        assert results["q3"].effect == "show"
+        assert results["q3"].matched is False
+
+    def test_no_rule_fires_gives_show_default(self, evaluator: RuleEvaluator) -> None:
+        """When a rule doesn't fire, the result is effect=show, matched=False."""
+        rule = DependencyRule(
+            conditions=[FieldRefCondition(field_id="q1", operator=ConditionOperator.EQ, value="yes")],
+        )
+        form = _simple_form(_field("q1"), _field("q2", rule))
+        results = evaluator.evaluate_form(form, EvaluationContext(answers={"q1": "no"}))
+        assert results["q2"].effect == "show"
+        assert results["q2"].matched is False
+
+    def test_matched_true_when_rule_fires(self, evaluator: RuleEvaluator) -> None:
+        """matched=True when the rule conditions fire."""
+        rule = DependencyRule(
+            conditions=[FieldRefCondition(field_id="q1", operator=ConditionOperator.EQ, value="yes")],
+            effect="hide",
+        )
+        form = _simple_form(_field("q1"), _field("q2", rule))
+        results = evaluator.evaluate_form(form, EvaluationContext(answers={"q1": "yes"}))
+        assert results["q2"].effect == "hide"
+        assert results["q2"].matched is True
+
+    def test_location_var_in_form_evaluation(
+        self, evaluator: RuleEvaluator, location_var_rule: DependencyRule
+    ) -> None:
+        """evaluate_form works with LocationVarCondition rules."""
+        form = _simple_form(_field("q1"), _field("q2", location_var_rule))
+        results = evaluator.evaluate_form(
+            form, EvaluationContext(location_vars={"store_type": "flagship"})
+        )
+        assert results["q2"].effect == "show"
+        assert results["q2"].matched is True
+
+    def test_empty_form_no_results(self, evaluator: RuleEvaluator) -> None:
+        """Form with no depends_on fields → empty results dict."""
+        form = _simple_form(_field("q1"), _field("q2"))
+        results = evaluator.evaluate_form(form, EvaluationContext())
+        assert results == {}
+
+    def test_numeric_coercion_string_vs_number(self, evaluator: RuleEvaluator) -> None:
+        """Numeric coercion: string "5" compared with number 5 via GT."""
+        rule = DependencyRule(
+            conditions=[FieldRefCondition(field_id="q1", operator=ConditionOperator.GT, value=3)],
+        )
+        ctx = EvaluationContext(answers={"q1": "5"})  # string answer
+        assert evaluator.evaluate(rule, ctx) == "show"

--- a/packages/parrot-formdesigner/tests/unit/test_version_backfill.py
+++ b/packages/parrot-formdesigner/tests/unit/test_version_backfill.py
@@ -1,0 +1,176 @@
+"""Unit tests for FormVersionService.backfill_published() (FEAT-300 TASK-005)."""
+
+from parrot_formdesigner.core.schema import FormField, FormSchema, FormSection
+from parrot_formdesigner.core.types import FieldType
+from parrot_formdesigner.services.form_version import FormVersionService
+from parrot_formdesigner.services.registry import FormRegistry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _legacy_form(form_id: str, version: str = "1.0") -> FormSchema:
+    """Create a form with no published_version (legacy state)."""
+    return FormSchema(
+        form_id=form_id,
+        version=version,
+        title=f"Legacy Form {form_id}",
+        sections=[
+            FormSection(
+                section_id="s1",
+                fields=[FormField(field_id="q1", field_type=FieldType.TEXT, label="Q1")],
+            )
+        ],
+        tenant="t1",
+        published_version=None,
+    )
+
+
+async def _registry_with_forms(*forms: FormSchema, tenant: str = "t1") -> FormRegistry:
+    reg = FormRegistry()
+    for form in forms:
+        await reg.register(form, tenant=tenant)
+    return reg
+
+
+# ---------------------------------------------------------------------------
+# Basic backfill
+# ---------------------------------------------------------------------------
+
+
+async def test_backfill_marks_existing_forms():
+    """backfill_published() sets published_version on legacy forms."""
+    reg = await _registry_with_forms(
+        _legacy_form("form-a"),
+        _legacy_form("form-b"),
+    )
+    svc = FormVersionService(reg)
+
+    changed = await svc.backfill_published(tenant="t1")
+    assert changed == 2
+
+    a = await reg.get("form-a", tenant="t1")
+    b = await reg.get("form-b", tenant="t1")
+    assert a.published_version == "1.0"
+    assert b.published_version == "1.0"
+
+
+async def test_backfill_preserves_existing_version_string():
+    """backfill_published() uses the form's existing version value, not always '1.0'."""
+    reg = await _registry_with_forms(_legacy_form("form-v2", version="2.0"))
+    svc = FormVersionService(reg)
+
+    await svc.backfill_published(tenant="t1")
+
+    form = await reg.get("form-v2", tenant="t1")
+    assert form.published_version == "2.0"
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+async def test_backfill_idempotent():
+    """Running backfill twice: second run returns 0 (nothing to do)."""
+    reg = await _registry_with_forms(
+        _legacy_form("form-a"),
+        _legacy_form("form-b"),
+    )
+    svc = FormVersionService(reg)
+
+    first = await svc.backfill_published(tenant="t1")
+    assert first == 2
+
+    second = await svc.backfill_published(tenant="t1")
+    assert second == 0
+
+
+async def test_backfill_already_published_forms_skipped():
+    """Forms with published_version already set are skipped."""
+    already_published = FormSchema(
+        form_id="form-pub",
+        version="1.0",
+        title="Published",
+        sections=[
+            FormSection(
+                section_id="s1",
+                fields=[FormField(field_id="q1", field_type=FieldType.TEXT, label="Q1")],
+            )
+        ],
+        tenant="t1",
+        published_version="1.0",  # already published
+    )
+    reg = await _registry_with_forms(already_published, _legacy_form("form-new"))
+    svc = FormVersionService(reg)
+
+    changed = await svc.backfill_published(tenant="t1")
+    assert changed == 1  # only form-new
+
+
+async def test_backfill_empty_tenant_returns_zero():
+    """backfill_published() returns 0 when no forms exist for the tenant."""
+    reg = FormRegistry()
+    svc = FormVersionService(reg)
+
+    changed = await svc.backfill_published(tenant="t1")
+    assert changed == 0
+
+
+# ---------------------------------------------------------------------------
+# Dry-run
+# ---------------------------------------------------------------------------
+
+
+async def test_backfill_dry_run_persists_nothing():
+    """dry_run=True returns a positive count but does not set published_version."""
+    reg = await _registry_with_forms(
+        _legacy_form("form-a"),
+        _legacy_form("form-b"),
+    )
+    svc = FormVersionService(reg)
+
+    changed = await svc.backfill_published(tenant="t1", dry_run=True)
+    assert changed == 2
+
+    # published_version must remain None after a dry-run
+    a = await reg.get("form-a", tenant="t1")
+    b = await reg.get("form-b", tenant="t1")
+    assert a.published_version is None
+    assert b.published_version is None
+
+
+async def test_backfill_dry_run_then_real_run():
+    """A dry-run followed by the real run correctly backfills."""
+    reg = await _registry_with_forms(_legacy_form("form-a"))
+    svc = FormVersionService(reg)
+
+    dry = await svc.backfill_published(tenant="t1", dry_run=True)
+    real = await svc.backfill_published(tenant="t1", dry_run=False)
+
+    assert dry == 1
+    assert real == 1
+
+    # Real run idempotency
+    second = await svc.backfill_published(tenant="t1", dry_run=False)
+    assert second == 0
+
+
+# ---------------------------------------------------------------------------
+# Version metadata
+# ---------------------------------------------------------------------------
+
+
+async def test_backfill_records_version_meta():
+    """After backfill, list_versions() returns the backfilled version entry."""
+    reg = await _registry_with_forms(_legacy_form("form-a"))
+    svc = FormVersionService(reg)
+
+    await svc.backfill_published(tenant="t1")
+
+    versions = await svc.list_versions("form-a", tenant="t1")
+    assert len(versions) == 1
+    assert versions[0].version == "1.0"
+    assert versions[0].is_frozen is True


### PR DESCRIPTION
## Summary

Ports the complete **FEAT-300 (Form Builder — Vision IQ Recap Parity)** and **FEAT-301 (Conditional Logic Engine)** features into the canonical `packages/parrot-formdesigner` package, three-way merged against the diverged tree so the monorepo-only features (audio FEAT-224, lifecycle events FEAT-188, CSRF) are fully preserved. Version bumped **0.3.17 → 0.4.0**.

These features were originally built in the standalone `Trocdigital/ai-formdesigner` repo (now superseded by this monorepo as the canonical source) and are required by the FieldSync forms modules.

## FEAT-300 — Form Builder Parity
- `FormType` enum + `form_type`/`product_bindings`/`published_version` on `FormSchema`
- `FieldType.FORMULA` with graceful fallback rendering across all renderers
- `QuestionBankService` + `field_bank` table (SQL-injection-safe identifiers)
- `FormVersionService`: immutable semver publish, history reconstruction, Vision IQ deletion rules, C3 backfill + CLI
- Networkninja importer: 9 production-verified `data_type` mappings, `block_type` form-type detection, legacy double-encoded normalization, per-field `ImportDiffReport` (never aborts)
- API: publish, fields, versions, import-report endpoints

## FEAT-301 — Conditional Logic Engine
- `FieldCondition` discriminated union (`FieldRefCondition` keeps `field_id` — zero-migration backward compat via a `DependencyRule` before-validator)
- `RuleEvaluator` (authoritative server-side D1, key-missing semantics, hidden-field downstream masking) + `LogicGraph` (iterative Kahn toposort, cycle detection)
- `POST /forms/{form_id}/evaluate` endpoint
- Pre-resolve embed ALWAYS ON: HTML5 `data-logic-state` + AdaptiveCard initial visibility (render + wizard `render_section`); `data-depends-on` byte-identical for legacy forms
- RF-02 parity suite: 60 golden vectors as a conformance contract for JS/native evaluators

## Review & verification
- Both pre-merge code reviews' fixes are included with their regression suites (FEAT-300: C1/C2/H1–H5; FEAT-301: H-1/H-2/M-1..M-4/L-1..L-4)
- **1410 tests pass** in the monorepo tree; **zero regressions vs `main`** (remaining failures are pre-existing environment gaps — moto/S3, audio WS — identical on `main`)
- Source: `Trocdigital/ai-formdesigner` dev@ea01728

Developed with Spec Driven Development
