### PR TITLE
feat(infographic): add render_template tool usable by any agent

### DIFF
--- a/docs/toolkits/infographic_toolkit.md
+++ b/docs/toolkits/infographic_toolkit.md
@@ -51,6 +51,47 @@ LLM-generated JavaScript interactivity, persist the artifact, and return the res
 
 ---
 
+### `infographic_render_template`
+
+Render a **pre-registered HTML+Jinja2 template** with data you already have into a
+self-contained infographic artifact. Unlike `infographic_render` (typed blocks
+computed from DataFrames in a pandas REPL), this path fills a trusted template
+directly, so it is usable by **any** agent — no pandas namespace required.
+
+Templates are **trusted** and supplied by the developer (never LLM-authored Jinja),
+so no sandbox is applied. Register them at construction or at runtime:
+
+```python
+toolkit = InfographicToolkit(
+    artifact_store=store,
+    template_dirs=["/path/to/templates"],           # filesystem templates
+    templates={"summary.html.j2": "<h1>{{ data.title }}</h1>"},  # in-memory
+)
+toolkit.add_template("late.html.j2", "<b>{{ data.v }}</b>")       # runtime
+toolkit.set_bot(agent)
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `template_name` | `str` | Name of a registered template. |
+| `data` | `Optional[Dict]` | Authoritative, JSON-serialisable payload exposed to the template as `data` (e.g. `{{ data.title }}`). This is the reliable channel. |
+| `theme` | `Optional[str]` | Theme name, exposed as `theme` and stored on the artifact. |
+| `title` | `Optional[str]` | Artifact title (defaults to `Infographic — <name>`). |
+
+**Template context**: `data` (your payload), `message` (best-effort snapshot of the
+bound bot's last `AIMessage` — may be `{}` mid-turn; prefer `data`), `meta`
+(`message.metadata`), `theme`, `title`, and `now` (UTC). Autoescaping is on and
+missing variables raise under `StrictUndefined`.
+
+**Returns**: `InfographicRenderResult` (same shape as `infographic_render`;
+`data_variables` is empty, `enhanced` is `false`).
+
+Any agent (not only `PandasAgent`) finalizes the result: the `BaseBot.ask()`
+post-loop detects `InfographicRenderResult` and sets `response.output` (HTML or
+signed URL), `response.output_mode = infographic`, and `response.artifact_id`.
+
+---
+
 ### `infographic_list_templates`
 
 List all registered templates with name and description.
@@ -89,7 +130,9 @@ never raises.
 
 | Code | When |
 |---|---|
-| `TEMPLATE_UNKNOWN` | `template_name` not in the registry. |
+| `TEMPLATE_UNKNOWN` | `template_name` not in the registry (or, for `render_template`, not a registered Jinja template). |
+| `TEMPLATE_ENGINE_UNSET` | `render_template` called but no `template_dirs`/`templates`/`add_template()` were configured. |
+| `TEMPLATE_RENDER_ERROR` | `render_template` hit a Jinja error (e.g. a missing variable under `StrictUndefined`). |
 | `SLOT_MISSING` | A required block slot has no corresponding block. |
 | `SLOT_TYPE_MISMATCH` | A block's `type` does not match the spec at that position. |
 | `SLOT_ITEM_COUNT_INVALID` | A block violates `min_items` / `max_items` constraints. |

--- a/packages/ai-parrot/src/parrot/bots/base.py
+++ b/packages/ai-parrot/src/parrot/bots/base.py
@@ -35,6 +35,15 @@ def _get_interactive_result_class() -> Optional[type]:
         return _cls
     except ImportError:
         return None
+
+
+def _get_infographic_result_class() -> Optional[type]:
+    """Lazy import of ``InfographicRenderResult`` (avoids circular deps)."""
+    try:
+        from ..tools.infographic_toolkit import InfographicRenderResult as _cls
+        return _cls
+    except ImportError:
+        return None
 # FEAT-176: Lifecycle Events
 from parrot.core.events.lifecycle.trace import TraceContext
 from parrot.core.events.lifecycle.events import (
@@ -841,6 +850,64 @@ class BaseBot(AbstractBot):
 
         return explanation
 
+    def _extract_last_infographic_result(
+        self, tool_calls: Optional[List[Any]],
+    ) -> Optional[Any]:
+        """Return the last ``InfographicRenderResult`` from the tool calls list.
+
+        Generalises FEAT-197 beyond ``PandasAgent``: any agent whose
+        ``infographic_render`` / ``infographic_render_template`` tool produced an
+        ``InfographicRenderResult`` can have it finalized to an HTML artifact.
+        When multiple render calls occurred in the same turn, only the LAST one
+        is returned.
+        """
+        if not tool_calls:
+            return None
+        cls = _get_infographic_result_class()
+        if cls is None:
+            return None
+        for tc in reversed(tool_calls):
+            result = getattr(tc, "result", None)
+            if isinstance(result, cls):
+                return result
+        return None
+
+    def _finalize_infographic_response(
+        self, response: Any, envelope: Any,
+    ) -> Optional[str]:
+        """Apply an ``InfographicRenderResult`` to the agent response in place.
+
+        Mirrors ``PandasAgent._finalize_infographic_response`` (FEAT-197): the
+        natural-language explanation is preserved on ``response.response`` (the
+        chat bubble) while ``response.output`` carries the infographic HTML
+        (inline when small, otherwise the signed URL). The explanation MUST be
+        captured before ``response.output`` is overwritten, because
+        ``AIMessage.content`` aliases ``output``.
+        """
+        explanation = getattr(response, "response", None)
+        if not explanation and isinstance(response.output, str):
+            explanation = response.output
+
+        response.output = envelope.html_inline or envelope.html_url
+        response.output_mode = OutputMode.INFOGRAPHIC
+        response.artifact_id = envelope.artifact_id
+        if explanation:
+            response.response = explanation
+
+        meta = dict(getattr(response, "metadata", None) or {})
+        meta.update({
+            "html_url": envelope.html_url,
+            "html_inline_omitted": envelope.html_inline is None,
+            "enhanced": envelope.enhanced,
+            "template_name": envelope.template_name,
+            "theme": envelope.theme,
+            "explanation": explanation,
+        })
+        if hasattr(response, "metadata"):
+            response.metadata = meta
+
+        return explanation
+
     async def ask(
         self,
         question: str,
@@ -1314,9 +1381,33 @@ class BaseBot(AbstractBot):
                     output_mode = OutputMode.DEFAULT
                     response.output_mode = OutputMode.DEFAULT
 
+                # Tool-driven infographic HTML artifact (FEAT-197, generalized):
+                # when any agent's ``infographic_render`` /
+                # ``infographic_render_template`` tool produced an
+                # ``InfographicRenderResult``, finalize it to an HTML artifact and
+                # bypass the formatter — the same contract ``PandasAgent`` uses,
+                # now available to every ``Agent``.
+                infographic_envelope = self._extract_last_infographic_result(
+                    getattr(response, "tool_calls", None)
+                )
+                if infographic_envelope is not None:
+                    self._finalize_infographic_response(response, infographic_envelope)
+                    self.logger.info(
+                        "InfographicRenderResult detected — bypassing formatter: "
+                        "artifact_id=%s",
+                        infographic_envelope.artifact_id,
+                    )
+                elif output_mode == OutputMode.INFOGRAPHIC:
+                    self.logger.warning(
+                        "output_mode=infographic requested but no infographic "
+                        "artifact was produced; falling back to plain response."
+                    )
+                    output_mode = OutputMode.DEFAULT
+                    response.output_mode = OutputMode.DEFAULT
+
                 # Determine output mode
                 format_kwargs = format_kwargs or {}
-                if interactive_envelope is not None:
+                if interactive_envelope is not None or infographic_envelope is not None:
                     pass  # already finalized above — skip the formatter
                 elif output_mode in [
                     OutputMode.TELEGRAM,

--- a/packages/ai-parrot/src/parrot/bots/prompts/__init__.py
+++ b/packages/ai-parrot/src/parrot/bots/prompts/__init__.py
@@ -111,6 +111,25 @@ Follow these steps IN ORDER:
    the `infographic_render` return envelope into your answer — the agent attaches
    the artifact (`html_url`/`artifact_id`) automatically. Your written answer must
    be ONLY the short summary from step 6.
+
+## Template-based Infographics (any agent)
+
+When a named HTML+Jinja template is registered on this toolkit, you can render an
+infographic directly from data you already have — no pandas namespace or typed
+blocks required. This path works for any agent. Close the turn by calling:
+
+    infographic_render_template(
+        template_name=<name>,      # a registered template
+        data={...},                # the payload your template reads as `data`
+        theme=<theme or null>,
+        title=<title or null>,
+    )
+
+The template accesses your payload as `data` (e.g. `{{ data.title }}`), plus an
+optional best-effort `message` context. Provide `data` explicitly — it is the
+reliable channel. As with `infographic_render`, do NOT paste the returned HTML or
+envelope into your answer (the artifact is attached automatically); reply only
+with a short natural-language summary.
 """
 
 # ── FEAT-197: Enhance prompt template (placeholders for str.replace()) ──────────

--- a/packages/ai-parrot/src/parrot/tools/infographic_toolkit.py
+++ b/packages/ai-parrot/src/parrot/tools/infographic_toolkit.py
@@ -23,6 +23,7 @@ import pandas as pd
 from pydantic import BaseModel, Field, ValidationError as PydanticValidationError
 
 from parrot.tools.toolkit import AbstractToolkit
+from parrot.template.engine import TemplateEngine
 from parrot.models.infographic import (
     InfographicBlock,
     InfographicResponse,
@@ -73,6 +74,8 @@ class InfographicValidationError(Exception):
         DATA_VAR_EMPTY
         THEME_INVALID
         ENHANCE_OUTPUT_INVALID
+        TEMPLATE_ENGINE_UNSET    # render_template: no templates configured
+        TEMPLATE_RENDER_ERROR    # render_template: Jinja render failure
     """
 
     def __init__(self, code: str, detail: Dict[str, Any]) -> None:
@@ -116,7 +119,8 @@ class InfographicToolkit(AbstractToolkit):
 
     Tools exposed (prefixed with ``infographic_``)::
 
-        infographic_render
+        infographic_render            — typed blocks + pandas (PandasAgent).
+        infographic_render_template   — trusted HTML+Jinja template + data (ANY agent).
         infographic_list_templates
         infographic_get_template_contract
         infographic_validate_blocks
@@ -127,11 +131,24 @@ class InfographicToolkit(AbstractToolkit):
     prefix_separator: str = "_"
     exclude_tools: Tuple[str, ...] = ()
 
-    def __init__(self, *, artifact_store: ArtifactStore, **kwargs) -> None:
+    def __init__(
+        self,
+        *,
+        artifact_store: ArtifactStore,
+        template_dirs: Optional[Any] = None,
+        templates: Optional[Dict[str, str]] = None,
+        **kwargs,
+    ) -> None:
         """Initialise the toolkit.
 
         Args:
             artifact_store: Initialised ``ArtifactStore`` instance.
+            template_dirs: Optional directory (or list of directories) of trusted
+                HTML+Jinja templates consumed by ``render_template``. Passed
+                straight to :class:`~parrot.template.engine.TemplateEngine`.
+            templates: Optional mapping of ``{name: source}`` in-memory HTML+Jinja
+                templates for ``render_template`` (registered via the engine's
+                ``DictLoader``). Combine with ``template_dirs`` or use alone.
             **kwargs: Forwarded to ``AbstractToolkit.__init__``.
         """
         super().__init__(**kwargs)
@@ -141,6 +158,28 @@ class InfographicToolkit(AbstractToolkit):
         # Ensure the class-level return_direct=True is set as an instance
         # attribute so AbstractToolkit._generate_tool can read it correctly.
         self.return_direct = True  # explicit — do not let kwargs override this
+        # Template-driven rendering (usable by ANY agent, not just PandasAgent):
+        # a trusted Jinja engine built lazily from developer-supplied templates.
+        self._template_engine: Optional[TemplateEngine] = None
+        if template_dirs is not None or templates:
+            self._template_engine = TemplateEngine(template_dirs=template_dirs)
+            if templates:
+                self._template_engine.add_templates(templates)
+
+    def add_template(self, name: str, source: str) -> None:
+        """Register a trusted in-memory HTML+Jinja template for ``render_template``.
+
+        Sync helper (not exposed as an LLM tool). Lets an agent register
+        templates after construction. Templates are trusted — never pass
+        untrusted/LLM-authored Jinja source here (no sandbox is applied).
+
+        Args:
+            name: Template name referenced by ``render_template(template_name=...)``.
+            source: HTML+Jinja template source.
+        """
+        if self._template_engine is None:
+            self._template_engine = TemplateEngine()
+        self._template_engine.add_templates({name: source})
 
     def get_tools(self, **kwargs):
         """Return the generated tools, ensuring return_direct is propagated."""
@@ -307,6 +346,205 @@ class InfographicToolkit(AbstractToolkit):
             data_variables=data_variables,
             enhanced=enhanced,
         )
+
+    async def render_template(
+        self,
+        template_name: str,
+        data: Optional[Dict[str, Any]] = None,
+        theme: Optional[str] = None,
+        title: Optional[str] = None,
+    ) -> InfographicRenderResult:
+        """Render a pre-registered HTML+Jinja template into an infographic artifact.
+
+        Use this when you already have the answer *data* (a dict, or the text/JSON
+        produced by a previous step) plus a named HTML+Jinja template registered
+        on this toolkit. Unlike ``infographic_render`` (typed blocks computed from
+        DataFrames in a pandas REPL), this path fills a trusted template directly,
+        so it works for **any** agent — no pandas namespace required.
+
+        Call it as the LAST tool in the turn. The result is returned *verbatim* —
+        do NOT summarise it or paste the HTML/envelope into your answer.
+
+        Args:
+            template_name: Name of a template registered via ``template_dirs``,
+                ``templates=`` or ``add_template()``.
+            data: Authoritative, JSON-serialisable payload exposed to the template
+                as ``data`` (e.g. ``{{ data.title }}``). This is the reliable
+                channel — prefer it over the best-effort ``message`` context.
+            theme: Optional theme name, exposed as ``theme`` and stored on the
+                artifact definition.
+            title: Optional artifact title (defaults to ``Infographic — <name>``).
+
+        Returns:
+            ``InfographicRenderResult`` with ``artifact_id``, ``html_url`` and
+            optional ``html_inline`` (populated only when the HTML is < 50 KB).
+
+        Raises:
+            InfographicValidationError: ``TEMPLATE_ENGINE_UNSET`` when no template
+                source is configured; ``TEMPLATE_UNKNOWN`` when ``template_name``
+                is not found; ``TEMPLATE_RENDER_ERROR`` on any Jinja error (e.g. a
+                missing variable under ``StrictUndefined``).
+        """
+        if self._template_engine is None:
+            raise InfographicValidationError(
+                "TEMPLATE_ENGINE_UNSET",
+                {
+                    "detail": (
+                        "No HTML+Jinja templates are configured. Pass "
+                        "template_dirs= or templates= to InfographicToolkit, or "
+                        "call add_template() before rendering."
+                    ),
+                },
+            )
+
+        # Resolve the template first so an unknown name is reported distinctly
+        # (``TemplateEngine.render`` wraps a missing template into a generic
+        # RuntimeError, collapsing it with genuine render errors).
+        try:
+            self._template_engine.get_template(template_name)
+        except FileNotFoundError as exc:
+            raise InfographicValidationError(
+                "TEMPLATE_UNKNOWN",
+                {"template_name": template_name},
+            ) from exc
+        except Exception:  # noqa: BLE001 — surfaces below as TEMPLATE_RENDER_ERROR
+            pass
+
+        context = self._build_template_context(data, theme, title)
+        try:
+            html = await self._template_engine.render(template_name, context)
+        except (ValueError, RuntimeError) as exc:
+            raise InfographicValidationError(
+                "TEMPLATE_RENDER_ERROR",
+                {"template_name": template_name, "error": str(exc)},
+            ) from exc
+
+        artifact_id, html_url = await self._persist_template(
+            html=html,
+            template_name=template_name,
+            theme=theme,
+            title=title,
+        )
+
+        self.logger.info(
+            "Rendered template infographic: template=%s theme=%s size=%d bytes",
+            template_name, theme, len(html),
+        )
+
+        return InfographicRenderResult(
+            artifact_id=artifact_id,
+            html_url=html_url,
+            html_inline=html if len(html) < _INLINE_THRESHOLD else None,
+            template_name=template_name,
+            theme=theme,
+            data_variables=[],
+            enhanced=False,
+        )
+
+    def _build_template_context(
+        self,
+        data: Optional[Dict[str, Any]],
+        theme: Optional[str],
+        title: Optional[str],
+    ) -> Dict[str, Any]:
+        """Assemble the Jinja context for ``render_template``.
+
+        ``data`` is the authoritative payload. ``message`` is a *best-effort*
+        snapshot of the bound bot's most recent ``AIMessage`` (may be ``{}`` when
+        the current turn is still in flight); templates should prefer ``data``.
+
+        Returns:
+            Dict with ``data``, ``message``, ``meta`` (``message.metadata``),
+            ``theme``, ``title`` and ``now`` (UTC).
+        """
+        message = self._snapshot_bot_message()
+        meta = message.get("metadata") if isinstance(message, dict) else None
+        return {
+            "data": data or {},
+            "message": message,
+            "meta": meta or {},
+            "theme": theme,
+            "title": title,
+            "now": datetime.now(timezone.utc),
+        }
+
+    def _snapshot_bot_message(self) -> Dict[str, Any]:
+        """Best-effort dict view of the bound bot's last ``AIMessage``.
+
+        Returns ``{}`` when no bot is bound or it exposes no last message. Any
+        serialisation failure degrades to a small set of well-known fields, and
+        finally to ``{}`` — this context is optional, never authoritative.
+        """
+        bot = getattr(self, "_bot", None)
+        if bot is None:
+            return {}
+        msg = (
+            getattr(bot, "last_response", None)
+            or getattr(bot, "_last_message", None)
+            or getattr(bot, "last_message", None)
+        )
+        if msg is None:
+            return {}
+        for attr in ("model_dump", "dict"):
+            dumper = getattr(msg, attr, None)
+            if callable(dumper):
+                try:
+                    return dumper()
+                except Exception:  # noqa: BLE001
+                    break
+        return {
+            k: getattr(msg, k, None)
+            for k in ("output", "response", "structured_output", "metadata", "sources")
+            if hasattr(msg, k)
+        }
+
+    async def _persist_template(
+        self,
+        *,
+        html: str,
+        template_name: str,
+        theme: Optional[str],
+        title: Optional[str],
+    ) -> Tuple[str, str]:
+        """Persist a template-rendered infographic; return ``(artifact_id, html_url)``.
+
+        Mirrors :meth:`_persist` but for the raw-HTML template path: the
+        definition carries the rendered ``html`` (served by the public HTML
+        route), the ``template`` name and ``theme``, and an empty ``js_bundles``
+        list (template output ships no vetted CDN bundles).
+        """
+        bot = getattr(self, "_bot", None)
+        user_id, agent_id, session_id = self._resolve_scope(bot)
+
+        now = datetime.now(timezone.utc)
+        artifact_id = f"infographic-{uuid.uuid4().hex[:12]}"
+
+        artifact = Artifact(
+            artifact_id=artifact_id,
+            artifact_type=ArtifactType.INFOGRAPHIC,
+            title=title or f"Infographic — {template_name}",
+            created_at=now,
+            updated_at=now,
+            source_turn_id=None,
+            created_by=ArtifactCreator.AGENT,
+            definition={
+                "html": html,
+                "template": template_name,
+                "theme": theme,
+                "js_bundles": [],
+            },
+        )
+
+        await self._artifact_store.save_artifact(user_id, agent_id, session_id, artifact)
+
+        html_url = build_public_html_url(
+            artifact_id,
+            user_id=user_id,
+            agent_id=agent_id,
+            session_id=session_id,
+        )
+
+        return artifact_id, html_url
 
     async def list_templates(self) -> List[Dict[str, str]]:
         """Return the list of available infographic templates.

--- a/packages/ai-parrot/tests/test_infographic_render_template.py
+++ b/packages/ai-parrot/tests/test_infographic_render_template.py
@@ -1,0 +1,196 @@
+"""Unit tests for InfographicToolkit.render_template (Jinja template path).
+
+Covers the template-driven infographic rendering that makes the toolkit usable
+by ANY agent (not just PandasAgent): trusted HTML+Jinja templates + explicit
+``data``, persisted as an INFOGRAPHIC artifact, and finalized to an HTML
+artifact by the generic-agent post-loop branch in ``base.py``.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from parrot.tools.infographic_toolkit import (
+    InfographicToolkit,
+    InfographicRenderResult,
+    InfographicValidationError,
+)
+from parrot.models.outputs import OutputMode
+from parrot.storage.models import ArtifactType
+from parrot.storage.artifact_signing import get_signing_key, verify_signature
+from parrot.bots.base import BaseBot
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def fake_store():
+    store = MagicMock()
+    store.save_artifact = AsyncMock(return_value=None)
+    return store
+
+
+def _bot(last_response=None):
+    bot = SimpleNamespace(
+        user_id="u", agent_id="agt", session_id="sess",
+        _current_user_id=None, _current_agent_id=None, _current_session_id=None,
+    )
+    if last_response is not None:
+        bot.last_response = last_response
+    return bot
+
+
+_TEMPLATES = {
+    "summary.html.j2": "<!DOCTYPE html><html><body><h1>{{ data.title }}</h1></body></html>",
+    "echo.html.j2": "<p>{{ data.x }}</p>",
+    "message.html.j2": "<p>{{ message.output }}</p>",
+    "missing.html.j2": "<p>{{ data.absent }}</p>",
+}
+
+
+@pytest.fixture
+def toolkit(fake_store):
+    tk = InfographicToolkit(artifact_store=fake_store, templates=_TEMPLATES)
+    tk._bot = _bot()
+    return tk
+
+
+# ---------------------------------------------------------------------------
+# Happy path + persistence
+# ---------------------------------------------------------------------------
+
+async def test_render_template_persists_and_returns_envelope(toolkit, fake_store):
+    result = await toolkit.render_template(
+        template_name="summary.html.j2", data={"title": "Hi"}, theme="dark",
+    )
+    assert isinstance(result, InfographicRenderResult)
+    assert result.enhanced is False
+    assert result.template_name == "summary.html.j2"
+    assert result.theme == "dark"
+    assert "Hi" in result.html_inline
+
+    assert fake_store.save_artifact.call_count == 1
+    artifact = fake_store.save_artifact.call_args[0][-1]
+    assert artifact.artifact_type == ArtifactType.INFOGRAPHIC
+    assert "Hi" in artifact.definition["html"]
+    assert artifact.definition["template"] == "summary.html.j2"
+    assert artifact.definition["theme"] == "dark"
+    assert artifact.definition["js_bundles"] == []
+
+    assert result.html_url.startswith("/api/v1/artifacts/public/")
+    assert f"/{result.artifact_id}.html" in result.html_url
+
+
+async def test_render_template_signed_url_roundtrips(toolkit):
+    result = await toolkit.render_template(
+        template_name="echo.html.j2", data={"x": "ok"},
+    )
+    segment = result.html_url.split("/api/v1/artifacts/public/")[1].split("/")[0]
+    assert verify_signature(result.artifact_id, segment, get_signing_key()) is True
+
+
+async def test_render_template_autoescapes_data(toolkit):
+    result = await toolkit.render_template(
+        template_name="echo.html.j2", data={"x": "<script>alert(1)</script>"},
+    )
+    assert "&lt;script&gt;" in result.html_inline
+    assert "<script>alert(1)</script>" not in result.html_inline
+
+
+async def test_render_template_message_autoinjected(fake_store):
+    tk = InfographicToolkit(artifact_store=fake_store, templates=_TEMPLATES)
+    last = SimpleNamespace(output="from previous turn", metadata={})
+    tk._bot = _bot(last_response=last)
+    result = await tk.render_template(template_name="message.html.j2")
+    assert "from previous turn" in result.html_inline
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+async def test_render_template_unknown_template(toolkit):
+    with pytest.raises(InfographicValidationError) as ei:
+        await toolkit.render_template(template_name="nope.html.j2", data={})
+    assert ei.value.code == "TEMPLATE_UNKNOWN"
+
+
+async def test_render_template_strict_undefined_missing_var(toolkit):
+    with pytest.raises(InfographicValidationError) as ei:
+        await toolkit.render_template(template_name="missing.html.j2", data={})
+    assert ei.value.code == "TEMPLATE_RENDER_ERROR"
+
+
+async def test_render_template_engine_unset(fake_store):
+    tk = InfographicToolkit(artifact_store=fake_store)  # no templates configured
+    tk._bot = _bot()
+    with pytest.raises(InfographicValidationError) as ei:
+        await tk.render_template(template_name="whatever", data={})
+    assert ei.value.code == "TEMPLATE_ENGINE_UNSET"
+
+
+async def test_add_template_registers_at_runtime(fake_store):
+    tk = InfographicToolkit(artifact_store=fake_store)
+    tk._bot = _bot()
+    tk.add_template("late.html.j2", "<b>{{ data.v }}</b>")
+    result = await tk.render_template(template_name="late.html.j2", data={"v": "z"})
+    assert "<b>z</b>" in result.html_inline
+
+
+# ---------------------------------------------------------------------------
+# Tool wiring
+# ---------------------------------------------------------------------------
+
+def test_render_template_is_return_direct(toolkit):
+    tools = {t.name: t for t in toolkit.get_tools()}
+    assert "infographic_render_template" in tools
+    assert tools["infographic_render_template"].return_direct is True
+
+
+# ---------------------------------------------------------------------------
+# Generic-agent finalize branch (base.py) — usable by ANY agent
+# ---------------------------------------------------------------------------
+
+def _envelope():
+    return InfographicRenderResult(
+        artifact_id="infographic-abc123",
+        html_url="/api/v1/artifacts/public/sig/infographic-abc123.html",
+        html_inline="<html>report</html>",
+        template_name="summary.html.j2",
+        theme="dark",
+        data_variables=[],
+        enhanced=False,
+    )
+
+
+def test_base_extracts_and_finalizes_infographic_result():
+    bot = BaseBot.__new__(BaseBot)  # bypass heavy __init__; methods use only args
+    envelope = _envelope()
+    tool_calls = [SimpleNamespace(result="not-an-envelope"), SimpleNamespace(result=envelope)]
+
+    extracted = bot._extract_last_infographic_result(tool_calls)
+    assert extracted is envelope
+
+    response = SimpleNamespace(
+        output="short explanation", response=None, output_mode=OutputMode.DEFAULT,
+        artifact_id=None, metadata={},
+    )
+    explanation = bot._finalize_infographic_response(response, envelope)
+
+    assert explanation == "short explanation"
+    assert response.output == "<html>report</html>"
+    assert response.output_mode == OutputMode.INFOGRAPHIC
+    assert response.artifact_id == "infographic-abc123"
+    assert response.response == "short explanation"
+    assert response.metadata["html_url"] == envelope.html_url
+    assert response.metadata["template_name"] == "summary.html.j2"
+
+
+def test_base_extract_returns_none_without_envelope():
+    bot = BaseBot.__new__(BaseBot)
+    assert bot._extract_last_infographic_result(None) is None
+    assert bot._extract_last_infographic_result([SimpleNamespace(result=123)]) is None


### PR DESCRIPTION
Add a Jinja-template rendering path to InfographicToolkit so any agent
can turn a pre-registered HTML+Jinja template plus its own answer data
into a self-contained HTML infographic artifact.

- infographic_render_template: renders a trusted, developer-registered
  template with an explicit `data` payload (authoritative) plus a
  best-effort `message` snapshot of the bound bot's AIMessage. Reuses
  the existing TemplateEngine, ArtifactStore persistence, signed public
  HTML URL, and the InfographicRenderResult envelope.
- InfographicToolkit gains template_dirs/templates constructor params
  and an add_template() runtime helper.
- BaseBot.ask() post-loop now finalizes InfographicRenderResult (extract
  + finalize + formatter bypass), mirroring the interactive branch, so
  the result works for every Agent — not just PandasAgent.
- Extend INFOGRAPHIC_SYSTEM_PROMPT_ADDON with template-based guidance.
- Tests for render/persist, autoescape, StrictUndefined, unknown
  template, engine-unset, runtime registration, message auto-inject,
  signed-URL round-trip, return_direct, and the generic-agent finalize
  branch. Docs updated.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GgPcrFffnESvkAvM2ghfeM