### PR TITLE
feat(formdesigner): Claims · T&E · Pay Periods (FEAT-304)

### DIFF
--- a/packages/parrot-formdesigner/src/parrot_formdesigner/core/schema.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/core/schema.py
@@ -33,11 +33,16 @@ class FormType(str, Enum):
         SURVEY: A form composed of survey-style question blocks
             (imported from ``networkninja.forms.question_blocks`` where
             ``block_type == "survey"``).
+        CLAIMS_CONFIG: A configuration form for the Claims / T&E engine
+            (FEAT-304) — Claim Type definitions, Pay Period management, and
+            Claim Exception thresholds. Tags forms produced by
+            :class:`~parrot_formdesigner.services.claims_forms.ClaimsFormService`.
     """
 
     SIMPLE = "simple"
     PRODUCT = "product"
     SURVEY = "survey"
+    CLAIMS_CONFIG = "claims_config"
 
 
 class FormField(BaseModel):

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/__init__.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/__init__.py
@@ -4,6 +4,16 @@ Provides validation, registry, caching, and storage for FormSchema objects.
 """
 
 from .cache import FormCache
+from .claims_forms import (
+    ClaimCategory,
+    ClaimEventConfig,
+    ClaimExceptionConfig,
+    ClaimExceptionThresholdType,
+    ClaimScope,
+    ClaimsFormService,
+    ClaimTypeConfig,
+    PayPeriodConfig,
+)
 from .csrf import (
     issue_form_csrf_token,
     validate_form_csrf_token,
@@ -63,4 +73,14 @@ __all__ = [
     # Rule evaluator (FEAT-234)
     "RuleEvaluator",
     "RuleResolution",
+    # Claims / T&E form design (FEAT-304). Domain/payroll/lifecycle logic
+    # lives in the FieldSync app (apps/claims), not in this package.
+    "ClaimsFormService",
+    "ClaimCategory",
+    "ClaimScope",
+    "ClaimEventConfig",
+    "ClaimExceptionThresholdType",
+    "ClaimTypeConfig",
+    "PayPeriodConfig",
+    "ClaimExceptionConfig",
 ]

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/claims_forms.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/claims_forms.py
@@ -1,0 +1,296 @@
+"""Claims / T&E / Pay Periods domain models and form builders (FEAT-304).
+
+This module provides:
+
+* **Domain models** (Pydantic v2) that are stored as the typed content of
+  :attr:`FormField.meta` for claim-related fields: :class:`ClaimTypeConfig`,
+  :class:`PayPeriodConfig`, :class:`ClaimExceptionConfig`, plus their enums.
+* :class:`ClaimsFormService` — builds :class:`FormSchema` objects for the three
+  Claims/T&E configuration flows (Claim Type, Pay Period, Claim Exception).
+
+Architectural boundary (D3 resolved 2026-06-14 — FieldSync is system of record):
+this package produces the *form schemas* and stores *submissions*; the ``Claim``
+domain entity (state machine, auditable table, Workday/Concur push) lives in the
+FieldSync application layer (ai-parrot), not here. FieldSync NEVER computes
+payroll amounts (Workday owns that — FEAT-321).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict
+
+from ..core.options import FieldOption
+from ..core.schema import FormField, FormSchema, FormSection, FormType
+from ..core.types import FieldType
+from .registry import FormRegistry
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+class ClaimCategory(str, Enum):
+    """The measurement category a Claim Type is denominated in."""
+
+    TIME = "time"
+    AMOUNT = "amount"
+    DISTANCE = "distance"
+
+
+class ClaimScope(str, Enum):
+    """Cascade scope at which a Claim Type is defined (Global→Client→Program)."""
+
+    GLOBAL = "global"
+    CLIENT = "client"
+    PROGRAM = "program"
+
+
+class ClaimEventConfig(str, Enum):
+    """How a claim of this type is created relative to a shift/event."""
+
+    ALLOW = "allow"  # rep submits manually
+    AUTO_GENERATE = "auto-generate"  # generated on shift completion (via FEAT-303)
+
+
+class ClaimExceptionThresholdType(str, Enum):
+    """Threshold dimensions that can flag a claim for manual approval.
+
+    This enum is intentionally **extensible**: the five members below are the
+    confirmed Vision IQ set; new members may be added without breaking
+    consumers (which must tolerate unknown threshold types gracefully).
+    """
+
+    DISTANCE = "distance"
+    MIN_PER_CLAIM = "min_per_claim"
+    DAILY_MINUTES = "daily_minutes"
+    TIME_AMOUNT = "time_amount"
+    DOLLAR_AMOUNT = "dollar_amount"
+
+
+# ---------------------------------------------------------------------------
+# Domain models (stored in FormField.meta)
+# ---------------------------------------------------------------------------
+class ClaimTypeConfig(BaseModel):
+    """Metadata stored in :attr:`FormField.meta` for a Claim Type field."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    category: ClaimCategory
+    scope: ClaimScope
+    budget_code: str | None = None
+    pay_code: str | None = None
+    auto_approve: bool = False
+    requires_receipt: bool = False
+    event_config: ClaimEventConfig = ClaimEventConfig.ALLOW
+
+
+class PayPeriodConfig(BaseModel):
+    """Metadata stored in :attr:`FormField.meta` for a Pay Period date group.
+
+    FieldSync persists these (system of record) and keeps them synced with the
+    Workday calendar. Workday still calculates and closes pay — FieldSync never
+    computes payroll amounts.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    start: date | None = None
+    end: date | None = None
+    paydate: date | None = None
+    lockdate: date | None = None
+    accrue_to_next: bool = True  # locked claims roll to next open period
+
+
+class ClaimExceptionConfig(BaseModel):
+    """Metadata stored in :attr:`FormField.meta` for a Claim Exception threshold."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    threshold_type: ClaimExceptionThresholdType
+    threshold_value: float
+    prompt: str
+    blocks_auto_approve: bool = True
+
+
+# ---------------------------------------------------------------------------
+# Form builder service
+# ---------------------------------------------------------------------------
+class ClaimsFormService:
+    """Builds :class:`FormSchema` objects for the Claims/T&E configuration flows.
+
+    All builder methods are ``async`` (per the async-first house style) even
+    though they perform no I/O today — registration is async and future
+    persistence calls require it. Each builder tags the form with
+    ``FormType.CLAIMS_CONFIG`` and registers it via the shared
+    :class:`FormRegistry`.
+    """
+
+    def __init__(self, registry: FormRegistry, *, tenant: str) -> None:
+        self.registry = registry
+        self.tenant = tenant
+        self.logger = logging.getLogger(__name__)
+
+    async def build_claim_type_form(
+        self, scope: ClaimScope, *, form_id: str | None = None
+    ) -> FormSchema:
+        """Return (and register) a form for defining a Claim Type at ``scope``."""
+        fid = form_id or f"claim_type_{scope.value}"
+        section = FormSection(
+            section_id="claim_type",
+            title="Claim Type",
+            fields=[
+                FormField(
+                    field_id="category",
+                    field_type=FieldType.SELECT,
+                    label="Category",
+                    required=True,
+                    options=[
+                        FieldOption(value=c.value, label=c.value.title())
+                        for c in ClaimCategory
+                    ],
+                ),
+                FormField(
+                    field_id="scope",
+                    field_type=FieldType.SELECT,
+                    label="Scope",
+                    required=True,
+                    default=scope.value,
+                    options=[
+                        FieldOption(value=s.value, label=s.value.title())
+                        for s in ClaimScope
+                    ],
+                ),
+                FormField(
+                    field_id="budget_code",
+                    field_type=FieldType.TEXT,
+                    label="Budget code",
+                ),
+                FormField(
+                    field_id="pay_code",
+                    field_type=FieldType.TEXT,
+                    label="Pay code",
+                ),
+                FormField(
+                    field_id="auto_approve",
+                    field_type=FieldType.BOOLEAN,
+                    label="Auto-approve",
+                    default=False,
+                ),
+                FormField(
+                    field_id="requires_receipt",
+                    field_type=FieldType.BOOLEAN,
+                    label="Requires receipt",
+                    default=False,
+                ),
+                FormField(
+                    field_id="event_config",
+                    field_type=FieldType.SELECT,
+                    label="Event handling",
+                    required=True,
+                    default=ClaimEventConfig.ALLOW.value,
+                    options=[
+                        FieldOption(value=e.value, label=e.value.replace("-", " ").title())
+                        for e in ClaimEventConfig
+                    ],
+                ),
+            ],
+        )
+        form = FormSchema(
+            form_id=fid,
+            title=f"Claim Type ({scope.value})",
+            form_type=FormType.CLAIMS_CONFIG,
+            sections=[section],
+            meta={"claim_context": "claim_type", "scope": scope.value},
+        )
+        await self.registry.register(form, tenant=self.tenant)
+        self.logger.info("Registered claim-type form %r (tenant=%s)", fid, self.tenant)
+        return form
+
+    async def build_pay_period_form(self, *, form_id: str | None = None) -> FormSchema:
+        """Return (and register) the Pay Period management/visualization form.
+
+        FieldSync persists the resulting ``PayPeriodConfig`` (system of record),
+        synced with Workday; this form does not compute payroll amounts.
+        """
+        fid = form_id or "pay_period"
+        section = FormSection(
+            section_id="pay_period",
+            title="Pay Period",
+            fields=[
+                FormField(field_id="start", field_type=FieldType.DATE, label="Start", required=True),
+                FormField(field_id="end", field_type=FieldType.DATE, label="End", required=True),
+                FormField(field_id="paydate", field_type=FieldType.DATE, label="Pay date"),
+                FormField(field_id="lockdate", field_type=FieldType.DATE, label="Lock date"),
+                FormField(
+                    field_id="accrue_to_next",
+                    field_type=FieldType.BOOLEAN,
+                    label="Accrue locked claims to next period",
+                    default=True,
+                ),
+            ],
+        )
+        form = FormSchema(
+            form_id=fid,
+            title="Pay Period",
+            form_type=FormType.CLAIMS_CONFIG,
+            sections=[section],
+            meta={"claim_context": "pay_period"},
+        )
+        await self.registry.register(form, tenant=self.tenant)
+        self.logger.info("Registered pay-period form %r (tenant=%s)", fid, self.tenant)
+        return form
+
+    async def build_exception_config_form(
+        self, *, form_id: str | None = None
+    ) -> FormSchema:
+        """Return (and register) the Claim Exception threshold configuration form."""
+        fid = form_id or "claim_exception"
+        section = FormSection(
+            section_id="claim_exception",
+            title="Claim Exception",
+            fields=[
+                FormField(
+                    field_id="threshold_type",
+                    field_type=FieldType.SELECT,
+                    label="Threshold type",
+                    required=True,
+                    options=[
+                        FieldOption(value=t.value, label=t.value.replace("_", " ").title())
+                        for t in ClaimExceptionThresholdType
+                    ],
+                ),
+                FormField(
+                    field_id="threshold_value",
+                    field_type=FieldType.NUMBER,
+                    label="Threshold value",
+                    required=True,
+                ),
+                FormField(
+                    field_id="prompt",
+                    field_type=FieldType.TEXT,
+                    label="Approval prompt",
+                    required=True,
+                ),
+                FormField(
+                    field_id="blocks_auto_approve",
+                    field_type=FieldType.BOOLEAN,
+                    label="Blocks auto-approve",
+                    default=True,
+                ),
+            ],
+        )
+        form = FormSchema(
+            form_id=fid,
+            title="Claim Exception",
+            form_type=FormType.CLAIMS_CONFIG,
+            sections=[section],
+            meta={"claim_context": "claim_exception"},
+        )
+        await self.registry.register(form, tenant=self.tenant)
+        self.logger.info("Registered claim-exception form %r (tenant=%s)", fid, self.tenant)
+        return form

--- a/packages/parrot-formdesigner/tests/unit/test_claims_form_service.py
+++ b/packages/parrot-formdesigner/tests/unit/test_claims_form_service.py
@@ -1,0 +1,60 @@
+"""Unit tests for ClaimsFormService builders (TASK-020)."""
+
+import pytest
+
+from parrot_formdesigner.core.schema import FormType
+from parrot_formdesigner.core.types import FieldType
+from parrot_formdesigner.services import ClaimsFormService, ClaimScope
+from parrot_formdesigner.services.registry import FormRegistry
+
+
+@pytest.fixture
+def registry() -> FormRegistry:
+    return FormRegistry(default_tenant="navigator", require_tenant=False)
+
+
+@pytest.fixture
+def service(registry: FormRegistry) -> ClaimsFormService:
+    return ClaimsFormService(registry, tenant="navigator")
+
+
+async def test_build_claim_type_form_returns_schema(service: ClaimsFormService) -> None:
+    form = await service.build_claim_type_form(ClaimScope.PROGRAM)
+    assert form.form_type is FormType.CLAIMS_CONFIG
+    assert len(form.sections) >= 1
+    field_ids = {f.field_id for f in form.iter_all_fields()}
+    assert {"category", "scope", "event_config"} <= field_ids
+
+
+async def test_build_pay_period_form_has_date_fields(service: ClaimsFormService) -> None:
+    form = await service.build_pay_period_form()
+    date_fields = {
+        f.field_id for f in form.iter_all_fields() if f.field_type is FieldType.DATE
+    }
+    assert {"start", "end", "paydate", "lockdate"} <= date_fields
+
+
+async def test_build_exception_config_form_has_number_fields(
+    service: ClaimsFormService,
+) -> None:
+    form = await service.build_exception_config_form()
+    number_fields = {
+        f.field_id for f in form.iter_all_fields() if f.field_type is FieldType.NUMBER
+    }
+    assert "threshold_value" in number_fields
+
+
+async def test_claims_form_service_registers_form(
+    service: ClaimsFormService, registry: FormRegistry
+) -> None:
+    form = await service.build_claim_type_form(ClaimScope.CLIENT)
+    fetched = await registry.get(form.form_id, tenant="navigator")
+    assert fetched is not None
+    assert fetched.form_id == form.form_id
+
+
+async def test_cascade_scope_forms_distinct_ids(service: ClaimsFormService) -> None:
+    g = await service.build_claim_type_form(ClaimScope.GLOBAL)
+    c = await service.build_claim_type_form(ClaimScope.CLIENT)
+    p = await service.build_claim_type_form(ClaimScope.PROGRAM)
+    assert len({g.form_id, c.form_id, p.form_id}) == 3

--- a/packages/parrot-formdesigner/tests/unit/test_claims_models.py
+++ b/packages/parrot-formdesigner/tests/unit/test_claims_models.py
@@ -1,0 +1,63 @@
+"""Unit tests for FEAT-304 claims domain models (TASK-019)."""
+
+import pytest
+from pydantic import ValidationError
+
+from parrot_formdesigner.services import (
+    ClaimCategory,
+    ClaimEventConfig,
+    ClaimExceptionConfig,
+    ClaimExceptionThresholdType,
+    ClaimScope,
+    ClaimTypeConfig,
+    PayPeriodConfig,
+)
+
+
+def test_claim_type_config_defaults() -> None:
+    cfg = ClaimTypeConfig(category=ClaimCategory.TIME, scope=ClaimScope.PROGRAM)
+    assert cfg.auto_approve is False
+    assert cfg.requires_receipt is False
+    assert cfg.event_config is ClaimEventConfig.ALLOW
+    assert cfg.budget_code is None
+
+
+def test_claim_category_enum_values() -> None:
+    assert {c.value for c in ClaimCategory} == {"time", "amount", "distance"}
+
+
+def test_claim_scope_enum_values() -> None:
+    assert {s.value for s in ClaimScope} == {"global", "client", "program"}
+
+
+def test_exception_threshold_type_has_five_members() -> None:
+    # Five confirmed Vision IQ thresholds (extensible enum).
+    assert {t.value for t in ClaimExceptionThresholdType} == {
+        "distance",
+        "min_per_claim",
+        "daily_minutes",
+        "time_amount",
+        "dollar_amount",
+    }
+
+
+def test_pay_period_config_accrue_default() -> None:
+    assert PayPeriodConfig().accrue_to_next is True
+
+
+def test_exception_config_blocks_auto_approve() -> None:
+    cfg = ClaimExceptionConfig(
+        threshold_type=ClaimExceptionThresholdType.DISTANCE,
+        threshold_value=100.0,
+        prompt="too far",
+    )
+    assert cfg.blocks_auto_approve is True
+
+
+def test_models_forbid_extra_keys() -> None:
+    with pytest.raises(ValidationError):
+        ClaimTypeConfig(
+            category=ClaimCategory.TIME,
+            scope=ClaimScope.GLOBAL,
+            bogus="x",  # type: ignore[call-arg]
+        )


### PR DESCRIPTION
Implements **FEAT-304 — Claims · T&E · Pay Periods** in `parrot-formdesigner`.

Spec: `Trocdigital/fieldsync` `sdd/specs/claims-te-payperiods.spec.md` (approved v0.5). Jira: **NAV-8738** (blocks NAV-8706 / FEAT-355 frontend). SDD task decomposition PR: Trocdigital/fieldsync#4 (TASK-019..023).

## Architectural decision (D3)
**FieldSync is system of record** — it persists all claims/T&E/pay-periods and pushes downstream to Workday/Concur (stores first). **Workday still owns payroll amounts (FEAT-321); this package never computes them.** The `Claim` state machine + auditable table live in the FieldSync app, not here — so lifecycle endpoints delegate to an injected `ClaimDomainService`.

## Changes
- **`services/claims_forms.py`** — Pydantic v2 models + enums (`ClaimTypeConfig`, `PayPeriodConfig`, `ClaimExceptionConfig`, `ClaimCategory`, `ClaimScope`, `ClaimEventConfig`, `ClaimExceptionThresholdType`); `ClaimsFormService` (3 form builders); `ClaimDomainService` Protocol (the FieldSync-app boundary contract).
- **`core/schema.py`** — add `FormType.CLAIMS_CONFIG`.
- **`services/pay_periods.py`** — `PayPeriodService.resolve_period` (pure lock/accrual resolution).
- **`services/claim_exceptions.py`** — `ClaimExceptionEvaluator` (pure threshold flagging; bool excluded from numeric; missing keys never raise).
- **`api/handlers.py` + `api/routes.py`** — `GET/POST /api/v1/claims/{forms,submit}` (fully served) and lifecycle `GET /claims`, `GET /claims/review`, `POST /claims/{id}/approve|reject` (delegate to `ClaimDomainService`; **503** when absent; approve/reject require a `reason` → **400** otherwise).
- New `setup_form_api(..., claim_service=None)` and `FormAPIHandler(..., claim_service=None)` — both optional/backward-compatible.

## Tests
- **40 new tests pass** (`tests/unit/test_claims_*.py`, `tests/integration/test_claims_api.py`): model defaults, builder field/type/registration, pay-period within-lock / accrual / no-open-period / no-accrual / lockdate-None, exception no/single/multiple/boundary/missing-key/bool, and the full API surface incl. 503 delegation + reason-required.
- `ruff check` clean (120 cols).
- Existing API/schema/renderer suites: **140 passed** — no regression from the `FormType` / handler / `setup_form_api` edits.

## Notes for reviewers
- `submit_claim` stores the submission with `is_valid=True` and defers claim-domain validation/state to the FieldSync app (per D3 boundary).
- Two pre-existing issues in the borrowed test env are unrelated to this PR: `test_field_type_enum_total_count` asserts `len(FieldType)==32` but `main` already has 33 (stale assertion; `types.py` untouched here), and `test_render_dispatcher`/`test_form_controls` error on a missing `pytest-aiohttp` fixture in my local venv.