### PR TITLE
fix: UserPromptsManagement GET always returned 403 (session read before load)

### DIFF
--- a/packages/ai-parrot-server/src/parrot/handlers/bots.py
+++ b/packages/ai-parrot-server/src/parrot/handlers/bots.py
@@ -186,12 +186,16 @@ class UserPromptsManagement(ModelView):
         return value
 
     async def get(self):
-        """Override GET to scope results to the authenticated user_id."""
-        user_id = await self.get_userid(session=self._session)
-        # Inject user_id into the query string so ModelView's generic
-        # filter machinery picks it up and scopes the query.
-        new_query = dict(self.request.rel_url.query)
-        new_query['user_id'] = str(user_id)
+        """Override GET to require an authenticated session.
+
+        self._session is only populated by service_auth, which wraps the
+        parent get() — so it must be loaded explicitly before reading the
+        user here, otherwise get_userid(None) rejects every request with
+        a 403. Row filtering comes from the query-string params handled
+        by ModelView's generic machinery (user_id, chatbot_id).
+        """
+        await self.session()
+        await self.get_userid(session=self._session)
         return await super().get()
 
 


### PR DESCRIPTION
## Problem

`GET /api/v1/agents/user_prompts` returned `403 {"error": "Unauthorized"}` on **every** request, even with a valid Bearer token. Writes were unaffected, so user prompts were being saved to `navigator.users_prompts` but never listed — from the UI they appeared to vanish on reload, and re-creating them failed with a duplicate-key error.

## Root cause

In `packages/ai-parrot-server/src/parrot/handlers/bots.py`, the `UserPromptsManagement.get()` override called:

```python
user_id = await self.get_userid(session=self._session)
```

before `super().get()`. But `self._session` starts as `None` (`navigator/views/abstract.py:174`) and is only populated by the `service_auth` decorator, which wraps the **parent** `get()`. So the override always passed `None`, and `get_userid(None)` responds 403 (`abstract.py:310-315`).

PUT/POST were unaffected because their `_set_user_id` hooks run inside the parent methods, after `service_auth` has loaded the session — which is why inserts carried the correct `user_id` while listing failed.

## Fix

Load the session explicitly before the auth check:

```python
await self.session()
await self.get_userid(session=self._session)
return await super().get()
```

Also removed the `new_query` lines: they built a dict that was never applied to the request (dead code).

## Verified

- Before: GET → 403 with a valid session (reproduced in local dev and prod).
- After: GET → 200; previously-trapped rows in `navigator.users_prompts` now list correctly in the Prompt Library UI (frontend QA passed).
- `filter()`/serialization for the model verified directly against the database.

## Follow-up (not in this PR)

The docstring says clients cannot spoof `user_id`, but row scoping still relies on the client-sent `user_id` query param — any authenticated user can read another user's prompts by changing it. Enforcing it server-side (e.g., a `_filter_user_id` hook overriding the param with the session user) is a separate change worth discussing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)