### PR TITLE
fix(voice): avatar no-credits passthrough + GeminiLiveClient instantiable

### DIFF
--- a/packages/ai-parrot-server/src/parrot/handlers/avatar.py
+++ b/packages/ai-parrot-server/src/parrot/handlers/avatar.py
@@ -40,7 +40,7 @@ import os
 import uuid
 from typing import Any, Dict, List, Optional
 
-from aiohttp import web
+from aiohttp import web, ClientResponseError
 from navconfig.logging import logging
 from navigator.views import BaseView
 from navigator_auth.decorators import is_authenticated, user_session
@@ -224,6 +224,20 @@ async def _start_avatar_session(request: web.Request) -> web.Response:
         handle.session_id = session_id
         handle.tenant_id = tenant_id
         await client.start_session(handle)
+    except ClientResponseError as exc:
+        # Upstream LiveAvatar rejected the start (e.g. no credits). Close the
+        # client and return a clean, machine-readable status the frontend can
+        # act on instead of leaking a bare 500.
+        try:
+            await client.aclose()
+        finally:
+            pass
+        _logger.warning(
+            "AvatarSessionView: LiveAvatar start failed for session %s: %s",
+            session_id,
+            getattr(exc, "message", exc),
+        )
+        return avatar_upstream_error_response(exc)
     except Exception:
         # On any failure, do not leak the client/session.
         try:
@@ -250,6 +264,36 @@ async def _start_avatar_session(request: web.Request) -> web.Response:
         "client_token": tokens.client_token,
         "session_id": session_id,
     })
+
+
+def avatar_upstream_error_response(exc: ClientResponseError) -> web.Response:
+    """Translate a LiveAvatar upstream error into a clean JSON response.
+
+    Without this, the upstream ``ClientResponseError`` propagates and aiohttp
+    returns a bare ``500`` whose body does NOT carry the reason — the frontend
+    cannot tell "no credits" from a real server bug.  Map the two cases the
+    frontend acts on:
+
+      * "No credits" (LiveAvatar code ``4033`` / ``403``) -> ``402`` so the UI
+        can show an actionable "avatar has no credits" message.
+      * Any other upstream failure -> ``502`` (provider error).
+    """
+    message = str(getattr(exc, "message", "") or "")
+    if "4033" in message or "credit" in message.lower():
+        return web.json_response(
+            {
+                "error": "avatar_no_credits",
+                "message": "No credits available for the avatar session.",
+            },
+            status=402,
+        )
+    return web.json_response(
+        {
+            "error": "avatar_upstream_error",
+            "message": message or "The avatar provider returned an error.",
+        },
+        status=502,
+    )
 
 
 async def _stop_avatar_session(request: web.Request) -> web.Response:

--- a/packages/ai-parrot-server/src/parrot/handlers/avatar_fullmode.py
+++ b/packages/ai-parrot-server/src/parrot/handlers/avatar_fullmode.py
@@ -37,7 +37,9 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, Optional
 
-from aiohttp import web
+from aiohttp import web, ClientResponseError
+
+from .avatar import avatar_upstream_error_response
 from navigator.views import BaseView
 from navigator_auth.decorators import is_authenticated, user_session
 
@@ -147,6 +149,17 @@ async def _start_fullmode_session(request: web.Request) -> web.Response:
         handle.session_id = session_id
         handle.tenant_id = tenant_id
         await client.start_session(handle)
+    except ClientResponseError as exc:
+        # Upstream LiveAvatar rejected the start (e.g. no credits). Close the
+        # client and return a clean, machine-readable status the frontend can
+        # act on instead of leaking a bare 500.
+        await client.aclose()
+        _logger.warning(
+            "AvatarFullmode: LiveAvatar start failed for session %s: %s",
+            session_id,
+            getattr(exc, "message", exc),
+        )
+        return avatar_upstream_error_response(exc)
     except Exception:
         # On any failure, do not leak the client/session.
         await client.aclose()

--- a/packages/ai-parrot/src/parrot/clients/live.py
+++ b/packages/ai-parrot/src/parrot/clients/live.py
@@ -1295,6 +1295,23 @@ class GeminiLiveClient(AbstractClient):
         async for response in self.ask(*args, **kwargs):
             yield response
 
+    async def invoke(self, *args, **kwargs):
+        """Not supported: GeminiLiveClient is a realtime voice client.
+
+        Defined only to satisfy AbstractClient's @abstractmethod contract so the
+        class can be instantiated. Use stream_voice() for the realtime flow.
+        """
+        raise NotImplementedError(
+            "GeminiLiveClient is realtime voice — use stream_voice(); "
+            "invoke() is not supported."
+        )
+
+    async def resume(self, *args, **kwargs):
+        """Not supported: GeminiLiveClient does not implement suspend/resume."""
+        raise NotImplementedError(
+            "GeminiLiveClient does not support suspend/resume."
+        )
+
 # =============================================================================
 # Factory function
 # =============================================================================


### PR DESCRIPTION
## Summary

Two backend fixes surfaced while stabilizing the VoiceChat transports (ws-pcm / LiveKit LITE / fullmode) against the running stack.

### 1. Avatar `start` no-credits / upstream passthrough
`_start_avatar_session` (LITE) and `_start_fullmode_session` (fullmode) let the LiveAvatar `start_session` `ClientResponseError` propagate uncaught → aiohttp returned a bare **500** whose body did **not** carry the reason. The frontend could not distinguish "no credits" from a real server bug.

- New helper `avatar_upstream_error_response(exc)` in `avatar.py` (reused by `avatar_fullmode.py`).
- `except ClientResponseError` in both start handlers:
  - LiveAvatar **no credits** (code `4033` / 403) → **402** `{error: avatar_no_credits, message}`
  - any other upstream failure → **502**
- The frontend already maps 402 → a clear "avatar has no credits" banner.

### 2. `GeminiLiveClient` instantiable
`GeminiLiveClient` did not implement `AbstractClient`'s `invoke`/`resume` `@abstractmethod`s, so it raised `TypeError: Can't instantiate abstract class …` — breaking the ws-pcm `/ws/voice` realtime path. Added `invoke()`/`resume()` stubs that `raise NotImplementedError` (realtime clients use `stream_voice()`), satisfying the contract.

## Test
- `py_compile` clean on all three files.
- Manually verified the no-credits path returns 402 (LiveAvatar account currently out of credits) and ws-pcm Gemini Live connects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)