### PR TITLE
feat(speech_report): script/TTS model overrides + single-narrator scripts

### DIFF
--- a/packages/ai-parrot/src/parrot/bots/agent.py
+++ b/packages/ai-parrot/src/parrot/bots/agent.py
@@ -493,6 +493,8 @@ class BasicAgent(Chatbot, NotificationMixin):
         podcast_instructions: Optional[str] = "for_podcast.txt",
         directory: Optional[Path] = None,
         output_directory: Optional[Path] = None,
+        script_model: Optional[str] = None,
+        tts_model: Optional[str] = None,
         **kwargs,
     ) -> Dict[str, Any]:
         """Generate a Transcript Report and a Podcast based on findings."""
@@ -539,11 +541,14 @@ class BasicAgent(Chatbot, NotificationMixin):
         )
         async with self.client as client:
             # 2. Generate the conversational script
-            response = await client.create_conversation_script(
-                report_data=script_config,
-                max_lines=max_lines,  # Limit to 15 lines for brevity,
-                use_structured_output=True,  # Use structured output for TTS
-            )
+            script_kwargs = {
+                "report_data": script_config,
+                "max_lines": max_lines,  # Limit to 15 lines for brevity,
+                "use_structured_output": True,  # Use structured output for TTS
+            }
+            if script_model is not None:
+                script_kwargs["model"] = script_model
+            response = await client.create_conversation_script(**script_kwargs)
             voice_prompt = response.output
             # 3. Save the script to a File:
             script_output_path = script_output_directory.joinpath(script_name)
@@ -555,10 +560,13 @@ class BasicAgent(Chatbot, NotificationMixin):
             output_directory = STATIC_DIR.joinpath(self.agent_id, "podcasts")
         output_directory.mkdir(parents=True, exist_ok=True)
         async with self.client as client:
-            speech_result = await client.generate_speech(
-                prompt_data=voice_prompt,
-                output_directory=output_directory,
-            )
+            speech_kwargs = {
+                "prompt_data": voice_prompt,
+                "output_directory": output_directory,
+            }
+            if tts_model is not None:
+                speech_kwargs["model"] = tts_model
+            speech_result = await client.generate_speech(**speech_kwargs)
             if speech_result and speech_result.files:
                 print(f"✅ Multi-voice speech saved to: {speech_result.files[0]}")
             # 5 Return the script and audio file paths

--- a/packages/ai-parrot/src/parrot/clients/google/generation.py
+++ b/packages/ai-parrot/src/parrot/clients/google/generation.py
@@ -389,9 +389,16 @@ class GoogleGeneration:
             elif speaker.role == "interviewee":
                 interviewee = speaker
 
-        if not interviewer or not interviewee:
-            raise ValueError("Must have exactly one interviewer and one interviewee.")
-        system_instruction = report_data.system_instruction or f"""
+        # The interviewer/interviewee requirement only applies to the
+        # auto-generated two-person template below. A caller-supplied
+        # system_instruction (e.g. a single-narrator monologue prompt) fully
+        # determines the script format on its own, so it's exempt.
+        if report_data.system_instruction:
+            system_instruction = report_data.system_instruction
+        else:
+            if not interviewer or not interviewee:
+                raise ValueError("Must have exactly one interviewer and one interviewee.")
+            system_instruction = f"""
 You are a scriptwriter. Your task is {system_prompt} for a conversation between {interviewer.name} and {interviewee.name}. "
 
 **Source Report:**"

--- a/packages/ai-parrot/tests/test_basic_agent_new.py
+++ b/packages/ai-parrot/tests/test_basic_agent_new.py
@@ -229,6 +229,71 @@ async def test_speech_report(mock_agent_deps):
 
 
 @pytest.mark.asyncio
+async def test_speech_report_forwards_script_and_tts_model(mock_agent_deps):
+    """script_model/tts_model, when provided, are forwarded as `model=` to
+    create_conversation_script()/generate_speech() respectively."""
+    from parrot.bots.agent import BasicAgent
+
+    agent = BasicAgent(name="Podcaster")
+    agent.open_prompt = AsyncMock(return_value="Podcast Instructions")
+    mock_agent_deps.__aenter__.return_value = mock_agent_deps
+
+    mock_script_response = MagicMock()
+    mock_script_response.output.prompt = "Script Content"
+    mock_agent_deps.create_conversation_script.return_value = mock_script_response
+
+    mock_speech_result = MagicMock()
+    mock_speech_result.files = ["/tmp/podcast.wav"]
+    mock_agent_deps.generate_speech.return_value = mock_speech_result
+
+    mock_file_handle = AsyncMock()
+    mock_ctx_manager = MagicMock()
+    mock_ctx_manager.__aenter__.return_value = mock_file_handle
+    mock_ctx_manager.__aexit__.return_value = None
+
+    with patch("parrot.bots.agent.aiofiles.open", return_value=mock_ctx_manager):
+        await agent.speech_report(
+            report="Analysis Text",
+            podcast_instructions="instructions.txt",
+            script_model="gemini-3.5-flash",
+            tts_model="gemini-3.1-flash-tts-preview",
+        )
+
+    assert mock_agent_deps.create_conversation_script.call_args.kwargs["model"] == "gemini-3.5-flash"
+    assert mock_agent_deps.generate_speech.call_args.kwargs["model"] == "gemini-3.1-flash-tts-preview"
+
+
+@pytest.mark.asyncio
+async def test_speech_report_omits_model_kwargs_by_default(mock_agent_deps):
+    """Without script_model/tts_model, no `model=` override is passed through —
+    create_conversation_script()/generate_speech() use their own defaults."""
+    from parrot.bots.agent import BasicAgent
+
+    agent = BasicAgent(name="Podcaster")
+    agent.open_prompt = AsyncMock(return_value="Podcast Instructions")
+    mock_agent_deps.__aenter__.return_value = mock_agent_deps
+
+    mock_script_response = MagicMock()
+    mock_script_response.output.prompt = "Script Content"
+    mock_agent_deps.create_conversation_script.return_value = mock_script_response
+
+    mock_speech_result = MagicMock()
+    mock_speech_result.files = ["/tmp/podcast.wav"]
+    mock_agent_deps.generate_speech.return_value = mock_speech_result
+
+    mock_file_handle = AsyncMock()
+    mock_ctx_manager = MagicMock()
+    mock_ctx_manager.__aenter__.return_value = mock_file_handle
+    mock_ctx_manager.__aexit__.return_value = None
+
+    with patch("parrot.bots.agent.aiofiles.open", return_value=mock_ctx_manager):
+        await agent.speech_report(report="Analysis Text", podcast_instructions="instructions.txt")
+
+    assert "model" not in mock_agent_deps.create_conversation_script.call_args.kwargs
+    assert "model" not in mock_agent_deps.generate_speech.call_args.kwargs
+
+
+@pytest.mark.asyncio
 async def test_report_workflow(mock_agent_deps):
     """Test high-level report() method which orchestrates everything."""
     from parrot.bots.agent import BasicAgent

--- a/packages/ai-parrot/tests/test_conversation_script.py
+++ b/packages/ai-parrot/tests/test_conversation_script.py
@@ -1,0 +1,103 @@
+"""Tests for GoogleGeneration.create_conversation_script().
+
+Covers the interviewer/interviewee validation relaxation added for
+single-narrator (monologue) podcast scripts: the two-role requirement only
+applies to the auto-generated two-person template, not when the caller
+supplies its own system_instruction.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+from parrot.clients.google.generation import GoogleGeneration
+from parrot.models.google import ConversationalScriptConfig, FictionalSpeaker
+
+
+@pytest.fixture
+def mock_generation():
+    gg = GoogleGeneration()
+    gg.client = MagicMock()
+    gg.logger = MagicMock()
+    gg.temperature = 0.7
+    gg.max_tokens = None
+    gg._ensure_client = AsyncMock()
+    mock_response = MagicMock()
+    mock_response.text = "Generated script text"
+    gg.client.models.generate_content = MagicMock(return_value=mock_response)
+    return gg
+
+
+def _patch_ai_message_factory():
+    return patch(
+        "parrot.clients.google.generation.AIMessageFactory.from_gemini",
+        return_value=MagicMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_single_speaker_with_custom_instruction_skips_role_validation(mock_generation):
+    """A lone 'interviewer' speaker + a custom system_instruction must NOT raise,
+    and the custom instruction must be used verbatim (not the two-person template).
+    """
+    narrator = FictionalSpeaker(
+        name="Alex", role="interviewer", characteristic="upbeat", gender="female"
+    )
+    config = ConversationalScriptConfig(
+        report_text="Store feedback summary.",
+        speakers=[narrator],
+        context="store briefing",
+        system_instruction="Custom monologue instructions.",
+    )
+
+    with _patch_ai_message_factory():
+        await mock_generation.create_conversation_script(
+            report_data=config, use_structured_output=False
+        )
+
+    _, kwargs = mock_generation.client.models.generate_content.call_args
+    assert kwargs["config"].system_instruction == "Custom monologue instructions."
+
+
+@pytest.mark.asyncio
+async def test_single_speaker_without_custom_instruction_still_raises(mock_generation):
+    """Without a caller-supplied system_instruction, the default two-person
+    template still requires both an interviewer and an interviewee.
+    """
+    narrator = FictionalSpeaker(
+        name="Alex", role="interviewer", characteristic="upbeat", gender="female"
+    )
+    config = ConversationalScriptConfig(
+        report_text="Store feedback summary.",
+        speakers=[narrator],
+        context="store briefing",
+    )
+
+    with pytest.raises(ValueError, match="interviewer and one interviewee"):
+        await mock_generation.create_conversation_script(
+            report_data=config, use_structured_output=False
+        )
+
+
+@pytest.mark.asyncio
+async def test_two_speakers_without_custom_instruction_uses_default_template(mock_generation):
+    """Backward compatibility: two properly-roled speakers with no custom
+    system_instruction still builds the default conversational template.
+    """
+    interviewer = FictionalSpeaker(
+        name="Alex", role="interviewer", characteristic="curious", gender="male"
+    )
+    interviewee = FictionalSpeaker(
+        name="Jordan", role="interviewee", characteristic="warm", gender="female"
+    )
+    config = ConversationalScriptConfig(
+        report_text="Store feedback summary.",
+        speakers=[interviewer, interviewee],
+        context="store briefing",
+    )
+
+    with _patch_ai_message_factory():
+        await mock_generation.create_conversation_script(
+            report_data=config, use_structured_output=False
+        )
+
+    _, kwargs = mock_generation.client.models.generate_content.call_args
+    system_instruction = kwargs["config"].system_instruction
+    assert "Alex" in system_instruction and "Jordan" in system_instruction


### PR DESCRIPTION
## Summary
- `BasicAgent.speech_report()` gains optional `script_model`/`tts_model` kwargs, forwarded as `model=` to `create_conversation_script()`/`generate_speech()`. Both default to `None` (unchanged Gemini 2.5 defaults) when omitted — fully backward compatible.
- `GoogleGeneration.create_conversation_script()` no longer hard-requires an `interviewer` AND `interviewee` when the caller supplies its own `system_instruction` — that instruction fully determines the script format on its own. This enables single-narrator (monologue) podcast scripts with just one speaker. The two-role requirement still applies to the built-in two-person default template (no `system_instruction` supplied).

## Motivation
flowtask's `PodcastMaker` component needed both to (a) test newer Gemini 3.x models for script/TTS generation instead of the hardcoded Gemini 2.5 defaults, and (b) run a single-voice narrator instead of a forced two-person interviewer/interviewee dialogue.

## Test plan
- [x] `test_basic_agent_new.py::test_speech_report_forwards_script_and_tts_model` — new, confirms `model=` is forwarded when set
- [x] `test_basic_agent_new.py::test_speech_report_omits_model_kwargs_by_default` — new, confirms no `model=` override when unset
- [x] `test_conversation_script.py` (new file, 3 tests) — single speaker + custom instruction skips validation; single speaker without custom instruction still raises; two speakers without custom instruction still uses default template
- [x] Full `test_basic_agent_new.py` + `test_google_reel.py` + new file: 19 passed, 2 pre-existing unrelated failures (`test_setup_mcp_servers`, `test_agent_real_integration` — confirmed failing identically on `dev` before this change, need real credentials/MCP servers)