### PR TITLE
Fix OAuth error handling and state payload nesting (FEAT-225)

### DIFF
--- a/packages/ai-parrot-integrations/src/parrot/integrations/msteams/oauth_callback.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/msteams/oauth_callback.py
@@ -172,7 +172,7 @@ class MSTeamsOAuthNotifier:
 
 async def handle_msteams_jira_callback(
     request: "web.Request",
-    token_set: "JiraTokenSet",
+    token_set: Optional["JiraTokenSet"],
     state_payload: Dict[str, Any],
 ) -> "web.Response":
     """Process a Jira OAuth callback originating from the MS Teams integration.
@@ -189,13 +189,25 @@ async def handle_msteams_jira_callback(
 
     Args:
         request: The incoming aiohttp request.
-        token_set: Token and identity data from ``JiraOAuthManager.handle_callback``.
-        state_payload: Parsed ``extra_state`` from the CSRF nonce.
+        token_set: Token and identity data from ``JiraOAuthManager.handle_callback``,
+            or ``None`` when invoked on the consent-denial (``?error=``) path.
+        state_payload: Full state payload (``channel``, ``user_id``, ``extra``)
+            decoded from the CSRF nonce.
 
     Returns:
         HTML :class:`aiohttp.web.Response` for the browser.
     """
     from aiohttp import web
+
+    # Channel-specific data is nested under ``state_payload["extra"]`` by
+    # JiraOAuthManager.create_authorization_url. Fall back to top-level keys
+    # for backward compatibility with any caller that flattens the payload.
+    extra: Dict[str, Any] = state_payload.get("extra") or {}
+
+    def _conv_ref() -> Dict[str, Any]:
+        return extra.get("conversation_reference") or state_payload.get(
+            "conversation_reference"
+        ) or {}
 
     # Handle Atlassian consent denial or other OAuth errors carried as query params.
     error_code = request.rel_url.query.get("error")
@@ -208,7 +220,7 @@ async def handle_msteams_jira_callback(
             error_code,
             error_description,
         )
-        conv_ref_err: Dict[str, Any] = state_payload.get("conversation_reference") or {}
+        conv_ref_err: Dict[str, Any] = _conv_ref()
         notifier_err: Optional[MSTeamsOAuthNotifier] = request.app.get(
             "msteams_jira_oauth_notifier"
         )
@@ -224,8 +236,8 @@ async def handle_msteams_jira_callback(
             content_type="text/html",
         )
 
-    conv_ref: Dict[str, Any] = state_payload.get("conversation_reference") or {}
-    nav_user_id: str = state_payload.get("user_id", "")
+    conv_ref: Dict[str, Any] = _conv_ref()
+    nav_user_id: str = state_payload.get("user_id") or extra.get("user_id", "")
 
     # 1. Persist identity mapping row
     identity_service = request.app.get("identity_mapping_service")
@@ -236,11 +248,9 @@ async def handle_msteams_jira_callback(
                 auth_provider="msteams",
                 auth_data={
                     "aad_object_id": nav_user_id,
-                    # tenant_id may be available from the conversation_reference
+                    # tenant_id, when present on the serialized conversation ref.
                     "tenant_id": (
-                        conv_ref.get("conversation", {}).get("tenantId")
-                        or conv_ref.get("activity", {}).get("channelData", {}).get("tenant", {}).get("id")
-                        or ""
+                        conv_ref.get("conversation", {}).get("tenantId") or ""
                     ),
                 },
                 display_name=token_set.display_name or None,

--- a/packages/ai-parrot-integrations/src/parrot/integrations/msteams/wrapper.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/msteams/wrapper.py
@@ -147,11 +147,20 @@ class MSTeamsAgentWrapper(ActivityHandler, MessageHandler):
         if oauth_manager is not None:
             self._command_router = MSTeamsCommandRouter()
             register_jira_commands(self._command_router, oauth_manager)
-            # Register the OAuth notifier for proactive messaging after callback
-            app["msteams_jira_oauth_notifier"] = MSTeamsOAuthNotifier(
-                adapter=self.adapter,
-                app_id=config.client_id or "",
-            )
+            # Register the OAuth notifier for proactive messaging after callback.
+            # continue_conversation needs a valid App ID, so skip (with a
+            # warning) when client_id is not configured rather than registering
+            # a notifier that will always fail.
+            if config.client_id:
+                app["msteams_jira_oauth_notifier"] = MSTeamsOAuthNotifier(
+                    adapter=self.adapter,
+                    app_id=config.client_id,
+                )
+            else:
+                self.logger.warning(
+                    "No client_id configured — MS Teams proactive notification "
+                    "after Jira OAuth will be skipped"
+                )
 
         # Route
         # Clean chatbot_id to be safe for URL
@@ -312,6 +321,18 @@ class MSTeamsAgentWrapper(ActivityHandler, MessageHandler):
             return
 
         self.logger.info("Card submission: %s", submitted_data)
+
+        # Slash-style commands embedded in Adaptive Card Submit actions — e.g.
+        # the Jira menu card buttons send {"command": "/connect_jira"}. These
+        # arrive as activity.value (not activity.text), so the text-based
+        # command interception in on_message_activity never sees them. Route
+        # them through the command router so card buttons behave like typed
+        # slash commands.
+        command = submitted_data.get('command')
+        if command and self._command_router is not None:
+            handled = await self._command_router.try_dispatch(command, turn_context)
+            if handled:
+                return
 
         # Check for action type
         action = submitted_data.get('_action', 'submit')

--- a/packages/ai-parrot-integrations/src/parrot/integrations/slack/oauth_callback.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/slack/oauth_callback.py
@@ -155,7 +155,7 @@ class SlackOAuthNotifier:
 
 async def handle_slack_jira_callback(
     request: "web.Request",
-    token_set: "JiraTokenSet",
+    token_set: Optional["JiraTokenSet"],
     state_payload: Dict[str, Any],
 ) -> "web.Response":
     """Process a Jira OAuth callback originating from the Slack integration.
@@ -171,13 +171,23 @@ async def handle_slack_jira_callback(
 
     Args:
         request: The incoming aiohttp request.
-        token_set: Token and identity data from ``JiraOAuthManager.handle_callback``.
-        state_payload: Parsed ``extra_state`` from the CSRF nonce.
+        token_set: Token and identity data from ``JiraOAuthManager.handle_callback``,
+            or ``None`` when invoked on the consent-denial (``?error=``) path.
+        state_payload: Full state payload (``channel``, ``user_id``, ``extra``)
+            decoded from the CSRF nonce.
 
     Returns:
         HTML :class:`aiohttp.web.Response` for the browser.
     """
     from aiohttp import web
+
+    # Channel-specific data is nested under ``state_payload["extra"]`` by
+    # JiraOAuthManager.create_authorization_url. Fall back to top-level keys
+    # for backward compatibility with any caller that flattens the payload.
+    extra: Dict[str, Any] = state_payload.get("extra") or {}
+
+    def _field(name: str, default: str = "") -> str:
+        return extra.get(name) or state_payload.get(name, default)
 
     # Handle Atlassian consent denial or other OAuth errors carried as query params.
     error_code = request.rel_url.query.get("error")
@@ -190,8 +200,8 @@ async def handle_slack_jira_callback(
             error_code,
             error_description,
         )
-        team_id_err: str = state_payload.get("team_id", "")
-        slack_user_id_err: str = state_payload.get("slack_user_id", "")
+        team_id_err: str = _field("team_id")
+        slack_user_id_err: str = _field("slack_user_id")
         notifier_err: Optional[SlackOAuthNotifier] = request.app.get(
             "slack_jira_oauth_notifier"
         )
@@ -208,10 +218,10 @@ async def handle_slack_jira_callback(
             content_type="text/html",
         )
 
-    team_id: str = state_payload.get("team_id", "")
-    slack_user_id: str = state_payload.get("slack_user_id", "")
-    # The composite user_id used in JiraOAuthManager
-    nav_user_id: str = state_payload.get("user_id", f"{team_id}:{slack_user_id}")
+    team_id: str = _field("team_id")
+    slack_user_id: str = _field("slack_user_id")
+    # The composite user_id used in JiraOAuthManager (stored at top level).
+    nav_user_id: str = state_payload.get("user_id") or f"{team_id}:{slack_user_id}"
 
     # 1. Persist identity mapping row
     identity_service = request.app.get("identity_mapping_service")

--- a/packages/ai-parrot-integrations/tests/integrations/msteams/test_msteams_jira_commands.py
+++ b/packages/ai-parrot-integrations/tests/integrations/msteams/test_msteams_jira_commands.py
@@ -267,6 +267,31 @@ class TestRegisterJiraCommandsTeams:
 
 
 # ---------------------------------------------------------------------------
+# Menu card contract (Bug 2 regression)
+# ---------------------------------------------------------------------------
+
+class TestJiraMenuCard:
+    """The discoverability menu card's buttons are Action.Submit actions that
+    carry a slash-prefixed ``command`` in their ``data``. The wrapper's
+    _handle_card_submission relies on this key to route the click through the
+    command router (otherwise the buttons silently no-op).
+    """
+
+    def test_menu_buttons_carry_slash_command_data(self):
+        from parrot.integrations.msteams.commands.jira_commands import _jira_menu_card
+
+        card = _jira_menu_card()
+        actions = card["actions"]
+        assert all(a["type"] == "Action.Submit" for a in actions)
+
+        commands = {a["data"]["command"] for a in actions}
+        assert commands == {"/connect_jira", "/disconnect_jira", "/jira_status"}
+        # Every command is slash-prefixed so try_dispatch (which requires a
+        # leading "/") will accept it.
+        assert all(c.startswith("/") for c in commands)
+
+
+# ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 

--- a/packages/ai-parrot-integrations/tests/integrations/msteams/test_msteams_oauth_callback.py
+++ b/packages/ai-parrot-integrations/tests/integrations/msteams/test_msteams_oauth_callback.py
@@ -21,14 +21,22 @@ def mock_token_set():
 
 @pytest.fixture
 def msteams_state_payload():
-    """State payload for an MS Teams-originated OAuth callback."""
+    """State payload as produced by JiraOAuthManager.
+
+    Channel-specific data (conversation_reference) is nested under ``extra`` —
+    this mirrors the real shape returned by ``handle_callback``.
+    """
     return {
         "channel": "msteams",
         "user_id": "aad-obj-123",
-        "conversation_reference": {
-            "conversation": {"id": "conv-123", "tenantId": "tenant-456"},
-            "bot": {"id": "bot-app-id"},
-            "user": {"id": "aad-obj-123", "aadObjectId": "aad-obj-123"},
+        "extra": {
+            "channel": "msteams",
+            "user_id": "aad-obj-123",
+            "conversation_reference": {
+                "conversation": {"id": "conv-123", "tenantId": "tenant-456"},
+                "bot": {"id": "bot-app-id"},
+                "user": {"id": "aad-obj-123", "aadObjectId": "aad-obj-123"},
+            },
         },
     }
 
@@ -240,3 +248,82 @@ class TestHandleMSTeamsJiraCallback:
         assert response.status == 200
         assert "Authorization Failed" in response.text
         assert "User denied access" in response.text
+
+
+# ---------------------------------------------------------------------------
+# State-payload shape parity (regression for the FEAT-225 nesting bug)
+# ---------------------------------------------------------------------------
+
+class _FakeRedis:
+    """Minimal in-memory async Redis stand-in for shape-parity tests."""
+
+    def __init__(self):
+        self.store = {}
+
+    async def set(self, key, value, ex=None):
+        self.store[key] = value
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def delete(self, key):
+        self.store.pop(key, None)
+
+
+class TestStatePayloadShapeParity:
+    """Drive the *real* payload JiraOAuthManager produces into the handler.
+
+    Guards against drift between what ``create_authorization_url`` stores
+    (conversation_reference nested under ``extra``) and what
+    ``handle_msteams_jira_callback`` reads. The original FEAT-225 code read
+    ``conversation_reference`` at top level, so the proactive confirmation
+    silently no-op'd in production despite green unit tests.
+    """
+
+    @pytest.mark.asyncio
+    async def test_manager_payload_drives_proactive_notification(self, mock_token_set):
+        from parrot.auth.jira_oauth import JiraOAuthManager
+        from parrot.integrations.msteams.oauth_callback import handle_msteams_jira_callback
+
+        fake = _FakeRedis()
+        mgr = JiraOAuthManager(
+            client_id="cid",
+            client_secret="sec",
+            redirect_uri="https://example/api/auth/jira/callback",
+            redis_client=fake,
+        )
+        conv_ref = {
+            "conversation": {"id": "conv-123", "tenantId": "tenant-456"},
+            "bot": {"id": "bot-app-id"},
+            "user": {"id": "aad-obj-123"},
+        }
+        _url, nonce = await mgr.create_authorization_url(
+            "msteams",
+            "aad-obj-123",
+            extra_state={
+                "channel": "msteams",
+                "user_id": "aad-obj-123",
+                "conversation_reference": conv_ref,
+            },
+        )
+        state_payload = await mgr.consume_state(nonce)
+
+        identity = MagicMock()
+        identity.upsert_identity = AsyncMock()
+        notifier = MagicMock()
+        notifier.notify_connected = AsyncMock()
+        mock_request = _make_success_request(
+            app={
+                "identity_mapping_service": identity,
+                "msteams_jira_oauth_notifier": notifier,
+            }
+        )
+
+        with patch("asyncio.create_task") as mock_create_task:
+            await handle_msteams_jira_callback(mock_request, mock_token_set, state_payload)
+            mock_create_task.assert_called_once()
+
+        identity.upsert_identity.assert_called_once()
+        call_kwargs = identity.upsert_identity.call_args[1]
+        assert call_kwargs["nav_user_id"] == "aad-obj-123"
+        assert call_kwargs["auth_data"]["tenant_id"] == "tenant-456"

--- a/packages/ai-parrot-integrations/tests/integrations/slack/test_slack_oauth_callback.py
+++ b/packages/ai-parrot-integrations/tests/integrations/slack/test_slack_oauth_callback.py
@@ -21,12 +21,19 @@ def mock_token_set():
 
 @pytest.fixture
 def slack_state_payload():
-    """State payload for a Slack-originated OAuth callback."""
+    """State payload as produced by JiraOAuthManager.
+
+    Channel-specific data (team_id, slack_user_id) is nested under ``extra`` —
+    this mirrors the real shape returned by ``handle_callback``.
+    """
     return {
         "channel": "slack",
-        "team_id": "T0001",
-        "slack_user_id": "U1234",
         "user_id": "T0001:U1234",
+        "extra": {
+            "channel": "slack",
+            "team_id": "T0001",
+            "slack_user_id": "U1234",
+        },
     }
 
 
@@ -218,3 +225,79 @@ class TestHandleSlackJiraCallback:
         assert response.status == 200
         assert "Authorization Failed" in response.text
         assert "User denied access" in response.text
+
+
+# ---------------------------------------------------------------------------
+# State-payload shape parity (regression for the FEAT-225 nesting bug)
+# ---------------------------------------------------------------------------
+
+class _FakeRedis:
+    """Minimal in-memory async Redis stand-in for shape-parity tests."""
+
+    def __init__(self):
+        self.store = {}
+
+    async def set(self, key, value, ex=None):
+        self.store[key] = value
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def delete(self, key):
+        self.store.pop(key, None)
+
+
+class TestStatePayloadShapeParity:
+    """Drive the *real* payload JiraOAuthManager produces into the handler.
+
+    Guards against drift between what ``create_authorization_url`` stores
+    (channel data nested under ``extra``) and what
+    ``handle_slack_jira_callback`` reads. The original FEAT-225 code read
+    ``team_id``/``slack_user_id`` at top level, so the identity write and DM
+    silently no-op'd in production despite green unit tests.
+    """
+
+    @pytest.mark.asyncio
+    async def test_manager_payload_drives_identity_and_dm(self, mock_token_set):
+        from parrot.auth.jira_oauth import JiraOAuthManager
+        from parrot.integrations.slack.oauth_callback import handle_slack_jira_callback
+
+        fake = _FakeRedis()
+        mgr = JiraOAuthManager(
+            client_id="cid",
+            client_secret="sec",
+            redirect_uri="https://example/api/auth/jira/callback",
+            redis_client=fake,
+        )
+        _url, nonce = await mgr.create_authorization_url(
+            "slack",
+            "T0001:U1234",
+            extra_state={
+                "channel": "slack",
+                "team_id": "T0001",
+                "slack_user_id": "U1234",
+            },
+        )
+        # Exactly the payload handle_callback would return for this nonce.
+        state_payload = await mgr.consume_state(nonce)
+
+        identity = MagicMock()
+        identity.upsert_identity = AsyncMock()
+        notifier = MagicMock()
+        notifier.notify_connected = AsyncMock()
+        request = _make_success_request(
+            app={
+                "identity_mapping_service": identity,
+                "slack_jira_oauth_notifier": notifier,
+            }
+        )
+
+        with patch("asyncio.create_task") as mock_create_task:
+            await handle_slack_jira_callback(request, mock_token_set, state_payload)
+            mock_create_task.assert_called_once()
+
+        identity.upsert_identity.assert_called_once()
+        assert identity.upsert_identity.call_args[1]["auth_data"] == {
+            "team_id": "T0001",
+            "slack_user_id": "U1234",
+        }

--- a/packages/ai-parrot/src/parrot/auth/jira_oauth.py
+++ b/packages/ai-parrot/src/parrot/auth/jira_oauth.py
@@ -316,19 +316,7 @@ class JiraOAuthManager:
             ValueError: If the state nonce is missing/expired or the token
                 exchange fails.
         """
-        nonce_key = self._nonce_key(state)
-        raw_state = await self.redis.get(nonce_key)
-        if not raw_state:
-            raise ValueError("Invalid or expired state nonce.")
-        if isinstance(raw_state, bytes):
-            raw_state = raw_state.decode("utf-8")
-        # One-time use: delete immediately.
-        await self.redis.delete(nonce_key)
-
-        try:
-            state_payload = json.loads(raw_state)
-        except json.JSONDecodeError as exc:
-            raise ValueError(f"Corrupted state payload: {exc}") from exc
+        state_payload = await self.consume_state(state)
 
         channel = state_payload.get("channel")
         user_id = state_payload.get("user_id")
@@ -378,6 +366,43 @@ class JiraOAuthManager:
             channel, user_id, display_name, site_url,
         )
         return token, state_payload
+
+    async def consume_state(self, state: str) -> Dict[str, Any]:
+        """Resolve and delete a one-time CSRF state nonce.
+
+        Reads the state payload stored under ``jira:nonce:<state>`` and
+        deletes it (single-use semantics) without exchanging an
+        authorization code. This is used by the callback route to handle
+        OAuth *error* redirects — when the user denies consent Atlassian
+        returns ``?error=...&state=...`` with **no** ``code`` — so the route
+        can still dispatch a channel-specific failure notification and avoid
+        leaving the nonce dangling in Redis until its TTL expires.
+
+        :meth:`handle_callback` delegates its nonce resolution here too, so
+        both paths share identical validation semantics.
+
+        Args:
+            state: The CSRF state nonce echoed back by Atlassian.
+
+        Returns:
+            The decoded state payload (``channel``, ``user_id``, ``extra``).
+
+        Raises:
+            ValueError: If the nonce is missing/expired or the payload is
+                corrupt.
+        """
+        nonce_key = self._nonce_key(state)
+        raw_state = await self.redis.get(nonce_key)
+        if not raw_state:
+            raise ValueError("Invalid or expired state nonce.")
+        if isinstance(raw_state, bytes):
+            raw_state = raw_state.decode("utf-8")
+        # One-time use: delete immediately.
+        await self.redis.delete(nonce_key)
+        try:
+            return json.loads(raw_state)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Corrupted state payload: {exc}") from exc
 
     # ------------------------------------------------------------------ reads
 

--- a/packages/ai-parrot/src/parrot/auth/routes.py
+++ b/packages/ai-parrot/src/parrot/auth/routes.py
@@ -183,6 +183,52 @@ async def _notify_telegram(
         )
 
 
+async def _handle_oauth_error(
+    request: web.Request,
+    manager: "JiraOAuthManager",
+    error: str,
+    state: str | None,
+) -> web.Response:
+    """Handle an OAuth error redirect (e.g. the user denied consent).
+
+    Resolves and consumes the CSRF nonce (so it is not left dangling in
+    Redis) and dispatches a channel-specific failure notification by routing
+    to the same per-channel callback handler, which detects the ``?error=``
+    query param and runs its failure branch. Falls back to a generic error
+    page for the web/telegram channels.
+
+    Args:
+        request: The incoming aiohttp request (carries ``?error=``).
+        manager: The Jira OAuth manager (used to consume the state nonce).
+        error: The OAuth ``error`` code from the query string.
+        state: The CSRF state nonce, if present.
+
+    Returns:
+        An HTML error response for the browser.
+    """
+    error_description = request.query.get("error_description", error)
+    logger.warning("Jira OAuth error redirect: %s — %s", error, error_description)
+
+    state_payload: Dict[str, Any] = {}
+    if state:
+        try:
+            state_payload = await manager.consume_state(state)
+        except ValueError:
+            logger.warning(
+                "OAuth error redirect carried an invalid/expired state nonce"
+            )
+
+    channel = state_payload.get("channel", "telegram")
+    if channel == "slack":
+        from parrot.integrations.slack.oauth_callback import handle_slack_jira_callback
+        return await handle_slack_jira_callback(request, None, state_payload)
+    if channel == "msteams":
+        from parrot.integrations.msteams.oauth_callback import handle_msteams_jira_callback
+        return await handle_msteams_jira_callback(request, None, state_payload)
+
+    return _error_response(error_description, status=400)
+
+
 async def jira_oauth_callback(request: web.Request) -> web.Response:
     """Handle ``GET /api/auth/jira/callback``.
 
@@ -193,9 +239,7 @@ async def jira_oauth_callback(request: web.Request) -> web.Response:
     """
     code = request.query.get("code")
     state = request.query.get("state")
-
-    if not code or not state:
-        return _error_response("Missing code or state parameter.", status=400)
+    error = request.query.get("error")
 
     manager: "JiraOAuthManager | None" = request.app.get("jira_oauth_manager")
     if manager is None:
@@ -203,6 +247,16 @@ async def jira_oauth_callback(request: web.Request) -> web.Response:
         return _error_response(
             "OAuth manager not configured on the server.", status=500,
         )
+
+    # OAuth error redirect (e.g. the user denied consent). Atlassian sends
+    # ``?error=...&state=...`` with NO authorization code, so this must be
+    # handled before the code check — otherwise the user-facing failure
+    # notification never fires and the one-time nonce lingers until its TTL.
+    if error:
+        return await _handle_oauth_error(request, manager, error, state)
+
+    if not code or not state:
+        return _error_response("Missing code or state parameter.", status=400)
 
     try:
         token_set, state_payload = await manager.handle_callback(code, state)

--- a/packages/ai-parrot/tests/unit/test_jira_oauth_manager.py
+++ b/packages/ai-parrot/tests/unit/test_jira_oauth_manager.py
@@ -256,6 +256,42 @@ class TestHandleCallback:
         assert ttl == 90 * 24 * 60 * 60
 
 
+class TestConsumeState:
+    @pytest.mark.asyncio
+    async def test_returns_payload_and_deletes_nonce(
+        self, manager: JiraOAuthManager, fake_redis: _FakeRedis
+    ) -> None:
+        # Channel data lives under "extra" — the shape the callback handlers read.
+        _, nonce = await manager.create_authorization_url(
+            "slack",
+            "T1:U1",
+            extra_state={"team_id": "T1", "slack_user_id": "U1"},
+        )
+        payload = await manager.consume_state(nonce)
+
+        assert payload["channel"] == "slack"
+        assert payload["user_id"] == "T1:U1"
+        assert payload["extra"] == {"team_id": "T1", "slack_user_id": "U1"}
+        # One-time use: the nonce is deleted after being consumed.
+        assert f"jira:nonce:{nonce}" in fake_redis.deleted
+
+    @pytest.mark.asyncio
+    async def test_second_consume_raises(
+        self, manager: JiraOAuthManager, fake_redis: _FakeRedis
+    ) -> None:
+        _, nonce = await manager.create_authorization_url("telegram", "u1")
+        await manager.consume_state(nonce)
+        with pytest.raises(ValueError, match="Invalid or expired state nonce"):
+            await manager.consume_state(nonce)
+
+    @pytest.mark.asyncio
+    async def test_unknown_state_raises(
+        self, manager: JiraOAuthManager
+    ) -> None:
+        with pytest.raises(ValueError, match="Invalid or expired state nonce"):
+            await manager.consume_state("does-not-exist")
+
+
 class TestGetValidToken:
     @pytest.mark.asyncio
     async def test_returns_none_when_empty(


### PR DESCRIPTION
## Summary

Fixes a critical bug where OAuth consent-denial errors (`?error=...`) were not triggering channel-specific failure notifications, and corrects state payload shape inconsistencies between what `JiraOAuthManager` produces and what callback handlers expect.

## Key Changes

### OAuth Error Handling
- **New `_handle_oauth_error()` function** in `routes.py`: Properly handles OAuth error redirects by resolving and consuming the CSRF nonce, then dispatching to the appropriate channel-specific callback handler (Slack/MS Teams) so failure notifications fire correctly
- **Error path now runs before code validation**: Moved error check before the `code` parameter check in `jira_oauth_callback()` to ensure the nonce is consumed even when the user denies consent (preventing dangling Redis entries)

### State Payload Shape Parity
- **New `consume_state()` method** in `JiraOAuthManager`: Extracted nonce resolution logic into a reusable method that both `handle_callback()` and the error handler can use, ensuring identical validation semantics
- **Callback handlers updated** (`handle_slack_jira_callback`, `handle_msteams_jira_callback`):
  - Now accept `Optional[JiraTokenSet]` (can be `None` on error path)
  - Read channel-specific data from `state_payload["extra"]` (where `JiraOAuthManager` nests it)
  - Fall back to top-level keys for backward compatibility
  - Updated docstrings to clarify the full state payload structure

### Test Coverage
- **Regression tests added** in both Slack and MS Teams test files:
  - `TestStatePayloadShapeParity` classes that drive the *real* payload produced by `JiraOAuthManager` through the callback handlers
  - Verify identity writes and notifications fire correctly with the nested payload structure
  - Guard against future drift between manager and handler expectations
- **Unit tests for `consume_state()`**: Verify nonce deletion, one-time use semantics, and error cases

### MS Teams Proactive Notification Safety
- **Wrapper initialization** now skips registering `MSTeamsOAuthNotifier` when `client_id` is not configured (with a warning), preventing silent failures in `continue_conversation` calls
- **Card submission routing**: Added command routing for Adaptive Card Submit actions that carry slash commands in their `data` field (e.g., menu card buttons), so card-based commands behave like typed slash commands

### Documentation
- Updated fixture docstrings to clarify the nested `extra` structure
- Added detailed comments explaining the state payload shape and backward compatibility fallbacks

https://claude.ai/code/session_01Dkea4CYBhDefE82M93memw