### PR TITLE
feat: Add RSS Feed Reader Toolkit with article archival

### DIFF
--- a/packages/ai-parrot-tools/pyproject.toml
+++ b/packages/ai-parrot-tools/pyproject.toml
@@ -62,6 +62,8 @@ kubernetes = ["kubernetes-asyncio>=24.2", "pyyaml>=6.0"]
 sitesearch = ["beautifulsoup4>=4.12", "html2text>=2024.0", "markitdown>=0.1.2"]
 office365 = ["msgraph-sdk>=1.8", "azure-identity>=1.18", "microsoft-kiota-authentication-azure>=1.2"]
 scraping = ["selenium>=4.35", "undetected-chromedriver>=3.5", "webdriver-manager>=4.0", "playwright>=1.52", "rapidfuzz>=3.0"]
+# Selenium fallback for JS-heavy article pages reuses the `scraping` extra.
+rss = ["feedparser>=6.0.11", "trafilatura>=1.12"]
 finance = ["ta-lib>=0.4.32", "pandas-datareader>=0.10.0", "yfinance>=0.2.54", "alpaca-py>=0.43"]
 db = ["querysource>=4.1.11", "psycopg-binary>=3.2"]
 # 5.12.3 relaxes its requests pin (==2.32.4 -> >=2.33.0), compatible with
@@ -74,7 +76,7 @@ weather = ["pyowm>=3.3"]
 messaging = ["gmqtt>=0.6", "aioimaplib>=1.1"]
 security = []  # cloudsploit is a Docker/Node.js tool, not a PyPI package
 all = [
-    "ai-parrot-tools[jira,pdf,msword,slack,aws,docker,git,analysis,excel,sandbox,codeinterpreter,pulumi,kubernetes,sitesearch,office365,scraping,finance,db,flowtask,google,arxiv,wikipedia,weather,messaging,security]"
+    "ai-parrot-tools[jira,pdf,msword,slack,aws,docker,git,analysis,excel,sandbox,codeinterpreter,pulumi,kubernetes,sitesearch,office365,scraping,finance,db,flowtask,google,arxiv,wikipedia,weather,messaging,security,rss]"
 ]
 
 [project.urls]

--- a/packages/ai-parrot-tools/src/parrot_tools/__init__.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/__init__.py
@@ -63,6 +63,7 @@ TOOL_REGISTRY: dict[str, str] = {
     "kubernetes": "parrot_tools.kubernetes.toolkit.KubernetesToolkit",  # FEAT-214
     "sitesearch": "parrot_tools.sitesearch.toolkit.SiteSearchToolkit",
     "web_scraping": "parrot_tools.scraping.toolkit.WebScrapingToolkit",
+    "rss_feed_reader": "parrot_tools.rss.toolkit.RSSFeedReaderToolkit",
     "computer_interaction": "parrot_tools.computer.toolkit.ComputerInteractionToolkit",
     "cloudsploit": "parrot_tools.cloudsploit.toolkit.CloudSploitToolkit",
     "cloud_posture": "parrot_tools.security.cloud_posture_toolkit.CloudPostureToolkit",

--- a/packages/ai-parrot-tools/src/parrot_tools/rss/__init__.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/rss/__init__.py
@@ -1,0 +1,8 @@
+"""
+RSS Feed Reader Toolkit — archive RSS articles to disk, feed the LLM only
+metadata + file paths, and retrieve archived content on demand.
+"""
+from .models import FeedItemMetadata, FeedSite
+from .toolkit import RSSFeedReaderToolkit
+
+__all__ = ("RSSFeedReaderToolkit", "FeedSite", "FeedItemMetadata")

--- a/packages/ai-parrot-tools/src/parrot_tools/rss/fetcher.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/rss/fetcher.py
@@ -1,0 +1,311 @@
+"""
+Article and feed fetching for the RSS Feed Reader Toolkit.
+
+Strategy: fast aiohttp GET first; fall back to a shared headless Selenium
+driver (reusing ``parrot_tools.scraping.driver.SeleniumSetup``, available via
+the ``scraping`` extra) when the response fails or looks like a JS-rendered
+shell. Feed XML parsing (feedparser) and all Selenium calls are blocking and
+run off the event loop via ``asyncio.to_thread`` / ``run_in_executor``.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from functools import partial
+from typing import Any, Optional
+
+import aiohttp
+from bs4 import BeautifulSoup
+
+from .models import FetchedPage
+
+try:
+    import feedparser
+    HAS_FEEDPARSER = True
+except ImportError:
+    feedparser = None  # type: ignore[assignment]
+    HAS_FEEDPARSER = False
+
+try:
+    import trafilatura
+    HAS_TRAFILATURA = True
+except ImportError:
+    trafilatura = None  # type: ignore[assignment]
+    HAS_TRAFILATURA = False
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+)
+
+#: Empty SPA mount points — a strong signal the page is JS-rendered.
+_JS_SHELL_RE = re.compile(r'<div\s+id="(?:root|app|__next)"\s*>\s*</div>', re.IGNORECASE)
+
+#: Lowercase markers that, combined with thin content, suggest a JS or
+#: bot-challenge wall that a real browser can pass.
+_JS_MARKERS = (
+    "enable javascript",
+    "javascript is required",
+    "cf-browser-verification",
+    "checking your browser",
+    "just a moment...",
+)
+
+
+def extract_text(html: str) -> str:
+    """Extract the main readable text from an HTML page.
+
+    Uses trafilatura when installed; otherwise falls back to a BeautifulSoup
+    text dump with script/style/noscript removed.
+
+    Args:
+        html: Raw page HTML.
+
+    Returns:
+        Extracted text, or '' when nothing could be extracted.
+    """
+    if not html:
+        return ""
+    if HAS_TRAFILATURA:
+        try:
+            extracted = trafilatura.extract(
+                html, include_comments=False, include_tables=True
+            )
+            if extracted:
+                return extracted
+        except Exception as exc:  # noqa: BLE001 — extraction must never break a fetch
+            logger.debug("trafilatura extraction failed: %s", exc)
+    try:
+        soup = BeautifulSoup(html, "html.parser")
+        for tag in soup(["script", "style", "noscript"]):
+            tag.decompose()
+        return soup.get_text("\n", strip=True)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("BeautifulSoup extraction failed: %s", exc)
+        return ""
+
+
+class ArticleFetcher:
+    """Fetches feed XML and article pages with bounded concurrency.
+
+    Args:
+        session: Shared aiohttp client session.
+        http_semaphore: Bounds concurrent aiohttp requests (feeds + pages).
+        browser_semaphore: Bounds concurrent Selenium fetch slots.
+        min_text_length: Extracted-text length below which a page is
+            considered "thin" (fallback candidate).
+        request_timeout: Per-request timeout in seconds.
+        selenium_config: Extra kwargs forwarded to ``SeleniumSetup``
+            (e.g. ``{"browser": "chrome", "headless": True}``).
+        use_browser_fallback: Master switch for the Selenium fallback.
+    """
+
+    def __init__(
+        self,
+        session: aiohttp.ClientSession,
+        http_semaphore: asyncio.Semaphore,
+        browser_semaphore: asyncio.Semaphore,
+        min_text_length: int = 500,
+        request_timeout: int = 30,
+        selenium_config: Optional[dict] = None,
+        use_browser_fallback: bool = True,
+    ):
+        self.session = session
+        self.http_semaphore = http_semaphore
+        self.browser_semaphore = browser_semaphore
+        self.min_text_length = min_text_length
+        self.timeout = aiohttp.ClientTimeout(total=request_timeout)
+        self.selenium_config = selenium_config or {}
+        self.use_browser_fallback = use_browser_fallback
+        self.logger = logging.getLogger(__name__)
+        self._headers = {"User-Agent": DEFAULT_USER_AGENT}
+        self._driver: Any = None
+        self._driver_lock = asyncio.Lock()
+        self._selenium_unavailable = False
+
+    async def fetch_feed_xml(self, url: str) -> str:
+        """Download a feed's raw XML.
+
+        Args:
+            url: Feed URL.
+
+        Returns:
+            The response body.
+
+        Raises:
+            RuntimeError: On non-200 responses.
+            aiohttp.ClientError / asyncio.TimeoutError: On transport errors.
+        """
+        async with self.http_semaphore:
+            async with self.session.get(
+                url, headers=self._headers, timeout=self.timeout
+            ) as resp:
+                if resp.status != 200:
+                    raise RuntimeError(f"HTTP {resp.status} fetching feed {url}")
+                return await resp.text()
+
+    async def parse_feed(self, xml: str) -> Any:
+        """Parse feed XML with feedparser off the event loop.
+
+        Args:
+            xml: Raw feed XML.
+
+        Returns:
+            The ``feedparser.FeedParserDict``.
+
+        Raises:
+            RuntimeError: When feedparser is not installed.
+        """
+        if not HAS_FEEDPARSER:
+            raise RuntimeError(
+                "feedparser is not installed — install ai-parrot-tools[rss]"
+            )
+        return await asyncio.to_thread(feedparser.parse, xml)
+
+    async def fetch_page(self, url: str, use_browser: bool = False) -> FetchedPage:
+        """Fetch the complete content of an article page.
+
+        Args:
+            url: Article URL.
+            use_browser: Skip aiohttp and go straight to Selenium.
+
+        Returns:
+            A :class:`FetchedPage`; on total failure ``html`` is '' and
+            ``error`` explains why.
+        """
+        if use_browser:
+            return await self._fetch_with_selenium(url)
+
+        page = await self._fetch_with_aiohttp(url)
+        if self.use_browser_fallback and self._needs_fallback(page):
+            self.logger.debug(
+                "Falling back to browser for %s (error=%s thin=%s)",
+                url, page.error, page.thin,
+            )
+            browser_page = await self._fetch_with_selenium(url)
+            if browser_page.html:
+                return browser_page
+            # Selenium also failed — keep the best-effort aiohttp result
+            # but record why the fallback did not help.
+            page.error = (
+                f"{page.error or 'thin content'}; browser fallback failed: "
+                f"{browser_page.error}"
+            )
+        return page
+
+    async def _fetch_with_aiohttp(self, url: str) -> FetchedPage:
+        """GET a page with aiohttp and extract its text."""
+        try:
+            async with self.http_semaphore:
+                async with self.session.get(
+                    url, headers=self._headers, timeout=self.timeout
+                ) as resp:
+                    if resp.status != 200:
+                        return FetchedPage(
+                            method="aiohttp",
+                            status_code=resp.status,
+                            error=f"HTTP {resp.status}",
+                        )
+                    content_type = resp.headers.get("Content-Type", "")
+                    if content_type and "html" not in content_type.lower():
+                        return FetchedPage(
+                            method="aiohttp",
+                            status_code=resp.status,
+                            error=f"Non-HTML content-type: {content_type}",
+                        )
+                    html = await resp.text(errors="replace")
+        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            return FetchedPage(method="aiohttp", error=f"{type(exc).__name__}: {exc}")
+
+        text = extract_text(html)
+        return FetchedPage(
+            html=html,
+            text=text,
+            method="aiohttp",
+            status_code=200,
+            thin=len(text) < self.min_text_length,
+        )
+
+    def _needs_fallback(self, page: FetchedPage) -> bool:
+        """Decide whether an aiohttp result warrants a browser retry."""
+        if page.error:
+            return True
+        if _JS_SHELL_RE.search(page.html):
+            return True
+        if page.thin:
+            # Thin extraction usually means a JS-rendered or challenge page;
+            # markers make it certain, but thin alone still warrants a retry.
+            return True
+        lowered = page.html.lower()
+        return any(marker in lowered for marker in _JS_MARKERS)
+
+    async def _get_selenium_driver(self) -> Any:
+        """Lazily create the shared Selenium WebDriver.
+
+        Returns:
+            The WebDriver, or None when the scraping extra is not installed
+            or driver creation failed (logged once).
+        """
+        if self._driver is not None or self._selenium_unavailable:
+            return self._driver
+        try:
+            from parrot_tools.scraping.driver import SeleniumSetup
+        except ImportError:
+            self._selenium_unavailable = True
+            self.logger.warning(
+                "Selenium fallback disabled: install ai-parrot-tools[scraping]"
+            )
+            return None
+        config = {"browser": "chrome", "headless": True, **self.selenium_config}
+        try:
+            setup = SeleniumSetup(**config)
+            self._driver = await setup.get_driver()
+        except Exception as exc:  # noqa: BLE001 — driver setup failures must not crash reads
+            self._selenium_unavailable = True
+            self.logger.warning("Selenium driver creation failed: %s", exc)
+            return None
+        return self._driver
+
+    async def _fetch_with_selenium(self, url: str) -> FetchedPage:
+        """Render a page in the shared headless browser and return its HTML."""
+        async with self.browser_semaphore:
+            driver = await self._get_selenium_driver()
+            if driver is None:
+                return FetchedPage(method="selenium", error="selenium unavailable")
+
+            def _blocking_fetch() -> str:
+                driver.get(url)
+                return driver.page_source
+
+            loop = asyncio.get_running_loop()
+            # A single shared driver holds one page at a time — serialize.
+            async with self._driver_lock:
+                try:
+                    html = await loop.run_in_executor(None, _blocking_fetch)
+                except Exception as exc:  # noqa: BLE001 — selenium raises many types
+                    return FetchedPage(
+                        method="selenium", error=f"{type(exc).__name__}: {exc}"
+                    )
+
+        text = extract_text(html)
+        return FetchedPage(
+            html=html,
+            text=text,
+            method="selenium",
+            thin=len(text) < self.min_text_length,
+        )
+
+    async def close(self) -> None:
+        """Quit the shared Selenium driver, ignoring shutdown errors."""
+        if self._driver is None:
+            return
+        loop = asyncio.get_running_loop()
+        try:
+            await loop.run_in_executor(None, partial(self._driver.quit))
+        except Exception as exc:  # noqa: BLE001
+            self.logger.debug("Error quitting selenium driver: %s", exc)
+        finally:
+            self._driver = None

--- a/packages/ai-parrot-tools/src/parrot_tools/rss/models.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/rss/models.py
@@ -1,0 +1,190 @@
+"""
+Pydantic models and internal data structures for the RSS Feed Reader Toolkit.
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, Literal, Optional, Union
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, Field
+
+MAX_SLUG_LENGTH = 60
+SUMMARY_MAX_CHARS = 500
+
+_ITEM_ID_RE = re.compile(r"^[0-9a-f]{16}$")
+
+
+def make_item_id(link: str) -> str:
+    """Derive a stable item identifier from an article link.
+
+    Args:
+        link: Article URL as found in the feed entry.
+
+    Returns:
+        First 16 hex chars of the SHA-256 digest of the link.
+    """
+    return hashlib.sha256(link.encode("utf-8")).hexdigest()[:16]
+
+
+def is_item_id(value: str) -> bool:
+    """Check whether a string looks like an item id produced by :func:`make_item_id`.
+
+    Args:
+        value: Candidate string.
+
+    Returns:
+        True when the value is exactly 16 lowercase hex characters.
+    """
+    return bool(_ITEM_ID_RE.match(value))
+
+
+def _slugify(value: str) -> str:
+    """Turn an arbitrary string into a filesystem-safe slug.
+
+    Args:
+        value: Raw string (feed name or URL fragment).
+
+    Returns:
+        Lowercase slug with non-alphanumeric runs collapsed to ``-``,
+        capped at :data:`MAX_SLUG_LENGTH` characters.
+    """
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug[:MAX_SLUG_LENGTH] or "feed"
+
+
+class FeedSite(BaseModel):
+    """A configured RSS/Atom feed source.
+
+    Attributes:
+        url: Feed URL (RSS or Atom XML endpoint).
+        name: Optional human-friendly name; used to derive the storage slug.
+        max_items: Optional per-site cap on items processed per read.
+        use_browser: When True, article pages for this site are always
+            fetched with the Selenium browser instead of aiohttp.
+    """
+
+    url: str = Field(..., description="RSS/Atom feed URL")
+    name: Optional[str] = Field(default=None, description="Human-friendly feed name")
+    max_items: Optional[int] = Field(
+        default=None, ge=1, description="Per-site cap on items processed per read"
+    )
+    use_browser: bool = Field(
+        default=False,
+        description="Always fetch article pages with the browser (JS-heavy sites)",
+    )
+
+    @classmethod
+    def from_config(cls, item: Union[str, Dict[str, Any], "FeedSite"]) -> "FeedSite":
+        """Coerce a feed configuration entry into a :class:`FeedSite`.
+
+        Args:
+            item: A plain URL string, a dict of ``FeedSite`` fields, or an
+                already-built ``FeedSite``.
+
+        Returns:
+            A ``FeedSite`` instance.
+
+        Raises:
+            TypeError: If the entry is not a supported type.
+        """
+        if isinstance(item, FeedSite):
+            return item
+        if isinstance(item, str):
+            return cls(url=item)
+        if isinstance(item, dict):
+            return cls(**item)
+        raise TypeError(f"Unsupported feed config entry: {type(item)!r}")
+
+    @property
+    def slug(self) -> str:
+        """Filesystem-safe identifier for this feed (name or URL host+path)."""
+        if self.name:
+            return _slugify(self.name)
+        parsed = urlparse(self.url)
+        return _slugify(f"{parsed.netloc}{parsed.path}")
+
+
+class FeedItemMetadata(BaseModel):
+    """LLM-facing record for a retrieved feed item.
+
+    This is the ONLY thing returned to the LLM by ``read_feeds`` — it carries
+    metadata plus the paths of the archived content, never the content itself.
+
+    Attributes:
+        item_id: Stable id (sha256(link)[:16]) usable with ``get_content``.
+        feed: Slug of the feed the item came from.
+        feed_url: URL of the feed the item came from.
+        title: Item title.
+        link: Article URL.
+        published: Publication timestamp (ISO-8601) when available.
+        summary: Feed-provided summary, truncated to 500 chars.
+        author: Item author when available.
+        html_path: Absolute path of the saved raw HTML page.
+        text_path: Absolute path of the saved extracted text.
+        fetch_method: How the page was retrieved.
+        fetch_status: Outcome of the retrieval.
+        error: Error detail when the fetch failed or degraded.
+    """
+
+    item_id: str
+    feed: str
+    feed_url: str
+    title: str = ""
+    link: str = ""
+    published: Optional[str] = None
+    summary: Optional[str] = None
+    author: Optional[str] = None
+    html_path: Optional[str] = None
+    text_path: Optional[str] = None
+    fetch_method: Literal["aiohttp", "selenium", "none"] = "none"
+    fetch_status: Literal["fetched", "cached", "failed"] = "failed"
+    error: Optional[str] = None
+
+    def to_llm_dict(self) -> Dict[str, Any]:
+        """Serialize for the LLM, dropping empty fields to save tokens."""
+        return self.model_dump(exclude_none=True)
+
+
+@dataclass
+class FetchedPage:
+    """Internal result of a single article-page fetch attempt.
+
+    Attributes:
+        html: Raw page HTML ('' when nothing was retrieved).
+        text: Extracted main text ('' when extraction produced nothing).
+        method: Mechanism that produced the html.
+        status_code: HTTP status code (aiohttp path only).
+        error: Error message when the fetch failed or degraded.
+        thin: True when the extracted text is below the minimum length.
+    """
+
+    html: str = ""
+    text: str = ""
+    method: Literal["aiohttp", "selenium", "none"] = "none"
+    status_code: Optional[int] = None
+    error: Optional[str] = None
+    thin: bool = False
+
+
+class GetContentInput(BaseModel):
+    """Input schema for ``rss_get_content``."""
+
+    item: str = Field(
+        ...,
+        description=(
+            "Item to read: either the 16-char item_id returned by "
+            "rss_read_feeds, or a saved html_path/text_path"
+        ),
+    )
+    format: Literal["text", "html"] = Field(
+        default="text",
+        description="Which archived representation to return",
+    )
+    max_chars: int = Field(
+        default=20000,
+        ge=100,
+        description="Maximum number of characters to return",
+    )

--- a/packages/ai-parrot-tools/src/parrot_tools/rss/storage.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/rss/storage.py
@@ -1,0 +1,192 @@
+"""
+Disk storage for archived RSS articles.
+
+Layout::
+
+    {base_dir}/{feed_slug}/{item_id}/page.html     raw fetched HTML
+    {base_dir}/{feed_slug}/{item_id}/content.txt   extracted main text
+    {base_dir}/{feed_slug}/{item_id}/item.json     FeedItemMetadata dump
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+from .models import FeedItemMetadata, is_item_id
+
+HTML_FILENAME = "page.html"
+TEXT_FILENAME = "content.txt"
+META_FILENAME = "item.json"
+
+_FORMAT_FILES = {"html": HTML_FILENAME, "text": TEXT_FILENAME}
+
+
+class RSSStorage:
+    """Filesystem archive for fetched feed items.
+
+    All blocking I/O is dispatched through ``asyncio.to_thread`` in the
+    async methods; the sync helpers are cheap path/metadata operations.
+    """
+
+    def __init__(self, base_dir: Union[str, Path]):
+        """Initialize the storage root.
+
+        Args:
+            base_dir: Directory under which all feed content is archived.
+                Created if missing.
+        """
+        self.base_dir = Path(base_dir).resolve()
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.logger = logging.getLogger(__name__)
+
+    def item_dir(self, feed_slug: str, item_id: str) -> Path:
+        """Return the directory for a feed item (not created)."""
+        return self.base_dir / feed_slug / item_id
+
+    def has_item(self, feed_slug: str, item_id: str) -> bool:
+        """Check whether an item is already archived (dedup check)."""
+        return (self.item_dir(feed_slug, item_id) / META_FILENAME).exists()
+
+    async def save_item(
+        self, meta: FeedItemMetadata, html: str, text: str
+    ) -> FeedItemMetadata:
+        """Persist an item's content and metadata to disk.
+
+        Sets ``html_path``/``text_path`` on the metadata (when the
+        corresponding content is non-empty) before writing ``item.json``.
+
+        Args:
+            meta: Item metadata to persist.
+            html: Raw page HTML.
+            text: Extracted main text.
+
+        Returns:
+            The updated metadata (paths filled in).
+        """
+        target = self.item_dir(meta.feed, meta.item_id)
+
+        def _write() -> None:
+            target.mkdir(parents=True, exist_ok=True)
+            if html:
+                html_file = target / HTML_FILENAME
+                html_file.write_text(html, encoding="utf-8")
+                meta.html_path = str(html_file)
+            if text:
+                text_file = target / TEXT_FILENAME
+                text_file.write_text(text, encoding="utf-8")
+                meta.text_path = str(text_file)
+            meta_file = target / META_FILENAME
+            meta_file.write_text(
+                json.dumps(meta.model_dump(), ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+
+        await asyncio.to_thread(_write)
+        return meta
+
+    def load_metadata(self, feed_slug: str, item_id: str) -> Optional[FeedItemMetadata]:
+        """Load archived metadata for an item, or None when absent/corrupt."""
+        meta_file = self.item_dir(feed_slug, item_id) / META_FILENAME
+        if not meta_file.exists():
+            return None
+        try:
+            return FeedItemMetadata(**json.loads(meta_file.read_text(encoding="utf-8")))
+        except (json.JSONDecodeError, ValueError, OSError) as exc:
+            self.logger.warning("Corrupt item metadata at %s: %s", meta_file, exc)
+            return None
+
+    def find_item(self, item_id: str) -> Optional[Path]:
+        """Locate an item directory by id across all feeds.
+
+        Args:
+            item_id: 16-hex item identifier.
+
+        Returns:
+            The item directory, or None when not archived.
+        """
+        for meta_file in self.base_dir.glob(f"*/{item_id}/{META_FILENAME}"):
+            return meta_file.parent
+        return None
+
+    def list_saved(
+        self, feed_slug: Optional[str] = None, limit: int = 50
+    ) -> List[Dict[str, Any]]:
+        """List archived item metadata, newest first.
+
+        Args:
+            feed_slug: Restrict to a single feed when provided.
+            limit: Maximum number of records returned.
+
+        Returns:
+            Metadata dicts (``FeedItemMetadata`` shape) sorted by
+            archive-file mtime, descending.
+        """
+        pattern = f"{feed_slug}/*/{META_FILENAME}" if feed_slug else f"*/*/{META_FILENAME}"
+        meta_files = sorted(
+            self.base_dir.glob(pattern),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        results: List[Dict[str, Any]] = []
+        for meta_file in meta_files[:limit]:
+            meta = self.load_metadata(meta_file.parent.parent.name, meta_file.parent.name)
+            if meta is not None:
+                results.append(meta.to_llm_dict())
+        return results
+
+    def resolve_content_path(self, ref: str, fmt: str = "text") -> Path:
+        """Resolve an item reference to a readable content file.
+
+        Args:
+            ref: A 16-hex ``item_id``, an item directory path, or a direct
+                path to an archived file.
+            fmt: ``"text"`` or ``"html"`` — which representation to read
+                when the ref is an item id or directory.
+
+        Returns:
+            Path to the content file, guaranteed to live under ``base_dir``.
+
+        Raises:
+            ValueError: On unknown format, unknown item id, missing file, or
+                any path escaping the storage root (traversal/symlink guard).
+        """
+        if fmt not in _FORMAT_FILES:
+            raise ValueError(f"Unknown format {fmt!r}; expected 'text' or 'html'")
+
+        if is_item_id(ref):
+            item_dir = self.find_item(ref)
+            if item_dir is None:
+                raise ValueError(f"No archived item with id {ref!r}")
+            path = item_dir / _FORMAT_FILES[fmt]
+        else:
+            path = Path(ref)
+            if not path.is_absolute():
+                path = self.base_dir / path
+            if path.is_dir():
+                path = path / _FORMAT_FILES[fmt]
+
+        resolved = path.resolve()
+        if not resolved.is_relative_to(self.base_dir):
+            raise ValueError(f"Refusing to read outside the RSS storage dir: {ref!r}")
+        if not resolved.is_file():
+            raise ValueError(f"No archived content at {ref!r} (format={fmt})")
+        return resolved
+
+    async def read_content(self, ref: str, fmt: str = "text") -> str:
+        """Read archived content for an item reference.
+
+        Args:
+            ref: Item id or path (see :meth:`resolve_content_path`).
+            fmt: ``"text"`` or ``"html"``.
+
+        Returns:
+            The file content.
+
+        Raises:
+            ValueError: Propagated from :meth:`resolve_content_path`.
+        """
+        path = self.resolve_content_path(ref, fmt)
+        return await asyncio.to_thread(path.read_text, encoding="utf-8")

--- a/packages/ai-parrot-tools/src/parrot_tools/rss/toolkit.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/rss/toolkit.py
@@ -1,0 +1,312 @@
+"""
+RSS Feed Reader Toolkit.
+
+Reads a configurable list of RSS/Atom feeds, fetches the COMPLETE page
+content of every linked article (aiohttp first, Selenium fallback for
+JS-heavy pages — the fallback needs the ``scraping`` extra), and archives
+raw HTML + extracted text on disk. The LLM only receives per-item metadata
+dictionaries carrying the paths of the archived files, never the page
+content itself; ``rss_get_content`` reads archived content on demand.
+
+Feed parsing requires the ``rss`` extra: ``pip install ai-parrot-tools[rss]``.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+import aiohttp
+
+from parrot.conf import OUTPUT_DIR
+from parrot.tools.decorators import tool_schema
+from parrot.tools.toolkit import AbstractToolkit
+
+from .fetcher import HAS_FEEDPARSER, ArticleFetcher, extract_text
+from .models import FeedItemMetadata, FeedSite, GetContentInput, SUMMARY_MAX_CHARS, make_item_id
+from .storage import RSSStorage
+
+FeedConfig = Union[str, Dict[str, Any], FeedSite]
+
+
+class RSSFeedReaderToolkit(AbstractToolkit):
+    """Toolkit that archives RSS feed articles to disk for later retrieval.
+
+    Args:
+        feeds: Feed list — plain URLs, dicts of :class:`FeedSite` fields
+            (``url``, ``name``, ``max_items``, ``use_browser``), or
+            ``FeedSite`` instances.
+        storage_dir: Archive root. Defaults to ``OUTPUT_DIR/rss_feeds``.
+        max_items_per_feed: Default cap on items processed per feed.
+        concurrency: Max concurrent aiohttp requests across all feeds.
+        browser_concurrency: Max concurrent Selenium fallback slots.
+        min_text_length: Extracted-text length under which a page is
+            considered JS-rendered and retried in the browser.
+        request_timeout: Per-request timeout in seconds.
+        use_browser_fallback: Disable to never launch a browser.
+        browser: Selenium browser type for the fallback.
+        headless: Run the fallback browser headless.
+    """
+
+    tool_prefix = "rss"
+
+    def __init__(
+        self,
+        feeds: Optional[Sequence[FeedConfig]] = None,
+        storage_dir: Optional[Union[str, Path]] = None,
+        max_items_per_feed: int = 10,
+        concurrency: int = 10,
+        browser_concurrency: int = 2,
+        min_text_length: int = 500,
+        request_timeout: int = 30,
+        use_browser_fallback: bool = True,
+        browser: str = "chrome",
+        headless: bool = True,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.feeds: List[FeedSite] = [
+            FeedSite.from_config(item) for item in (feeds or [])
+        ]
+        self.storage = RSSStorage(storage_dir or Path(OUTPUT_DIR) / "rss_feeds")
+        self.max_items_per_feed = max_items_per_feed
+        self.concurrency = concurrency
+        self.browser_concurrency = browser_concurrency
+        self.min_text_length = min_text_length
+        self.request_timeout = request_timeout
+        self.use_browser_fallback = use_browser_fallback
+        self.selenium_config = {"browser": browser, "headless": headless}
+        self._session: Optional[aiohttp.ClientSession] = None
+        self._fetcher: Optional[ArticleFetcher] = None
+
+    async def start(self) -> None:
+        """Create the HTTP session, semaphores, and article fetcher."""
+        if self._fetcher is not None:
+            return
+        if not HAS_FEEDPARSER:
+            raise RuntimeError(
+                "feedparser is not installed — install ai-parrot-tools[rss]"
+            )
+        self._session = aiohttp.ClientSession()
+        self._fetcher = ArticleFetcher(
+            session=self._session,
+            http_semaphore=asyncio.Semaphore(self.concurrency),
+            browser_semaphore=asyncio.Semaphore(self.browser_concurrency),
+            min_text_length=self.min_text_length,
+            request_timeout=self.request_timeout,
+            selenium_config=self.selenium_config,
+            use_browser_fallback=self.use_browser_fallback,
+        )
+
+    async def stop(self) -> None:
+        """Close the fetcher (Selenium driver) and the HTTP session."""
+        if self._fetcher is not None:
+            await self._fetcher.close()
+            self._fetcher = None
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+
+    async def _ensure_started(self) -> ArticleFetcher:
+        """Lazily start the toolkit — agents don't always call ``start()``."""
+        if self._fetcher is None:
+            await self.start()
+        return self._fetcher  # type: ignore[return-value]
+
+    # ------------------------------------------------------------------
+    # Tools
+    # ------------------------------------------------------------------
+
+    async def read_feeds(
+        self,
+        feed_urls: Optional[List[str]] = None,
+        max_items: Optional[int] = None,
+        force_refresh: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Fetch RSS feeds and archive the full content of every linked article.
+
+        Reads the configured feeds (plus any ad-hoc feed_urls) concurrently,
+        downloads the complete page of each item, and saves raw HTML and
+        extracted text to disk. Returns one metadata dictionary per item
+        (title, link, published, summary, item_id, html_path, text_path,
+        fetch_status) — never the article content itself. Use rss_get_content
+        with an item_id to read an article's content.
+
+        Args:
+            feed_urls: Optional additional feed URLs to read alongside the
+                configured feeds.
+            max_items: Cap on items processed per feed for this call.
+            force_refresh: Re-download items that are already archived.
+
+        Returns:
+            A list of item metadata dictionaries.
+        """
+        fetcher = await self._ensure_started()
+        sites = self.feeds + [FeedSite(url=u) for u in (feed_urls or [])]
+        if not sites:
+            return [{"error": "No feeds configured and no feed_urls provided."}]
+        results = await asyncio.gather(
+            *(
+                self._process_feed(fetcher, site, max_items, force_refresh)
+                for site in sites
+            )
+        )
+        return [meta.to_llm_dict() for feed_metas in results for meta in feed_metas]
+
+    @tool_schema(GetContentInput)
+    async def get_content(
+        self, item: str, format: str = "text", max_chars: int = 20000
+    ) -> Dict[str, Any]:
+        """Retrieve the archived content of a previously fetched article.
+
+        Args:
+            item: The 16-char item_id returned by rss_read_feeds, or a saved
+                html_path/text_path.
+            format: 'text' for the extracted article text, 'html' for the
+                raw page HTML.
+            max_chars: Maximum number of characters to return.
+
+        Returns:
+            A dict with keys item, format, content, and truncated — or an
+            error dict when the item is unknown or the path is invalid.
+        """
+        try:
+            content = await self.storage.read_content(item, format)
+        except ValueError as exc:
+            return {"error": str(exc)}
+        truncated = len(content) > max_chars
+        return {
+            "item": item,
+            "format": format,
+            "content": content[:max_chars],
+            "truncated": truncated,
+        }
+
+    async def list_feeds(self) -> List[Dict[str, Any]]:
+        """List the RSS feeds this toolkit is configured to read.
+
+        Returns:
+            One dict per configured feed with url, name, slug, max_items,
+            and use_browser.
+        """
+        return [
+            {**site.model_dump(exclude_none=True), "slug": site.slug}
+            for site in self.feeds
+        ]
+
+    async def list_saved(
+        self, feed: Optional[str] = None, limit: int = 50
+    ) -> List[Dict[str, Any]]:
+        """List previously archived feed items, newest first.
+
+        Args:
+            feed: Optional feed slug to filter by (see rss_list_feeds).
+            limit: Maximum number of items to return.
+
+        Returns:
+            A list of archived item metadata dictionaries.
+        """
+        return await asyncio.to_thread(self.storage.list_saved, feed, limit)
+
+    # ------------------------------------------------------------------
+    # Internal pipeline
+    # ------------------------------------------------------------------
+
+    async def _process_feed(
+        self,
+        fetcher: ArticleFetcher,
+        site: FeedSite,
+        max_items: Optional[int],
+        force_refresh: bool,
+    ) -> List[FeedItemMetadata]:
+        """Fetch, parse, and archive one feed; errors stay local to the feed."""
+        try:
+            xml = await fetcher.fetch_feed_xml(site.url)
+            parsed = await fetcher.parse_feed(xml)
+        except Exception as exc:  # noqa: BLE001 — one bad feed must not kill the batch
+            self.logger.warning("Failed to read feed %s: %s", site.url, exc)
+            return [
+                FeedItemMetadata(
+                    item_id=make_item_id(site.url),
+                    feed=site.slug,
+                    feed_url=site.url,
+                    fetch_status="failed",
+                    error=f"Feed fetch failed: {exc}",
+                )
+            ]
+        limit = site.max_items or max_items or self.max_items_per_feed
+        entries = parsed.entries[:limit]
+        if not entries:
+            return []
+        return list(
+            await asyncio.gather(
+                *(
+                    self._process_entry(fetcher, site, entry, force_refresh)
+                    for entry in entries
+                )
+            )
+        )
+
+    async def _process_entry(
+        self,
+        fetcher: ArticleFetcher,
+        site: FeedSite,
+        entry: Any,
+        force_refresh: bool,
+    ) -> FeedItemMetadata:
+        """Archive one feed entry's article page and return its metadata."""
+        link = entry.get("link", "") or ""
+        item_id = make_item_id(link or entry.get("id", site.url))
+
+        if link and not force_refresh and self.storage.has_item(site.slug, item_id):
+            cached = self.storage.load_metadata(site.slug, item_id)
+            if cached is not None:
+                cached.fetch_status = "cached"
+                return cached
+
+        meta = FeedItemMetadata(
+            item_id=item_id,
+            feed=site.slug,
+            feed_url=site.url,
+            title=entry.get("title", "") or "",
+            link=link,
+            published=self._published_iso(entry),
+            summary=self._entry_summary(entry),
+            author=entry.get("author") or None,
+        )
+        if not link:
+            meta.error = "Feed entry has no link"
+            return meta
+
+        page = await fetcher.fetch_page(link, use_browser=site.use_browser)
+        meta.fetch_method = page.method
+        if page.html:
+            meta.fetch_status = "fetched"
+            meta.error = page.error
+            meta = await self.storage.save_item(meta, page.html, page.text)
+        else:
+            meta.fetch_status = "failed"
+            meta.error = page.error or "Empty response"
+        return meta
+
+    @staticmethod
+    def _published_iso(entry: Any) -> Optional[str]:
+        """Best-effort ISO-8601 publication timestamp from a feed entry."""
+        parsed = entry.get("published_parsed") or entry.get("updated_parsed")
+        if parsed:
+            try:
+                return time.strftime("%Y-%m-%dT%H:%M:%SZ", parsed)
+            except (TypeError, ValueError):
+                pass
+        return entry.get("published") or entry.get("updated") or None
+
+    @staticmethod
+    def _entry_summary(entry: Any) -> Optional[str]:
+        """Feed-provided summary, truncated for token economy."""
+        summary = entry.get("summary") or entry.get("description") or ""
+        if not summary:
+            return None
+        # Summaries often carry HTML markup.
+        clean = extract_text(summary) or summary
+        return clean[:SUMMARY_MAX_CHARS]

--- a/packages/ai-parrot-tools/tests/rss/test_fetcher.py
+++ b/packages/ai-parrot-tools/tests/rss/test_fetcher.py
@@ -1,0 +1,195 @@
+"""Tests for parrot_tools.rss.fetcher."""
+import asyncio
+from unittest.mock import AsyncMock
+
+import aiohttp
+import pytest
+from aiohttp import web
+
+from parrot_tools.rss import fetcher as fetcher_mod
+from parrot_tools.rss.fetcher import ArticleFetcher, extract_text
+from parrot_tools.rss.models import FetchedPage
+
+RICH_HTML = "<html><body><article>" + ("Lots of real content. " * 100) + "</article></body></html>"
+JS_SHELL_HTML = '<html><body><div id="root"></div></body></html>'
+
+
+def _make_fetcher(session, **kwargs) -> ArticleFetcher:
+    defaults = dict(
+        session=session,
+        http_semaphore=asyncio.Semaphore(5),
+        browser_semaphore=asyncio.Semaphore(1),
+        min_text_length=100,
+    )
+    defaults.update(kwargs)
+    return ArticleFetcher(**defaults)
+
+
+def test_extract_text_bs4_fallback(monkeypatch):
+    monkeypatch.setattr(fetcher_mod, "HAS_TRAFILATURA", False)
+    html = "<html><head><style>x{}</style><script>bad()</script></head><body><p>Hello world</p></body></html>"
+    text = extract_text(html)
+    assert "Hello world" in text
+    assert "bad()" not in text
+    assert "x{}" not in text
+    assert extract_text("") == ""
+
+
+def test_needs_fallback_truth_table():
+    f = ArticleFetcher(
+        session=None,  # type: ignore[arg-type]
+        http_semaphore=asyncio.Semaphore(1),
+        browser_semaphore=asyncio.Semaphore(1),
+        min_text_length=100,
+    )
+    assert f._needs_fallback(FetchedPage(error="HTTP 403"))
+    assert f._needs_fallback(FetchedPage(html=JS_SHELL_HTML, text="", thin=True))
+    assert f._needs_fallback(FetchedPage(html="<html></html>", text="short", thin=True))
+    assert f._needs_fallback(
+        FetchedPage(html="<html>Please enable JavaScript to continue" + "x" * 500, text="y" * 200)
+    )
+    assert not f._needs_fallback(
+        FetchedPage(html=RICH_HTML, text="y" * 200, thin=False)
+    )
+
+
+async def test_fetch_page_aiohttp_happy_path(aiohttp_server):
+    async def handler(request):
+        return web.Response(text=RICH_HTML, content_type="text/html")
+
+    app = web.Application()
+    app.router.add_get("/article", handler)
+    server = await aiohttp_server(app)
+
+    async with aiohttp.ClientSession() as session:
+        f = _make_fetcher(session)
+        f._fetch_with_selenium = AsyncMock()
+        page = await f.fetch_page(str(server.make_url("/article")))
+
+    assert page.method == "aiohttp"
+    assert page.status_code == 200
+    assert "Lots of real content" in page.text
+    assert not page.thin
+    f._fetch_with_selenium.assert_not_awaited()
+
+
+async def test_fetch_page_js_shell_triggers_selenium(aiohttp_server):
+    async def handler(request):
+        return web.Response(text=JS_SHELL_HTML, content_type="text/html")
+
+    app = web.Application()
+    app.router.add_get("/spa", handler)
+    server = await aiohttp_server(app)
+
+    selenium_result = FetchedPage(
+        html=RICH_HTML, text="rendered " * 50, method="selenium"
+    )
+    async with aiohttp.ClientSession() as session:
+        f = _make_fetcher(session)
+        f._fetch_with_selenium = AsyncMock(return_value=selenium_result)
+        page = await f.fetch_page(str(server.make_url("/spa")))
+
+    f._fetch_with_selenium.assert_awaited_once()
+    assert page.method == "selenium"
+    assert page.html == RICH_HTML
+
+
+async def test_fetch_page_no_fallback_when_disabled(aiohttp_server):
+    async def handler(request):
+        return web.Response(text=JS_SHELL_HTML, content_type="text/html")
+
+    app = web.Application()
+    app.router.add_get("/spa", handler)
+    server = await aiohttp_server(app)
+
+    async with aiohttp.ClientSession() as session:
+        f = _make_fetcher(session, use_browser_fallback=False)
+        f._fetch_with_selenium = AsyncMock()
+        page = await f.fetch_page(str(server.make_url("/spa")))
+
+    f._fetch_with_selenium.assert_not_awaited()
+    assert page.method == "aiohttp"
+    assert page.thin
+
+
+async def test_fetch_page_keeps_aiohttp_result_when_selenium_fails(aiohttp_server):
+    async def handler(request):
+        return web.Response(text=JS_SHELL_HTML, content_type="text/html")
+
+    app = web.Application()
+    app.router.add_get("/spa", handler)
+    server = await aiohttp_server(app)
+
+    async with aiohttp.ClientSession() as session:
+        f = _make_fetcher(session)
+        f._fetch_with_selenium = AsyncMock(
+            return_value=FetchedPage(method="selenium", error="selenium unavailable")
+        )
+        page = await f.fetch_page(str(server.make_url("/spa")))
+
+    assert page.method == "aiohttp"
+    assert page.html == JS_SHELL_HTML
+    assert "browser fallback failed" in page.error
+
+
+async def test_fetch_page_use_browser_goes_straight_to_selenium():
+    selenium_result = FetchedPage(html=RICH_HTML, text="rendered", method="selenium")
+    f = _make_fetcher(None)  # session unused on the selenium path
+    f._fetch_with_selenium = AsyncMock(return_value=selenium_result)
+    page = await f.fetch_page("https://example.com/x", use_browser=True)
+    f._fetch_with_selenium.assert_awaited_once()
+    assert page is selenium_result
+
+
+async def test_fetch_with_aiohttp_error_statuses(aiohttp_server):
+    async def not_found(request):
+        return web.Response(status=404)
+
+    async def json_endpoint(request):
+        return web.json_response({"a": 1})
+
+    app = web.Application()
+    app.router.add_get("/missing", not_found)
+    app.router.add_get("/api", json_endpoint)
+    server = await aiohttp_server(app)
+
+    async with aiohttp.ClientSession() as session:
+        f = _make_fetcher(session, use_browser_fallback=False)
+        missing = await f.fetch_page(str(server.make_url("/missing")))
+        api = await f.fetch_page(str(server.make_url("/api")))
+
+    assert missing.error == "HTTP 404"
+    assert missing.status_code == 404
+    assert "Non-HTML" in api.error
+
+
+async def test_parse_feed_requires_feedparser(monkeypatch):
+    f = _make_fetcher(None)
+    monkeypatch.setattr(fetcher_mod, "HAS_FEEDPARSER", False)
+    with pytest.raises(RuntimeError, match=r"ai-parrot-tools\[rss\]"):
+        await f.parse_feed("<rss/>")
+
+
+async def test_parse_feed_with_feedparser():
+    pytest.importorskip("feedparser")
+    xml = """<?xml version="1.0"?>
+    <rss version="2.0"><channel><title>T</title>
+    <item><title>Item 1</title><link>https://example.com/1</link></item>
+    </channel></rss>"""
+    f = _make_fetcher(None)
+    parsed = await f.parse_feed(xml)
+    assert len(parsed.entries) == 1
+    assert parsed.entries[0]["link"] == "https://example.com/1"
+
+
+async def test_selenium_unavailable_returns_error(monkeypatch):
+    f = _make_fetcher(None)
+    f._selenium_unavailable = True
+    page = await f._fetch_with_selenium("https://example.com/x")
+    assert page.method == "selenium"
+    assert page.error == "selenium unavailable"
+
+
+async def test_close_without_driver_is_noop():
+    f = _make_fetcher(None)
+    await f.close()  # must not raise

--- a/packages/ai-parrot-tools/tests/rss/test_storage.py
+++ b/packages/ai-parrot-tools/tests/rss/test_storage.py
@@ -1,0 +1,133 @@
+"""Tests for parrot_tools.rss.storage — no optional dependencies required."""
+import time
+
+import pytest
+
+from parrot_tools.rss.models import FeedItemMetadata, make_item_id
+from parrot_tools.rss.storage import RSSStorage
+
+
+def _meta(link: str = "https://example.com/article-1", feed: str = "example") -> FeedItemMetadata:
+    return FeedItemMetadata(
+        item_id=make_item_id(link),
+        feed=feed,
+        feed_url="https://example.com/feed.xml",
+        title="An Article",
+        link=link,
+        fetch_method="aiohttp",
+        fetch_status="fetched",
+    )
+
+
+async def test_save_and_load_roundtrip(tmp_path):
+    storage = RSSStorage(tmp_path)
+    meta = _meta()
+    saved = await storage.save_item(meta, "<html><body>hi</body></html>", "hi")
+
+    item_dir = tmp_path / "example" / meta.item_id
+    assert (item_dir / "page.html").exists()
+    assert (item_dir / "content.txt").exists()
+    assert (item_dir / "item.json").exists()
+    assert saved.html_path == str(item_dir / "page.html")
+    assert saved.text_path == str(item_dir / "content.txt")
+
+    loaded = storage.load_metadata("example", meta.item_id)
+    assert loaded is not None
+    assert loaded.title == "An Article"
+    assert loaded.html_path == saved.html_path
+
+
+async def test_has_item_dedup(tmp_path):
+    storage = RSSStorage(tmp_path)
+    meta = _meta()
+    assert not storage.has_item("example", meta.item_id)
+    await storage.save_item(meta, "<html></html>", "text")
+    assert storage.has_item("example", meta.item_id)
+
+
+async def test_find_item_across_feeds(tmp_path):
+    storage = RSSStorage(tmp_path)
+    meta = _meta(feed="other-feed")
+    await storage.save_item(meta, "<html></html>", "text")
+    found = storage.find_item(meta.item_id)
+    assert found is not None
+    assert found.name == meta.item_id
+    assert found.parent.name == "other-feed"
+    assert storage.find_item("0" * 16) is None
+
+
+async def test_list_saved_filter_limit_order(tmp_path):
+    storage = RSSStorage(tmp_path)
+    links = [f"https://example.com/a{i}" for i in range(3)]
+    for i, link in enumerate(links):
+        feed = "feed-a" if i < 2 else "feed-b"
+        await storage.save_item(_meta(link=link, feed=feed), "<html></html>", "t")
+        time.sleep(0.01)  # distinct mtimes for deterministic ordering
+
+    all_items = storage.list_saved()
+    assert len(all_items) == 3
+    # Newest first
+    assert all_items[0]["link"] == links[2]
+
+    only_a = storage.list_saved(feed_slug="feed-a")
+    assert len(only_a) == 2
+    assert {m["feed"] for m in only_a} == {"feed-a"}
+
+    limited = storage.list_saved(limit=1)
+    assert len(limited) == 1
+
+
+async def test_read_content_by_item_id_and_path(tmp_path):
+    storage = RSSStorage(tmp_path)
+    meta = _meta()
+    saved = await storage.save_item(meta, "<html>raw</html>", "clean text")
+
+    assert await storage.read_content(meta.item_id, "text") == "clean text"
+    assert await storage.read_content(meta.item_id, "html") == "<html>raw</html>"
+    assert await storage.read_content(saved.text_path, "text") == "clean text"
+    # Directory ref gets the format file appended
+    item_dir = str(tmp_path / "example" / meta.item_id)
+    assert await storage.read_content(item_dir, "html") == "<html>raw</html>"
+
+
+def test_resolve_content_path_html(tmp_path):
+    storage = RSSStorage(tmp_path)
+    meta = _meta()
+    item_dir = tmp_path / "example" / meta.item_id
+    item_dir.mkdir(parents=True)
+    (item_dir / "page.html").write_text("<html></html>")
+    (item_dir / "item.json").write_text("{}")
+    resolved = storage.resolve_content_path(meta.item_id, "html")
+    assert resolved.name == "page.html"
+
+
+def test_traversal_rejected(tmp_path):
+    storage = RSSStorage(tmp_path / "store")
+    outside = tmp_path / "secret.txt"
+    outside.write_text("secret")
+
+    with pytest.raises(ValueError, match="outside"):
+        storage.resolve_content_path("../secret.txt", "text")
+    with pytest.raises(ValueError, match="outside"):
+        storage.resolve_content_path(str(outside), "text")
+    with pytest.raises(ValueError, match="outside"):
+        storage.resolve_content_path("/etc/passwd", "text")
+
+
+def test_symlink_escape_rejected(tmp_path):
+    storage = RSSStorage(tmp_path / "store")
+    outside = tmp_path / "secret.txt"
+    outside.write_text("secret")
+    link = storage.base_dir / "sneaky.txt"
+    link.symlink_to(outside)
+
+    with pytest.raises(ValueError, match="outside"):
+        storage.resolve_content_path("sneaky.txt", "text")
+
+
+def test_unknown_format_and_missing_item(tmp_path):
+    storage = RSSStorage(tmp_path)
+    with pytest.raises(ValueError, match="format"):
+        storage.resolve_content_path("a" * 16, "pdf")
+    with pytest.raises(ValueError, match="No archived item"):
+        storage.resolve_content_path("a" * 16, "text")

--- a/packages/ai-parrot-tools/tests/rss/test_toolkit.py
+++ b/packages/ai-parrot-tools/tests/rss/test_toolkit.py
@@ -1,0 +1,261 @@
+"""Tests for parrot_tools.rss.toolkit.RSSFeedReaderToolkit."""
+import asyncio
+
+import pytest
+from aiohttp import web
+
+from parrot_tools import TOOL_REGISTRY
+from parrot_tools.rss.models import FeedSite
+
+EXPECTED_TOOLS = {"rss_read_feeds", "rss_get_content", "rss_list_feeds", "rss_list_saved"}
+
+ARTICLE_HTML = (
+    "<html><body><article>" + ("Interesting article content. " * 60) + "</article></body></html>"
+)
+
+
+def _rss_xml(base_url: str, n_items: int = 2) -> str:
+    items = "".join(
+        f"""<item>
+            <title>Article {i}</title>
+            <link>{base_url}/articles/{i}</link>
+            <description>Summary of article {i}</description>
+            <pubDate>Mon, 13 Jul 2026 10:0{i}:00 GMT</pubDate>
+        </item>"""
+        for i in range(n_items)
+    )
+    return f"""<?xml version="1.0"?>
+    <rss version="2.0"><channel><title>Test Feed</title>{items}</channel></rss>"""
+
+
+def test_registered_in_tool_registry():
+    assert TOOL_REGISTRY["rss_feed_reader"] == "parrot_tools.rss.toolkit.RSSFeedReaderToolkit"
+
+
+def test_module_imports_without_optional_deps():
+    # The module must import even when feedparser/trafilatura/selenium are
+    # absent (guarded imports) — this mirrors test_imports_integrity.py.
+    from parrot_tools.rss import toolkit as _  # noqa: F401
+
+
+# Everything below exercises feed parsing and needs feedparser.
+feedparser = pytest.importorskip("feedparser")
+
+from parrot_tools.rss.toolkit import RSSFeedReaderToolkit  # noqa: E402
+
+
+@pytest.fixture
+async def feed_server(aiohttp_server):
+    """Local server exposing /feed.xml plus two article pages, with hit counts."""
+    hits = {"feed": 0, "articles": 0}
+
+    async def feed_handler(request):
+        hits["feed"] += 1
+        base = f"http://{request.host}"
+        return web.Response(text=_rss_xml(base), content_type="application/rss+xml")
+
+    async def article_handler(request):
+        hits["articles"] += 1
+        return web.Response(text=ARTICLE_HTML, content_type="text/html")
+
+    app = web.Application()
+    app.router.add_get("/feed.xml", feed_handler)
+    app.router.add_get("/articles/{i}", article_handler)
+    server = await aiohttp_server(app)
+    server.hits = hits
+    return server
+
+
+def _toolkit(tmp_path, server=None, **kwargs) -> RSSFeedReaderToolkit:
+    feeds = kwargs.pop(
+        "feeds",
+        [str(server.make_url("/feed.xml"))] if server else [],
+    )
+    defaults = dict(
+        feeds=feeds,
+        storage_dir=tmp_path / "rss",
+        use_browser_fallback=False,
+        min_text_length=50,
+    )
+    defaults.update(kwargs)
+    return RSSFeedReaderToolkit(**defaults)
+
+
+def test_tool_surface(tmp_path):
+    tk = _toolkit(tmp_path)
+    names = {t.name for t in tk.get_tools()}
+    assert EXPECTED_TOOLS <= names
+
+
+def test_feed_normalization(tmp_path):
+    tk = _toolkit(
+        tmp_path,
+        feeds=[
+            "https://example.com/a.xml",
+            {"url": "https://example.com/b.xml", "name": "My Feed", "use_browser": True},
+            FeedSite(url="https://example.com/c.xml", max_items=3),
+        ],
+    )
+    assert all(isinstance(site, FeedSite) for site in tk.feeds)
+    assert tk.feeds[1].use_browser is True
+    assert tk.feeds[1].slug == "my-feed"
+    assert tk.feeds[2].max_items == 3
+
+
+def test_default_storage_dir(tmp_path):
+    tk = RSSFeedReaderToolkit(feeds=[])
+    assert str(tk.storage.base_dir).endswith("outputs/rss_feeds")
+
+
+async def test_read_feeds_end_to_end(tmp_path, feed_server):
+    tk = _toolkit(tmp_path, feed_server)
+    try:
+        items = await tk.read_feeds()
+    finally:
+        await tk.stop()
+
+    assert len(items) == 2
+    for item in items:
+        assert item["fetch_status"] == "fetched"
+        assert item["fetch_method"] == "aiohttp"
+        assert item["title"].startswith("Article")
+        assert item["summary"].startswith("Summary")
+        assert item["published"].startswith("2026-07-13")
+        assert len(item["item_id"]) == 16
+        # Paths returned, content NOT returned
+        assert "content" not in item
+        assert "html" not in item
+        html_path = tmp_path / "rss"
+        assert item["html_path"].startswith(str(html_path))
+        assert item["text_path"].startswith(str(html_path))
+
+    # Files really on disk
+    from pathlib import Path
+
+    assert "Interesting article content" in Path(items[0]["text_path"]).read_text()
+    assert Path(items[0]["html_path"]).read_text() == ARTICLE_HTML
+
+
+async def test_read_feeds_dedup_and_force_refresh(tmp_path, feed_server):
+    tk = _toolkit(tmp_path, feed_server)
+    try:
+        first = await tk.read_feeds()
+        assert feed_server.hits["articles"] == 2
+
+        second = await tk.read_feeds()
+        assert all(item["fetch_status"] == "cached" for item in second)
+        assert feed_server.hits["articles"] == 2  # no article re-fetch
+
+        third = await tk.read_feeds(force_refresh=True)
+        assert all(item["fetch_status"] == "fetched" for item in third)
+        assert feed_server.hits["articles"] == 4
+    finally:
+        await tk.stop()
+    assert {i["item_id"] for i in first} == {i["item_id"] for i in second}
+
+
+async def test_read_feeds_adhoc_urls(tmp_path, feed_server):
+    tk = _toolkit(tmp_path, feeds=[])
+    try:
+        items = await tk.read_feeds(feed_urls=[str(feed_server.make_url("/feed.xml"))])
+    finally:
+        await tk.stop()
+    assert len(items) == 2
+    assert all(item["fetch_status"] == "fetched" for item in items)
+
+
+async def test_read_feeds_max_items(tmp_path, feed_server):
+    tk = _toolkit(tmp_path, feed_server)
+    try:
+        items = await tk.read_feeds(max_items=1)
+    finally:
+        await tk.stop()
+    assert len(items) == 1
+
+
+async def test_read_feeds_empty_config(tmp_path):
+    tk = _toolkit(tmp_path, feeds=[])
+    try:
+        result = await tk.read_feeds()
+    finally:
+        await tk.stop()
+    assert result == [{"error": "No feeds configured and no feed_urls provided."}]
+
+
+async def test_bad_feed_does_not_kill_batch(tmp_path, feed_server):
+    good = str(feed_server.make_url("/feed.xml"))
+    bad = str(feed_server.make_url("/nope.xml"))
+    tk = _toolkit(tmp_path, feeds=[bad, good])
+    try:
+        items = await tk.read_feeds()
+    finally:
+        await tk.stop()
+    failed = [i for i in items if i["fetch_status"] == "failed"]
+    fetched = [i for i in items if i["fetch_status"] == "fetched"]
+    assert len(failed) == 1
+    assert "Feed fetch failed" in failed[0]["error"]
+    assert len(fetched) == 2
+
+
+async def test_get_content(tmp_path, feed_server):
+    tk = _toolkit(tmp_path, feed_server)
+    try:
+        items = await tk.read_feeds()
+        item_id = items[0]["item_id"]
+
+        text = await tk.get_content(item_id)
+        assert text["format"] == "text"
+        assert "Interesting article content" in text["content"]
+        assert text["truncated"] is False
+
+        html = await tk.get_content(item_id, format="html")
+        assert html["content"] == ARTICLE_HTML
+
+        short = await tk.get_content(item_id, max_chars=100)
+        assert len(short["content"]) == 100
+        assert short["truncated"] is True
+
+        missing = await tk.get_content("0" * 16)
+        assert "error" in missing
+
+        traversal = await tk.get_content("../../etc/passwd")
+        assert "error" in traversal
+    finally:
+        await tk.stop()
+
+
+async def test_list_feeds_and_list_saved(tmp_path, feed_server):
+    tk = _toolkit(tmp_path, feed_server)
+    try:
+        feeds = await tk.list_feeds()
+        assert len(feeds) == 1
+        assert feeds[0]["url"] == str(feed_server.make_url("/feed.xml"))
+        assert "slug" in feeds[0]
+
+        assert await tk.list_saved() == []
+        await tk.read_feeds()
+        saved = await tk.list_saved()
+        assert len(saved) == 2
+        assert await tk.list_saved(limit=1) != []
+        assert await tk.list_saved(feed="does-not-exist") == []
+    finally:
+        await tk.stop()
+
+
+async def test_start_requires_feedparser(tmp_path, monkeypatch):
+    import parrot_tools.rss.toolkit as toolkit_mod
+
+    monkeypatch.setattr(toolkit_mod, "HAS_FEEDPARSER", False)
+    tk = _toolkit(tmp_path)
+    with pytest.raises(RuntimeError, match=r"ai-parrot-tools\[rss\]"):
+        await tk.start()
+
+
+async def test_stop_closes_session(tmp_path, feed_server):
+    tk = _toolkit(tmp_path, feed_server)
+    await tk.read_feeds()
+    session = tk._session
+    assert session is not None and not session.closed
+    await tk.stop()
+    assert session.closed
+    assert tk._session is None and tk._fetcher is None


### PR DESCRIPTION
## Summary

Introduces a new **RSS Feed Reader Toolkit** that fetches RSS/Atom feeds, downloads complete article pages, and archives raw HTML + extracted text to disk. The LLM receives only metadata dictionaries with file paths, never the article content itself; content is retrieved on-demand via `rss_get_content`.

## Key Changes

- **New `parrot_tools.rss` module** with four main components:
  - `toolkit.py`: `RSSFeedReaderToolkit` class exposing four tools:
    - `rss_read_feeds`: Fetch configured feeds and archive article content
    - `rss_get_content`: Retrieve archived content by item ID or path
    - `rss_list_feeds`: List configured feed sources
    - `rss_list_saved`: List previously archived items (newest first)
  
  - `fetcher.py`: `ArticleFetcher` class implementing dual-strategy page fetching:
    - Fast aiohttp GET with bounded concurrency
    - Selenium browser fallback for JS-rendered pages (when `scraping` extra installed)
    - Automatic detection of thin/shell content and bot-challenge walls
    - Feed XML parsing via feedparser (off event loop)
  
  - `storage.py`: `RSSStorage` class for disk archival:
    - Hierarchical layout: `{base_dir}/{feed_slug}/{item_id}/{page.html,content.txt,item.json}`
    - Deduplication via stable item IDs (SHA-256 of article URL)
    - Path traversal protection and symlink guards
    - Async I/O dispatched via `asyncio.to_thread`
  
  - `models.py`: Pydantic data structures:
    - `FeedSite`: Feed configuration (URL, name, max_items, use_browser flag)
    - `FeedItemMetadata`: LLM-facing item record (metadata + file paths, no content)
    - `FetchedPage`: Internal fetch result tracking (HTML, text, method, error)
    - `GetContentInput`: Tool schema for content retrieval

- **Comprehensive test suite** (`tests/rss/`):
  - `test_toolkit.py`: End-to-end feed reading, deduplication, force-refresh, content retrieval
  - `test_fetcher.py`: aiohttp happy path, JS-shell detection, Selenium fallback logic, error handling
  - `test_storage.py`: Save/load roundtrip, dedup checks, cross-feed search, list ordering, traversal rejection

- **Integration**:
  - Registered in `TOOL_REGISTRY` as `rss_feed_reader`
  - Added `rss` extra to `pyproject.toml` (feedparser, trafilatura)
  - Optional `scraping` extra for Selenium fallback

## Notable Implementation Details

- **Guarded imports**: Module imports safely even when feedparser/trafilatura/selenium are absent; runtime errors only when features are actually used
- **Bounded concurrency**: Separate semaphores for HTTP requests and browser slots prevent resource exhaustion
- **Lazy initialization**: Toolkit starts HTTP session and fetcher on first tool call (agents don't always call `start()`)
- **Graceful degradation**: When Selenium fallback fails, best-effort aiohttp result is returned with combined error message
- **Token efficiency**: LLM receives only metadata with file paths; content is fetched on-demand to avoid bloating context
- **Stable item IDs**: SHA-256(link)[:16] ensures consistent deduplication across runs
- **Filesystem safety**: Slugification of feed names, path resolution guards against traversal attacks

https://claude.ai/code/session_01UsBQimgpk5zSrFuh6HUat8