### PR TITLE
fix(dev-loop): workflow-agnostic Jira transitions + read-only code-review cwd

### DIFF
--- a/packages/ai-parrot/src/parrot/conf.py
+++ b/packages/ai-parrot/src/parrot/conf.py
@@ -900,6 +900,26 @@ DEV_LOOP_CODEREVIEW_MODEL: str = config.get(
     "DEV_LOOP_CODEREVIEW_MODEL", fallback="claude-sonnet-4-6"
 )
 
+# Jira transition labels the dev-loop applies at each hand-off point. Every
+# Jira project ships its own workflow, so each setting is an *ordered list of
+# candidate labels* (most specific first); the dev-loop tries them against the
+# issue's live available-transitions and applies the first that resolves. This
+# keeps the flow working across projects with no config, while letting an
+# operator pin exact labels via env when the defaults don't cover their
+# workflow. Matching is alias/substring-tolerant (jira_transition_issue).
+DEV_LOOP_JIRA_TRANSITIONS_READY: list[str] = config.getlist(
+    "DEV_LOOP_JIRA_TRANSITIONS_READY",
+    fallback=["Ready to Deploy", "Resolve Issue", "Resolved", "Done", "Close Issue", "Closed"],
+) or ["Ready to Deploy", "Resolve Issue", "Resolved", "Done", "Close Issue", "Closed"]
+DEV_LOOP_JIRA_TRANSITIONS_BLOCKED: list[str] = config.getlist(
+    "DEV_LOOP_JIRA_TRANSITIONS_BLOCKED",
+    fallback=["Deployment Blocked", "Blocked", "On Hold", "Stop Progress"],
+) or ["Deployment Blocked", "Blocked", "On Hold", "Stop Progress"]
+DEV_LOOP_JIRA_TRANSITIONS_REVISION: list[str] = config.getlist(
+    "DEV_LOOP_JIRA_TRANSITIONS_REVISION",
+    fallback=["In Review – revised", "In Review", "Resolve Issue", "In Progress", "Reopen"],
+) or ["In Review – revised", "In Review", "Resolve Issue", "In Progress", "Reopen"]
+
 # ---------------------------------------------------------------------------
 # Remote Tool Executors (parrot.tools.executors)
 # ---------------------------------------------------------------------------

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/dispatcher.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/dispatcher.py
@@ -65,6 +65,29 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 
 T = TypeVar("T", bound=BaseModel)
 
+# Edit/Write tools that let a dispatched session mutate the filesystem through
+# the SDK's own tool surface. A dispatch whose profile excludes ALL of these
+# AND runs in ``permission_mode="plan"`` cannot make changes, so the
+# WORKTREE_BASE_PATH confinement (which exists to stop a write-capable agent
+# escaping the worktree) does not apply to it. ``Bash`` is intentionally NOT
+# here: plan mode gates command execution to read-only behaviour, and the
+# read-only QA/code-review gates legitimately need a shell.
+_WRITE_CAPABLE_TOOLS = frozenset({"Edit", "Write", "MultiEdit", "NotebookEdit"})
+
+
+def _claude_profile_is_read_only(profile: ClaudeCodeDispatchProfile) -> bool:
+    """True when a Claude Code profile cannot mutate the filesystem.
+
+    Read-only means ``permission_mode="plan"`` (plan mode forbids edits) AND no
+    Edit/Write tool in ``allowed_tools``. Such a dispatch (e.g. the additive
+    ``sdd-codereview`` gate) is safe to run against a path outside
+    ``WORKTREE_BASE_PATH`` — an already-checked-out repo or the demo's own
+    checkout — because the confinement only matters for write-capable sessions.
+    """
+    if profile.permission_mode != "plan":
+        return False
+    return not (set(profile.allowed_tools) & _WRITE_CAPABLE_TOOLS)
+
 
 # ---------------------------------------------------------------------------
 # Exceptions
@@ -190,8 +213,10 @@ class ClaudeCodeDispatcher:
         stream_key = f"flow:{run_id}:dispatch:{node_id}"
         json_schema_path: Optional[str] = None
 
-        # Spec §7 R4 — defense in depth.
-        self._enforce_cwd_under_worktree_base(cwd)
+        # Spec §7 R4 — defense in depth. Waived for read-only (plan-mode,
+        # no-edit) dispatches such as the sdd-codereview gate, which may run
+        # against a checkout outside the worktree base.
+        self._enforce_cwd_under_worktree_base(cwd, profile)
 
         await self._publish_event(
             stream_key,
@@ -346,12 +371,24 @@ class ClaudeCodeDispatcher:
     # Internal helpers (underscored — but accessible to unit tests)
     # ------------------------------------------------------------------
 
-    def _enforce_cwd_under_worktree_base(self, cwd: str) -> None:
+    def _enforce_cwd_under_worktree_base(
+        self,
+        cwd: str,
+        profile: Optional[ClaudeCodeDispatchProfile] = None,
+    ) -> None:
         """Spec §7 R4: refuse dispatch when ``cwd`` is not in worktree base.
+
+        The confinement protects against a *write-capable* session escaping its
+        worktree. A read-only dispatch (plan mode, no Edit/Write tools) cannot
+        write anywhere, so when *profile* is read-only the check is waived —
+        this lets the additive ``sdd-codereview`` gate review a checkout that
+        legitimately lives outside ``WORKTREE_BASE_PATH``.
 
         Raises:
             DispatchExecutionError: when the path check fails.
         """
+        if profile is not None and _claude_profile_is_read_only(profile):
+            return
         base = os.path.abspath(conf.WORKTREE_BASE_PATH)
         target = os.path.abspath(cwd)
         try:

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/base.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/base.py
@@ -17,9 +17,10 @@ Cross-node payloads (``bug_brief``, ``research_output``,
 
 from __future__ import annotations
 
+import logging
 import os
 import re
-from typing import Any, Dict, Optional, Set, Union
+from typing import Any, Dict, Optional, Sequence, Set, Union
 
 from pydantic import Field
 
@@ -47,6 +48,78 @@ def scrub_git_output(text: str) -> str:
     if token:
         redacted = redacted.replace(token, "***")
     return redacted
+
+
+async def transition_issue_with_candidates(
+    jira: Any,
+    issue: str,
+    candidates: Sequence[str],
+    *,
+    logger: logging.Logger,
+    **kwargs: Any,
+) -> Optional[Dict[str, Any]]:
+    """Apply the first candidate Jira transition that the workflow exposes.
+
+    The dev-loop drives many Jira projects, each with its own workflow
+    transition names — a single hard-coded label (e.g. ``"Ready to Deploy"``)
+    only exists in one of them. Callers therefore pass an *ordered* list of
+    synonym labels (most specific first). Each is handed to
+    ``jira_transition_issue``, whose alias/substring matcher resolves it against
+    the issue's live available-transitions; the first label that resolves is
+    applied and its result returned.
+
+    A non-matching label raises ``ValueError`` inside the toolkit (it lists the
+    available transitions) — that is treated as "try the next candidate", not a
+    failure. Any other exception (network/auth) propagates so the caller's own
+    error handling sees it. Returns ``None`` when no candidate matched, leaving
+    the decision of whether that is fatal to the caller.
+
+    Args:
+        jira: A ``JiraToolkit`` instance.
+        issue: Issue key (e.g. ``"NAV-6239"``).
+        candidates: Ordered transition-label synonyms; empties are skipped.
+        logger: Logger for diagnostics.
+        **kwargs: Forwarded to ``jira_transition_issue`` (``fields``,
+            ``resolution``, ``assignee`` …).
+
+    Returns:
+        The toolkit's ``jira_transition_issue`` result on success, else
+        ``None``.
+    """
+    preferred = next((c for c in candidates if c), None)
+    last_error: Optional[ValueError] = None
+    tried: list[str] = []
+    for label in candidates:
+        if not label:
+            continue
+        tried.append(label)
+        try:
+            result = await jira.jira_transition_issue(
+                issue=issue, transition=label, **kwargs
+            )
+            if label != preferred:
+                logger.info(
+                    "Applied fallback transition %r for %s (preferred %r unavailable).",
+                    label,
+                    issue,
+                    preferred,
+                )
+            return result
+        except ValueError as exc:
+            last_error = exc
+            logger.debug(
+                "Transition candidate %r not available for %s: %s",
+                label,
+                issue,
+                exc,
+            )
+    logger.warning(
+        "No candidate transition resolved for %s (tried %s). Last error: %s",
+        issue,
+        tried,
+        last_error,
+    )
+    return None
 
 
 def register_dev_loop_node(name: str):
@@ -142,4 +215,9 @@ class DevLoopNode(Node):
         return ""
 
 
-__all__ = ["DevLoopNode", "register_dev_loop_node", "scrub_git_output"]
+__all__ = [
+    "DevLoopNode",
+    "register_dev_loop_node",
+    "scrub_git_output",
+    "transition_issue_with_candidates",
+]

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/close.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/close.py
@@ -14,19 +14,17 @@ Jira-side errors are logged and surfaced as a degraded status dict.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
+from parrot import conf
 from parrot.bots.flows.core.context import FlowContext
 from parrot.bots.flows.core.types import DependencyResults
 from parrot.flows.dev_loop.models import QAReport, ResearchOutput
-from parrot.flows.dev_loop.nodes.base import DevLoopNode, register_dev_loop_node
-
-
-# Transition label per run mode.
-_TRANSITION_BY_MODE = {
-    "initial": "Ready to Deploy",
-    "revision": "In Review – revised",
-}
+from parrot.flows.dev_loop.nodes.base import (
+    DevLoopNode,
+    register_dev_loop_node,
+    transition_issue_with_candidates,
+)
 
 
 @register_dev_loop_node("dev_loop.close")
@@ -72,13 +70,13 @@ class DevLoopCloseNode(DevLoopNode):
             )
             return {"status": "closed_without_ticket", "mode": mode}
 
-        transition = _TRANSITION_BY_MODE.get(mode, _TRANSITION_BY_MODE["initial"])
+        candidates = self._transition_candidates(mode)
         body = self._build_summary(mode, shared)
 
         try:
             await self._jira.jira_add_comment(issue=issue_key, body=body)
-            await self._jira.jira_transition_issue(
-                issue=issue_key, transition=transition
+            await transition_issue_with_candidates(
+                self._jira, issue_key, candidates, logger=self.logger
             )
         except Exception as exc:  # noqa: BLE001 - terminal node, never raises
             self.logger.exception("DevLoopClose Jira call failed: %s", exc)
@@ -90,6 +88,22 @@ class DevLoopCloseNode(DevLoopNode):
             }
 
         return {"status": "closed", "issue_key": issue_key, "mode": mode}
+
+    # ------------------------------------------------------------------
+    # Internal — transition resolution
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _transition_candidates(mode: str) -> List[str]:
+        """Ordered transition-label candidates for the run *mode*.
+
+        ``revision`` runs aim for an "in review again" label; everything else
+        (the initial success path) aims for a "ready/done" label. Both fall
+        back through workflow-agnostic synonyms (see ``conf``).
+        """
+        if mode == "revision":
+            return list(conf.DEV_LOOP_JIRA_TRANSITIONS_REVISION)
+        return list(conf.DEV_LOOP_JIRA_TRANSITIONS_READY)
 
     # ------------------------------------------------------------------
     # Internal — summary construction

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/deployment_handoff.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/deployment_handoff.py
@@ -25,6 +25,7 @@ import os
 import shutil
 from typing import Any, Dict, Optional, Union
 
+from parrot import conf
 from parrot.bots.flows.core.context import FlowContext
 from parrot.bots.flows.core.types import DependencyResults
 from parrot.flows.dev_loop.models import (
@@ -37,6 +38,7 @@ from parrot.flows.dev_loop.nodes.base import (
     DevLoopNode,
     register_dev_loop_node,
     scrub_git_output,
+    transition_issue_with_candidates,
 )
 
 
@@ -161,8 +163,11 @@ class DeploymentHandoffNode(DevLoopNode):
 
         # 3. Transition Jira.
         try:
-            await self._jira.jira_transition_issue(
-                issue=issue_key, transition="Ready to Deploy"
+            await transition_issue_with_candidates(
+                self._jira,
+                issue_key,
+                conf.DEV_LOOP_JIRA_TRANSITIONS_READY,
+                logger=self.logger,
             )
         except Exception as exc:  # noqa: BLE001 - degraded path
             self.logger.warning(
@@ -305,8 +310,11 @@ class DeploymentHandoffNode(DevLoopNode):
 
     async def _mark_blocked(self, issue_key: str, error: str) -> None:
         try:
-            await self._jira.jira_transition_issue(
-                issue=issue_key, transition="Deployment Blocked"
+            await transition_issue_with_candidates(
+                self._jira,
+                issue_key,
+                conf.DEV_LOOP_JIRA_TRANSITIONS_BLOCKED,
+                logger=self.logger,
             )
         except Exception as exc:  # noqa: BLE001 - degraded path
             self.logger.warning("Blocked transition failed: %s", exc)

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/qa.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/qa.py
@@ -34,6 +34,11 @@ from parrot.flows.dev_loop.nodes.base import DevLoopNode, register_dev_loop_node
 
 _DEFAULT_LINT_COMMAND = "ruff check . && mypy --no-incremental"
 
+# Prefix of the synthetic finding emitted when the code-review gate could not
+# run (infra error). Used to detect a *skipped* (vs. genuinely passed) review
+# so the skip is surfaced loudly instead of masquerading as a clean review.
+_CODE_REVIEW_SKIP_PREFIX = "code-review could not run:"
+
 
 class _QABrief(BaseModel):
     """Internal brief shape passed to the ``sdd-qa`` subagent.
@@ -172,20 +177,39 @@ class QANode(DevLoopNode):
         cr_passed, cr_findings = await self._run_code_review(
             shared, research, brief
         )
-        report = report.model_copy(
-            update={
-                "passed": deterministic_passed and cr_passed,
-                "code_review_passed": cr_passed,
-                "code_review_findings": cr_findings,
-            }
+        cr_skipped = any(
+            f.startswith(_CODE_REVIEW_SKIP_PREFIX) for f in cr_findings
         )
+        update: Dict[str, Any] = {
+            "passed": deterministic_passed and cr_passed,
+            "code_review_passed": cr_passed,
+            "code_review_findings": cr_findings,
+        }
+        if cr_skipped:
+            # Degrade-to-pass (FEAT-250 G4) keeps the deterministic gate as the
+            # hard guarantee, but a skipped review must NOT read as green: here
+            # ``code_review_passed=True`` means "not reviewed", not "reviewed
+            # clean". Make that loud in the log AND in the report's notes.
+            self.logger.warning(
+                "Code-review gate did NOT run for %s — QA is passing on the "
+                "DETERMINISTIC gate only; code_review_passed=True means "
+                "'not reviewed', not 'reviewed clean'. Detail: %s",
+                research.jira_issue_key or research.feat_id,
+                "; ".join(cr_findings),
+            )
+            skip_note = "⚠ Code-review gate SKIPPED (infra) — change NOT reviewed."
+            existing_notes = report.notes or ""
+            sep = "\n\n" if existing_notes else ""
+            update["notes"] = f"{existing_notes}{sep}{skip_note}"
+        report = report.model_copy(update=update)
 
         self.logger.info(
             "QA report: passed=%s, deterministic=%s, code_review=%s, "
-            "lint_passed=%s, n_executable=%s, n_manual=%s",
+            "code_review_ran=%s, lint_passed=%s, n_executable=%s, n_manual=%s",
             report.passed,
             deterministic_passed,
             cr_passed,
+            not cr_skipped,
             report.lint_passed,
             len(executable),
             len(manual),

--- a/packages/ai-parrot/tests/flows/dev_loop/test_dispatcher.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_dispatcher.py
@@ -269,6 +269,42 @@ class TestCwdSafetyCheck:
                 cwd="/etc",
             )
 
+    def test_cwd_outside_waived_for_readonly_codereview_profile(self, dispatcher):
+        # A read-only (plan-mode, no Edit/Write) profile such as the
+        # sdd-codereview gate may run against a checkout outside the worktree
+        # base — the confinement only protects write-capable sessions.
+        readonly = ClaudeCodeDispatchProfile(
+            subagent="sdd-codereview",
+            permission_mode="plan",
+            allowed_tools=["Read", "Bash", "Grep", "Glob"],
+        )
+        # Must NOT raise.
+        dispatcher._enforce_cwd_under_worktree_base("/etc", readonly)
+
+    def test_cwd_outside_still_rejected_for_write_profile(self, dispatcher):
+        write = ClaudeCodeDispatchProfile(
+            subagent="sdd-worker",
+            permission_mode="acceptEdits",
+            allowed_tools=["Read", "Edit", "Write"],
+        )
+        with pytest.raises(DispatchExecutionError):
+            dispatcher._enforce_cwd_under_worktree_base("/etc", write)
+
+    def test_cwd_outside_rejected_when_plan_mode_but_edit_tool_present(
+        self, dispatcher
+    ):
+        # plan mode alone is not enough: an Edit tool makes it write-capable.
+        mixed = ClaudeCodeDispatchProfile(
+            permission_mode="plan", allowed_tools=["Read", "Edit"]
+        )
+        with pytest.raises(DispatchExecutionError):
+            dispatcher._enforce_cwd_under_worktree_base("/etc", mixed)
+
+    def test_no_profile_arg_preserves_strict_check(self, dispatcher):
+        # Backward-compat: called without a profile, the guard stays strict.
+        with pytest.raises(DispatchExecutionError):
+            dispatcher._enforce_cwd_under_worktree_base("/etc")
+
 
 # ---------------------------------------------------------------------------
 # Output validation

--- a/packages/ai-parrot/tests/flows/dev_loop/test_jira_transition_fallback.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_jira_transition_fallback.py
@@ -1,0 +1,99 @@
+"""Regression tests for the workflow-agnostic Jira transition helper.
+
+Covers the dev-loop bugfix where nodes hard-coded transition labels
+(``"Ready to Deploy"`` / ``"Deployment Blocked"`` / ``"In Review – revised"``)
+that don't exist in every Jira project's workflow. The helper now tries an
+ordered list of candidate labels and applies the first the workflow exposes.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+import pytest
+
+from parrot.flows.dev_loop.nodes.base import transition_issue_with_candidates
+
+
+_LOG = logging.getLogger("test.jira_transition_fallback")
+
+
+class _FakeJira:
+    """Jira double whose transition resolves only a known label set.
+
+    Mirrors ``JiraToolkit.jira_transition_issue``: a non-matching label raises
+    ``ValueError`` (the real toolkit lists available transitions in the
+    message); a matching one returns the post-transition issue envelope.
+    """
+
+    def __init__(self, available: List[str]) -> None:
+        self._available = {a.lower() for a in available}
+        self.calls: List[str] = []
+
+    async def jira_transition_issue(
+        self, *, issue: str, transition: str, **kwargs: Any
+    ) -> Dict[str, Any]:
+        self.calls.append(transition)
+        if transition.lower() not in self._available:
+            raise ValueError(f"Invalid transition '{transition}' for issue {issue}.")
+        return {"ok": True, "issue": issue, "applied": transition, "kwargs": kwargs}
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_second_candidate():
+    # Workflow exposes only "Resolve Issue" — the dev-loop's preferred
+    # "Ready to Deploy" must fall through to it.
+    jira = _FakeJira(available=["Resolve Issue"])
+    result = await transition_issue_with_candidates(
+        jira, "NAV-1", ["Ready to Deploy", "Resolve Issue", "Done"], logger=_LOG
+    )
+    assert result is not None and result["applied"] == "Resolve Issue"
+    assert jira.calls == ["Ready to Deploy", "Resolve Issue"]
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_no_candidate_matches():
+    jira = _FakeJira(available=["Backlog"])
+    result = await transition_issue_with_candidates(
+        jira, "NAV-1", ["Ready to Deploy", "Resolved"], logger=_LOG
+    )
+    assert result is None
+    assert jira.calls == ["Ready to Deploy", "Resolved"]
+
+
+@pytest.mark.asyncio
+async def test_first_candidate_short_circuits_and_forwards_kwargs():
+    jira = _FakeJira(available=["Ready to Deploy", "Resolved"])
+    result = await transition_issue_with_candidates(
+        jira,
+        "NAV-1",
+        ["Ready to Deploy", "Resolved"],
+        logger=_LOG,
+        resolution="Fixed",
+    )
+    assert result is not None and result["applied"] == "Ready to Deploy"
+    assert result["kwargs"] == {"resolution": "Fixed"}
+    assert jira.calls == ["Ready to Deploy"]  # second candidate never tried
+
+
+@pytest.mark.asyncio
+async def test_non_value_error_propagates():
+    class _Boom:
+        async def jira_transition_issue(self, **_kw: Any) -> Dict[str, Any]:
+            raise RuntimeError("network down")
+
+    with pytest.raises(RuntimeError):
+        await transition_issue_with_candidates(
+            _Boom(), "NAV-1", ["X"], logger=_LOG
+        )
+
+
+@pytest.mark.asyncio
+async def test_empty_candidate_labels_skipped():
+    jira = _FakeJira(available=["Resolved"])
+    result = await transition_issue_with_candidates(
+        jira, "NAV-1", ["", "Resolved"], logger=_LOG
+    )
+    assert result is not None and result["applied"] == "Resolved"
+    assert jira.calls == ["Resolved"]


### PR DESCRIPTION
## Problem

Found running `examples/dev_loop/server.py` against a real Jira project (NAV-6239):

1. **Jira transitions always failed.** The `deployment_handoff` and `close` nodes hard-coded transition labels (`Ready to Deploy`, `Deployment Blocked`, `In Review – revised`) that don't exist in every project's workflow, so `jira_transition_issue` raised `Invalid transition`. (The toolkit itself was fine — it already fetches available transitions and alias-matches; the labels simply had no match in the NAV workflow: `Blocked` / `Resolve Issue` / `Close Issue` / …)
2. **The `sdd-codereview` QA gate was always skipped** with `cwd '...' is not under WORKTREE_BASE_PATH`. The dispatcher's worktree-confinement guard — meant for *write-capable* sessions — also blocked the read-only review.

## Changes

- **Workflow-agnostic transitions.** New `transition_issue_with_candidates()` helper tries an ordered list of candidate labels against the issue's live available-transitions and applies the first that resolves. Hand-offs use it; candidate lists are overridable via `DEV_LOOP_JIRA_TRANSITIONS_{READY,BLOCKED,REVISION}`. For NAV-6239, `Ready to Deploy` now falls through to `Resolve Issue`, and blocked falls through to `Blocked`.
- **Read-only cwd waiver.** The dispatcher's `_enforce_cwd_under_worktree_base` guard is waived for read-only Claude dispatches (`permission_mode=plan` + no Edit/Write tools), so the code-review gate can review a checkout outside the worktree base. Write paths stay confined.
- **Louder skip.** A skipped/errored code-review is now logged at WARNING and noted in the `QAReport`, so a green `code_review_passed` can't be mistaken for "reviewed clean" (degrade-to-pass behavior preserved — the deterministic gate stays authoritative).

## Tests

- New `test_jira_transition_fallback.py` (fallback to next candidate, returns None when none match, short-circuit + kwargs forwarding, non-ValueError propagation, empty-label skip).
- New cwd-guard cases in `test_dispatcher.py` (waived for read-only codereview profile; still rejected for write profile; rejected when plan-mode but Edit present; strict when no profile arg).
- Affected dev-loop suites green (48 passed). The one pre-existing suite-ordering flake in `test_server_repo_wiring.py` is unrelated (reproduces identically on baseline without these edits).

## Note

Branched off an in-flight `sdd-worker` commit on `dev`; isolated and clean, may need a trivial reconciliation with concurrent `dispatcher.py` work at merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)