### PR TITLE
feat(formdesigner): FEAT-301 location variables + visit context (v0.5.0)

### DIFF
--- a/packages/parrot-formdesigner/src/parrot_formdesigner/core/constraints.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/core/constraints.py
@@ -156,6 +156,12 @@ class FieldCondition(BaseModel):
     field_id: str
     operator: ConditionOperator
     value: Any = None
+    # FEAT-301: condition source discriminator. "field" (default) reads from
+    # answers[field_id] — fully backward compatible. "location_variable" /
+    # "visit_context" read from the eval context's location_vars / visit_context
+    # using `key`. Legacy serialized conditions (no source) deserialize as field.
+    source: str = "field"
+    key: str | None = None
 
 
 class DependencyRule(BaseModel):

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/rule_evaluator.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/rule_evaluator.py
@@ -91,19 +91,37 @@ def _to_comparable(value: Any) -> Any:
     return str(value)
 
 
-def _eval_condition(condition: FieldCondition, answers: dict[str, Any]) -> bool:
+def _eval_condition(
+    condition: FieldCondition,
+    answers: dict[str, Any],
+    location_vars: dict[str, Any] | None = None,
+    visit_context: dict[str, Any] | None = None,
+) -> bool:
     """Evaluate a single :class:`~parrot_formdesigner.core.constraints.FieldCondition`.
 
     Args:
         condition: The condition to evaluate.
         answers: Current answer dict keyed by ``field_id``.
+        location_vars: Org-graph location variables (FEAT-301), keyed by name.
+        visit_context: Visit-level metadata (FEAT-301), keyed by name.
 
     Returns:
         ``True`` if the condition is satisfied, ``False`` otherwise.
-        Never raises — missing field answers return ``False`` for relational
-        operators and ``True`` for ``is_empty``.
+        Never raises — a missing source value returns ``False`` for relational
+        operators and ``True`` for ``is_empty`` (key-missing semantics).
+
+    The value source is selected by ``condition.source``:
+    ``"field"`` (default) → ``answers[field_id]``;
+    ``"location_variable"`` → ``location_vars[key]``;
+    ``"visit_context"`` → ``visit_context[key]``.
     """
-    raw = answers.get(condition.field_id)
+    source = getattr(condition, "source", "field") or "field"
+    if source == "location_variable":
+        raw = (location_vars or {}).get(condition.key)
+    elif source == "visit_context":
+        raw = (visit_context or {}).get(condition.key)
+    else:
+        raw = answers.get(condition.field_id)
     op = condition.operator
     expected = condition.value
 
@@ -162,6 +180,8 @@ def _eval_logic(
     conditions: list[FieldCondition],
     logic: str,
     answers: dict[str, Any],
+    location_vars: dict[str, Any] | None = None,
+    visit_context: dict[str, Any] | None = None,
 ) -> bool:
     """Evaluate a list of conditions under the given logic gate.
 
@@ -176,7 +196,7 @@ def _eval_logic(
     if not conditions:
         # No conditions → rule always fires (spec §8: empty condition list = unconditional)
         return True
-    results = [_eval_condition(c, answers) for c in conditions]
+    results = [_eval_condition(c, answers, location_vars, visit_context) for c in conditions]
     match logic:
         case "and":
             return all(results)
@@ -428,6 +448,8 @@ class RuleEvaluator:
         answers: dict[str, Any],
         *,
         locale: str = "en",
+        location_vars: dict[str, Any] | None = None,
+        visit_context: dict[str, Any] | None = None,
     ) -> RuleResolution:
         """Resolve all conditional-section rules for ``form`` against ``answers``.
 
@@ -456,11 +478,12 @@ class RuleEvaluator:
         ordered = _topo_order(all_fields)
 
         for field in ordered:
-            await self._apply_pre_dependency(field, answers, visible, required, computed)
+            await self._apply_pre_dependency(field, answers, visible, required, computed, location_vars, visit_context)
 
         for field in ordered:
             await self._apply_post_dependencies(
-                field, answers, visible, required, computed, cleared
+                field, answers, visible, required, computed, cleared,
+                location_vars, visit_context,
             )
 
         return RuleResolution(
@@ -477,6 +500,8 @@ class RuleEvaluator:
         visible: dict[str, bool],
         required: dict[str, bool],
         computed: dict[str, Any],
+        location_vars: dict[str, Any] | None = None,
+        visit_context: dict[str, Any] | None = None,
     ) -> None:
         """Apply ``FormField.depends_on`` (pre-dependency) to resolution dicts.
 
@@ -491,7 +516,7 @@ class RuleEvaluator:
         if rule is None:
             return
 
-        fired = _eval_logic(rule.conditions, rule.logic, answers)
+        fired = _eval_logic(rule.conditions, rule.logic, answers, location_vars, visit_context)
 
         # Apply visibility/required effect
         effect = rule.effect
@@ -528,6 +553,8 @@ class RuleEvaluator:
         required: dict[str, bool],
         computed: dict[str, Any],
         cleared: list[str],
+        location_vars: dict[str, Any] | None = None,
+        visit_context: dict[str, Any] | None = None,
     ) -> None:
         """Apply ``FormField.post_depends`` (post-dependencies) to resolution dicts.
 
@@ -549,7 +576,7 @@ class RuleEvaluator:
         for post in post_list:
             # Evaluate conditions (if any)
             if post.conditions:
-                fired = _eval_logic(post.conditions, post.logic, answers)
+                fired = _eval_logic(post.conditions, post.logic, answers, location_vars, visit_context)
             else:
                 # No conditions: post-dep fires if the owner field has a non-empty value
                 fired = owner_answer is not None and owner_answer != "" and owner_answer != []

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/version.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/version.py
@@ -2,7 +2,7 @@
 
 __title__ = "parrot-formdesigner"
 __description__ = "Platform-agnostic form design and rendering package for AI-Parrot"
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 __author__ = "Jesus Lara"
 __author_email__ = "jesuslara@phenobarbital.info"
 __license__ = "MIT"

--- a/packages/parrot-formdesigner/tests/unit/test_feat301_location_variables.py
+++ b/packages/parrot-formdesigner/tests/unit/test_feat301_location_variables.py
@@ -1,0 +1,205 @@
+"""FEAT-301 reconciliation — location variables & visit context on main's RuleEvaluator.
+
+This is the additive port of FEAT-301's location-variable / visit-context
+support onto the conditional-sections ``RuleEvaluator`` that landed on main.
+Main's evaluator previously conditioned only on field answers; FEAT-301 adds
+two new condition sources, selected by ``FieldCondition.source``:
+
+- ``"field"`` (default) → ``answers[field_id]`` (unchanged, backward compatible)
+- ``"location_variable"`` → ``location_vars[key]`` (Org Graph, FEAT-302)
+- ``"visit_context"`` → ``visit_context[key]`` (visit metadata)
+
+These golden cases are the conformance contract for client-side evaluators
+(JS/native) that must match the server. Backward compatibility (legacy
+field conditions with no ``source``) is asserted explicitly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from parrot_formdesigner.core.constraints import (
+    ConditionOperator,
+    DependencyRule,
+    FieldCondition,
+)
+from parrot_formdesigner.core.schema import FormField, FormSchema, FormSection
+from parrot_formdesigner.core.types import FieldType
+from parrot_formdesigner.services.rule_evaluator import RuleEvaluator
+
+
+def _form_with_rule(rule: DependencyRule, target: str = "q_target") -> FormSchema:
+    """A 2-field form where ``target`` has the given show-rule."""
+    return FormSchema(
+        form_id="f1",
+        title="F",
+        sections=[
+            FormSection(
+                section_id="s1",
+                fields=[
+                    FormField(field_id="q1", field_type=FieldType.TEXT, label="Q1"),
+                    FormField(
+                        field_id=target,
+                        field_type=FieldType.TEXT,
+                        label="Target",
+                        depends_on=rule,
+                    ),
+                ],
+            )
+        ],
+    )
+
+
+def _show_rule(cond: FieldCondition) -> DependencyRule:
+    return DependencyRule(conditions=[cond], logic="and", effect="show")
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility — legacy field conditions (no source)
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompat:
+    async def test_legacy_field_condition_no_source(self):
+        """A condition dict with no `source` resolves as a field condition."""
+        rule = DependencyRule.model_validate({
+            "conditions": [{"field_id": "q1", "operator": "eq", "value": "yes"}],
+            "logic": "and", "effect": "show",
+        })
+        assert rule.conditions[0].source == "field"  # default
+        res = await RuleEvaluator().resolve(_form_with_rule(rule), {"q1": "yes"})
+        assert res.visible["q_target"] is True
+
+    async def test_legacy_field_condition_hides_when_no_match(self):
+        rule = _show_rule(FieldCondition(field_id="q1", operator=ConditionOperator.EQ, value="yes"))
+        res = await RuleEvaluator().resolve(_form_with_rule(rule), {"q1": "no"})
+        assert res.visible["q_target"] is False
+
+
+# ---------------------------------------------------------------------------
+# Location variables
+# ---------------------------------------------------------------------------
+
+
+class TestLocationVariables:
+    async def test_locvar_eq_match_shows(self):
+        rule = _show_rule(FieldCondition(
+            field_id="", source="location_variable", key="store_type",
+            operator=ConditionOperator.EQ, value="flagship",
+        ))
+        res = await RuleEvaluator().resolve(
+            _form_with_rule(rule), {}, location_vars={"store_type": "flagship"}
+        )
+        assert res.visible["q_target"] is True
+
+    async def test_locvar_eq_nomatch_hides(self):
+        rule = _show_rule(FieldCondition(
+            field_id="", source="location_variable", key="store_type",
+            operator=ConditionOperator.EQ, value="flagship",
+        ))
+        res = await RuleEvaluator().resolve(
+            _form_with_rule(rule), {}, location_vars={"store_type": "regional"}
+        )
+        assert res.visible["q_target"] is False
+
+    async def test_locvar_key_missing_eq_false(self):
+        """Key-missing semantics: EQ against an absent location var → no match."""
+        rule = _show_rule(FieldCondition(
+            field_id="", source="location_variable", key="store_type",
+            operator=ConditionOperator.EQ, value="flagship",
+        ))
+        res = await RuleEvaluator().resolve(_form_with_rule(rule), {}, location_vars={})
+        assert res.visible["q_target"] is False
+
+    async def test_locvar_key_missing_is_empty_true(self):
+        """Key-missing semantics: IS_EMPTY against an absent location var → fires."""
+        rule = _show_rule(FieldCondition(
+            field_id="", source="location_variable", key="store_type",
+            operator=ConditionOperator.IS_EMPTY,
+        ))
+        res = await RuleEvaluator().resolve(_form_with_rule(rule), {}, location_vars={})
+        assert res.visible["q_target"] is True
+
+    @pytest.mark.parametrize("op,value,locvar,expected", [
+        (ConditionOperator.NEQ, "flagship", "regional", True),
+        (ConditionOperator.IN, ["flagship", "outlet"], "outlet", True),
+        (ConditionOperator.NOT_IN, ["flagship"], "regional", True),
+        (ConditionOperator.GT, 100, 250, True),
+        (ConditionOperator.LT, 100, 50, True),
+        (ConditionOperator.GTE, 100, 100, True),
+        (ConditionOperator.LTE, 100, 100, True),
+        (ConditionOperator.IS_NOT_EMPTY, None, "x", True),
+    ])
+    async def test_locvar_operator_sweep(self, op, value, locvar, expected):
+        cond = FieldCondition(
+            field_id="", source="location_variable", key="lv",
+            operator=op, value=value,
+        )
+        res = await RuleEvaluator().resolve(
+            _form_with_rule(_show_rule(cond)), {}, location_vars={"lv": locvar}
+        )
+        assert res.visible["q_target"] is expected
+
+
+# ---------------------------------------------------------------------------
+# Visit context
+# ---------------------------------------------------------------------------
+
+
+class TestVisitContext:
+    async def test_visitctx_in_match(self):
+        rule = _show_rule(FieldCondition(
+            field_id="", source="visit_context", key="visit_type",
+            operator=ConditionOperator.IN, value=["audit", "training"],
+        ))
+        res = await RuleEvaluator().resolve(
+            _form_with_rule(rule), {}, visit_context={"visit_type": "audit"}
+        )
+        assert res.visible["q_target"] is True
+
+    async def test_visitctx_key_missing_is_empty(self):
+        rule = _show_rule(FieldCondition(
+            field_id="", source="visit_context", key="visit_type",
+            operator=ConditionOperator.IS_EMPTY,
+        ))
+        res = await RuleEvaluator().resolve(_form_with_rule(rule), {}, visit_context={})
+        assert res.visible["q_target"] is True
+
+
+# ---------------------------------------------------------------------------
+# Mixed-source logic
+# ---------------------------------------------------------------------------
+
+
+class TestMixedSources:
+    async def test_and_field_and_locvar(self):
+        """AND across a field answer and a location variable — both must hold."""
+        rule = DependencyRule(
+            conditions=[
+                FieldCondition(field_id="q1", operator=ConditionOperator.EQ, value="yes"),
+                FieldCondition(field_id="", source="location_variable", key="store_type",
+                               operator=ConditionOperator.EQ, value="flagship"),
+            ],
+            logic="and", effect="show",
+        )
+        form = _form_with_rule(rule)
+        ev = RuleEvaluator()
+        both = await ev.resolve(form, {"q1": "yes"}, location_vars={"store_type": "flagship"})
+        assert both.visible["q_target"] is True
+        one = await ev.resolve(form, {"q1": "yes"}, location_vars={"store_type": "regional"})
+        assert one.visible["q_target"] is False
+
+    async def test_or_field_or_visitctx(self):
+        rule = DependencyRule(
+            conditions=[
+                FieldCondition(field_id="q1", operator=ConditionOperator.EQ, value="yes"),
+                FieldCondition(field_id="", source="visit_context", key="visit_type",
+                               operator=ConditionOperator.EQ, value="audit"),
+            ],
+            logic="or", effect="show",
+        )
+        form = _form_with_rule(rule)
+        res = await RuleEvaluator().resolve(
+            form, {"q1": "no"}, visit_context={"visit_type": "audit"}
+        )
+        assert res.visible["q_target"] is True


### PR DESCRIPTION
## Summary

**FEAT-301 reconciliation (option 2a)** — adds location-variable & visit-context condition sources to main's `RuleEvaluator` (the conditional-sections engine), v0.5.0.

Per the agreed approach, main's `RuleEvaluator` is the canonical conditional engine. FEAT-301's original discriminated-union `FieldCondition` and standalone `LogicGraph` are **not** ported — instead this contributes, additively, the two condition sources FEAT-301 added that main lacked.

## What's added (fully backward-compatible)
- `FieldCondition` gains optional `source` (`"field"` default | `"location_variable"` | `"visit_context"`) + `key`. Legacy conditions with no `source` deserialize as `"field"` and behave exactly as before (the model has no `extra="forbid"`).
- `RuleEvaluator._eval_condition` selects the value source; `resolve()`, `_apply_pre_dependency`, `_apply_post_dependencies`, and `_eval_logic` thread an optional `location_vars` / `visit_context` context (default `None` → empty).
- Key-missing semantics preserved: `IS_EMPTY` fires, relational ops return `False`.

## Verification
- New conformance suite `tests/unit/test_feat301_location_variables.py` — **18 cases** (backward compat, locvar/visitctx operator sweep, key-missing, mixed-source AND/OR) — the contract for client-side JS/native evaluators.
- **150 existing conditional-sections tests unchanged**; zero regressions vs baseline (91 pre-existing environment failures — moto/S3, audio WS).
- version `0.4.0 → 0.5.0`.

Developed with Spec Driven Development
