### PR TITLE
feat(formdesigner): FEAT-302 Org Graph · Projects · Cost Centers · RBAC (v0.6.0)

### DIFF
--- a/packages/parrot-formdesigner/scripts/seed_fieldsync_projects.py
+++ b/packages/parrot-formdesigner/scripts/seed_fieldsync_projects.py
@@ -1,0 +1,175 @@
+"""Seed ``fieldsync.projects`` from ``networkninja.projects`` (idempotente).
+
+Lee los proyectos existentes de la tabla read-only ``networkninja.projects``
+e inserta/actualiza filas en ``fieldsync.projects`` usando ON CONFLICT DO
+NOTHING para garantizar idempotencia (segunda ejecución no duplica filas).
+
+Columnas verificadas en ``networkninja.projects`` (2026-06-12):
+    project_id, project_name, description, start_timestamp, end_timestamp,
+    orgid, client_id, client_name, is_active, accounting_code
+
+NUNCA escribe de vuelta a ``networkninja.projects`` — es solo fuente de
+lectura para el seed inicial.
+
+Uso::
+
+    python scripts/seed_fieldsync_projects.py --dsn postgresql://...
+    python scripts/seed_fieldsync_projects.py --dsn postgresql://... --dry-run
+
+Flags:
+    --dsn       Cadena de conexión asyncpg (o DATABASE_URL del entorno).
+    --dry-run   Muestra cuántas filas se inserirían sin ejecutar nada.
+    --batch     Tamaño del batch de INSERT (default: 200).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+
+logger = logging.getLogger("seed_fieldsync_projects")
+
+
+# ---------------------------------------------------------------------------
+# SQL
+# ---------------------------------------------------------------------------
+
+_SELECT_NETWORKNINJA = """
+SELECT
+    project_id,
+    project_name,
+    description,
+    start_timestamp,
+    end_timestamp,
+    orgid,
+    client_id,
+    is_active,
+    accounting_code
+FROM networkninja.projects
+ORDER BY project_id
+"""
+
+_UPSERT_FIELDSYNC = """
+INSERT INTO fieldsync.projects
+    (client_id, name, description, accounting_code,
+     start_timestamp, end_timestamp, is_active, org_id)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+ON CONFLICT (client_id, accounting_code) DO NOTHING
+"""
+
+
+# ---------------------------------------------------------------------------
+# Core seed logic (async)
+# ---------------------------------------------------------------------------
+
+
+async def _seed(dsn: str, *, dry_run: bool, batch_size: int) -> None:
+    """Perform the actual seed operation.
+
+    Args:
+        dsn: asyncpg connection string.
+        dry_run: When True, read rows and report counts but insert nothing.
+        batch_size: Number of rows per INSERT batch.
+    """
+    try:
+        import asyncpg  # type: ignore[import-untyped]
+    except ImportError:
+        logger.error("asyncpg is required: pip install asyncpg")
+        sys.exit(1)
+
+    pool = await asyncpg.create_pool(dsn, min_size=1, max_size=3)
+    try:
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(_SELECT_NETWORKNINJA)
+
+        total = len(rows)
+        logger.info("Found %d row(s) in networkninja.projects", total)
+
+        if dry_run:
+            logger.info("[DRY-RUN] Would insert/skip up to %d row(s).", total)
+            return
+
+        inserted = 0
+        skipped = 0
+        for offset in range(0, total, batch_size):
+            batch = rows[offset : offset + batch_size]
+            async with pool.acquire() as conn:
+                async with conn.transaction():
+                    for row in batch:
+                        status = await conn.execute(
+                            _UPSERT_FIELDSYNC,
+                            row["client_id"],
+                            row["project_name"],
+                            row["description"],
+                            row["accounting_code"],
+                            row["start_timestamp"],
+                            row["end_timestamp"],
+                            row["is_active"],
+                            row["orgid"],
+                        )
+                        # asyncpg returns "INSERT 0 1" on success, "INSERT 0 0"
+                        # when ON CONFLICT DO NOTHING fires.
+                        if status.endswith(" 1"):
+                            inserted += 1
+                        else:
+                            skipped += 1
+
+        logger.info(
+            "Seed complete: %d inserted, %d skipped (already existed).",
+            inserted,
+            skipped,
+        )
+    finally:
+        await pool.close()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Seed fieldsync.projects from networkninja.projects."
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("DATABASE_URL"),
+        help="asyncpg DSN (default: $DATABASE_URL)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report how many rows would be inserted without writing.",
+    )
+    parser.add_argument(
+        "--batch",
+        type=int,
+        default=200,
+        help="Batch size for INSERT operations (default: 200).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for the seed script.
+
+    Args:
+        argv: Argument list (defaults to ``sys.argv[1:]`` when ``None``).
+    """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s — %(message)s",
+    )
+    args = _parse_args(argv)
+    if not args.dsn:
+        logger.error("--dsn is required (or set DATABASE_URL)")
+        sys.exit(1)
+    asyncio.run(_seed(args.dsn, dry_run=args.dry_run, batch_size=args.batch))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/api/handlers.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/api/handlers.py
@@ -32,9 +32,13 @@ if TYPE_CHECKING:
 
     from ..services.form_version import FormVersionService
     from ..services.forwarder import SubmissionForwarder
+    from ..services.org_graph import OrgGraphService
     from ..services.partial_saves import PartialSaveStore
+    from ..services.project_service import ProjectService
     from ..services.question_bank import QuestionBankService
+    from ..services.rbac import RBACService
     from ..services.submissions import FormSubmissionStorage
+    from ..services.workday_sync import WorkdayIdentitySyncAdapter
     from ..tools.services.networkninja import ImportDiffReport
 
 
@@ -56,6 +60,16 @@ class FormAPIHandler:
         forwarder: Optional submission forwarder for endpoint-bound submits.
         partial_store: Optional Redis-backed store for ephemeral partial form
             answers.  When ``None``, partial save endpoints return 503.
+        org_graph_service: Optional ``OrgGraphService`` for ``GET /org/graph``.
+            When ``None``, the endpoint returns 501 Not Implemented.
+        project_service: Optional ``ProjectService`` for org project endpoints.
+        rbac_service: Optional ``RBACService`` for policy management endpoints.
+        workday_adapter: Optional ``WorkdayIdentitySyncAdapter`` for
+            ``POST /org/sync/workday``.
+        rbac_enforcing: When ``False`` (default), RBAC gate-keeping on existing
+            form endpoints runs in **shadow mode** — it logs permission checks
+            but never blocks requests. Set to ``True`` only when nav-auth
+            policies are fully configured. Consistent with ``Policy.enforcing=False``.
     """
 
     def __init__(
@@ -65,12 +79,23 @@ class FormAPIHandler:
         submission_storage: "FormSubmissionStorage | None" = None,
         forwarder: "SubmissionForwarder | None" = None,
         partial_store: "PartialSaveStore | None" = None,
+        org_graph_service: "OrgGraphService | None" = None,
+        project_service: "ProjectService | None" = None,
+        rbac_service: "RBACService | None" = None,
+        workday_adapter: "WorkdayIdentitySyncAdapter | None" = None,
+        rbac_enforcing: bool = False,
     ) -> None:
         self.registry = registry
         self._client = client
         self._submission_storage = submission_storage
         self._forwarder = forwarder
         self._partial_store = partial_store
+        # FEAT-302 — Org Graph services
+        self._org_graph_service = org_graph_service
+        self._project_service = project_service
+        self._rbac_service = rbac_service
+        self._workday_adapter = workday_adapter
+        self.rbac_enforcing = rbac_enforcing
         self.schema_renderer = JsonSchemaRenderer()
         self.validator = FormValidator()
         self.logger = logging.getLogger(__name__)
@@ -715,6 +740,8 @@ class FormAPIHandler:
 
     async def create_form(self, request: web.Request) -> web.Response:
         """POST /api/v1/forms — Create a form from a natural language prompt."""
+        # FEAT-302: RBAC gate-keeping (shadow mode by default)
+        await self._rbac_shadow_gate(request, "create_form")
         # _create_tool was initialised with the client available at construction
         # time. Check its client directly rather than calling _get_llm_client()
         # again, so the guard accurately reflects the tool's actual state.
@@ -769,6 +796,8 @@ class FormAPIHandler:
         LLM along with the user's edit prompt, and returns the updated form.
         The LLM is instructed to strictly preserve the FormSchema JSON structure.
         """
+        # FEAT-302: RBAC gate-keeping (shadow mode by default)
+        await self._rbac_shadow_gate(request, "edit_form")
         if self._create_tool.client is None:
             return JSONResponse(
                 {"error": "No LLM client configured for form editing"},
@@ -891,6 +920,8 @@ class FormAPIHandler:
         ``FormValidator.check_schema()`` before persisting. Automatically bumps
         the form version.
         """
+        # FEAT-302: RBAC gate-keeping (shadow mode by default)
+        await self._rbac_shadow_gate(request, "update_form")
         form_id = request.match_info["form_id"]
         tenant = self._get_tenant(request)
         existing = await self.registry.get(form_id, tenant=tenant)
@@ -937,6 +968,8 @@ class FormAPIHandler:
         element-by-element. ``form_id`` cannot be changed via PATCH.
         Runs structural validation after merging. Automatically bumps version.
         """
+        # FEAT-302: RBAC gate-keeping (shadow mode by default)
+        await self._rbac_shadow_gate(request, "patch_form")
         form_id = request.match_info["form_id"]
         tenant = self._get_tenant(request)
         existing = await self.registry.get(form_id, tenant=tenant)
@@ -987,6 +1020,8 @@ class FormAPIHandler:
         resolve correctly). Returns ``204 No Content`` on success, ``404``
         when no form with the given id exists.
         """
+        # FEAT-302: RBAC gate-keeping (shadow mode by default)
+        await self._rbac_shadow_gate(request, "delete_form")
         form_id = request.match_info["form_id"]
         tenant = self._get_tenant(request)
         existing = await self.registry.get(form_id, tenant=tenant)
@@ -1552,3 +1587,391 @@ class FormAPIHandler:
                 status=404,
             )
         return web.json_response(report.model_dump(mode="json"))
+
+    # ------------------------------------------------------------------
+    # FEAT-302 — RBAC shadow-mode gate-keeping helper
+    # ------------------------------------------------------------------
+
+    async def _rbac_shadow_gate(
+        self,
+        request: web.Request,
+        codename: str,
+    ) -> None:
+        """Log RBAC gate-keeping check in shadow mode (never blocks).
+
+        When ``self.rbac_enforcing`` is ``False`` (default), this method
+        only logs a DEBUG message with the permission check result.
+        This is consistent with ``Policy.enforcing=False`` (nav-auth shadow
+        mode) — gate-keeping is visible in logs but never blocks deployments.
+
+        When ``self.rbac_enforcing`` is ``True`` and the user lacks the
+        permission, ``web.HTTPForbidden`` is raised.
+
+        Args:
+            request: Incoming aiohttp request.
+            codename: Permission codename to check (e.g. "create_form").
+        """
+        if self._rbac_service is None:
+            return
+
+        user = getattr(request, "user", None)
+        user_id = str(getattr(user, "id", "anonymous")) if user else "anonymous"
+        tenant = self._get_tenant(request)
+        # H-4: _get_programs() returns program SLUGS, not numeric IDs. There is
+        # no reliable numeric program_id in the slug-only session, so the gate
+        # resolves at tenant+user granularity (program_id=0). RBACService.resolve
+        # filters policies by user+tenant, so program scoping is not required here.
+        program_id = 0
+
+        try:
+            ctx = await self._rbac_service.resolve(
+                user_id, program_id=program_id, tenant=tenant
+            )
+            allowed = ctx.has_permission(codename)
+        except Exception as exc:  # noqa: BLE001
+            self.logger.debug(
+                "_rbac_shadow_gate: resolution failed for %s/%s: %s",
+                user_id,
+                codename,
+                exc,
+            )
+            return
+
+        if allowed:
+            self.logger.debug(
+                "_rbac_shadow_gate: ALLOW user=%s codename=%s tenant=%s",
+                user_id, codename, tenant,
+            )
+        else:
+            if self.rbac_enforcing:
+                self.logger.warning(
+                    "_rbac_shadow_gate: DENY (enforcing) user=%s codename=%s tenant=%s",
+                    user_id, codename, tenant,
+                )
+                raise web.HTTPForbidden(
+                    reason=f"Permission denied: {codename}"
+                )
+            else:
+                self.logger.debug(
+                    "_rbac_shadow_gate: WOULD-DENY (shadow) user=%s codename=%s tenant=%s",
+                    user_id, codename, tenant,
+                )
+
+    # ------------------------------------------------------------------
+    # FEAT-302 — Org Graph endpoints
+    # ------------------------------------------------------------------
+
+    async def get_org_graph(self, request: web.Request) -> web.Response:
+        """GET /api/v1/org/graph — Return the org graph for the session's org.
+
+        Calls ``OrgGraphService.get_graph()`` using the org_id extracted from
+        the navigator-auth session (``request.user.organizations[0].org_id``).
+
+        Args:
+            request: Incoming HTTP request with navigator-auth session.
+
+        Returns:
+            200: Serialized ``OrgGraph`` as JSON.
+            400: Missing org_id in session.
+            501: OrgGraphService not configured.
+        """
+        if self._org_graph_service is None:
+            return JSONResponse(
+                {"error": "OrgGraphService not configured"}, status=501
+            )
+
+        org_id = self._get_org_id(request)
+        if org_id is None:
+            return JSONResponse(
+                {"error": "org_id not found in session"}, status=400
+            )
+
+        tenant = self._get_tenant(request)
+        try:
+            graph = await self._org_graph_service.get_graph(org_id, tenant=tenant)
+        except KeyError as exc:
+            return JSONResponse({"error": str(exc)}, status=404)
+        except Exception as exc:
+            self.logger.exception("get_org_graph failed: %s", exc)
+            return JSONResponse({"error": "Internal server error"}, status=500)
+
+        return JSONResponse(graph.model_dump(mode="json"), status=200)
+
+    async def create_project(self, request: web.Request) -> web.Response:
+        """POST /api/v1/org/projects — Create a fieldsync project.
+
+        Request body::
+
+            {
+                "accounting_code": "ACC-001",
+                "name": "Q1 Campaign",
+                "client_id": 42,
+                "org_id": 7
+            }
+
+        Args:
+            request: Incoming HTTP request.
+
+        Returns:
+            201: Created ``Project`` as JSON.
+            400: Invalid/missing fields.
+            409: Duplicate accounting_code for client.
+            501: ProjectService not configured.
+        """
+        if self._project_service is None:
+            return JSONResponse(
+                {"error": "ProjectService not configured"}, status=501
+            )
+
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, ValueError):
+            return JSONResponse({"error": "Invalid JSON body"}, status=400)
+
+        accounting_code = body.get("accounting_code")
+        if not accounting_code:
+            return JSONResponse(
+                {"error": "accounting_code is required"}, status=400
+            )
+
+        client_id = body.get("client_id")
+        if client_id is None:
+            return JSONResponse({"error": "client_id is required"}, status=400)
+        # H-2: reject non-numeric client_id with 400, not 500.
+        try:
+            client_id_int = int(client_id)
+        except (TypeError, ValueError):
+            return JSONResponse(
+                {"error": "client_id must be an integer"}, status=400
+            )
+
+        # C-4 (write isolation): org_id comes from the authenticated session,
+        # NEVER from the request body — a caller cannot create a project under
+        # another tenant's org.
+        org_id = self._get_org_id(request)
+        if org_id is None:
+            return JSONResponse(
+                {"error": "org_id not found in session"}, status=400
+            )
+
+        tenant = self._get_tenant(request)
+        try:
+            project = await self._project_service.create_project(
+                accounting_code=str(accounting_code),
+                name=body.get("name"),
+                client_id=client_id_int,
+                org_id=org_id,
+                tenant=tenant,
+            )
+        except Exception as exc:
+            from ..services.project_service import DuplicateAccountingCodeError
+
+            if isinstance(exc, DuplicateAccountingCodeError):
+                return JSONResponse({"error": str(exc)}, status=409)
+            self.logger.exception("create_project failed: %s", exc)
+            return JSONResponse({"error": "Internal server error"}, status=500)
+
+        return JSONResponse(project.model_dump(mode="json"), status=201)
+
+    async def map_project_workday(self, request: web.Request) -> web.Response:
+        """POST /api/v1/org/cost-centers/{project_id}/workday-map
+
+        Maps a fieldsync project to a Workday cost center code.
+
+        Request body::
+
+            {"workday_code": "WD-99001"}
+
+        Args:
+            request: Incoming HTTP request (path param: ``project_id``).
+
+        Returns:
+            200: ``WorkdayCostCenterMapping`` as JSON.
+            400: Missing workday_code.
+            404: Project not found.
+            501: ProjectService not configured.
+        """
+        if self._project_service is None:
+            return JSONResponse(
+                {"error": "ProjectService not configured"}, status=501
+            )
+
+        project_id_str = request.match_info.get("project_id", "")
+        try:
+            project_id = int(project_id_str)
+        except (ValueError, TypeError):
+            return JSONResponse(
+                {"error": f"Invalid project_id: {project_id_str!r}"}, status=400
+            )
+
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, ValueError):
+            return JSONResponse({"error": "Invalid JSON body"}, status=400)
+
+        workday_code = body.get("workday_code")
+        if not workday_code:
+            return JSONResponse({"error": "workday_code is required"}, status=400)
+
+        tenant = self._get_tenant(request)
+        try:
+            mapping = await self._project_service.map_to_workday(
+                project_id, str(workday_code), tenant=tenant
+            )
+        except Exception as exc:
+            from ..services.project_service import ProjectNotFoundError
+
+            if isinstance(exc, ProjectNotFoundError):
+                return JSONResponse({"error": str(exc)}, status=404)
+            self.logger.exception("map_project_workday failed: %s", exc)
+            return JSONResponse({"error": "Internal server error"}, status=500)
+
+        return JSONResponse(mapping.model_dump(mode="json"), status=200)
+
+    async def assign_user_role(self, request: web.Request) -> web.Response:
+        """POST /api/v1/org/users/{user_id}/assign — Assign a role to a user.
+
+        Compiles the given scope + codename to an ABAC policy and persists it
+        in ``fieldsync.auth_policies``. NEVER writes to ``auth.user_permissions``.
+
+        Request body::
+
+            {
+                "codename": "edit_form",
+                "scope": "own",
+                "program_id": 7
+            }
+
+        Args:
+            request: Incoming HTTP request (path param: ``user_id``).
+
+        Returns:
+            200: ``PermissionRecord`` as JSON.
+            400: Missing/invalid fields.
+            501: RBACService not configured.
+        """
+        if self._rbac_service is None:
+            return JSONResponse(
+                {"error": "RBACService not configured"}, status=501
+            )
+
+        user_id = request.match_info.get("user_id", "")
+        if not user_id:
+            return JSONResponse({"error": "user_id is required"}, status=400)
+
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, ValueError):
+            return JSONResponse({"error": "Invalid JSON body"}, status=400)
+
+        codename = body.get("codename")
+        scope_str = body.get("scope")
+        program_id = body.get("program_id")
+
+        if not codename:
+            return JSONResponse({"error": "codename is required"}, status=400)
+        if not scope_str:
+            return JSONResponse({"error": "scope is required"}, status=400)
+        if program_id is None:
+            return JSONResponse({"error": "program_id is required"}, status=400)
+
+        from ..services.rbac import RBACScope
+
+        try:
+            scope = RBACScope(scope_str)
+        except ValueError:
+            valid = [s.value for s in RBACScope]
+            return JSONResponse(
+                {"error": f"Invalid scope {scope_str!r}; valid: {valid}"},
+                status=400,
+            )
+
+        tenant = self._get_tenant(request)
+
+        # H-1: assigning roles is a privileged action — ALWAYS enforce (never
+        # shadow-only). The caller must hold the "manage_roles" permission.
+        caller = getattr(request, "user", None)
+        caller_id = str(getattr(caller, "id", "anonymous")) if caller else "anonymous"
+        try:
+            caller_ctx = await self._rbac_service.resolve(
+                caller_id, program_id=int(program_id), tenant=tenant
+            )
+            if not caller_ctx.has_permission("manage_roles"):
+                return JSONResponse(
+                    {"error": "Permission denied: manage_roles required"},
+                    status=403,
+                )
+        except Exception as exc:  # noqa: BLE001
+            self.logger.warning(
+                "assign_user_role: privilege check failed for %s: %s",
+                caller_id, exc,
+            )
+            return JSONResponse(
+                {"error": "Permission denied: manage_roles required"},
+                status=403,
+            )
+
+        try:
+            record = await self._rbac_service.assign_role(
+                user_id,
+                program_id=int(program_id),
+                codename=str(codename),
+                scope=scope,
+                tenant=tenant,
+            )
+        except Exception as exc:
+            self.logger.exception("assign_user_role failed: %s", exc)
+            return JSONResponse({"error": "Internal server error"}, status=500)
+
+        return JSONResponse(record.model_dump(mode="json"), status=200)
+
+    async def sync_workday_identities(self, request: web.Request) -> web.Response:
+        """POST /api/v1/org/sync/workday — Trigger Workday identity sync (stub).
+
+        Calls ``WorkdayIdentitySyncAdapter.sync_user()`` which is a stub in
+        FEAT-302 (FEAT-026/027 not available). Always returns 202 Accepted.
+
+        Request body::
+
+            {"user_id": "user-abc", "action": "provision", "org_id": 7}
+
+        Args:
+            request: Incoming HTTP request.
+
+        Returns:
+            202: Stub acceptance dict as JSON.
+            400: Missing/invalid fields.
+            501: WorkdayIdentitySyncAdapter not configured.
+        """
+        if self._workday_adapter is None:
+            return JSONResponse(
+                {"error": "WorkdayIdentitySyncAdapter not configured"}, status=501
+            )
+
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, ValueError):
+            return JSONResponse({"error": "Invalid JSON body"}, status=400)
+
+        user_id = body.get("user_id")
+        action = body.get("action")
+        org_id = body.get("org_id")
+
+        if not user_id:
+            return JSONResponse({"error": "user_id is required"}, status=400)
+        if action not in ("provision", "deprovision"):
+            return JSONResponse(
+                {"error": "action must be 'provision' or 'deprovision'"}, status=400
+            )
+        if org_id is None:
+            return JSONResponse({"error": "org_id is required"}, status=400)
+
+        try:
+            result = await self._workday_adapter.sync_user(
+                str(user_id), action=action, org_id=int(org_id)
+            )
+        except Exception as exc:
+            self.logger.exception("sync_workday_identities failed: %s", exc)
+            return JSONResponse({"error": "Internal server error"}, status=500)
+
+        return JSONResponse(result, status=202)

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/api/routes.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/api/routes.py
@@ -49,9 +49,13 @@ if TYPE_CHECKING:
 
     from ..services.blob_storage import AbstractBlobStorage
     from ..services.forwarder import SubmissionForwarder
+    from ..services.org_graph import OrgGraphService
     from ..services.partial_saves import PartialSaveStore
+    from ..services.project_service import ProjectService
+    from ..services.rbac import RBACService
     from ..services.rest_field_resolver import RestFieldResolver
     from ..services.submissions import FormSubmissionStorage
+    from ..services.workday_sync import WorkdayIdentitySyncAdapter
 
 
 logger = logging.getLogger(__name__)
@@ -99,6 +103,11 @@ def setup_form_api(
     synthesizer: "VoiceSynthesizer | None" = None,
     transcriber: "FasterWhisperBackend | None" = None,
     token_validator: "TokenValidator | None" = None,
+    org_graph_service: "OrgGraphService | None" = None,
+    project_service: "ProjectService | None" = None,
+    rbac_service: "RBACService | None" = None,
+    workday_adapter: "WorkdayIdentitySyncAdapter | None" = None,
+    rbac_enforcing: bool = False,
 ) -> None:
     """Mount the JSON REST surface on ``app`` under ``base_path``.
 
@@ -136,6 +145,13 @@ def setup_form_api(
             Providing it (or ``token_validator``) mounts the audio WS endpoint.
         token_validator: Optional ``TokenValidator`` for audio-form WebSocket
             JWT authentication. Providing it mounts the audio WS endpoint.
+        org_graph_service: Optional ``OrgGraphService`` for ``GET /org/graph``.
+        project_service: Optional ``ProjectService`` for org project endpoints.
+        rbac_service: Optional ``RBACService`` for RBAC policy endpoints.
+        workday_adapter: Optional ``WorkdayIdentitySyncAdapter`` for
+            ``POST /org/sync/workday``.
+        rbac_enforcing: When ``False`` (default), RBAC gate-keeping on existing
+            form endpoints runs in shadow mode (log only, never block).
     """
     # Stash the registry on the app for the dispatcher / operations handler.
     # Guard: skip if already set (FormRegistry.__init__ sets it when app= is
@@ -174,6 +190,11 @@ def setup_form_api(
         submission_storage=submission_storage,
         forwarder=forwarder,
         partial_store=partial_store,
+        org_graph_service=org_graph_service,
+        project_service=project_service,
+        rbac_service=rbac_service,
+        workday_adapter=workday_adapter,
+        rbac_enforcing=rbac_enforcing,
     )
 
     bp = base_path.rstrip("/")
@@ -306,6 +327,25 @@ def setup_form_api(
     app.router.add_get(
         f"{bp}/forms/{{form_id}}/import-report",
         _wrap_auth(handler.get_import_report),
+    )
+
+    # FEAT-302 — Org Graph + RBAC + Projects + Workday sync
+    app.router.add_get(
+        f"{bp}/org/graph", _wrap_auth(handler.get_org_graph)
+    )
+    app.router.add_post(
+        f"{bp}/org/projects", _wrap_auth(handler.create_project)
+    )
+    app.router.add_post(
+        f"{bp}/org/cost-centers/{{project_id}}/workday-map",
+        _wrap_auth(handler.map_project_workday),
+    )
+    app.router.add_post(
+        f"{bp}/org/users/{{user_id}}/assign",
+        _wrap_auth(handler.assign_user_role),
+    )
+    app.router.add_post(
+        f"{bp}/org/sync/workday", _wrap_auth(handler.sync_workday_identities)
     )
 
     logger.info("setup_form_api: mounted on %s", bp)

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/fieldsync_schema.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/fieldsync_schema.py
@@ -1,0 +1,143 @@
+"""DDL canónico para el schema ``fieldsync`` — idempotente, sin migraciones.
+
+El schema ``fieldsync`` es el *system of record* de FEAT-302:
+
+- ``fieldsync.projects`` — proyectos internos (contienen ``accounting_code``
+  = cost center propio; UNIQUE por ``(client_id, accounting_code)``).
+- ``fieldsync.workday_cost_center_mappings`` — mapeo de salida hacia Workday;
+  un proyecto → un código Workday (UNIQUE por ``project_id``).
+- ``fieldsync.auth_policies`` — policies ABAC/PBAC persistidas como JSONB;
+  compatibles con el formato YAML del engine de nav-auth.
+
+Diseño:
+- NUNCA se lee ni escribe directamente sobre ``networkninja.projects``.
+  El seed inicial (scripts/seed_fieldsync_projects.py) lee de allí solo
+  para poblar ``fieldsync.projects``; después este schema es autónomo.
+- DDL 100% idempotente: ``CREATE SCHEMA IF NOT EXISTS`` +
+  ``CREATE TABLE IF NOT EXISTS``; segunda ejecución no falla.
+- Sin framework de migraciones; columnas añadidas en futuras tasks con
+  ALTER TABLE idempotente o un script de migración explícito.
+
+Uso::
+
+    pool = await asyncpg.create_pool(dsn=...)
+    schema_mgr = FieldsyncSchemaManager(pool)
+    await schema_mgr.initialize()  # crea schema + 3 tablas si no existen
+"""
+
+from __future__ import annotations
+
+import logging
+
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# DDL constants
+# ---------------------------------------------------------------------------
+
+_CREATE_SCHEMA_SQL = "CREATE SCHEMA IF NOT EXISTS fieldsync;"
+
+_CREATE_PROJECTS_SQL = """
+CREATE TABLE IF NOT EXISTS fieldsync.projects (
+    project_id      SERIAL PRIMARY KEY,
+    client_id       INTEGER NOT NULL,
+    name            VARCHAR(255),
+    description     TEXT,
+    accounting_code VARCHAR(100) NOT NULL,
+    start_timestamp TIMESTAMPTZ,
+    end_timestamp   TIMESTAMPTZ,
+    is_active       BOOLEAN NOT NULL DEFAULT TRUE,
+    org_id          INTEGER,
+    inserted_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_projects_client_accounting UNIQUE (client_id, accounting_code)
+);
+"""
+
+_CREATE_WORKDAY_COST_CENTER_MAPPINGS_SQL = """
+CREATE TABLE IF NOT EXISTS fieldsync.workday_cost_center_mappings (
+    id           SERIAL PRIMARY KEY,
+    project_id   INTEGER NOT NULL
+                   REFERENCES fieldsync.projects (project_id)
+                   ON DELETE CASCADE,
+    workday_code VARCHAR(100) NOT NULL,
+    direction    VARCHAR(50) NOT NULL DEFAULT 'internal_to_workday',
+    CONSTRAINT uq_workday_mapping_project UNIQUE (project_id)
+);
+"""
+
+_CREATE_AUTH_POLICIES_SQL = """
+CREATE TABLE IF NOT EXISTS fieldsync.auth_policies (
+    id         SERIAL PRIMARY KEY,
+    name       VARCHAR(255) UNIQUE NOT NULL,
+    policy     JSONB NOT NULL,
+    tenant     VARCHAR(63),
+    priority   INTEGER NOT NULL DEFAULT 50,
+    enforcing  BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+"""
+
+# Ordered list of DDL statements executed by ``initialize()``.
+_ALL_DDL: list[str] = [
+    _CREATE_SCHEMA_SQL,
+    _CREATE_PROJECTS_SQL,
+    _CREATE_WORKDAY_COST_CENTER_MAPPINGS_SQL,
+    _CREATE_AUTH_POLICIES_SQL,
+]
+
+
+class FieldsyncSchemaManager:
+    """Apply the canonical ``fieldsync`` DDL to a Postgres database.
+
+    All DDL statements are idempotent — executing ``initialize()`` twice on
+    the same database is safe and produces no side effects.
+
+    This class never opens a connection itself; it receives an existing
+    asyncpg pool (or a compatible fake pool for unit tests).
+
+    Args:
+        pool: asyncpg connection pool (or fake with the same ``acquire()``
+            async context manager interface).
+
+    Example::
+
+        pool = await asyncpg.create_pool(dsn=DB_DSN)
+        mgr = FieldsyncSchemaManager(pool)
+        await mgr.initialize()
+    """
+
+    def __init__(self, pool: Any) -> None:
+        self._pool = pool
+        self.logger = logging.getLogger(__name__)
+
+    async def initialize(self) -> None:
+        """Run all DDL statements in order, creating schema + 3 tables.
+
+        Idempotent: safe to call on startup even if the objects already exist.
+
+        Raises:
+            Exception: Any asyncpg error propagates as-is (e.g. permission
+                denied, connection error).
+        """
+        async with self._pool.acquire() as conn:
+            for sql in _ALL_DDL:
+                self.logger.debug("fieldsync DDL: %s", sql.strip()[:80])
+                await conn.execute(sql)
+        self.logger.info("fieldsync schema initialized (idempotent)")
+
+    # ------------------------------------------------------------------
+    # Introspection helpers (useful for tests)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def ddl_statements() -> list[str]:
+        """Return the ordered list of DDL SQL strings (read-only copy).
+
+        Returns:
+            List of SQL strings in execution order.
+        """
+        return list(_ALL_DDL)

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/org_graph.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/org_graph.py
@@ -1,0 +1,418 @@
+"""OrgGraphService — árbol multi-jerarquía read-only sobre auth.* + geografía.
+
+Lee tablas de solo-lectura:
+- ``auth.organizations``, ``auth.organization_clients``, ``auth.clients``,
+  ``auth.programs``, ``auth.program_clients``
+- Geografía per-client: ``networkninja.markets``, ``networkninja.districts``,
+  ``networkninja.regions``
+- Proyectos propios: ``fieldsync.projects``
+
+Principios de diseño (§8 spec):
+- **Hard tenant isolation**: todo query filtra ``org_id`` / ``client_id``
+  explícitamente; sin leakage cross-tenant.
+- **SQL 100% parametrizado**: valores siempre vía ``$1``/``$2`` etc.;
+  nombres de schema/tabla fijados como constantes (no interpolados desde
+  input de usuario).
+- **Múltiples jerarquías**: un "company" super-node agrupa todas las
+  sub-jerarquías del tenant (por si un cliente tiene >1 organización).
+- **Read-only**: no hay ningún INSERT/UPDATE/DELETE en este servicio.
+- **Pool inyectado**: acepta pool o fake-pool para testabilidad completa.
+
+Uso::
+
+    svc = OrgGraphService(pool)
+    graph = await svc.get_graph(org_id=7, tenant="myco")
+    node  = await svc.get_node("client", "42", tenant="myco")
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Node type literal
+# ---------------------------------------------------------------------------
+
+NodeType = Literal[
+    "organization",
+    "company",
+    "client",
+    "program",
+    "project",
+    "market",
+    "district",
+    "region",
+    "territory",
+    "store",
+]
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+class OrgNode(BaseModel):
+    """A single node in the organizational hierarchy.
+
+    Attributes:
+        node_type: Type of the node (organization, client, program, etc.).
+        node_id: String identifier unique within the ``node_type`` namespace.
+        parent_id: String identifier of the parent node, or ``None`` for root.
+        metadata: Arbitrary key-value metadata (name, client_id, etc.).
+        children: Nested child nodes (populated up to requested ``depth``).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    node_type: NodeType
+    node_id: str
+    parent_id: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    children: list["OrgNode"] = Field(default_factory=list)
+
+
+class OrgGraph(BaseModel):
+    """Full organizational graph for a tenant.
+
+    Attributes:
+        org_id: Numeric identifier of the organization.
+        tenant: Tenant slug (program slug from navigator-auth).
+        root: Root ``OrgNode`` (type ``"company"``); children are the tree.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    org_id: int
+    tenant: str
+    root: OrgNode
+
+
+# ---------------------------------------------------------------------------
+# SQL constants — schema/table names are FIXED constants, never interpolated
+# from user input.
+# ---------------------------------------------------------------------------
+
+_SQL_GET_ORG = """
+SELECT org_id, name
+FROM auth.organizations
+WHERE org_id = $1
+"""
+
+_SQL_GET_CLIENTS = """
+SELECT c.client_id, c.client_name
+FROM auth.clients c
+JOIN auth.organization_clients oc ON oc.client_id = c.client_id
+WHERE oc.org_id = $1
+"""
+
+_SQL_GET_PROGRAMS_FOR_CLIENT = """
+SELECT p.program_id, p.program_name
+FROM auth.programs p
+JOIN auth.program_clients pc ON pc.program_id = p.program_id
+WHERE pc.client_id = $1
+"""
+
+_SQL_GET_PROJECTS_FOR_CLIENT = """
+SELECT project_id, name, accounting_code, org_id, is_active
+FROM fieldsync.projects
+WHERE client_id = $1 AND org_id = $2
+"""
+
+_SQL_GET_MARKETS_FOR_CLIENT = """
+SELECT market_id, market_name
+FROM networkninja.markets
+WHERE client_id = $1 AND orgid = $2
+"""
+
+_SQL_GET_DISTRICTS_FOR_CLIENT = """
+SELECT district_id, district_name
+FROM networkninja.districts
+WHERE client_id = $1 AND orgid = $2
+"""
+
+_SQL_GET_REGIONS_FOR_CLIENT = """
+SELECT region_id, region_name
+FROM networkninja.regions
+WHERE client_id = $1 AND orgid = $2
+"""
+
+# Tenant-scoped single-node lookups (hard isolation: filtered by org_id).
+_SQL_GET_CLIENT_SCOPED = """
+SELECT c.client_id, c.client_name
+FROM auth.clients c
+JOIN auth.organization_clients oc ON oc.client_id = c.client_id
+WHERE c.client_id = $1 AND oc.org_id = $2
+"""
+
+_SQL_GET_PROGRAM_SCOPED = """
+SELECT DISTINCT p.program_id, p.program_name
+FROM auth.programs p
+JOIN auth.program_clients pc ON pc.program_id = p.program_id
+JOIN auth.organization_clients oc ON oc.client_id = pc.client_id
+WHERE p.program_id = $1 AND oc.org_id = $2
+"""
+
+# ---------------------------------------------------------------------------
+# OrgGraphService
+# ---------------------------------------------------------------------------
+
+
+class OrgGraphService:
+    """Build in-memory org-graph trees from navigator-auth + networkninja.
+
+    Designed for read-only access. Enforces hard tenant isolation by always
+    filtering on ``org_id`` / ``client_id`` passed as parameters.
+
+    Args:
+        pool: asyncpg pool (or compatible fake). When ``None``, falls back
+            to creating a pool from ``FIELDSYNC_AUTH_RO_DSN`` env var.
+            In unit tests pass a fake pool explicitly.
+
+    Example::
+
+        svc = OrgGraphService(pool)
+        graph = await svc.get_graph(7, tenant="acme")
+    """
+
+    def __init__(self, pool: Any | None = None) -> None:
+        self._pool: Any | None = pool
+        self.logger = logging.getLogger(__name__)
+
+    async def _get_pool(self) -> Any:
+        """Return pool, creating one from env DSN if needed.
+
+        Returns:
+            asyncpg pool or fake pool.
+
+        Raises:
+            RuntimeError: If no pool was provided and ``FIELDSYNC_AUTH_RO_DSN``
+                is not set.
+        """
+        if self._pool is not None:
+            return self._pool
+        dsn = os.environ.get("FIELDSYNC_AUTH_RO_DSN")
+        if not dsn:
+            raise RuntimeError(
+                "OrgGraphService: no pool provided and FIELDSYNC_AUTH_RO_DSN is not set"
+            )
+        try:
+            import asyncpg  # type: ignore[import-untyped]
+        except ImportError as exc:
+            raise RuntimeError("asyncpg is required for OrgGraphService") from exc
+        self._pool = await asyncpg.create_pool(dsn, min_size=1, max_size=5)
+        return self._pool
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def get_graph(
+        self,
+        org_id: int,
+        *,
+        tenant: str,
+        depth: int = 3,
+    ) -> OrgGraph:
+        """Build the full org graph for ``org_id`` / ``tenant``.
+
+        Args:
+            org_id: Numeric organization identifier.
+            tenant: Tenant slug (used for metadata and isolation).
+            depth: How many levels deep to traverse (default 3).  Level 0 =
+                company root only; 1 = + orgs; 2 = + clients/programs; 3 =
+                + projects/geography.
+
+        Returns:
+            ``OrgGraph`` with a ``"company"`` root node containing all
+            discovered sub-hierarchies.
+
+        Raises:
+            KeyError: If the organization is not found.
+            RuntimeError: If no pool is available.
+        """
+        pool = await self._get_pool()
+
+        async with pool.acquire() as conn:
+            # Level 1: resolve the organization
+            org_row = await conn.fetchrow(_SQL_GET_ORG, org_id)
+            if org_row is None:
+                raise KeyError(f"Organization {org_id} not found")
+
+            org_node = OrgNode(
+                node_type="organization",
+                node_id=str(org_id),
+                parent_id=f"company:{tenant}",  # parent is the company root
+                metadata={"name": org_row["name"] if "name" in org_row.keys() else str(org_id)},
+            )
+
+            client_nodes: list[OrgNode] = []
+            if depth >= 2:
+                client_rows = await conn.fetch(_SQL_GET_CLIENTS, org_id)
+                for crow in client_rows:
+                    client_id = crow["client_id"]
+                    client_node = OrgNode(
+                        node_type="client",
+                        node_id=str(client_id),
+                        parent_id=str(org_id),
+                        metadata={
+                            "client_name": crow["client_name"],
+                            "client_id": client_id,
+                        },
+                    )
+
+                    if depth >= 3:
+                        # Programs
+                        prog_rows = await conn.fetch(
+                            _SQL_GET_PROGRAMS_FOR_CLIENT, client_id
+                        )
+                        for prow in prog_rows:
+                            prog_node = OrgNode(
+                                node_type="program",
+                                node_id=str(prow["program_id"]),
+                                parent_id=str(client_id),
+                                metadata={
+                                    "program_name": prow["program_name"],
+                                    "program_id": prow["program_id"],
+                                },
+                            )
+                            client_node.children.append(prog_node)
+
+                        # Projects
+                        proj_rows = await conn.fetch(
+                            _SQL_GET_PROJECTS_FOR_CLIENT, client_id, org_id
+                        )
+                        for proj in proj_rows:
+                            proj_node = OrgNode(
+                                node_type="project",
+                                node_id=str(proj["project_id"]),
+                                parent_id=str(client_id),
+                                metadata={
+                                    "name": proj["name"],
+                                    "accounting_code": proj["accounting_code"],
+                                    "is_active": proj["is_active"],
+                                },
+                            )
+                            client_node.children.append(proj_node)
+
+                        # Geography: regions, districts, markets (per-client)
+                        for _sql, _ntype, _id_col, _name_col in (
+                            (_SQL_GET_REGIONS_FOR_CLIENT, "region", "region_id", "region_name"),
+                            (_SQL_GET_DISTRICTS_FOR_CLIENT, "district", "district_id", "district_name"),
+                            (_SQL_GET_MARKETS_FOR_CLIENT, "market", "market_id", "market_name"),
+                        ):
+                            geo_rows = await conn.fetch(_sql, client_id, org_id)
+                            for g in geo_rows:
+                                client_node.children.append(OrgNode(
+                                    node_type=_ntype,
+                                    node_id=str(g[_id_col]),
+                                    parent_id=str(client_id),
+                                    metadata={_name_col: g[_name_col]},
+                                ))
+
+                    client_nodes.append(client_node)
+
+            org_node.children = client_nodes
+
+        # Company super-root groups all organizations under this tenant
+        company_root = OrgNode(
+            node_type="company",
+            node_id=f"company:{tenant}",
+            parent_id=None,
+            metadata={"tenant": tenant},
+            children=[org_node],
+        )
+
+        return OrgGraph(org_id=org_id, tenant=tenant, root=company_root)
+
+    async def get_node(
+        self,
+        node_type: NodeType,
+        node_id: str,
+        *,
+        tenant: str,
+        org_id: int,
+    ) -> OrgNode:
+        """Retrieve a single node by type and ID, enforcing tenant isolation.
+
+        Currently supports ``"organization"``, ``"client"``, and ``"program"``
+        node types. Other types return a stub node with metadata from a
+        best-effort query.
+
+        Args:
+            node_type: Type of node to retrieve.
+            node_id: String identifier for the node.
+            tenant: Tenant slug for isolation (stored in metadata).
+
+        Returns:
+            ``OrgNode`` with ``metadata`` populated from the DB.
+
+        Raises:
+            KeyError: If the node is not found.
+            RuntimeError: If no pool is available.
+        """
+        pool = await self._get_pool()
+
+        async with pool.acquire() as conn:
+            if node_type == "organization":
+                # Hard isolation: a caller may only resolve its own session org.
+                if int(node_id) != org_id:
+                    raise KeyError(f"Organization {node_id} not found")
+                row = await conn.fetchrow(_SQL_GET_ORG, int(node_id))
+                if row is None:
+                    raise KeyError(f"Organization {node_id} not found")
+                return OrgNode(
+                    node_type="organization",
+                    node_id=node_id,
+                    metadata={
+                        "name": row["name"] if "name" in row.keys() else node_id,
+                        "tenant": tenant,
+                    },
+                )
+
+            if node_type == "client":
+                # Hard isolation: client must belong to the caller's org.
+                rows = await conn.fetch(
+                    _SQL_GET_CLIENT_SCOPED, int(node_id), org_id
+                )
+                if not rows:
+                    raise KeyError(f"Client {node_id} not found")
+                row = rows[0]
+                return OrgNode(
+                    node_type="client",
+                    node_id=node_id,
+                    metadata={
+                        "client_name": row["client_name"],
+                        "tenant": tenant,
+                    },
+                )
+
+            if node_type == "program":
+                # Hard isolation: program must reach the caller's org via
+                # program_clients → organization_clients.
+                rows = await conn.fetch(
+                    _SQL_GET_PROGRAM_SCOPED, int(node_id), org_id
+                )
+                if not rows:
+                    raise KeyError(f"Program {node_id} not found")
+                row = rows[0]
+                return OrgNode(
+                    node_type="program",
+                    node_id=node_id,
+                    metadata={
+                        "program_name": row["program_name"],
+                        "tenant": tenant,
+                    },
+                )
+
+        # Geography / store node types are only available within get_graph();
+        # a direct single-node lookup is not supported (fail loudly, no stub).
+        raise NotImplementedError(
+            f"get_node does not support node_type={node_type!r}; "
+            "use get_graph() for geography/store nodes"
+        )

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/project_service.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/project_service.py
@@ -1,0 +1,390 @@
+"""ProjectService — CRUD sobre ``fieldsync.projects`` + mapping Workday.
+
+Implementa el *system of record* de proyectos internos (FEAT-302 Module 2):
+- ``create_project`` / ``get_project`` / ``list_projects``
+- ``map_to_workday`` (upsert en ``fieldsync.workday_cost_center_mappings``)
+
+Reglas de negocio confirmadas (§8 spec):
+- ``accounting_code`` es el **cost center interno**; NUNCA se importa desde
+  Workday (Workday es destino de salida, no fuente).
+- UNIQUE ``(client_id, accounting_code)`` — duplicate → ``DuplicateAccountingCodeError``.
+- ``map_to_workday`` hace UPSERT por ``project_id`` (un proyecto tiene como
+  máximo un Workday mapping).
+- NUNCA se escribe en ``networkninja.projects``.
+
+Diseño:
+- Pool inyectado en constructor → testable sin DB real.
+- SQL 100% parametrizado ($1, $2…); nombres de tabla fijados en constantes.
+- Pydantic v2 para modelos de datos.
+
+Uso::
+
+    svc = ProjectService(pool)
+    proj = await svc.create_project(
+        accounting_code="ACC-001",
+        name="Q1 Campaign",
+        client_id=42,
+        org_id=7,
+        tenant="acme",
+    )
+    mapping = await svc.map_to_workday(proj.project_id, "WD-99001", tenant="acme")
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class DuplicateAccountingCodeError(Exception):
+    """Raised when ``(client_id, accounting_code)`` already exists.
+
+    Attributes:
+        client_id: Client the conflict belongs to.
+        accounting_code: The duplicate code.
+    """
+
+    def __init__(self, client_id: int, accounting_code: str) -> None:
+        self.client_id = client_id
+        self.accounting_code = accounting_code
+        super().__init__(
+            f"accounting_code {accounting_code!r} already exists for client {client_id}"
+        )
+
+
+class ProjectNotFoundError(Exception):
+    """Raised when a project lookup returns no row.
+
+    Attributes:
+        project_id: The missing project identifier.
+    """
+
+    def __init__(self, project_id: int) -> None:
+        self.project_id = project_id
+        super().__init__(f"Project {project_id} not found")
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+class Project(BaseModel):
+    """A project stored in ``fieldsync.projects``.
+
+    Attributes:
+        project_id: Auto-incremented serial PK.
+        name: Human-readable project name.
+        accounting_code: Internal cost center code (source of truth).
+        client_id: Client this project belongs to.
+        org_id: Organization identifier.
+        start_timestamp: Optional project start date.
+        end_timestamp: Optional project end date.
+        is_active: Whether the project is currently active.
+        tenant: Tenant slug (metadata, not stored in the table directly).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    project_id: int
+    name: str | None
+    accounting_code: str
+    client_id: int
+    org_id: int | None
+    start_timestamp: datetime | None = None
+    end_timestamp: datetime | None = None
+    is_active: bool = True
+    tenant: str | None = None
+
+
+class WorkdayCostCenterMapping(BaseModel):
+    """Mapping from an internal project to a Workday cost center code.
+
+    Attributes:
+        project_id: FK to ``fieldsync.projects``.
+        workday_code: Workday cost center identifier (output side only).
+        direction: Flow direction; default is ``"internal_to_workday"``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    project_id: int
+    workday_code: str
+    direction: str = "internal_to_workday"
+
+
+# ---------------------------------------------------------------------------
+# SQL constants (table names FIXED in constants — not from user input)
+# ---------------------------------------------------------------------------
+
+_INSERT_PROJECT_SQL = """
+INSERT INTO fieldsync.projects
+    (client_id, name, accounting_code, org_id)
+VALUES ($1, $2, $3, $4)
+RETURNING project_id, client_id, name, accounting_code, org_id,
+          start_timestamp, end_timestamp, is_active
+"""
+
+_SELECT_PROJECT_SQL = """
+SELECT project_id, client_id, name, accounting_code, org_id,
+       start_timestamp, end_timestamp, is_active
+FROM fieldsync.projects
+WHERE project_id = $1 AND org_id = $2
+"""
+
+_SELECT_PROJECTS_BY_CLIENT_SQL = """
+SELECT project_id, client_id, name, accounting_code, org_id,
+       start_timestamp, end_timestamp, is_active
+FROM fieldsync.projects
+WHERE client_id = $1 AND org_id = $2
+ORDER BY project_id
+"""
+
+_SELECT_PROJECTS_BY_ORG_SQL = """
+SELECT project_id, client_id, name, accounting_code, org_id,
+       start_timestamp, end_timestamp, is_active
+FROM fieldsync.projects
+WHERE org_id = $1
+ORDER BY project_id
+"""
+
+_UPSERT_WORKDAY_MAPPING_SQL = """
+INSERT INTO fieldsync.workday_cost_center_mappings
+    (project_id, workday_code, direction)
+VALUES ($1, $2, $3)
+ON CONFLICT (project_id) DO UPDATE
+    SET workday_code = EXCLUDED.workday_code,
+        direction    = EXCLUDED.direction
+RETURNING project_id, workday_code, direction
+"""
+
+_SELECT_WORKDAY_MAPPING_SQL = """
+SELECT project_id, workday_code, direction
+FROM fieldsync.workday_cost_center_mappings
+WHERE project_id = $1
+"""
+
+# asyncpg error code for UNIQUE constraint violation
+_UNIQUE_VIOLATION_CODE = "23505"
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class ProjectService:
+    """CRUD service for ``fieldsync.projects`` and Workday mappings.
+
+    Args:
+        pool: asyncpg pool (or fake pool for tests).
+
+    Example::
+
+        svc = ProjectService(pool)
+        proj = await svc.create_project(
+            accounting_code="ACC-001",
+            name="My Project",
+            client_id=42,
+            org_id=7,
+            tenant="acme",
+        )
+        await svc.map_to_workday(proj.project_id, "WD-12345", tenant="acme")
+    """
+
+    def __init__(self, pool: Any) -> None:
+        self._pool = pool
+        self.logger = logging.getLogger(__name__)
+
+    # ------------------------------------------------------------------
+    # Project CRUD
+    # ------------------------------------------------------------------
+
+    async def create_project(
+        self,
+        *,
+        accounting_code: str,
+        name: str | None = None,
+        client_id: int,
+        org_id: int | None = None,
+        tenant: str | None = None,
+    ) -> Project:
+        """Create a new project in ``fieldsync.projects``.
+
+        Args:
+            accounting_code: Internal cost center code (UNIQUE per client).
+            name: Human-readable project name.
+            client_id: Client this project belongs to.
+            org_id: Organization identifier.
+            tenant: Tenant slug (stored in the returned model metadata only).
+
+        Returns:
+            The newly created ``Project`` with its DB-assigned ``project_id``.
+
+        Raises:
+            DuplicateAccountingCodeError: If ``(client_id, accounting_code)``
+                already exists.
+        """
+        async with self._pool.acquire() as conn:
+            try:
+                row = await conn.fetchrow(
+                    _INSERT_PROJECT_SQL,
+                    client_id,
+                    name,
+                    accounting_code,
+                    org_id,
+                )
+            except Exception as exc:
+                # Detect asyncpg UniqueViolationError by message or code
+                exc_str = str(exc)
+                if (
+                    "unique" in exc_str.lower()
+                    or _UNIQUE_VIOLATION_CODE in exc_str
+                    or "uq_projects_client_accounting" in exc_str
+                    or "UniqueViolation" in type(exc).__name__
+                ):
+                    raise DuplicateAccountingCodeError(client_id, accounting_code) from exc
+                raise
+
+        return Project(
+            project_id=row["project_id"],
+            client_id=row["client_id"],
+            name=row["name"],
+            accounting_code=row["accounting_code"],
+            org_id=row["org_id"],
+            start_timestamp=row["start_timestamp"],
+            end_timestamp=row["end_timestamp"],
+            is_active=row["is_active"],
+            tenant=tenant,
+        )
+
+    async def get_project(
+        self, project_id: int, *, org_id: int, tenant: str | None = None
+    ) -> Project:
+        """Retrieve a project by its primary key, scoped to ``org_id``.
+
+        Args:
+            project_id: Primary key of the project.
+            org_id: Organization the caller is scoped to (hard isolation).
+            tenant: Optional tenant slug (stored in returned model).
+
+        Returns:
+            ``Project`` model populated from the DB row.
+
+        Raises:
+            ProjectNotFoundError: If no project with ``project_id`` exists
+                within ``org_id``.
+        """
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(_SELECT_PROJECT_SQL, project_id, org_id)
+        if row is None:
+            raise ProjectNotFoundError(project_id)
+        return Project(
+            project_id=row["project_id"],
+            client_id=row["client_id"],
+            name=row["name"],
+            accounting_code=row["accounting_code"],
+            org_id=row["org_id"],
+            start_timestamp=row["start_timestamp"],
+            end_timestamp=row["end_timestamp"],
+            is_active=row["is_active"],
+            tenant=tenant,
+        )
+
+    async def list_projects(
+        self,
+        *,
+        org_id: int,
+        client_id: int | None = None,
+        tenant: str | None = None,
+    ) -> list[Project]:
+        """List projects within ``org_id`` (hard isolation), optionally by client.
+
+        Args:
+            org_id: Organization the caller is scoped to (REQUIRED — every
+                query is filtered by it; there is no cross-tenant list path).
+            client_id: Optionally narrow to a single client within the org.
+            tenant: Tenant slug stored in returned models.
+
+        Returns:
+            List of ``Project`` instances (empty list if none match).
+        """
+        async with self._pool.acquire() as conn:
+            if client_id is not None:
+                rows = await conn.fetch(
+                    _SELECT_PROJECTS_BY_CLIENT_SQL, client_id, org_id
+                )
+            else:
+                rows = await conn.fetch(_SELECT_PROJECTS_BY_ORG_SQL, org_id)
+
+        return [
+            Project(
+                project_id=row["project_id"],
+                client_id=row["client_id"],
+                name=row["name"],
+                accounting_code=row["accounting_code"],
+                org_id=row["org_id"],
+                start_timestamp=row["start_timestamp"],
+                end_timestamp=row["end_timestamp"],
+                is_active=row["is_active"],
+                tenant=tenant,
+            )
+            for row in rows
+        ]
+
+    # ------------------------------------------------------------------
+    # Workday mapping
+    # ------------------------------------------------------------------
+
+    async def map_to_workday(
+        self,
+        project_id: int,
+        workday_code: str,
+        *,
+        tenant: str | None = None,
+        direction: str = "internal_to_workday",
+    ) -> WorkdayCostCenterMapping:
+        """Create or update a Workday cost center mapping for a project.
+
+        Uses UPSERT — if a mapping already exists for ``project_id``, its
+        ``workday_code`` is updated in place.
+
+        Args:
+            project_id: FK to ``fieldsync.projects``.
+            workday_code: Workday cost center identifier.
+            tenant: Tenant slug (not stored in the mapping table; used for logs).
+            direction: Flow direction (default ``"internal_to_workday"``).
+
+        Returns:
+            ``WorkdayCostCenterMapping`` reflecting the persisted row.
+
+        Raises:
+            Exception: Any DB error (e.g. FK violation if project_id unknown).
+        """
+        self.logger.info(
+            "map_to_workday: project_id=%s workday_code=%s tenant=%s",
+            project_id,
+            workday_code,
+            tenant,
+        )
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                _UPSERT_WORKDAY_MAPPING_SQL,
+                project_id,
+                workday_code,
+                direction,
+            )
+        return WorkdayCostCenterMapping(
+            project_id=row["project_id"],
+            workday_code=row["workday_code"],
+            direction=row["direction"],
+        )

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/rbac.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/rbac.py
@@ -1,0 +1,593 @@
+"""RBACService — policies ABAC/PBAC (nav-auth format) + RBACContext.
+
+Implementa Module 3 de FEAT-302 (C4 RESUELTO §8):
+
+- **NO** motor RBAC paralelo.
+- **NO** columna ``scope`` en ``auth.permissions``.
+- **NUNCA** escribe en ``auth.user_permissions``.
+
+Las policies son declarativas, compatibles con el formato YAML del engine
+ABAC/PBAC de nav-auth, persistidas como JSONB en ``fieldsync.auth_policies``.
+El enforcement autoritativo lo ejecuta nav-auth; este módulo gestiona la
+emisión, almacenamiento y compilación de policies, y proyecta el
+``RBACContext`` a los handlers para shadow-mode gate-keeping.
+
+``RBACScope`` es vocabulario de alto nivel que se **compila** a una ``Policy``
+ABAC antes de persistir:
+
+- ``own``    → subjects.users = [user_id]
+- ``team``   → subjects.groups = [team/<program_id>]
+- ``client`` → conditions.resource.client_id = (computed)
+- ``global`` → sin restricción de subjects/conditions
+
+Ejemplo de policy referencia (§8)::
+
+    Policy(
+        name="eng_agents_biz_hours",
+        effect="allow",
+        description="Engineering agents during business hours",
+        resources=["agent:*"],
+        actions=["agent:chat"],
+        subjects={"groups": ["engineering", "developers"]},
+        conditions={"environment": {"is_business_hours": True}},
+        priority=20,
+        enforcing=False,
+    )
+
+Uso::
+
+    svc = RBACService(pool)
+    record = await svc.assign_role(
+        "user-abc",
+        program_id=7,
+        codename="edit_form",
+        scope=RBACScope.OWN,
+        tenant="acme",
+    )
+    ctx = await svc.resolve("user-abc", program_id=7, tenant="acme")
+    ctx.has_permission("edit_form", scope=RBACScope.OWN)   # → True
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from enum import Enum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# RBACScope vocabulary
+# ---------------------------------------------------------------------------
+
+
+class RBACScope(str, Enum):
+    """Vocabulary of RBAC scopes that compile to ABAC policies.
+
+    Values:
+        OWN: Access restricted to resources owned by the user.
+        TEAM: Access to resources owned by the user's team.
+        CLIENT: Access to all resources within a client boundary.
+        GLOBAL: Unrestricted access within a tenant.
+    """
+
+    OWN = "own"
+    TEAM = "team"
+    CLIENT = "client"
+    GLOBAL = "global"
+
+
+# Scope hierarchy: lower index = narrower scope.
+_SCOPE_ORDER = [RBACScope.OWN, RBACScope.TEAM, RBACScope.CLIENT, RBACScope.GLOBAL]
+
+
+def _scope_level(scope: RBACScope) -> int:
+    """Return the numeric level of a scope (0 = narrowest, 3 = widest)."""
+    try:
+        return _SCOPE_ORDER.index(scope)
+    except ValueError:
+        return -1
+
+
+# ---------------------------------------------------------------------------
+# Policy model (nav-auth ABAC/PBAC format)
+# ---------------------------------------------------------------------------
+
+
+class Policy(BaseModel):
+    """Declarative ABAC/PBAC policy — mirrors the nav-auth YAML format.
+
+    Attributes:
+        name: Unique policy identifier (UNIQUE constraint in DB).
+        effect: "allow" or "deny".
+        description: Human-readable description.
+        resources: List of resource patterns (e.g. ``["form:*", "agent:chat"]``).
+        actions: List of permitted/denied action patterns.
+        subjects: Dict with ``groups`` and/or ``users`` keys.
+        conditions: Optional conditions dict (e.g. environment, resource).
+        priority: Numeric priority; lower = evaluated first. Default 50.
+        enforcing: When False, policy is in shadow mode (log only). Default False.
+        tenant: Tenant scope for this policy, or None for global.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    effect: Literal["allow", "deny"] = "allow"
+    description: str = ""
+    resources: list[str] = Field(default_factory=list)
+    actions: list[str] = Field(default_factory=list)
+    subjects: dict[str, Any] = Field(default_factory=dict)
+    conditions: dict[str, Any] = Field(default_factory=dict)
+    priority: int = 50
+    enforcing: bool = False
+    tenant: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# PermissionRecord — a compiled permission entry
+# ---------------------------------------------------------------------------
+
+
+class PermissionRecord(BaseModel):
+    """A compiled permission entry (result of assign_role).
+
+    Attributes:
+        user_id: The user this record belongs to.
+        codename: Permission code (e.g. "edit_form").
+        scope: The ``RBACScope`` the permission was issued with.
+        program_id: Program context for the permission.
+        policy_name: Name of the generated ``Policy`` in DB.
+        tenant: Tenant this record is scoped to.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    user_id: str
+    codename: str
+    scope: RBACScope
+    program_id: int
+    policy_name: str
+    tenant: str
+
+
+# ---------------------------------------------------------------------------
+# RBACContext — runtime permission projection
+# ---------------------------------------------------------------------------
+
+
+class RBACContext(BaseModel):
+    """Runtime RBAC context projected for a user in a program.
+
+    Used by handlers for shadow-mode gate-keeping. The authoritative
+    enforcement lives in nav-auth.
+
+    Attributes:
+        user_id: Authenticated user identifier.
+        program_id: Program context.
+        permissions: List of ``PermissionRecord`` resolved for this user.
+        groups: Group memberships resolved from ``auth.*`` (read-only).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    user_id: str
+    program_id: int
+    permissions: list[PermissionRecord] = Field(default_factory=list)
+    groups: list[str] = Field(default_factory=list)
+
+    def has_permission(
+        self,
+        codename: str,
+        scope: RBACScope | None = None,
+    ) -> bool:
+        """Return True if the user has the given permission at the given scope.
+
+        Scope enforcement: a permission issued at scope S grants access
+        to scope S' only if S' is at least as narrow as S (i.e.
+        ``level(S') <= level(S)``).
+
+        Args:
+            codename: Permission codename to check.
+            scope: Required scope level. When ``None``, any scope matches.
+
+        Returns:
+            True if at least one matching ``PermissionRecord`` is found.
+        """
+        for rec in self.permissions:
+            if rec.codename != codename:
+                continue
+            if scope is None:
+                return True
+            # The requested scope must be ≤ the granted scope level
+            if _scope_level(scope) <= _scope_level(rec.scope):
+                return True
+        return False
+
+
+# ---------------------------------------------------------------------------
+# SQL constants
+# ---------------------------------------------------------------------------
+
+_INSERT_POLICY_SQL = """
+INSERT INTO fieldsync.auth_policies (name, policy, tenant, priority, enforcing)
+VALUES ($1, $2::jsonb, $3, $4, $5)
+ON CONFLICT (name) DO UPDATE
+    SET policy    = EXCLUDED.policy,
+        tenant    = EXCLUDED.tenant,
+        priority  = EXCLUDED.priority,
+        enforcing = EXCLUDED.enforcing,
+        updated_at = NOW()
+RETURNING id, name, policy, tenant, priority, enforcing
+"""
+
+_SELECT_POLICY_SQL = """
+SELECT id, name, policy, tenant, priority, enforcing
+FROM fieldsync.auth_policies
+WHERE name = $1
+"""
+
+_SELECT_POLICIES_BY_TENANT_SQL = """
+SELECT id, name, policy, tenant, priority, enforcing
+FROM fieldsync.auth_policies
+WHERE tenant = $1
+ORDER BY priority, name
+"""
+
+_DELETE_POLICY_SQL = """
+DELETE FROM fieldsync.auth_policies
+WHERE name = $1
+"""
+
+# Read-only query against auth.* — NEVER write here
+_SELECT_USER_GROUPS_SQL = """
+SELECT g.name AS group_name
+FROM auth.groups g
+JOIN auth.user_groups ug ON ug.group_id = g.id
+WHERE ug.user_id = $1
+"""
+
+# ---------------------------------------------------------------------------
+# Helper: compile scope → Policy
+# ---------------------------------------------------------------------------
+
+
+def _compile_scope_to_policy(
+    user_id: str,
+    *,
+    program_id: int,
+    codename: str,
+    scope: RBACScope,
+    tenant: str,
+) -> Policy:
+    """Compile a (user_id, codename, scope) triple into a nav-auth ABAC policy.
+
+    Args:
+        user_id: The user receiving the permission.
+        program_id: Program context for the permission.
+        codename: Permission codename.
+        scope: RBACScope vocabulary value.
+        tenant: Tenant this policy belongs to.
+
+    Returns:
+        A ``Policy`` instance ready to persist in ``fieldsync.auth_policies``.
+    """
+    policy_name = f"user__{user_id}__{codename}__{scope.value}__prog{program_id}"
+
+    subjects: dict[str, Any] = {}
+    conditions: dict[str, Any] = {}
+
+    if scope == RBACScope.OWN:
+        subjects = {"users": [user_id]}
+    elif scope == RBACScope.TEAM:
+        subjects = {"groups": [f"team/{program_id}"]}
+    elif scope == RBACScope.CLIENT:
+        conditions = {"resource": {"program_id": program_id}}
+    # GLOBAL: no subjects/conditions restriction
+
+    return Policy(
+        name=policy_name,
+        effect="allow",
+        description=f"Compiled from assign_role: {user_id} / {codename} / {scope.value}",
+        resources=["form:*"],
+        actions=[codename],
+        subjects=subjects,
+        conditions=conditions,
+        priority=50,
+        enforcing=False,
+        tenant=tenant,
+    )
+
+
+# ---------------------------------------------------------------------------
+# RBACService
+# ---------------------------------------------------------------------------
+
+
+class RBACService:
+    """Manage ABAC/PBAC policies in ``fieldsync.auth_policies`` + project context.
+
+    All writes target ``fieldsync.*`` exclusively — NEVER ``auth.*``.
+    Auth tables are only read (read-only pool) for group resolution.
+
+    Args:
+        pool: asyncpg pool (or fake pool for tests).
+
+    Example::
+
+        svc = RBACService(pool)
+        record = await svc.assign_role(
+            "user-1", program_id=7, codename="edit_form",
+            scope=RBACScope.OWN, tenant="acme"
+        )
+        ctx = await svc.resolve("user-1", program_id=7, tenant="acme")
+        assert ctx.has_permission("edit_form", scope=RBACScope.OWN)
+    """
+
+    def __init__(self, pool: Any) -> None:
+        self._pool = pool
+        self.logger = logging.getLogger(__name__)
+
+    # ------------------------------------------------------------------
+    # Policy CRUD
+    # ------------------------------------------------------------------
+
+    async def create_policy(self, policy: Policy) -> Policy:
+        """Upsert a policy in ``fieldsync.auth_policies``.
+
+        If a policy with the same ``name`` already exists, its content is
+        updated (ON CONFLICT DO UPDATE).
+
+        Args:
+            policy: ``Policy`` instance to persist.
+
+        Returns:
+            The persisted ``Policy`` (reflected from DB row).
+        """
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                _INSERT_POLICY_SQL,
+                policy.name,
+                json.dumps(policy.model_dump(mode="json")),
+                policy.tenant,
+                policy.priority,
+                policy.enforcing,
+            )
+        return self._row_to_policy(row)
+
+    async def get_policy(self, name: str) -> Policy | None:
+        """Retrieve a policy by name.
+
+        Args:
+            name: Unique policy name.
+
+        Returns:
+            ``Policy`` or ``None`` if not found.
+        """
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(_SELECT_POLICY_SQL, name)
+        if row is None:
+            return None
+        return self._row_to_policy(row)
+
+    async def list_policies(self, *, tenant: str) -> list[Policy]:
+        """List all policies for a tenant, ordered by priority.
+
+        Args:
+            tenant: Tenant slug to filter by.
+
+        Returns:
+            List of ``Policy`` instances (empty if none found).
+        """
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(_SELECT_POLICIES_BY_TENANT_SQL, tenant)
+        return [self._row_to_policy(row) for row in rows]
+
+    async def delete_policy(self, name: str) -> bool:
+        """Delete a policy by name.
+
+        Args:
+            name: Unique policy name.
+
+        Returns:
+            True if the policy was deleted; False if it did not exist.
+        """
+        async with self._pool.acquire() as conn:
+            status = await conn.execute(_DELETE_POLICY_SQL, name)
+        # asyncpg returns "DELETE N"
+        try:
+            deleted_count = int(status.split()[-1])
+        except (IndexError, ValueError):
+            deleted_count = 0
+        return deleted_count > 0
+
+    # ------------------------------------------------------------------
+    # Role assignment
+    # ------------------------------------------------------------------
+
+    async def assign_role(
+        self,
+        user_id: str,
+        *,
+        program_id: int,
+        codename: str,
+        scope: RBACScope,
+        tenant: str,
+    ) -> PermissionRecord:
+        """Compile (user_id, codename, scope) to a Policy and persist it.
+
+        NEVER writes to ``auth.user_permissions``.
+        The compiled policy is stored in ``fieldsync.auth_policies`` (JSONB).
+
+        Args:
+            user_id: User to assign the role to.
+            program_id: Program context.
+            codename: Permission codename.
+            scope: ``RBACScope`` level.
+            tenant: Tenant this assignment belongs to.
+
+        Returns:
+            ``PermissionRecord`` reflecting the persisted policy.
+        """
+        policy = _compile_scope_to_policy(
+            user_id,
+            program_id=program_id,
+            codename=codename,
+            scope=scope,
+            tenant=tenant,
+        )
+        await self.create_policy(policy)
+        self.logger.info(
+            "assign_role: user=%s codename=%s scope=%s tenant=%s → policy=%s",
+            user_id,
+            codename,
+            scope.value,
+            tenant,
+            policy.name,
+        )
+        return PermissionRecord(
+            user_id=user_id,
+            codename=codename,
+            scope=scope,
+            program_id=program_id,
+            policy_name=policy.name,
+            tenant=tenant,
+        )
+
+    # ------------------------------------------------------------------
+    # Context resolution
+    # ------------------------------------------------------------------
+
+    async def resolve(
+        self,
+        user_id: str,
+        *,
+        program_id: int,
+        tenant: str,
+    ) -> RBACContext:
+        """Build ``RBACContext`` for a user by reading ``fieldsync.auth_policies``.
+
+        Reads policies from ``fieldsync.auth_policies`` for the tenant.
+        Optionally reads group memberships from ``auth.groups`` / ``auth.user_groups``
+        (read-only). Falls back to empty groups list if auth tables are unavailable.
+
+        Args:
+            user_id: Authenticated user identifier.
+            program_id: Program context.
+            tenant: Tenant slug.
+
+        Returns:
+            ``RBACContext`` with permissions and groups populated.
+        """
+        policies = await self.list_policies(tenant=tenant)
+
+        permissions: list[PermissionRecord] = []
+        for policy in policies:
+            # Only include allow policies that target this user
+            if policy.effect != "allow":
+                continue
+            # Check if this policy was compiled for this user
+            if policy.name.startswith(f"user__{user_id}__"):
+                # Parse scope and codename from policy name:
+                # "user__<uid>__<codename>__<scope>__prog<pid>"
+                parts = policy.name.split("__")
+                if len(parts) >= 4:
+                    codename = parts[2]
+                    scope_str = parts[3]
+                    prog_str = parts[4] if len(parts) > 4 else f"prog{program_id}"
+                    try:
+                        scope = RBACScope(scope_str)
+                        rec_program_id = int(prog_str.replace("prog", ""))
+                    except (ValueError, IndexError):
+                        continue
+                    permissions.append(
+                        PermissionRecord(
+                            user_id=user_id,
+                            codename=codename,
+                            scope=scope,
+                            program_id=rec_program_id,
+                            policy_name=policy.name,
+                            tenant=tenant,
+                        )
+                    )
+
+        # Try to read group memberships (read-only, auth.* best-effort)
+        groups: list[str] = []
+        try:
+            async with self._pool.acquire() as conn:
+                rows = await conn.fetch(_SELECT_USER_GROUPS_SQL, user_id)
+            groups = [row["group_name"] for row in rows]
+        except Exception as exc:  # noqa: BLE001
+            self.logger.debug(
+                "resolve: could not read auth.user_groups for %s: %s", user_id, exc
+            )
+
+        return RBACContext(
+            user_id=user_id,
+            program_id=program_id,
+            permissions=permissions,
+            groups=groups,
+        )
+
+    # ------------------------------------------------------------------
+    # Revoke all
+    # ------------------------------------------------------------------
+
+    async def revoke_all(self, user_id: str, *, tenant: str) -> int:
+        """Delete all policies compiled for ``user_id`` in ``tenant``.
+
+        NEVER touches ``auth.user_permissions``.
+
+        Args:
+            user_id: User whose compiled policies should be deleted.
+            tenant: Tenant scope.
+
+        Returns:
+            Number of policies deleted.
+        """
+        # Fetch matching policies and delete by name (safer than LIKE on JSONB)
+        policies = await self.list_policies(tenant=tenant)
+        deleted = 0
+        for pol in policies:
+            if pol.name.startswith(f"user__{user_id}__"):
+                ok = await self.delete_policy(pol.name)
+                if ok:
+                    deleted += 1
+        self.logger.info(
+            "revoke_all: user=%s tenant=%s → %d policies deleted",
+            user_id,
+            tenant,
+            deleted,
+        )
+        return deleted
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _row_to_policy(row: Any) -> Policy:
+        """Deserialise a DB row (from ``fieldsync.auth_policies``) to ``Policy``.
+
+        Args:
+            row: asyncpg Record (or compatible dict-like).
+
+        Returns:
+            ``Policy`` instance.
+        """
+        raw = row["policy"]
+        if isinstance(raw, str):
+            policy_data = json.loads(raw)
+        else:
+            policy_data = dict(raw)  # asyncpg returns a dict for JSONB
+
+        # Merge DB-level fields (may override JSONB body)
+        policy_data["name"] = row["name"]
+        policy_data["tenant"] = row["tenant"]
+        policy_data["priority"] = row["priority"]
+        policy_data["enforcing"] = row["enforcing"]
+
+        return Policy(**{k: v for k, v in policy_data.items() if k in Policy.model_fields})

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/workday_sync.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/workday_sync.py
@@ -1,0 +1,123 @@
+"""WorkdayIdentitySyncAdapter — stub de sincronización de identidades con Workday.
+
+FEAT-302 Module 4 — STUB ONLY (§8 RESUELTO).
+
+Por qué solo stub:
+- FEAT-026 / FEAT-027 (Workday Identity Sync en ai-parrot) **no existen**.
+- Su construcción está bloqueada por un spec prerequisito de guardrails
+  ABAC/PBAC para la API de Workday y el Toolkit de Workday.
+- Hasta que ese spec esté aprobado e implementado, cualquier llamada HTTP
+  real a la API de Workday es prematura e insegura.
+
+Contrato de upgrade:
+- La interfaz pública (``sync_user()``) es estable; un upgrade drop-in
+  a cliente real requiere únicamente:
+  1. Poner ``base_url`` y ``api_key`` reales.
+  2. Implementar el cuerpo HTTP en ``sync_user()`` según el contrato del
+     spec de guardrails Workday.
+  3. Eliminar la bandera ``stub=True`` del retorno.
+- El adapter NO modifica permisos; para revocar acceso completo combinar
+  con ``RBACService.revoke_all()``.
+
+Uso::
+
+    adapter = WorkdayIdentitySyncAdapter()  # stub
+    result = await adapter.sync_user(
+        "user-abc",
+        action="provision",
+        org_id=7,
+    )
+    # → {"status": "accepted", "stub": True, "action": "provision",
+    #    "user_id": "user-abc", "org_id": 7}
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal
+
+logger = logging.getLogger(__name__)
+
+
+class WorkdayIdentitySyncAdapter:
+    """Stub de sincronización de identidades hacia Workday.
+
+    Interfaz estable para upgrade drop-in cuando FEAT-026/027 estén
+    disponibles. Actualmente: loggea la operación y devuelve un dict
+    de aceptación con ``stub=True``; **cero llamadas HTTP**.
+
+    Args:
+        base_url: URL base del endpoint Workday (ignorada en stub mode).
+            Cuando ``None``, el adapter opera siempre en stub mode.
+        api_key: API key para autenticación Workday (ignorada en stub mode).
+            Cuando ``None``, no se intenta autenticación.
+
+    Note:
+        ``WORKDAY_SYNC_BASE_URL`` no existe como variable de entorno definida
+        porque el endpoint upstream no está disponible (§8). No leer esa
+        variable hasta que el spec de guardrails Workday esté aprobado.
+    """
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        *,
+        api_key: str | None = None,
+    ) -> None:
+        self._base_url = base_url
+        self._api_key = api_key
+        self.logger = logging.getLogger(__name__)
+
+    async def sync_user(
+        self,
+        user_id: str,
+        *,
+        action: Literal["provision", "deprovision"],
+        org_id: int,
+    ) -> dict[str, Any]:
+        """Stub: loggea la operación y devuelve aceptación sin llamada HTTP.
+
+        Contrato de retorno estable (no cambia al hacer upgrade):
+        - ``status``: siempre ``"accepted"`` (HTTP 202).
+        - ``stub``: ``True`` en stub mode; se elimina al implementar real.
+        - ``action``: la acción recibida.
+        - ``user_id``: el usuario afectado.
+        - ``org_id``: la organización de contexto.
+
+        Args:
+            user_id: Identificador del usuario a provisionar/desprovisionar.
+            action: ``"provision"`` (crear acceso) o ``"deprovision"``
+                (revocar acceso). Para deprovisión completa combinar con
+                ``RBACService.revoke_all()``.
+            org_id: Identificador de la organización de contexto.
+
+        Returns:
+            Dict de aceptación::
+
+                {
+                    "status": "accepted",
+                    "stub": True,
+                    "action": "provision" | "deprovision",
+                    "user_id": str,
+                    "org_id": int,
+                }
+
+        Note:
+            Esta implementación no abre ningún ``aiohttp.ClientSession``
+            ni hace ninguna llamada de red. El stub es seguro de llamar
+            sin internet y en entornos de CI.
+        """
+        self.logger.info(
+            "WorkdayIdentitySyncAdapter.sync_user: STUB — action=%s user_id=%s org_id=%s"
+            " (FEAT-026/027 not available; spec prerequisite pending)",
+            action,
+            user_id,
+            org_id,
+        )
+        return {
+            "status": "accepted",
+            "stub": True,
+            "action": action,
+            "user_id": user_id,
+            "org_id": org_id,
+        }

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/version.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/version.py
@@ -2,7 +2,7 @@
 
 __title__ = "parrot-formdesigner"
 __description__ = "Platform-agnostic form design and rendering package for AI-Parrot"
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 __author__ = "Jesus Lara"
 __author_email__ = "jesuslara@phenobarbital.info"
 __license__ = "MIT"

--- a/packages/parrot-formdesigner/tests/unit/test_api_feat302.py
+++ b/packages/parrot-formdesigner/tests/unit/test_api_feat302.py
@@ -1,0 +1,563 @@
+"""Unit tests for FEAT-302 API endpoints (TASK-018).
+
+Tests the five new handler methods on FormAPIHandler:
+  - get_org_graph          GET  /org/graph
+  - create_project         POST /org/projects
+  - map_project_workday    POST /org/cost-centers/{project_id}/workday-map
+  - assign_user_role       POST /org/users/{user_id}/assign
+  - sync_workday_identities POST /org/sync/workday
+
+Also tests:
+  - RBAC shadow-mode retrofit gate-keeping (rbac_enforcing=False vs True).
+  - 501 when services are not configured.
+  - 400 on missing required fields.
+
+All tests use mocked requests — no live HTTP server required.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from parrot_formdesigner.api.handlers import FormAPIHandler
+from parrot_formdesigner.services.org_graph import OrgGraph, OrgNode
+from parrot_formdesigner.services.project_service import (
+    DuplicateAccountingCodeError,
+    Project,
+    WorkdayCostCenterMapping,
+)
+from parrot_formdesigner.services.rbac import (
+    PermissionRecord,
+    RBACContext,
+    RBACScope,
+)
+from parrot_formdesigner.services.workday_sync import WorkdayIdentitySyncAdapter
+from parrot_formdesigner.services.registry import FormRegistry
+
+
+# ---------------------------------------------------------------------------
+# Request / handler helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_request(
+    *,
+    method: str = "GET",
+    body: dict | None = None,
+    match_info: dict | None = None,
+    session_programs: list[str] | None = None,
+    tenant: str = "t1",
+    user_id: str | None = None,
+) -> MagicMock:
+    """Build a mocked aiohttp web.Request for FEAT-302 tests."""
+    from aiohttp import web
+
+    req = MagicMock(spec=web.Request)
+    req.method = method
+    req.match_info = match_info or {}
+
+    programs = session_programs if session_programs is not None else [tenant]
+    session_obj = {"session": {"programs": programs}}
+    req.session = session_obj
+    req.__contains__ = lambda self, key: False
+
+    # Mock request.user.organizations[0].org_id
+    if user_id is not None:
+        user = MagicMock()
+        user.id = user_id
+        user.organizations = []
+        req.user = user
+    else:
+        user = MagicMock()
+        user.id = "test-user"
+        org = MagicMock()
+        org.org_id = 7
+        user.organizations = [org]
+        req.user = user
+
+    if body is not None:
+        req.json = AsyncMock(return_value=body)
+    else:
+        req.json = AsyncMock(side_effect=ValueError("no body"))
+
+    req.headers = {}
+    return req
+
+
+def _make_handler(
+    *,
+    org_graph_service=None,
+    project_service=None,
+    rbac_service=None,
+    workday_adapter=None,
+    rbac_enforcing: bool = False,
+    tenant: str = "t1",
+) -> FormAPIHandler:
+    """Build a FormAPIHandler with FEAT-302 services mocked."""
+    registry = MagicMock(spec=FormRegistry)
+    registry.get = AsyncMock(return_value=None)
+    registry.storage = None
+    registry.default_tenant = tenant
+    return FormAPIHandler(
+        registry=registry,
+        org_graph_service=org_graph_service,
+        project_service=project_service,
+        rbac_service=rbac_service,
+        workday_adapter=workday_adapter,
+        rbac_enforcing=rbac_enforcing,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fake service helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_org_graph(org_id: int = 7, tenant: str = "t1") -> OrgGraph:
+    root = OrgNode(
+        node_type="company",
+        node_id=f"company:{tenant}",
+        metadata={"tenant": tenant},
+        children=[
+            OrgNode(
+                node_type="organization",
+                node_id=str(org_id),
+                parent_id=f"company:{tenant}",
+                metadata={"name": "Test Org"},
+            )
+        ],
+    )
+    return OrgGraph(org_id=org_id, tenant=tenant, root=root)
+
+
+def _make_project(
+    project_id: int = 1,
+    accounting_code: str = "ACC-001",
+    client_id: int = 42,
+    org_id: int = 7,
+    tenant: str = "t1",
+) -> Project:
+    return Project(
+        project_id=project_id,
+        name="Test Project",
+        accounting_code=accounting_code,
+        client_id=client_id,
+        org_id=org_id,
+        tenant=tenant,
+    )
+
+
+def _make_mapping(project_id: int = 1, workday_code: str = "WD-001") -> WorkdayCostCenterMapping:
+    return WorkdayCostCenterMapping(project_id=project_id, workday_code=workday_code)
+
+
+def _make_permission_record(user_id: str = "u1", codename: str = "edit_form") -> PermissionRecord:
+    return PermissionRecord(
+        user_id=user_id,
+        codename=codename,
+        scope=RBACScope.OWN,
+        program_id=7,
+        policy_name=f"user__{user_id}__{codename}__own__prog7",
+        tenant="t1",
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_org_graph
+# ---------------------------------------------------------------------------
+
+
+class TestGetOrgGraph:
+    @pytest.mark.asyncio
+    async def test_get_org_graph_200(self) -> None:
+        graph = _make_org_graph()
+        svc = MagicMock()
+        svc.get_graph = AsyncMock(return_value=graph)
+        handler = _make_handler(org_graph_service=svc)
+        req = _make_request(method="GET")
+        resp = await handler.get_org_graph(req)
+        assert resp.status == 200
+        body = json.loads(resp.body)
+        assert body["org_id"] == 7
+        assert body["root"]["node_type"] == "company"
+
+    @pytest.mark.asyncio
+    async def test_get_org_graph_400_no_org_id(self) -> None:
+        svc = MagicMock()
+        handler = _make_handler(org_graph_service=svc)
+        # No organizations
+        req = _make_request(method="GET", user_id="anonymous")
+        req.user.organizations = []
+        resp = await handler.get_org_graph(req)
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_get_org_graph_501_not_configured(self) -> None:
+        handler = _make_handler()  # no org_graph_service
+        req = _make_request()
+        resp = await handler.get_org_graph(req)
+        assert resp.status == 501
+
+    @pytest.mark.asyncio
+    async def test_get_org_graph_404_not_found(self) -> None:
+        svc = MagicMock()
+        svc.get_graph = AsyncMock(side_effect=KeyError("Organization 99 not found"))
+        handler = _make_handler(org_graph_service=svc)
+        req = _make_request()
+        resp = await handler.get_org_graph(req)
+        assert resp.status == 404
+
+
+# ---------------------------------------------------------------------------
+# create_project
+# ---------------------------------------------------------------------------
+
+
+class TestCreateProject:
+    @pytest.mark.asyncio
+    async def test_create_project_201(self) -> None:
+        project = _make_project()
+        svc = MagicMock()
+        svc.create_project = AsyncMock(return_value=project)
+        handler = _make_handler(project_service=svc)
+        req = _make_request(
+            method="POST",
+            body={"accounting_code": "ACC-001", "name": "Test", "client_id": 42, "org_id": 7},
+        )
+        resp = await handler.create_project(req)
+        assert resp.status == 201
+        body = json.loads(resp.body)
+        assert body["accounting_code"] == "ACC-001"
+
+    @pytest.mark.asyncio
+    async def test_create_project_409_duplicate(self) -> None:
+        svc = MagicMock()
+        svc.create_project = AsyncMock(
+            side_effect=DuplicateAccountingCodeError(42, "ACC-001")
+        )
+        handler = _make_handler(project_service=svc)
+        req = _make_request(
+            method="POST",
+            body={"accounting_code": "ACC-001", "client_id": 42},
+        )
+        resp = await handler.create_project(req)
+        assert resp.status == 409
+
+    @pytest.mark.asyncio
+    async def test_create_project_400_missing_accounting_code(self) -> None:
+        svc = MagicMock()
+        handler = _make_handler(project_service=svc)
+        req = _make_request(method="POST", body={"client_id": 42})
+        resp = await handler.create_project(req)
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_create_project_400_missing_client_id(self) -> None:
+        svc = MagicMock()
+        handler = _make_handler(project_service=svc)
+        req = _make_request(method="POST", body={"accounting_code": "ACC"})
+        resp = await handler.create_project(req)
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_create_project_501_not_configured(self) -> None:
+        handler = _make_handler()
+        req = _make_request(method="POST", body={"accounting_code": "A", "client_id": 1})
+        resp = await handler.create_project(req)
+        assert resp.status == 501
+
+
+# ---------------------------------------------------------------------------
+# map_project_workday
+# ---------------------------------------------------------------------------
+
+
+class TestMapProjectWorkday:
+    @pytest.mark.asyncio
+    async def test_map_workday_200(self) -> None:
+        mapping = _make_mapping(project_id=5, workday_code="WD-999")
+        svc = MagicMock()
+        svc.map_to_workday = AsyncMock(return_value=mapping)
+        handler = _make_handler(project_service=svc)
+        req = _make_request(
+            method="POST",
+            match_info={"project_id": "5"},
+            body={"workday_code": "WD-999"},
+        )
+        resp = await handler.map_project_workday(req)
+        assert resp.status == 200
+        body = json.loads(resp.body)
+        assert body["workday_code"] == "WD-999"
+
+    @pytest.mark.asyncio
+    async def test_map_workday_400_missing_workday_code(self) -> None:
+        svc = MagicMock()
+        handler = _make_handler(project_service=svc)
+        req = _make_request(
+            method="POST",
+            match_info={"project_id": "5"},
+            body={},
+        )
+        resp = await handler.map_project_workday(req)
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_map_workday_400_invalid_project_id(self) -> None:
+        svc = MagicMock()
+        handler = _make_handler(project_service=svc)
+        req = _make_request(
+            method="POST",
+            match_info={"project_id": "notanint"},
+            body={"workday_code": "WD-X"},
+        )
+        resp = await handler.map_project_workday(req)
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_map_workday_501_not_configured(self) -> None:
+        handler = _make_handler()
+        req = _make_request(
+            method="POST",
+            match_info={"project_id": "1"},
+            body={"workday_code": "WD-001"},
+        )
+        resp = await handler.map_project_workday(req)
+        assert resp.status == 501
+
+
+# ---------------------------------------------------------------------------
+# assign_user_role
+# ---------------------------------------------------------------------------
+
+
+class TestAssignUserRole:
+    @pytest.mark.asyncio
+    async def test_assign_role_200(self) -> None:
+        from parrot_formdesigner.services.rbac import RBACContext
+        record = _make_permission_record("user1", "edit_form")
+        svc = MagicMock()
+        svc.assign_role = AsyncMock(return_value=record)
+        # H-1: caller must hold manage_roles — grant it via the resolve mock.
+        svc.resolve = AsyncMock(return_value=RBACContext(
+            user_id="caller", program_id=7,
+            permissions=[_make_permission_record("caller", "manage_roles")],
+        ))
+        handler = _make_handler(rbac_service=svc)
+        req = _make_request(
+            method="POST",
+            match_info={"user_id": "user1"},
+            body={"codename": "edit_form", "scope": "own", "program_id": 7},
+        )
+        resp = await handler.assign_user_role(req)
+        assert resp.status == 200
+        body = json.loads(resp.body)
+        assert body["user_id"] == "user1"
+        assert body["codename"] == "edit_form"
+
+    @pytest.mark.asyncio
+    async def test_assign_role_403_without_manage_roles(self) -> None:
+        """H-1: caller lacking manage_roles is denied (privilege escalation guard)."""
+        from parrot_formdesigner.services.rbac import RBACContext
+        svc = MagicMock()
+        svc.assign_role = AsyncMock(return_value=_make_permission_record("u1", "edit_form"))
+        svc.resolve = AsyncMock(return_value=RBACContext(
+            user_id="caller", program_id=7, permissions=[],
+        ))
+        handler = _make_handler(rbac_service=svc)
+        req = _make_request(
+            method="POST",
+            match_info={"user_id": "u1"},
+            body={"codename": "edit_form", "scope": "global", "program_id": 7},
+        )
+        resp = await handler.assign_user_role(req)
+        assert resp.status == 403
+        svc.assign_role.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_assign_role_400_missing_codename(self) -> None:
+        svc = MagicMock()
+        handler = _make_handler(rbac_service=svc)
+        req = _make_request(
+            method="POST",
+            match_info={"user_id": "u1"},
+            body={"scope": "own", "program_id": 7},
+        )
+        resp = await handler.assign_user_role(req)
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_assign_role_400_invalid_scope(self) -> None:
+        svc = MagicMock()
+        handler = _make_handler(rbac_service=svc)
+        req = _make_request(
+            method="POST",
+            match_info={"user_id": "u1"},
+            body={"codename": "edit_form", "scope": "invalid_scope", "program_id": 7},
+        )
+        resp = await handler.assign_user_role(req)
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_assign_role_501_not_configured(self) -> None:
+        handler = _make_handler()
+        req = _make_request(
+            method="POST",
+            match_info={"user_id": "u1"},
+            body={"codename": "x", "scope": "own", "program_id": 1},
+        )
+        resp = await handler.assign_user_role(req)
+        assert resp.status == 501
+
+
+# ---------------------------------------------------------------------------
+# sync_workday_identities
+# ---------------------------------------------------------------------------
+
+
+class TestSyncWorkdayIdentities:
+    @pytest.mark.asyncio
+    async def test_sync_workday_202(self) -> None:
+        adapter = WorkdayIdentitySyncAdapter()
+        handler = _make_handler(workday_adapter=adapter)
+        req = _make_request(
+            method="POST",
+            body={"user_id": "u1", "action": "provision", "org_id": 7},
+        )
+        resp = await handler.sync_workday_identities(req)
+        assert resp.status == 202
+        body = json.loads(resp.body)
+        assert body["status"] == "accepted"
+        assert body["stub"] is True
+
+    @pytest.mark.asyncio
+    async def test_sync_workday_202_deprovision(self) -> None:
+        adapter = WorkdayIdentitySyncAdapter()
+        handler = _make_handler(workday_adapter=adapter)
+        req = _make_request(
+            method="POST",
+            body={"user_id": "u2", "action": "deprovision", "org_id": 3},
+        )
+        resp = await handler.sync_workday_identities(req)
+        assert resp.status == 202
+
+    @pytest.mark.asyncio
+    async def test_sync_workday_400_missing_user_id(self) -> None:
+        adapter = WorkdayIdentitySyncAdapter()
+        handler = _make_handler(workday_adapter=adapter)
+        req = _make_request(
+            method="POST",
+            body={"action": "provision", "org_id": 7},
+        )
+        resp = await handler.sync_workday_identities(req)
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_sync_workday_400_invalid_action(self) -> None:
+        adapter = WorkdayIdentitySyncAdapter()
+        handler = _make_handler(workday_adapter=adapter)
+        req = _make_request(
+            method="POST",
+            body={"user_id": "u1", "action": "teleport", "org_id": 7},
+        )
+        resp = await handler.sync_workday_identities(req)
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_sync_workday_501_not_configured(self) -> None:
+        handler = _make_handler()
+        req = _make_request(
+            method="POST",
+            body={"user_id": "u1", "action": "provision", "org_id": 1},
+        )
+        resp = await handler.sync_workday_identities(req)
+        assert resp.status == 501
+
+
+# ---------------------------------------------------------------------------
+# RBAC shadow-mode gate-keeping
+# ---------------------------------------------------------------------------
+
+
+class TestRBACRetrofitGateKeeping:
+    """Tests for the _rbac_shadow_gate helper."""
+
+    @pytest.mark.asyncio
+    async def test_shadow_mode_no_rbac_service_noop(self) -> None:
+        """Without an RBACService, shadow gate does nothing (no error)."""
+        handler = _make_handler(rbac_enforcing=False)
+        req = _make_request()
+        # Should not raise
+        await handler._rbac_shadow_gate(req, "create_form")
+
+    @pytest.mark.asyncio
+    async def test_shadow_mode_allowed_no_block(self) -> None:
+        """Shadow mode: allowed permission doesn't block even with enforcing=False."""
+        svc = MagicMock()
+        ctx = RBACContext(
+            user_id="test-user",
+            program_id=0,
+            permissions=[
+                PermissionRecord(
+                    user_id="test-user",
+                    codename="create_form",
+                    scope=RBACScope.GLOBAL,
+                    program_id=0,
+                    policy_name="p1",
+                    tenant="t1",
+                )
+            ],
+        )
+        svc.resolve = AsyncMock(return_value=ctx)
+        handler = _make_handler(rbac_service=svc, rbac_enforcing=False)
+        req = _make_request()
+        await handler._rbac_shadow_gate(req, "create_form")  # no exception
+
+    @pytest.mark.asyncio
+    async def test_shadow_mode_denied_no_block_when_not_enforcing(self) -> None:
+        """Shadow mode with rbac_enforcing=False: denied permission logs but never blocks."""
+        svc = MagicMock()
+        ctx = RBACContext(user_id="test-user", program_id=0, permissions=[])
+        svc.resolve = AsyncMock(return_value=ctx)
+        handler = _make_handler(rbac_service=svc, rbac_enforcing=False)
+        req = _make_request()
+        # Must NOT raise even though permission is denied
+        await handler._rbac_shadow_gate(req, "delete_form")
+
+    @pytest.mark.asyncio
+    async def test_enforcing_mode_denied_raises_403(self) -> None:
+        """When rbac_enforcing=True: denied permission raises HTTPForbidden."""
+        from aiohttp import web
+
+        svc = MagicMock()
+        ctx = RBACContext(user_id="test-user", program_id=0, permissions=[])
+        svc.resolve = AsyncMock(return_value=ctx)
+        handler = _make_handler(rbac_service=svc, rbac_enforcing=True)
+        req = _make_request()
+        with pytest.raises(web.HTTPForbidden):
+            await handler._rbac_shadow_gate(req, "delete_form")
+
+    @pytest.mark.asyncio
+    async def test_enforcing_mode_allowed_no_raise(self) -> None:
+        """When rbac_enforcing=True and permission is granted: no exception."""
+        svc = MagicMock()
+        ctx = RBACContext(
+            user_id="test-user",
+            program_id=0,
+            permissions=[
+                PermissionRecord(
+                    user_id="test-user",
+                    codename="delete_form",
+                    scope=RBACScope.GLOBAL,
+                    program_id=0,
+                    policy_name="p2",
+                    tenant="t1",
+                )
+            ],
+        )
+        svc.resolve = AsyncMock(return_value=ctx)
+        handler = _make_handler(rbac_service=svc, rbac_enforcing=True)
+        req = _make_request()
+        await handler._rbac_shadow_gate(req, "delete_form")  # no exception

--- a/packages/parrot-formdesigner/tests/unit/test_feat302_review_fixes.py
+++ b/packages/parrot-formdesigner/tests/unit/test_feat302_review_fixes.py
@@ -1,0 +1,187 @@
+"""Regression tests for the FEAT-302 code-review fixes.
+
+- C-1/C-2/C-3 — get_node enforces tenant isolation via org_id scope.
+- C-4 — list_projects/get_project require org_id; create_project handler
+        uses the session org_id, never the request body.
+- C-5 — _rbac_shadow_gate is wired into the form mutation handlers.
+- C-6 — organization node parent_id points to the company root, not itself.
+- H-1 — assign_user_role denies callers lacking manage_roles (in API tests).
+- H-3 — delete_policy returns False on a "DELETE 0" status.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from parrot_formdesigner.services.org_graph import OrgGraphService
+from parrot_formdesigner.services.project_service import ProjectService
+
+
+# ---------------------------------------------------------------------------
+# Fake asyncpg pool that records every (sql, args) call
+# ---------------------------------------------------------------------------
+
+
+def _make_pool(rows_by_marker: dict[str, list[dict]] | None = None) -> tuple[MagicMock, list]:
+    rows_by_marker = rows_by_marker or {}
+    calls: list[tuple[str, tuple]] = []
+
+    def _row(d: dict) -> MagicMock:
+        r = MagicMock()
+        r.__getitem__ = lambda self, k, _d=d: _d[k]
+        r.keys = lambda _d=d: list(_d.keys())
+        return r
+
+    async def _fetch(sql: str, *args: Any) -> list:
+        calls.append((sql, args))
+        for marker, rows in rows_by_marker.items():
+            if marker in sql:
+                return [_row(d) for d in rows]
+        return []
+
+    async def _fetchrow(sql: str, *args: Any) -> Any:
+        calls.append((sql, args))
+        for marker, rows in rows_by_marker.items():
+            if marker in sql:
+                return _row(rows[0]) if rows else None
+        return None
+
+    conn = MagicMock()
+    conn.fetch = AsyncMock(side_effect=_fetch)
+    conn.fetchrow = AsyncMock(side_effect=_fetchrow)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=conn)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=cm)
+    return pool, calls
+
+
+# ---------------------------------------------------------------------------
+# C-1/C-2/C-3 — tenant isolation in get_node
+# ---------------------------------------------------------------------------
+
+
+class TestTenantIsolation:
+    async def test_org_node_rejects_foreign_org(self):
+        """C-1: requesting an org != session org_id raises KeyError (no leak)."""
+        pool, _ = _make_pool({"auth.organizations": [{"org_id": 999, "name": "Other"}]})
+        svc = OrgGraphService(pool)
+        with pytest.raises(KeyError):
+            await svc.get_node("organization", "999", tenant="t1", org_id=7)
+
+    async def test_client_node_query_carries_org_id(self):
+        """C-2: client lookup passes org_id as a bind parameter."""
+        pool, calls = _make_pool({"auth.clients": [{"client_id": 42, "client_name": "C"}]})
+        svc = OrgGraphService(pool)
+        await svc.get_node("client", "42", tenant="t1", org_id=7)
+        client_calls = [c for c in calls if "auth.clients" in c[0]]
+        assert client_calls and 7 in client_calls[0][1]  # org_id bound
+
+    async def test_program_node_query_carries_org_id(self):
+        """C-3: program lookup passes org_id as a bind parameter."""
+        pool, calls = _make_pool({"auth.programs": [{"program_id": 5, "program_name": "P"}]})
+        svc = OrgGraphService(pool)
+        await svc.get_node("program", "5", tenant="t1", org_id=7)
+        prog_calls = [c for c in calls if "auth.programs" in c[0]]
+        assert prog_calls and 7 in prog_calls[0][1]
+
+    async def test_unknown_node_type_raises(self):
+        """M-7: geography/store single-node lookup fails loudly (no stub)."""
+        pool, _ = _make_pool()
+        svc = OrgGraphService(pool)
+        with pytest.raises(NotImplementedError):
+            await svc.get_node("store", "1", tenant="t1", org_id=7)
+
+
+# ---------------------------------------------------------------------------
+# C-6 — org node parent_id points to the company root
+# ---------------------------------------------------------------------------
+
+
+class TestParentPointer:
+    async def test_org_parent_is_company_root(self):
+        pool, _ = _make_pool({"auth.organizations": [{"org_id": 7, "name": "Acme"}]})
+        svc = OrgGraphService(pool)
+        graph = await svc.get_graph(7, tenant="acme", depth=1)
+        org_node = graph.root.children[0]
+        assert graph.root.node_id == "company:acme"
+        assert org_node.parent_id == "company:acme"   # not "7"
+
+
+# ---------------------------------------------------------------------------
+# C-4 — project reads require org_id
+# ---------------------------------------------------------------------------
+
+
+class TestProjectScoping:
+    async def test_list_projects_binds_org_id(self):
+        pool, calls = _make_pool({"fieldsync.projects": []})
+        svc = ProjectService(pool)
+        await svc.list_projects(org_id=7)
+        assert calls and 7 in calls[0][1]
+
+    async def test_get_project_binds_org_id(self):
+        pool, calls = _make_pool({"fieldsync.projects": [{
+            "project_id": 1, "client_id": 2, "name": "P", "accounting_code": "A",
+            "org_id": 7, "start_timestamp": None, "end_timestamp": None,
+            "is_active": True,
+        }]})
+        svc = ProjectService(pool)
+        await svc.get_project(1, org_id=7)
+        assert calls and calls[0][1] == (1, 7)
+
+    def test_no_unscoped_list_sql_exists(self):
+        """C-4: the cross-tenant 'select all projects' constant is gone."""
+        from parrot_formdesigner.services import project_service as ps
+        assert not hasattr(ps, "_SELECT_PROJECTS_ALL_SQL")
+
+
+# ---------------------------------------------------------------------------
+# C-5 — shadow gate wired into form mutation handlers
+# ---------------------------------------------------------------------------
+
+
+class TestShadowGateWired:
+    def test_form_handlers_call_shadow_gate(self):
+        import inspect
+        from parrot_formdesigner.api import handlers as h
+
+        for name in ("create_form", "edit_form", "update_form",
+                     "patch_form", "delete_form"):
+            src = inspect.getsource(getattr(h.FormAPIHandler, name))
+            assert "_rbac_shadow_gate" in src, f"{name} does not call the gate"
+
+
+# ---------------------------------------------------------------------------
+# H-3 — delete_policy robust return
+# ---------------------------------------------------------------------------
+
+
+class TestDeletePolicyReturn:
+    async def test_delete_zero_returns_false(self):
+        from parrot_formdesigner.services.rbac import RBACService
+        conn = MagicMock()
+        conn.execute = AsyncMock(return_value="DELETE 0")
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=conn)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        pool = MagicMock()
+        pool.acquire = MagicMock(return_value=cm)
+        svc = RBACService(pool)
+        assert await svc.delete_policy("nope") is False
+
+    async def test_delete_one_returns_true(self):
+        from parrot_formdesigner.services.rbac import RBACService
+        conn = MagicMock()
+        conn.execute = AsyncMock(return_value="DELETE 1")
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=conn)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        pool = MagicMock()
+        pool.acquire = MagicMock(return_value=cm)
+        svc = RBACService(pool)
+        assert await svc.delete_policy("yes") is True

--- a/packages/parrot-formdesigner/tests/unit/test_fieldsync_schema.py
+++ b/packages/parrot-formdesigner/tests/unit/test_fieldsync_schema.py
@@ -1,0 +1,129 @@
+"""Unit tests for TASK-013 — fieldsync schema DDL (no real DB).
+
+Verifies:
+- DDL strings are well-formed and contain expected identifiers.
+- FieldsyncSchemaManager.initialize() calls conn.execute for every DDL
+  statement (idempotence path tested via fake pool).
+- Second call to initialize() runs without error (idempotent).
+- ddl_statements() returns a fresh copy (mutation-safe).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from parrot_formdesigner.services.fieldsync_schema import (
+    FieldsyncSchemaManager,
+    _CREATE_AUTH_POLICIES_SQL,
+    _CREATE_PROJECTS_SQL,
+    _CREATE_SCHEMA_SQL,
+    _CREATE_WORKDAY_COST_CENTER_MAPPINGS_SQL,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake pool / connection helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_pool() -> MagicMock:
+    """Build a fake asyncpg-style pool that records executed SQL."""
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=None)
+
+    pool = MagicMock()
+    # acquire() is an async context manager
+    acquire_cm = MagicMock()
+    acquire_cm.__aenter__ = AsyncMock(return_value=conn)
+    acquire_cm.__aexit__ = AsyncMock(return_value=False)
+    pool.acquire = MagicMock(return_value=acquire_cm)
+    pool._conn = conn  # expose for assertions
+    return pool
+
+
+# ---------------------------------------------------------------------------
+# DDL content tests (pure string assertions — no I/O)
+# ---------------------------------------------------------------------------
+
+
+class TestDDLContent:
+    """Verify DDL strings contain the expected Postgres constructs."""
+
+    def test_schema_ddl_is_idempotent(self) -> None:
+        assert "CREATE SCHEMA IF NOT EXISTS fieldsync" in _CREATE_SCHEMA_SQL
+
+    def test_projects_table_ddl(self) -> None:
+        sql = _CREATE_PROJECTS_SQL
+        assert "CREATE TABLE IF NOT EXISTS fieldsync.projects" in sql
+        assert "accounting_code" in sql
+        assert "client_id" in sql
+        assert "UNIQUE (client_id, accounting_code)" in sql or "UNIQUE(client_id, accounting_code)" in sql or "uq_projects_client_accounting" in sql
+
+    def test_workday_mappings_ddl(self) -> None:
+        sql = _CREATE_WORKDAY_COST_CENTER_MAPPINGS_SQL
+        assert "CREATE TABLE IF NOT EXISTS fieldsync.workday_cost_center_mappings" in sql
+        assert "project_id" in sql
+        assert "workday_code" in sql
+        # UNIQUE on project_id
+        assert "UNIQUE" in sql
+
+    def test_auth_policies_ddl(self) -> None:
+        sql = _CREATE_AUTH_POLICIES_SQL
+        assert "CREATE TABLE IF NOT EXISTS fieldsync.auth_policies" in sql
+        assert "policy" in sql
+        assert "JSONB" in sql
+        assert "enforcing" in sql
+        assert "priority" in sql
+
+    def test_ddl_statements_returns_four(self) -> None:
+        stmts = FieldsyncSchemaManager.ddl_statements()
+        assert len(stmts) == 4
+
+    def test_ddl_statements_is_copy(self) -> None:
+        stmts = FieldsyncSchemaManager.ddl_statements()
+        stmts.clear()
+        assert len(FieldsyncSchemaManager.ddl_statements()) == 4
+
+
+# ---------------------------------------------------------------------------
+# Fake-pool integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestFieldsyncSchemaManager:
+    """Test FieldsyncSchemaManager behavior with a fake pool."""
+
+    @pytest.mark.asyncio
+    async def test_initialize_calls_all_ddl_statements(self) -> None:
+        pool = _make_fake_pool()
+        mgr = FieldsyncSchemaManager(pool)
+        await mgr.initialize()
+
+        conn = pool._conn
+        calls = [call.args[0] for call in conn.execute.call_args_list]
+        expected = FieldsyncSchemaManager.ddl_statements()
+        assert len(calls) == len(expected), f"Expected {len(expected)} DDL calls, got {len(calls)}"
+        for stmt in expected:
+            assert stmt in calls, f"DDL statement not executed: {stmt[:60]!r}"
+
+    @pytest.mark.asyncio
+    async def test_initialize_twice_no_error(self) -> None:
+        """Second call must not raise (idempotent)."""
+        pool = _make_fake_pool()
+        mgr = FieldsyncSchemaManager(pool)
+        await mgr.initialize()
+        await mgr.initialize()  # should not raise
+        conn = pool._conn
+        # 4 statements × 2 calls = 8
+        assert conn.execute.call_count == 8
+
+    @pytest.mark.asyncio
+    async def test_initialize_propagates_db_error(self) -> None:
+        """DB errors must propagate (not swallowed)."""
+        pool = _make_fake_pool()
+        pool._conn.execute = AsyncMock(side_effect=RuntimeError("DB down"))
+        mgr = FieldsyncSchemaManager(pool)
+        with pytest.raises(RuntimeError, match="DB down"):
+            await mgr.initialize()

--- a/packages/parrot-formdesigner/tests/unit/test_org_graph_service.py
+++ b/packages/parrot-formdesigner/tests/unit/test_org_graph_service.py
@@ -1,0 +1,317 @@
+"""Unit tests for TASK-014 — OrgGraphService (fake pool, no real DB).
+
+Verifies:
+- OrgNode / OrgGraph model construction.
+- get_graph() builds tree with correct nesting and depth.
+- Hard tenant isolation: nodes carry tenant in metadata.
+- Multi-hierarchy: two organizations under the same company root.
+- get_node() returns correct node for org / client / program.
+- KeyError raised when org not found.
+- RuntimeError raised when no pool and no env var.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from parrot_formdesigner.services.org_graph import OrgGraph, OrgGraphService, OrgNode
+
+
+# ---------------------------------------------------------------------------
+# Fake pool helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_conn(fetchrow_results: dict | None = None, fetch_results: dict | None = None) -> MagicMock:
+    """Build a fake asyncpg-style connection.
+
+    Args:
+        fetchrow_results: Mapping of SQL → row dict (or None for not found).
+        fetch_results: Mapping of SQL → list of row dicts.
+    """
+    conn = MagicMock()
+    fetchrow_results = fetchrow_results or {}
+    fetch_results = fetch_results or {}
+
+    async def _fetchrow(sql: str, *args: Any) -> MagicMock | None:
+        # Match on sql prefix
+        for key, val in fetchrow_results.items():
+            if key in sql:
+                if val is None:
+                    return None
+                row = MagicMock()
+                row.__getitem__ = lambda self, k: val[k]
+                row.keys = lambda: list(val.keys())
+                return row
+        return None
+
+    async def _fetch(sql: str, *args: Any) -> list[MagicMock]:
+        for key, val in fetch_results.items():
+            if key in sql:
+                rows = []
+                for item in val:
+                    row = MagicMock()
+                    row.__getitem__ = lambda self, k, _item=item: _item[k]
+                    rows.append(row)
+                return rows
+        return []
+
+    conn.fetchrow = AsyncMock(side_effect=_fetchrow)
+    conn.fetch = AsyncMock(side_effect=_fetch)
+    return conn
+
+
+def _make_pool(conn: MagicMock) -> MagicMock:
+    pool = MagicMock()
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=conn)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    pool.acquire = MagicMock(return_value=cm)
+    return pool
+
+
+# ---------------------------------------------------------------------------
+# Model tests
+# ---------------------------------------------------------------------------
+
+
+class TestOrgNodeModel:
+    def test_basic_construction(self) -> None:
+        node = OrgNode(node_type="organization", node_id="7")
+        assert node.node_id == "7"
+        assert node.children == []
+        assert node.metadata == {}
+
+    def test_company_node(self) -> None:
+        node = OrgNode(
+            node_type="company",
+            node_id="company:acme",
+            metadata={"tenant": "acme"},
+        )
+        assert node.parent_id is None
+        assert node.node_type == "company"
+
+    def test_nested_children(self) -> None:
+        child = OrgNode(node_type="client", node_id="42", parent_id="7")
+        parent = OrgNode(node_type="organization", node_id="7", children=[child])
+        assert len(parent.children) == 1
+        assert parent.children[0].node_id == "42"
+
+
+class TestOrgGraphModel:
+    def test_basic_construction(self) -> None:
+        root = OrgNode(node_type="company", node_id="company:t1")
+        graph = OrgGraph(org_id=7, tenant="t1", root=root)
+        assert graph.org_id == 7
+        assert graph.tenant == "t1"
+        assert graph.root.node_type == "company"
+
+
+# ---------------------------------------------------------------------------
+# get_graph() tests
+# ---------------------------------------------------------------------------
+
+
+class TestOrgGraphServiceGetGraph:
+    """Tests using fake pool — no real DB required."""
+
+    def _svc(self, conn: MagicMock) -> OrgGraphService:
+        pool = _make_pool(conn)
+        return OrgGraphService(pool)
+
+    @pytest.mark.asyncio
+    async def test_get_graph_returns_company_root(self) -> None:
+        conn = _make_conn(
+            fetchrow_results={"auth.organizations": {"name": "Acme Corp"}},
+            fetch_results={
+                "auth.clients": [],
+            },
+        )
+        svc = self._svc(conn)
+        graph = await svc.get_graph(7, tenant="acme", depth=2)
+        assert graph.org_id == 7
+        assert graph.tenant == "acme"
+        assert graph.root.node_type == "company"
+        assert graph.root.node_id == "company:acme"
+
+    @pytest.mark.asyncio
+    async def test_get_graph_org_node_in_children(self) -> None:
+        conn = _make_conn(
+            fetchrow_results={"auth.organizations": {"name": "Acme Corp"}},
+            fetch_results={"auth.clients": []},
+        )
+        svc = self._svc(conn)
+        graph = await svc.get_graph(7, tenant="acme", depth=2)
+        assert len(graph.root.children) == 1
+        org_node = graph.root.children[0]
+        assert org_node.node_type == "organization"
+        assert org_node.node_id == "7"
+
+    @pytest.mark.asyncio
+    async def test_get_graph_depth_1_no_clients(self) -> None:
+        conn = _make_conn(
+            fetchrow_results={"auth.organizations": {"name": "Org"}},
+            fetch_results={},
+        )
+        svc = self._svc(conn)
+        graph = await svc.get_graph(7, tenant="t1", depth=1)
+        org_node = graph.root.children[0]
+        assert org_node.children == []
+
+    @pytest.mark.asyncio
+    async def test_get_graph_depth_2_includes_clients(self) -> None:
+        conn = _make_conn(
+            fetchrow_results={"auth.organizations": {"name": "Org"}},
+            fetch_results={
+                "auth.clients": [
+                    {"client_id": 42, "client_name": "ClientA"},
+                    {"client_id": 43, "client_name": "ClientB"},
+                ],
+            },
+        )
+        svc = self._svc(conn)
+        graph = await svc.get_graph(7, tenant="t1", depth=2)
+        org_node = graph.root.children[0]
+        assert len(org_node.children) == 2
+        assert org_node.children[0].node_type == "client"
+        assert org_node.children[0].node_id == "42"
+
+    @pytest.mark.asyncio
+    async def test_get_graph_depth_3_includes_programs_and_projects(self) -> None:
+        conn = _make_conn(
+            fetchrow_results={"auth.organizations": {"name": "Org"}},
+            fetch_results={
+                "auth.clients": [{"client_id": 10, "client_name": "C1"}],
+                "auth.programs": [{"program_id": 1, "program_name": "P1"}],
+                "fieldsync.projects": [
+                    {
+                        "project_id": 99,
+                        "name": "Proj1",
+                        "accounting_code": "ACC001",
+                        "is_active": True,
+                    }
+                ],
+                "networkninja.markets": [],
+            },
+        )
+        svc = self._svc(conn)
+        graph = await svc.get_graph(7, tenant="t1", depth=3)
+        client_node = graph.root.children[0].children[0]
+        types = {n.node_type for n in client_node.children}
+        assert "program" in types
+        assert "project" in types
+
+    @pytest.mark.asyncio
+    async def test_get_graph_org_not_found_raises(self) -> None:
+        conn = _make_conn(fetchrow_results={"auth.organizations": None})
+        svc = self._svc(conn)
+        with pytest.raises(KeyError, match="Organization 99 not found"):
+            await svc.get_graph(99, tenant="t1")
+
+    @pytest.mark.asyncio
+    async def test_tenant_in_company_root_metadata(self) -> None:
+        conn = _make_conn(
+            fetchrow_results={"auth.organizations": {"name": "Org"}},
+            fetch_results={"auth.clients": []},
+        )
+        svc = self._svc(conn)
+        graph = await svc.get_graph(7, tenant="isolated_tenant")
+        assert graph.root.metadata["tenant"] == "isolated_tenant"
+
+    @pytest.mark.asyncio
+    async def test_multi_hierarchy_two_orgs_share_company_root(self) -> None:
+        """Two separate get_graph() calls for two orgs → same tenant, separate graphs."""
+        conn1 = _make_conn(
+            fetchrow_results={"auth.organizations": {"name": "Org A"}},
+            fetch_results={"auth.clients": []},
+        )
+        conn2 = _make_conn(
+            fetchrow_results={"auth.organizations": {"name": "Org B"}},
+            fetch_results={"auth.clients": []},
+        )
+        svc1 = OrgGraphService(_make_pool(conn1))
+        svc2 = OrgGraphService(_make_pool(conn2))
+        g1 = await svc1.get_graph(1, tenant="bigco")
+        g2 = await svc2.get_graph(2, tenant="bigco")
+        # Both roots are company:bigco
+        assert g1.root.node_id == "company:bigco"
+        assert g2.root.node_id == "company:bigco"
+        # Each graph has its own organization child
+        assert g1.root.children[0].node_id == "1"
+        assert g2.root.children[0].node_id == "2"
+
+
+# ---------------------------------------------------------------------------
+# get_node() tests
+# ---------------------------------------------------------------------------
+
+
+class TestOrgGraphServiceGetNode:
+    @pytest.mark.asyncio
+    async def test_get_org_node(self) -> None:
+        conn = _make_conn(
+            fetchrow_results={"auth.organizations": {"name": "MyOrg"}},
+        )
+        svc = OrgGraphService(_make_pool(conn))
+        node = await svc.get_node("organization", "7", tenant="t1", org_id=7)
+        assert node.node_type == "organization"
+        assert node.node_id == "7"
+        assert node.metadata["name"] == "MyOrg"
+
+    @pytest.mark.asyncio
+    async def test_get_org_node_not_found(self) -> None:
+        conn = _make_conn(fetchrow_results={"auth.organizations": None})
+        svc = OrgGraphService(_make_pool(conn))
+        with pytest.raises(KeyError, match="Organization 99 not found"):
+            await svc.get_node("organization", "99", tenant="t1", org_id=7)
+
+    @pytest.mark.asyncio
+    async def test_get_client_node(self) -> None:
+        conn = _make_conn(
+            fetch_results={
+                "auth.clients": [{"client_id": 42, "client_name": "ClientX"}]
+            }
+        )
+        svc = OrgGraphService(_make_pool(conn))
+        node = await svc.get_node("client", "42", tenant="t1", org_id=7)
+        assert node.node_type == "client"
+        assert node.metadata["client_name"] == "ClientX"
+
+    @pytest.mark.asyncio
+    async def test_get_client_not_found(self) -> None:
+        conn = _make_conn(fetch_results={"auth.clients": []})
+        svc = OrgGraphService(_make_pool(conn))
+        with pytest.raises(KeyError, match="Client 99 not found"):
+            await svc.get_node("client", "99", tenant="t1", org_id=7)
+
+    @pytest.mark.asyncio
+    async def test_get_program_node(self) -> None:
+        conn = _make_conn(
+            fetch_results={
+                "auth.programs": [{"program_id": 5, "program_name": "ProgramX"}]
+            }
+        )
+        svc = OrgGraphService(_make_pool(conn))
+        node = await svc.get_node("program", "5", tenant="t1", org_id=7)
+        assert node.node_type == "program"
+        assert node.metadata["program_name"] == "ProgramX"
+
+
+# ---------------------------------------------------------------------------
+# No-pool / env fallback tests
+# ---------------------------------------------------------------------------
+
+
+class TestOrgGraphServiceNoPool:
+    @pytest.mark.asyncio
+    async def test_no_pool_no_env_raises(self) -> None:
+        svc = OrgGraphService(pool=None)
+        with patch.dict("os.environ", {}, clear=False):
+            # Ensure env var is absent
+            import os
+            os.environ.pop("FIELDSYNC_AUTH_RO_DSN", None)
+            with pytest.raises(RuntimeError, match="FIELDSYNC_AUTH_RO_DSN"):
+                await svc.get_graph(1, tenant="t1")

--- a/packages/parrot-formdesigner/tests/unit/test_project_service.py
+++ b/packages/parrot-formdesigner/tests/unit/test_project_service.py
@@ -1,0 +1,304 @@
+"""Unit tests for TASK-015 — ProjectService (fake pool, no real DB).
+
+Covers:
+- create_project() happy path (returns Project with project_id).
+- DuplicateAccountingCodeError on unique constraint violation.
+- get_project() happy path + ProjectNotFoundError.
+- list_projects() with no filter / client_id filter / org_id filter.
+- map_to_workday() upsert round-trip.
+- NEVER writes to networkninja.projects (verified by inspecting SQL constants).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from parrot_formdesigner.services.project_service import (
+    DuplicateAccountingCodeError,
+    Project,
+    ProjectNotFoundError,
+    ProjectService,
+    WorkdayCostCenterMapping,
+    _INSERT_PROJECT_SQL,
+    _SELECT_PROJECT_SQL,
+    _UPSERT_WORKDAY_MAPPING_SQL,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake pool / connection helpers
+# ---------------------------------------------------------------------------
+
+
+def _row(data: dict) -> MagicMock:
+    """Build a MagicMock that behaves like an asyncpg Record."""
+    row = MagicMock()
+    row.__getitem__ = lambda self, k: data[k]
+    return row
+
+
+def _make_conn(
+    fetchrow_result: Any = None,
+    fetch_result: list | None = None,
+    fetchrow_side_effect: Any = None,
+) -> MagicMock:
+    conn = MagicMock()
+    if fetchrow_side_effect is not None:
+        conn.fetchrow = AsyncMock(side_effect=fetchrow_side_effect)
+    else:
+        conn.fetchrow = AsyncMock(return_value=fetchrow_result)
+    conn.fetch = AsyncMock(return_value=fetch_result or [])
+    return conn
+
+
+def _make_pool(conn: MagicMock) -> MagicMock:
+    pool = MagicMock()
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=conn)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    pool.acquire = MagicMock(return_value=cm)
+    return pool
+
+
+def _project_row(
+    project_id: int = 1,
+    client_id: int = 42,
+    name: str = "Test Project",
+    accounting_code: str = "ACC001",
+    org_id: int = 7,
+    is_active: bool = True,
+) -> MagicMock:
+    return _row(
+        {
+            "project_id": project_id,
+            "client_id": client_id,
+            "name": name,
+            "accounting_code": accounting_code,
+            "org_id": org_id,
+            "start_timestamp": None,
+            "end_timestamp": None,
+            "is_active": is_active,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# SQL safety: verify no writes to networkninja
+# ---------------------------------------------------------------------------
+
+
+class TestSQLSafety:
+    """Ensure we never reference networkninja writes in our SQL constants."""
+
+    def test_insert_sql_targets_fieldsync(self) -> None:
+        assert "fieldsync.projects" in _INSERT_PROJECT_SQL
+        assert "networkninja" not in _INSERT_PROJECT_SQL
+
+    def test_select_sql_targets_fieldsync(self) -> None:
+        assert "fieldsync.projects" in _SELECT_PROJECT_SQL
+        assert "networkninja" not in _SELECT_PROJECT_SQL
+
+    def test_workday_upsert_targets_fieldsync(self) -> None:
+        assert "fieldsync.workday_cost_center_mappings" in _UPSERT_WORKDAY_MAPPING_SQL
+        assert "networkninja" not in _UPSERT_WORKDAY_MAPPING_SQL
+
+
+# ---------------------------------------------------------------------------
+# create_project tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateProject:
+    @pytest.mark.asyncio
+    async def test_create_returns_project(self) -> None:
+        row = _project_row()
+        conn = _make_conn(fetchrow_result=row)
+        svc = ProjectService(_make_pool(conn))
+        proj = await svc.create_project(
+            accounting_code="ACC001",
+            name="Test Project",
+            client_id=42,
+            org_id=7,
+            tenant="acme",
+        )
+        assert isinstance(proj, Project)
+        assert proj.project_id == 1
+        assert proj.accounting_code == "ACC001"
+        assert proj.client_id == 42
+        assert proj.tenant == "acme"
+
+    @pytest.mark.asyncio
+    async def test_create_passes_correct_params(self) -> None:
+        row = _project_row()
+        conn = _make_conn(fetchrow_result=row)
+        pool = _make_pool(conn)
+        svc = ProjectService(pool)
+        await svc.create_project(
+            accounting_code="ACC-X",
+            name="Proj X",
+            client_id=99,
+            org_id=5,
+            tenant="t1",
+        )
+        call_args = conn.fetchrow.call_args
+        assert call_args[0][1] == 99   # client_id
+        assert call_args[0][3] == "ACC-X"  # accounting_code (pos 3 in INSERT)
+
+    @pytest.mark.asyncio
+    async def test_create_duplicate_raises(self) -> None:
+        class _UniqueViolation(Exception):
+            pass
+
+        err = _UniqueViolation("duplicate key value violates unique constraint uq_projects_client_accounting")
+        conn = _make_conn(fetchrow_side_effect=err)
+        svc = ProjectService(_make_pool(conn))
+        with pytest.raises(DuplicateAccountingCodeError) as exc_info:
+            await svc.create_project(
+                accounting_code="ACC001",
+                name="Dupe",
+                client_id=42,
+                org_id=7,
+                tenant="t1",
+            )
+        assert exc_info.value.accounting_code == "ACC001"
+        assert exc_info.value.client_id == 42
+
+    @pytest.mark.asyncio
+    async def test_create_other_error_propagates(self) -> None:
+        conn = _make_conn(fetchrow_side_effect=RuntimeError("connection lost"))
+        svc = ProjectService(_make_pool(conn))
+        with pytest.raises(RuntimeError, match="connection lost"):
+            await svc.create_project(
+                accounting_code="ACC001",
+                client_id=42,
+                org_id=7,
+                tenant="t1",
+            )
+
+
+# ---------------------------------------------------------------------------
+# get_project tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetProject:
+    @pytest.mark.asyncio
+    async def test_get_returns_project(self) -> None:
+        row = _project_row(project_id=5, accounting_code="ACC-5")
+        conn = _make_conn(fetchrow_result=row)
+        svc = ProjectService(_make_pool(conn))
+        proj = await svc.get_project(5, org_id=7)
+        assert proj.project_id == 5
+        assert proj.accounting_code == "ACC-5"
+
+    @pytest.mark.asyncio
+    async def test_get_not_found_raises(self) -> None:
+        conn = _make_conn(fetchrow_result=None)
+        svc = ProjectService(_make_pool(conn))
+        with pytest.raises(ProjectNotFoundError) as exc_info:
+            await svc.get_project(999, org_id=7)
+        assert exc_info.value.project_id == 999
+
+    @pytest.mark.asyncio
+    async def test_get_passes_tenant_to_model(self) -> None:
+        row = _project_row()
+        conn = _make_conn(fetchrow_result=row)
+        svc = ProjectService(_make_pool(conn))
+        proj = await svc.get_project(1, org_id=7, tenant="mytenant")
+        assert proj.tenant == "mytenant"
+
+
+# ---------------------------------------------------------------------------
+# list_projects tests
+# ---------------------------------------------------------------------------
+
+
+class TestListProjects:
+    @pytest.mark.asyncio
+    async def test_list_all_no_filter(self) -> None:
+        rows = [_project_row(1), _project_row(2, accounting_code="ACC002")]
+        conn = _make_conn(fetch_result=rows)
+        svc = ProjectService(_make_pool(conn))
+        projects = await svc.list_projects(org_id=7)
+        assert len(projects) == 2
+
+    @pytest.mark.asyncio
+    async def test_list_by_client_id(self) -> None:
+        rows = [_project_row(1, client_id=10)]
+        conn = _make_conn(fetch_result=rows)
+        svc = ProjectService(_make_pool(conn))
+        projects = await svc.list_projects(org_id=7, client_id=10)
+        assert len(projects) == 1
+        assert projects[0].client_id == 10
+
+    @pytest.mark.asyncio
+    async def test_list_by_org_id(self) -> None:
+        rows = [_project_row(1, org_id=99)]
+        conn = _make_conn(fetch_result=rows)
+        svc = ProjectService(_make_pool(conn))
+        projects = await svc.list_projects(org_id=99)
+        assert len(projects) == 1
+
+    @pytest.mark.asyncio
+    async def test_list_empty(self) -> None:
+        conn = _make_conn(fetch_result=[])
+        svc = ProjectService(_make_pool(conn))
+        projects = await svc.list_projects(org_id=7, client_id=9999)
+        assert projects == []
+
+
+# ---------------------------------------------------------------------------
+# map_to_workday tests
+# ---------------------------------------------------------------------------
+
+
+class TestMapToWorkday:
+    def _mapping_row(
+        self,
+        project_id: int = 1,
+        workday_code: str = "WD-001",
+        direction: str = "internal_to_workday",
+    ) -> MagicMock:
+        return _row(
+            {
+                "project_id": project_id,
+                "workday_code": workday_code,
+                "direction": direction,
+            }
+        )
+
+    @pytest.mark.asyncio
+    async def test_map_returns_mapping(self) -> None:
+        row = self._mapping_row(project_id=5, workday_code="WD-999")
+        conn = _make_conn(fetchrow_result=row)
+        svc = ProjectService(_make_pool(conn))
+        mapping = await svc.map_to_workday(5, "WD-999", tenant="acme")
+        assert isinstance(mapping, WorkdayCostCenterMapping)
+        assert mapping.project_id == 5
+        assert mapping.workday_code == "WD-999"
+        assert mapping.direction == "internal_to_workday"
+
+    @pytest.mark.asyncio
+    async def test_map_upsert_called_with_correct_params(self) -> None:
+        row = self._mapping_row()
+        conn = _make_conn(fetchrow_result=row)
+        pool = _make_pool(conn)
+        svc = ProjectService(pool)
+        await svc.map_to_workday(42, "WD-100", tenant="t1")
+        conn.fetchrow.assert_called_once()
+        call_sql = conn.fetchrow.call_args[0][0]
+        assert "ON CONFLICT" in call_sql
+        assert "DO UPDATE" in call_sql
+
+    @pytest.mark.asyncio
+    async def test_map_custom_direction(self) -> None:
+        row = self._mapping_row(direction="bidirectional")
+        conn = _make_conn(fetchrow_result=row)
+        svc = ProjectService(_make_pool(conn))
+        mapping = await svc.map_to_workday(
+            1, "WD-200", tenant="t1", direction="bidirectional"
+        )
+        assert mapping.direction == "bidirectional"

--- a/packages/parrot-formdesigner/tests/unit/test_rbac_service.py
+++ b/packages/parrot-formdesigner/tests/unit/test_rbac_service.py
@@ -1,0 +1,477 @@
+"""Unit tests for TASK-016 — RBACService (fake pool, no real DB).
+
+Covers:
+- Policy model construction + round-trip serialization.
+- RBACScope vocabulary values.
+- _compile_scope_to_policy produces correct subjects/conditions per scope.
+- RBACContext.has_permission() scope enforcement.
+- assign_role() creates a policy (NEVER writes to auth.user_permissions).
+- create_policy/get_policy/list_policies/delete_policy CRUD.
+- resolve() builds RBACContext from policies.
+- revoke_all() removes compiled policies.
+- SQL constants: no writes to auth.* (only reads).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from parrot_formdesigner.services.rbac import (
+    PermissionRecord,
+    Policy,
+    RBACContext,
+    RBACScope,
+    RBACService,
+    _compile_scope_to_policy,
+    _DELETE_POLICY_SQL,
+    _INSERT_POLICY_SQL,
+    _SELECT_POLICIES_BY_TENANT_SQL,
+    _SELECT_POLICY_SQL,
+    _SELECT_USER_GROUPS_SQL,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake pool helpers
+# ---------------------------------------------------------------------------
+
+
+def _row(data: dict) -> MagicMock:
+    """Fake asyncpg-style Record."""
+    r = MagicMock()
+    r.__getitem__ = lambda self, k: data[k]
+    return r
+
+
+def _make_conn(
+    fetchrow_result: Any = None,
+    fetch_result: list | None = None,
+    execute_result: str = "INSERT 0 1",
+) -> MagicMock:
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=fetchrow_result)
+    conn.fetch = AsyncMock(return_value=fetch_result or [])
+    conn.execute = AsyncMock(return_value=execute_result)
+    return conn
+
+
+def _make_pool(conn: MagicMock) -> MagicMock:
+    pool = MagicMock()
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=conn)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    pool.acquire = MagicMock(return_value=cm)
+    return pool
+
+
+def _policy_row(
+    name: str = "test_policy",
+    policy_dict: dict | None = None,
+    tenant: str = "acme",
+    priority: int = 50,
+    enforcing: bool = False,
+) -> MagicMock:
+    data = policy_dict or {
+        "name": name,
+        "effect": "allow",
+        "description": "",
+        "resources": ["form:*"],
+        "actions": ["edit_form"],
+        "subjects": {},
+        "conditions": {},
+        "priority": priority,
+        "enforcing": enforcing,
+        "tenant": tenant,
+    }
+    return _row(
+        {
+            "id": 1,
+            "name": name,
+            "policy": json.dumps(data),
+            "tenant": tenant,
+            "priority": priority,
+            "enforcing": enforcing,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# SQL safety — no writes to auth.*
+# ---------------------------------------------------------------------------
+
+
+class TestSQLSafety:
+    """Verify SQL constants never write to auth schema."""
+
+    def test_insert_targets_fieldsync(self) -> None:
+        assert "fieldsync.auth_policies" in _INSERT_POLICY_SQL
+        assert "auth.user_permissions" not in _INSERT_POLICY_SQL
+
+    def test_delete_targets_fieldsync(self) -> None:
+        assert "fieldsync.auth_policies" in _DELETE_POLICY_SQL
+        assert "auth." not in _DELETE_POLICY_SQL
+
+    def test_select_targets_fieldsync(self) -> None:
+        assert "fieldsync.auth_policies" in _SELECT_POLICY_SQL
+        assert "fieldsync.auth_policies" in _SELECT_POLICIES_BY_TENANT_SQL
+
+    def test_user_groups_is_read_only(self) -> None:
+        assert "SELECT" in _SELECT_USER_GROUPS_SQL.upper()
+        assert "INSERT" not in _SELECT_USER_GROUPS_SQL.upper()
+        assert "UPDATE" not in _SELECT_USER_GROUPS_SQL.upper()
+        assert "DELETE" not in _SELECT_USER_GROUPS_SQL.upper()
+
+
+# ---------------------------------------------------------------------------
+# Policy model
+# ---------------------------------------------------------------------------
+
+
+class TestPolicyModel:
+    def test_basic_construction(self) -> None:
+        pol = Policy(
+            name="eng_biz_hours",
+            effect="allow",
+            resources=["agent:*"],
+            actions=["agent:chat"],
+            subjects={"groups": ["engineering"]},
+            conditions={"environment": {"is_business_hours": True}},
+            priority=20,
+            enforcing=False,
+        )
+        assert pol.name == "eng_biz_hours"
+        assert pol.effect == "allow"
+        assert pol.priority == 20
+        assert not pol.enforcing
+
+    def test_defaults(self) -> None:
+        pol = Policy(name="minimal")
+        assert pol.effect == "allow"
+        assert pol.priority == 50
+        assert pol.enforcing is False
+        assert pol.resources == []
+
+    def test_round_trip_json(self) -> None:
+        pol = Policy(
+            name="test",
+            effect="deny",
+            resources=["form:edit"],
+            actions=["edit_form"],
+        )
+        data = pol.model_dump(mode="json")
+        pol2 = Policy(**data)
+        assert pol2 == pol
+
+
+# ---------------------------------------------------------------------------
+# RBACScope + compile
+# ---------------------------------------------------------------------------
+
+
+class TestRBACScope:
+    def test_scope_values(self) -> None:
+        assert RBACScope.OWN.value == "own"
+        assert RBACScope.TEAM.value == "team"
+        assert RBACScope.CLIENT.value == "client"
+        assert RBACScope.GLOBAL.value == "global"
+
+    def test_compile_own_scope(self) -> None:
+        pol = _compile_scope_to_policy(
+            "user-1", program_id=7, codename="edit_form",
+            scope=RBACScope.OWN, tenant="acme"
+        )
+        assert "user-1" in pol.subjects.get("users", [])
+        assert pol.actions == ["edit_form"]
+        assert pol.tenant == "acme"
+
+    def test_compile_team_scope(self) -> None:
+        pol = _compile_scope_to_policy(
+            "user-1", program_id=7, codename="view_form",
+            scope=RBACScope.TEAM, tenant="acme"
+        )
+        assert "team/7" in pol.subjects.get("groups", [])
+
+    def test_compile_client_scope(self) -> None:
+        pol = _compile_scope_to_policy(
+            "user-1", program_id=7, codename="view_form",
+            scope=RBACScope.CLIENT, tenant="acme"
+        )
+        assert pol.conditions.get("resource", {}).get("program_id") == 7
+
+    def test_compile_global_scope(self) -> None:
+        pol = _compile_scope_to_policy(
+            "user-1", program_id=7, codename="admin",
+            scope=RBACScope.GLOBAL, tenant="acme"
+        )
+        assert pol.subjects == {}
+        assert pol.conditions == {}
+
+    def test_compile_not_enforcing_by_default(self) -> None:
+        pol = _compile_scope_to_policy(
+            "user-1", program_id=7, codename="edit_form",
+            scope=RBACScope.OWN, tenant="acme"
+        )
+        assert pol.enforcing is False
+
+    def test_compile_policy_name_includes_codename_and_scope(self) -> None:
+        pol = _compile_scope_to_policy(
+            "user-abc", program_id=3, codename="delete_form",
+            scope=RBACScope.TEAM, tenant="t1"
+        )
+        assert "delete_form" in pol.name
+        assert "team" in pol.name
+        assert "user-abc" in pol.name
+
+
+# ---------------------------------------------------------------------------
+# RBACContext.has_permission
+# ---------------------------------------------------------------------------
+
+
+class TestRBACContext:
+    def _ctx(self, codename: str, scope: RBACScope) -> RBACContext:
+        rec = PermissionRecord(
+            user_id="u1", codename=codename, scope=scope,
+            program_id=7, policy_name="p1", tenant="t1"
+        )
+        return RBACContext(user_id="u1", program_id=7, permissions=[rec])
+
+    def test_has_permission_true_exact_scope(self) -> None:
+        ctx = self._ctx("edit_form", RBACScope.OWN)
+        assert ctx.has_permission("edit_form", scope=RBACScope.OWN)
+
+    def test_has_permission_narrower_scope_denied(self) -> None:
+        """OWN permission does NOT cover TEAM-scoped query."""
+        ctx = self._ctx("edit_form", RBACScope.OWN)
+        # OWN is narrower than TEAM; requesting TEAM when granted OWN → False
+        assert not ctx.has_permission("edit_form", scope=RBACScope.TEAM)
+
+    def test_has_permission_broader_scope_allowed(self) -> None:
+        """GLOBAL permission covers OWN query (wider ≥ narrower)."""
+        ctx = self._ctx("edit_form", RBACScope.GLOBAL)
+        assert ctx.has_permission("edit_form", scope=RBACScope.OWN)
+        assert ctx.has_permission("edit_form", scope=RBACScope.TEAM)
+        assert ctx.has_permission("edit_form", scope=RBACScope.CLIENT)
+
+    def test_has_permission_no_scope_always_matches(self) -> None:
+        ctx = self._ctx("view_form", RBACScope.OWN)
+        assert ctx.has_permission("view_form")
+
+    def test_has_permission_wrong_codename_false(self) -> None:
+        ctx = self._ctx("edit_form", RBACScope.GLOBAL)
+        assert not ctx.has_permission("delete_form")
+
+    def test_has_permission_empty_permissions(self) -> None:
+        ctx = RBACContext(user_id="u1", program_id=7)
+        assert not ctx.has_permission("any_perm")
+
+
+# ---------------------------------------------------------------------------
+# Policy CRUD via fake pool
+# ---------------------------------------------------------------------------
+
+
+class TestRBACServicePolicyCRUD:
+    @pytest.mark.asyncio
+    async def test_create_policy_inserts_row(self) -> None:
+        pol = Policy(name="p1", effect="allow", tenant="t1")
+        row = _policy_row("p1", tenant="t1")
+        conn = _make_conn(fetchrow_result=row)
+        svc = RBACService(_make_pool(conn))
+        result = await svc.create_policy(pol)
+        assert result.name == "p1"
+        conn.fetchrow.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_policy_found(self) -> None:
+        row = _policy_row("my_pol", tenant="t1")
+        conn = _make_conn(fetchrow_result=row)
+        svc = RBACService(_make_pool(conn))
+        result = await svc.get_policy("my_pol")
+        assert result is not None
+        assert result.name == "my_pol"
+
+    @pytest.mark.asyncio
+    async def test_get_policy_not_found(self) -> None:
+        conn = _make_conn(fetchrow_result=None)
+        svc = RBACService(_make_pool(conn))
+        result = await svc.get_policy("nonexistent")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_list_policies_returns_list(self) -> None:
+        rows = [_policy_row("p1", tenant="t1"), _policy_row("p2", tenant="t1")]
+        conn = _make_conn(fetch_result=rows)
+        svc = RBACService(_make_pool(conn))
+        result = await svc.list_policies(tenant="t1")
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_delete_policy_true_on_success(self) -> None:
+        conn = _make_conn(execute_result="DELETE 1")
+        svc = RBACService(_make_pool(conn))
+        ok = await svc.delete_policy("pol_to_delete")
+        assert ok
+
+    @pytest.mark.asyncio
+    async def test_delete_policy_false_on_not_found(self) -> None:
+        conn = _make_conn(execute_result="DELETE 0")
+        svc = RBACService(_make_pool(conn))
+        ok = await svc.delete_policy("missing_pol")
+        assert not ok
+
+
+# ---------------------------------------------------------------------------
+# assign_role
+# ---------------------------------------------------------------------------
+
+
+class TestRBACServiceAssignRole:
+    @pytest.mark.asyncio
+    async def test_assign_role_returns_record(self) -> None:
+        pol_name = "user__u1__edit_form__own__prog7"
+        row = _policy_row(pol_name, tenant="acme")
+        conn = _make_conn(fetchrow_result=row)
+        svc = RBACService(_make_pool(conn))
+        record = await svc.assign_role(
+            "u1", program_id=7, codename="edit_form",
+            scope=RBACScope.OWN, tenant="acme"
+        )
+        assert isinstance(record, PermissionRecord)
+        assert record.user_id == "u1"
+        assert record.codename == "edit_form"
+        assert record.scope == RBACScope.OWN
+        assert record.tenant == "acme"
+
+    @pytest.mark.asyncio
+    async def test_assign_role_writes_only_to_fieldsync(self) -> None:
+        row = _policy_row()
+        conn = _make_conn(fetchrow_result=row)
+        svc = RBACService(_make_pool(conn))
+        await svc.assign_role(
+            "u1", program_id=7, codename="edit_form",
+            scope=RBACScope.OWN, tenant="acme"
+        )
+        # Verify the SQL used targets fieldsync, not auth.user_permissions
+        call_sql = conn.fetchrow.call_args[0][0]
+        assert "fieldsync.auth_policies" in call_sql
+        assert "auth.user_permissions" not in call_sql
+
+    @pytest.mark.asyncio
+    async def test_assign_role_ref_policy_example_from_spec(self) -> None:
+        """The compiled policy matches the nav-auth YAML format example (§8)."""
+        pol = _compile_scope_to_policy(
+            "user-eng", program_id=7, codename="agent:chat",
+            scope=RBACScope.TEAM, tenant="engineering"
+        )
+        # Should produce a policy compatible with nav-auth YAML format
+        assert pol.effect == "allow"
+        assert "agent:chat" in pol.actions
+        assert pol.enforcing is False  # shadow mode default
+
+
+# ---------------------------------------------------------------------------
+# resolve()
+# ---------------------------------------------------------------------------
+
+
+class TestRBACServiceResolve:
+    @pytest.mark.asyncio
+    async def test_resolve_builds_context(self) -> None:
+        pol_name = "user__u1__edit_form__own__prog7"
+        pol_data = {
+            "name": pol_name, "effect": "allow",
+            "resources": ["form:*"], "actions": ["edit_form"],
+            "subjects": {"users": ["u1"]}, "conditions": {},
+            "priority": 50, "enforcing": False, "tenant": "t1", "description": "",
+        }
+        rows = [_policy_row(pol_name, pol_data, "t1")]
+        conn = _make_conn(fetch_result=rows)
+        svc = RBACService(_make_pool(conn))
+        ctx = await svc.resolve("u1", program_id=7, tenant="t1")
+        assert isinstance(ctx, RBACContext)
+        assert ctx.user_id == "u1"
+        assert len(ctx.permissions) == 1
+        assert ctx.permissions[0].codename == "edit_form"
+
+    @pytest.mark.asyncio
+    async def test_resolve_no_policies_empty_context(self) -> None:
+        conn = _make_conn(fetch_result=[])
+        svc = RBACService(_make_pool(conn))
+        ctx = await svc.resolve("u1", program_id=7, tenant="t1")
+        assert ctx.permissions == []
+
+    @pytest.mark.asyncio
+    async def test_resolve_skips_deny_policies(self) -> None:
+        pol_name = "user__u1__edit_form__own__prog7"
+        pol_data = {
+            "name": pol_name, "effect": "deny",
+            "resources": [], "actions": ["edit_form"],
+            "subjects": {}, "conditions": {},
+            "priority": 50, "enforcing": False, "tenant": "t1", "description": "",
+        }
+        rows = [_policy_row(pol_name, pol_data, "t1")]
+        conn = _make_conn(fetch_result=rows)
+        svc = RBACService(_make_pool(conn))
+        ctx = await svc.resolve("u1", program_id=7, tenant="t1")
+        # deny policies are skipped in permissions build
+        assert len(ctx.permissions) == 0
+
+    @pytest.mark.asyncio
+    async def test_resolve_groups_auth_fallback(self) -> None:
+        """If auth.user_groups query fails, groups = [] (graceful)."""
+        pol_name = "user__u1__edit_form__own__prog7"
+        pol_data = {
+            "name": pol_name, "effect": "allow",
+            "resources": [], "actions": ["edit_form"],
+            "subjects": {}, "conditions": {},
+            "priority": 50, "enforcing": False, "tenant": "t1", "description": "",
+        }
+
+        # First call: list_policies (fetch) succeeds; second call (auth groups) raises
+        conn = MagicMock()
+
+        async def _fetch(sql: str, *args: Any) -> list:
+            if "fieldsync" in sql:
+                return [_policy_row(pol_name, pol_data, "t1")]
+            raise RuntimeError("auth DB not available")
+
+        conn.fetch = AsyncMock(side_effect=_fetch)
+        conn.fetchrow = AsyncMock(return_value=None)
+
+        svc = RBACService(_make_pool(conn))
+        ctx = await svc.resolve("u1", program_id=7, tenant="t1")
+        assert ctx.groups == []
+
+
+# ---------------------------------------------------------------------------
+# revoke_all
+# ---------------------------------------------------------------------------
+
+
+class TestRBACServiceRevokeAll:
+    @pytest.mark.asyncio
+    async def test_revoke_all_deletes_user_policies(self) -> None:
+        pol_name = "user__u1__edit_form__own__prog7"
+        pol_data = {
+            "name": pol_name, "effect": "allow",
+            "resources": [], "actions": ["edit_form"],
+            "subjects": {}, "conditions": {},
+            "priority": 50, "enforcing": False, "tenant": "t1", "description": "",
+        }
+        rows = [_policy_row(pol_name, pol_data, "t1")]
+        conn = _make_conn(fetch_result=rows, execute_result="DELETE 1")
+        svc = RBACService(_make_pool(conn))
+        count = await svc.revoke_all("u1", tenant="t1")
+        assert count == 1
+
+    @pytest.mark.asyncio
+    async def test_revoke_all_zero_when_no_policies(self) -> None:
+        conn = _make_conn(fetch_result=[], execute_result="DELETE 0")
+        svc = RBACService(_make_pool(conn))
+        count = await svc.revoke_all("u1", tenant="t1")
+        assert count == 0

--- a/packages/parrot-formdesigner/tests/unit/test_workday_sync.py
+++ b/packages/parrot-formdesigner/tests/unit/test_workday_sync.py
@@ -1,0 +1,97 @@
+"""Unit tests for TASK-017 — WorkdayIdentitySyncAdapter stub.
+
+Verifies:
+- sync_user returns accepted dict with stub=True (no HTTP calls).
+- Both action=provision and action=deprovision work.
+- Response keys are stable (upgrade contract).
+- No aiohttp.ClientSession is opened (zero network I/O).
+- Adapter can be instantiated with or without base_url/api_key.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from parrot_formdesigner.services.workday_sync import WorkdayIdentitySyncAdapter
+
+
+class TestWorkdayIdentitySyncAdapterConstruction:
+    def test_no_args_construction(self) -> None:
+        adapter = WorkdayIdentitySyncAdapter()
+        assert adapter._base_url is None
+        assert adapter._api_key is None
+
+    def test_with_base_url(self) -> None:
+        adapter = WorkdayIdentitySyncAdapter("https://workday.example.com")
+        assert adapter._base_url == "https://workday.example.com"
+
+    def test_with_api_key(self) -> None:
+        adapter = WorkdayIdentitySyncAdapter(api_key="secret")
+        assert adapter._api_key == "secret"
+
+
+class TestWorkdayIdentitySyncAdapterSyncUser:
+    @pytest.mark.asyncio
+    async def test_provision_returns_accepted(self) -> None:
+        adapter = WorkdayIdentitySyncAdapter()
+        result = await adapter.sync_user("user-1", action="provision", org_id=7)
+        assert result["status"] == "accepted"
+        assert result["stub"] is True
+        assert result["action"] == "provision"
+        assert result["user_id"] == "user-1"
+        assert result["org_id"] == 7
+
+    @pytest.mark.asyncio
+    async def test_deprovision_returns_accepted(self) -> None:
+        adapter = WorkdayIdentitySyncAdapter()
+        result = await adapter.sync_user("user-2", action="deprovision", org_id=3)
+        assert result["status"] == "accepted"
+        assert result["stub"] is True
+        assert result["action"] == "deprovision"
+        assert result["user_id"] == "user-2"
+        assert result["org_id"] == 3
+
+    @pytest.mark.asyncio
+    async def test_response_has_all_required_keys(self) -> None:
+        adapter = WorkdayIdentitySyncAdapter()
+        result = await adapter.sync_user("u", action="provision", org_id=1)
+        for key in ("status", "stub", "action", "user_id", "org_id"):
+            assert key in result, f"Missing key: {key}"
+
+    @pytest.mark.asyncio
+    async def test_no_http_call_made(self) -> None:
+        """Verify no aiohttp.ClientSession is opened (no network I/O)."""
+        with patch("aiohttp.ClientSession") as mock_session:
+            adapter = WorkdayIdentitySyncAdapter("https://example.com")
+            result = await adapter.sync_user("u", action="provision", org_id=1)
+            mock_session.assert_not_called()
+        assert result["stub"] is True
+
+    @pytest.mark.asyncio
+    async def test_no_aiohttp_import_needed(self) -> None:
+        """Stub works even if aiohttp is not importable."""
+        import sys
+        aiohttp_backup = sys.modules.get("aiohttp")
+        try:
+            sys.modules["aiohttp"] = None  # type: ignore[assignment]
+            # Re-import should not be needed — stub has no HTTP dependency
+            adapter = WorkdayIdentitySyncAdapter()
+            result = await adapter.sync_user("u", action="deprovision", org_id=5)
+            assert result["stub"] is True
+        finally:
+            if aiohttp_backup is not None:
+                sys.modules["aiohttp"] = aiohttp_backup
+            elif "aiohttp" in sys.modules:
+                del sys.modules["aiohttp"]
+
+    @pytest.mark.asyncio
+    async def test_stub_logs_info(self) -> None:
+        """Verify that sync_user emits an INFO log."""
+        adapter = WorkdayIdentitySyncAdapter()
+        with patch.object(adapter.logger, "info") as mock_log:
+            await adapter.sync_user("u1", action="provision", org_id=1)
+            mock_log.assert_called_once()
+            call_args = mock_log.call_args[0]
+            assert "STUB" in call_args[0] or "stub" in str(call_args).lower()


### PR DESCRIPTION
## Summary

**FEAT-302 — Org Graph · Programs/Markets · Cost Centers · RBAC** (v0.6.0), re-ported cleanly onto current `main` (now carrying FEAT-300 + FEAT-301 location-vars).

FEAT-302 is independent of the FEAT-300/301 collision — it adds org/projects/RBAC/Workday and does not touch `FieldCondition`.

## What's included
- **`fieldsync` schema** owns all writes: `projects` (UNIQUE(client_id, accounting_code)), `workday_cost_center_mappings` (FK), `auth_policies` (JSONB). `networkninja.projects` is read-only seed source. Idempotent DDL + seed.
- **OrgGraphService**: read-only multi-hierarchy tree over `auth.*` + per-client geography + `fieldsync.projects`; hard tenant isolation; `company` super-node for multiple hierarchies per tenant.
- **ProjectService**: CRUD over `fieldsync.projects` (cost center = `accounting_code`, UNIQUE per client) + Workday cost-center mapping (output only).
- **RBACService**: ABAC/PBAC policies (JSONB) — compiles scope→policy; never writes `auth.user_permissions`; nav-auth remains the enforcement engine.
- **WorkdayIdentitySyncAdapter**: stub (202 + log, zero I/O — FEAT-026/027 pending a Workday guardrails spec).
- **API**: `GET /org/graph`, `POST /org/projects`, `/org/cost-centers/{id}/workday-map`, `/org/users/{id}/assign`, `/org/sync/workday`; RBAC shadow-gate retrofit on form endpoints (`rbac_enforcing=False` default — log only).

## Verification
- Includes the FEAT-302 pre-merge review fixes (C-1..C-6 tenant isolation, H-1 privilege guard, etc.).
- Excludes the FEAT-301 `/evaluate` endpoint (main's `RuleEvaluator` uses `resolve()`, not `evaluate_form`).
- **127 FEAT-302 tests pass**; **zero regressions** vs baseline (91 pre-existing env failures).
- version `0.5.0 → 0.6.0`.

Developed with Spec Driven Development
