### PR TITLE
fix(security): patch pyo3 and pytorch-lightning dependabot alerts

### DIFF
--- a/packages/ai-parrot-loaders/pyproject.toml
+++ b/packages/ai-parrot-loaders/pyproject.toml
@@ -90,7 +90,9 @@ ml = [
     "torch>=2.8.0,<2.9",
     "torchaudio>=2.8.0,<2.9",
     "torchvision>=0.23.0,<0.24",
-    "pytorch-lightning==2.5.5",
+    # 2.6.5: fixes CWE-502 insecure checkpoint deserialization (load_from_checkpoint
+    # called torch.load without weights_only=True). Affected: <=2.6.0.
+    "pytorch-lightning==2.6.5",
     "pytorch-metric-learning==2.9.0",
     "nvidia-cudnn-cu12>=9.10.2.21",
 ]

--- a/packages/ai-parrot/src/parrot/yaml-rs/Cargo.lock
+++ b/packages/ai-parrot/src/parrot/yaml-rs/Cargo.lock
@@ -3,18 +3,6 @@
 version = 4
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "cfg-if"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,15 +31,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,15 +47,6 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "once_cell"
@@ -101,37 +71,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da310086b068fbdcefbba30aeb3721d5bb9af8db4987d6735b2183ca567229"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27165889bd793000a098bb966adc4300c312497ea25cf7a690a9f0ac5aa5fc1"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05280526e1dbf6b420062f3ef228b78c0c54ba94e157f5cb724a609d0f2faabc"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -139,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3ce5686aa4d3f63359a5100c62a127c9f15e8398e5fdeb5deef1fed5cd5f44"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -151,13 +116,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4cf6faa0cbfb0ed08e89beb8103ae9724eb4750e3a78084ba4017cbe94f3855"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -170,12 +134,6 @@ checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -261,12 +219,6 @@ name = "unicode-ident"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/packages/ai-parrot/src/parrot/yaml-rs/Cargo.toml
+++ b/packages/ai-parrot/src/parrot/yaml-rs/Cargo.toml
@@ -8,7 +8,7 @@ name = "yaml_rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.24", features = ["extension-module"] }
+pyo3 = { version = "0.29", features = ["extension-module"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"

--- a/packages/ai-parrot/src/parrot/yaml-rs/src/lib.rs
+++ b/packages/ai-parrot/src/parrot/yaml-rs/src/lib.rs
@@ -6,7 +6,7 @@ use serde_yaml;
 
 /// Convert Python object to YAML string
 #[pyfunction]
-fn dumps(py: Python, obj: &PyAny) -> PyResult<String> {
+fn dumps(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<String> {
     // Convert Python object to serde_json::Value first
     let json_value = python_to_json(py, obj)?;
     // Serialize to YAML using serde_yaml
@@ -23,8 +23,8 @@ fn dumps(py: Python, obj: &PyAny) -> PyResult<String> {
 #[pyfunction]
 #[pyo3(signature = (obj, indent=2, flow_style=false, sort_keys=false))]
 fn dumps_formatted(
-    py: Python,
-    obj: &PyAny,
+    py: Python<'_>,
+    obj: &Bound<'_, PyAny>,
     indent: usize,
     flow_style: bool,
     sort_keys: bool,
@@ -60,7 +60,7 @@ fn dumps_formatted(
 
 /// Convert YAML string to Python object
 #[pyfunction]
-fn loads(py: Python, yaml_str: &str) -> PyResult<PyObject> {
+fn loads<'py>(py: Python<'py>, yaml_str: &str) -> PyResult<Bound<'py, PyAny>> {
     // Parse YAML to serde_json::Value
     let value: serde_json::Value = match serde_yaml::from_str(yaml_str) {
         Ok(v) => v,
@@ -76,7 +76,7 @@ fn loads(py: Python, yaml_str: &str) -> PyResult<PyObject> {
 }
 
 /// Helper: Convert Python object to JSON Value
-fn python_to_json(py: Python, obj: &PyAny) -> PyResult<serde_json::Value> {
+fn python_to_json(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<serde_json::Value> {
     if obj.is_none() {
         Ok(serde_json::Value::Null)
     } else if let Ok(b) = obj.extract::<bool>() {
@@ -91,33 +91,33 @@ fn python_to_json(py: Python, obj: &PyAny) -> PyResult<serde_json::Value> {
         }
     } else if let Ok(s) = obj.extract::<String>() {
         Ok(serde_json::Value::String(s))
-    } else if let Ok(list) = obj.downcast::<PyList>() {
+    } else if let Ok(list) = obj.cast::<PyList>() {
         let mut vec = Vec::new();
         for item in list.iter() {
-            vec.push(python_to_json(py, item)?);
+            vec.push(python_to_json(py, &item)?);
         }
         Ok(serde_json::Value::Array(vec))
-    } else if let Ok(dict) = obj.downcast::<PyDict>() {
+    } else if let Ok(dict) = obj.cast::<PyDict>() {
         let mut map = serde_json::Map::new();
         for (key, value) in dict.iter() {
             let key_str = key.extract::<String>()?;
-            map.insert(key_str, python_to_json(py, value)?);
+            map.insert(key_str, python_to_json(py, &value)?);
         }
         Ok(serde_json::Value::Object(map))
     } else if obj.hasattr("model_dump")? {
         // Handle Pydantic BaseModel
         let dict = obj.call_method0("model_dump")?;
-        python_to_json(py, dict)
+        python_to_json(py, &dict)
     } else if obj.hasattr("__dataclass_fields__")? {
         // Handle dataclass objects
         let dataclasses = py.import("dataclasses")?;
         let asdict = dataclasses.getattr("asdict")?;
         let dict = asdict.call1((obj,))?;
-        python_to_json(py, dict)
+        python_to_json(py, &dict)
     } else if obj.hasattr("dict")? {
         // Handle dataclass or regular objects
         let dict = obj.getattr("dict")?;
-        python_to_json(py, dict)
+        python_to_json(py, &dict)
     } else {
         // Try string representation
         let s = obj.str()?.extract::<String>()?;
@@ -126,35 +126,39 @@ fn python_to_json(py: Python, obj: &PyAny) -> PyResult<serde_json::Value> {
 }
 
 /// Helper: Convert JSON Value to Python object
-fn json_to_python(py: Python, value: &serde_json::Value) -> PyResult<PyObject> {
-    match value {
-        serde_json::Value::Null => Ok(py.None()),
-        serde_json::Value::Bool(b) => Ok(b.into_py(py)),
+fn json_to_python<'py>(
+    py: Python<'py>,
+    value: &serde_json::Value,
+) -> PyResult<Bound<'py, PyAny>> {
+    let obj = match value {
+        serde_json::Value::Null => py.None().into_bound(py),
+        serde_json::Value::Bool(b) => b.into_pyobject(py)?.to_owned().into_any(),
         serde_json::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
-                Ok(i.into_py(py))
+                i.into_pyobject(py)?.into_any()
             } else if let Some(f) = n.as_f64() {
-                Ok(f.into_py(py))
+                f.into_pyobject(py)?.into_any()
             } else {
-                Ok(py.None())
+                py.None().into_bound(py)
             }
         }
-        serde_json::Value::String(s) => Ok(s.into_py(py)),
+        serde_json::Value::String(s) => s.into_pyobject(py)?.into_any(),
         serde_json::Value::Array(arr) => {
             let list = PyList::empty(py);
             for item in arr {
                 list.append(json_to_python(py, item)?)?;
             }
-            Ok(list.into())
+            list.into_any()
         }
         serde_json::Value::Object(map) => {
             let dict = PyDict::new(py);
             for (key, value) in map {
                 dict.set_item(key, json_to_python(py, value)?)?;
             }
-            Ok(dict.into())
+            dict.into_any()
         }
-    }
+    };
+    Ok(obj)
 }
 
 fn sort_json_value(value: &mut serde_json::Value) {
@@ -214,7 +218,7 @@ fn adjust_yaml_indent(yaml: &str, indent: usize) -> String {
 
 /// Module definition
 #[pymodule]
-fn yaml_rs(_py: Python, m: &PyModule) -> PyResult<()> {
+fn yaml_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(dumps, m)?)?;
     m.add_function(wrap_pyfunction!(dumps_formatted, m)?)?;
     m.add_function(wrap_pyfunction!(loads, m)?)?;


### PR DESCRIPTION
Closes two Dependabot security advisories.

## 1. pyo3 `0.24.1 → 0.29.0` (`yaml-rs` crate)
Bumps pyo3 past the alerted versions. The crate still used the **removed GIL-Ref API** (`&PyAny`, `&PyList`, `&PyModule`, `into_py`) — it no longer compiled even on 0.24 — so `src/lib.rs` was migrated to the modern `Bound<'py, T>` API:
- function signatures take `&Bound<'_, PyAny>` / `Python<'_>`
- `json_to_python` returns `Bound<'py, PyAny>` via `IntoPyObject`
- `downcast()` → `cast()` (renamed in 0.29)
- `#[pymodule]` takes `&Bound<'_, PyModule>`

**Verified:**
- `cargo build --release` — clean
- `maturin develop --release` — builds + imports
- functional round-trip: `dumps`, `dumps_formatted(indent, sort_keys)`, `loads`, pydantic `model_dump` path
- 46 yaml-related Python tests pass

## 2. pytorch-lightning `2.5.5 → 2.6.5` (`ai-parrot-loaders` `ml` extra)
Fixes **CWE-502**: `LightningModule.load_from_checkpoint()` internally called `torch.load()` without `weights_only=True`, allowing arbitrary code execution via a crafted checkpoint. Affected: `<=2.6.0`.

- 2.6.5 requires only `torch>=2.1.0` — compatible with the project's `torch>=2.8.0,<2.9` cap (verified against PyPI metadata).
- No direct `load_from_checkpoint`/`torch.load` usage in the codebase; pulled transitively via the audio/whisperx/pyannote stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)