### PR TITLE
Add GraphIndex HTML/JSON export and CLI for interactive knowledge graphs

### DIFF
--- a/packages/ai-parrot-tools/src/parrot_tools/graphindex/toolkit.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/graphindex/toolkit.py
@@ -26,7 +26,7 @@ Tool surface:
   find_node, find_references, get_neighborhood, traverse,
   search_hybrid, find_central_nodes, shortest_path, explain,
   relevance, neighborhood_by_relevance, list_communities,
-  find_community
+  find_community, export_graph_html
 
   # WRITE
   create_concept, create_node, link_nodes, unlink_nodes,
@@ -399,6 +399,61 @@ class GraphIndexToolkit(AbstractToolkit):
 
         result.sort(key=lambda x: x["centrality_score"], reverse=True)
         return result[:top_k]
+
+    async def export_graph_html(
+        self, output_dir: str, top_k_god_nodes: int = 15
+    ) -> dict:
+        """Export an interactive ``graph.html`` map plus ``graph.json``.
+
+        Renders the current in-memory graph as a self-contained, clickable
+        force-directed page: nodes are concepts, colour is the detected
+        community, node size scales with centrality (god nodes are highlighted),
+        and clicking a node opens a detail panel. The page inlines the ECharts
+        runtime so it works fully offline. A sibling ``graph.json`` carries the
+        serialized graph for programmatic reuse.
+
+        Args:
+            output_dir: Directory where ``graph.html`` and ``graph.json`` are
+                written (created if missing).
+            top_k_god_nodes: Number of most-central "god" nodes to highlight.
+
+        Returns:
+            Dict with ``graph_html``, ``graph_json``, ``node_count``,
+            ``edge_count`` and ``community_count`` — or an ``error`` dict when
+            the export module is unavailable.
+        """
+        try:
+            from parrot.knowledge.graphindex.export_html import export_graph
+        except ImportError as exc:
+            return {"error": f"HTML export unavailable: {exc}"}
+
+        if self.graph.num_nodes() == 0:
+            return {"error": "Graph is empty; nothing to export."}
+
+        communities = self._get_or_compute_communities()
+        analytics = self._get_or_compute_analytics()
+        try:
+            html_path, json_path = export_graph(
+                self.graph,
+                output_dir,
+                communities=communities,
+                analytics=analytics,
+                god_top_k=top_k_god_nodes,
+            )
+        except Exception as exc:
+            logger.error("export_graph_html failed: %s", exc)
+            return {"error": str(exc)}
+
+        community_count = (
+            len(communities.communities) if communities is not None else 0
+        )
+        return {
+            "graph_html": str(html_path),
+            "graph_json": str(json_path),
+            "node_count": self.graph.num_nodes(),
+            "edge_count": self.graph.num_edges(),
+            "community_count": community_count,
+        }
 
     async def shortest_path(self, from_id: str, to_id: str) -> list[dict]:
         """Find the shortest path between two nodes.

--- a/packages/ai-parrot-tools/tests/graphindex/test_toolkit.py
+++ b/packages/ai-parrot-tools/tests/graphindex/test_toolkit.py
@@ -426,3 +426,28 @@ class TestSearchWithExpansion:
 
         assert result["budget_limit"] == 4000
         assert isinstance(result["nodes"], list)
+
+
+class TestExportGraphHtml:
+    @pytest.mark.asyncio
+    async def test_export_writes_html_and_json(self, tmp_path):
+        tk = make_toolkit()
+        result = await tk.export_graph_html(str(tmp_path))
+        assert "error" not in result
+        assert (tmp_path / "graph.html").exists()
+        assert (tmp_path / "graph.json").exists()
+        assert result["node_count"] == 4
+        assert result["edge_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_export_empty_graph_returns_error(self, tmp_path):
+        import rustworkx
+        import faiss
+        tk = GraphIndexToolkit(
+            graph=rustworkx.PyDiGraph(),
+            faiss_index=faiss.IndexFlatIP(8),
+            node_map={},
+            node_id_list=[],
+        )
+        result = await tk.export_graph_html(str(tmp_path))
+        assert "error" in result

--- a/packages/ai-parrot/pyproject.toml
+++ b/packages/ai-parrot/pyproject.toml
@@ -104,6 +104,8 @@ dependencies = [
 
 [project.scripts]
 parrot = "parrot.cli:cli"
+# GraphIndex CLI — build an interactive knowledge graph from a code repo.
+parrot-graphindex = "parrot.knowledge.graphindex.cli:main"
 # parrot-fs moved to ai-parrot-server in FEAT-203
 
 [project.optional-dependencies]

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/__init__.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/__init__.py
@@ -35,9 +35,17 @@ from parrot.knowledge.graphindex.communities import (
     Community,
     CommunitiesResult,
     cohesion_for_community,
+    derive_community_label,
     detect_communities,
 )
-from parrot.knowledge.graphindex.loader import GraphIndexLoader
+from parrot.knowledge.graphindex.export_html import (
+    GraphExportPayload,
+    build_export_payload,
+    community_color,
+    export_graph,
+    write_graph_html,
+    write_graph_json,
+)
 from parrot.knowledge.graphindex.persist_sqlite import SQLitePersistence
 from parrot.knowledge.graphindex.projection import (
     project_graph_sidecars,
@@ -66,7 +74,14 @@ __all__ = [
     "Community",
     "CommunitiesResult",
     "cohesion_for_community",
+    "derive_community_label",
     "detect_communities",
+    "GraphExportPayload",
+    "build_export_payload",
+    "community_color",
+    "export_graph",
+    "write_graph_html",
+    "write_graph_json",
     "GraphIndexLoader",
     "OdooCodeExtractor",
     "SQLitePersistence",
@@ -76,3 +91,20 @@ __all__ = [
     "project_report_frontmatter",
     "node_to_frontmatter_dict",
 ]
+
+# ``GraphIndexLoader`` transitively pulls the full loaders/clients web-framework
+# stack (aiohttp, navigator, embeddings). Import it lazily (PEP 562) so that
+# ``import parrot.knowledge.graphindex`` — and the local-first CLI / pure graph
+# modules — stay lightweight and usable without those heavyweight dependencies.
+_LAZY_ATTRS = {"GraphIndexLoader": "parrot.knowledge.graphindex.loader"}
+
+
+def __getattr__(name: str):
+    """Resolve lazily-exported attributes on first access (PEP 562)."""
+    module_path = _LAZY_ATTRS.get(name)
+    if module_path is not None:
+        import importlib
+
+        module = importlib.import_module(module_path)
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/builder.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/builder.py
@@ -94,6 +94,12 @@ class GraphIndexBuilder:
         code_extractor_class: The ``CodeExtractor`` subclass to use for
             Python source files (FEAT-240). Defaults to ``CodeExtractor``.
             Pass ``OdooCodeExtractor`` to enable Odoo model extraction.
+        export_html_enabled: When True and ``output_dir`` is set, emit an
+            interactive ``graph.html`` map plus a serialized ``graph.json``
+            after analytics. Communities colour the nodes and god nodes are
+            sized/highlighted, so pairing this with
+            ``detect_communities_enabled=True`` yields the richest map.
+            Default False — opt-in.
     """
 
     def __init__(
@@ -108,6 +114,7 @@ class GraphIndexBuilder:
         detect_communities_enabled: bool = False,
         community_resolution: float = 1.0,
         code_extractor_class: Type = CodeExtractor,
+        export_html_enabled: bool = False,
     ) -> None:
         self.persistence = persistence
         self.embedder = embedder
@@ -118,6 +125,7 @@ class GraphIndexBuilder:
         self.signal_config = signal_config
         self.detect_communities_enabled = detect_communities_enabled
         self.community_resolution = community_resolution
+        self.export_html_enabled = export_html_enabled
         self.last_community_result: Optional[CommunitiesResult] = None
         self.logger = logging.getLogger(__name__)
         self._ignore_spec: Optional[pathspec.PathSpec] = self._load_ignore(ignore_file)
@@ -271,6 +279,31 @@ class GraphIndexBuilder:
                 logger.error("Projection stage failed: %s", exc)
                 errors.append(f"Projection failed: {exc}")
 
+        # Stage 6.6: Interactive HTML map — emit graph.html + graph.json.
+        graph_html_path: Optional[Path] = None
+        graph_json_path: Optional[Path] = None
+        if self.export_html_enabled and self.output_dir is not None:
+            try:
+                # Deferred import: export_html is optional and keeps the
+                # builder importable when its (light) deps are absent.
+                from parrot.knowledge.graphindex.export_html import (  # noqa: PLC0415
+                    export_graph,
+                )
+
+                graph_html_path, graph_json_path = export_graph(
+                    assembler.graph,
+                    self.output_dir,
+                    communities=self.last_community_result,
+                    analytics=analytics,
+                )
+                logger.info(
+                    "Stage 6.6 complete: interactive map written to %s",
+                    graph_html_path,
+                )
+            except Exception as exc:
+                logger.error("HTML export stage failed: %s", exc)
+                errors.append(f"HTML export failed: {exc}")
+
         inferred_count = sum(
             1 for e in all_edges if e.provenance == Provenance.INFERRED
         )
@@ -282,6 +315,8 @@ class GraphIndexBuilder:
             report_path=report_path,
             errors=errors,
             projection_report=projection_report,
+            graph_html_path=graph_html_path,
+            graph_json_path=graph_json_path,
         )
 
     async def ingest_document(self, uri: str, ctx: TenantContext) -> IngestResult:

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/cli.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/cli.py
@@ -1,0 +1,338 @@
+"""GraphIndex CLI — build a knowledge graph from a code repository.
+
+A local-first, Graphify-style command that turns an existing code repository
+into a ``graphindex`` directory containing:
+
+* ``graph.html``   — an interactive, clickable force-directed map (communities
+  as colours, god nodes highlighted);
+* ``graph.json``   — the serialized graph for programmatic reuse;
+* ``GRAPH_REPORT.md`` — a deterministic report (god nodes, communities,
+  surprising connections, suggested questions).
+
+The code pass is **deterministic and LLM-free**: files are parsed with
+tree-sitter, the graph is assembled in-process with ``rustworkx``, communities
+come from Louvain, and centrality identifies god nodes. Nothing leaves the
+machine and no API keys, database, or embedding model are required.
+
+Usage::
+
+    parrot-graphindex .                     # index the current repo
+    parrot-graphindex ./src -o ./graphindex # choose the output directory
+    parrot-graphindex . --no-communities    # skip community detection
+    python -m parrot.knowledge.graphindex .
+
+The heavy semantic pass over docs/PDFs/media (which does use a model) lives in
+the full :class:`~parrot.knowledge.graphindex.builder.GraphIndexBuilder`
+pipeline; this CLI intentionally covers only the local code path.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from pathlib import Path
+from typing import Optional, Sequence
+
+import pathspec
+
+from parrot.knowledge.graphindex.analytics import compute_analytics, generate_report
+from parrot.knowledge.graphindex.assemble import GraphAssembler
+from parrot.knowledge.graphindex.communities import detect_communities
+from parrot.knowledge.graphindex.export_html import export_graph
+from parrot.knowledge.graphindex.extractors.code import CodeExtractor
+from parrot.knowledge.graphindex.schema import UniversalEdge, UniversalNode
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OUTPUT_DIRNAME = "graphindex"
+
+#: Directories skipped during discovery regardless of any ignore file.
+_ALWAYS_SKIP: frozenset[str] = frozenset({
+    ".git", ".hg", ".svn", "__pycache__", ".mypy_cache", ".pytest_cache",
+    ".ruff_cache", ".venv", "venv", "node_modules", ".tox", "build", "dist",
+    ".eggs", ".idea", ".vscode",
+})
+
+
+def discover_python_files(
+    root: Path, ignore_spec: Optional[pathspec.PathSpec] = None
+) -> list[Path]:
+    """Recursively find Python source files under ``root``.
+
+    Skips well-known noise directories (``.git``, ``__pycache__``,
+    ``node_modules``, virtualenvs, build output, …) and any path matching the
+    optional gitignore-style ``ignore_spec``.
+
+    Args:
+        root: Repository root (or a single ``.py`` file).
+        ignore_spec: Optional compiled ``pathspec`` for ``.graphindexignore``.
+
+    Returns:
+        A sorted list of ``.py`` file paths (deterministic order).
+    """
+    if root.is_file():
+        return [root] if root.suffix == ".py" else []
+
+    files: list[Path] = []
+    for path in root.rglob("*.py"):
+        if any(part in _ALWAYS_SKIP for part in path.relative_to(root).parts):
+            continue
+        if ignore_spec is not None:
+            rel = path.relative_to(root).as_posix()
+            if ignore_spec.match_file(rel):
+                continue
+        files.append(path)
+    return sorted(files)
+
+
+async def build_code_graph(
+    paths: Sequence[Path],
+    output_dir: Path,
+    *,
+    tenant_id: str = "default",
+    detect_comms: bool = True,
+    community_resolution: float = 1.0,
+    ignore_file: Optional[Path] = None,
+    title: Optional[str] = None,
+    allow_cdn_fallback: bool = True,
+) -> dict:
+    """Build the code knowledge graph and write the ``graphindex`` artefacts.
+
+    Args:
+        paths: Repository roots and/or individual ``.py`` files to index.
+        output_dir: Directory to write ``graph.html`` / ``graph.json`` /
+            ``GRAPH_REPORT.md`` into (created if missing).
+        tenant_id: Tenant id used for node namespacing.
+        detect_comms: Whether to run Louvain community detection.
+        community_resolution: Louvain γ resolution (>1.0 → smaller communities).
+        ignore_file: Optional ``.graphindexignore`` path (gitignore syntax).
+        title: Graph title shown in the page header; defaults to the first
+            path's name.
+        allow_cdn_fallback: Fall back to the ECharts CDN when the vendored
+            offline asset is unavailable.
+
+    Returns:
+        A summary dict with counts, output paths, top god nodes and top
+        communities.
+    """
+    ignore_spec: Optional[pathspec.PathSpec] = None
+    if ignore_file is not None and ignore_file.is_file():
+        ignore_spec = pathspec.PathSpec.from_lines(
+            "gitwildmatch", ignore_file.read_text(encoding="utf-8").splitlines()
+        )
+
+    extractor = CodeExtractor(
+        ignore_file=str(ignore_file) if ignore_file else None
+    )
+
+    all_nodes: list[UniversalNode] = []
+    all_edges: list[UniversalEdge] = []
+    files_indexed = 0
+    errors: list[str] = []
+
+    for base in paths:
+        base = base.resolve()
+        discovery_root = base if base.is_dir() else base.parent
+        for file_path in discover_python_files(base, ignore_spec):
+            try:
+                source = file_path.read_text(encoding="utf-8", errors="replace")
+            except OSError as exc:
+                errors.append(f"read failed: {file_path}: {exc}")
+                continue
+            try:
+                rel = file_path.relative_to(discovery_root).as_posix()
+            except ValueError:
+                rel = str(file_path)
+            nodes, edges = await extractor.extract(rel, source)
+            all_nodes.extend(nodes)
+            all_edges.extend(edges)
+            files_indexed += 1
+
+    logger.info(
+        "Extracted %d nodes and %d edges from %d files",
+        len(all_nodes), len(all_edges), files_indexed,
+    )
+
+    assembler = GraphAssembler(tenant_id=tenant_id)
+    assembler.add_nodes(all_nodes)
+    assembler.add_edges(all_edges)
+
+    communities = None
+    if detect_comms and assembler.graph.num_nodes() > 0:
+        communities = detect_communities(
+            assembler.graph,
+            all_nodes,
+            resolution=community_resolution,
+            write_back_to_nodes=False,
+        )
+
+    analytics = compute_analytics(assembler.graph, all_nodes, all_edges)
+    analytics.communities = communities
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    report_path = generate_report(analytics, output_dir, tenant_id=tenant_id)
+    html_path, json_path = export_graph(
+        assembler.graph,
+        output_dir,
+        communities=communities,
+        analytics=analytics,
+        title=title or f"GraphIndex — {Path(paths[0]).resolve().name}",
+        allow_cdn_fallback=allow_cdn_fallback,
+    )
+
+    return {
+        "files_indexed": files_indexed,
+        "node_count": assembler.graph.num_nodes(),
+        "edge_count": assembler.graph.num_edges(),
+        "community_count": len(communities.communities) if communities else 0,
+        "modularity": communities.modularity if communities else None,
+        "graph_html": str(html_path),
+        "graph_json": str(json_path),
+        "report": str(report_path),
+        "god_nodes": analytics.god_nodes[:10],
+        "communities": (
+            [
+                {"label": c.label or c.community_id[:8], "size": c.size}
+                for c in communities.communities[:10]
+            ]
+            if communities
+            else []
+        ),
+        "errors": errors,
+    }
+
+
+def _print_summary(summary: dict, output_dir: Path) -> None:
+    """Print a human-readable run summary to stdout.
+
+    Args:
+        summary: The dict returned by :func:`build_code_graph`.
+        output_dir: The output directory (for the closing hint).
+    """
+    print(f"\nGraphIndex built for {summary['files_indexed']} file(s):")
+    print(f"  nodes:       {summary['node_count']}")
+    print(f"  edges:       {summary['edge_count']}")
+    if summary["modularity"] is not None:
+        print(
+            f"  communities: {summary['community_count']} "
+            f"(modularity {summary['modularity']:.4f})"
+        )
+    if summary["god_nodes"]:
+        print("\nGod nodes (most connected):")
+        for i, node in enumerate(summary["god_nodes"][:5], start=1):
+            print(f"  {i}. {node.get('title', '?')}  [{node.get('kind', '')}]")
+    if summary["communities"]:
+        print("\nTop communities:")
+        for comm in summary["communities"][:5]:
+            print(f"  • {comm['label']}  ({comm['size']} nodes)")
+    print("\nArtifacts:")
+    print(f"  {summary['graph_html']}")
+    print(f"  {summary['graph_json']}")
+    print(f"  {summary['report']}")
+    if summary["errors"]:
+        print(f"\n{len(summary['errors'])} non-fatal error(s) during indexing.")
+    print(f"\nOpen {Path(summary['graph_html'])} in a browser to explore.")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Construct the argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="parrot-graphindex",
+        description=(
+            "Build an interactive knowledge graph (graph.html + graph.json + "
+            "GRAPH_REPORT.md) from a code repository — local-first, no LLM."
+        ),
+    )
+    parser.add_argument(
+        "path", nargs="?", default=".",
+        help="Repository root or file to index (default: current directory).",
+    )
+    parser.add_argument(
+        "-o", "--output", default=None,
+        help=(
+            "Output directory for the artefacts "
+            f"(default: <path>/{DEFAULT_OUTPUT_DIRNAME})."
+        ),
+    )
+    parser.add_argument(
+        "--tenant", default="default", help="Tenant id for node namespacing."
+    )
+    parser.add_argument(
+        "--no-communities", action="store_true",
+        help="Skip Louvain community detection (nodes render uncoloured).",
+    )
+    parser.add_argument(
+        "--resolution", type=float, default=1.0,
+        help="Louvain resolution γ (>1.0 finds smaller/tighter communities).",
+    )
+    parser.add_argument(
+        "--ignore-file", default=None,
+        help="Path to a .graphindexignore file (gitignore syntax).",
+    )
+    parser.add_argument("--title", default=None, help="Graph title for the page header.")
+    parser.add_argument(
+        "--no-cdn-fallback", action="store_true",
+        help="Fail instead of referencing the ECharts CDN when the offline "
+             "asset is unavailable.",
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Enable debug logging."
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """CLI entry point.
+
+    Args:
+        argv: Optional argument vector (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        Process exit code (0 on success, non-zero on error).
+    """
+    args = _build_parser().parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
+    target = Path(args.path)
+    if not target.exists():
+        print(f"error: path does not exist: {target}", file=sys.stderr)
+        return 2
+
+    default_base = target if target.is_dir() else target.parent
+    output_dir = Path(args.output) if args.output else default_base / DEFAULT_OUTPUT_DIRNAME
+    ignore_file = Path(args.ignore_file) if args.ignore_file else None
+
+    try:
+        summary = asyncio.run(
+            build_code_graph(
+                [target],
+                output_dir,
+                tenant_id=args.tenant,
+                detect_comms=not args.no_communities,
+                community_resolution=args.resolution,
+                ignore_file=ignore_file,
+                title=args.title,
+                allow_cdn_fallback=not args.no_cdn_fallback,
+            )
+        )
+    except Exception as exc:  # noqa: BLE001 — surface a clean CLI error
+        logger.error("GraphIndex build failed: %s", exc)
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if summary["node_count"] == 0:
+        print("No Python files found to index.", file=sys.stderr)
+        return 1
+
+    _print_summary(summary, output_dir)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/communities.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/communities.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import re
+from collections import Counter
 from typing import TYPE_CHECKING, Iterable, Optional
 
 import networkx as nx
@@ -53,6 +55,10 @@ class Community(BaseModel):
         modularity_contribution: This community's contribution to the
             global modularity Q. The full Q is the sum of these.
         top_titles: Titles of the first ≤ 5 members in display order.
+        label: Deterministic, LLM-free label summarising the community,
+            derived from the most frequent salient keywords across member
+            titles (see :func:`derive_community_label`). Empty string when
+            no salient keyword could be extracted.
     """
 
     community_id: str
@@ -62,6 +68,7 @@ class Community(BaseModel):
     cohesion: float
     modularity_contribution: float
     top_titles: list[str]
+    label: str = ""
 
     model_config = ConfigDict(frozen=True)
 
@@ -82,6 +89,75 @@ class CommunitiesResult(BaseModel):
 # ---------------------------------------------------------------------------
 # Stable IDs
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# LLM-free community labels
+# ---------------------------------------------------------------------------
+
+#: Generic tokens that carry no discriminative signal for a label.
+_LABEL_STOPWORDS: frozenset[str] = frozenset({
+    "the", "and", "for", "with", "from", "this", "that", "into", "over",
+    "get", "set", "new", "old", "def", "class", "func", "function", "method",
+    "module", "self", "value", "values", "data", "item", "items", "list",
+    "dict", "str", "int", "bool", "none", "true", "false", "test", "tests",
+    "init", "main", "util", "utils", "helper", "helpers", "base", "abstract",
+    "type", "types", "kind", "node", "edge", "graph", "id", "ids", "name",
+    "names", "obj", "object", "args", "kwargs", "return", "returns", "param",
+    "params", "note", "todo", "why", "hack", "fixme", "xxx", "add", "remove",
+})
+
+#: Splits identifiers into word tokens (camelCase, snake_case, punctuation).
+_LABEL_SPLIT_RE = re.compile(r"[^A-Za-z0-9]+|(?<=[a-z0-9])(?=[A-Z])")
+
+
+def _tokenize_title(title: str) -> list[str]:
+    """Split a title/identifier into lower-cased salient word tokens.
+
+    Handles ``snake_case``, ``camelCase`` and punctuation-separated words,
+    dropping stopwords, pure numbers and 1-2 char fragments.
+
+    Args:
+        title: The node title to tokenize.
+
+    Returns:
+        A list of salient lower-case tokens (possibly empty).
+    """
+    tokens: list[str] = []
+    for raw in _LABEL_SPLIT_RE.split(title or ""):
+        tok = raw.lower()
+        if len(tok) < 3 or tok.isdigit() or tok in _LABEL_STOPWORDS:
+            continue
+        tokens.append(tok)
+    return tokens
+
+
+def derive_community_label(titles: Iterable[str], max_terms: int = 3) -> str:
+    """Derive a deterministic, LLM-free label from member titles.
+
+    Counts salient keyword frequency across the supplied titles and joins the
+    most common terms. Ties are broken alphabetically so the result is stable
+    across runs. Returns an empty string when no salient keyword survives
+    stopword filtering.
+
+    Args:
+        titles: Member node titles to summarise.
+        max_terms: Maximum number of keywords to include in the label.
+
+    Returns:
+        A capitalised label such as ``"Payment Gateway"``, or ``""``.
+    """
+    counter: Counter[str] = Counter()
+    for title in titles:
+        # Count each token once per title so a repeated word in one title
+        # does not dominate the community label.
+        for tok in set(_tokenize_title(title)):
+            counter[tok] += 1
+    if not counter:
+        return ""
+    ranked = sorted(counter.items(), key=lambda kv: (-kv[1], kv[0]))
+    top = [term for term, _ in ranked[:max_terms]]
+    return " ".join(term.capitalize() for term in top)
 
 
 def _stable_community_id(member_node_ids: Iterable[str]) -> str:
@@ -346,9 +422,9 @@ def detect_communities(
         contribution = _community_modularity_contribution(
             nx_graph, member_set, total_weight, resolution,
         )
-        top_titles = [
-            title_lookup.get(nid, nid) for nid in ordered_members[:5]
-        ]
+        member_titles = [title_lookup.get(nid, nid) for nid in ordered_members]
+        top_titles = member_titles[:5]
+        label = derive_community_label(member_titles)
         community = Community(
             community_id=cid,
             size=len(ordered_members),
@@ -357,6 +433,7 @@ def detect_communities(
             cohesion=cohesion,
             modularity_contribution=contribution,
             top_titles=top_titles,
+            label=label,
         )
         communities.append(community)
         for nid in ordered_members:

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/export_html.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/export_html.py
@@ -1,0 +1,775 @@
+"""GraphIndex HTML export — interactive, self-contained knowledge-graph map.
+
+Emits two sibling artefacts from an assembled :class:`rustworkx.PyDiGraph`:
+
+* ``graph.json`` — the serialized graph (nodes, edges, communities) for
+  programmatic reuse, mirroring Graphify's ``graph.json`` artefact.
+* ``graph.html`` — a fully offline, clickable force-directed visualization.
+  Every node is a concept, its colour is the detected community, and its size
+  scales with centrality so "god nodes" (the most-connected concepts) stand
+  out. Clicking a node opens a detail panel; the legend toggles communities;
+  a search box filters nodes by title.
+
+Design goals mirror the rest of GraphIndex:
+
+* **Deterministic** — no LLM calls; community colours come from a fixed
+  palette keyed by display order, so the same graph renders identically.
+* **Local-first** — the ECharts runtime is inlined from the vendored asset
+  shipped by ``ai-parrot-visualizations`` (``parrot.outputs.formats.assets``),
+  so the produced page works with no network access ("nothing leaves your
+  machine"). A CDN ``<script>`` fallback is emitted only when the asset cannot
+  be located, accompanied by a logged warning.
+
+The public surface is intentionally decoupled from the analytics/communities
+models: :func:`build_export_payload` accepts plain dicts/lists so it can be
+unit-tested without those modules, while :func:`export_graph` adapts a
+``CommunitiesResult`` / ``AnalyticsResult`` into that payload and writes both
+files in one call (used by the builder and the agent toolkit).
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import logging
+from importlib.resources import files as _resource_files
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:  # pragma: no cover - typing only, avoids heavy imports
+    import rustworkx
+
+logger = logging.getLogger(__name__)
+
+JSON_FILENAME = "graph.json"
+HTML_FILENAME = "graph.html"
+
+#: Default CDN used only when the vendored ECharts asset cannot be located.
+ECHARTS_CDN_URL = "https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"
+
+#: Deterministic, colour-blind-friendly palette for community categories.
+#: Colours are assigned by community display order (largest first), so a
+#: given partition always renders with the same colours.
+_PALETTE: tuple[str, ...] = (
+    "#4e79a7", "#f28e2b", "#59a14f", "#e15759", "#76b7b2",
+    "#edc948", "#b07aa1", "#ff9da7", "#9c755f", "#bab0ac",
+    "#86bcb6", "#d37295", "#a0cbe8", "#ffbe7d", "#8cd17d",
+    "#b6992d", "#499894", "#fabfd2", "#79706e", "#d4a6c8",
+)
+
+#: Colour used for nodes that belong to no detected community.
+_UNCLUSTERED_COLOR = "#c8c8c8"
+_UNCLUSTERED_LABEL = "Unclustered"
+
+# Node-size scaling (pixels). God nodes are pushed toward the maximum.
+_MIN_SYMBOL_SIZE = 8.0
+_MAX_SYMBOL_SIZE = 46.0
+_GOD_SYMBOL_BOOST = 10.0
+
+
+def community_color(index: int) -> str:
+    """Return the deterministic colour for a community display index.
+
+    Args:
+        index: Zero-based position of the community in display order.
+
+    Returns:
+        A hex colour string. Indices beyond the palette wrap around.
+    """
+    return _PALETTE[index % len(_PALETTE)]
+
+
+class GraphExportNode(BaseModel):
+    """A single node in the export payload / ECharts ``graph`` series.
+
+    Field names ``id``/``name``/``category``/``symbolSize``/``value`` match the
+    ECharts graph-series schema so the payload can be handed to ECharts with no
+    remapping. The remaining fields feed the click-through detail panel.
+
+    Args:
+        id: The graph ``node_id``.
+        name: Human-readable title shown as the node label.
+        kind: :class:`NodeKind` value (e.g. ``"symbol"``, ``"concept"``).
+        category: Index into the payload's ``categories`` list (community).
+        symbolSize: Rendered node diameter in pixels (centrality-scaled).
+        value: Ranking score (centrality when available, else degree).
+        community_id: Stable id of the owning community, if any.
+        community_label: Human-readable community label, if any.
+        source_uri: Source artefact URI for the detail panel.
+        summary: Optional short summary for the detail panel.
+        provenance: How the node was created (``extracted``/``inferred``/...).
+        degree: Total (in + out) degree in the graph.
+        is_god: True when the node ranks among the top god nodes.
+    """
+
+    id: str
+    name: str
+    kind: str
+    category: int
+    symbolSize: float
+    value: float = 0.0
+    community_id: Optional[str] = None
+    community_label: Optional[str] = None
+    source_uri: str = ""
+    summary: Optional[str] = None
+    provenance: str = "extracted"
+    degree: int = 0
+    is_god: bool = False
+
+
+class GraphExportEdge(BaseModel):
+    """A single directed edge in the export payload / ECharts ``links``.
+
+    Args:
+        source: Tail ``node_id``.
+        target: Head ``node_id``.
+        kind: :class:`EdgeKind` value (e.g. ``"references"``).
+        provenance: How the edge was created.
+        confidence: Cosine similarity for inferred edges, else ``None``.
+    """
+
+    source: str
+    target: str
+    kind: str = "references"
+    provenance: str = "extracted"
+    confidence: Optional[float] = None
+
+
+class GraphExportCategory(BaseModel):
+    """A community category (an ECharts legend entry + colour).
+
+    Args:
+        index: Display index (also the value stored on member nodes).
+        community_id: Stable community id, or ``None`` for the unclustered bin.
+        label: Human-readable legend label.
+        color: Hex colour shared by the legend swatch and member nodes.
+        size: Number of member nodes.
+    """
+
+    index: int
+    community_id: Optional[str]
+    label: str
+    color: str
+    size: int
+
+
+class GraphExportPayload(BaseModel):
+    """The complete, serializable graph export.
+
+    Serialized verbatim to ``graph.json`` and embedded into ``graph.html``.
+
+    Args:
+        title: Human-readable graph title shown in the page header.
+        nodes: All exported nodes.
+        edges: All exported edges.
+        categories: Community categories in display order.
+        god_node_ids: Ids of the highlighted god nodes (most connected).
+        modularity: Global modularity Q of the partition, if known.
+        meta: Free-form metadata (counts, generator, etc.).
+    """
+
+    title: str = "GraphIndex Knowledge Map"
+    nodes: list[GraphExportNode] = Field(default_factory=list)
+    edges: list[GraphExportEdge] = Field(default_factory=list)
+    categories: list[GraphExportCategory] = Field(default_factory=list)
+    god_node_ids: list[str] = Field(default_factory=list)
+    modularity: Optional[float] = None
+    meta: dict[str, Any] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Payload construction (pure — no analytics/communities imports required)
+# ---------------------------------------------------------------------------
+
+
+def _scale_symbol_size(value: float, max_value: float, is_god: bool) -> float:
+    """Map a ranking score to a node diameter in pixels.
+
+    Args:
+        value: The node's ranking score (centrality or degree).
+        max_value: The largest score across all nodes (for normalisation).
+        is_god: Whether the node is a god node (gets a size boost).
+
+    Returns:
+        A diameter in ``[_MIN_SYMBOL_SIZE, _MAX_SYMBOL_SIZE]``.
+    """
+    if max_value <= 0.0:
+        base = _MIN_SYMBOL_SIZE
+    else:
+        frac = max(0.0, min(1.0, value / max_value))
+        base = _MIN_SYMBOL_SIZE + frac * (_MAX_SYMBOL_SIZE - _MIN_SYMBOL_SIZE)
+    if is_god:
+        base = min(_MAX_SYMBOL_SIZE, base + _GOD_SYMBOL_BOOST)
+    return round(base, 2)
+
+
+def build_export_payload(
+    graph: "rustworkx.PyDiGraph",
+    *,
+    node_to_community: Optional[dict[str, str]] = None,
+    community_order: Optional[list[str]] = None,
+    community_labels: Optional[dict[str, str]] = None,
+    community_sizes: Optional[dict[str, int]] = None,
+    god_scores: Optional[dict[str, float]] = None,
+    god_node_ids: Optional[list[str]] = None,
+    title: str = "GraphIndex Knowledge Map",
+    modularity: Optional[float] = None,
+) -> GraphExportPayload:
+    """Build a :class:`GraphExportPayload` from an assembled graph.
+
+    Pure and deterministic: it reads only the node/edge payload dicts stored on
+    the ``rustworkx.PyDiGraph`` plus the plain community/god-node lookups, so it
+    needs neither the analytics nor the communities modules. :func:`export_graph`
+    supplies these lookups from the richer result objects.
+
+    Args:
+        graph: The assembled ``rustworkx.PyDiGraph``. Node payloads must be
+            dicts carrying at least ``node_id``, ``kind`` and ``title``; edge
+            payloads carry ``source_id``/``target_id``/``kind``.
+        node_to_community: Map ``node_id`` → ``community_id``. Nodes absent from
+            this map are placed in the ``Unclustered`` category.
+        community_order: Community ids in display order (largest first). Defines
+            the colour assignment. Ids missing here are appended in first-seen
+            order.
+        community_labels: Map ``community_id`` → human-readable label.
+        community_sizes: Map ``community_id`` → member count (for the legend).
+        god_scores: Map ``node_id`` → centrality score used for node sizing.
+        god_node_ids: Ids to flag as god nodes (highlighted + size boost).
+        title: Graph title for the page header.
+        modularity: Global modularity Q, recorded in metadata.
+
+    Returns:
+        A fully populated :class:`GraphExportPayload`.
+    """
+    node_to_community = node_to_community or {}
+    community_labels = community_labels or {}
+    community_sizes = community_sizes or {}
+    god_scores = god_scores or {}
+    god_ids = set(god_node_ids or [])
+
+    # --- Establish the community display order → category index mapping. ---
+    ordered_cids: list[str] = list(community_order or [])
+    seen_cids = set(ordered_cids)
+    for cid in node_to_community.values():
+        if cid not in seen_cids:
+            ordered_cids.append(cid)
+            seen_cids.add(cid)
+    cid_to_index: dict[str, int] = {cid: i for i, cid in enumerate(ordered_cids)}
+
+    # --- Degree lookup (in + out) keyed by node_id. ---
+    degree_by_id: dict[str, int] = {}
+    for idx in graph.node_indices():
+        payload = graph[idx]
+        if not isinstance(payload, dict):
+            continue
+        nid = payload.get("node_id")
+        if not nid:
+            continue
+        degree_by_id[nid] = graph.in_degree(idx) + graph.out_degree(idx)
+
+    # --- Build nodes. ---
+    export_nodes: list[GraphExportNode] = []
+    used_cids: set[str] = set()
+    max_score = max(god_scores.values(), default=0.0)
+    max_degree = float(max(degree_by_id.values(), default=0))
+
+    for idx in graph.node_indices():
+        payload = graph[idx]
+        if not isinstance(payload, dict):
+            continue
+        nid = payload.get("node_id")
+        if not nid:
+            continue
+        cid = node_to_community.get(nid)
+        if cid is not None and cid in cid_to_index:
+            category = cid_to_index[cid]
+            used_cids.add(cid)
+            clabel = community_labels.get(cid)
+        else:
+            cid = None
+            category = len(ordered_cids)  # the unclustered bin
+            clabel = None
+        is_god = nid in god_ids
+        # Prefer centrality for sizing; fall back to normalised degree.
+        if god_scores:
+            score = god_scores.get(nid, 0.0)
+            symbol_size = _scale_symbol_size(score, max_score, is_god)
+            value = score
+        else:
+            deg = float(degree_by_id.get(nid, 0))
+            symbol_size = _scale_symbol_size(deg, max_degree, is_god)
+            value = deg
+        export_nodes.append(
+            GraphExportNode(
+                id=nid,
+                name=payload.get("title", nid),
+                kind=str(payload.get("kind", "")),
+                category=category,
+                symbolSize=symbol_size,
+                value=round(float(value), 6),
+                community_id=cid,
+                community_label=clabel,
+                source_uri=payload.get("source_uri", "") or "",
+                summary=payload.get("summary"),
+                provenance=str(payload.get("provenance", "extracted")),
+                degree=degree_by_id.get(nid, 0),
+                is_god=is_god,
+            )
+        )
+
+    # --- Build categories in display order, then the unclustered bin. ---
+    categories: list[GraphExportCategory] = []
+    for i, cid in enumerate(ordered_cids):
+        categories.append(
+            GraphExportCategory(
+                index=i,
+                community_id=cid,
+                label=community_labels.get(cid) or f"Community {i + 1}",
+                color=community_color(i),
+                size=community_sizes.get(
+                    cid, sum(1 for n in export_nodes if n.community_id == cid)
+                ),
+            )
+        )
+    unclustered_size = sum(1 for n in export_nodes if n.community_id is None)
+    if unclustered_size:
+        categories.append(
+            GraphExportCategory(
+                index=len(ordered_cids),
+                community_id=None,
+                label=_UNCLUSTERED_LABEL,
+                color=_UNCLUSTERED_COLOR,
+                size=unclustered_size,
+            )
+        )
+
+    # --- Build edges. ---
+    export_edges: list[GraphExportEdge] = []
+    for _src, _tgt, epayload in graph.weighted_edge_list():
+        if not isinstance(epayload, dict):
+            continue
+        source = epayload.get("source_id")
+        target = epayload.get("target_id")
+        if not source or not target:
+            continue
+        export_edges.append(
+            GraphExportEdge(
+                source=source,
+                target=target,
+                kind=str(epayload.get("kind", "references")),
+                provenance=str(epayload.get("provenance", "extracted")),
+                confidence=epayload.get("confidence"),
+            )
+        )
+
+    return GraphExportPayload(
+        title=title,
+        nodes=export_nodes,
+        edges=export_edges,
+        categories=categories,
+        god_node_ids=[n.id for n in export_nodes if n.is_god],
+        modularity=modularity,
+        meta={
+            "node_count": len(export_nodes),
+            "edge_count": len(export_edges),
+            "community_count": len(ordered_cids),
+            "generated_by": "parrot.knowledge.graphindex.export_html",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Writers
+# ---------------------------------------------------------------------------
+
+
+def write_graph_json(payload: GraphExportPayload, output_dir: Path) -> Path:
+    """Write ``graph.json`` to ``output_dir``.
+
+    Args:
+        payload: The export payload.
+        output_dir: Destination directory (created if missing).
+
+    Returns:
+        The path to the written ``graph.json``.
+    """
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / JSON_FILENAME
+    path.write_text(
+        json.dumps(payload.model_dump(mode="json"), indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    logger.info("Wrote %s (%d nodes, %d edges)", path, len(payload.nodes), len(payload.edges))
+    return path
+
+
+def _locate_echarts_asset() -> Optional[str]:
+    """Return the inline JS of the vendored ECharts asset, if available.
+
+    Looks up ``echarts.min.js`` shipped by ``ai-parrot-visualizations`` under
+    the ``parrot.outputs.formats.assets`` namespace package.
+
+    Returns:
+        The JavaScript source as a string, or ``None`` when not found.
+    """
+    try:
+        resource = _resource_files("parrot.outputs.formats.assets") / "echarts.min.js"
+        if resource.is_file():
+            return resource.read_text(encoding="utf-8")
+    except (ModuleNotFoundError, FileNotFoundError, OSError) as exc:
+        logger.debug("Vendored ECharts asset not available: %s", exc)
+    return None
+
+
+def _render_html(payload: GraphExportPayload, echarts_script_tag: str) -> str:
+    """Render the full ``graph.html`` document.
+
+    Args:
+        payload: The export payload to embed.
+        echarts_script_tag: A complete ``<script>...</script>`` tag providing
+            the ECharts runtime (inline asset or CDN reference).
+
+    Returns:
+        The complete HTML document as a string.
+    """
+    payload_json = json.dumps(payload.model_dump(mode="json"), ensure_ascii=False)
+    safe_title = html.escape(payload.title)
+    node_count = len(payload.nodes)
+    edge_count = len(payload.edges)
+    community_count = sum(1 for c in payload.categories if c.community_id is not None)
+    god_count = len(payload.god_node_ids)
+    modularity = "n/a" if payload.modularity is None else f"{payload.modularity:.4f}"
+
+    return _HTML_TEMPLATE.format(
+        title=safe_title,
+        echarts_script_tag=echarts_script_tag,
+        payload_json=payload_json,
+        node_count=node_count,
+        edge_count=edge_count,
+        community_count=community_count,
+        god_count=god_count,
+        modularity=modularity,
+    )
+
+
+def write_graph_html(
+    payload: GraphExportPayload,
+    output_dir: Path,
+    *,
+    echarts_js: Optional[str] = None,
+    allow_cdn_fallback: bool = True,
+) -> Path:
+    """Write a self-contained ``graph.html`` to ``output_dir``.
+
+    Args:
+        payload: The export payload.
+        output_dir: Destination directory (created if missing).
+        echarts_js: Explicit ECharts runtime JavaScript to inline. When
+            ``None``, the vendored asset is located automatically.
+        allow_cdn_fallback: When the asset cannot be located and this is True,
+            reference the ECharts CDN and log a warning (the page then needs
+            network access). When False, raise instead.
+
+    Returns:
+        The path to the written ``graph.html``.
+
+    Raises:
+        RuntimeError: When no ECharts runtime is available and CDN fallback is
+            disabled.
+    """
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    js = echarts_js if echarts_js is not None else _locate_echarts_asset()
+    if js is not None:
+        # Inline the runtime so the page is fully offline.
+        script_tag = f"<script>{js}</script>"
+    elif allow_cdn_fallback:
+        logger.warning(
+            "Vendored ECharts asset not found; falling back to CDN %s. "
+            "The generated graph.html will require network access. Install "
+            "ai-parrot-visualizations for a fully offline export.",
+            ECHARTS_CDN_URL,
+        )
+        script_tag = f'<script src="{ECHARTS_CDN_URL}"></script>'
+    else:
+        raise RuntimeError(
+            "ECharts runtime unavailable and CDN fallback disabled; "
+            "pass echarts_js= or install ai-parrot-visualizations."
+        )
+
+    path = output_dir / HTML_FILENAME
+    path.write_text(_render_html(payload, script_tag), encoding="utf-8")
+    logger.info("Wrote interactive graph to %s", path)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# High-level convenience (adapts CommunitiesResult / AnalyticsResult)
+# ---------------------------------------------------------------------------
+
+
+def export_graph(
+    graph: "rustworkx.PyDiGraph",
+    output_dir: Path,
+    *,
+    communities: Optional[Any] = None,
+    analytics: Optional[Any] = None,
+    god_top_k: int = 15,
+    title: str = "GraphIndex Knowledge Map",
+    echarts_js: Optional[str] = None,
+    allow_cdn_fallback: bool = True,
+) -> tuple[Path, Path]:
+    """Build the payload and write both ``graph.json`` and ``graph.html``.
+
+    Adapts a ``CommunitiesResult`` and an ``AnalyticsResult`` into the plain
+    lookups :func:`build_export_payload` consumes, then writes both artefacts.
+
+    Args:
+        graph: The assembled ``rustworkx.PyDiGraph``.
+        output_dir: Destination directory.
+        communities: Optional ``CommunitiesResult`` for node colouring/labels.
+        analytics: Optional ``AnalyticsResult`` whose ``god_nodes`` drive node
+            sizing and highlighting.
+        god_top_k: Number of top god nodes to highlight.
+        title: Graph title for the page header.
+        echarts_js: Explicit ECharts runtime to inline (else auto-located).
+        allow_cdn_fallback: See :func:`write_graph_html`.
+
+    Returns:
+        ``(html_path, json_path)``.
+    """
+    node_to_community: dict[str, str] = {}
+    community_order: list[str] = []
+    community_labels: dict[str, str] = {}
+    community_sizes: dict[str, int] = {}
+    modularity: Optional[float] = None
+
+    if communities is not None:
+        node_to_community = dict(getattr(communities, "node_to_community", {}) or {})
+        modularity = getattr(communities, "modularity", None)
+        for community in getattr(communities, "communities", []) or []:
+            cid = community.community_id
+            community_order.append(cid)
+            community_sizes[cid] = community.size
+            label = getattr(community, "label", "") or ""
+            if not label:
+                top = getattr(community, "top_titles", None) or []
+                label = top[0] if top else cid[:8]
+            community_labels[cid] = label
+
+    god_scores: dict[str, float] = {}
+    god_node_ids: list[str] = []
+    if analytics is not None:
+        for entry in (getattr(analytics, "god_nodes", None) or [])[:god_top_k]:
+            nid = entry.get("node_id")
+            if not nid:
+                continue
+            # Prefer betweenness, then eigenvector, then any 'centrality_score'.
+            score = (
+                entry.get("betweenness")
+                or entry.get("eigenvector")
+                or entry.get("centrality_score")
+                or 0.0
+            )
+            god_scores[nid] = float(score)
+            god_node_ids.append(nid)
+
+    payload = build_export_payload(
+        graph,
+        node_to_community=node_to_community,
+        community_order=community_order,
+        community_labels=community_labels,
+        community_sizes=community_sizes,
+        god_scores=god_scores,
+        god_node_ids=god_node_ids,
+        title=title,
+        modularity=modularity,
+    )
+
+    json_path = write_graph_json(payload, output_dir)
+    html_path = write_graph_html(
+        payload,
+        output_dir,
+        echarts_js=echarts_js,
+        allow_cdn_fallback=allow_cdn_fallback,
+    )
+    return html_path, json_path
+
+
+# ---------------------------------------------------------------------------
+# HTML template (single-file, offline, theme-aware)
+# ---------------------------------------------------------------------------
+
+_HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>{title}</title>
+<style>
+  :root {{ color-scheme: light dark; }}
+  * {{ box-sizing: border-box; }}
+  body {{
+    margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, Helvetica, Arial, sans-serif; background: #f7f8fa; color: #1f2328;
+  }}
+  header {{
+    padding: 12px 18px; background: #22272e; color: #f0f3f6;
+    display: flex; flex-wrap: wrap; align-items: baseline; gap: 16px;
+  }}
+  header h1 {{ font-size: 16px; margin: 0; font-weight: 600; }}
+  header .stats {{ font-size: 12px; opacity: 0.85; display: flex; gap: 14px; flex-wrap: wrap; }}
+  header .stats b {{ color: #7ee3c1; font-weight: 600; }}
+  #wrap {{ display: flex; height: calc(100vh - 49px); }}
+  #chart {{ flex: 1 1 auto; min-width: 0; }}
+  #side {{
+    width: 320px; flex: 0 0 320px; border-left: 1px solid #d0d7de;
+    background: #ffffff; overflow-y: auto; padding: 14px;
+  }}
+  #search {{
+    width: 100%; padding: 8px 10px; border: 1px solid #d0d7de; border-radius: 6px;
+    font-size: 13px; margin-bottom: 10px;
+  }}
+  .panel-title {{ font-size: 12px; text-transform: uppercase; letter-spacing: .04em;
+    color: #656d76; margin: 10px 0 6px; }}
+  #detail {{ font-size: 13px; line-height: 1.5; }}
+  #detail .empty {{ color: #8b949e; }}
+  #detail .k {{ color: #656d76; }}
+  #detail .badge {{ display: inline-block; padding: 1px 7px; border-radius: 10px;
+    font-size: 11px; color: #fff; margin-left: 4px; }}
+  #detail pre {{ white-space: pre-wrap; word-break: break-word; background: #f6f8fa;
+    padding: 8px; border-radius: 6px; font-size: 12px; }}
+  #results {{ list-style: none; padding: 0; margin: 0; max-height: 40vh; overflow-y: auto; }}
+  #results li {{ padding: 6px 8px; border-radius: 5px; cursor: pointer; font-size: 13px;
+    display: flex; align-items: center; gap: 7px; }}
+  #results li:hover {{ background: #f0f3f6; }}
+  #results .dot {{ width: 9px; height: 9px; border-radius: 50%; flex: 0 0 9px; }}
+  #results .gd {{ font-size: 10px; color: #e15759; font-weight: 700; }}
+  @media (prefers-color-scheme: dark) {{
+    body {{ background: #0d1117; color: #e6edf3; }}
+    #side {{ background: #161b22; border-color: #30363d; }}
+    #search {{ background: #0d1117; color: #e6edf3; border-color: #30363d; }}
+    #detail pre {{ background: #0d1117; }}
+    #results li:hover {{ background: #21262d; }}
+  }}
+</style>
+{echarts_script_tag}
+</head>
+<body>
+<header>
+  <h1>{title}</h1>
+  <div class="stats">
+    <span><b>{node_count}</b> nodes</span>
+    <span><b>{edge_count}</b> edges</span>
+    <span><b>{community_count}</b> communities</span>
+    <span><b>{god_count}</b> god nodes</span>
+    <span>modularity <b>{modularity}</b></span>
+  </div>
+</header>
+<div id="wrap">
+  <div id="chart"></div>
+  <aside id="side">
+    <input id="search" type="search" placeholder="Search concepts…" autocomplete="off"/>
+    <div class="panel-title">Selection</div>
+    <div id="detail"><span class="empty">Click a node to inspect it.</span></div>
+    <div class="panel-title">Matches</div>
+    <ul id="results"></ul>
+  </aside>
+</div>
+<script>
+const GRAPH = {payload_json};
+const catColor = i => (GRAPH.categories[i] && GRAPH.categories[i].color) || "#888";
+const nodeById = {{}};
+GRAPH.nodes.forEach(n => {{ nodeById[n.id] = n; }});
+
+const chart = echarts.init(document.getElementById("chart"), null, {{ renderer: "canvas" }});
+const option = {{
+  tooltip: {{
+    confine: true,
+    formatter: p => p.dataType === "node"
+      ? `<b>${{p.data.name}}</b><br/>${{p.data.kind}}` +
+        (p.data.community_label ? `<br/><span style="opacity:.7">${{p.data.community_label}}</span>` : "")
+      : `${{p.data.kind || "edge"}}`
+  }},
+  legend: [{{
+    type: "scroll", top: 6, left: 6, right: 6,
+    data: GRAPH.categories.map(c => c.label),
+    textStyle: {{ color: getComputedStyle(document.body).color }}
+  }}],
+  series: [{{
+    type: "graph", layout: "force", roam: true, draggable: true,
+    focusNodeAdjacency: true,
+    label: {{ show: GRAPH.nodes.length <= 250, position: "right", fontSize: 11,
+      color: getComputedStyle(document.body).color, formatter: "{{b}}" }},
+    labelLayout: {{ hideOverlap: true }},
+    force: {{ repulsion: 140, edgeLength: [50, 190], gravity: 0.06, friction: 0.16 }},
+    lineStyle: {{ color: "source", opacity: 0.45, curveness: 0.08, width: 1 }},
+    emphasis: {{ focus: "adjacency", lineStyle: {{ width: 2.5, opacity: 0.9 }} }},
+    categories: GRAPH.categories.map(c => ({{ name: c.label, itemStyle: {{ color: c.color }} }})),
+    data: GRAPH.nodes.map(n => ({{
+      id: n.id, name: n.name, category: n.category, value: n.value,
+      symbolSize: n.symbolSize,
+      itemStyle: {{ borderColor: n.is_god ? "#e15759" : "rgba(0,0,0,0.25)",
+        borderWidth: n.is_god ? 2.5 : 0.6 }}
+    }})),
+    links: GRAPH.edges.map(e => ({{
+      source: e.source, target: e.target,
+      lineStyle: e.provenance === "inferred" ? {{ type: "dashed" }} : {{}}
+    }}))
+  }}]
+}};
+chart.setOption(option);
+window.addEventListener("resize", () => chart.resize());
+
+const detail = document.getElementById("detail");
+function showDetail(n) {{
+  const cat = GRAPH.categories[n.category];
+  const color = cat ? cat.color : "#888";
+  detail.innerHTML =
+    `<div style="font-weight:600;font-size:14px">${{esc(n.name)}}` +
+      (n.is_god ? `<span class="badge" style="background:#e15759">GOD</span>` : "") + `</div>` +
+    `<div><span class="badge" style="background:${{color}}">${{esc(cat ? cat.label : "—")}}</span> ` +
+      `<span class="badge" style="background:#57606a">${{esc(n.kind)}}</span></div>` +
+    `<div style="margin-top:6px"><span class="k">provenance:</span> ${{esc(n.provenance)}} ` +
+      `&middot; <span class="k">degree:</span> ${{n.degree}}</div>` +
+    (n.source_uri ? `<div><span class="k">source:</span> ${{esc(n.source_uri)}}</div>` : "") +
+    (n.summary ? `<pre>${{esc(n.summary)}}</pre>` : "");
+}}
+function esc(s) {{
+  return String(s == null ? "" : s).replace(/[&<>"]/g, c =>
+    ({{ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }}[c]));
+}}
+chart.on("click", p => {{ if (p.dataType === "node" && nodeById[p.data.id]) showDetail(nodeById[p.data.id]); }});
+
+const results = document.getElementById("results");
+const search = document.getElementById("search");
+function renderResults(q) {{
+  q = q.trim().toLowerCase();
+  results.innerHTML = "";
+  if (!q) return;
+  const hits = GRAPH.nodes
+    .filter(n => n.name.toLowerCase().includes(q))
+    .sort((a, b) => b.value - a.value).slice(0, 40);
+  hits.forEach(n => {{
+    const li = document.createElement("li");
+    const dot = `<span class="dot" style="background:${{catColor(n.category)}}"></span>`;
+    li.innerHTML = dot + `<span>${{esc(n.name)}}</span>` + (n.is_god ? ` <span class="gd">god</span>` : "");
+    li.onclick = () => {{
+      showDetail(n);
+      chart.dispatchAction({{ type: "focusNodeAdjacency", seriesIndex: 0, dataIndex: idxOf(n.id) }});
+      chart.dispatchAction({{ type: "highlight", seriesIndex: 0, dataIndex: idxOf(n.id) }});
+    }};
+    results.appendChild(li);
+  }});
+}}
+const idOrder = GRAPH.nodes.map(n => n.id);
+function idxOf(id) {{ return idOrder.indexOf(id); }}
+search.addEventListener("input", e => renderResults(e.target.value));
+</script>
+</body>
+</html>
+"""

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/export_html.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/export_html.py
@@ -435,7 +435,22 @@ def _render_html(payload: GraphExportPayload, echarts_script_tag: str) -> str:
     Returns:
         The complete HTML document as a string.
     """
-    payload_json = json.dumps(payload.model_dump(mode="json"), ensure_ascii=False)
+    # Embed the payload inside an inline <script>. Node summaries can contain
+    # arbitrary source text — including the literal "</script>" (any web or
+    # template repo) — which would otherwise close the script tag early and
+    # dump the rest of the page as raw text. "<", ">" and "&" only ever occur
+    # inside JSON *string* values (JSON structure never uses them), so escaping
+    # them to \uXXXX yields equivalent JSON that JSON.parse restores exactly.
+    # U+2028/U+2029 are valid JSON but break JS string parsing when embedded
+    # raw (ensure_ascii=False leaves them literal), so escape them too.
+    payload_json = (
+        json.dumps(payload.model_dump(mode="json"), ensure_ascii=False)
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+        .replace(" ", "\\u2028")
+        .replace(" ", "\\u2029")
+    )
     safe_title = html.escape(payload.title)
     node_count = len(payload.nodes)
     edge_count = len(payload.edges)

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/extractors/code.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/extractors/code.py
@@ -29,6 +29,10 @@ logger = logging.getLogger(__name__)
 _DEFAULT_TAGS: set[str] = {"NOTE", "WHY", "HACK", "TODO", "FIXME", "XXX"}
 # Regex for tagged comments: # TAG: text  or  # TAG text
 _TAG_RE = re.compile(r"#\s*({tags}):?\s*(.*)", re.IGNORECASE)
+# Design-reference citations in comments/docstrings, e.g. "ADR-12",
+# "RFC 4180", "ADR/007". Captured as first-class Rationale nodes and linked
+# to the code that cites them.
+_CITATION_RE = re.compile(r"\b(ADR|RFC)[\s\-/]?(\d{1,5})\b", re.IGNORECASE)
 
 
 def _make_node_id(source_uri: str, symbol: str) -> str:
@@ -167,6 +171,13 @@ class CodeExtractor:
         )
         nodes.extend(rationale_nodes)
         edges.extend(rationale_edges)
+
+        # Extract ADR/RFC design-reference citations as first-class nodes.
+        citation_nodes, citation_edges = self._extract_citations(
+            root, file_path, source_bytes, nodes
+        )
+        nodes.extend(citation_nodes)
+        edges.extend(citation_edges)
 
         return nodes, edges
 
@@ -549,3 +560,108 @@ class CodeExtractor:
             if n.kind == NodeKind.SYMBOL and n.domain_tags.get("symbol_type") == "module":
                 return n.node_id
         return None
+
+    def _extract_citations(
+        self,
+        root,
+        file_path: str,
+        source_bytes: bytes,
+        existing_nodes: list[UniversalNode],
+    ) -> tuple[list[UniversalNode], list[UniversalEdge]]:
+        """Extract ADR/RFC design-reference citations as first-class nodes.
+
+        Scans both comments (linked to the nearest enclosing symbol) and
+        symbol docstrings (linked to their owning symbol) for references such
+        as ``ADR-12`` or ``RFC 4180``. Identical citations within a file
+        collapse into a single ``Rationale`` node (``domain_tags['tag'] ==
+        "CITATION"``); each citing symbol gets a ``REFERENCES`` edge to it.
+
+        Args:
+            root: AST root node.
+            file_path: Source URI.
+            source_bytes: Raw source bytes.
+            existing_nodes: Already-created nodes (symbols + rationale) used
+                for symbol lookup and docstring scanning.
+
+        Returns:
+            Tuple of ``(citation_nodes, reference_edges)``.
+        """
+        citation_nodes: list[UniversalNode] = []
+        citation_edges: list[UniversalEdge] = []
+        seen_nodes: dict[str, str] = {}          # normalized ref -> node_id
+        seen_edges: set[tuple[str, str]] = set()  # (symbol_id, normalized ref)
+
+        def _register(raw_kind: str, number: str, link_target: Optional[str]) -> None:
+            norm = f"{raw_kind.upper()}-{int(number)}"
+            cid = seen_nodes.get(norm)
+            if cid is None:
+                cid = _make_node_id(file_path, f"__citation__{norm}")
+                citation_nodes.append(
+                    UniversalNode(
+                        node_id=cid,
+                        kind=NodeKind.RATIONALE,
+                        title=norm,
+                        source_uri=file_path,
+                        summary=f"Design reference {norm} cited in {Path(file_path).name}",
+                        domain_tags={
+                            "tag": "CITATION",
+                            "citation_kind": raw_kind.upper(),
+                            "citation_ref": norm,
+                        },
+                    )
+                )
+                seen_nodes[norm] = cid
+            if link_target and (link_target, norm) not in seen_edges:
+                citation_edges.append(
+                    UniversalEdge(
+                        source_id=link_target,
+                        target_id=cid,
+                        kind=EdgeKind.REFERENCES,
+                    )
+                )
+                seen_edges.add((link_target, norm))
+
+        # 1) Citations inside comments — link to the nearest enclosing symbol.
+        self._walk_for_citations(
+            root, file_path, source_bytes, existing_nodes, _register
+        )
+        # 2) Citations inside docstrings captured as symbol summaries.
+        for node in existing_nodes:
+            if node.kind == NodeKind.SYMBOL and node.summary:
+                for match in _CITATION_RE.finditer(node.summary):
+                    _register(match.group(1), match.group(2), node.node_id)
+
+        return citation_nodes, citation_edges
+
+    def _walk_for_citations(
+        self,
+        node,
+        file_path: str,
+        source_bytes: bytes,
+        existing_nodes: list[UniversalNode],
+        register,
+    ) -> None:
+        """Recursively walk the AST, registering ADR/RFC refs in comments.
+
+        Args:
+            node: Current AST node.
+            file_path: Source URI.
+            source_bytes: Raw source bytes.
+            existing_nodes: Already-created nodes for nearest-symbol lookup.
+            register: Callback ``(kind, number, link_target)`` from
+                :meth:`_extract_citations`.
+        """
+        if node.type == "comment":
+            text = _get_node_text(node, source_bytes)
+            matches = list(_CITATION_RE.finditer(text))
+            if matches:
+                target = self._find_nearest_symbol(
+                    node, file_path, source_bytes, existing_nodes
+                )
+                for match in matches:
+                    register(match.group(1), match.group(2), target)
+
+        for child in node.children:
+            self._walk_for_citations(
+                child, file_path, source_bytes, existing_nodes, register
+            )

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/schema.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/schema.py
@@ -197,6 +197,11 @@ class BuildResult(BaseModel):
         projection_report: Summary of the OKF projection stage (FEAT-239).
             ``None`` when the builder has no ``output_dir`` or projection
             was skipped.
+        graph_html_path: Path to the interactive ``graph.html`` map, if the
+            HTML export stage ran. ``None`` when export was disabled or no
+            ``output_dir`` was configured.
+        graph_json_path: Path to the serialized ``graph.json`` written
+            alongside ``graph.html``. ``None`` when export was skipped.
     """
 
     model_config = {"arbitrary_types_allowed": True}
@@ -211,6 +216,8 @@ class BuildResult(BaseModel):
         default=None,
         description="OKF projection summary; None when projection was skipped.",
     )
+    graph_html_path: Optional[Path] = None
+    graph_json_path: Optional[Path] = None
 
 
 class IngestResult(BaseModel):

--- a/packages/ai-parrot/tests/knowledge/graphindex/test_cli.py
+++ b/packages/ai-parrot/tests/knowledge/graphindex/test_cli.py
@@ -1,0 +1,125 @@
+"""Tests for the GraphIndex CLI (parrot-graphindex).
+
+Exercises repository discovery and the local, LLM-free build → the produced
+``graph.html`` / ``graph.json`` / ``GRAPH_REPORT.md`` artefacts.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from parrot.knowledge.graphindex import cli
+
+
+SAMPLE_A = '''\
+# WHY: central hub per ADR-1
+class Engine:
+    """Core engine. See RFC-2119."""
+
+    def start(self):
+        return Wheel()
+
+
+class Wheel:
+    """A wheel."""
+    pass
+'''
+
+SAMPLE_B = '''\
+from a import Engine
+
+
+def drive():
+    """Drive the engine."""
+    return Engine().start()
+'''
+
+
+@pytest.fixture
+def sample_repo(tmp_path: Path) -> Path:
+    (tmp_path / "a.py").write_text(SAMPLE_A)
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "b.py").write_text(SAMPLE_B)
+    # Noise that must be skipped.
+    (tmp_path / ".venv").mkdir()
+    (tmp_path / ".venv" / "junk.py").write_text("x = 1\n")
+    (tmp_path / "__pycache__").mkdir()
+    (tmp_path / "__pycache__" / "cached.py").write_text("y = 2\n")
+    return tmp_path
+
+
+class TestDiscovery:
+    def test_skips_noise_directories(self, sample_repo):
+        found = cli.discover_python_files(sample_repo)
+        names = {p.name for p in found}
+        assert names == {"a.py", "b.py"}
+        assert not any(".venv" in p.parts for p in found)
+
+    def test_single_file(self, sample_repo):
+        found = cli.discover_python_files(sample_repo / "a.py")
+        assert [p.name for p in found] == ["a.py"]
+
+    def test_deterministic_order(self, sample_repo):
+        assert cli.discover_python_files(sample_repo) == cli.discover_python_files(
+            sample_repo
+        )
+
+
+class TestBuildCodeGraph:
+    @pytest.mark.asyncio
+    async def test_writes_all_artifacts(self, sample_repo, tmp_path):
+        out = tmp_path / "graphindex"
+        summary = await cli.build_code_graph([sample_repo], out)
+        assert (out / "graph.html").exists()
+        assert (out / "graph.json").exists()
+        assert (out / "GRAPH_REPORT.md").exists()
+        assert summary["files_indexed"] == 2
+        assert summary["node_count"] > 0
+
+    @pytest.mark.asyncio
+    async def test_graph_html_is_offline(self, sample_repo, tmp_path):
+        out = tmp_path / "gi"
+        await cli.build_code_graph([sample_repo], out)
+        html = (out / "graph.html").read_text()
+        assert "echarts.init" in html
+        assert "cdn.jsdelivr.net" not in html  # vendored asset inlined
+
+    @pytest.mark.asyncio
+    async def test_communities_toggle(self, sample_repo, tmp_path):
+        with_comms = await cli.build_code_graph([sample_repo], tmp_path / "c1")
+        without = await cli.build_code_graph(
+            [sample_repo], tmp_path / "c2", detect_comms=False
+        )
+        assert with_comms["community_count"] >= 0
+        assert without["community_count"] == 0
+        assert without["modularity"] is None
+
+    @pytest.mark.asyncio
+    async def test_adr_rfc_citations_present(self, sample_repo, tmp_path):
+        out = tmp_path / "gi"
+        await cli.build_code_graph([sample_repo], out)
+        data = json.loads((out / "graph.json").read_text())
+        titles = {n["name"] for n in data["nodes"]}
+        assert {"ADR-1", "RFC-2119"} <= titles
+
+
+class TestMain:
+    def test_main_end_to_end(self, sample_repo, tmp_path, capsys):
+        out = tmp_path / "out"
+        rc = cli.main([str(sample_repo), "-o", str(out)])
+        assert rc == 0
+        assert (out / "graph.html").exists()
+        captured = capsys.readouterr().out
+        assert "GraphIndex built" in captured
+        assert "Artifacts:" in captured
+
+    def test_main_missing_path(self, tmp_path):
+        rc = cli.main([str(tmp_path / "nope")])
+        assert rc == 2
+
+    def test_main_empty_repo(self, tmp_path, capsys):
+        rc = cli.main([str(tmp_path), "-o", str(tmp_path / "out")])
+        assert rc == 1
+        assert "No Python files" in capsys.readouterr().err

--- a/packages/ai-parrot/tests/knowledge/graphindex/test_export_html.py
+++ b/packages/ai-parrot/tests/knowledge/graphindex/test_export_html.py
@@ -1,0 +1,232 @@
+"""Tests for parrot.knowledge.graphindex.export_html.
+
+Covers the interactive HTML / JSON graph exporter: payload construction,
+deterministic community colouring, god-node sizing/highlighting, the
+unclustered bin, offline asset inlining, and the CDN fallback.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from parrot.knowledge.graphindex.analytics import compute_analytics
+from parrot.knowledge.graphindex.assemble import GraphAssembler
+from parrot.knowledge.graphindex.communities import detect_communities
+from parrot.knowledge.graphindex import export_html as EH
+from parrot.knowledge.graphindex.export_html import (
+    GraphExportPayload,
+    build_export_payload,
+    community_color,
+    export_graph,
+    write_graph_html,
+    write_graph_json,
+)
+from parrot.knowledge.graphindex.schema import (
+    EdgeKind,
+    NodeKind,
+    UniversalEdge,
+    UniversalNode,
+)
+
+FAKE_ECHARTS = "/*FAKE_ECHARTS*/window.echarts={init:function(){}};"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _two_cluster_graph() -> tuple[GraphAssembler, list[UniversalNode], list[UniversalEdge]]:
+    """Two 4-node rings joined by a single bridge edge (n3 → n4)."""
+    nodes: list[UniversalNode] = [
+        UniversalNode(
+            node_id=f"n{i}",
+            kind=NodeKind.SYMBOL,
+            title=f"Payment {i}" if i < 4 else f"Shipping {i}",
+            source_uri=f"file{i}.py",
+            summary=f"summary for node {i}",
+        )
+        for i in range(8)
+    ]
+    ring = [(0, 1), (1, 2), (2, 3), (3, 0), (4, 5), (5, 6), (6, 7), (7, 4), (3, 4)]
+    edges = [
+        UniversalEdge(source_id=f"n{a}", target_id=f"n{b}", kind=EdgeKind.REFERENCES)
+        for a, b in ring
+    ]
+    asm = GraphAssembler(tenant_id="t")
+    asm.add_nodes(nodes)
+    asm.add_edges(edges)
+    return asm, nodes, edges
+
+
+@pytest.fixture
+def graph_bundle():
+    asm, nodes, edges = _two_cluster_graph()
+    communities = detect_communities(asm.graph, nodes, write_back_to_nodes=False)
+    analytics = compute_analytics(asm.graph, nodes, edges)
+    return asm, nodes, edges, communities, analytics
+
+
+# ---------------------------------------------------------------------------
+# community_color
+# ---------------------------------------------------------------------------
+
+
+class TestCommunityColor:
+    def test_deterministic(self):
+        assert community_color(0) == community_color(0)
+        assert community_color(0) != community_color(1)
+
+    def test_wraps_around_palette(self):
+        assert community_color(0) == community_color(len(EH._PALETTE))
+
+    def test_all_hex(self):
+        for i in range(len(EH._PALETTE)):
+            assert community_color(i).startswith("#") and len(community_color(i)) == 7
+
+
+# ---------------------------------------------------------------------------
+# build_export_payload
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPayload:
+    def test_counts_match_graph(self, graph_bundle):
+        asm, nodes, edges, comm, ana = graph_bundle
+        p = build_export_payload(
+            asm.graph,
+            node_to_community=comm.node_to_community,
+            community_order=[c.community_id for c in comm.communities],
+        )
+        assert isinstance(p, GraphExportPayload)
+        assert len(p.nodes) == asm.graph.num_nodes() == 8
+        assert len(p.edges) == asm.graph.num_edges() == 9
+
+    def test_categories_have_deterministic_colors(self, graph_bundle):
+        asm, nodes, edges, comm, ana = graph_bundle
+        order = [c.community_id for c in comm.communities]
+        p = build_export_payload(
+            asm.graph, node_to_community=comm.node_to_community, community_order=order
+        )
+        colors = [c.color for c in p.categories if c.community_id is not None]
+        assert colors == [community_color(i) for i in range(len(order))]
+
+    def test_every_node_has_valid_category_index(self, graph_bundle):
+        asm, nodes, edges, comm, ana = graph_bundle
+        order = [c.community_id for c in comm.communities]
+        p = build_export_payload(
+            asm.graph, node_to_community=comm.node_to_community, community_order=order
+        )
+        for n in p.nodes:
+            assert 0 <= n.category < len(p.categories)
+
+    def test_unclustered_bin_created_for_orphans(self):
+        # A lone node with no community assignment lands in the unclustered bin.
+        node = UniversalNode(
+            node_id="solo", kind=NodeKind.CONCEPT, title="Solo", source_uri="x"
+        )
+        asm = GraphAssembler(tenant_id="t")
+        asm.add_nodes([node])
+        p = build_export_payload(asm.graph)  # no communities supplied
+        assert len(p.categories) == 1
+        assert p.categories[0].community_id is None
+        assert p.categories[0].label == EH._UNCLUSTERED_LABEL
+        assert p.nodes[0].community_id is None
+
+    def test_god_nodes_flagged_and_sized_larger(self, graph_bundle):
+        asm, nodes, edges, comm, ana = graph_bundle
+        # n3 and n4 are the bridge endpoints — highest betweenness.
+        god_scores = {"n3": 0.9, "n4": 0.8}
+        p = build_export_payload(
+            asm.graph,
+            node_to_community=comm.node_to_community,
+            god_scores=god_scores,
+            god_node_ids=["n3", "n4"],
+        )
+        by_id = {n.id: n for n in p.nodes}
+        assert by_id["n3"].is_god and by_id["n4"].is_god
+        assert set(p.god_node_ids) == {"n3", "n4"}
+        # A god node is drawn larger than a zero-score non-god node.
+        assert by_id["n3"].symbolSize > by_id["n0"].symbolSize
+
+    def test_falls_back_to_degree_when_no_god_scores(self, graph_bundle):
+        asm, nodes, edges, comm, ana = graph_bundle
+        p = build_export_payload(asm.graph, node_to_community=comm.node_to_community)
+        # Sizing uses degree; every node keeps a positive size.
+        assert all(n.symbolSize >= EH._MIN_SYMBOL_SIZE for n in p.nodes)
+
+
+# ---------------------------------------------------------------------------
+# Writers
+# ---------------------------------------------------------------------------
+
+
+class TestWriters:
+    def test_write_graph_json_roundtrips(self, graph_bundle, tmp_path):
+        asm, nodes, edges, comm, ana = graph_bundle
+        p = build_export_payload(asm.graph, node_to_community=comm.node_to_community)
+        path = write_graph_json(p, tmp_path)
+        assert path.name == "graph.json"
+        data = json.loads(path.read_text())
+        assert len(data["nodes"]) == 8
+        assert len(data["edges"]) == 9
+        assert "categories" in data and "god_node_ids" in data
+
+    def test_write_graph_html_inlines_offline_asset(self, graph_bundle, tmp_path):
+        asm, nodes, edges, comm, ana = graph_bundle
+        p = build_export_payload(asm.graph, node_to_community=comm.node_to_community)
+        path = write_graph_html(p, tmp_path, echarts_js=FAKE_ECHARTS)
+        html = path.read_text()
+        assert path.name == "graph.html"
+        assert "/*FAKE_ECHARTS*/" in html          # runtime inlined
+        assert "cdn.jsdelivr.net" not in html       # no network dependency
+        assert '"nodes"' in html                    # payload embedded
+        assert "echarts.init" in html               # chart bootstrapped
+
+    def test_write_graph_html_cdn_fallback(self, graph_bundle, tmp_path, monkeypatch):
+        asm, nodes, edges, comm, ana = graph_bundle
+        p = build_export_payload(asm.graph)
+        monkeypatch.setattr(EH, "_locate_echarts_asset", lambda: None)
+        path = write_graph_html(p, tmp_path, allow_cdn_fallback=True)
+        assert EH.ECHARTS_CDN_URL in path.read_text()
+
+    def test_write_graph_html_raises_without_asset_when_fallback_disabled(
+        self, graph_bundle, tmp_path, monkeypatch
+    ):
+        asm, nodes, edges, comm, ana = graph_bundle
+        p = build_export_payload(asm.graph)
+        monkeypatch.setattr(EH, "_locate_echarts_asset", lambda: None)
+        with pytest.raises(RuntimeError):
+            write_graph_html(p, tmp_path, allow_cdn_fallback=False)
+
+
+# ---------------------------------------------------------------------------
+# export_graph (high-level convenience)
+# ---------------------------------------------------------------------------
+
+
+class TestExportGraph:
+    def test_writes_both_artifacts(self, graph_bundle, tmp_path):
+        asm, nodes, edges, comm, ana = graph_bundle
+        html_path, json_path = export_graph(
+            asm.graph,
+            tmp_path,
+            communities=comm,
+            analytics=ana,
+            echarts_js=FAKE_ECHARTS,
+        )
+        assert html_path.exists() and json_path.exists()
+        data = json.loads(json_path.read_text())
+        # Community labels flow from CommunitiesResult into the categories.
+        labels = {c["label"] for c in data["categories"] if c["community_id"]}
+        assert labels  # non-empty, LLM-free labels present
+        assert data["modularity"] == pytest.approx(comm.modularity)
+
+    def test_deterministic_across_runs(self, graph_bundle, tmp_path):
+        asm, nodes, edges, comm, ana = graph_bundle
+        _, j1 = export_graph(asm.graph, tmp_path / "a", communities=comm,
+                             analytics=ana, echarts_js=FAKE_ECHARTS)
+        _, j2 = export_graph(asm.graph, tmp_path / "b", communities=comm,
+                             analytics=ana, echarts_js=FAKE_ECHARTS)
+        assert j1.read_text() == j2.read_text()

--- a/packages/ai-parrot/tests/knowledge/graphindex/test_export_html.py
+++ b/packages/ai-parrot/tests/knowledge/graphindex/test_export_html.py
@@ -184,6 +184,42 @@ class TestWriters:
         assert '"nodes"' in html                    # payload embedded
         assert "echarts.init" in html               # chart bootstrapped
 
+    def test_write_graph_html_escapes_script_in_payload(self, tmp_path):
+        # A node summary containing "</script>" must NOT close the inline
+        # <script> early (regression: page rendered as raw text otherwise).
+        node = UniversalNode(
+            node_id="danger",
+            kind=NodeKind.SYMBOL,
+            title="Renderer",
+            source_uri="x.py",
+            summary="Builds a </script><h1>pwned</h1> tag & more",
+        )
+        asm = GraphAssembler(tenant_id="t")
+        asm.add_nodes([node])
+        p = build_export_payload(asm.graph)
+        html = write_graph_html(p, tmp_path, echarts_js=FAKE_ECHARTS).read_text()
+        # The raw breakout sequence must be gone; the payload occurrence is
+        # escaped to </script...
+        assert "</script><h1>" not in html
+        assert "\\u003c/script" in html
+        # Exactly two real closers: the echarts runtime and the main script.
+        assert html.count("</script>") == 2
+
+    def test_write_graph_html_escapes_line_separators(self, tmp_path):
+        node = UniversalNode(
+            node_id="ls",
+            kind=NodeKind.SYMBOL,
+            title="Sep",
+            source_uri="x.py",
+            summary="line1 line2 line3",
+        )
+        asm = GraphAssembler(tenant_id="t")
+        asm.add_nodes([node])
+        p = build_export_payload(asm.graph)
+        html = write_graph_html(p, tmp_path, echarts_js=FAKE_ECHARTS).read_text()
+        assert " " not in html and " " not in html
+        assert "\\u2028" in html and "\\u2029" in html
+
     def test_write_graph_html_cdn_fallback(self, graph_bundle, tmp_path, monkeypatch):
         asm, nodes, edges, comm, ana = graph_bundle
         p = build_export_payload(asm.graph)

--- a/packages/ai-parrot/tests/knowledge/graphindex/test_graphify_parity.py
+++ b/packages/ai-parrot/tests/knowledge/graphindex/test_graphify_parity.py
@@ -1,0 +1,154 @@
+"""Graphify-parity tests: LLM-free community labels + ADR/RFC citation nodes.
+
+These cover the two capabilities added to close the gap with Graphify:
+deterministic community labels (no LLM) and design-reference citations
+(``ADR-NNN`` / ``RFC-NNN``) promoted to first-class rationale nodes linked to
+the code that cites them.
+"""
+from __future__ import annotations
+
+import pytest
+
+from parrot.knowledge.graphindex.communities import (
+    derive_community_label,
+    detect_communities,
+)
+from parrot.knowledge.graphindex.assemble import GraphAssembler
+from parrot.knowledge.graphindex.extractors.code import CodeExtractor
+from parrot.knowledge.graphindex.schema import (
+    EdgeKind,
+    NodeKind,
+    UniversalEdge,
+    UniversalNode,
+)
+
+
+# ---------------------------------------------------------------------------
+# LLM-free community labels
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveCommunityLabel:
+    def test_ranks_by_frequency(self):
+        label = derive_community_label(
+            ["PaymentGateway", "payment_processor", "PaymentError", "refund_handler"]
+        )
+        # "payment" appears in 3 titles → leads the label.
+        assert label.lower().startswith("payment")
+
+    def test_handles_camel_and_snake_case(self):
+        label = derive_community_label(["OrderService", "order_repository"])
+        assert "Order" in label
+
+    def test_all_stopwords_yields_empty(self):
+        assert derive_community_label(["the", "get", "set", "data"]) == ""
+
+    def test_deterministic_tie_break(self):
+        # Two equally-frequent terms → alphabetical, stable across calls.
+        a = derive_community_label(["alpha beta", "beta alpha"])
+        b = derive_community_label(["beta alpha", "alpha beta"])
+        assert a == b
+
+    def test_respects_max_terms(self):
+        label = derive_community_label(
+            ["alpha bravo charlie delta echo"], max_terms=2
+        )
+        assert len(label.split()) <= 2
+
+
+class TestCommunitiesCarryLabels:
+    def test_detect_communities_populates_label(self):
+        # Two rings with descriptive titles → each community gets a label.
+        nodes = [
+            UniversalNode(
+                node_id=f"n{i}",
+                kind=NodeKind.SYMBOL,
+                title="PaymentGateway" if i < 4 else "ShippingTracker",
+                source_uri="m.py",
+            )
+            for i in range(8)
+        ]
+        ring = [(0, 1), (1, 2), (2, 3), (3, 0), (4, 5), (5, 6), (6, 7), (7, 4)]
+        edges = [
+            UniversalEdge(source_id=f"n{a}", target_id=f"n{b}", kind=EdgeKind.REFERENCES)
+            for a, b in ring
+        ]
+        asm = GraphAssembler(tenant_id="t")
+        asm.add_nodes(nodes)
+        asm.add_edges(edges)
+        result = detect_communities(asm.graph, nodes, write_back_to_nodes=False)
+        assert result.communities
+        assert all(isinstance(c.label, str) for c in result.communities)
+        assert any(c.label for c in result.communities)
+
+
+# ---------------------------------------------------------------------------
+# ADR/RFC citation nodes
+# ---------------------------------------------------------------------------
+
+_SRC = '''
+# WHY: chosen per ADR-42 and RFC 4180
+def parse_csv(path):
+    """Parse a CSV file.
+
+    See ADR/007 for rationale; also references ADR-42 again.
+    """
+    return path
+
+
+class Loader:
+    """Follows RFC-2119 keyword conventions."""
+    pass
+'''
+
+
+async def _extract(src: str):
+    return await CodeExtractor().extract("mod.py", src)
+
+
+class TestCitationExtraction:
+    @pytest.mark.asyncio
+    async def test_citations_become_rationale_nodes(self):
+        nodes, _edges = await _extract(_SRC)
+        cites = {
+            n.title for n in nodes if n.domain_tags.get("tag") == "CITATION"
+        }
+        assert cites == {"ADR-42", "ADR-7", "RFC-4180", "RFC-2119"}
+        assert all(
+            n.kind == NodeKind.RATIONALE
+            for n in nodes
+            if n.domain_tags.get("tag") == "CITATION"
+        )
+
+    @pytest.mark.asyncio
+    async def test_identical_citation_deduplicated(self):
+        nodes, _edges = await _extract(_SRC)
+        adr42 = [n for n in nodes if n.title == "ADR-42"]
+        assert len(adr42) == 1  # cited 3× → single node
+
+    @pytest.mark.asyncio
+    async def test_reference_edges_link_code_to_citations(self):
+        nodes, edges = await _extract(_SRC)
+        cite_ids = {
+            n.node_id for n in nodes if n.domain_tags.get("tag") == "CITATION"
+        }
+        ref_edges = [
+            e
+            for e in edges
+            if e.kind == EdgeKind.REFERENCES and e.target_id in cite_ids
+        ]
+        assert ref_edges  # code → citation links exist
+        # Edges point FROM a symbol TO the citation node.
+        symbol_ids = {n.node_id for n in nodes if n.kind == NodeKind.SYMBOL}
+        assert all(e.source_id in symbol_ids for e in ref_edges)
+
+    @pytest.mark.asyncio
+    async def test_no_citations_when_absent(self):
+        nodes, _edges = await _extract("def f():\n    return 1\n")
+        assert not [n for n in nodes if n.domain_tags.get("tag") == "CITATION"]
+
+    @pytest.mark.asyncio
+    async def test_adr_slash_form_normalized(self):
+        nodes, _edges = await _extract('# see ADR/007\ndef g():\n    return 2\n')
+        titles = {n.title for n in nodes if n.domain_tags.get("tag") == "CITATION"}
+        assert titles == {"ADR-7"}


### PR DESCRIPTION
## Summary

Adds a complete interactive knowledge-graph visualization and export system to GraphIndex, enabling users to build and explore code-derived knowledge graphs locally without LLM calls or network access. Includes a new `parrot-graphindex` CLI command for building graphs from Python repositories.

## Key Changes

### New Modules

- **`export_html.py`** — Interactive graph export system
  - `build_export_payload()`: Pure, deterministic payload construction from a `rustworkx.PyDiGraph` (no analytics/communities imports required for unit testing)
  - `write_graph_json()` / `write_graph_html()`: Writers for `graph.json` and self-contained `graph.html`
  - Deterministic community colouring via fixed palette keyed by display order
  - God-node detection and size scaling based on centrality
  - Vendored ECharts runtime inlined for offline use; CDN fallback with warning when asset unavailable
  - Full HTML template with force-directed visualization, legend, search, and click-through detail panels

- **`cli.py`** — GraphIndex command-line interface
  - `parrot-graphindex` entry point for building graphs from code repositories
  - `discover_python_files()`: Deterministic file discovery with `.graphindexignore` support and noise-directory skipping
  - `build_code_graph()`: Orchestrates extraction → assembly → community detection → analytics → export
  - LLM-free, local-first: tree-sitter parsing, rustworkx assembly, Louvain communities, in-process analytics

### Enhanced Modules

- **`communities.py`**
  - `derive_community_label()`: New LLM-free label derivation from member titles using frequency analysis and stopword filtering
  - `Community` model now carries a `label` field populated deterministically

- **`extractors/code.py`**
  - `_extract_citations()`: New method to extract ADR/RFC design-reference citations as first-class `Rationale` nodes
  - Citations (e.g., `ADR-12`, `RFC 4180`) are deduplicated per file and linked to citing symbols

- **`builder.py`**
  - `export_html_enabled` parameter to opt-in to HTML/JSON export after analytics

- **`__init__.py`**
  - Exports new public API: `export_graph`, `write_graph_html`, `write_graph_json`, `build_export_payload`, `community_color`, `derive_community_label`

- **`pyproject.toml`**
  - Added `parrot-graphindex` console script entry point

### Tests

- **`test_export_html.py`** — Comprehensive coverage of payload construction, deterministic colouring, god-node sizing, unclustered bins, asset inlining, and CDN fallback
- **`test_graphify_parity.py`** — LLM-free community labels and ADR/RFC citation extraction
- **`test_cli.py`** — Repository discovery, artifact generation, offline verification, and community detection toggle
- **`test_toolkit.py`** — Agent toolkit integration for `export_graph_html()`

## Notable Implementation Details

- **Deterministic & Offline**: No LLM calls, no network access required. Community colours come from a fixed palette keyed by display order; the same graph renders identically every time.
- **Decoupled Payload Construction**: `build_export_payload()` accepts plain dicts/lists so it can be unit-tested without importing analytics or communities modules.
- **God-Node Highlighting**: Nodes are sized by centrality (or degree as fallback); top nodes get a size boost and are flagged for visual emphasis.
- **Unclustered Bin**: Nodes without a detected community are placed in a dedicated grey category.
- **Vendored ECharts**: The visualization runtime is inlined from `ai-parrot-visualizations` assets; a CDN fallback is emitted only when the asset cannot be located, with a logged warning.
- **Design-Reference Citations**: ADR/RFC citations in code comments and docstrings are promoted to first-class rationale nodes, closing the gap with Graphify.

https://claude.ai/code/session_01UH72kVLJ6agwHEfNtqSkvU