### PR TITLE
Add ToolNode: deterministic tool-execution crew member

### DIFF
--- a/packages/ai-parrot-server/src/parrot/handlers/crew/__init__.py
+++ b/packages/ai-parrot-server/src/parrot/handlers/crew/__init__.py
@@ -2,10 +2,12 @@ from .handler import CrewHandler
 from .execution_handler import CrewExecutionHandler
 from .execution_history_handler import CrewExecutionHistoryHandler
 from .tool_catalog import CrewToolCatalogHandler
+from .special_nodes import CrewSpecialNodeCatalogHandler
 
 __all__ = (
     'CrewHandler',
     'CrewExecutionHandler',
     'CrewExecutionHistoryHandler',
     'CrewToolCatalogHandler',
+    'CrewSpecialNodeCatalogHandler',
 )

--- a/packages/ai-parrot-server/src/parrot/handlers/crew/handler.py
+++ b/packages/ai-parrot-server/src/parrot/handlers/crew/handler.py
@@ -136,6 +136,24 @@ class CrewHandler(BaseView):
             if tool := self.bot_manager.get_tool(tool_name):
                 crew.add_shared_tool(tool, tool_name)
 
+        # Add deterministic tool nodes (must precede flow relations so
+        # relations can reference them by node_id). Unresolvable tools
+        # raise: a tool node is a structural DAG member.
+        for tool_node_def in crew_def.tool_nodes:
+            tool = self.bot_manager.get_tool(tool_node_def.tool)
+            if not tool:
+                raise ValueError(
+                    f"Tool '{tool_node_def.tool}' not found for tool node "
+                    f"'{tool_node_def.node_id}'"
+                )
+            crew.add_tool_node(
+                tool,
+                tool_node_def.node_id,
+                args=tool_node_def.args,
+                kwargs=tool_node_def.kwargs,
+                description=tool_node_def.description,
+            )
+
         # Setup flow relations if in flow mode
         if crew_def.execution_mode == ExecutionMode.FLOW and crew_def.flow_relations:
             for relation in crew_def.flow_relations:
@@ -158,23 +176,13 @@ class CrewHandler(BaseView):
         return crew
 
     def _get_agents_by_ids(self, crew: AgentCrew, agent_ids: list) -> list:
-        """Helper to get agent instances by their IDs/names."""
-        # This helper might also be missing, implementing a simple version based on context
-        # Assumes agent name matches what was set during creation (name or agent_id)
-        # But wait, User snippet used self._get_agents_by_ids so I should check if that exists or add it.
-        # Since I am adding it here, I should implement it.
-        found = []
-        for aid in agent_ids:
-            # Logic to find agent in crew.agents list
-            # The agent.name was set to agent_def.name or agent_def.agent_id
-            # This might be tricky if names are not unique or if we don't know the exact mapping.
-            # Ideally AgentCrew has a method to get agent by valid identifier?
-            # For now, let's iterate.
-            for agent in crew.agents:
-                if agent.name == aid: # weak match?
-                    found.append(agent)
-                    break
-        return found
+        """Resolve crew members (agents or tool nodes) by their id/name.
+
+        ``crew.agents`` is a dict keyed by agent name/node_id, so resolution
+        delegates to ``AgentCrew._resolve_agents_by_ids`` (the same helper
+        ``AgentCrew.from_definition`` uses). Missing ids are skipped.
+        """
+        return AgentCrew._resolve_agents_by_ids(crew.agents, agent_ids)
 
     async def upload(self):
         """

--- a/packages/ai-parrot-server/src/parrot/handlers/crew/models.py
+++ b/packages/ai-parrot-server/src/parrot/handlers/crew/models.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, Field
 from parrot.models.crew_definition import (  # noqa: F401
     ExecutionMode,
     AgentDefinition,
+    ToolNodeDefinition,
     FlowRelation,
     CrewDefinition,
 )

--- a/packages/ai-parrot-server/src/parrot/handlers/crew/special_nodes.py
+++ b/packages/ai-parrot-server/src/parrot/handlers/crew/special_nodes.py
@@ -1,0 +1,86 @@
+"""Curated special-node catalog for the crew builder UI.
+
+Exposes the list of "special nodes" — crew members that are not LLM agents
+(e.g. the deterministic tool-execution node). The frontend uses this
+catalog to present non-agent node types when composing a crew.
+
+Mirrors the curated-catalog pattern of ``tool_catalog.py``: entries are
+hand-picked and carry display metadata plus a JSON-Schema-ish
+``config_schema`` fragment describing the node's configuration.
+
+Route:
+    GET /api/v1/crew/special_nodes
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from navconfig.logging import logging
+from navigator.views import BaseView
+from navigator_auth.decorators import is_authenticated, user_session
+
+
+CREW_SPECIAL_NODE_CATALOG: List[Dict[str, Any]] = [
+    {
+        "slug": "tool_node",
+        "name": "ToolNode",
+        "display_name": "Deterministic Tool Call",
+        "description": (
+            "Executes a tool directly with statically declared args/kwargs "
+            "— no LLM tokens are spent. String values support {input} and "
+            "{nodes.<node_name>.output} template placeholders resolved "
+            "deterministically from prior node results at run time. The "
+            "result is wrapped as an agent-execution result, so the node "
+            "participates in every crew execution mode (sequential, "
+            "parallel, flow, loop)."
+        ),
+        "category": "deterministic",
+        "type": "special_node",
+        "config_schema": {
+            "node_id": {
+                "type": "string",
+                "description": "Unique node identifier within the crew",
+            },
+            "tool": {
+                "type": "string",
+                "description": (
+                    "Tool slug to execute — see GET /api/v1/crew/tools "
+                    "for the available tool catalog"
+                ),
+            },
+            "args": {
+                "type": "array",
+                "items": {},
+                "description": "Positional arguments passed to the tool",
+            },
+            "kwargs": {
+                "type": "object",
+                "additionalProperties": True,
+                "description": (
+                    "Keyword arguments passed to the tool. String values "
+                    "may embed {input} or {nodes.<node_name>.output} "
+                    "template placeholders."
+                ),
+            },
+            "description": {
+                "type": "string",
+                "description": "Optional display description for the node",
+            },
+        },
+    },
+]
+
+
+@is_authenticated()
+@user_session()
+class CrewSpecialNodeCatalogHandler(BaseView):
+    """Returns the curated special-node catalog for the crew builder UI."""
+
+    _logger_name: str = "Parrot.CrewSpecialNodeCatalogHandler"
+
+    def post_init(self, *args, **kwargs) -> None:
+        self.logger = logging.getLogger(self._logger_name)
+
+    async def get(self) -> Any:
+        """Return the curated special-node catalog as a JSON array."""
+        return self.json_response(CREW_SPECIAL_NODE_CATALOG)

--- a/packages/ai-parrot-server/src/parrot/manager/manager.py
+++ b/packages/ai-parrot-server/src/parrot/manager/manager.py
@@ -70,6 +70,7 @@ from ..models.crew_definition import CrewDefinition
 from ..handlers.crew.handler import CrewHandler
 from ..handlers.crew.execution_handler import CrewExecutionHandler
 from ..handlers.crew.tool_catalog import CrewToolCatalogHandler
+from ..handlers.crew.special_nodes import CrewSpecialNodeCatalogHandler
 from ..handlers.crew.redis_persistence import CrewRedis
 from ..openapi.config import setup_swagger
 from ..conf import (
@@ -1899,6 +1900,11 @@ class BotManager:
         # Crew Configuration
         if ENABLE_CREWS:
             router.add_view('/api/v1/crew/tools', CrewToolCatalogHandler)
+            # Must register BEFORE CrewHandler.configure — its '{id:.*}'
+            # catch-all route would otherwise shadow this path.
+            router.add_view(
+                '/api/v1/crew/special_nodes', CrewSpecialNodeCatalogHandler
+            )
             CrewHandler.configure(self.app, '/api/v1/crew')
             CrewExecutionHandler.configure(self.app, '/api/v1/crews')
         # Agent Config CRUD

--- a/packages/ai-parrot/src/parrot/bots/flows/crew/__init__.py
+++ b/packages/ai-parrot/src/parrot/bots/flows/crew/__init__.py
@@ -3,9 +3,21 @@
 Exports the crew orchestrator and its node type.
 """
 from .nodes import CrewAgentNode
+from .tool_node import (
+    TemplateResolutionError,
+    ToolLike,
+    ToolNode,
+    ToolNodeExecutionError,
+    resolve_templates,
+)
 from .crew import AgentCrew
 
 __all__ = [
     "CrewAgentNode",
     "AgentCrew",
+    "ToolNode",
+    "ToolLike",
+    "ToolNodeExecutionError",
+    "TemplateResolutionError",
+    "resolve_templates",
 ]

--- a/packages/ai-parrot/src/parrot/bots/flows/crew/crew.py
+++ b/packages/ai-parrot/src/parrot/bots/flows/crew/crew.py
@@ -40,7 +40,7 @@ from ....clients.factory import SUPPORTED_CLIENTS
 from ....clients.google import GoogleGenAIClient
 from ....tools.manager import ToolManager
 from ....tools.agent import AgentTool
-from ....tools.abstract import AbstractTool
+from ....tools.abstract import AbstractTool, ToolResult
 from ....models.responses import (
     AIMessage,
     AgentResponse
@@ -73,6 +73,7 @@ from ..core.types import (
 from ..core.fsm import AgentTaskMachine
 from ..tools import ResultRetrievalTool
 from .nodes import CrewAgentNode
+from .tool_node import ToolNode, extract_tool_output
 
 __all__ = [
     "AgentCrew",
@@ -485,6 +486,9 @@ class AgentCrew(PersistenceMixin, SynthesisMixin):
             return
 
         for agent_id, agent in self.agents.items():
+            if isinstance(agent, ToolNode):
+                # Deterministic tool nodes are not agents — nothing to wrap.
+                continue
             try:
                 agent_tool = agent.as_tool(
                     tool_name=f"agent_{agent_id}",
@@ -564,6 +568,27 @@ class AgentCrew(PersistenceMixin, SynthesisMixin):
             for tool_name in crew_def.shared_tools:
                 if tool := tool_resolver(tool_name):
                     crew.add_shared_tool(tool, tool_name)
+
+        # Deterministic tool nodes (ToolNodeDefinition) — added before
+        # flow_relations so relations can reference them by node_id.
+        # Unlike shared tools, an unresolvable tool node raises: it is a
+        # structural DAG member and skipping it silently would produce a
+        # broken/stuck workflow.
+        for tool_node_def in getattr(crew_def, "tool_nodes", None) or []:
+            tool = tool_resolver(tool_node_def.tool) if tool_resolver else None
+            if tool is None:
+                raise ValueError(
+                    f"Cannot resolve tool '{tool_node_def.tool}' for tool "
+                    f"node '{tool_node_def.node_id}'. A tool_resolver that "
+                    "knows this tool is required."
+                )
+            crew.add_tool_node(
+                tool,
+                tool_node_def.node_id,
+                args=tool_node_def.args,
+                kwargs=tool_node_def.kwargs,
+                description=tool_node_def.description,
+            )
 
         if crew_def.execution_mode == ExecutionMode.FLOW and crew_def.flow_relations:
             for relation in crew_def.flow_relations:
@@ -665,10 +690,73 @@ class AgentCrew(PersistenceMixin, SynthesisMixin):
 
         self.logger.info(f"Agents added and tracking initialized for '{agent_id}'")
 
+    def add_tool_node(
+        self,
+        tool: AbstractTool,
+        node_id: str,
+        *,
+        args: Optional[List[Any]] = None,
+        kwargs: Optional[Dict[str, Any]] = None,
+        description: Optional[str] = None,
+    ) -> ToolNode:
+        """Add a deterministic tool-execution node as a crew member.
+
+        The node calls ``tool`` directly with the declared ``args``/``kwargs``
+        (template placeholders ``{input}`` and ``{nodes.<name>.output}`` are
+        resolved from prior results at execution time) — no LLM tokens are
+        spent. The result is wrapped so it behaves like any agent execution
+        result throughout the crew flow.
+
+        Registered into BOTH ``self.agents`` (so sequential/parallel/loop
+        modes pick it up — ``_execute_agent`` dispatches on isinstance) and
+        ``self.workflow_graph`` (flow mode: the ToolNode is its own graph
+        node). Agent-only machinery is skipped: shared-tool distribution,
+        AgentTool wrapping, LLM tool registration and event listeners.
+
+        Args:
+            tool: The ``AbstractTool`` instance to execute.
+            node_id: Unique identifier for the node within the crew.
+            args: Positional arguments passed through to the tool.
+            kwargs: Keyword arguments passed through to the tool.
+            description: Optional human-readable description.
+
+        Returns:
+            The created ``ToolNode``.
+
+        Raises:
+            ValueError: If ``node_id`` already exists in the crew.
+        """
+        if node_id in self.agents or node_id in self.workflow_graph:
+            raise ValueError(
+                f"Crew member '{node_id}' already exists"
+            )
+        node = ToolNode(
+            tool=tool,
+            node_id=node_id,
+            args=list(args or []),
+            kwargs=dict(kwargs or {}),
+            description=description or f"Deterministic call of tool '{tool.name}'",
+        )
+        self.agents[node_id] = node
+        self.workflow_graph[node_id] = node
+        self._agent_statuses[node_id] = {
+            "status": AgentStatus.IDLE.value,
+            "last_active": datetime.now(),
+            "task": None,
+            "result": None,
+            "error": None
+        }
+        self.logger.info(
+            f"Added tool node '{node_id}' (tool '{tool.name}') to crew"
+        )
+        return node
+
     def remove_agent(self, agent_id: str) -> bool:
-        """Remove an agent from the crew."""
+        """Remove an agent (or tool node) from the crew."""
         if agent_id in self.agents:
             del self.agents[agent_id]
+            self.workflow_graph.pop(agent_id, None)
+            self._agent_statuses.pop(agent_id, None)
             self.logger.info(
                 f"Removed agent '{agent_id}' from crew"
             )
@@ -679,8 +767,10 @@ class AgentCrew(PersistenceMixin, SynthesisMixin):
         """Add a tool shared across all agents."""
         self.shared_tool_manager.add_tool(tool, tool_name)
 
-        # Add to all existing agents
+        # Add to all existing agents (tool nodes have no tool_manager)
         for agent in self.agents.values():
+            if not hasattr(agent, 'tool_manager'):
+                continue
             if not agent.tool_manager.get_tool(tool_name or tool.name):
                 agent.tool_manager.add_tool(tool, tool_name)
 
@@ -1148,6 +1238,7 @@ class AgentCrew(PersistenceMixin, SynthesisMixin):
         index: int,
         model: Optional[str] = None,
         max_tokens: Optional[int] = None,
+        flow_context: Optional[FlowContext] = None,
         **kwargs,
     ) -> Any:
         """Execute a single agent with proper rate limiting and error handling.
@@ -1165,14 +1256,30 @@ class AgentCrew(PersistenceMixin, SynthesisMixin):
                 build a unique sub-session ID).
             model: Optional model override forwarded to the agent.
             max_tokens: Optional token limit forwarded to the agent.
+            flow_context: Optional ``FlowContext`` of the current run — used
+                by ``ToolNode`` members to resolve ``{nodes.<name>.output}``
+                template placeholders from prior results.
             **kwargs: Arbitrary additional keyword arguments forwarded to the
                 agent call (replaces the former ``AgentContext.shared_data``
                 spread).
 
         Returns:
             The raw response from the agent (``AIMessage``, ``AgentResponse``,
-            or other type depending on the agent implementation).
+            or other type depending on the agent implementation), or a
+            ``ToolResult`` for ``ToolNode`` members.
         """
+        # Deterministic tool node: no LLM, no configuration — resolve the
+        # declared args/kwargs (templates included) and call the tool
+        # directly. Session/model kwargs deliberately do NOT reach the tool.
+        if isinstance(agent, ToolNode):
+            async with self.semaphore:
+                return await agent.call_tool(
+                    input_text=query,
+                    results=(
+                        flow_context.results if flow_context is not None else {}
+                    ),
+                    timeout=self.agent_execution_timeout,
+                )
         await self._ensure_agent_ready(agent)
         async with self.semaphore:
             if hasattr(agent, 'ask'):
@@ -1210,6 +1317,8 @@ class AgentCrew(PersistenceMixin, SynthesisMixin):
 
     def _extract_result(self, response: Any) -> str:
         """Extract result string from response."""
+        if isinstance(response, ToolResult):
+            return extract_tool_output(response)
         if isinstance(response, (AIMessage, AgentResponse)) or hasattr(
             response, 'content'
         ):
@@ -1506,6 +1615,7 @@ Current task: {current_input}"""
                 response: AIMessage = await self._execute_agent(
                     agent, agent_input, session_id, user_id, i,
                     model=model, max_tokens=max_tokens,
+                    flow_context=context,
                     **_agent_kwargs
                 )
 
@@ -1976,6 +2086,7 @@ Current task: {current_input}"""
                         agent_position,
                         model=model,
                         max_tokens=max_tokens,
+                        flow_context=context,
                         **_agent_kwargs
                     )
 
@@ -2339,7 +2450,7 @@ Current task: {current_input}"""
 
             async def _run_with_hooks(
                 _agent=agent, _query=query, _idx=i, _node=node,
-                _kwargs=_agent_kwargs,
+                _kwargs=_agent_kwargs, _ctx=context,
             ):
                 """Wrap _execute_agent with pre/post action hooks."""
                 if _node:
@@ -2347,6 +2458,7 @@ Current task: {current_input}"""
                 resp = await self._execute_agent(
                     _agent, _query, session_id, user_id, _idx,
                     max_tokens=max_tokens,
+                    flow_context=_ctx,
                     **_kwargs
                 )
                 if _node:

--- a/packages/ai-parrot/src/parrot/bots/flows/crew/tool_node.py
+++ b/packages/ai-parrot/src/parrot/bots/flows/crew/tool_node.py
@@ -1,0 +1,398 @@
+"""ToolNode — deterministic tool execution node for AgentCrew.
+
+Provides a crew member that is NOT an LLM agent but a direct tool caller:
+it invokes an ``AbstractTool`` with statically declared ``args``/``kwargs``
+(pass-through) and wraps the outcome so it is indistinguishable from an
+agent-execution result to the rest of the flow machinery (``FlowResult``,
+context summaries, persistence, FSM lifecycle). No LLM tokens are spent.
+
+Template placeholders — resolved deterministically at execution time from
+prior results (never via an LLM):
+
+- ``{input}`` — the node's input. Sequential/loop modes: the composed
+  previous input; parallel mode: the task's query; flow mode: the last
+  completed dependency's output (or the initial task when the node has
+  no dependencies).
+- ``{nodes.<node_name>.output}`` — the stored output of a previously
+  completed node. Avoid dots in node ids: they are ambiguous inside
+  this placeholder syntax.
+
+A string value that consists of exactly one placeholder is replaced by the
+referenced value with its native type preserved (a dict result passes
+through to the tool as a dict). Placeholders embedded in a larger string
+are substituted via ``str()``. Literal braces that do not match the
+placeholder grammar (e.g. inline JSON) are left untouched.
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+from typing import (
+    Any,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Protocol,
+    Set,
+    Tuple,
+    runtime_checkable,
+)
+
+from pydantic import Field
+
+from datamodel.parsers.json import json_encoder  # pylint: disable=E0611 # noqa
+
+from ....tools.abstract import ToolResult
+from ..core.fsm import AgentTaskMachine
+from ..core.node import Node
+
+
+@runtime_checkable
+class ToolLike(Protocol):
+    """Structural protocol for any object usable as a ToolNode tool.
+
+    Mirrors the ``AgentLike`` pattern from ``flows.core.types``: using a
+    Protocol (rather than requiring an ``AbstractTool`` subclass) keeps the
+    node testable with lightweight doubles while every real
+    ``AbstractTool`` satisfies the contract.
+
+    Attributes:
+        name: Tool identifier.
+
+    Methods:
+        execute: Async call returning a ``ToolResult``-shaped object.
+    """
+
+    name: str
+
+    async def execute(self, *args: Any, **kwargs: Any) -> Any:
+        """Execute the tool and return a ``ToolResult``."""
+        ...
+
+
+class TemplateResolutionError(ValueError):
+    """A template placeholder references a node with no stored result."""
+
+
+class ToolNodeExecutionError(RuntimeError):
+    """The wrapped tool reported failure (``ToolResult.success == False``)."""
+
+
+# ``{input}`` or ``{nodes.<node name>.output}`` — node names may contain
+# spaces ("Data Fetcher"); the non-greedy group stops at the first
+# ``.output}`` suffix.
+_PLACEHOLDER_RE = re.compile(r"\{(input|nodes\.(.+?)\.output)\}")
+
+
+def resolve_templates(
+    value: Any,
+    *,
+    input_text: str,
+    results: Mapping[str, Any],
+) -> Any:
+    """Recursively resolve template placeholders inside a value.
+
+    Walks nested dicts/lists/tuples and substitutes placeholders found in
+    string values. Non-string leaves pass through unchanged.
+
+    Args:
+        value: The value to resolve (str, dict, list, tuple, or any leaf).
+        input_text: Replacement for the ``{input}`` placeholder.
+        results: Mapping of node_id → stored output, used to resolve
+            ``{nodes.<node_name>.output}`` placeholders.
+
+    Returns:
+        The value with all placeholders resolved. A string that is exactly
+        one placeholder returns the referenced value with native type
+        preserved; embedded placeholders are substituted via ``str()``.
+
+    Raises:
+        TemplateResolutionError: If a ``{nodes.<name>.output}`` placeholder
+            references a node absent from ``results``.
+    """
+    if isinstance(value, str):
+
+        def _lookup(match: re.Match) -> Any:
+            if match.group(1) == "input":
+                return input_text
+            node_name = match.group(2)
+            if node_name not in results:
+                raise TemplateResolutionError(
+                    f"Placeholder '{{nodes.{node_name}.output}}' cannot be "
+                    f"resolved: node '{node_name}' has no result yet. "
+                    f"Available nodes: {sorted(results.keys())}"
+                )
+            return results[node_name]
+
+        if full := _PLACEHOLDER_RE.fullmatch(value):
+            # Exact single placeholder — preserve the native type.
+            return _lookup(full)
+        return _PLACEHOLDER_RE.sub(lambda m: str(_lookup(m)), value)
+    if isinstance(value, dict):
+        return {
+            key: resolve_templates(item, input_text=input_text, results=results)
+            for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [
+            resolve_templates(item, input_text=input_text, results=results)
+            for item in value
+        ]
+    return value
+
+
+def extract_tool_output(tool_result: ToolResult) -> str:
+    """Return the string form of a ``ToolResult`` payload.
+
+    Used wherever the crew stores node outputs as strings
+    (``FlowContext.results``, context summaries, ``NodeResult``).
+
+    Args:
+        tool_result: The tool execution result to stringify.
+
+    Returns:
+        The raw string when the payload already is one, otherwise its JSON
+        encoding (falling back to ``str()`` for non-serialisable payloads).
+    """
+    payload = tool_result.result
+    if isinstance(payload, str):
+        return payload
+    try:
+        encoded = json_encoder(payload)
+    except Exception:  # pylint: disable=W0703
+        return str(payload)
+    return encoded if isinstance(encoded, str) else str(encoded)
+
+
+class ToolNode(Node):
+    """Deterministic tool-caller crew node (no LLM involved).
+
+    Registered into a crew via ``AgentCrew.add_tool_node()``, this node
+    participates in every execution mode: sequential/parallel/loop runs
+    dispatch to :meth:`call_tool` (via ``AgentCrew._execute_agent``), while
+    flow mode invokes :meth:`execute` with the same contract as
+    ``AgentNode.execute``.
+
+    Duck-typing notes:
+
+    - ``is_configured`` defaults to ``True`` so ``_ensure_agent_ready``
+      never attempts LLM configuration.
+    - ``agent`` is a self-referencing property: flow-mode plumbing reads
+      ``node.agent.name`` and ``build_node_metadata`` probes agent
+      attributes with ``getattr(..., None)`` — both are safe on this model.
+    - The FSM lifecycle is driven externally by the crew scheduler, exactly
+      as for ``CrewAgentNode``.
+
+    Args:
+        tool: The tool to invoke (any ``AbstractTool`` or ``ToolLike``).
+        node_id: Unique identifier for this node within the crew.
+        args: Positional arguments passed through to the tool (template
+            placeholders allowed in string values).
+        kwargs: Keyword arguments passed through to the tool (template
+            placeholders allowed in string values).
+        description: Optional human-readable description.
+        dependencies: Node ids that must complete before this node runs.
+        successors: Node ids dispatched after this node completes.
+        fsm: Optional pre-built FSM (auto-created when ``None``).
+    """
+
+    tool: ToolLike
+    node_id: str
+    args: List[Any] = Field(default_factory=list)
+    kwargs: Dict[str, Any] = Field(default_factory=dict)
+    description: Optional[str] = None
+    dependencies: Set[str] = Field(default_factory=set)
+    successors: Set[str] = Field(default_factory=set)
+    fsm: Optional[AgentTaskMachine] = None
+    is_configured: bool = True
+
+    def model_post_init(self, __context: Any) -> None:
+        """Auto-create the FSM if not provided; initialise logger."""
+        super().model_post_init(__context)
+        if self.fsm is None:
+            # object.__setattr__ is the frozen-Pydantic escape hatch for
+            # setting a field inside model_post_init (see core/node.py).
+            object.__setattr__(
+                self, "fsm", AgentTaskMachine(agent_name=self.node_id)
+            )
+
+    @property
+    def name(self) -> str:
+        """Node identity (same as ``node_id`` for tool nodes)."""
+        return self.node_id
+
+    @property
+    def agent(self) -> "ToolNode":
+        """Self-reference for flow-mode plumbing that reads ``node.agent``."""
+        return self
+
+    async def configure(self) -> None:
+        """No-op — the wrapped tool needs no LLM configuration."""
+
+    # ── Template resolution ───────────────────────────────────────────────
+
+    def _resolve_call(
+        self,
+        input_text: str,
+        results: Mapping[str, Any],
+    ) -> Tuple[List[Any], Dict[str, Any]]:
+        """Resolve template placeholders in the declared args/kwargs.
+
+        Args:
+            input_text: Replacement for ``{input}`` placeholders.
+            results: Prior node outputs for ``{nodes.<name>.output}``.
+
+        Returns:
+            Tuple of (resolved positional args, resolved keyword args).
+        """
+        resolved_args = resolve_templates(
+            self.args, input_text=input_text, results=results
+        )
+        resolved_kwargs = resolve_templates(
+            self.kwargs, input_text=input_text, results=results
+        )
+        return resolved_args, resolved_kwargs
+
+    def _render_call(
+        self,
+        resolved_args: List[Any],
+        resolved_kwargs: Dict[str, Any],
+    ) -> str:
+        """Human-readable call description (used as the log/memory prompt)."""
+        try:
+            args_repr = json_encoder(resolved_args)
+            kwargs_repr = json_encoder(resolved_kwargs)
+        except Exception:  # pylint: disable=W0703
+            args_repr = str(resolved_args)
+            kwargs_repr = str(resolved_kwargs)
+        return f"tool:{self.tool.name}(args={args_repr}, kwargs={kwargs_repr})"
+
+    def _derive_input(self, ctx: Any, deps: Mapping[str, Any]) -> str:
+        """Derive the ``{input}`` value in flow mode.
+
+        Returns the last completed dependency's output when the node has
+        dependencies, otherwise the flow's initial task.
+
+        Args:
+            ctx: The current ``FlowContext``.
+            deps: Dependency results (unused directly; ordering comes from
+                ``ctx.completion_order``).
+
+        Returns:
+            The derived input string.
+        """
+        if self.dependencies:
+            completion_order = getattr(ctx, "completion_order", None) or []
+            ctx_results = getattr(ctx, "results", {}) or {}
+            for dep in reversed(completion_order):
+                if dep in self.dependencies and dep in ctx_results:
+                    value = ctx_results[dep]
+                    return value if isinstance(value, str) else str(value)
+        return getattr(ctx, "initial_task", "") or ""
+
+    # ── Execution ─────────────────────────────────────────────────────────
+
+    async def _invoke(
+        self,
+        resolved_args: List[Any],
+        resolved_kwargs: Dict[str, Any],
+        timeout: Optional[float] = None,
+    ) -> ToolResult:
+        """Invoke the wrapped tool with already-resolved arguments.
+
+        Args:
+            resolved_args: Positional arguments for the tool.
+            resolved_kwargs: Keyword arguments for the tool.
+            timeout: Optional per-call timeout in seconds.
+
+        Returns:
+            The successful ``ToolResult``.
+
+        Raises:
+            ToolNodeExecutionError: If the tool reports failure.
+            asyncio.TimeoutError: If the call exceeds ``timeout``.
+        """
+        coro = self.tool.execute(*resolved_args, **resolved_kwargs)
+        tool_result: ToolResult = (
+            await asyncio.wait_for(coro, timeout) if timeout else await coro
+        )
+        if not tool_result.success:
+            raise ToolNodeExecutionError(
+                f"ToolNode '{self.node_id}' (tool '{self.tool.name}') failed "
+                f"[{tool_result.status}]: {tool_result.error}"
+            )
+        return tool_result
+
+    async def call_tool(
+        self,
+        *,
+        input_text: str,
+        results: Mapping[str, Any],
+        timeout: Optional[float] = None,
+    ) -> ToolResult:
+        """Resolve templates and invoke the tool (sequential/parallel/loop path).
+
+        Does NOT fire pre/post actions — the sequential, parallel, and loop
+        modes fire ``run_pre_actions``/``run_post_actions`` externally around
+        ``_execute_agent``, so firing them here would double-invoke hooks.
+
+        Args:
+            input_text: The node's input for ``{input}`` placeholders.
+            results: Prior node outputs for ``{nodes.<name>.output}``.
+            timeout: Optional per-call timeout in seconds.
+
+        Returns:
+            The successful ``ToolResult``.
+
+        Raises:
+            TemplateResolutionError: If a placeholder cannot be resolved.
+            ToolNodeExecutionError: If the tool reports failure.
+        """
+        resolved_args, resolved_kwargs = self._resolve_call(input_text, results)
+        return await self._invoke(resolved_args, resolved_kwargs, timeout)
+
+    async def execute(
+        self,
+        ctx: Any,
+        deps: Mapping[str, Any],
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Execute the tool node in flow mode.
+
+        Signature/return contract mirrors ``AgentNode.execute`` so
+        ``AgentCrew._execute_parallel_agents`` can consume the result
+        uniformly.
+
+        **The FSM lifecycle (start/succeed/fail) is managed externally by
+        the scheduler — do NOT touch ``self.fsm`` here.**
+
+        Args:
+            ctx: The current flow execution context.
+            deps: Mapping of completed dependency node_id → result.
+            **kwargs: Scheduler kwargs; ``timeout`` is honoured, the rest
+                are ignored (never forwarded to the tool).
+
+        Returns:
+            Dict with keys ``'response'`` (the ``ToolResult``),
+            ``'output'`` (string form), ``'execution_time'`` and
+            ``'prompt'`` (rendered call description).
+        """
+        timeout = kwargs.pop("timeout", None)
+        input_text = self._derive_input(ctx, deps)
+        ctx_results = getattr(ctx, "results", {}) or {}
+        resolved_args, resolved_kwargs = self._resolve_call(
+            input_text, ctx_results
+        )
+        prompt = self._render_call(resolved_args, resolved_kwargs)
+        await self.run_pre_actions(prompt=prompt)
+        start_time = asyncio.get_running_loop().time()
+        tool_result = await self._invoke(resolved_args, resolved_kwargs, timeout)
+        execution_time = asyncio.get_running_loop().time() - start_time
+        await self.run_post_actions(result=tool_result)
+        return {
+            "response": tool_result,
+            "output": extract_tool_output(tool_result),
+            "execution_time": execution_time,
+            "prompt": prompt,
+        }

--- a/packages/ai-parrot/src/parrot/models/__init__.py
+++ b/packages/ai-parrot/src/parrot/models/__init__.py
@@ -93,6 +93,7 @@ from .zai import ZaiModel
 from .crew_definition import (
     ExecutionMode,
     AgentDefinition,
+    ToolNodeDefinition,
     FlowRelation,
     CrewDefinition,
 )
@@ -186,6 +187,7 @@ __all__ = (
     # Crew definition models
     "ExecutionMode",
     "AgentDefinition",
+    "ToolNodeDefinition",
     "FlowRelation",
     "CrewDefinition",
     # Conference models (FEAT-223)

--- a/packages/ai-parrot/src/parrot/models/crew_definition.py
+++ b/packages/ai-parrot/src/parrot/models/crew_definition.py
@@ -67,6 +67,59 @@ class AgentDefinition(BaseModel):
     )
 
 
+class ToolNodeDefinition(BaseModel):
+    """Definition of a deterministic tool-execution node in a crew.
+
+    A tool node is NOT an LLM agent: it invokes the referenced tool
+    directly with the declared ``args``/``kwargs`` (pass-through) and wraps
+    the result as an agent-execution result, so it participates in every
+    crew execution mode without spending LLM tokens.
+
+    String values inside ``args``/``kwargs`` may contain template
+    placeholders resolved deterministically at execution time:
+
+    - ``{input}`` — the node's input (previous output / initial task).
+    - ``{nodes.<node_name>.output}`` — a previously completed node's output.
+
+    Avoid dots in ``node_id``: they are ambiguous inside the
+    ``{nodes.<node_name>.output}`` placeholder syntax.
+
+    Attributes:
+        node_id: Unique identifier for the tool node within this crew.
+        tool: Tool name/slug resolved via the tool resolver.
+        name: Human-readable display name (defaults to ``node_id``).
+        description: Optional description of the node's purpose.
+        args: Positional arguments passed through to the tool.
+        kwargs: Keyword arguments passed through to the tool.
+    """
+
+    node_id: str = Field(
+        description="Unique identifier for the tool node within the crew"
+    )
+    tool: str = Field(
+        description="Tool name/slug resolved via the tool resolver"
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="Human-readable display name (defaults to node_id)"
+    )
+    description: Optional[str] = Field(
+        default=None,
+        description="Description of the tool node's purpose"
+    )
+    args: List[Any] = Field(
+        default_factory=list,
+        description="Positional arguments passed through to the tool"
+    )
+    kwargs: Dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Keyword arguments passed through to the tool. String values "
+            "may embed {input} or {nodes.<node_name>.output} placeholders."
+        )
+    )
+
+
 class FlowRelation(BaseModel):
     """Defines a dependency relationship between agents in flow mode.
 
@@ -97,6 +150,8 @@ class CrewDefinition(BaseModel):
         description: Optional human-readable description of the crew's purpose.
         execution_mode: How the crew should execute its agents.
         agents: Ordered list of agent definitions.
+        tool_nodes: Deterministic tool-execution nodes (no LLM) that
+            participate in the crew alongside agents.
         flow_relations: Directed dependency edges used when ``execution_mode``
             is ``FLOW``. Ignored for other modes.
         shared_tools: Tool names that are shared across all agents.
@@ -125,6 +180,13 @@ class CrewDefinition(BaseModel):
     )
     agents: List[AgentDefinition] = Field(
         description="List of agent definitions in the crew"
+    )
+    tool_nodes: List[ToolNodeDefinition] = Field(
+        default_factory=list,
+        description=(
+            "Deterministic tool-execution nodes (no LLM) that participate "
+            "in the crew alongside agents"
+        )
     )
     flow_relations: List[FlowRelation] = Field(
         default_factory=list,
@@ -159,6 +221,7 @@ class CrewDefinition(BaseModel):
 __all__ = [
     "ExecutionMode",
     "AgentDefinition",
+    "ToolNodeDefinition",
     "FlowRelation",
     "CrewDefinition",
 ]

--- a/packages/ai-parrot/tests/_crew_test_helpers.py
+++ b/packages/ai-parrot/tests/_crew_test_helpers.py
@@ -28,6 +28,47 @@ class DummyToolManager:
         return list(self._tools.keys())
 
 
+class DummyTool:
+    """AbstractTool stand-in for ToolNode tests.
+
+    Records every call in ``calls`` and returns a canned ``ToolResult``.
+
+    Args:
+        name: Tool identity.
+        result: Payload placed in ``ToolResult.result`` on success.
+        fail: If True, ``execute()`` returns a failed ``ToolResult``.
+        delay: Optional asyncio sleep before returning.
+    """
+
+    def __init__(
+        self,
+        name: str = "dummy_tool",
+        result: Any = "tool-output",
+        *,
+        fail: bool = False,
+        delay: float = 0.0,
+    ) -> None:
+        self.name = name
+        self.description = f"Dummy tool {name}"
+        self._result = result
+        self._fail = fail
+        self._delay = delay
+        self.calls: List[tuple] = []
+
+    async def execute(self, *args: Any, **kwargs: Any) -> Any:
+        """Record the call and return a canned ToolResult."""
+        from parrot.tools.abstract import ToolResult
+
+        self.calls.append((args, kwargs))
+        if self._delay:
+            await asyncio.sleep(self._delay)
+        if self._fail:
+            return ToolResult(
+                success=False, status="error", result=None, error="boom"
+            )
+        return ToolResult(success=True, status="success", result=self._result)
+
+
 class DummyAgent:
     """Deterministic agent for testing AgentCrew.
 

--- a/packages/ai-parrot/tests/test_crew_tool_node_regression.py
+++ b/packages/ai-parrot/tests/test_crew_tool_node_regression.py
@@ -1,0 +1,301 @@
+"""Regression tests for deterministic ToolNode members in AgentCrew.
+
+Verifies that a ToolNode (direct tool caller, no LLM) participates in all
+four execution modes — sequential, parallel, flow, and loop — with its
+result wrapped as a regular agent-execution result (FlowResult nodes,
+context passing, FSM lifecycle).
+
+The condition evaluation in loop mode (LLM-based) is monkeypatched to
+avoid requiring real LLM access.
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from _crew_test_helpers import DummyAgent, DummyTool  # shared test infrastructure
+from parrot.bots.flows.crew import AgentCrew, ToolNode
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_crew(*agents: DummyAgent, **kwargs: Any) -> AgentCrew:
+    """Create an AgentCrew with DummyAgents."""
+    return AgentCrew(
+        name="TestToolNodeCrew",
+        agents=list(agents),
+        auto_configure=False,
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# add_tool_node basics
+# ---------------------------------------------------------------------------
+
+
+class TestAddToolNode:
+    """Tests for AgentCrew.add_tool_node registration."""
+
+    def test_registers_in_agents_and_workflow_graph(self) -> None:
+        """The node must appear in both membership structures."""
+        crew = _make_crew(DummyAgent("a"))
+        tool = DummyTool("fetcher")
+        node = crew.add_tool_node(tool, "fetch", kwargs={"q": "{input}"})
+        assert isinstance(node, ToolNode)
+        assert crew.agents["fetch"] is node
+        assert crew.workflow_graph["fetch"] is node
+        assert "fetch" in crew._agent_statuses
+
+    def test_duplicate_node_id_raises(self) -> None:
+        """Adding a member with an existing id must raise ValueError."""
+        crew = _make_crew(DummyAgent("a"))
+        crew.add_tool_node(DummyTool(), "fetch")
+        with pytest.raises(ValueError):
+            crew.add_tool_node(DummyTool(), "fetch")
+        with pytest.raises(ValueError):
+            crew.add_tool_node(DummyTool(), "a")  # collides with agent
+
+    def test_add_shared_tool_after_tool_node_does_not_raise(self) -> None:
+        """Shared-tool distribution must skip tool nodes (no tool_manager)."""
+        crew = _make_crew(DummyAgent("a"))
+        crew.add_tool_node(DummyTool(), "fetch")
+        crew.add_shared_tool(DummyTool("shared"), "shared")
+
+    def test_remove_agent_cleans_workflow_graph(self) -> None:
+        """remove_agent must also drop graph and status entries."""
+        crew = _make_crew(DummyAgent("a"))
+        crew.add_tool_node(DummyTool(), "fetch")
+        assert crew.remove_agent("fetch") is True
+        assert "fetch" not in crew.agents
+        assert "fetch" not in crew.workflow_graph
+        assert "fetch" not in crew._agent_statuses
+
+
+# ---------------------------------------------------------------------------
+# Sequential mode
+# ---------------------------------------------------------------------------
+
+
+class TestSequentialToolNode:
+    """run_sequential with a ToolNode in the pipeline."""
+
+    async def test_agent_tool_agent_pipeline(self) -> None:
+        """agent -> tool -> agent: tool output feeds the downstream agent."""
+        a = DummyAgent("a", "alpha-result")
+        b = DummyAgent("b", "beta-result")
+        crew = _make_crew(a, b)
+        tool = DummyTool("fetcher", result="TOOL-PAYLOAD")
+        crew.add_tool_node(
+            tool, "fetch", kwargs={"symbol": "{nodes.a.output}"}
+        )
+        result = await crew.run_sequential(
+            "start",
+            agent_sequence=["a", "fetch", "b"],
+            generate_summary=False,
+        )
+        assert result.status == "completed"
+        # Template resolved against the prior node's stored output
+        assert len(tool.calls) == 1
+        _, called_kwargs = tool.calls[0]
+        assert "alpha-result" in called_kwargs["symbol"]
+        # Downstream agent saw the tool output in its prompt
+        assert any("TOOL-PAYLOAD" in p for p in b.prompts_received)
+        # Tool node reported as a completed node in FlowResult
+        info = {n.node_id: n for n in result.nodes}
+        assert info["fetch"].status == "completed"
+
+    async def test_input_placeholder_gets_previous_output(self) -> None:
+        """{input} in sequential mode is the composed previous input."""
+        a = DummyAgent("a", "alpha")
+        crew = _make_crew(a)
+        tool = DummyTool("fetcher")
+        crew.add_tool_node(tool, "fetch", kwargs={"q": "{input}"})
+        result = await crew.run_sequential(
+            "start",
+            agent_sequence=["a", "fetch"],
+            generate_summary=False,
+        )
+        assert result.status == "completed"
+        _, called_kwargs = tool.calls[0]
+        assert "alpha" in called_kwargs["q"]
+
+    async def test_failed_tool_marks_node_failed(self) -> None:
+        """A failed ToolResult marks the node failed and the run partial."""
+        a = DummyAgent("a", "alpha")
+        crew = _make_crew(a)
+        crew.add_tool_node(DummyTool("fetcher", fail=True), "fetch")
+        result = await crew.run_sequential(
+            "start",
+            agent_sequence=["a", "fetch"],
+            generate_summary=False,
+        )
+        assert result.status == "partial"
+        assert "fetch" in result.errors
+        info = {n.node_id: n for n in result.nodes}
+        assert info["fetch"].status == "failed"
+        node = crew.workflow_graph["fetch"]
+        assert str(node.fsm.current_state.id) == "failed"
+
+    async def test_fsm_completed_on_success(self) -> None:
+        """The tool node FSM reaches completed on success."""
+        crew = _make_crew(DummyAgent("a"))
+        crew.add_tool_node(DummyTool(), "fetch")
+        result = await crew.run_sequential(
+            "start",
+            agent_sequence=["a", "fetch"],
+            generate_summary=False,
+        )
+        assert result.status == "completed"
+        node = crew.workflow_graph["fetch"]
+        assert str(node.fsm.current_state.id) == "completed"
+
+
+# ---------------------------------------------------------------------------
+# Flow mode
+# ---------------------------------------------------------------------------
+
+
+class TestFlowToolNode:
+    """run_flow with ToolNode members in the DAG."""
+
+    async def test_tool_node_between_agents(self) -> None:
+        """a -> fetch(tool) -> b: template resolves the upstream output."""
+        a = DummyAgent("a", "alpha-out")
+        b = DummyAgent("b", "beta-out")
+        crew = _make_crew(a, b)
+        tool = DummyTool("fetcher", result="FLOW-PAYLOAD")
+        node = crew.add_tool_node(
+            tool, "fetch", kwargs={"symbol": "{nodes.a.output}"}
+        )
+        crew.task_flow(a, node)
+        crew.task_flow(node, b)
+        result = await crew.run_flow("start", generate_summary=False)
+        assert result.status == "completed"
+        _, called_kwargs = tool.calls[0]
+        assert "alpha-out" in called_kwargs["symbol"]
+        # Downstream agent consumed the tool output
+        assert any("FLOW-PAYLOAD" in p for p in b.prompts_received)
+        # FSM lifecycle handled by the scheduler
+        assert str(crew.workflow_graph["fetch"].fsm.current_state.id) == "completed"
+
+    async def test_tool_node_as_initial_node(self) -> None:
+        """A tool node with no dependencies uses the initial task as input."""
+        b = DummyAgent("b", "beta")
+        crew = _make_crew(b)
+        tool = DummyTool("fetcher", result="INITIAL-PAYLOAD")
+        node = crew.add_tool_node(tool, "fetch", kwargs={"q": "{input}"})
+        crew.task_flow(node, b)
+        result = await crew.run_flow("the-initial-task", generate_summary=False)
+        assert result.status == "completed"
+        _, called_kwargs = tool.calls[0]
+        assert called_kwargs["q"] == "the-initial-task"
+
+    async def test_failed_tool_blocks_downstream(self) -> None:
+        """A failing tool node prevents downstream agents from running."""
+        b = DummyAgent("b", "beta")
+        crew = _make_crew(b)
+        node = crew.add_tool_node(DummyTool("fetcher", fail=True), "fetch")
+        crew.task_flow(node, b)
+        result = await crew.run_flow("start", generate_summary=False)
+        assert result.status in ("partial", "failed")
+        assert "fetch" in result.errors
+        assert len(b.prompts_received) == 0
+        assert str(crew.workflow_graph["fetch"].fsm.current_state.id) == "failed"
+
+    async def test_native_type_passthrough(self) -> None:
+        """A full-match placeholder inside kwargs keeps native types."""
+        a = DummyAgent("a", "alpha")
+        crew = _make_crew(a)
+        tool = DummyTool("fetcher")
+        node = crew.add_tool_node(
+            tool,
+            "fetch",
+            kwargs={"query": "{nodes.a.output}", "top_k": 3},
+        )
+        crew.task_flow(a, node)
+        result = await crew.run_flow("start", generate_summary=False)
+        assert result.status == "completed"
+        _, called_kwargs = tool.calls[0]
+        assert called_kwargs["top_k"] == 3
+        assert isinstance(called_kwargs["query"], str)
+
+
+# ---------------------------------------------------------------------------
+# Parallel mode
+# ---------------------------------------------------------------------------
+
+
+class TestParallelToolNode:
+    """run_parallel with ToolNode tasks."""
+
+    async def test_tool_node_task_uses_query_as_input(self) -> None:
+        """{input} in parallel mode is the task's own query."""
+        a = DummyAgent("a", "alpha")
+        crew = _make_crew(a)
+        tool = DummyTool("fetcher", result="PAR-PAYLOAD")
+        crew.add_tool_node(tool, "fetch", kwargs={"symbol": "{input}"})
+        result = await crew.run_parallel(
+            tasks=[
+                {"agent_id": "a", "query": "task-for-a"},
+                {"agent_id": "fetch", "query": "AAPL"},
+            ],
+            generate_summary=False,
+        )
+        assert result.status == "completed"
+        _, called_kwargs = tool.calls[0]
+        assert called_kwargs["symbol"] == "AAPL"
+        assert result.responses["fetch"] is not None
+
+    async def test_failed_tool_node_partial_status(self) -> None:
+        """A failing tool node yields partial status without killing others."""
+        a = DummyAgent("a", "alpha")
+        crew = _make_crew(a)
+        crew.add_tool_node(DummyTool("fetcher", fail=True), "fetch")
+        result = await crew.run_parallel(
+            tasks=[
+                {"agent_id": "a", "query": "task-for-a"},
+                {"agent_id": "fetch", "query": "AAPL"},
+            ],
+            generate_summary=False,
+        )
+        assert result.status == "partial"
+        assert "fetch" in result.errors
+
+
+# ---------------------------------------------------------------------------
+# Loop mode
+# ---------------------------------------------------------------------------
+
+
+class TestLoopToolNode:
+    """run_loop with a ToolNode in the iterated sequence."""
+
+    async def test_tool_node_runs_each_iteration(self) -> None:
+        """The tool executes once per iteration with a fresh FSM."""
+        a = DummyAgent("a", "alpha")
+        crew = _make_crew(a)
+        tool = DummyTool("fetcher", result="LOOP-PAYLOAD")
+        crew.add_tool_node(tool, "fetch", kwargs={"q": "{input}"})
+        with patch.object(
+            crew,
+            "_evaluate_loop_condition",
+            new_callable=AsyncMock,
+            return_value=False,
+        ):
+            result = await crew.run_loop(
+                initial_task="start",
+                condition="never true",
+                max_iterations=2,
+                generate_summary=False,
+            )
+        assert result.metadata["iterations"] == 2
+        assert result.status == "completed"
+        assert len(tool.calls) == 2
+        node = crew.workflow_graph["fetch"]
+        assert str(node.fsm.current_state.id) == "completed"

--- a/tests/unit/test_agentcrew_tool_nodes_definition.py
+++ b/tests/unit/test_agentcrew_tool_nodes_definition.py
@@ -1,0 +1,121 @@
+"""
+Unit tests for deterministic tool nodes in AgentCrew.from_definition().
+
+Verifies that:
+- ToolNodeDefinition entries become ToolNode crew members (registered in
+  both crew.agents and crew.workflow_graph).
+- args/kwargs/description are passed through to the node.
+- Flow relations may reference tool nodes by node_id as source or target.
+- An unresolvable tool raises ValueError (structural DAG member).
+- tool_nodes without a tool_resolver raises ValueError.
+"""
+from unittest.mock import create_autospec
+
+import pytest
+
+from parrot.models.crew_definition import (
+    CrewDefinition,
+    AgentDefinition,
+    ToolNodeDefinition,
+    FlowRelation,
+    ExecutionMode,
+)
+from parrot.bots.flows.crew import AgentCrew, ToolNode
+from parrot.bots.agent import BasicAgent
+from parrot.tools.abstract import AbstractTool
+
+
+def make_crew_def(**overrides):
+    """Build a minimal valid CrewDefinition with a tool node."""
+    defaults = dict(
+        name="test-crew",
+        agents=[
+            AgentDefinition(agent_id="agent-1", name="Agent One"),
+        ],
+        tool_nodes=[
+            ToolNodeDefinition(
+                node_id="fetch",
+                tool="yfinance",
+                description="Fetch prices deterministically",
+                kwargs={"symbol": "{input}", "period": "1mo"},
+                args=["positional"],
+            ),
+        ],
+    )
+    defaults.update(overrides)
+    return CrewDefinition(**defaults)
+
+
+def dummy_resolver(class_name: str):
+    """Always resolves to BasicAgent regardless of class_name."""
+    return BasicAgent
+
+
+class TestFromDefinitionToolNodes:
+    """Tests for tool_nodes wiring in AgentCrew.from_definition()."""
+
+    def test_tool_node_registered_in_crew(self):
+        """The tool node appears in crew.agents and crew.workflow_graph."""
+        mock_tool = create_autospec(AbstractTool, instance=True)
+        mock_tool.name = "yfinance"
+        crew = AgentCrew.from_definition(
+            make_crew_def(),
+            class_resolver=dummy_resolver,
+            tool_resolver=lambda name: mock_tool if name == "yfinance" else None,
+        )
+        node = crew.agents["fetch"]
+        assert isinstance(node, ToolNode)
+        assert crew.workflow_graph["fetch"] is node
+        assert node.tool is mock_tool
+        assert node.args == ["positional"]
+        assert node.kwargs == {"symbol": "{input}", "period": "1mo"}
+        assert node.description == "Fetch prices deterministically"
+
+    def test_flow_relation_references_tool_node(self):
+        """Tool nodes can be flow-relation sources/targets by node_id."""
+        mock_tool = create_autospec(AbstractTool, instance=True)
+        mock_tool.name = "yfinance"
+        crew_def = make_crew_def(
+            execution_mode=ExecutionMode.FLOW,
+            flow_relations=[
+                FlowRelation(source="fetch", target="Agent One"),
+            ],
+        )
+        crew = AgentCrew.from_definition(
+            crew_def,
+            class_resolver=dummy_resolver,
+            tool_resolver=lambda name: mock_tool,
+        )
+        assert "fetch" in crew.workflow_graph["Agent One"].dependencies
+        assert "Agent One" in crew.workflow_graph["fetch"].successors
+
+    def test_unresolvable_tool_raises(self):
+        """A tool the resolver cannot find must raise (not silently skip)."""
+        with pytest.raises(ValueError) as excinfo:
+            AgentCrew.from_definition(
+                make_crew_def(),
+                class_resolver=dummy_resolver,
+                tool_resolver=lambda name: None,
+            )
+        assert "yfinance" in str(excinfo.value)
+        assert "fetch" in str(excinfo.value)
+
+    def test_tool_nodes_without_resolver_raises(self):
+        """tool_nodes present but no tool_resolver must raise."""
+        with pytest.raises(ValueError):
+            AgentCrew.from_definition(
+                make_crew_def(),
+                class_resolver=dummy_resolver,
+            )
+
+    def test_no_tool_nodes_backward_compatible(self):
+        """Definitions without tool_nodes build exactly as before."""
+        crew_def = make_crew_def(tool_nodes=[])
+        crew = AgentCrew.from_definition(
+            crew_def,
+            class_resolver=dummy_resolver,
+        )
+        assert "Agent One" in crew.agents
+        assert not any(
+            isinstance(member, ToolNode) for member in crew.agents.values()
+        )

--- a/tests/unit/test_crew_definition_models.py
+++ b/tests/unit/test_crew_definition_models.py
@@ -9,6 +9,7 @@ Verifies that:
 from parrot.models.crew_definition import (
     ExecutionMode,
     AgentDefinition,
+    ToolNodeDefinition,
     FlowRelation,
     CrewDefinition,
 )
@@ -71,6 +72,55 @@ class TestModelRelocation:
         assert cd.flow_relations == []
         assert cd.max_parallel_tasks == 10
         assert cd.tenant == "global"
+        # FEAT: deterministic tool nodes default to empty (backward compat)
+        assert cd.tool_nodes == []
+
+
+class TestToolNodeDefinition:
+    """Test the deterministic ToolNodeDefinition model."""
+
+    def test_defaults(self):
+        """ToolNodeDefinition must have sensible defaults."""
+        tn = ToolNodeDefinition(node_id="fetch", tool="yfinance")
+        assert tn.node_id == "fetch"
+        assert tn.tool == "yfinance"
+        assert tn.name is None
+        assert tn.description is None
+        assert tn.args == []
+        assert tn.kwargs == {}
+
+    def test_roundtrip_preserves_placeholders(self):
+        """Template placeholders survive a dump/reload round-trip verbatim."""
+        tn = ToolNodeDefinition(
+            node_id="fetch",
+            tool="yfinance",
+            args=["{input}"],
+            kwargs={"symbol": "{nodes.researcher.output}", "period": "1mo"},
+        )
+        tn2 = ToolNodeDefinition(**tn.model_dump())
+        assert tn2.args == ["{input}"]
+        assert tn2.kwargs["symbol"] == "{nodes.researcher.output}"
+
+    def test_crew_definition_with_tool_nodes_roundtrip(self):
+        """CrewDefinition carrying tool_nodes must round-trip."""
+        cd = CrewDefinition(
+            name="crew-with-tools",
+            agents=[AgentDefinition(agent_id="a1")],
+            tool_nodes=[ToolNodeDefinition(node_id="fetch", tool="yfinance")],
+        )
+        cd2 = CrewDefinition(**cd.model_dump())
+        assert len(cd2.tool_nodes) == 1
+        assert cd2.tool_nodes[0].node_id == "fetch"
+
+    def test_backward_compat_reexport(self):
+        """parrot.handlers.crew.models re-exports ToolNodeDefinition."""
+        from parrot.handlers.crew.models import ToolNodeDefinition as TND
+        assert TND is ToolNodeDefinition
+
+    def test_parrot_models_init_export(self):
+        """parrot.models package must export ToolNodeDefinition."""
+        from parrot.models import ToolNodeDefinition as TND
+        assert TND is ToolNodeDefinition
 
 
 class TestFlowRelation:

--- a/tests/unit/test_special_nodes_catalog.py
+++ b/tests/unit/test_special_nodes_catalog.py
@@ -1,0 +1,145 @@
+"""Unit tests for the crew special-nodes catalog handler.
+
+We load special_nodes.py directly via importlib (mirroring
+test_tools_catalog.py) to avoid triggering the full parrot-server package
+chain. Navigator/navconfig dependencies are stubbed when not installed.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub out heavy navigator / navconfig dependencies before loading the module.
+# ---------------------------------------------------------------------------
+
+_STUBS = (
+    "navconfig",
+    "navconfig.logging",
+    "navigator",
+    "navigator.views",
+    "navigator_auth",
+    "navigator_auth.decorators",
+)
+
+for _stub_name in _STUBS:
+    if _stub_name not in sys.modules:
+        _mod = types.ModuleType(_stub_name)
+        _mod.logging = MagicMock()  # type: ignore[attr-defined]
+        _mod.logging.getLogger = lambda name="": MagicMock()  # type: ignore[attr-defined]
+        _mod.BaseView = object  # type: ignore[attr-defined]
+
+        def _identity_decorator(*a, **kw):  # noqa: E306
+            def _dec(cls):
+                return cls
+            return _dec
+
+        _mod.is_authenticated = _identity_decorator  # type: ignore[attr-defined]
+        _mod.user_session = _identity_decorator  # type: ignore[attr-defined]
+        sys.modules[_stub_name] = _mod
+
+_WT_ROOT = Path(__file__).resolve().parents[2]
+_SN_SRC = (
+    _WT_ROOT
+    / "packages"
+    / "ai-parrot-server"
+    / "src"
+    / "parrot"
+    / "handlers"
+    / "crew"
+    / "special_nodes.py"
+)
+_MOD_NAME = "crew_special_nodes_under_test"
+
+if _MOD_NAME not in sys.modules:
+    _spec = importlib.util.spec_from_file_location(_MOD_NAME, str(_SN_SRC))
+    _sn_mod = importlib.util.module_from_spec(_spec)
+    sys.modules[_MOD_NAME] = _sn_mod
+    _spec.loader.exec_module(_sn_mod)
+
+_SN_MOD = sys.modules[_MOD_NAME]
+CREW_SPECIAL_NODE_CATALOG = _SN_MOD.CREW_SPECIAL_NODE_CATALOG
+CrewSpecialNodeCatalogHandler = _SN_MOD.CrewSpecialNodeCatalogHandler
+
+
+# ---------------------------------------------------------------------------
+# Tests — catalog contents
+# ---------------------------------------------------------------------------
+
+
+class TestSpecialNodeCatalog:
+    """Contract tests for the curated special-node catalog."""
+
+    def test_catalog_is_nonempty_list(self) -> None:
+        assert isinstance(CREW_SPECIAL_NODE_CATALOG, list)
+        assert len(CREW_SPECIAL_NODE_CATALOG) >= 1
+
+    def test_every_entry_has_required_fields(self) -> None:
+        required = {
+            "slug", "name", "display_name", "description",
+            "category", "type", "config_schema",
+        }
+        for entry in CREW_SPECIAL_NODE_CATALOG:
+            assert required.issubset(entry.keys()), entry.get("slug")
+            assert entry["type"] == "special_node"
+
+    def test_slugs_are_unique(self) -> None:
+        slugs = [e["slug"] for e in CREW_SPECIAL_NODE_CATALOG]
+        assert len(slugs) == len(set(slugs))
+
+    def test_tool_node_entry_present(self) -> None:
+        entry = next(
+            e for e in CREW_SPECIAL_NODE_CATALOG if e["slug"] == "tool_node"
+        )
+        assert entry["name"] == "ToolNode"
+        assert entry["category"] == "deterministic"
+        schema = entry["config_schema"]
+        assert set(schema.keys()) == {
+            "node_id", "tool", "args", "kwargs", "description",
+        }
+        # The template syntax must be documented for the builder UI
+        assert "{input}" in schema["kwargs"]["description"]
+        assert "{nodes.<node_name>.output}" in schema["kwargs"]["description"]
+
+
+# ---------------------------------------------------------------------------
+# Tests — handler
+# ---------------------------------------------------------------------------
+
+
+class _StubHandler:
+    """Minimal stand-in exposing json_response for testing get().
+
+    Mirrors test_tools_catalog.py: the real handler class may be wrapped by
+    navigator_auth decorators (session/auth plumbing), so the stub replays
+    the handler's one-line get() body against the real catalog constant.
+    """
+
+    def __init__(self) -> None:
+        self.logger = MagicMock()
+
+    def json_response(self, data: Any) -> Any:
+        return data
+
+    async def get(self) -> Any:
+        return self.json_response(_SN_MOD.CREW_SPECIAL_NODE_CATALOG)
+
+
+class TestSpecialNodeCatalogHandler:
+    """Tests for CrewSpecialNodeCatalogHandler.get."""
+
+    def test_is_a_class_with_get(self) -> None:
+        assert isinstance(CrewSpecialNodeCatalogHandler, type)
+        assert callable(getattr(CrewSpecialNodeCatalogHandler, "get", None))
+
+    @pytest.mark.asyncio
+    async def test_get_returns_catalog(self) -> None:
+        stub = _StubHandler()
+        result = await stub.get()
+        assert result is CREW_SPECIAL_NODE_CATALOG

--- a/tests/unit/test_tool_node.py
+++ b/tests/unit/test_tool_node.py
@@ -1,0 +1,247 @@
+"""
+Unit tests for the deterministic ToolNode and its template resolver.
+
+Verifies that:
+- resolve_templates substitutes {input} and {nodes.<name>.output}
+  placeholders, preserves native types on full-match, walks nested
+  structures, leaves literal braces alone, and raises a clear error for
+  unresolvable node references.
+- ToolNode duck-types the crew node contract (name, agent, is_configured,
+  auto-created FSM) and its execute() returns the AgentNode-compatible
+  result dict.
+- A failed ToolResult raises ToolNodeExecutionError.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from parrot.bots.flows.crew import (
+    TemplateResolutionError,
+    ToolNode,
+    ToolNodeExecutionError,
+    resolve_templates,
+)
+from parrot.bots.flows.crew.tool_node import extract_tool_output
+from parrot.tools.abstract import ToolResult
+
+
+class RecordingTool:
+    """Minimal ToolLike double that records calls."""
+
+    def __init__(
+        self,
+        name: str = "recording_tool",
+        result: Any = "tool-output",
+        *,
+        fail: bool = False,
+    ) -> None:
+        self.name = name
+        self._result = result
+        self._fail = fail
+        self.calls: list = []
+
+    async def execute(self, *args: Any, **kwargs: Any) -> ToolResult:
+        self.calls.append((args, kwargs))
+        if self._fail:
+            return ToolResult(
+                success=False, status="error", result=None, error="boom"
+            )
+        return ToolResult(success=True, status="success", result=self._result)
+
+
+def make_ctx(**overrides: Any) -> SimpleNamespace:
+    """Build a minimal FlowContext-shaped object for execute() tests."""
+    defaults = dict(
+        initial_task="the-initial-task",
+        results={},
+        completion_order=[],
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class TestResolveTemplates:
+    """Tests for the deterministic template resolver."""
+
+    def test_input_placeholder(self):
+        assert resolve_templates("{input}", input_text="AAPL", results={}) == "AAPL"
+
+    def test_embedded_placeholder_stringifies(self):
+        out = resolve_templates(
+            "symbol={input}!", input_text="AAPL", results={}
+        )
+        assert out == "symbol=AAPL!"
+
+    def test_node_output_placeholder(self):
+        out = resolve_templates(
+            "{nodes.researcher.output}",
+            input_text="",
+            results={"researcher": "found-it"},
+        )
+        assert out == "found-it"
+
+    def test_full_match_preserves_native_type(self):
+        payload = {"price": 42, "rows": [1, 2]}
+        out = resolve_templates(
+            "{nodes.fetch.output}", input_text="", results={"fetch": payload}
+        )
+        assert out is payload
+
+    def test_embedded_node_output_stringifies(self):
+        out = resolve_templates(
+            "data: {nodes.fetch.output}",
+            input_text="",
+            results={"fetch": {"k": 1}},
+        )
+        assert out == "data: {'k': 1}"
+
+    def test_nested_structures_walked(self):
+        value = {
+            "q": "sym={input}",
+            "n": 3,
+            "inner": {"ref": "{nodes.a.output}"},
+            "items": ["{input}", 7],
+        }
+        out = resolve_templates(value, input_text="X", results={"a": "A-OUT"})
+        assert out == {
+            "q": "sym=X",
+            "n": 3,
+            "inner": {"ref": "A-OUT"},
+            "items": ["X", 7],
+        }
+
+    def test_literal_braces_untouched(self):
+        literal = '{"json": 1, "other": {"nested": true}}'
+        assert resolve_templates(literal, input_text="", results={}) == literal
+
+    def test_missing_node_raises_with_available_keys(self):
+        with pytest.raises(TemplateResolutionError) as excinfo:
+            resolve_templates(
+                "{nodes.missing.output}", input_text="", results={"a": 1}
+            )
+        assert "missing" in str(excinfo.value)
+        assert "'a'" in str(excinfo.value)
+
+    def test_non_string_leaves_pass_through(self):
+        assert resolve_templates(42, input_text="x", results={}) == 42
+        assert resolve_templates(None, input_text="x", results={}) is None
+
+
+class TestExtractToolOutput:
+    """Tests for ToolResult payload stringification."""
+
+    def test_string_passthrough(self):
+        tr = ToolResult(success=True, status="success", result="plain")
+        assert extract_tool_output(tr) == "plain"
+
+    def test_dict_payload_serialised(self):
+        tr = ToolResult(success=True, status="success", result={"a": 1})
+        out = extract_tool_output(tr)
+        assert isinstance(out, str)
+        assert '"a"' in out or "'a'" in out
+
+
+class TestToolNodeContract:
+    """Duck-typing invariants required by the crew engine."""
+
+    def test_identity_and_configuration(self):
+        node = ToolNode(tool=RecordingTool(), node_id="fetch")
+        assert node.name == "fetch"
+        assert node.agent is node
+        assert node.is_configured is True
+        assert node.fsm is not None
+        assert node.dependencies == set()
+        assert node.successors == set()
+
+    def test_default_description(self):
+        node = ToolNode(tool=RecordingTool("weather"), node_id="fetch")
+        assert node.description is None
+
+    @pytest.mark.asyncio
+    async def test_configure_is_noop(self):
+        node = ToolNode(tool=RecordingTool(), node_id="fetch")
+        assert await node.configure() is None
+
+
+class TestToolNodeExecute:
+    """Tests for flow-mode execute() and call_tool()."""
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_agentnode_shaped_dict(self):
+        tool = RecordingTool(result={"price": 42})
+        node = ToolNode(tool=tool, node_id="fetch", kwargs={"q": "{input}"})
+        result = await node.execute(make_ctx(), {})
+        assert sorted(result.keys()) == [
+            "execution_time", "output", "prompt", "response",
+        ]
+        assert isinstance(result["response"], ToolResult)
+        assert isinstance(result["output"], str)
+        assert "42" in result["output"]
+        assert result["prompt"].startswith("tool:recording_tool(")
+        assert tool.calls == [((), {"q": "the-initial-task"})]
+
+    @pytest.mark.asyncio
+    async def test_derive_input_uses_last_completed_dependency(self):
+        tool = RecordingTool()
+        node = ToolNode(
+            tool=tool,
+            node_id="fetch",
+            kwargs={"q": "{input}"},
+            dependencies={"a", "b"},
+        )
+        ctx = make_ctx(
+            results={"a": "a-out", "b": "b-out", "c": "c-out"},
+            completion_order=["a", "c", "b"],
+        )
+        await node.execute(ctx, ctx.results)
+        assert tool.calls[0][1]["q"] == "b-out"
+
+    @pytest.mark.asyncio
+    async def test_positional_args_passed_through(self):
+        tool = RecordingTool()
+        node = ToolNode(tool=tool, node_id="fetch", args=["{input}", 5])
+        await node.execute(make_ctx(initial_task="AAPL"), {})
+        assert tool.calls[0][0] == ("AAPL", 5)
+
+    @pytest.mark.asyncio
+    async def test_failed_tool_result_raises(self):
+        node = ToolNode(tool=RecordingTool(fail=True), node_id="fetch")
+        with pytest.raises(ToolNodeExecutionError) as excinfo:
+            await node.execute(make_ctx(), {})
+        assert "fetch" in str(excinfo.value)
+        assert "boom" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_call_tool_resolves_node_references(self):
+        tool = RecordingTool()
+        node = ToolNode(
+            tool=tool, node_id="fetch", kwargs={"sym": "{nodes.a.output}"}
+        )
+        result = await node.call_tool(
+            input_text="ignored", results={"a": "A-VALUE"}
+        )
+        assert isinstance(result, ToolResult)
+        assert tool.calls[0][1]["sym"] == "A-VALUE"
+
+    @pytest.mark.asyncio
+    async def test_call_tool_missing_reference_raises(self):
+        node = ToolNode(
+            tool=RecordingTool(),
+            node_id="fetch",
+            kwargs={"sym": "{nodes.absent.output}"},
+        )
+        with pytest.raises(TemplateResolutionError):
+            await node.call_tool(input_text="", results={})
+
+    @pytest.mark.asyncio
+    async def test_pre_and_post_actions_fire_in_execute(self):
+        events: list = []
+        node = ToolNode(tool=RecordingTool(), node_id="fetch")
+        node.add_pre_action(lambda name, prompt, **ctx: events.append(("pre", name)))
+        node.add_post_action(lambda name, result, **ctx: events.append(("post", name)))
+        await node.execute(make_ctx(), {})
+        assert events == [("pre", "fetch"), ("post", "fetch")]


### PR DESCRIPTION
## Summary

Introduces `ToolNode`, a new crew member type that executes tools directly without LLM involvement. Tool nodes participate in all crew execution modes (sequential, parallel, flow, loop) with results wrapped as agent-execution outcomes, enabling deterministic tool calls to integrate seamlessly into crew workflows.

## Key Changes

- **New `ToolNode` class** (`tool_node.py`): Deterministic tool-caller crew node with:
  - Template placeholder resolution (`{input}`, `{nodes.<node_name>.output}`) resolved from prior results at execution time
  - Duck-typing support for any `ToolLike` object (Protocol-based, not requiring `AbstractTool` subclass)
  - FSM lifecycle integration matching `CrewAgentNode` contract
  - Async tool invocation with optional timeout support
  - Result wrapping as `FlowResult`-compatible output

- **Template resolution system** (`resolve_templates`, `extract_tool_output`):
  - Recursive placeholder substitution in nested dicts/lists/tuples
  - Native type preservation for full-match placeholders (e.g., dict results pass through as dicts)
  - String embedding for partial matches
  - Clear error messages for unresolvable node references

- **`AgentCrew` integration**:
  - `add_tool_node()` method registers tool nodes in both `agents` and `workflow_graph`
  - Tool nodes skipped from agent-only machinery (shared-tool distribution, LLM tool registration)
  - `from_definition()` support for `ToolNodeDefinition` entries with tool resolution
  - Proper FSM lifecycle handling in all execution modes

- **Data model** (`ToolNodeDefinition`):
  - New model in `crew_definition.py` for declarative tool node configuration
  - Supports `args`, `kwargs`, `description`, and template placeholders
  - Integrated into crew definition schema

- **UI/API support**:
  - New `special_nodes.py` catalog handler exposing tool nodes to crew builder UI
  - `GET /api/v1/crew/special_nodes` endpoint with curated metadata
  - JSON-Schema config fragment documenting template syntax

- **Comprehensive test coverage**:
  - Unit tests for template resolution, type preservation, error handling
  - Regression tests for all four execution modes (sequential, parallel, flow, loop)
  - Definition model round-trip and flow-relation integration tests
  - Catalog handler contract tests

## Implementation Details

- Tool nodes are registered as `Node` subclasses with `is_configured=True` to skip LLM setup
- `agent` property returns self-reference for flow-mode plumbing compatibility
- Template resolution happens deterministically at execution time from `FlowContext.results` and `completion_order`
- Failed `ToolResult` (success=False) raises `ToolNodeExecutionError` and marks node as failed
- Tool output stringified via `extract_tool_output()` for consistent storage in context/summaries
- Timeout support via `asyncio.wait_for()` with configurable per-call limits

https://claude.ai/code/session_01D1LSrmydrPm3w1gSN1gjPC