### PR TITLE
feat(formdesigner): extend FEAT-188 dispatcher with visit.* namespace (FEAT-329)

### DIFF
--- a/packages/parrot-formdesigner/src/parrot_formdesigner/core/__init__.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/core/__init__.py
@@ -20,6 +20,8 @@ from .events import (
     FormEventContext,
     FormEventName,
     FormEventsConfig,
+    VisitEventContext,
+    VisitEventName,
 )
 from .options import FieldOption, OptionsSource
 from .schema import (
@@ -88,4 +90,7 @@ __all__ = [
     "FormEventContext",
     "EventResolution",
     "FormEventAbort",
+    # Visit lifecycle events (FEAT-329)
+    "VisitEventName",
+    "VisitEventContext",
 ]

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/core/events.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/core/events.py
@@ -4,6 +4,11 @@ This module defines the Pydantic models and typed exception used by the
 form lifecycle events system (FEAT-188). All later modules (event_registry,
 event_dispatcher, schema extension, handlers, renderer) import from here.
 
+FEAT-329 extends the same pattern with the ``visit.*`` namespace: visit /
+assignment lifecycle events reuse the FEAT-188 registry and semantics
+(context → handler → ``EventResolution`` | ``FormEventAbort``) without a
+``FormSchema`` in the path.
+
 Public surface:
     - FormEventName
     - FormEventBinding
@@ -11,6 +16,8 @@ Public surface:
     - FormEventContext
     - EventResolution
     - FormEventAbort
+    - VisitEventName
+    - VisitEventContext
 """
 
 from collections.abc import Mapping
@@ -28,6 +35,14 @@ FormEventName = Literal[
     "onBeforeSubmit",
     "onAfterSubmit",
     "onError",
+]
+
+VisitEventName = Literal[
+    "visit.onAssignmentCreated",
+    "visit.onArtifactAttached",
+    "visit.onArrival",
+    "visit.onGeofenceExit",
+    "visit.onCheckout",
 ]
 
 
@@ -115,6 +130,40 @@ class FormEventContext(BaseModel):
     schema_dump: Mapping[str, Any] | None = None   # open / schema_loaded only
     error: BaseException | None = None             # onError only
     user_message: str | None = None                # onError mutable
+    extra: dict[str, Any] = Field(default_factory=dict)  # correlation_id, etc.
+
+
+class VisitEventContext(BaseModel):
+    """Payload passed to a visit lifecycle event handler (FEAT-329).
+
+    Mirror of ``FormEventContext`` for the ``visit.*`` namespace: same
+    context → handler → resolution semantics, but scoped to a visit /
+    assignment rather than a form — no ``form_id`` / ``schema_dump``
+    in the path.
+
+    Attributes:
+        event: The name of the visit lifecycle event being dispatched.
+        tenant: Tenant slug used to resolve the handler in the registry.
+        auth_context: Resolved auth credentials.  Typed as ``Any`` to
+            avoid a circular import through ``core/`` → ``services/``.
+        event_id: Identifier of the parent Event (FEAT-303), if any.
+        shift_id: Identifier of the Shift the visit belongs to, if any.
+        visit_id: Identifier of the Visit being processed, if any.
+        staff_id: Identifier of the staff member performing the visit.
+        payload: Event-specific data (artifact metadata, GPS fix, ...).
+        extra: Free-form bag for correlation IDs, tracing data, etc.
+    """
+
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    event: VisitEventName
+    tenant: str | None
+    auth_context: Any  # services.auth_context.AuthContext — avoid circular
+    event_id: str | None = None
+    shift_id: str | None = None
+    visit_id: str | None = None
+    staff_id: str | None = None
+    payload: Mapping[str, Any] | None = None
     extra: dict[str, Any] = Field(default_factory=dict)  # correlation_id, etc.
 
 

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/__init__.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/__init__.py
@@ -8,7 +8,7 @@ from .csrf import (
     issue_form_csrf_token,
     validate_form_csrf_token,
 )
-from .event_dispatcher import apply_schema_overrides, dispatch
+from .event_dispatcher import apply_schema_overrides, dispatch, dispatch_visit
 from .event_registry import (
     get_form_event,
     list_form_events,
@@ -57,6 +57,8 @@ __all__ = [
     # Lifecycle event dispatcher (FEAT-188)
     "dispatch",
     "apply_schema_overrides",
+    # Visit lifecycle dispatcher (FEAT-329)
+    "dispatch_visit",
     # CSRF helpers for remote events endpoint (FEAT-188)
     "issue_form_csrf_token",
     "validate_form_csrf_token",

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/event_dispatcher.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/event_dispatcher.py
@@ -23,6 +23,13 @@ Responsibilities
 Also exposes ``apply_schema_overrides(base, overrides)`` — a pure helper
 for shallow-merging ``EventResolution.schema_overrides`` into a serialised
 ``FormSchema`` dict (top-level keys only, per spec §7).
+
+FEAT-329 adds ``dispatch_visit(...)`` — the same pattern for the
+``visit.*`` namespace (visit / assignment lifecycle). Visit events reuse
+the FEAT-188 string-keyed tenant-scoped registry: the visit event name
+itself acts as the ``handler_ref`` (``"visit.onArrival"`` vs
+``"<form_id>.onBeforeSubmit"`` — the namespace disambiguates). No
+``FormSchema`` / binding / ``schema_dump`` is involved in the visit path.
 """
 
 from __future__ import annotations
@@ -35,13 +42,23 @@ from aiohttp import web
 
 from parrot_formdesigner.core.events import (
     EventResolution,
+    FormEventAbort,
     FormEventContext,
     FormEventName,
+    VisitEventContext,
+    VisitEventName,
 )
 from parrot_formdesigner.core.schema import FormSchema
 from parrot_formdesigner.services.event_registry import get_form_event
 
 logger = logging.getLogger(__name__)
+
+# Visit events with pre-hook (interceptor) semantics: ``FormEventAbort``
+# raised by the handler is re-raised to the caller, mirroring the
+# ``before*`` form events of FEAT-188 (per FEAT-329 spec §2). All other
+# visit events are post-hooks: fire-and-forget, handler failures are
+# logged and never break the visit flow.
+_VISIT_PRE_HOOKS: frozenset[str] = frozenset({"visit.onArrival"})
 
 
 # ---------------------------------------------------------------------------
@@ -179,6 +196,136 @@ async def dispatch(
     result = await handler(ctx)
 
     # --- Step 4: normalise result ---------------------------------------
+    if result is None:
+        return EventResolution()
+
+    return result
+
+
+async def dispatch_visit(
+    event: VisitEventName,
+    *,
+    tenant: str | None,
+    auth_context: Any,
+    event_id: str | None = None,
+    shift_id: str | None = None,
+    visit_id: str | None = None,
+    staff_id: str | None = None,
+    payload: Mapping[str, Any] | None = None,
+    extra: dict[str, Any] | None = None,
+    handler_ref: str | None = None,
+) -> EventResolution:
+    """Resolve and run the handler bound to a visit lifecycle ``event``.
+
+    Mirror of :func:`dispatch` for the ``visit.*`` namespace (FEAT-329).
+    Reuses the FEAT-188 tenant-scoped registry: handlers are registered
+    with ``@register_form_event("visit.onArrival")`` (optionally with
+    ``tenant="<slug>"``) and the visit event name itself acts as the
+    ``handler_ref``. No ``FormSchema`` / binding / ``schema_dump`` is
+    involved in the visit path.
+
+    Hook semantics (per FEAT-329 spec §2):
+
+    - **Pre-hooks** (``visit.onArrival``): ``FormEventAbort`` raised by
+      the handler is re-raised intact (the caller converts it to an HTTP
+      ``status_code`` + ``user_message``); other exceptions propagate
+      unchanged, mirroring the ``before*`` form events.
+    - **Post-hooks** (all other visit events): fire-and-forget — any
+      exception raised by the handler (including ``FormEventAbort``) is
+      logged and swallowed so side-effects never break the visit flow.
+
+    Args:
+        event: The visit lifecycle event name to dispatch
+            (e.g. ``"visit.onArrival"``).
+        tenant: Tenant slug used for registry lookup with global fallback.
+        auth_context: Resolved authentication credentials (typed ``Any``
+            to avoid a circular import; typically an ``AuthContext`` instance).
+        event_id: Identifier of the parent Event (FEAT-303), if any.
+        shift_id: Identifier of the Shift the visit belongs to, if any.
+        visit_id: Identifier of the Visit being processed, if any.
+        staff_id: Identifier of the staff member performing the visit.
+        payload: Event-specific data (artifact metadata, GPS fix, ...).
+        extra: Free-form bag for correlation IDs, tracing data, etc.
+        handler_ref: Registry key to look up. Defaults to ``event``
+            itself (the ``visit.*`` namespace disambiguates it from
+            form-scoped ``'<form_id>.<event>'`` refs in the shared registry).
+
+    Returns:
+        An ``EventResolution``. If no handler is registered for
+        ``handler_ref`` (tenant-specific or global), returns an empty
+        ``EventResolution()`` (no-op).
+
+    Raises:
+        FormEventAbort: Re-raised intact when a **pre-hook** handler
+            aborts (``visit.onArrival``). Never raised for post-hooks.
+        Exception: Any other exception raised by a **pre-hook** handler
+            propagates unchanged. Post-hook exceptions are logged and
+            swallowed (fire-and-forget).
+    """
+    ref = handler_ref if handler_ref is not None else event
+    is_pre_hook = event in _VISIT_PRE_HOOKS
+
+    # --- Step 1: look up handler (tenant → global fallback) --------------
+    try:
+        handler = get_form_event(ref, tenant=tenant)
+    except KeyError:
+        logger.warning(
+            "no handler registered for %r (event=%r, tenant=%r); skipping",
+            ref,
+            event,
+            tenant,
+        )
+        return EventResolution()
+
+    # --- Step 2: build context and run ------------------------------------
+    ctx = VisitEventContext(
+        event=event,
+        tenant=tenant,
+        auth_context=auth_context,
+        event_id=event_id,
+        shift_id=shift_id,
+        visit_id=visit_id,
+        staff_id=staff_id,
+        payload=payload,
+        extra=extra if extra is not None else {},
+    )
+
+    logger.debug(
+        "dispatching %r → %r (visit=%r, tenant=%r)",
+        event,
+        ref,
+        visit_id,
+        tenant,
+    )
+
+    if is_pre_hook:
+        # FormEventAbort propagates intact (not caught here).
+        # All other exceptions also propagate; the caller handles them.
+        result = await handler(ctx)
+    else:
+        # Post-hooks are fire-and-forget: never break the visit flow.
+        try:
+            result = await handler(ctx)
+        except FormEventAbort:
+            logger.warning(
+                "handler %r raised FormEventAbort for post-hook %r; "
+                "aborts are only meaningful for pre-hooks — ignoring",
+                ref,
+                event,
+            )
+            return EventResolution()
+        except Exception:  # noqa: BLE001 — fire-and-forget by design
+            logger.exception(
+                "handler %r failed for post-hook %r (visit=%r, tenant=%r); "
+                "ignoring (fire-and-forget)",
+                ref,
+                event,
+                visit_id,
+                tenant,
+            )
+            return EventResolution()
+
+    # --- Step 3: normalise result -----------------------------------------
     if result is None:
         return EventResolution()
 

--- a/packages/parrot-formdesigner/tests/unit/services/test_visit_events.py
+++ b/packages/parrot-formdesigner/tests/unit/services/test_visit_events.py
@@ -1,0 +1,270 @@
+"""Unit tests for the ``visit.*`` namespace of the event dispatcher — FEAT-329.
+
+Tests cover the dispatch_visit() coroutine added by TASK-337: registration
+and dispatch of visit handlers through the shared FEAT-188 registry,
+pre-hook FormEventAbort propagation, tenant → global fallback, post-hook
+fire-and-forget semantics, and non-regression of the form-scoped dispatch().
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from parrot_formdesigner.core.events import (
+    EventResolution,
+    FormEventAbort,
+    FormEventBinding,
+    FormEventsConfig,
+    VisitEventContext,
+)
+from parrot_formdesigner.services.event_dispatcher import (
+    dispatch,
+    dispatch_visit,
+)
+from parrot_formdesigner.services.event_registry import (
+    _clear_event_registry_for_tests,
+    register_form_event,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry() -> None:  # type: ignore[return]
+    """Isolate registry state between tests."""
+    yield
+    _clear_event_registry_for_tests()
+
+
+@pytest.fixture()
+def auth_context() -> None:
+    """Minimal auth context (None is valid — auth_context typed Any)."""
+    return None
+
+
+class TestDispatchVisit:
+    """Tests for the dispatch_visit() coroutine."""
+
+    async def test_visit_handler_registration_and_dispatch(
+        self, auth_context: None
+    ) -> None:
+        """A handler registered under the visit event name runs and its
+        EventResolution is returned; the context carries the visit fields."""
+        seen: list[VisitEventContext] = []
+        expected = EventResolution(metadata={"checked_in": True})
+
+        @register_form_event("visit.onCheckout")
+        async def h(ctx: VisitEventContext) -> EventResolution | None:
+            seen.append(ctx)
+            return expected
+
+        result = await dispatch_visit(
+            "visit.onCheckout",
+            tenant="acme",
+            auth_context=auth_context,
+            event_id="ev-1",
+            shift_id="sh-1",
+            visit_id="v-1",
+            staff_id="st-1",
+            payload={"lat": 1.0, "lng": 2.0},
+        )
+        assert result is expected
+        assert len(seen) == 1
+        ctx = seen[0]
+        assert ctx.event == "visit.onCheckout"
+        assert ctx.tenant == "acme"
+        assert ctx.event_id == "ev-1"
+        assert ctx.shift_id == "sh-1"
+        assert ctx.visit_id == "v-1"
+        assert ctx.staff_id == "st-1"
+        assert ctx.payload == {"lat": 1.0, "lng": 2.0}
+
+    async def test_visit_prehook_abort_propagates_status_and_message(
+        self, auth_context: None
+    ) -> None:
+        """FormEventAbort raised by the visit.onArrival pre-hook is re-raised
+        intact with user_message and status_code."""
+
+        @register_form_event("visit.onArrival")
+        async def h(ctx: VisitEventContext) -> EventResolution | None:
+            raise FormEventAbort(
+                "outside geofence",
+                user_message="You are too far from the store.",
+                status_code=422,
+            )
+
+        with pytest.raises(FormEventAbort, match="outside geofence") as exc_info:
+            await dispatch_visit(
+                "visit.onArrival",
+                tenant=None,
+                auth_context=auth_context,
+                visit_id="v-1",
+            )
+        assert exc_info.value.user_message == "You are too far from the store."
+        assert exc_info.value.status_code == 422
+
+    async def test_tenant_fallback_to_global_handler(
+        self, auth_context: None
+    ) -> None:
+        """A tenant with no specific registration falls back to the global
+        handler; a tenant-specific registration shadows it."""
+        calls: list[str] = []
+
+        @register_form_event("visit.onAssignmentCreated")
+        async def global_h(ctx: VisitEventContext) -> EventResolution | None:
+            calls.append("global")
+            return None
+
+        @register_form_event("visit.onAssignmentCreated", tenant="acme")
+        async def acme_h(ctx: VisitEventContext) -> EventResolution | None:
+            calls.append("acme")
+            return None
+
+        await dispatch_visit(
+            "visit.onAssignmentCreated",
+            tenant="globex",  # no globex-specific handler → global fallback
+            auth_context=auth_context,
+        )
+        await dispatch_visit(
+            "visit.onAssignmentCreated",
+            tenant="acme",  # tenant-specific shadows global
+            auth_context=auth_context,
+        )
+        assert calls == ["global", "acme"]
+
+    async def test_missing_handler_is_noop(self, auth_context: None) -> None:
+        """No registered handler for the visit event returns an empty
+        EventResolution (no-op)."""
+        result = await dispatch_visit(
+            "visit.onArtifactAttached",
+            tenant="acme",
+            auth_context=auth_context,
+        )
+        assert result == EventResolution()
+
+    async def test_handler_returns_none_is_empty_resolution(
+        self, auth_context: None
+    ) -> None:
+        """Handler returning None is normalised to empty EventResolution."""
+
+        @register_form_event("visit.onGeofenceExit")
+        async def h(ctx: VisitEventContext) -> EventResolution | None:
+            return None
+
+        result = await dispatch_visit(
+            "visit.onGeofenceExit",
+            tenant=None,
+            auth_context=auth_context,
+        )
+        assert result == EventResolution()
+
+    async def test_posthook_exception_is_swallowed(
+        self, auth_context: None
+    ) -> None:
+        """A post-hook handler failure is fire-and-forget: logged, swallowed,
+        and an empty EventResolution is returned."""
+
+        @register_form_event("visit.onArtifactAttached")
+        async def h(ctx: VisitEventContext) -> EventResolution | None:
+            raise ValueError("observer blew up")
+
+        result = await dispatch_visit(
+            "visit.onArtifactAttached",
+            tenant=None,
+            auth_context=auth_context,
+        )
+        assert result == EventResolution()
+
+    async def test_posthook_abort_is_ignored(self, auth_context: None) -> None:
+        """FormEventAbort raised by a post-hook is ignored (aborts are only
+        meaningful for pre-hooks)."""
+
+        @register_form_event("visit.onCheckout")
+        async def h(ctx: VisitEventContext) -> EventResolution | None:
+            raise FormEventAbort("late abort", user_message="Nope")
+
+        result = await dispatch_visit(
+            "visit.onCheckout",
+            tenant=None,
+            auth_context=auth_context,
+        )
+        assert result == EventResolution()
+
+    async def test_prehook_other_exceptions_propagate(
+        self, auth_context: None
+    ) -> None:
+        """Non-abort exceptions from the pre-hook propagate unchanged
+        (mirror of the form-scoped before* semantics)."""
+
+        @register_form_event("visit.onArrival")
+        async def h(ctx: VisitEventContext) -> EventResolution | None:
+            raise ValueError("unexpected problem")
+
+        with pytest.raises(ValueError, match="unexpected problem"):
+            await dispatch_visit(
+                "visit.onArrival",
+                tenant=None,
+                auth_context=auth_context,
+            )
+
+    async def test_explicit_handler_ref_overrides_event_name(
+        self, auth_context: None
+    ) -> None:
+        """A custom handler_ref is used for the registry lookup instead of
+        the event name."""
+        calls: list[str] = []
+
+        @register_form_event("visit.custom.arrival_check")
+        async def h(ctx: VisitEventContext) -> EventResolution | None:
+            calls.append(ctx.event)
+            return None
+
+        await dispatch_visit(
+            "visit.onArrival",
+            tenant=None,
+            auth_context=auth_context,
+            handler_ref="visit.custom.arrival_check",
+        )
+        assert calls == ["visit.onArrival"]
+
+
+class TestFormDispatchUnaffected:
+    """Non-regression: form-scoped dispatch() behaviour is unchanged."""
+
+    async def test_form_dispatch_unaffected(self, auth_context: None) -> None:
+        """dispatch() still resolves form bindings from the shared registry
+        while visit handlers coexist under the visit.* namespace."""
+        from parrot_formdesigner.core.schema import FormSchema
+
+        calls: list[str] = []
+
+        @register_form_event("visit.onArrival")
+        async def visit_h(ctx: VisitEventContext) -> EventResolution | None:
+            calls.append("visit")
+            return None
+
+        expected = EventResolution(payload={"email": "a@b.com"})
+
+        @register_form_event("f1.onBeforeSubmit")
+        async def form_h(ctx):  # type: ignore[no-untyped-def]
+            calls.append("form")
+            return expected
+
+        form = FormSchema(
+            form_id="f1",
+            title={"en": "Test Form"},
+            sections=[],
+            events=FormEventsConfig(
+                onBeforeSubmit=FormEventBinding(handler_ref="f1.onBeforeSubmit"),
+            ),
+        )
+        result = await dispatch(
+            "onBeforeSubmit",
+            form=form,
+            request=MagicMock(),
+            tenant=None,
+            auth_context=auth_context,
+            payload={"email": "A@B.COM"},
+        )
+        assert result is expected
+        assert calls == ["form"]  # visit handler was never invoked


### PR DESCRIPTION
## Summary

Extends the FEAT-188 form lifecycle event system with a **`visit.*` namespace** so FieldSync can dispatch visit/assignment lifecycle hooks through the same tenant-scoped registry — per **Jesús's resolution** of FEAT-329 §8 (extend the FEAT-188 dispatcher rather than build a sibling one). Spec: `Trocdigital/fieldsync` → `sdd/specs/visit-lifecycle-event-bus.spec.md` (FEAT-329, **approved**) · Jira NAV-9086.

## What's added (packages/parrot-formdesigner)

- `core/events.py`: `VisitEventName` Literal (`visit.onAssignmentCreated`, `visit.onArtifactAttached`, `visit.onArrival`, `visit.onGeofenceExit`, `visit.onCheckout`) + `VisitEventContext` (Pydantic, `extra="forbid"`).
- `services/event_dispatcher.py`: `dispatch_visit()` — reuses the existing string-keyed registry via `get_form_event` (tenant → global fallback; `handler_ref` defaults to the event name). Pre-hook `visit.onArrival` re-raises `FormEventAbort` intact; post-hooks are fire-and-forget (errors logged and swallowed). **Zero lines of the existing `dispatch()` changed.**
- Re-exports from `core` and `services`; new `tests/unit/services/test_visit_events.py` (10 tests).

## Tests

- 41 unit (10 new + 31 pre-existing FEAT-188) + 43 lifecycle integration tests passing.
- Full unit tree: same 13F/5E pre-existing failures as `main` baseline (verified by stash/re-run) — no regressions.

## Downstream

FieldSync consumes this from `feat-329-visit-lifecycle-event-bus` (recap validation with abort, visit hook emission, geofence D5 observability, realtime publisher — 222 tests green there).

Developed with Spec Driven Development

https://claude.ai/code/session_01HgJj8j2rnYEJHgzhcM9Law