### PR TITLE
FEAT-250: Add revision mode, code-review gate, and Close node

### DIFF
--- a/examples/dev_loop/README.md
+++ b/examples/dev_loop/README.md
@@ -1,4 +1,4 @@
-# Dev-Loop Orchestration — Examples (FEAT-129 + FEAT-132)
+# Dev-Loop Orchestration — Examples (FEAT-129 + FEAT-132 + FEAT-250)
 
 > **FEAT-132 upgrades** (2026-04-28): The flow now starts with an
 > `IntentClassifierNode` that validates the incoming brief and routes
@@ -7,9 +7,19 @@
 > `ResearchNode`. The Jira issuetype is now derived from the kind field
 > (Bug / Story / New Feature). A plan-summary comment is posted on newly
 > created tickets. See **Routing by kind** below.
+>
+> **FEAT-250 upgrades**: the flow gained a terminal **`CloseNode`** (closes
+> out the run / transitions Jira), the QA node now runs an additional
+> **code-review gate** (`sdd-codereview`) on top of the deterministic
+> criteria, `DeploymentHandoffNode` opens the PR as a **draft**, the clone
+> is **provisioned before Development**, and there is a separate
+> **revision-mode** run (`DevLoopRunner.run_revision`) that updates an
+> existing PR instead of opening a new one. See **What FEAT-250 changed**
+> below.
 
-Runnable examples for the six-node `AgentsFlow`
-(`IntentClassifier → [BugIntake →] Research → Development → QA → DeploymentHandoff`)
+Runnable examples for the eight-node `AgentsFlow`
+(`IntentClassifier → [BugIntake →] Research → Development → QA →
+DeploymentHandoff → Close`, with a `FailureHandler` `on_error` fan-in)
 defined in `sdd/specs/dev-loop-orchestration.spec.md` and implemented
 under `parrot/flows/dev_loop/`.
 
@@ -29,6 +39,38 @@ through `DevLoopRunner` once and exits; `server.py` exposes an HTTP +
 WebSocket surface so the UI client can start runs and visualise the merged
 event stream live.
 
+## Setup — running from a clean checkout
+
+This repository is a **`uv` workspace** (`[tool.uv.workspace]` in the root
+`pyproject.toml`). One sync installs every member package editable, with all
+transitive dependencies, into `.venv`:
+
+```bash
+uv sync                       # creates .venv + installs the workspace
+source .venv/bin/activate
+python examples/dev_loop/e2e_demo.py
+```
+
+That is **all** `e2e_demo.py` needs — it imports only `parrot.*` and simulates
+every external service in-process (no Redis, `claude` CLI, Jira, or API keys).
+
+For the **real-mode** scripts (`quickstart.py` / `server.py`) you additionally
+need:
+
+* the **`jira`** package — `parrot_tools.jiratoolkit.JiraToolkit` imports it
+  lazily and raises `ImportError: Please install the 'jira' package` otherwise:
+  ```bash
+  uv pip install jira
+  ```
+* a running **Redis** and the credentials listed in **Prerequisites (real
+  mode)** below.
+
+> **Note:** a couple of direct imports (`tenacity`, `tqdm`) are currently
+> satisfied transitively rather than being declared in `ai-parrot`'s
+> `pyproject.toml`. `uv sync` resolves them from the lockfile, so a normal
+> workspace sync works; this is only a concern if you install `ai-parrot`
+> standalone outside the workspace.
+
 ## Zero-dependency demo — `e2e_demo.py`
 
 The fastest way to see the whole flow working. It executes the REAL engine
@@ -45,22 +87,34 @@ source .venv/bin/activate
 python examples/dev_loop/e2e_demo.py
 ```
 
-It runs four scenarios and prints, for each: executed/failed/skipped nodes,
+It runs six scenarios and prints, for each: executed/failed/skipped nodes,
 the `FlowResult`, the simulated Jira audit trail, the captured
 `flow:{run_id}:flow` stream events, and the typed FEAT-176 lifecycle event
 timeline (one trace per run, per-node durations):
 
 1. **Bug, happy path** — `IntentClassifier → BugIntake → Research →
-   Development → QA → DeploymentHandoff`; `failure_handler` skip-propagated;
-   PR opened + Jira "Ready to Deploy".
+   Development → QA → DeploymentHandoff → Close`; `failure_handler`
+   skip-propagated; draft PR opened + `Close` transitions Jira.
 2. **Enhancement** — `bug_intake` is skip-propagated (kind routing).
-3. **QA fails** — `deployment_handoff` skipped; escalation comment +
-   "Needs Human Review" + reassignment.
+3. **QA fails (deterministic)** — `deployment_handoff` + `close` skipped;
+   escalation comment + "Needs Human Review" + reassignment.
 4. **Hard error in Development** — the `on_error` fan-in fires
-   `failure_handler`; `qa`/`deployment_handoff` are skipped; status `partial`.
+   `failure_handler`; `qa`/`deployment_handoff`/`close` are skipped; status
+   `partial`.
+5. **Code-review fails (FEAT-250 gate)** — the deterministic criteria pass
+   but the `sdd-codereview` verdict fails, so the QA gate
+   (`passed = deterministic AND code_review`) blocks: `deployment_handoff` +
+   `close` skipped, escalation via `failure_handler`.
+6. **Revision mode (FEAT-250 G6)** — `DevLoopRunner.run_revision(RevisionBrief)`
+   runs the short flow `development → qa → revision_handoff → close`. The
+   `RevisionHandoffNode` pushes the **existing** branch and comments the
+   **same** PR (`add_pr_comment`) — it never opens a new PR — and `Close`
+   runs in `mode="revision"`.
 
 Use it as a template for wiring the flow into your own harness: everything
-specific to the simulation lives in the `Simulated*`/`Fake*` classes.
+specific to the simulation lives in the `Simulated*`/`Fake*` classes
+(`SimulatedDispatcher`, `SimulatedJira`, `SimulatedGit`, `FakeRedis`,
+`FakeLLM`).
 
 ## Prerequisites (real mode)
 
@@ -110,6 +164,56 @@ generation is controlled by `DEV_LOOP_PLAN_LLM` (see Prerequisites table).
 On the **reuse** path (`existing_issue_key` is set), no plan-summary comment
 is posted — only the standard re-trigger comment.
 
+## What FEAT-250 changed
+
+The flow topology and QA gate were extended after FEAT-132. The examples
+exercise all of it:
+
+* **Terminal `CloseNode`** — runs after `DeploymentHandoff` (initial path) or
+  `RevisionHandoff` (revision path) and finalises the run. Its output carries
+  a `mode` field (`"initial"` vs `"revision"`). On failure/QA-fail paths it is
+  skipped and `FailureHandler` runs instead.
+* **Code-review QA gate** — `QANode` now dispatches an `sdd-codereview`
+  subagent in addition to the deterministic `sdd-qa` run. The report's
+  `passed` is `deterministic_passed AND code_review_passed`, so a qualitative
+  review failure blocks deployment even when every executable criterion
+  passes. The verdict is backward-tolerant: a dispatch error is treated as a
+  pass so an infra hiccup never blocks the flow (the deterministic gate is the
+  hard guarantee; code-review is additive). Scenario 5 in `e2e_demo.py`
+  demonstrates the blocking case.
+* **Draft PR** — `DeploymentHandoffNode` opens the PR as a draft.
+* **Repo provisioning before Development** — the clone is provisioned ahead of
+  the Development node rather than inside Research.
+* **Revision mode** — `DevLoopRunner.run_revision(RevisionBrief)` builds a
+  short flow (`development → qa → revision_handoff → close`) that reuses an
+  existing clone + branch + open PR. `RevisionHandoffNode` pushes the existing
+  branch and comments the same PR via `git_toolkit.add_pr_comment(...)`; it
+  never opens a new PR. To use it, construct the runner with the revision
+  dependencies:
+
+  ```python
+  runner = DevLoopRunner(
+      flow,
+      dispatcher=dispatcher,
+      jira_toolkit=jira_toolkit,
+      git_toolkit=git_toolkit,   # exposes async add_pr_comment(pr_number, body)
+      redis_url=redis_url,
+  )
+  result = await runner.run_revision(
+      RevisionBrief(
+          repo_path="…",          # existing clone (the Development node's cwd)
+          branch="feat-999-…",     # existing feature branch
+          pr_number=4242,          # the open draft PR to update
+          repository="owner/name",
+          jira_issue_key="NAV-1",
+          feedback="reviewer comment to act on",
+          head_sha="…",            # head SHA at trigger time (dedup)
+      )
+  )
+  ```
+
+  Scenario 6 in `e2e_demo.py` runs this end-to-end with simulated I/O.
+
 ## Programmatic example — `quickstart.py`
 
 ```bash
@@ -151,9 +255,12 @@ python examples/dev_loop/server.py
 
 The UI is a single static file with no build step:
 
-* Six panels, one per node (IntentClassifier, BugIntake, Research,
-  Development, QA, Handoff), with status pills
-  (`idle / queued / running / passed / failed`).
+* Eight panels, one per node (IntentClassifier, BugIntake, Research,
+  Development, QA, Handoff, Close, Failure), with status pills
+  (`idle / queued / running / passed / failed`). The Close and Failure
+  panels are driven by the flow-level `flow.node_started` /
+  `flow.node_completed` envelopes (those nodes aren't dispatched, so they
+  emit no `dispatch.*` events).
 * "Start dev-loop run" POSTs to `/api/flow/run`, gets back a `run_id`,
   then opens a WebSocket to `/api/flow/{run_id}/ws?view=both&replay=true`.
 * Each event is appended under its node's panel; the pill colour follows

--- a/examples/dev_loop/e2e_demo.py
+++ b/examples/dev_loop/e2e_demo.py
@@ -1,11 +1,15 @@
-"""FEAT-129 — Dev-Loop Orchestration: self-contained end-to-end demo.
+"""FEAT-129 / FEAT-250 — Dev-Loop Orchestration: self-contained end-to-end demo.
 
-Runs the REAL seven-node ``AgentsFlow`` (engine, scheduler, OR-join
-routing, ``DevLoopRunner`` semaphore, lifecycle telemetry) end-to-end —
-but with every external service simulated in-process:
+Runs the REAL eight-node ``AgentsFlow`` (``IntentClassifier → [BugIntake →]
+Research → Development → QA → DeploymentHandoff → Close`` with a
+``FailureHandler`` fan-in) end-to-end — engine, scheduler, OR-join routing,
+``DevLoopRunner`` semaphore, lifecycle telemetry — but with every external
+service simulated in-process:
 
-* ``ClaudeCodeDispatcher``  → ``SimulatedDispatcher`` (canned subagent outputs)
+* ``ClaudeCodeDispatcher``  → ``SimulatedDispatcher`` (canned subagent outputs,
+  including the FEAT-250 code-review verdict the QA gate now dispatches)
 * Jira toolkit              → ``SimulatedJira`` (records every call)
+* git toolkit (PR comments) → ``SimulatedGit`` (records ``add_pr_comment``)
 * Redis streams             → ``FakeRedis`` (captures XADDs in memory)
 * git push / gh pr create   → patched to no-ops returning a fake PR URL
 * Plan/summary LLM          → ``FakeLLM`` (deterministic text)
@@ -19,12 +23,17 @@ Run::
     source .venv/bin/activate
     python examples/dev_loop/e2e_demo.py
 
-Four scenarios are executed:
+Six scenarios are executed:
 
-1. Bug brief, everything green        → PR opened, Jira "Ready to Deploy".
+1. Bug brief, everything green        → PR opened, Close → Jira "Ready to Deploy".
 2. Enhancement brief                  → BugIntake is skip-propagated.
-3. QA fails                           → DeploymentHandoff skipped, escalation.
+3. QA fails (deterministic)           → DeploymentHandoff skipped, escalation.
 4. Hard error in Development          → on_error fan-in fires FailureHandler.
+5. Code-review fails (FEAT-250 gate)  → QA gate blocks even though the
+                                        deterministic criteria pass.
+6. Revision-mode run (FEAT-250 G6)    → ``run_revision`` pushes the existing
+                                        branch + comments the same PR (no new
+                                        PR), then Close in ``mode="revision"``.
 """
 from __future__ import annotations
 
@@ -53,8 +62,10 @@ from parrot.flows.dev_loop import (
     WorkBrief,
     build_dev_loop_flow,
 )
-from parrot.flows.dev_loop.models import DevelopmentOutput
+from parrot.flows.dev_loop.models import DevelopmentOutput, RevisionBrief
 from parrot.flows.dev_loop.nodes.deployment_handoff import DeploymentHandoffNode
+from parrot.flows.dev_loop.nodes.revision_handoff import RevisionHandoffNode
+from parrot.flows.dev_loop.runner import build_dev_loop_revision_flow
 
 logging.basicConfig(level=logging.WARNING)  # keep the demo output readable
 
@@ -70,6 +81,9 @@ class SimulatedDispatcher:
     Args:
         worktree_base: Directory used for the fake worktree path.
         qa_passed: Whether the simulated ``sdd-qa`` run reports success.
+        code_review_passed: Whether the simulated ``sdd-codereview`` verdict
+            passes. The FEAT-250 QA gate is ``deterministic AND code_review``,
+            so a ``False`` here blocks the gate even when ``qa_passed`` is True.
         fail_at_node: Optional node_id whose dispatch raises (hard error).
     """
 
@@ -78,10 +92,12 @@ class SimulatedDispatcher:
         worktree_base: str,
         *,
         qa_passed: bool = True,
+        code_review_passed: bool = True,
         fail_at_node: Optional[str] = None,
     ) -> None:
         self._worktree_base = worktree_base
         self._qa_passed = qa_passed
+        self._code_review_passed = code_review_passed
         self._fail_at_node = fail_at_node
 
     async def dispatch(
@@ -116,6 +132,18 @@ class SimulatedDispatcher:
                 lint_passed=self._qa_passed,
                 notes="(simulated QA run)",
             )
+        # FEAT-250: the QA node now dispatches a code-review verdict in
+        # addition to the deterministic sdd-qa run. Match by name to avoid
+        # importing the private ``_CodeReviewVerdict`` symbol from qa.py.
+        if output_model.__name__ == "_CodeReviewVerdict":
+            return output_model(
+                passed=self._code_review_passed,
+                findings=(
+                    [] if self._code_review_passed
+                    else ["simulated reviewer finding: missing regression test"]
+                ),
+                summary="(simulated code review)",
+            )
         raise AssertionError(f"unexpected output_model: {output_model!r}")
 
 
@@ -149,6 +177,26 @@ class SimulatedJira:
     async def jira_assign_issue(self, *, issue: str, assignee: str, **kw: Any) -> Dict:
         self.actions.append(f"assign {issue} → {assignee}")
         return {"ok": True}
+
+
+class SimulatedGit:
+    """Records git-toolkit interactions for revision mode (FEAT-250 G6).
+
+    ``RevisionHandoffNode`` comments the existing PR via
+    ``git_toolkit.add_pr_comment(...)`` (and pushes the existing branch via a
+    subprocess that ``main()`` patches to a no-op).
+    """
+
+    def __init__(self) -> None:
+        self.comments: List[Tuple[int, str]] = []
+
+    async def add_pr_comment(
+        self, pr_number: int, body: str, **kw: Any
+    ) -> Dict:
+        self.comments.append((pr_number, body))
+        first_line = body.splitlines()[0] if body else ""
+        print(f"    [git] add_pr_comment #{pr_number}: {first_line[:50]}…")
+        return {"id": "prc1"}
 
 
 class FakeRedis:
@@ -224,13 +272,17 @@ async def run_scenario(
     worktree_base: str,
     kind: str = "bug",
     qa_passed: bool = True,
+    code_review_passed: bool = True,
     fail_at_node: Optional[str] = None,
 ) -> None:
     """Build, run, and report one end-to-end scenario."""
     print(f"\n{'=' * 70}\n  {title}\n{'=' * 70}")
 
     dispatcher = SimulatedDispatcher(
-        worktree_base, qa_passed=qa_passed, fail_at_node=fail_at_node
+        worktree_base,
+        qa_passed=qa_passed,
+        code_review_passed=code_review_passed,
+        fail_at_node=fail_at_node,
     )
     jira = SimulatedJira()
     fake_redis = FakeRedis()
@@ -283,9 +335,82 @@ async def run_scenario(
         print(f"    {name:<22} {node:<20}{extra}")
 
 
+async def run_revision_scenario(title: str, *, worktree_base: str) -> None:
+    """Build, run, and report a revision-mode run (FEAT-250 G6).
+
+    Unlike :func:`run_scenario`, this does not start from a brief: it reuses
+    an existing clone + branch + open PR and runs the short revision flow
+    (``development → qa → revision_handoff → close``). ``RevisionHandoffNode``
+    pushes the existing branch and comments the same PR — it never opens a
+    new PR.
+    """
+    print(f"\n{'=' * 70}\n  {title}\n{'=' * 70}")
+
+    # An existing "clone" on disk, inside the worktree sandbox so QA's
+    # deterministic ``ruff check .`` runs under WORKTREE_BASE_PATH. A single
+    # clean file keeps the lint gate green.
+    repo_path = os.path.join(worktree_base, "rev-clone")
+    os.makedirs(repo_path, exist_ok=True)
+    with open(os.path.join(repo_path, "clean.py"), "w", encoding="utf-8") as fh:
+        fh.write('"""A clean module so ruff has something to pass."""\n')
+
+    dispatcher = SimulatedDispatcher(worktree_base)
+    jira = SimulatedJira()
+    git = SimulatedGit()
+    fake_redis = FakeRedis()
+
+    # Build the revision flow explicitly so we can redirect its event
+    # publisher at the in-memory Redis before any run (run_revision would
+    # otherwise lazily build it against the real redis_url).
+    rev_flow = build_dev_loop_revision_flow(
+        dispatcher=dispatcher,
+        jira_toolkit=jira,
+        git_toolkit=git,
+        redis_url="redis://demo-not-used:0/0",
+    )
+    rev_flow._event_publisher._redis = fake_redis
+
+    runner = DevLoopRunner(
+        rev_flow,
+        max_concurrent_runs=2,
+        dispatcher=dispatcher,
+        jira_toolkit=jira,
+        git_toolkit=git,
+        redis_url="redis://demo-not-used:0/0",
+    )
+    runner._rev_flow = rev_flow  # reuse the publisher we just rewired
+
+    brief = RevisionBrief(
+        repo_path=repo_path,
+        branch="feat-999-fix-customer-sync",
+        pr_number=4242,
+        repository="example/repo",
+        jira_issue_key="DEMO-7",
+        feedback="Reviewer: please add a regression test for the 1500-row case.",
+        head_sha="deadbeef",
+    )
+    result = await runner.run_revision(brief)
+    await asyncio.sleep(0.1)  # drain fire-and-forget telemetry tasks
+
+    executed = list(result.responses)
+    skipped = sorted(set(rev_flow._nodes) - set(executed) - set(result.errors))
+    print(f"\n  status      : {result.status.value}")
+    print(f"  executed    : {executed}")
+    print(f"  failed      : {list(result.errors) or '—'}")
+    print(f"  skipped     : {skipped or '—'}")
+    print(f"  flow output : {result.output}")
+    print(f"\n  PR comments (simulated, same PR #{brief.pr_number}):")
+    for pr_number, body in git.comments:
+        print(f"    - #{pr_number}: {body.splitlines()[0][:60]}…")
+    print("\n  Jira actions (simulated):")
+    for action in jira.actions:
+        print(f"    - {action}")
+
+
 async def main() -> None:
-    # SIMULATION: neutralize the two real-world side effects of the
-    # handoff node (git push + gh pr create) for this offline demo.
+    # SIMULATION: neutralize the real-world side effects of the handoff
+    # nodes (git push + gh pr create on the deployment path; git push on the
+    # revision path) for this offline demo.
     async def _fake_push(self: Any, branch: str, cwd: str) -> None:
         print(f"    [git] push -u origin {branch} (simulated)")
 
@@ -295,6 +420,7 @@ async def main() -> None:
 
     DeploymentHandoffNode._push_branch = _fake_push       # type: ignore[method-assign]
     DeploymentHandoffNode._create_pr = _fake_pr           # type: ignore[method-assign]
+    RevisionHandoffNode._push_branch = _fake_push         # type: ignore[method-assign]
 
     with tempfile.TemporaryDirectory(prefix="devloop-demo-") as tmp:
         # Keep the worktree-safety check inside the sandbox dir.
@@ -315,6 +441,14 @@ async def main() -> None:
         await run_scenario(
             "4) Hard error in Development — on_error fan-in fires",
             worktree_base=tmp, fail_at_node="development",
+        )
+        await run_scenario(
+            "5) Code-review fails — QA gate blocks despite green criteria",
+            worktree_base=tmp, code_review_passed=False,
+        )
+        await run_revision_scenario(
+            "6) Revision mode — push existing branch + comment same PR",
+            worktree_base=tmp,
         )
 
     print("\nDone. See quickstart.py / server.py for the real-mode versions.")

--- a/examples/dev_loop/quickstart.py
+++ b/examples/dev_loop/quickstart.py
@@ -1,12 +1,18 @@
-"""FEAT-129 — Dev-Loop Orchestration: real-mode quickstart.
+"""FEAT-129 / FEAT-250 — Dev-Loop Orchestration: real-mode quickstart.
 
-Wires the seven-node ``AgentsFlow`` (IntentClassifier → BugIntake →
-Research → Development → QA → DeploymentHandoff | FailureHandler) with a
-real :class:`ClaudeCodeDispatcher`, a service-account ``JiraToolkit``,
-and the CloudWatch / Elasticsearch log toolkits, then runs it end-to-end
-against a sample :class:`BugBrief` via :class:`DevLoopRunner`.
+Wires the eight-node ``AgentsFlow`` (IntentClassifier → [BugIntake →]
+Research → Development → QA → DeploymentHandoff → Close, with a
+FailureHandler ``on_error`` fan-in) with a real
+:class:`ClaudeCodeDispatcher`, a service-account ``JiraToolkit``, and the
+CloudWatch / Elasticsearch log toolkits, then runs it end-to-end against a
+sample :class:`BugBrief` via :class:`DevLoopRunner`.
 
-Use ``server.py`` (next to this file) for a self-contained demo that does
+To update an existing PR instead of opening a new one, build the runner
+with ``dispatcher=``, ``jira_toolkit=``, ``git_toolkit=`` and ``redis_url=``
+and call ``DevLoopRunner.run_revision(RevisionBrief(...))`` — see
+``e2e_demo.py`` scenario 6 and the README's "What FEAT-250 changed".
+
+Use ``e2e_demo.py`` (next to this file) for a self-contained demo that does
 not need Claude / Jira / GitHub credentials.
 
 Run::

--- a/examples/dev_loop/server.py
+++ b/examples/dev_loop/server.py
@@ -1,8 +1,9 @@
-"""FEAT-129 — Dev-Loop Orchestration: real demo server.
+"""FEAT-129 / FEAT-250 — Dev-Loop Orchestration: real demo server.
 
-Hosts an aiohttp app that wires the **real** five-node ``AgentsFlow``
-(BugIntake → Research → Development → QA → DeploymentHandoff) behind
-three HTTP endpoints, plus a vanilla-JS UI client at ``/`` that
+Hosts an aiohttp app that wires the **real** eight-node ``AgentsFlow``
+(IntentClassifier → [BugIntake →] Research → Development → QA →
+DeploymentHandoff → Close, with a FailureHandler ``on_error`` fan-in)
+behind three HTTP endpoints, plus a vanilla-JS UI client at ``/`` that
 visualises the merged event stream.
 
 Endpoints:

--- a/examples/dev_loop/static/index.html
+++ b/examples/dev_loop/static/index.html
@@ -233,6 +233,8 @@ const NODES = [
   { id: "development",        label: "4. Development"},
   { id: "qa",                 label: "5. QA"         },
   { id: "deployment_handoff", label: "6. Handoff"    },
+  { id: "close",              label: "7. Close"      },  // FEAT-250
+  { id: "failure_handler",    label: "8. Failure"    },  // on_error fan-in
 ];
 
 const board    = document.getElementById("board");
@@ -297,6 +299,10 @@ function classify(env) {
   if (k === "flow.bug_brief_validated") return "passed";
   if (k === "flow.intake_validated") return "passed";   // FEAT-132
   if (k === "flow.pr_opened" || k === "flow.completed") return "passed";
+  // Flow-level node lifecycle (FEAT-250): the Close and FailureHandler
+  // nodes aren't dispatched, so they only emit these envelopes.
+  if (k === "flow.node_started")   return "running";
+  if (k === "flow.node_completed") return "passed";
   return null;
 }
 


### PR DESCRIPTION
## Summary

Extends the dev-loop orchestration flow with three major features from FEAT-250:

1. **Revision mode** (`DevLoopRunner.run_revision`) — a short flow that updates an existing PR instead of opening a new one
2. **Code-review QA gate** — `QANode` now dispatches an `sdd-codereview` subagent; the gate passes only if both deterministic criteria AND code-review verdict pass
3. **Terminal `CloseNode`** — finalizes runs after `DeploymentHandoff` (initial path) or `RevisionHandoff` (revision path)

## Key Changes

### Core Flow Changes
- **Eight-node topology** (was seven): `IntentClassifier → [BugIntake →] Research → Development → QA → DeploymentHandoff → Close`, with `FailureHandler` `on_error` fan-in
- **`CloseNode`** runs after successful deployment or revision handoff; skipped on failure/QA-fail paths
- **`RevisionHandoffNode`** — new node that pushes existing branch and comments the same PR (never opens new PR)
- **Code-review gate** — `QANode` dispatches `sdd-codereview` verdict; gate is `deterministic_passed AND code_review_passed`
- **Draft PR** — `DeploymentHandoffNode` opens PRs as drafts
- **Repo provisioning** — clone is provisioned before Development (not inside Research)

### Demo Updates (`e2e_demo.py`)
- **`SimulatedDispatcher`** now handles `_CodeReviewVerdict` output model with configurable `code_review_passed` flag
- **`SimulatedGit`** — new class that records `add_pr_comment` calls for revision mode testing
- **Six scenarios** (was four):
  1. Bug, happy path → PR opened, Close transitions Jira
  2. Enhancement → BugIntake skip-propagated
  3. QA fails (deterministic) → escalation, Close skipped
  4. Hard error in Development → FailureHandler fires
  5. **Code-review fails** — deterministic passes but code-review blocks (new)
  6. **Revision mode** — `run_revision` pushes existing branch + comments same PR (new)
- Patched `RevisionHandoffNode._push_branch` to no-op for offline demo

### Documentation Updates
- **README.md** — updated topology descriptions, added "What FEAT-250 changed" section explaining all new features and revision-mode usage
- **`quickstart.py` / `server.py`** docstrings — updated to reflect eight-node flow and revision mode
- **`static/index.html`** — added Close and Failure panels; added flow-level node lifecycle event handling for non-dispatched nodes

## Implementation Details

- **Backward-tolerant code-review gate** — dispatch errors are treated as passes so infra hiccups never block the flow; deterministic gate is the hard guarantee
- **Revision mode flow** — built separately via `build_dev_loop_revision_flow()` and reused by `DevLoopRunner.run_revision(RevisionBrief)`
- **Event publisher rewiring** — demo explicitly builds revision flow and redirects its event publisher to in-memory Redis before any run
- All six demo scenarios execute end-to-end with simulated I/O; no external services required

https://claude.ai/code/session_01JswkiYj1EbVPFjJiupUm37