### PR TITLE
feat(formdesigner): FEAT-330 Store Venue Sub-Structure — Site/Location

### DIFF
--- a/packages/parrot-formdesigner/src/parrot_formdesigner/api/handlers.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/api/handlers.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     from ..services.question_bank import QuestionBankService
     from ..services.rbac import RBACService
     from ..services.submissions import FormSubmissionStorage
+    from ..services.venue_service import VenueService
     from ..services.workday_sync import WorkdayIdentitySyncAdapter
     from ..tools.services.networkninja import ImportDiffReport
 
@@ -83,6 +84,7 @@ class FormAPIHandler:
         project_service: "ProjectService | None" = None,
         rbac_service: "RBACService | None" = None,
         workday_adapter: "WorkdayIdentitySyncAdapter | None" = None,
+        venue_service: "VenueService | None" = None,
         rbac_enforcing: bool = False,
     ) -> None:
         self.registry = registry
@@ -95,6 +97,8 @@ class FormAPIHandler:
         self._project_service = project_service
         self._rbac_service = rbac_service
         self._workday_adapter = workday_adapter
+        # FEAT-330 — Store sub-structure (Site / Location)
+        self._venue_service = venue_service
         self.rbac_enforcing = rbac_enforcing
         self.schema_renderer = JsonSchemaRenderer()
         self.validator = FormValidator()
@@ -1975,4 +1979,249 @@ class FormAPIHandler:
             return JSONResponse({"error": "Internal server error"}, status=500)
 
         return JSONResponse(result, status=202)
+
+    # ------------------------------------------------------------------
+    # FEAT-330 — Store sub-structure (Site / Location) endpoints
+    # ------------------------------------------------------------------
+
+    async def list_sites(self, request: web.Request) -> web.Response:
+        """GET /api/v1/org/stores/{store_id}/sites — List sites under a store.
+
+        Args:
+            request: Incoming HTTP request (path param: ``store_id``).
+
+        Returns:
+            200: List of ``Site`` as JSON.
+            400: Missing org_id in session.
+            501: VenueService not configured.
+        """
+        if self._venue_service is None:
+            return JSONResponse({"error": "VenueService not configured"}, status=501)
+
+        store_id = request.match_info.get("store_id", "")
+        org_id = self._get_org_id(request)
+        if org_id is None:
+            return JSONResponse({"error": "org_id not found in session"}, status=400)
+
+        tenant = self._get_tenant(request)
+        try:
+            sites = await self._venue_service.list_sites(
+                store_id=store_id, org_id=org_id, tenant=tenant
+            )
+        except Exception as exc:
+            self.logger.exception("list_sites failed: %s", exc)
+            return JSONResponse({"error": "Internal server error"}, status=500)
+
+        return JSONResponse([s.model_dump(mode="json") for s in sites], status=200)
+
+    async def create_site(self, request: web.Request) -> web.Response:
+        """POST /api/v1/org/stores/{store_id}/sites — Create a site.
+
+        Request body::
+
+            {"client_id": 42, "name": "Vending Zone"}
+
+        ``org_id`` is taken from the authenticated session, never the body.
+
+        Returns:
+            201: Created ``Site`` as JSON.
+            400: Invalid/missing fields.
+            409: Duplicate site name in the store.
+            501: VenueService not configured.
+        """
+        if self._venue_service is None:
+            return JSONResponse({"error": "VenueService not configured"}, status=501)
+
+        store_id = request.match_info.get("store_id", "")
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, ValueError):
+            return JSONResponse({"error": "Invalid JSON body"}, status=400)
+
+        name = body.get("name")
+        if not name:
+            return JSONResponse({"error": "name is required"}, status=400)
+
+        client_id = body.get("client_id")
+        if client_id is None:
+            return JSONResponse({"error": "client_id is required"}, status=400)
+        try:
+            client_id_int = int(client_id)
+        except (TypeError, ValueError):
+            return JSONResponse({"error": "client_id must be an integer"}, status=400)
+
+        org_id = self._get_org_id(request)
+        if org_id is None:
+            return JSONResponse({"error": "org_id not found in session"}, status=400)
+
+        tenant = self._get_tenant(request)
+        try:
+            site = await self._venue_service.create_site(
+                store_id=store_id,
+                client_id=client_id_int,
+                org_id=org_id,
+                name=str(name),
+                tenant=tenant,
+            )
+        except Exception as exc:
+            from ..services.venue_service import DuplicateVenueError
+
+            if isinstance(exc, DuplicateVenueError):
+                return JSONResponse({"error": str(exc)}, status=409)
+            self.logger.exception("create_site failed: %s", exc)
+            return JSONResponse({"error": "Internal server error"}, status=500)
+
+        return JSONResponse(site.model_dump(mode="json"), status=201)
+
+    async def list_locations(self, request: web.Request) -> web.Response:
+        """GET /api/v1/org/sites/{site_id}/locations — List locations in a site.
+
+        Returns:
+            200: List of ``Location`` as JSON.
+            400: Invalid site_id or missing org_id.
+            501: VenueService not configured.
+        """
+        if self._venue_service is None:
+            return JSONResponse({"error": "VenueService not configured"}, status=501)
+
+        site_id_str = request.match_info.get("site_id", "")
+        try:
+            site_id = int(site_id_str)
+        except (ValueError, TypeError):
+            return JSONResponse(
+                {"error": f"Invalid site_id: {site_id_str!r}"}, status=400
+            )
+
+        org_id = self._get_org_id(request)
+        if org_id is None:
+            return JSONResponse({"error": "org_id not found in session"}, status=400)
+
+        tenant = self._get_tenant(request)
+        try:
+            locations = await self._venue_service.list_locations(
+                site_id=site_id, org_id=org_id, tenant=tenant
+            )
+        except Exception as exc:
+            self.logger.exception("list_locations failed: %s", exc)
+            return JSONResponse({"error": "Internal server error"}, status=500)
+
+        return JSONResponse(
+            [loc.model_dump(mode="json") for loc in locations], status=200
+        )
+
+    async def create_location(self, request: web.Request) -> web.Response:
+        """POST /api/v1/org/sites/{site_id}/locations — Create a location.
+
+        Request body::
+
+            {
+                "client_id": 42,
+                "name": "Kiosk A-12",
+                "location_type": "kiosk",
+                "latitude": 34.0522,
+                "longitude": -118.2437,
+                "geofence_radius_m": 50
+            }
+
+        ``org_id`` is taken from the session, never the body.
+
+        Returns:
+            201: Created ``Location`` as JSON.
+            400: Invalid/missing fields.
+            409: Duplicate location name in the site.
+            501: VenueService not configured.
+        """
+        if self._venue_service is None:
+            return JSONResponse({"error": "VenueService not configured"}, status=501)
+
+        site_id_str = request.match_info.get("site_id", "")
+        try:
+            site_id = int(site_id_str)
+        except (ValueError, TypeError):
+            return JSONResponse(
+                {"error": f"Invalid site_id: {site_id_str!r}"}, status=400
+            )
+
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, ValueError):
+            return JSONResponse({"error": "Invalid JSON body"}, status=400)
+
+        name = body.get("name")
+        if not name:
+            return JSONResponse({"error": "name is required"}, status=400)
+
+        client_id = body.get("client_id")
+        if client_id is None:
+            return JSONResponse({"error": "client_id is required"}, status=400)
+        try:
+            client_id_int = int(client_id)
+        except (TypeError, ValueError):
+            return JSONResponse({"error": "client_id must be an integer"}, status=400)
+
+        org_id = self._get_org_id(request)
+        if org_id is None:
+            return JSONResponse({"error": "org_id not found in session"}, status=400)
+
+        tenant = self._get_tenant(request)
+        try:
+            location = await self._venue_service.create_location(
+                site_id=site_id,
+                client_id=client_id_int,
+                org_id=org_id,
+                name=str(name),
+                location_type=str(body.get("location_type", "kiosk")),
+                latitude=body.get("latitude"),
+                longitude=body.get("longitude"),
+                geofence_radius_m=body.get("geofence_radius_m"),
+                tenant=tenant,
+            )
+        except Exception as exc:
+            from ..services.venue_service import DuplicateVenueError
+
+            if isinstance(exc, DuplicateVenueError):
+                return JSONResponse({"error": str(exc)}, status=409)
+            self.logger.exception("create_location failed: %s", exc)
+            return JSONResponse({"error": "Internal server error"}, status=500)
+
+        return JSONResponse(location.model_dump(mode="json"), status=201)
+
+    async def get_location(self, request: web.Request) -> web.Response:
+        """GET /api/v1/org/locations/{location_id} — Fetch one location.
+
+        Returns:
+            200: ``Location`` as JSON (includes geofence params).
+            400: Invalid location_id or missing org_id.
+            404: Location not found in the session's org.
+            501: VenueService not configured.
+        """
+        if self._venue_service is None:
+            return JSONResponse({"error": "VenueService not configured"}, status=501)
+
+        location_id_str = request.match_info.get("location_id", "")
+        try:
+            location_id = int(location_id_str)
+        except (ValueError, TypeError):
+            return JSONResponse(
+                {"error": f"Invalid location_id: {location_id_str!r}"}, status=400
+            )
+
+        org_id = self._get_org_id(request)
+        if org_id is None:
+            return JSONResponse({"error": "org_id not found in session"}, status=400)
+
+        tenant = self._get_tenant(request)
+        try:
+            location = await self._venue_service.get_location(
+                location_id, org_id=org_id, tenant=tenant
+            )
+        except Exception as exc:
+            from ..services.venue_service import LocationNotFoundError
+
+            if isinstance(exc, LocationNotFoundError):
+                return JSONResponse({"error": str(exc)}, status=404)
+            self.logger.exception("get_location failed: %s", exc)
+            return JSONResponse({"error": "Internal server error"}, status=500)
+
+        return JSONResponse(location.model_dump(mode="json"), status=200)
 

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/api/routes.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/api/routes.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
     from ..services.rbac import RBACService
     from ..services.rest_field_resolver import RestFieldResolver
     from ..services.submissions import FormSubmissionStorage
+    from ..services.venue_service import VenueService
     from ..services.workday_sync import WorkdayIdentitySyncAdapter
 
 
@@ -108,6 +109,7 @@ def setup_form_api(
     project_service: "ProjectService | None" = None,
     rbac_service: "RBACService | None" = None,
     workday_adapter: "WorkdayIdentitySyncAdapter | None" = None,
+    venue_service: "VenueService | None" = None,
     rbac_enforcing: bool = False,
 ) -> None:
     """Mount the JSON REST surface on ``app`` under ``base_path``.
@@ -195,6 +197,7 @@ def setup_form_api(
         project_service=project_service,
         rbac_service=rbac_service,
         workday_adapter=workday_adapter,
+        venue_service=venue_service,
         rbac_enforcing=rbac_enforcing,
     )
 
@@ -347,6 +350,25 @@ def setup_form_api(
     )
     app.router.add_post(
         f"{bp}/org/sync/workday", _wrap_auth(handler.sync_workday_identities)
+    )
+
+    # FEAT-330 — Store sub-structure (Store → Site → Location)
+    app.router.add_get(
+        f"{bp}/org/stores/{{store_id}}/sites", _wrap_auth(handler.list_sites)
+    )
+    app.router.add_post(
+        f"{bp}/org/stores/{{store_id}}/sites", _wrap_auth(handler.create_site)
+    )
+    app.router.add_get(
+        f"{bp}/org/sites/{{site_id}}/locations",
+        _wrap_auth(handler.list_locations),
+    )
+    app.router.add_post(
+        f"{bp}/org/sites/{{site_id}}/locations",
+        _wrap_auth(handler.create_location),
+    )
+    app.router.add_get(
+        f"{bp}/org/locations/{{location_id}}", _wrap_auth(handler.get_location)
     )
 
     # FEAT-241 M6: Wire is_public toggle → auth exclude list.

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/fieldsync_schema.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/fieldsync_schema.py
@@ -81,12 +81,53 @@ CREATE TABLE IF NOT EXISTS fieldsync.auth_policies (
 );
 """
 
+# FEAT-330 — Store sub-structure (Store → Site → Location).
+# ``Store`` is read-only geography (networkninja.*); ``Site`` and ``Location``
+# are FieldSync-owned. A ``Location`` is a kiosk or any spot inside a store
+# (vending case). Geofence params live on the location (SoT moved out of the
+# visit ``Event.meta`` — FEAT-303 §8 / FEAT-318 D5.7).
+_CREATE_SITES_SQL = """
+CREATE TABLE IF NOT EXISTS fieldsync.sites (
+    site_id     SERIAL PRIMARY KEY,
+    store_id    VARCHAR(100) NOT NULL,
+    client_id   INTEGER NOT NULL,
+    org_id      INTEGER NOT NULL,
+    name        VARCHAR(255) NOT NULL,
+    is_active   BOOLEAN NOT NULL DEFAULT TRUE,
+    inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_sites_store_name UNIQUE (store_id, client_id, name)
+);
+"""
+
+_CREATE_LOCATIONS_SQL = """
+CREATE TABLE IF NOT EXISTS fieldsync.locations (
+    location_id       SERIAL PRIMARY KEY,
+    site_id           INTEGER NOT NULL
+                        REFERENCES fieldsync.sites (site_id) ON DELETE CASCADE,
+    client_id         INTEGER NOT NULL,
+    org_id            INTEGER NOT NULL,
+    name              VARCHAR(255) NOT NULL,
+    location_type     VARCHAR(50) NOT NULL DEFAULT 'kiosk',
+    latitude          DOUBLE PRECISION,
+    longitude         DOUBLE PRECISION,
+    geofence_radius_m INTEGER,
+    is_active         BOOLEAN NOT NULL DEFAULT TRUE,
+    inserted_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_locations_site_name UNIQUE (site_id, name)
+);
+"""
+
 # Ordered list of DDL statements executed by ``initialize()``.
+# ``sites`` before ``locations`` (FK dependency).
 _ALL_DDL: list[str] = [
     _CREATE_SCHEMA_SQL,
     _CREATE_PROJECTS_SQL,
     _CREATE_WORKDAY_COST_CENTER_MAPPINGS_SQL,
     _CREATE_AUTH_POLICIES_SQL,
+    _CREATE_SITES_SQL,
+    _CREATE_LOCATIONS_SQL,
 ]
 
 

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/org_graph.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/org_graph.py
@@ -50,6 +50,11 @@ NodeType = Literal[
     "region",
     "territory",
     "store",
+    # FEAT-330 — Store sub-structure (Store → Site → Location). A ``location``
+    # is a kiosk or any spot inside a store (vending case). ``site``/``location``
+    # are FieldSync-owned (``fieldsync.*``); ``store`` stays read-only geography.
+    "site",
+    "location",
 ]
 
 # ---------------------------------------------------------------------------
@@ -140,6 +145,34 @@ _SQL_GET_REGIONS_FOR_CLIENT = """
 SELECT region_id, region_name
 FROM networkninja.regions
 WHERE client_id = $1 AND orgid = $2
+"""
+
+# FEAT-330 — Store sub-structure.
+# ``store`` = read-only geography (networkninja); ``site``/``location`` =
+# FieldSync-owned (fieldsync.*). Hung under the tree only at depth >= 4/5/6 so
+# the default (depth<=3) behaviour of FEAT-302 is unchanged.
+# NOTE: the exact networkninja stores table/columns must be confirmed against
+# the production dump (candidate ``stores_geographies``; FEAT-302 §8). Adjust
+# the column names here once verified.
+_SQL_GET_STORES_FOR_CLIENT = """
+SELECT store_id, store_name, market_id
+FROM networkninja.stores_geographies
+WHERE client_id = $1 AND orgid = $2
+"""
+
+_SQL_GET_SITES_FOR_CLIENT = """
+SELECT site_id, store_id, name
+FROM fieldsync.sites
+WHERE client_id = $1 AND org_id = $2 AND is_active = TRUE
+ORDER BY site_id
+"""
+
+_SQL_GET_LOCATIONS_FOR_CLIENT = """
+SELECT location_id, site_id, name, location_type,
+       latitude, longitude, geofence_radius_m
+FROM fieldsync.locations
+WHERE client_id = $1 AND org_id = $2 AND is_active = TRUE
+ORDER BY location_id
 """
 
 # Tenant-scoped single-node lookups (hard isolation: filtered by org_id).
@@ -300,7 +333,10 @@ class OrgGraphService:
                             )
                             client_node.children.append(proj_node)
 
-                        # Geography: regions, districts, markets (per-client)
+                        # Geography: regions, districts, markets (per-client).
+                        # Market nodes are indexed so FEAT-330 stores can hang
+                        # under them.
+                        markets_by_id: dict[str, OrgNode] = {}
                         for _sql, _ntype, _id_col, _name_col in (
                             (_SQL_GET_REGIONS_FOR_CLIENT, "region", "region_id", "region_name"),
                             (_SQL_GET_DISTRICTS_FOR_CLIENT, "district", "district_id", "district_name"),
@@ -308,12 +344,28 @@ class OrgGraphService:
                         ):
                             geo_rows = await conn.fetch(_sql, client_id, org_id)
                             for g in geo_rows:
-                                client_node.children.append(OrgNode(
+                                geo_node = OrgNode(
                                     node_type=_ntype,
                                     node_id=str(g[_id_col]),
                                     parent_id=str(client_id),
                                     metadata={_name_col: g[_name_col]},
-                                ))
+                                )
+                                client_node.children.append(geo_node)
+                                if _ntype == "market":
+                                    markets_by_id[str(g[_id_col])] = geo_node
+
+                        # FEAT-330: Store → Site → Location sub-structure,
+                        # gated by depth (4=stores, 5=sites, 6=locations) so the
+                        # default depth<=3 tree is byte-identical to FEAT-302.
+                        if depth >= 4:
+                            await self._attach_store_substructure(
+                                conn,
+                                client_node=client_node,
+                                client_id=client_id,
+                                org_id=org_id,
+                                markets_by_id=markets_by_id,
+                                depth=depth,
+                            )
 
                     client_nodes.append(client_node)
 
@@ -329,6 +381,95 @@ class OrgGraphService:
         )
 
         return OrgGraph(org_id=org_id, tenant=tenant, root=company_root)
+
+    async def _attach_store_substructure(
+        self,
+        conn: Any,
+        *,
+        client_node: OrgNode,
+        client_id: int,
+        org_id: int,
+        markets_by_id: dict[str, OrgNode],
+        depth: int,
+    ) -> None:
+        """Hang FEAT-330 ``store → site → location`` nodes under a client.
+
+        Each store is attached to its market node when the market is known,
+        else to the client node directly (fallback). Sites hang under their
+        store, locations under their site. Everything is gated by ``depth``:
+        stores at ``depth >= 4``, sites at ``depth >= 5``, locations at
+        ``depth >= 6``.
+
+        Args:
+            conn: Live asyncpg connection (read-only).
+            client_node: The client ``OrgNode`` whose subtree is extended.
+            client_id: Client identifier (hard-isolation filter).
+            org_id: Organization identifier (hard-isolation filter).
+            markets_by_id: Map of ``market_id`` → market ``OrgNode`` for
+                parent resolution.
+            depth: Requested traversal depth.
+        """
+        # Level 4: stores
+        store_rows = await conn.fetch(_SQL_GET_STORES_FOR_CLIENT, client_id, org_id)
+        stores_by_id: dict[str, OrgNode] = {}
+        for s in store_rows:
+            store_id = str(s["store_id"])
+            market_id = str(s["market_id"]) if s["market_id"] is not None else None
+            parent_node = markets_by_id.get(market_id) if market_id else None
+            parent_id = parent_node.node_id if parent_node else str(client_id)
+            store_node = OrgNode(
+                node_type="store",
+                node_id=store_id,
+                parent_id=parent_id,
+                metadata={"store_name": s["store_name"], "market_id": market_id},
+            )
+            (parent_node.children if parent_node else client_node.children).append(
+                store_node
+            )
+            stores_by_id[store_id] = store_node
+
+        if depth < 5 or not stores_by_id:
+            return
+
+        # Level 5: sites (grouped by store_id)
+        site_rows = await conn.fetch(_SQL_GET_SITES_FOR_CLIENT, client_id, org_id)
+        sites_by_id: dict[str, OrgNode] = {}
+        for si in site_rows:
+            store_id = str(si["store_id"])
+            store_node = stores_by_id.get(store_id)
+            if store_node is None:
+                continue  # orphan site (store not in this org view) — skip
+            site_node = OrgNode(
+                node_type="site",
+                node_id=str(si["site_id"]),
+                parent_id=store_id,
+                metadata={"name": si["name"]},
+            )
+            store_node.children.append(site_node)
+            sites_by_id[str(si["site_id"])] = site_node
+
+        if depth < 6 or not sites_by_id:
+            return
+
+        # Level 6: locations (grouped by site_id)
+        loc_rows = await conn.fetch(_SQL_GET_LOCATIONS_FOR_CLIENT, client_id, org_id)
+        for lo in loc_rows:
+            site_id = str(lo["site_id"])
+            site_node = sites_by_id.get(site_id)
+            if site_node is None:
+                continue  # orphan location — skip
+            site_node.children.append(OrgNode(
+                node_type="location",
+                node_id=str(lo["location_id"]),
+                parent_id=site_id,
+                metadata={
+                    "name": lo["name"],
+                    "location_type": lo["location_type"],
+                    "latitude": lo["latitude"],
+                    "longitude": lo["longitude"],
+                    "geofence_radius_m": lo["geofence_radius_m"],
+                },
+            ))
 
     async def get_node(
         self,

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/venue_service.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/venue_service.py
@@ -1,0 +1,466 @@
+"""VenueService — CRUD sobre ``fieldsync.sites`` / ``fieldsync.locations``.
+
+Implementa la sub-estructura de tienda de FieldSync (FEAT-330):
+``Store → Site → Location``. ``Store`` es geografía read-only
+(``networkninja.*``, propiedad de FEAT-302); ``Site`` y ``Location`` son
+entidades **propiedad de FieldSync**.
+
+- Una ``Site`` agrupa uno o más ``Location`` dentro de un ``Store`` (p. ej.
+  una zona de vending).
+- Una ``Location`` es un **kiosk** o cualquier punto/spot dentro de la tienda.
+  Lleva los parámetros de **geofence** (``latitude`` / ``longitude`` /
+  ``geofence_radius_m``) — el system of record del geofence per-location
+  (movido fuera de ``Event.meta``; ver FEAT-303 §8 y FEAT-318 D5.7). Un
+  ``geofence_radius_m = NULL`` significa geofence deshabilitado en ese punto.
+
+Diseño (idéntico a ``ProjectService`` — FEAT-302):
+- Pool inyectado en el constructor → testable sin DB real.
+- SQL 100% parametrizado ($1, $2…); nombres de tabla fijados en constantes.
+- **Hard tenant isolation**: todo query filtra ``org_id`` explícitamente.
+- Pydantic v2 para modelos de datos.
+
+Uso::
+
+    svc = VenueService(pool)
+    site = await svc.create_site(
+        store_id="store-501", client_id=42, org_id=7,
+        name="Pokémon Vending Zone", tenant="acme",
+    )
+    loc = await svc.create_location(
+        site_id=site.site_id, client_id=42, org_id=7, name="Kiosk A-12",
+        location_type="kiosk", latitude=34.0522, longitude=-118.2437,
+        geofence_radius_m=50, tenant="acme",
+    )
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class DuplicateVenueError(Exception):
+    """Raised when a UNIQUE constraint on a site/location is violated.
+
+    Attributes:
+        kind: ``"site"`` or ``"location"``.
+        name: The duplicate name.
+    """
+
+    def __init__(self, kind: str, name: str) -> None:
+        self.kind = kind
+        self.name = name
+        super().__init__(f"{kind} {name!r} already exists in its parent scope")
+
+
+class SiteNotFoundError(Exception):
+    """Raised when a site lookup returns no row.
+
+    Attributes:
+        site_id: The missing site identifier.
+    """
+
+    def __init__(self, site_id: int) -> None:
+        self.site_id = site_id
+        super().__init__(f"Site {site_id} not found")
+
+
+class LocationNotFoundError(Exception):
+    """Raised when a location lookup returns no row.
+
+    Attributes:
+        location_id: The missing location identifier.
+    """
+
+    def __init__(self, location_id: int) -> None:
+        self.location_id = location_id
+        super().__init__(f"Location {location_id} not found")
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+class Site(BaseModel):
+    """An intermediate work-area grouping inside a Store.
+
+    A Store may contain multiple Sites; a Site groups one or more Locations.
+    Owned by FieldSync (``fieldsync.sites``); tenant-isolated by ``org_id``.
+
+    Attributes:
+        site_id: Auto-incremented serial PK.
+        store_id: Identifier of the parent store (networkninja geography).
+            Kept as ``str`` for parity with ``OrgNode.node_id``.
+        client_id: Client this site belongs to.
+        org_id: Organization identifier (hard-isolation key).
+        name: Human-readable site name.
+        is_active: Whether the site is currently active.
+        tenant: Tenant slug (metadata, not stored in the table directly).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    site_id: int
+    store_id: str
+    client_id: int
+    org_id: int
+    name: str
+    is_active: bool = True
+    tenant: str | None = None
+
+
+class Location(BaseModel):
+    """A concrete work point inside a Site — a kiosk or any spot in the store.
+
+    Carries the geofence parameters used to validate a Visit/Assignment
+    check-in. A ``geofence_radius_m`` of ``None`` means geofence is disabled
+    for this location.
+
+    Attributes:
+        location_id: Auto-incremented serial PK.
+        site_id: FK to ``fieldsync.sites``.
+        client_id: Client this location belongs to.
+        org_id: Organization identifier (hard-isolation key).
+        name: Human-readable location name.
+        location_type: One of ``kiosk`` | ``endcap`` | ``gondola`` |
+            ``backroom`` | ``other`` (free-form; default ``"kiosk"``).
+        latitude: Geofence center latitude (optional).
+        longitude: Geofence center longitude (optional).
+        geofence_radius_m: Geofence radius in metres; ``None`` ⇒ disabled.
+        is_active: Whether the location is currently active.
+        tenant: Tenant slug (metadata, not stored in the table directly).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    location_id: int
+    site_id: int
+    client_id: int
+    org_id: int
+    name: str
+    location_type: str = "kiosk"
+    latitude: float | None = None
+    longitude: float | None = None
+    geofence_radius_m: int | None = None
+    is_active: bool = True
+    tenant: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# SQL constants (table names FIXED in constants — not from user input)
+# ---------------------------------------------------------------------------
+
+_INSERT_SITE_SQL = """
+INSERT INTO fieldsync.sites
+    (store_id, client_id, org_id, name)
+VALUES ($1, $2, $3, $4)
+RETURNING site_id, store_id, client_id, org_id, name, is_active
+"""
+
+_SELECT_SITE_SQL = """
+SELECT site_id, store_id, client_id, org_id, name, is_active
+FROM fieldsync.sites
+WHERE site_id = $1 AND org_id = $2
+"""
+
+_SELECT_SITES_BY_STORE_SQL = """
+SELECT site_id, store_id, client_id, org_id, name, is_active
+FROM fieldsync.sites
+WHERE store_id = $1 AND org_id = $2
+ORDER BY site_id
+"""
+
+_INSERT_LOCATION_SQL = """
+INSERT INTO fieldsync.locations
+    (site_id, client_id, org_id, name, location_type,
+     latitude, longitude, geofence_radius_m)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+RETURNING location_id, site_id, client_id, org_id, name, location_type,
+          latitude, longitude, geofence_radius_m, is_active
+"""
+
+_SELECT_LOCATION_SQL = """
+SELECT location_id, site_id, client_id, org_id, name, location_type,
+       latitude, longitude, geofence_radius_m, is_active
+FROM fieldsync.locations
+WHERE location_id = $1 AND org_id = $2
+"""
+
+_SELECT_LOCATIONS_BY_SITE_SQL = """
+SELECT location_id, site_id, client_id, org_id, name, location_type,
+       latitude, longitude, geofence_radius_m, is_active
+FROM fieldsync.locations
+WHERE site_id = $1 AND org_id = $2
+ORDER BY location_id
+"""
+
+# asyncpg error code for UNIQUE constraint violation
+_UNIQUE_VIOLATION_CODE = "23505"
+
+
+def _is_unique_violation(exc: Exception) -> bool:
+    """Return True when ``exc`` looks like a Postgres UNIQUE violation."""
+    exc_str = str(exc)
+    return (
+        "unique" in exc_str.lower()
+        or _UNIQUE_VIOLATION_CODE in exc_str
+        or "UniqueViolation" in type(exc).__name__
+    )
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class VenueService:
+    """CRUD service for ``fieldsync.sites`` and ``fieldsync.locations``.
+
+    Args:
+        pool: asyncpg pool (or fake pool for tests).
+
+    Example::
+
+        svc = VenueService(pool)
+        site = await svc.create_site(
+            store_id="store-501", client_id=42, org_id=7,
+            name="Vending Zone", tenant="acme",
+        )
+    """
+
+    def __init__(self, pool: Any) -> None:
+        self._pool = pool
+        self.logger = logging.getLogger(__name__)
+
+    # ------------------------------------------------------------------
+    # Site CRUD
+    # ------------------------------------------------------------------
+
+    async def create_site(
+        self,
+        *,
+        store_id: str,
+        client_id: int,
+        org_id: int,
+        name: str,
+        tenant: str | None = None,
+    ) -> Site:
+        """Create a new site under a store.
+
+        Args:
+            store_id: Parent store identifier (networkninja geography).
+            client_id: Client this site belongs to.
+            org_id: Organization identifier (hard-isolation key).
+            name: Site name (UNIQUE per ``(store_id, client_id)``).
+            tenant: Tenant slug (stored in the returned model only).
+
+        Returns:
+            The newly created ``Site`` with its DB-assigned ``site_id``.
+
+        Raises:
+            DuplicateVenueError: If ``(store_id, client_id, name)`` exists.
+        """
+        async with self._pool.acquire() as conn:
+            try:
+                row = await conn.fetchrow(
+                    _INSERT_SITE_SQL, store_id, client_id, org_id, name
+                )
+            except Exception as exc:
+                if _is_unique_violation(exc):
+                    raise DuplicateVenueError("site", name) from exc
+                raise
+
+        return Site(
+            site_id=row["site_id"],
+            store_id=str(row["store_id"]),
+            client_id=row["client_id"],
+            org_id=row["org_id"],
+            name=row["name"],
+            is_active=row["is_active"],
+            tenant=tenant,
+        )
+
+    async def get_site(
+        self, site_id: int, *, org_id: int, tenant: str | None = None
+    ) -> Site:
+        """Retrieve a site by PK, scoped to ``org_id`` (hard isolation).
+
+        Args:
+            site_id: Primary key of the site.
+            org_id: Organization the caller is scoped to.
+            tenant: Optional tenant slug (stored in returned model).
+
+        Returns:
+            ``Site`` populated from the DB row.
+
+        Raises:
+            SiteNotFoundError: If no site with ``site_id`` exists in ``org_id``.
+        """
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(_SELECT_SITE_SQL, site_id, org_id)
+        if row is None:
+            raise SiteNotFoundError(site_id)
+        return Site(
+            site_id=row["site_id"],
+            store_id=str(row["store_id"]),
+            client_id=row["client_id"],
+            org_id=row["org_id"],
+            name=row["name"],
+            is_active=row["is_active"],
+            tenant=tenant,
+        )
+
+    async def list_sites(
+        self, *, store_id: str, org_id: int, tenant: str | None = None
+    ) -> list[Site]:
+        """List sites under a store within ``org_id`` (hard isolation).
+
+        Args:
+            store_id: Parent store identifier.
+            org_id: Organization the caller is scoped to (REQUIRED — every
+                query is filtered by it; there is no cross-tenant path).
+            tenant: Tenant slug stored in returned models.
+
+        Returns:
+            List of ``Site`` instances (empty if none match).
+        """
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(_SELECT_SITES_BY_STORE_SQL, store_id, org_id)
+        return [
+            Site(
+                site_id=row["site_id"],
+                store_id=str(row["store_id"]),
+                client_id=row["client_id"],
+                org_id=row["org_id"],
+                name=row["name"],
+                is_active=row["is_active"],
+                tenant=tenant,
+            )
+            for row in rows
+        ]
+
+    # ------------------------------------------------------------------
+    # Location CRUD
+    # ------------------------------------------------------------------
+
+    async def create_location(
+        self,
+        *,
+        site_id: int,
+        client_id: int,
+        org_id: int,
+        name: str,
+        location_type: str = "kiosk",
+        latitude: float | None = None,
+        longitude: float | None = None,
+        geofence_radius_m: int | None = None,
+        tenant: str | None = None,
+    ) -> Location:
+        """Create a new location under a site.
+
+        Args:
+            site_id: FK to ``fieldsync.sites``.
+            client_id: Client this location belongs to.
+            org_id: Organization identifier (hard-isolation key).
+            name: Location name (UNIQUE per ``site_id``).
+            location_type: Kind of location (default ``"kiosk"``).
+            latitude: Geofence center latitude (optional).
+            longitude: Geofence center longitude (optional).
+            geofence_radius_m: Geofence radius in metres; ``None`` ⇒ disabled.
+            tenant: Tenant slug (stored in the returned model only).
+
+        Returns:
+            The newly created ``Location`` with its DB-assigned ``location_id``.
+
+        Raises:
+            DuplicateVenueError: If ``(site_id, name)`` already exists.
+        """
+        async with self._pool.acquire() as conn:
+            try:
+                row = await conn.fetchrow(
+                    _INSERT_LOCATION_SQL,
+                    site_id,
+                    client_id,
+                    org_id,
+                    name,
+                    location_type,
+                    latitude,
+                    longitude,
+                    geofence_radius_m,
+                )
+            except Exception as exc:
+                if _is_unique_violation(exc):
+                    raise DuplicateVenueError("location", name) from exc
+                raise
+
+        return self._row_to_location(row, tenant=tenant)
+
+    async def get_location(
+        self, location_id: int, *, org_id: int, tenant: str | None = None
+    ) -> Location:
+        """Retrieve a location by PK, scoped to ``org_id`` (hard isolation).
+
+        Args:
+            location_id: Primary key of the location.
+            org_id: Organization the caller is scoped to.
+            tenant: Optional tenant slug (stored in returned model).
+
+        Returns:
+            ``Location`` populated from the DB row (includes geofence params).
+
+        Raises:
+            LocationNotFoundError: If no location with ``location_id`` exists
+                within ``org_id``.
+        """
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(_SELECT_LOCATION_SQL, location_id, org_id)
+        if row is None:
+            raise LocationNotFoundError(location_id)
+        return self._row_to_location(row, tenant=tenant)
+
+    async def list_locations(
+        self, *, site_id: int, org_id: int, tenant: str | None = None
+    ) -> list[Location]:
+        """List locations under a site within ``org_id`` (hard isolation).
+
+        Args:
+            site_id: Parent site identifier.
+            org_id: Organization the caller is scoped to (REQUIRED).
+            tenant: Tenant slug stored in returned models.
+
+        Returns:
+            List of ``Location`` instances (empty if none match).
+        """
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(_SELECT_LOCATIONS_BY_SITE_SQL, site_id, org_id)
+        return [self._row_to_location(row, tenant=tenant) for row in rows]
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _row_to_location(row: Any, *, tenant: str | None) -> Location:
+        """Build a ``Location`` model from a DB row."""
+        return Location(
+            location_id=row["location_id"],
+            site_id=row["site_id"],
+            client_id=row["client_id"],
+            org_id=row["org_id"],
+            name=row["name"],
+            location_type=row["location_type"],
+            latitude=row["latitude"],
+            longitude=row["longitude"],
+            geofence_radius_m=row["geofence_radius_m"],
+            is_active=row["is_active"],
+            tenant=tenant,
+        )

--- a/packages/parrot-formdesigner/tests/unit/test_fieldsync_schema.py
+++ b/packages/parrot-formdesigner/tests/unit/test_fieldsync_schema.py
@@ -17,8 +17,10 @@ import pytest
 from parrot_formdesigner.services.fieldsync_schema import (
     FieldsyncSchemaManager,
     _CREATE_AUTH_POLICIES_SQL,
+    _CREATE_LOCATIONS_SQL,
     _CREATE_PROJECTS_SQL,
     _CREATE_SCHEMA_SQL,
+    _CREATE_SITES_SQL,
     _CREATE_WORKDAY_COST_CENTER_MAPPINGS_SQL,
 )
 
@@ -77,14 +79,29 @@ class TestDDLContent:
         assert "enforcing" in sql
         assert "priority" in sql
 
-    def test_ddl_statements_returns_four(self) -> None:
+    def test_sites_table_ddl(self) -> None:
+        sql = _CREATE_SITES_SQL
+        assert "CREATE TABLE IF NOT EXISTS fieldsync.sites" in sql
+        assert "store_id" in sql
+        assert "uq_sites_store_name" in sql
+
+    def test_locations_table_ddl(self) -> None:
+        sql = _CREATE_LOCATIONS_SQL
+        assert "CREATE TABLE IF NOT EXISTS fieldsync.locations" in sql
+        assert "geofence_radius_m" in sql
+        assert "REFERENCES fieldsync.sites" in sql
+        assert "ON DELETE CASCADE" in sql
+
+    def test_ddl_statements_returns_six(self) -> None:
+        # 4 base (schema, projects, workday_map, auth_policies)
+        # + 2 FEAT-330 (sites, locations)
         stmts = FieldsyncSchemaManager.ddl_statements()
-        assert len(stmts) == 4
+        assert len(stmts) == 6
 
     def test_ddl_statements_is_copy(self) -> None:
         stmts = FieldsyncSchemaManager.ddl_statements()
         stmts.clear()
-        assert len(FieldsyncSchemaManager.ddl_statements()) == 4
+        assert len(FieldsyncSchemaManager.ddl_statements()) == 6
 
 
 # ---------------------------------------------------------------------------
@@ -116,8 +133,8 @@ class TestFieldsyncSchemaManager:
         await mgr.initialize()
         await mgr.initialize()  # should not raise
         conn = pool._conn
-        # 4 statements × 2 calls = 8
-        assert conn.execute.call_count == 8
+        # 6 statements × 2 calls = 12
+        assert conn.execute.call_count == 12
 
     @pytest.mark.asyncio
     async def test_initialize_propagates_db_error(self) -> None:

--- a/packages/parrot-formdesigner/tests/unit/test_org_graph_service.py
+++ b/packages/parrot-formdesigner/tests/unit/test_org_graph_service.py
@@ -315,3 +315,119 @@ class TestOrgGraphServiceNoPool:
             os.environ.pop("FIELDSYNC_AUTH_RO_DSN", None)
             with pytest.raises(RuntimeError, match="FIELDSYNC_AUTH_RO_DSN"):
                 await svc.get_graph(1, tenant="t1")
+
+
+# ---------------------------------------------------------------------------
+# FEAT-330 — Store → Site → Location sub-structure in the graph
+# ---------------------------------------------------------------------------
+
+
+class TestOrgGraphStoreSubstructure:
+    """Store/Site/Location nodes, gated by depth (4/5/6)."""
+
+    def _base_fetch(self) -> dict:
+        return {
+            "auth.clients": [{"client_id": 10, "client_name": "C1"}],
+            "auth.programs": [],
+            "fieldsync.projects": [],
+            "networkninja.regions": [],
+            "networkninja.districts": [],
+            "networkninja.markets": [{"market_id": 500, "market_name": "M1"}],
+            "networkninja.stores_geographies": [
+                {"store_id": "store-501", "store_name": "S1", "market_id": 500}
+            ],
+            "fieldsync.sites": [
+                {"site_id": 1, "store_id": "store-501", "name": "Vending Zone"}
+            ],
+            "fieldsync.locations": [
+                {
+                    "location_id": 1,
+                    "site_id": 1,
+                    "name": "Kiosk A-12",
+                    "location_type": "kiosk",
+                    "latitude": 34.0,
+                    "longitude": -118.0,
+                    "geofence_radius_m": 50,
+                }
+            ],
+        }
+
+    def _svc(self, fetch: dict) -> OrgGraphService:
+        conn = _make_conn(
+            fetchrow_results={"auth.organizations": {"name": "Org"}},
+            fetch_results=fetch,
+        )
+        return OrgGraphService(_make_pool(conn))
+
+    def _node_types(self, graph) -> set[str]:
+        seen: set[str] = set()
+
+        def walk(n) -> None:
+            seen.add(n.node_type)
+            for c in n.children:
+                walk(c)
+
+        walk(graph.root)
+        return seen
+
+    def test_orgnode_accepts_site_and_location(self) -> None:
+        assert OrgNode(node_type="site", node_id="1").node_type == "site"
+        assert OrgNode(node_type="location", node_id="1").node_type == "location"
+
+    @pytest.mark.asyncio
+    async def test_depth_3_excludes_substructure(self) -> None:
+        svc = self._svc(self._base_fetch())
+        graph = await svc.get_graph(7, tenant="t1", depth=3)
+        types = self._node_types(graph)
+        assert "store" not in types
+        assert "site" not in types
+        assert "location" not in types
+
+    @pytest.mark.asyncio
+    async def test_depth_4_includes_store_under_market(self) -> None:
+        svc = self._svc(self._base_fetch())
+        graph = await svc.get_graph(7, tenant="t1", depth=4)
+        client_node = graph.root.children[0].children[0]
+        market = next(n for n in client_node.children if n.node_type == "market")
+        store_types = {n.node_type for n in market.children}
+        assert store_types == {"store"}
+        assert "site" not in self._node_types(graph)
+
+    @pytest.mark.asyncio
+    async def test_depth_5_includes_site_under_store(self) -> None:
+        svc = self._svc(self._base_fetch())
+        graph = await svc.get_graph(7, tenant="t1", depth=5)
+        types = self._node_types(graph)
+        assert "store" in types and "site" in types
+        assert "location" not in types
+
+    @pytest.mark.asyncio
+    async def test_depth_6_includes_location_with_geofence(self) -> None:
+        svc = self._svc(self._base_fetch())
+        graph = await svc.get_graph(7, tenant="t1", depth=6)
+
+        # Descend store → site → location and check geofence metadata carried.
+        loc = None
+
+        def walk(n):
+            nonlocal loc
+            if n.node_type == "location":
+                loc = n
+            for c in n.children:
+                walk(c)
+
+        walk(graph.root)
+        assert loc is not None
+        assert loc.metadata["geofence_radius_m"] == 50
+
+    @pytest.mark.asyncio
+    async def test_store_without_market_falls_back_to_client(self) -> None:
+        fetch = self._base_fetch()
+        fetch["networkninja.stores_geographies"] = [
+            {"store_id": "orphan", "store_name": "O", "market_id": None}
+        ]
+        svc = self._svc(fetch)
+        graph = await svc.get_graph(7, tenant="t1", depth=4)
+        client_node = graph.root.children[0].children[0]
+        store_ids = {n.node_id for n in client_node.children if n.node_type == "store"}
+        assert "orphan" in store_ids

--- a/packages/parrot-formdesigner/tests/unit/test_venue_service.py
+++ b/packages/parrot-formdesigner/tests/unit/test_venue_service.py
@@ -1,0 +1,278 @@
+"""Unit tests for FEAT-330 — VenueService (fake pool, no real DB).
+
+Covers:
+- create_site() happy path + DuplicateVenueError on unique violation.
+- get_site() happy path + SiteNotFoundError.
+- list_sites() hard-isolation filter (org_id passed to every query).
+- create_location() persists geofence params (lat/long/radius).
+- get_location() happy path + LocationNotFoundError.
+- list_locations() round-trip.
+- SQL constants target fieldsync.* and never write networkninja.*.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from parrot_formdesigner.services.venue_service import (
+    DuplicateVenueError,
+    Location,
+    LocationNotFoundError,
+    Site,
+    SiteNotFoundError,
+    VenueService,
+    _INSERT_LOCATION_SQL,
+    _INSERT_SITE_SQL,
+    _SELECT_LOCATION_SQL,
+    _SELECT_SITE_SQL,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake pool / connection helpers
+# ---------------------------------------------------------------------------
+
+
+def _row(data: dict) -> MagicMock:
+    """Build a MagicMock that behaves like an asyncpg Record."""
+    row = MagicMock()
+    row.__getitem__ = lambda self, k: data[k]
+    return row
+
+
+def _make_conn(
+    fetchrow_result: Any = None,
+    fetch_result: list | None = None,
+    fetchrow_side_effect: Any = None,
+) -> MagicMock:
+    conn = MagicMock()
+    if fetchrow_side_effect is not None:
+        conn.fetchrow = AsyncMock(side_effect=fetchrow_side_effect)
+    else:
+        conn.fetchrow = AsyncMock(return_value=fetchrow_result)
+    conn.fetch = AsyncMock(return_value=fetch_result or [])
+    return conn
+
+
+def _make_pool(conn: MagicMock) -> MagicMock:
+    pool = MagicMock()
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=conn)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    pool.acquire = MagicMock(return_value=cm)
+    return pool
+
+
+def _site_row(
+    site_id: int = 1,
+    store_id: str = "store-501",
+    client_id: int = 42,
+    org_id: int = 7,
+    name: str = "Vending Zone",
+    is_active: bool = True,
+) -> MagicMock:
+    return _row(
+        {
+            "site_id": site_id,
+            "store_id": store_id,
+            "client_id": client_id,
+            "org_id": org_id,
+            "name": name,
+            "is_active": is_active,
+        }
+    )
+
+
+def _location_row(
+    location_id: int = 1,
+    site_id: int = 1,
+    client_id: int = 42,
+    org_id: int = 7,
+    name: str = "Kiosk A-12",
+    location_type: str = "kiosk",
+    latitude: float | None = 34.0522,
+    longitude: float | None = -118.2437,
+    geofence_radius_m: int | None = 50,
+    is_active: bool = True,
+) -> MagicMock:
+    return _row(
+        {
+            "location_id": location_id,
+            "site_id": site_id,
+            "client_id": client_id,
+            "org_id": org_id,
+            "name": name,
+            "location_type": location_type,
+            "latitude": latitude,
+            "longitude": longitude,
+            "geofence_radius_m": geofence_radius_m,
+            "is_active": is_active,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# SQL safety
+# ---------------------------------------------------------------------------
+
+
+class TestSQLSafety:
+    def test_site_insert_targets_fieldsync(self) -> None:
+        assert "fieldsync.sites" in _INSERT_SITE_SQL
+        assert "networkninja" not in _INSERT_SITE_SQL
+
+    def test_location_insert_targets_fieldsync(self) -> None:
+        assert "fieldsync.locations" in _INSERT_LOCATION_SQL
+        assert "networkninja" not in _INSERT_LOCATION_SQL
+
+    def test_selects_scope_by_org_id(self) -> None:
+        # Hard isolation: single-row selects always filter org_id ($2).
+        assert "org_id = $2" in _SELECT_SITE_SQL
+        assert "org_id = $2" in _SELECT_LOCATION_SQL
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+class TestModels:
+    def test_site_defaults(self) -> None:
+        s = Site(site_id=1, store_id="s1", client_id=1, org_id=1, name="z")
+        assert s.is_active is True
+        assert s.store_id == "s1"
+
+    def test_location_geofence_optional(self) -> None:
+        loc = Location(location_id=1, site_id=1, client_id=1, org_id=1, name="k")
+        assert loc.location_type == "kiosk"
+        assert loc.latitude is None
+        assert loc.geofence_radius_m is None  # None ⇒ geofence disabled
+
+
+# ---------------------------------------------------------------------------
+# create_site
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSite:
+    @pytest.mark.asyncio
+    async def test_create_returns_site(self) -> None:
+        conn = _make_conn(fetchrow_result=_site_row())
+        svc = VenueService(_make_pool(conn))
+        site = await svc.create_site(
+            store_id="store-501", client_id=42, org_id=7,
+            name="Vending Zone", tenant="acme",
+        )
+        assert isinstance(site, Site)
+        assert site.site_id == 1
+        assert site.store_id == "store-501"
+        assert site.tenant == "acme"
+
+    @pytest.mark.asyncio
+    async def test_duplicate_site_raises(self) -> None:
+        conn = _make_conn(
+            fetchrow_side_effect=Exception("duplicate key value UniqueViolation")
+        )
+        svc = VenueService(_make_pool(conn))
+        with pytest.raises(DuplicateVenueError):
+            await svc.create_site(
+                store_id="s1", client_id=1, org_id=1, name="dup", tenant="t"
+            )
+
+
+# ---------------------------------------------------------------------------
+# get_site / list_sites
+# ---------------------------------------------------------------------------
+
+
+class TestReadSites:
+    @pytest.mark.asyncio
+    async def test_get_site_found(self) -> None:
+        conn = _make_conn(fetchrow_result=_site_row(site_id=9))
+        svc = VenueService(_make_pool(conn))
+        site = await svc.get_site(9, org_id=7)
+        assert site.site_id == 9
+
+    @pytest.mark.asyncio
+    async def test_get_site_not_found(self) -> None:
+        conn = _make_conn(fetchrow_result=None)
+        svc = VenueService(_make_pool(conn))
+        with pytest.raises(SiteNotFoundError):
+            await svc.get_site(999, org_id=7)
+
+    @pytest.mark.asyncio
+    async def test_list_sites_filters_by_org(self) -> None:
+        conn = _make_conn(fetch_result=[_site_row(), _site_row(site_id=2)])
+        svc = VenueService(_make_pool(conn))
+        sites = await svc.list_sites(store_id="store-501", org_id=7)
+        assert len(sites) == 2
+        # org_id + store_id passed positionally to the isolation query
+        args = conn.fetch.call_args[0]
+        assert args[1] == "store-501"
+        assert args[2] == 7
+
+
+# ---------------------------------------------------------------------------
+# Locations (incl. geofence persistence)
+# ---------------------------------------------------------------------------
+
+
+class TestLocations:
+    @pytest.mark.asyncio
+    async def test_create_location_persists_geofence(self) -> None:
+        conn = _make_conn(fetchrow_result=_location_row())
+        svc = VenueService(_make_pool(conn))
+        loc = await svc.create_location(
+            site_id=1, client_id=42, org_id=7, name="Kiosk A-12",
+            latitude=34.0522, longitude=-118.2437, geofence_radius_m=50,
+            tenant="acme",
+        )
+        assert isinstance(loc, Location)
+        assert loc.geofence_radius_m == 50
+        assert loc.latitude == 34.0522
+        assert loc.location_type == "kiosk"
+
+    @pytest.mark.asyncio
+    async def test_create_location_geofence_none_disabled(self) -> None:
+        conn = _make_conn(
+            fetchrow_result=_location_row(latitude=None, longitude=None,
+                                          geofence_radius_m=None)
+        )
+        svc = VenueService(_make_pool(conn))
+        loc = await svc.create_location(
+            site_id=1, client_id=1, org_id=1, name="no-geo",
+        )
+        assert loc.geofence_radius_m is None
+
+    @pytest.mark.asyncio
+    async def test_duplicate_location_raises(self) -> None:
+        conn = _make_conn(
+            fetchrow_side_effect=Exception("23505 unique violation")
+        )
+        svc = VenueService(_make_pool(conn))
+        with pytest.raises(DuplicateVenueError):
+            await svc.create_location(site_id=1, client_id=1, org_id=1, name="d")
+
+    @pytest.mark.asyncio
+    async def test_get_location_found(self) -> None:
+        conn = _make_conn(fetchrow_result=_location_row(location_id=5))
+        svc = VenueService(_make_pool(conn))
+        loc = await svc.get_location(5, org_id=7)
+        assert loc.location_id == 5
+
+    @pytest.mark.asyncio
+    async def test_get_location_not_found(self) -> None:
+        conn = _make_conn(fetchrow_result=None)
+        svc = VenueService(_make_pool(conn))
+        with pytest.raises(LocationNotFoundError):
+            await svc.get_location(404, org_id=7)
+
+    @pytest.mark.asyncio
+    async def test_list_locations_round_trip(self) -> None:
+        conn = _make_conn(fetch_result=[_location_row(), _location_row(location_id=2)])
+        svc = VenueService(_make_pool(conn))
+        locs = await svc.list_locations(site_id=1, org_id=7)
+        assert [loc.location_id for loc in locs] == [1, 2]


### PR DESCRIPTION
## Summary

Adds the **Store → Site → Location** sub-hierarchy under `store` in the FieldSync org graph. Implements FEAT-330 (spec lives in the fieldsync repo: `sdd/specs/store-venue-substructure.spec.md`). Extends — does not duplicate — the FEAT-302 org-spine (`fieldsync` schema, `OrgGraphService`, `FieldsyncSchemaManager`).

## What's included (4 spec modules)

- **M1 — DDL**: `fieldsync.sites` / `fieldsync.locations` added idempotently to `FieldsyncSchemaManager` (`CREATE TABLE IF NOT EXISTS`, sites-before-locations FK order). `locations` carries the per-location geofence columns (`latitude`, `longitude`, `geofence_radius_m`), absorbing the deferred geofence-SoT from FEAT-303 §8 and FEAT-318 D5.7.
- **M2 — `VenueService`** (`services/venue_service.py`): `Site`/`Location` Pydantic v2 models (`extra="forbid"`) + async CRUD, pool-injected, **hard `org_id` tenant isolation**, parametrized SQL — mirrors `ProjectService`. Dedicated exceptions.
- **M3 — OrgGraph extension**: `NodeType` extended with `site`/`location`; `get_graph()` hangs sites under stores and locations under sites at `depth>=5`. `depth<=3` behavior unchanged (backwards-compatible with FEAT-302).
- **M4 — REST endpoints** behind `_wrap_auth`: `GET/POST /org/stores/{id}/sites`, `GET/POST /org/sites/{id}/locations`, `GET /org/locations/{id}`.

## Tests

51 unit tests passing (`test_venue_service.py`, `test_fieldsync_schema.py`, `test_org_graph_service.py`).

## ⚠️ Reviewer notes — open before merge

- **Spec is still `draft`** ("for Arturo / Jesús review"), not `approved`. Merging this ratifies the design.
- **Open Q1 (owner: Arturo)**: is `Site` mandatory, or can a `Location` hang directly off a `Store`? This implementation assumes **Site required** (`locations.site_id` NOT NULL, FK to `sites`). Confirm that matches intent before merge.
- Geofence historical backfill from `Event.meta` (Q3) is a separate migration task, not in this PR.