### PR TITLE
FEAT-260: Machine-first wiki retrieval plane (SQLite + in-memory stores)

### DIFF
--- a/packages/ai-parrot/src/parrot/knowledge/okf/ontology.py
+++ b/packages/ai-parrot/src/parrot/knowledge/okf/ontology.py
@@ -63,6 +63,12 @@ class ConceptType(str, Enum):
     WIKI_SYNTHESIS = "Wiki Synthesis"
     WIKI_OVERVIEW = "Wiki Overview"
 
+    # --- Open-vocabulary fallback (FEAT-216) ---
+    # bundle.py maps unknown foreign OKF ``type`` values here on import;
+    # the member was documented since FEAT-216 but never added, so any
+    # foreign-typed bundle import raised AttributeError.
+    OTHER = "Other"
+
 
 class RelationType(str, Enum):
     """Typed edge vocabulary (OKF-superset).

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/__init__.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/__init__.py
@@ -1,14 +1,18 @@
 """parrot.knowledge.wiki — LLM Wiki: Persistent Knowledge Base (FEAT-260).
 
-Implements Karpathy's 3-layer LLM Wiki architecture on top of
-AI-Parrot's existing PageIndex and GraphIndex modules:
+Implements Karpathy's 3-layer LLM Wiki architecture, optimised for
+machine retrieval (tools and LLMs) rather than human-readable storage:
 
 - **Raw Sources** — :class:`SourceCollectionManager` tracks ingested
-  documents with SHA-1 hash + mtime staleness detection.
-- **Wiki Pages** — LLM-generated Markdown pages stored in PageIndex trees
-  and synchronised to GraphIndex as ``WIKI_PAGE`` nodes.
-- **Schema** — OKF ontology extensions (wiki ConceptType values,
-  SUMMARIZES / CONTRADICTS relation types).
+  documents with SHA-1 hash + mtime staleness detection (persisted in
+  the wiki's SQLite plane).
+- **Wiki Pages** — structured by PageIndex at ingest time, then served
+  from :class:`WikiStore` — a single-file SQLite retrieval plane
+  (FTS5/BM25 + optional embedding cosine + typed edges) — with
+  token-budgeted context packing (:func:`pack_results`) and
+  progressive disclosure.
+- **Schema** — open-string categories/relations in the machine plane;
+  OKF ontology extensions retained at the export boundary.
 
 Public API::
 
@@ -24,10 +28,15 @@ Public API::
         WikiCombinedSearch,
         WikiIngestOrchestrator,
         IngestReport,
+        WikiStore,
+        WikiPageRecord,
+        PackedContext,
+        pack_results,
     )
 """
 
 from parrot.knowledge.wiki.bookkeeper import WikiBookkeeper
+from parrot.knowledge.wiki.context import PackedContext, pack_results
 from parrot.knowledge.wiki.ingest import IngestReport, WikiIngestOrchestrator
 from parrot.knowledge.wiki.models import (
     SourceManifestEntry,
@@ -38,6 +47,7 @@ from parrot.knowledge.wiki.models import (
 )
 from parrot.knowledge.wiki.search import WikiCombinedSearch
 from parrot.knowledge.wiki.sources import SourceCollectionManager
+from parrot.knowledge.wiki.store import WikiPageRecord, WikiStore
 from parrot.knowledge.wiki.toolkit import LLMWikiToolkit
 
 __all__ = [
@@ -59,4 +69,10 @@ __all__ = [
     "IngestReport",
     # Lint
     "WikiLintReport",
+    # Retrieval plane (machine-first)
+    "WikiStore",
+    "WikiPageRecord",
+    # Context packing
+    "PackedContext",
+    "pack_results",
 ]

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/__init__.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/__init__.py
@@ -45,9 +45,16 @@ from parrot.knowledge.wiki.models import (
     WikiPageCategory,
     WikiSearchResult,
 )
+from parrot.knowledge.wiki.file_store import InMemoryWikiStore
 from parrot.knowledge.wiki.search import WikiCombinedSearch
 from parrot.knowledge.wiki.sources import SourceCollectionManager
-from parrot.knowledge.wiki.store import WikiPageRecord, WikiStore
+from parrot.knowledge.wiki.store import (
+    BaseWikiStore,
+    SQLiteWikiStore,
+    WikiPageRecord,
+    WikiStore,
+    create_wiki_store,
+)
 from parrot.knowledge.wiki.toolkit import LLMWikiToolkit
 
 __all__ = [
@@ -69,8 +76,12 @@ __all__ = [
     "IngestReport",
     # Lint
     "WikiLintReport",
-    # Retrieval plane (machine-first)
+    # Retrieval plane (machine-first, pluggable backends)
+    "BaseWikiStore",
     "WikiStore",
+    "SQLiteWikiStore",
+    "InMemoryWikiStore",
+    "create_wiki_store",
     "WikiPageRecord",
     # Context packing
     "PackedContext",

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/context.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/context.py
@@ -1,0 +1,201 @@
+"""Token-efficient context packing for wiki retrieval results.
+
+The wiki optimises for what the LLM actually pays for: tokens.  Instead
+of dumping full page bodies (or raw model dumps) into context, search
+results are packed as **compact stubs** — one line per page with its
+identity, title, lead sentence, score, and token cost — under an
+explicit token budget.  The model then *progressively discloses* only
+what it needs via ``wiki_read`` (full body, optionally truncated) and
+``wiki_expand`` (edge neighbours).
+
+All token accounting uses the per-page ``token_count`` stored in the
+WikiStore at ingest time plus :func:`estimate_tokens` for the stub
+lines themselves — nothing is re-tokenised at query time.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable, Optional
+
+from pydantic import BaseModel, Field
+
+from parrot.knowledge.wiki.store import estimate_tokens
+
+_SENTENCE_END_RE = re.compile(r"(?<=[.!?])\s")
+
+DEFAULT_BUDGET_TOKENS = 1200
+_MAX_LEAD_CHARS = 240
+
+
+class PackedContext(BaseModel):
+    """A budgeted, LLM-ready packing of wiki search results.
+
+    Attributes:
+        text: Compact context block — one stub line per result.
+        stubs: Structured stubs (id, title, lead, score, token cost of
+            the FULL page — what ``wiki_read`` would spend).
+        tokens_used: Estimated tokens of ``text``.
+        results_packed: Number of results that fit the budget.
+        total_available: Number of results before budgeting.
+        truncated: ``True`` when the budget cut results off.
+    """
+
+    text: str = ""
+    stubs: list[dict[str, Any]] = Field(default_factory=list)
+    tokens_used: int = 0
+    results_packed: int = 0
+    total_available: int = 0
+    truncated: bool = False
+
+
+def first_sentence(text: str, max_chars: int = _MAX_LEAD_CHARS) -> str:
+    """Return the lead sentence of ``text``, hard-capped at ``max_chars``.
+
+    Args:
+        text: Source text (summary or body).
+        max_chars: Maximum characters returned.
+
+    Returns:
+        The first sentence (or the truncated text when no sentence
+        boundary is found), single-line.
+    """
+    lead = " ".join(text.strip().split())
+    if not lead:
+        return ""
+    parts = _SENTENCE_END_RE.split(lead, maxsplit=1)
+    lead = parts[0]
+    if len(lead) > max_chars:
+        lead = lead[: max_chars - 1].rstrip() + "…"
+    return lead
+
+
+def stub_line(result: dict[str, Any]) -> str:
+    """Render one search result as a compact single-line stub.
+
+    Format::
+
+        - [<id>] <title> — <lead sentence> (score=0.87, ~120tok)
+
+    The token figure is the cost of reading the FULL page via
+    ``wiki_read`` — it lets the model budget its next move.
+
+    Args:
+        result: Result dict with at least an id field; ``score``,
+            ``snippet``/``summary``, and ``token_count`` are optional.
+
+    Returns:
+        The rendered stub line.
+    """
+    rid = str(
+        result.get("concept_id") or result.get("node_id") or result.get("page_id") or "?"
+    )
+    title = str(result.get("title") or "").strip() or rid
+    lead = first_sentence(str(result.get("snippet") or result.get("summary") or ""))
+    meta: list[str] = []
+    score = result.get("score")
+    if score is not None:
+        meta.append(f"score={float(score):.2f}")
+    tokens = result.get("token_count")
+    if tokens:
+        meta.append(f"~{int(tokens)}tok")
+    suffix = f" ({', '.join(meta)})" if meta else ""
+    body = f"- [{rid}] {title}"
+    if lead:
+        body += f" — {lead}"
+    return body + suffix
+
+
+def pack_results(
+    results: Iterable[Any],
+    budget_tokens: int = DEFAULT_BUDGET_TOKENS,
+) -> PackedContext:
+    """Pack search results into a token-budgeted context block.
+
+    Results are consumed in ranked order; packing stops as soon as the
+    next stub would exceed ``budget_tokens``.  Duplicate ids are
+    skipped.
+
+    Args:
+        results: ``WikiSearchResult`` models or plain result dicts, in
+            ranked order.
+        budget_tokens: Hard token ceiling for the packed text.
+
+    Returns:
+        A :class:`PackedContext`.
+    """
+    items: list[dict[str, Any]] = []
+    for r in results:
+        items.append(r.model_dump() if hasattr(r, "model_dump") else dict(r))
+
+    lines: list[str] = []
+    stubs: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    used = 0
+    truncated = False
+
+    for item in items:
+        rid = str(
+            item.get("concept_id") or item.get("node_id") or item.get("page_id") or ""
+        )
+        if not rid or rid in seen:
+            continue
+        line = stub_line(item)
+        cost = estimate_tokens(line)
+        if used + cost > budget_tokens and lines:
+            truncated = True
+            break
+        if cost > budget_tokens and not lines:
+            # A single stub over budget still gets included (never
+            # return an empty pack for a non-empty result set).
+            truncated = True
+        seen.add(rid)
+        lines.append(line)
+        used += cost
+        stubs.append(
+            {
+                "id": rid,
+                "title": item.get("title") or "",
+                "lead": first_sentence(
+                    str(item.get("snippet") or item.get("summary") or "")
+                ),
+                "score": item.get("score"),
+                "token_count": item.get("token_count"),
+                "category": item.get("category"),
+            }
+        )
+
+    return PackedContext(
+        text="\n".join(lines),
+        stubs=stubs,
+        tokens_used=used,
+        results_packed=len(lines),
+        total_available=len(items),
+        truncated=truncated or len(lines) < len(items),
+    )
+
+
+def truncate_to_tokens(text: str, max_tokens: Optional[int]) -> tuple[str, bool]:
+    """Deterministically truncate ``text`` to approximately ``max_tokens``.
+
+    Uses the same 4-chars-per-token heuristic as the fallback estimator
+    so truncation never requires a tokenizer; cuts on a whitespace
+    boundary where possible.
+
+    Args:
+        text: Text to truncate.
+        max_tokens: Token ceiling; ``None`` disables truncation.
+
+    Returns:
+        ``(text, truncated_flag)``.
+    """
+    if max_tokens is None or max_tokens <= 0:
+        return text, False
+    if estimate_tokens(text) <= max_tokens:
+        return text, False
+    max_chars = max_tokens * 4
+    cut = text[:max_chars]
+    last_space = cut.rfind(" ")
+    if last_space > max_chars // 2:
+        cut = cut[:last_space]
+    return cut.rstrip() + "\n\n[…truncated]", True

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/export.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/export.py
@@ -30,7 +30,7 @@ import yaml
 from pydantic import BaseModel, Field
 
 from parrot.knowledge.okf.utils import flatten_concept_id_for_filename
-from parrot.knowledge.wiki.store import WikiStore
+from parrot.knowledge.wiki.store import BaseWikiStore
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +42,11 @@ CATEGORY_TO_OKF_TYPE: dict[str, str] = {
     "synthesis": "Wiki Synthesis",
     "overview": "Wiki Overview",
     "concept": "Concept",
+}
+
+# Inverse map for consumers that read bundles back (file_store backend).
+OKF_TYPE_TO_CATEGORY: dict[str, str] = {
+    v: k for k, v in CATEGORY_TO_OKF_TYPE.items()
 }
 
 
@@ -63,12 +68,12 @@ class WikiExportReport(BaseModel):
     categories: dict[str, int] = Field(default_factory=dict)
 
 
-def _okf_type(category: str) -> str:
+def okf_type(category: str) -> str:
     """Map a wiki category to an OKF ``type`` string."""
     return CATEGORY_TO_OKF_TYPE.get(category, category.title() or "Other")
 
 
-def _category_dir(category: str) -> str:
+def category_dir(category: str) -> str:
     """Directory name for a category (naive English plural, lowercase)."""
     cat = (category or "concept").lower()
     if cat.endswith("s"):
@@ -78,13 +83,13 @@ def _category_dir(category: str) -> str:
     return f"{cat}s"
 
 
-def _page_frontmatter(
+def page_frontmatter(
     page: dict[str, Any],
     relates_to: list[dict[str, str]],
 ) -> str:
     """Render OKF frontmatter for one page (deterministic key order)."""
     data: dict[str, Any] = {
-        "type": _okf_type(str(page.get("category") or "concept")),
+        "type": okf_type(str(page.get("category") or "concept")),
         "title": page.get("title") or page["concept_id"],
         "id": page["concept_id"],
         "tags": [str(page.get("category") or "concept")],
@@ -101,7 +106,7 @@ def _page_frontmatter(
     return f"---\n{rendered}---\n"
 
 
-def _generate_index(wiki_name: str, entries: list[tuple[str, str, str]]) -> str:
+def generate_index(wiki_name: str, entries: list[tuple[str, str, str]]) -> str:
     """Render the root ``index.md`` (title, relative path, summary)."""
     lines = [
         f"# {wiki_name}",
@@ -118,14 +123,18 @@ def _generate_index(wiki_name: str, entries: list[tuple[str, str, str]]) -> str:
 
 
 async def export_okf_bundle(
-    store: WikiStore,
+    store: BaseWikiStore,
     output_dir: Path,
     wiki_name: str = "",
 ) -> WikiExportReport:
-    """Project the WikiStore plane into an OKF v0.1 markdown bundle.
+    """Project a wiki store into an OKF v0.1 markdown bundle.
+
+    Works with any :class:`BaseWikiStore` backend via ``dump_pages`` /
+    ``dump_edges`` (for the file backend this re-projects the live
+    bundle into ``output_dir``).
 
     Args:
-        store: Source :class:`WikiStore`.
+        store: Source store (any backend).
         output_dir: Bundle root (created if missing).
         wiki_name: Name used in the bundle index header.
 
@@ -155,11 +164,11 @@ async def export_okf_bundle(
 
     for page in pages:
         category = str(page.get("category") or "concept")
-        cat_dir = _category_dir(category)
+        cat_dir = category_dir(category)
         filename = f"{flatten_concept_id_for_filename(page['concept_id'])}.md"
         rel_path = f"{cat_dir}/{filename}"
 
-        frontmatter = _page_frontmatter(
+        frontmatter = page_frontmatter(
             page, relates_by_src.get(page["concept_id"], [])
         )
         body = page.get("body") or page.get("summary") or ""
@@ -192,7 +201,7 @@ async def export_okf_bundle(
     await asyncio.to_thread(
         _write,
         output_dir / "index.md",
-        _generate_index(wiki_name or "wiki", index_entries),
+        generate_index(wiki_name or "wiki", index_entries),
     )
     report.index_generated = True
 

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/export.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/export.py
@@ -1,0 +1,202 @@
+"""OKF v0.1 bundle export for the LLM Wiki (export-only boundary).
+
+The wiki's internal representation is the machine-first
+:class:`WikiStore` SQLite plane; OKF markdown is generated **lazily and
+only at export time** as an interchange projection, never read back on
+the retrieval path.
+
+Bundle layout (Google OKF v0.1 — markdown files with YAML frontmatter,
+one concept per file, ``type`` as the only required field)::
+
+    <output_dir>/
+    ├── index.md                 # root catalog of exported pages
+    ├── summaries/<id>.md
+    ├── entities/<id>.md
+    └── <category>s/<id>.md      # one directory per page category
+
+Wiki categories map onto the ``ConceptType.WIKI_*`` vocabulary where a
+member exists; other categories export their title-cased raw string —
+OKF types are producer-defined, so this remains conformant.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field
+
+from parrot.knowledge.okf.utils import flatten_concept_id_for_filename
+from parrot.knowledge.wiki.store import WikiStore
+
+logger = logging.getLogger(__name__)
+
+# WikiPageCategory value → OKF ConceptType string (FEAT-260 vocabulary).
+CATEGORY_TO_OKF_TYPE: dict[str, str] = {
+    "summary": "Wiki Summary",
+    "entity": "Wiki Entity",
+    "comparison": "Wiki Comparison",
+    "synthesis": "Wiki Synthesis",
+    "overview": "Wiki Overview",
+    "concept": "Concept",
+}
+
+
+class WikiExportReport(BaseModel):
+    """Result of an OKF bundle export.
+
+    Attributes:
+        wiki_name: Exported wiki.
+        output_dir: Bundle root directory.
+        files_written: Number of concept files written.
+        index_generated: Whether the root ``index.md`` was written.
+        categories: Files written per category directory.
+    """
+
+    wiki_name: str = ""
+    output_dir: str = ""
+    files_written: int = 0
+    index_generated: bool = False
+    categories: dict[str, int] = Field(default_factory=dict)
+
+
+def _okf_type(category: str) -> str:
+    """Map a wiki category to an OKF ``type`` string."""
+    return CATEGORY_TO_OKF_TYPE.get(category, category.title() or "Other")
+
+
+def _category_dir(category: str) -> str:
+    """Directory name for a category (naive English plural, lowercase)."""
+    cat = (category or "concept").lower()
+    if cat.endswith("s"):
+        return cat
+    if cat.endswith("y"):
+        return f"{cat[:-1]}ies"
+    return f"{cat}s"
+
+
+def _page_frontmatter(
+    page: dict[str, Any],
+    relates_to: list[dict[str, str]],
+) -> str:
+    """Render OKF frontmatter for one page (deterministic key order)."""
+    data: dict[str, Any] = {
+        "type": _okf_type(str(page.get("category") or "concept")),
+        "title": page.get("title") or page["concept_id"],
+        "id": page["concept_id"],
+        "tags": [str(page.get("category") or "concept")],
+        "timestamp": page.get("updated_at") or "",
+    }
+    summary = page.get("summary") or ""
+    if summary:
+        data["summary"] = summary
+    if relates_to:
+        data["relates_to"] = relates_to
+    rendered = yaml.dump(
+        data, sort_keys=False, allow_unicode=True, default_flow_style=False
+    )
+    return f"---\n{rendered}---\n"
+
+
+def _generate_index(wiki_name: str, entries: list[tuple[str, str, str]]) -> str:
+    """Render the root ``index.md`` (title, relative path, summary)."""
+    lines = [
+        f"# {wiki_name}",
+        "",
+        "<!-- Auto-generated OKF bundle index. Do not edit. -->",
+        "",
+    ]
+    for title, rel_path, summary in entries:
+        lines.append(f"## [{title}]({rel_path})")
+        if summary:
+            lines.append(f"\n{summary}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+async def export_okf_bundle(
+    store: WikiStore,
+    output_dir: Path,
+    wiki_name: str = "",
+) -> WikiExportReport:
+    """Project the WikiStore plane into an OKF v0.1 markdown bundle.
+
+    Args:
+        store: Source :class:`WikiStore`.
+        output_dir: Bundle root (created if missing).
+        wiki_name: Name used in the bundle index header.
+
+    Returns:
+        A :class:`WikiExportReport`.
+    """
+    output_dir = Path(output_dir)
+    pages = await store.dump_pages()
+    edges = await store.dump_edges()
+
+    # Outgoing typed edges per page → relates_to frontmatter entries.
+    known_targets = {p["concept_id"] for p in pages}
+    relates_by_src: dict[str, list[dict[str, str]]] = {}
+    for edge in edges:
+        relates_by_src.setdefault(edge["src"], []).append(
+            {"concept": edge["dst"], "rel": edge["rel"]}
+        )
+
+    report = WikiExportReport(
+        wiki_name=wiki_name, output_dir=str(output_dir)
+    )
+    index_entries: list[tuple[str, str, str]] = []
+
+    def _write(path: Path, content: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    for page in pages:
+        category = str(page.get("category") or "concept")
+        cat_dir = _category_dir(category)
+        filename = f"{flatten_concept_id_for_filename(page['concept_id'])}.md"
+        rel_path = f"{cat_dir}/{filename}"
+
+        frontmatter = _page_frontmatter(
+            page, relates_by_src.get(page["concept_id"], [])
+        )
+        body = page.get("body") or page.get("summary") or ""
+        await asyncio.to_thread(
+            _write, output_dir / rel_path, frontmatter + "\n" + body
+        )
+
+        report.files_written += 1
+        report.categories[cat_dir] = report.categories.get(cat_dir, 0) + 1
+        index_entries.append(
+            (
+                str(page.get("title") or page["concept_id"]),
+                rel_path,
+                str(page.get("summary") or ""),
+            )
+        )
+
+    unknown = {
+        e["dst"]
+        for e in edges
+        if e["dst"] not in known_targets and not e["dst"].startswith("src-")
+    }
+    if unknown:
+        logger.debug(
+            "export_okf_bundle: %d relates_to target(s) are not exported "
+            "pages (OKF consumers must tolerate broken links)",
+            len(unknown),
+        )
+
+    await asyncio.to_thread(
+        _write,
+        output_dir / "index.md",
+        _generate_index(wiki_name or "wiki", index_entries),
+    )
+    report.index_generated = True
+
+    logger.info(
+        "export_okf_bundle: %d page(s) → %s", report.files_written, output_dir
+    )
+    return report

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/file_store.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/file_store.py
@@ -1,0 +1,662 @@
+"""In-memory wiki retrieval plane persisted as an OKF markdown bundle.
+
+The SQLite-free backend (``WikiConfig.storage_backend = "memory"``):
+all retrieval runs against RAM indexes — page dicts, a node-id map, a
+hierarchical concept-id prefix tree, in/out edge adjacency, TF-IDF term
+postings, and an embeddings map — while durability comes from a plain
+**directory of OKF v0.1 markdown files**::
+
+    {storage_dir}/pages/
+    ├── index.md                  # auto-generated catalog
+    ├── .embeddings.json          # vector sidecar (machine-only)
+    ├── summaries/<id>.md         # YAML frontmatter + body
+    ├── entities/<id>.md
+    └── <category-plural>/<id>.md
+
+The directory is therefore a valid, browsable OKF bundle at all times:
+frontmatter carries the OKF fields (``type``, ``title``, ``id``,
+``tags``, ``timestamp``, ``summary``, ``relates_to``) plus the wiki's
+machine fields (``node_id``, ``source_id``, ``token_count``) — OKF
+consumers tolerate unknown keys.
+
+Loading walks the bundle once (lazily, on first use) and rebuilds every
+index; queries never re-read files.  Mutations rewrite only the
+affected page files plus ``index.md``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import math
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+from parrot.knowledge.okf.utils import flatten_concept_id_for_filename
+from parrot.knowledge.wiki.export import (
+    OKF_TYPE_TO_CATEGORY,
+    category_dir,
+    generate_index,
+    page_frontmatter,
+)
+from parrot.knowledge.wiki.store import (
+    BaseWikiStore,
+    WikiPageRecord,
+    _FTS_TOKEN_RE,
+    estimate_tokens,
+    rank_by_cosine,
+)
+
+logger = logging.getLogger(__name__)
+
+_TITLE_BOOST = 3
+_EMBEDDINGS_FILENAME = ".embeddings.json"
+
+
+def _now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string."""
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+00:00")
+
+
+def _tokenize(text: str) -> list[str]:
+    """Lowercased word tokens (same tokenizer as the FTS query builder)."""
+    return [t.lower() for t in _FTS_TOKEN_RE.findall(text)]
+
+
+class InMemoryWikiStore(BaseWikiStore):
+    """RAM-indexed wiki store persisted as an OKF markdown directory.
+
+    Args:
+        bundle_dir: Root of the OKF bundle (typically
+            ``{storage_dir}/pages`` — created automatically).
+        wiki_name: Wiki name used in the bundle ``index.md`` header.
+
+    Example::
+
+        store = InMemoryWikiStore(storage_dir / "pages", wiki_name="my-wiki")
+        await store.upsert_pages([WikiPageRecord(concept_id="intro", ...)])
+        hits = await store.search_fts("neural networks", limit=5)
+    """
+
+    def __init__(self, bundle_dir: str | Path, wiki_name: str = "") -> None:
+        self._bundle_dir = Path(bundle_dir)
+        self._bundle_dir.mkdir(parents=True, exist_ok=True)
+        self._wiki_name = wiki_name
+        self.logger = logging.getLogger(__name__)
+
+        self._loaded = False
+        self._lock = asyncio.Lock()
+
+        # RAM indexes (built by _load_bundle / maintained on mutation)
+        self._pages: dict[str, dict[str, Any]] = {}
+        self._by_node: dict[str, str] = {}
+        self._out_edges: dict[str, list[tuple[str, str]]] = {}
+        self._in_edges: dict[str, list[tuple[str, str]]] = {}
+        self._embeddings: dict[str, dict[str, Any]] = {}
+        self._postings: dict[str, dict[str, int]] = {}
+        self._doc_len: dict[str, int] = {}
+        self._tree: dict[str, Any] = {}  # nested prefix tree of concept_ids
+
+    @property
+    def bundle_dir(self) -> Path:
+        """Root directory of the OKF bundle."""
+        return self._bundle_dir
+
+    # ------------------------------------------------------------------
+    # Loading / persistence
+    # ------------------------------------------------------------------
+
+    async def _ensure_loaded(self) -> None:
+        """Build all RAM indexes from the bundle directory once."""
+        if self._loaded:
+            return
+        async with self._lock:
+            if self._loaded:
+                return
+            await asyncio.to_thread(self._load_bundle)
+            self._loaded = True
+
+    def _load_bundle(self) -> None:
+        """Walk ``bundle_dir`` and rebuild every index (sync, threaded)."""
+        count = 0
+        for md_file in sorted(self._bundle_dir.rglob("*.md")):
+            if md_file.name == "index.md":
+                continue
+            try:
+                page, relates = self._parse_page_file(md_file)
+            except Exception as exc:  # noqa: BLE001 — skip bad files
+                self.logger.warning(
+                    "Skipping unparseable bundle file %s: %s", md_file, exc
+                )
+                continue
+            self._index_page(page)
+            for target, rel in relates:
+                self._index_edge(page["concept_id"], target, rel)
+            count += 1
+
+        emb_path = self._bundle_dir / _EMBEDDINGS_FILENAME
+        if emb_path.exists():
+            try:
+                self._embeddings = json.loads(emb_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError) as exc:
+                self.logger.warning("Could not load embeddings sidecar: %s", exc)
+                self._embeddings = {}
+
+        self.logger.debug(
+            "InMemoryWikiStore loaded %d page(s) from %s", count, self._bundle_dir
+        )
+
+    @staticmethod
+    def _parse_page_file(
+        path: Path,
+    ) -> tuple[dict[str, Any], list[tuple[str, str]]]:
+        """Parse one bundle markdown file into a page row + edges.
+
+        Uses plain ``yaml.safe_load`` (NOT the shared OKF parser, which
+        enforces the closed ConceptType enum — open-string categories
+        like ``"Answer"`` must load fine).
+        """
+        text = path.read_text(encoding="utf-8")
+        if not text.startswith("---\n"):
+            raise ValueError("missing frontmatter delimiter")
+        _, front_raw, body = text.split("---\n", 2)
+        front = yaml.safe_load(front_raw) or {}
+        if not isinstance(front, dict):
+            raise ValueError("frontmatter is not a mapping")
+
+        concept_id = str(front.get("id") or path.stem)
+        okf_type_str = str(front.get("type") or "")
+        tags = front.get("tags") or []
+        category = str(
+            front.get("category")
+            or (tags[0] if tags else "")
+            or OKF_TYPE_TO_CATEGORY.get(okf_type_str, okf_type_str.lower())
+            or "concept"
+        )
+        body = body.lstrip("\n")
+        page = {
+            "concept_id": concept_id,
+            "node_id": front.get("node_id"),
+            "title": str(front.get("title") or concept_id),
+            "category": category,
+            "summary": str(front.get("summary") or ""),
+            "body": body,
+            "source_id": front.get("source_id"),
+            "token_count": int(front.get("token_count") or 0)
+            or estimate_tokens(body),
+            "created_at": str(front.get("created_at") or front.get("timestamp") or ""),
+            "updated_at": str(front.get("timestamp") or ""),
+        }
+        relates = [
+            (str(item.get("concept")), str(item.get("rel") or "references"))
+            for item in front.get("relates_to") or []
+            if isinstance(item, dict) and item.get("concept")
+        ]
+        return page, relates
+
+    def _page_path(self, page: dict[str, Any]) -> Path:
+        """Bundle file path for a page row."""
+        cat_dir = category_dir(str(page.get("category") or "concept"))
+        stem = flatten_concept_id_for_filename(page["concept_id"])
+        return self._bundle_dir / cat_dir / f"{stem}.md"
+
+    def _write_page_file(self, page: dict[str, Any]) -> None:
+        """Render + write one page's OKF markdown file (sync, threaded)."""
+        relates = [
+            {"concept": dst, "rel": rel}
+            for dst, rel in self._out_edges.get(page["concept_id"], [])
+        ]
+        front = page_frontmatter(page, relates)
+        # Machine fields appended into the same frontmatter block — OKF
+        # consumers tolerate unknown keys.
+        machine: dict[str, Any] = {}
+        for key in ("category", "node_id", "source_id", "token_count", "created_at"):
+            if page.get(key) not in (None, ""):
+                machine[key] = page[key]
+        if machine:
+            extra = yaml.dump(
+                machine, sort_keys=False, allow_unicode=True,
+                default_flow_style=False,
+            )
+            front = front[: -len("---\n")] + extra + "---\n"
+        path = self._page_path(page)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(front + "\n" + (page.get("body") or ""), encoding="utf-8")
+
+    def _write_index_md(self) -> None:
+        """Regenerate the bundle's root ``index.md`` (sync, threaded)."""
+        entries = []
+        for page in sorted(self._pages.values(), key=lambda p: p["concept_id"]):
+            rel_path = self._page_path(page).relative_to(self._bundle_dir)
+            entries.append(
+                (
+                    str(page.get("title") or page["concept_id"]),
+                    str(rel_path),
+                    str(page.get("summary") or ""),
+                )
+            )
+        (self._bundle_dir / "index.md").write_text(
+            generate_index(self._wiki_name or "wiki", entries),
+            encoding="utf-8",
+        )
+
+    def _write_embeddings(self) -> None:
+        """Persist the embeddings sidecar (sync, threaded)."""
+        (self._bundle_dir / _EMBEDDINGS_FILENAME).write_text(
+            json.dumps(self._embeddings), encoding="utf-8"
+        )
+
+    async def _persist_pages(self, pages: list[dict[str, Any]]) -> None:
+        """Write the given pages' files + refresh index.md."""
+
+        def _write_all() -> None:
+            for page in pages:
+                self._write_page_file(page)
+            self._write_index_md()
+
+        await asyncio.to_thread(_write_all)
+
+    # ------------------------------------------------------------------
+    # Index maintenance
+    # ------------------------------------------------------------------
+
+    def _index_page(self, page: dict[str, Any]) -> None:
+        """Insert/replace a page in every RAM index."""
+        cid = page["concept_id"]
+        self._unindex_page(cid)
+        self._pages[cid] = page
+        if page.get("node_id"):
+            self._by_node[str(page["node_id"])] = cid
+
+        # term postings: title boosted, then summary + body
+        counts: Counter[str] = Counter()
+        for token in _tokenize(str(page.get("title") or "")):
+            counts[token] += _TITLE_BOOST
+        for token in _tokenize(
+            f"{page.get('summary') or ''} {page.get('body') or ''}"
+        ):
+            counts[token] += 1
+        self._doc_len[cid] = sum(counts.values())
+        for term, tf in counts.items():
+            self._postings.setdefault(term, {})[cid] = tf
+
+        # hierarchical prefix tree from concept_id slash segments
+        node = self._tree
+        for segment in cid.split("/"):
+            node = node.setdefault(segment, {})
+
+    def _unindex_page(self, concept_id: str) -> None:
+        """Remove a page from every RAM index (keeps its edges)."""
+        old = self._pages.pop(concept_id, None)
+        if old is None:
+            return
+        if old.get("node_id"):
+            self._by_node.pop(str(old["node_id"]), None)
+        self._doc_len.pop(concept_id, None)
+        for term in list(self._postings):
+            self._postings[term].pop(concept_id, None)
+            if not self._postings[term]:
+                del self._postings[term]
+        node = self._tree
+        # prune only the leaf (cheap; intermediate nodes may be shared)
+        segments = concept_id.split("/")
+        for segment in segments[:-1]:
+            node = node.get(segment)
+            if node is None:
+                return
+        if not node.get(segments[-1]):
+            node.pop(segments[-1], None)
+
+    def _index_edge(self, src: str, dst: str, rel: str) -> None:
+        """Insert an edge into both adjacency maps (idempotent)."""
+        entry = (dst, rel)
+        out = self._out_edges.setdefault(src, [])
+        if entry not in out:
+            out.append(entry)
+        rentry = (src, rel)
+        inbound = self._in_edges.setdefault(dst, [])
+        if rentry not in inbound:
+            inbound.append(rentry)
+
+    def _remove_edges_touching(self, concept_id: str) -> None:
+        """Drop every edge where ``concept_id`` is src or dst."""
+        for dst, rel in self._out_edges.pop(concept_id, []):
+            self._in_edges[dst] = [
+                e for e in self._in_edges.get(dst, []) if e[0] != concept_id
+            ]
+        for src, rel in self._in_edges.pop(concept_id, []):
+            self._out_edges[src] = [
+                e for e in self._out_edges.get(src, []) if e[0] != concept_id
+            ]
+
+    def _stub(self, page: dict[str, Any]) -> dict[str, Any]:
+        """Stub view of a page row (no body)."""
+        return {
+            k: page.get(k)
+            for k in (
+                "concept_id",
+                "node_id",
+                "title",
+                "category",
+                "summary",
+                "source_id",
+                "token_count",
+                "updated_at",
+            )
+        }
+
+    # ------------------------------------------------------------------
+    # Write API
+    # ------------------------------------------------------------------
+
+    async def upsert_pages(self, pages: list[WikiPageRecord]) -> int:
+        """Insert or update wiki pages (RAM indexes + bundle files)."""
+        if not pages:
+            return 0
+        await self._ensure_loaded()
+        now = _now_iso()
+        rows: list[dict[str, Any]] = []
+        for p in pages:
+            existing = self._pages.get(p.concept_id, {})
+            row = {
+                "concept_id": p.concept_id,
+                "node_id": p.node_id,
+                "title": p.title,
+                "category": p.category,
+                "summary": p.summary,
+                "body": p.body,
+                "source_id": p.source_id,
+                "token_count": p.token_count or estimate_tokens(p.body),
+                "created_at": existing.get("created_at") or now,
+                "updated_at": now,
+            }
+            old_path = (
+                self._page_path(existing) if existing else None
+            )
+            self._index_page(row)
+            new_path = self._page_path(row)
+            if old_path and old_path != new_path and old_path.exists():
+                old_path.unlink()
+            rows.append(row)
+        await self._persist_pages(rows)
+        return len(rows)
+
+    async def add_edges(self, edges: list[tuple[str, str, str]]) -> int:
+        """Insert typed edges and re-persist affected source pages."""
+        if not edges:
+            return 0
+        await self._ensure_loaded()
+        touched: set[str] = set()
+        for src, dst, rel in edges:
+            self._index_edge(src, dst, rel)
+            touched.add(src)
+        # relates_to lives in the source page's frontmatter
+        await self._persist_pages(
+            [self._pages[cid] for cid in touched if cid in self._pages]
+        )
+        return len(edges)
+
+    async def replace_source_slice(
+        self,
+        source_id: str,
+        pages: list[WikiPageRecord],
+        edges: Optional[list[tuple[str, str, str]]] = None,
+    ) -> dict[str, Any]:
+        """Atomically replace all pages/edges derived from one source."""
+        await self._ensure_loaded()
+        old_ids = [
+            cid
+            for cid, page in self._pages.items()
+            if page.get("source_id") == source_id
+        ]
+        for cid in old_ids:
+            await self.delete_page(cid)
+        written = await self.upsert_pages(pages)
+        if edges:
+            await self.add_edges(edges)
+        return {
+            "pages_deleted": len(old_ids),
+            "pages_written": written,
+            "edges_written": len(edges or []),
+        }
+
+    async def delete_page(self, concept_id: str) -> bool:
+        """Delete a page: RAM indexes, edges, embedding, bundle file."""
+        await self._ensure_loaded()
+        page = self._pages.get(concept_id)
+        if page is None:
+            return False
+        path = self._page_path(page)
+        self._unindex_page(concept_id)
+        self._remove_edges_touching(concept_id)
+        had_embedding = self._embeddings.pop(concept_id, None) is not None
+
+        def _cleanup() -> None:
+            if path.exists():
+                path.unlink()
+            self._write_index_md()
+            if had_embedding:
+                self._write_embeddings()
+
+        await asyncio.to_thread(_cleanup)
+        return True
+
+    async def upsert_embedding(
+        self,
+        concept_id: str,
+        vector: list[float],
+        model: str = "",
+    ) -> None:
+        """Store (or replace) the embedding vector for a page."""
+        await self._ensure_loaded()
+        self._embeddings[concept_id] = {"vector": list(vector), "model": model}
+        await asyncio.to_thread(self._write_embeddings)
+
+    # ------------------------------------------------------------------
+    # Read API
+    # ------------------------------------------------------------------
+
+    async def get_page(
+        self, concept_id: str, include_body: bool = True
+    ) -> Optional[dict[str, Any]]:
+        """Fetch a page by ``concept_id`` (falls back to ``node_id``)."""
+        await self._ensure_loaded()
+        page = self._pages.get(concept_id)
+        if page is None:
+            mapped = self._by_node.get(concept_id)
+            page = self._pages.get(mapped) if mapped else None
+        if page is None:
+            return None
+        row = dict(page)
+        if not include_body:
+            row.pop("body", None)
+        return row
+
+    async def list_pages(
+        self,
+        category: Optional[str] = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """List page stubs, optionally filtered by category."""
+        await self._ensure_loaded()
+        rows = [
+            self._stub(p)
+            for p in self._pages.values()
+            if category is None or p.get("category") == category
+        ]
+        rows.sort(key=lambda r: str(r.get("updated_at") or ""), reverse=True)
+        return rows[:limit]
+
+    async def search_fts(
+        self,
+        query: str,
+        category: Optional[str] = None,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        """TF-IDF lexical search over title/summary/body postings.
+
+        Raw (unnormalised) scores — callers normalise per group, same
+        contract as the SQLite backend's ``-bm25`` scores.
+        """
+        await self._ensure_loaded()
+        terms = _tokenize(query)
+        if not terms or not self._pages:
+            return []
+        n_docs = len(self._pages)
+        scores: dict[str, float] = {}
+        for term in set(terms):
+            posting = self._postings.get(term)
+            if not posting:
+                continue
+            idf = math.log(1.0 + n_docs / len(posting))
+            for cid, tf in posting.items():
+                doc_len = self._doc_len.get(cid) or 1
+                scores[cid] = scores.get(cid, 0.0) + (tf / doc_len) * idf
+        ranked = sorted(scores.items(), key=lambda kv: kv[1], reverse=True)
+        out: list[dict[str, Any]] = []
+        for cid, score in ranked:
+            page = self._pages.get(cid)
+            if page is None:
+                continue
+            if category is not None and page.get("category") != category:
+                continue
+            stub = self._stub(page)
+            stub["score"] = score
+            out.append(stub)
+            if len(out) >= limit:
+                break
+        return out
+
+    async def search_vector(
+        self,
+        embedding: list[float],
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        """Cosine-similarity search over the embeddings map."""
+        await self._ensure_loaded()
+        candidates: list[tuple[dict[str, Any], list[float]]] = []
+        for cid, entry in self._embeddings.items():
+            page = self._pages.get(cid)
+            if page is None:
+                continue
+            candidates.append((self._stub(page), entry.get("vector") or []))
+        return rank_by_cosine(embedding, candidates, limit=limit)
+
+    async def neighbors(
+        self,
+        concept_id: str,
+        rel: Optional[str] = None,
+        direction: str = "both",
+    ) -> list[dict[str, Any]]:
+        """Return edge-adjacent pages/targets of a concept."""
+        await self._ensure_loaded()
+        results: list[dict[str, Any]] = []
+        if direction in ("out", "both"):
+            for dst, edge_rel in self._out_edges.get(concept_id, []):
+                if rel is not None and edge_rel != rel:
+                    continue
+                results.append(self._neighbor_item(dst, edge_rel, "out"))
+        if direction in ("in", "both"):
+            for src, edge_rel in self._in_edges.get(concept_id, []):
+                if rel is not None and edge_rel != rel:
+                    continue
+                results.append(self._neighbor_item(src, edge_rel, "in"))
+        return results
+
+    def _neighbor_item(
+        self, concept_id: str, rel: str, direction: str
+    ) -> dict[str, Any]:
+        """Build one neighbors() result row (page stub when known)."""
+        page = self._pages.get(concept_id)
+        return {
+            "concept_id": concept_id,
+            "rel": rel,
+            "title": page.get("title") if page else None,
+            "category": page.get("category") if page else None,
+            "summary": page.get("summary") if page else None,
+            "token_count": page.get("token_count") if page else None,
+            "direction": direction,
+        }
+
+    async def dump_pages(self) -> list[dict[str, Any]]:
+        """Return every page row WITH bodies (bulk export path)."""
+        await self._ensure_loaded()
+        return [
+            dict(self._pages[cid]) for cid in sorted(self._pages)
+        ]
+
+    async def dump_edges(self) -> list[dict[str, Any]]:
+        """Return every edge row (bulk export path)."""
+        await self._ensure_loaded()
+        rows = [
+            {"src": src, "dst": dst, "rel": rel}
+            for src, targets in self._out_edges.items()
+            for dst, rel in targets
+        ]
+        rows.sort(key=lambda r: (r["src"], r["dst"], r["rel"]))
+        return rows
+
+    async def stats(self) -> dict[str, Any]:
+        """Aggregate counters for the wiki."""
+        await self._ensure_loaded()
+        categories: Counter[str] = Counter(
+            str(p.get("category") or "") for p in self._pages.values()
+        )
+        return {
+            "pages": len(self._pages),
+            "edges": sum(len(v) for v in self._out_edges.values()),
+            "sources": len(self._load_source_manifest()),
+            "embeddings": len(self._embeddings),
+            "total_tokens": sum(
+                int(p.get("token_count") or 0) for p in self._pages.values()
+            ),
+            "categories": dict(categories),
+        }
+
+    # ------------------------------------------------------------------
+    # Lint API
+    # ------------------------------------------------------------------
+
+    def _load_source_manifest(self) -> dict[str, Any]:
+        """Read the JSON source manifest maintained by the sources
+        manager in ``json`` mode (``{storage_dir}/sources/.manifest.json``)."""
+        manifest = self._bundle_dir.parent / "sources" / ".manifest.json"
+        if not manifest.exists():
+            return {}
+        try:
+            return json.loads(manifest.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return {}
+
+    async def orphan_sources(self) -> list[str]:
+        """Sources (from the JSON manifest) that produced no pages."""
+        await self._ensure_loaded()
+        covered = {
+            p.get("source_id") for p in self._pages.values() if p.get("source_id")
+        }
+        return [
+            sid for sid in self._load_source_manifest() if sid not in covered
+        ]
+
+    async def broken_edges(self) -> list[dict[str, Any]]:
+        """Edges whose destination is neither a page nor a source."""
+        await self._ensure_loaded()
+        sources = set(self._load_source_manifest())
+        return [
+            {"src": src, "dst": dst, "rel": rel}
+            for src, targets in self._out_edges.items()
+            for dst, rel in targets
+            if dst not in self._pages and dst not in sources
+        ]
+
+    async def missing_bodies(self) -> list[str]:
+        """Pages with an empty body."""
+        await self._ensure_loaded()
+        return [
+            cid for cid, p in sorted(self._pages.items()) if not p.get("body")
+        ]

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/ingest.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/ingest.py
@@ -3,17 +3,21 @@
 Implements the "Ingest" operation from Karpathy's 3-layer architecture.
 Orchestrates the full pipeline for a single source document:
 
-1. Check source manifest — skip if already ingested and not stale.
+1. Check the source registry — skip if already ingested and not stale.
 2. Load source content from the file path.
 3. Process via ``PageIndexToolkit.insert_content()`` (which internally
    delegates to ``TwoStepIngester``).
-4. Create a ``WIKI_PAGE`` node in GraphIndex for the generated content.
-5. Link the graph node to the source URI via ``EdgeKind.REFERENCES``.
-6. Update the source manifest (hash + mtime + pages generated).
+4. Upsert the generated pages into the :class:`WikiStore` retrieval
+   plane (bodies, categories, token counts) and record
+   ``summarizes`` edges page → source.  ``replace_source_slice``
+   guarantees re-ingest never accumulates duplicates.
+5. Optionally (``sync_graph=True``) mirror a ``wiki_page`` node into
+   GraphIndex.
+6. Update the source registry (hash + mtime + pages generated).
 7. Append to the operation log via ``WikiBookkeeper.log_operation()``.
 
 All operations are async.  On partial failure the error is logged but
-no corrupt state is left: the manifest is only updated after all steps
+no corrupt state is left: the registry is only updated after all steps
 succeed.
 """
 
@@ -31,6 +35,11 @@ from pydantic import BaseModel, Field
 from parrot.knowledge.wiki.bookkeeper import WikiBookkeeper
 from parrot.knowledge.wiki.models import WikiConfig
 from parrot.knowledge.wiki.sources import SourceCollectionManager
+from parrot.knowledge.wiki.store import (
+    WikiPageRecord,
+    WikiStore,
+    estimate_tokens,
+)
 
 
 class IngestReport(BaseModel):
@@ -83,6 +92,8 @@ class WikiIngestOrchestrator:
         graphindex_toolkit: Any,
         source_manager: SourceCollectionManager,
         bookkeeper: WikiBookkeeper,
+        store: Optional[WikiStore] = None,
+        sync_graph: bool = False,
     ) -> None:
         """Initialise the orchestrator with all dependencies.
 
@@ -91,11 +102,18 @@ class WikiIngestOrchestrator:
             graphindex_toolkit: A ``GraphIndexToolkit`` instance.
             source_manager: :class:`SourceCollectionManager` for the wiki.
             bookkeeper: :class:`WikiBookkeeper` for log/index management.
+            store: :class:`WikiStore` retrieval plane.  When ``None``,
+                store sync is skipped (legacy behaviour).
+            sync_graph: When ``True``, additionally mirror a
+                ``wiki_page`` node into GraphIndex (off by default —
+                the WikiStore is the retrieval plane).
         """
         self._pi = pageindex_toolkit
         self._gi = graphindex_toolkit
         self._sources = source_manager
         self._bookkeeper = bookkeeper
+        self._store = store
+        self._sync_graph = sync_graph
         self.logger: logging.Logger = logging.getLogger(__name__)
 
     # ------------------------------------------------------------------
@@ -191,22 +209,54 @@ class WikiIngestOrchestrator:
             self.logger.error("PageIndex insert failed for %s: %s", source_uri, exc)
             return self._error_report(source_id, source_uri, t0, str(exc))
 
-        # Step 4 — sync to GraphIndex
+        # Step 4 — upsert into the WikiStore retrieval plane.
+        # replace_source_slice deletes the source's previous pages first,
+        # so re-ingest never accumulates duplicates.
+        if self._store is not None:
+            try:
+                records = await self._build_page_records(
+                    tree_name,
+                    page_ids,
+                    source_id=source_id,
+                    fallback_title=str(pi_result.get("title") or ""),
+                    fallback_summary=str(
+                        pi_result.get("summary") or content[:500]
+                    ),
+                )
+                edges = [
+                    (r.concept_id, source_id, "summarizes") for r in records
+                ]
+                await self._store.replace_source_slice(
+                    source_id, records, edges
+                )
+                # Stable concept_ids become the recorded page identities.
+                page_ids = [r.concept_id for r in records]
+            except Exception as exc:  # noqa: BLE001
+                self.logger.warning(
+                    "WikiStore sync failed for %s (non-fatal): %s",
+                    source_uri,
+                    exc,
+                )
+
+        # Step 4b — optional GraphIndex mirror (off by default).
         graph_nodes_created = 0
         graph_node_id: Optional[str] = None
-        try:
-            graph_node_id = await self._sync_to_graph(
-                source_uri,
-                tree_name=tree_name,
-                summary=content[:500],
-            )
-            if graph_node_id:
-                graph_nodes_created = 1
-                page_ids.append(graph_node_id)
-        except Exception as exc:  # noqa: BLE001
-            self.logger.warning(
-                "GraphIndex sync failed for %s (non-fatal): %s", source_uri, exc
-            )
+        if self._sync_graph:
+            try:
+                graph_node_id = await self._sync_to_graph(
+                    source_uri,
+                    tree_name=tree_name,
+                    summary=content[:500],
+                )
+                if graph_node_id:
+                    graph_nodes_created = 1
+                    page_ids.append(graph_node_id)
+            except Exception as exc:  # noqa: BLE001
+                self.logger.warning(
+                    "GraphIndex sync failed for %s (non-fatal): %s",
+                    source_uri,
+                    exc,
+                )
 
         # Step 5 — update manifest (blocking I/O offloaded to thread)
         try:
@@ -292,6 +342,120 @@ class WikiIngestOrchestrator:
         """
         result = await self._pi.insert_content(tree_name, content)
         return result if isinstance(result, dict) else {}
+
+    async def _build_page_records(
+        self,
+        tree_name: str,
+        node_ids: list[str],
+        source_id: str,
+        fallback_title: str = "",
+        fallback_summary: str = "",
+    ) -> list[WikiPageRecord]:
+        """Build :class:`WikiPageRecord` rows for freshly inserted nodes.
+
+        Reads the PageIndex tree (``get_tree``) to resolve each node's
+        stable ``concept_id``, title, summary, and category, and loads
+        the markdown body through the toolkit's content store when
+        available.  Degrades gracefully to minimal records (identity =
+        ``node_id``, empty body) when the tree or bodies cannot be read
+        — e.g. with mocked toolkits.
+
+        Args:
+            tree_name: PageIndex tree (wiki) name.
+            node_ids: ``new_node_ids`` returned by ``insert_content``.
+            source_id: Source these pages were derived from.
+            fallback_title: Title used when a node cannot be resolved.
+            fallback_summary: Summary used when a node cannot be resolved.
+
+        Returns:
+            One record per node id.
+        """
+        tree: Optional[dict[str, Any]] = None
+        try:
+            candidate = await self._pi.get_tree(tree_name)
+            if isinstance(candidate, dict):
+                tree = candidate
+        except Exception:  # noqa: BLE001 — mocked/legacy toolkits
+            tree = None
+
+        loader = None
+        content_store = getattr(self._pi, "_content_store", None)
+        if tree is not None and content_store is not None:
+            try:
+                candidate_loader = content_store.loader_for(tree_name)
+                if callable(candidate_loader):
+                    loader = candidate_loader
+            except Exception:  # noqa: BLE001
+                loader = None
+
+        records: list[WikiPageRecord] = []
+        for nid in node_ids:
+            node: Optional[dict[str, Any]] = None
+            if tree is not None:
+                node = self._find_node(tree, nid)
+
+            if node is None:
+                records.append(
+                    WikiPageRecord(
+                        concept_id=nid,
+                        node_id=nid,
+                        title=fallback_title or nid,
+                        summary=fallback_summary,
+                        source_id=source_id,
+                        token_count=estimate_tokens(fallback_summary),
+                    )
+                )
+                continue
+
+            concept_id = str(node.get("concept_id") or nid)
+            body = self._load_body(loader, concept_id, nid)
+            summary = str(node.get("summary") or fallback_summary)
+            records.append(
+                WikiPageRecord(
+                    concept_id=concept_id,
+                    node_id=nid,
+                    title=str(node.get("title") or fallback_title or nid),
+                    category=str(
+                        node.get("category") or node.get("type") or "concept"
+                    ).lower(),
+                    summary=summary,
+                    body=body,
+                    source_id=source_id,
+                    token_count=estimate_tokens(body or summary),
+                )
+            )
+        return records
+
+    @staticmethod
+    def _find_node(tree: dict[str, Any], node_id: str) -> Optional[dict[str, Any]]:
+        """Locate a node dict by ``node_id`` in a PageIndex tree."""
+        try:
+            from parrot.knowledge.pageindex.utils import find_node_by_id
+
+            return find_node_by_id(tree.get("structure", tree), node_id)
+        except Exception:  # noqa: BLE001
+            return None
+
+    @staticmethod
+    def _load_body(
+        loader: Optional[Any],
+        concept_id: str,
+        node_id: str,
+    ) -> str:
+        """Load a node's markdown body, trying every known sidecar key."""
+        if loader is None:
+            return ""
+        keys = [concept_id, node_id]
+        if "/" in concept_id:
+            keys.insert(1, concept_id.replace("/", "--"))
+        for key in keys:
+            try:
+                loaded = loader(key)
+            except Exception:  # noqa: BLE001
+                continue
+            if isinstance(loaded, str) and loaded:
+                return loaded
+        return ""
 
     async def _sync_to_graph(
         self,

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/ingest.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/ingest.py
@@ -182,13 +182,11 @@ class WikiIngestOrchestrator:
 
         try:
             pi_result = await self._create_wiki_pages(content, tree_name)
-            pages_created = pi_result.get("nodes_added", 0)
-            # Collect node IDs from the result
-            inserted_ids = pi_result.get("node_ids", [])
-            if isinstance(inserted_ids, list):
-                page_ids = [str(nid) for nid in inserted_ids]
-            elif pi_result.get("node_id"):
-                page_ids = [str(pi_result["node_id"])]
+            # PageIndexToolkit.insert_content() contract:
+            # {"tree_name", "new_node_ids", "title", "summary"}
+            inserted_ids = pi_result.get("new_node_ids") or []
+            page_ids = [str(nid) for nid in inserted_ids]
+            pages_created = len(page_ids)
         except Exception as exc:  # noqa: BLE001
             self.logger.error("PageIndex insert failed for %s: %s", source_uri, exc)
             return self._error_report(source_id, source_uri, t0, str(exc))

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/models.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/models.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from enum import Enum
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -63,8 +63,11 @@ class WikiConfig(BaseModel):
         model: Optional model identifier for the heavyweight generation
             step of TwoStepIngester.
         sync_graph: When ``True``, wiki writes also mirror pages into
-            GraphIndex.  Off by default — the WikiStore SQLite plane is
-            the wiki's retrieval backend.
+            GraphIndex.  Off by default — the WikiStore plane is the
+            wiki's retrieval backend.
+        storage_backend: ``"sqlite"`` (default; single-file ``wiki.db``)
+            or ``"memory"`` (in-memory indexes + OKF markdown bundle
+            directory — no SQLite dependency).
     """
 
     wiki_name: str = Field(..., description="Unique wiki name / identifier")
@@ -93,7 +96,16 @@ class WikiConfig(BaseModel):
         default=False,
         description=(
             "Mirror wiki pages into GraphIndex on write. Off by default — "
-            "the WikiStore SQLite plane is the retrieval backend."
+            "the WikiStore plane is the retrieval backend."
+        ),
+    )
+    storage_backend: Literal["sqlite", "memory"] = Field(
+        default="sqlite",
+        description=(
+            "Retrieval-plane backend: 'sqlite' (single-file wiki.db, "
+            "FTS5/BM25) or 'memory' (in-memory indexes persisted as an "
+            "OKF markdown bundle under {storage_dir}/pages/). Explicit "
+            "selection only — no auto-fallback."
         ),
     )
 

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/models.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/models.py
@@ -158,16 +158,20 @@ class SourceManifestEntry(BaseModel):
 
 
 class WikiSearchResult(BaseModel):
-    """Unified search result returned by combined (PageIndex + GraphIndex) search.
+    """Unified wiki search result.
 
     Attributes:
-        node_id: Stable node/page identifier in the underlying index.
+        node_id: Stable page identifier (``concept_id`` on the WikiStore
+            path; index node id on the legacy path).
         title: Human-readable page or node title.
         score: Normalised relevance score in [0, 1] after weight application.
-        source: Which backend produced this result — ``"pageindex"`` or
-            ``"graphindex"``.
+        source: Which search leg produced this result — ``"lexical"`` /
+            ``"vector"`` (WikiStore plane) or ``"pageindex"`` /
+            ``"graphindex"`` (legacy toolkit path).
         snippet: Short excerpt or summary extracted from the page content.
         category: Optional WikiPageCategory if the page has one.
+        token_count: Token cost of reading the full page body — used by
+            context packing to budget progressive disclosure.
     """
 
     node_id: str = Field(..., description="Stable node/page identifier")
@@ -180,7 +184,15 @@ class WikiSearchResult(BaseModel):
     )
     source: str = Field(
         ...,
-        description="Search backend: 'pageindex' or 'graphindex'",
+        description=(
+            "Search leg: 'lexical'/'vector' (WikiStore) or "
+            "'pageindex'/'graphindex' (legacy)"
+        ),
+    )
+    token_count: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description="Token cost of the full page body (for budgeting)",
     )
     snippet: str = Field(
         default="",

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/models.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/models.py
@@ -62,6 +62,9 @@ class WikiConfig(BaseModel):
             when ``None``.
         model: Optional model identifier for the heavyweight generation
             step of TwoStepIngester.
+        sync_graph: When ``True``, wiki writes also mirror pages into
+            GraphIndex.  Off by default — the WikiStore SQLite plane is
+            the wiki's retrieval backend.
     """
 
     wiki_name: str = Field(..., description="Unique wiki name / identifier")
@@ -85,6 +88,13 @@ class WikiConfig(BaseModel):
     model: Optional[str] = Field(
         default=None,
         description="LLM model for heavyweight generation step",
+    )
+    sync_graph: bool = Field(
+        default=False,
+        description=(
+            "Mirror wiki pages into GraphIndex on write. Off by default — "
+            "the WikiStore SQLite plane is the retrieval backend."
+        ),
     )
 
     @field_validator("search_weights")

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/search.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/search.py
@@ -221,6 +221,7 @@ class WikiCombinedSearch:
             category = WikiPageCategory(raw_category) if raw_category else None
         except ValueError:
             category = None
+        token_count = row.get("token_count")
         return WikiSearchResult(
             node_id=str(row.get("concept_id") or row.get("node_id") or ""),
             title=str(row.get("title") or ""),
@@ -228,6 +229,7 @@ class WikiCombinedSearch:
             source=source,
             snippet=str(row.get("summary") or ""),
             category=category,
+            token_count=int(token_count) if token_count is not None else None,
         )
 
     async def find_related(
@@ -490,14 +492,5 @@ class WikiCombinedSearch:
                 normalised = 1.0
 
             weighted_score = min(max(normalised * weight, 0.0), 1.0)
-            weighted.append(
-                WikiSearchResult(
-                    node_id=r.node_id,
-                    title=r.title,
-                    score=weighted_score,
-                    source=r.source,
-                    snippet=r.snippet,
-                    category=r.category,
-                )
-            )
+            weighted.append(r.model_copy(update={"score": weighted_score}))
         return weighted

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/search.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/search.py
@@ -1,28 +1,32 @@
-"""Combined search across PageIndex and GraphIndex for the LLM Wiki (FEAT-260).
+"""Combined search for the LLM Wiki (FEAT-260 + WikiStore plane).
 
-Implements unified search that merges results from:
+Preferred path — when a :class:`WikiStore` is provided, every query is
+answered directly from the single-file SQLite plane (no toolkit
+fan-out, no markdown parsing at query time):
 
-- **PageIndex** ``HybridPageIndexSearch`` (BM25 + LLM walk) via
-  ``PageIndexToolkit.search()``.
-- **GraphIndex** ``GraphExpandedRetriever`` via
-  ``GraphIndexToolkit.search_hybrid()``.
+- **lexical** — FTS5/BM25 over title/summary/body.
+- **vector** — cosine over stored page embeddings (requires an
+  ``embedder`` callable).
+- ``"combined"`` (default) merges both with configurable weights.
+  Legacy mode names map onto the plane: ``"pageindex"`` → lexical,
+  ``"graphindex"`` → vector.
 
-Results from each backend are min-max normalised to [0, 1], weighted by
-the configurable ``search_weights`` dictionary, deduplicated by ``node_id``,
-and returned as a sorted :class:`WikiSearchResult` list.
+Legacy path — without a store, results are merged from
+``PageIndexToolkit.search()`` and ``GraphIndexToolkit.search_hybrid()``
+exactly as before (kept for one release).
 
-Search modes:
-- ``"pageindex"`` — PageIndex only; GraphIndex is not called.
-- ``"graphindex"`` — GraphIndex only; PageIndex is not called.
-- ``"combined"`` (default) — both backends, weights applied.
+Results from each group are min-max normalised to [0, 1], weighted by
+the configurable ``search_weights`` dictionary, deduplicated by
+``node_id``, and returned as a sorted :class:`WikiSearchResult` list.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional
+from typing import Any, Awaitable, Callable, Optional
 
-from parrot.knowledge.wiki.models import WikiSearchResult
+from parrot.knowledge.wiki.models import WikiPageCategory, WikiSearchResult
+from parrot.knowledge.wiki.store import WikiStore
 
 
 class WikiCombinedSearch:
@@ -45,18 +49,29 @@ class WikiCombinedSearch:
         pageindex_toolkit: Any,
         graphindex_toolkit: Any,
         default_weights: Optional[dict[str, float]] = None,
+        store: Optional[WikiStore] = None,
+        embedder: Optional[Callable[[str], Awaitable[list[float]]]] = None,
     ) -> None:
-        """Initialise combined search with two toolkit backends.
+        """Initialise combined search.
 
         Args:
-            pageindex_toolkit: A ``PageIndexToolkit`` instance.
-            graphindex_toolkit: A ``GraphIndexToolkit`` instance.
-            default_weights: Optional weighting dict with keys
-                ``"pageindex"`` and ``"graphindex"``.  Defaults to
+            pageindex_toolkit: A ``PageIndexToolkit`` instance (legacy
+                path only — unused when ``store`` is provided).
+            graphindex_toolkit: A ``GraphIndexToolkit`` instance (legacy
+                path only).
+            default_weights: Optional weighting dict.  Accepts the new
+                keys ``"lexical"`` / ``"vector"`` or the legacy aliases
+                ``"pageindex"`` / ``"graphindex"``.  Defaults to
                 ``{"pageindex": 0.6, "graphindex": 0.4}``.
+            store: :class:`WikiStore` retrieval plane.  When provided,
+                all searches run against it (preferred path).
+            embedder: Optional async ``text -> vector`` callable used
+                for the vector leg of store-backed search.
         """
         self._pi = pageindex_toolkit
         self._gi = graphindex_toolkit
+        self._store = store
+        self._embedder = embedder
         self._weights: dict[str, float] = default_weights or {
             "pageindex": 0.6,
             "graphindex": 0.4,
@@ -94,6 +109,11 @@ class WikiCombinedSearch:
         effective_weights = weights or self._weights
         mode = mode.lower()
 
+        if self._store is not None:
+            return await self._search_store(
+                query, mode=mode, top_k=top_k, weights=effective_weights
+            )
+
         pi_results: list[WikiSearchResult] = []
         gi_results: list[WikiSearchResult] = []
 
@@ -110,6 +130,105 @@ class WikiCombinedSearch:
 
         merged = self._merge_results(pi_results, gi_results, effective_weights)
         return merged[:top_k]
+
+    async def _search_store(
+        self,
+        query: str,
+        mode: str,
+        top_k: int,
+        weights: dict[str, float],
+    ) -> list[WikiSearchResult]:
+        """Answer a search entirely from the WikiStore SQLite plane.
+
+        Args:
+            query: Natural-language query.
+            mode: ``"combined"``, ``"lexical"`` (alias ``"pageindex"``),
+                or ``"vector"`` (alias ``"graphindex"``).
+            top_k: Maximum merged results.
+            weights: Weight mapping (new or legacy key names).
+
+        Returns:
+            Sorted, deduplicated :class:`WikiSearchResult` list.
+        """
+        lex_weight = weights.get("lexical", weights.get("pageindex", 0.6))
+        vec_weight = weights.get("vector", weights.get("graphindex", 0.4))
+
+        want_lexical = mode in ("combined", "lexical", "pageindex")
+        want_vector = mode in ("combined", "vector", "graphindex")
+
+        lexical_results: list[WikiSearchResult] = []
+        if want_lexical:
+            try:
+                rows = await self._store.search_fts(query, limit=top_k)
+                lexical_results = [
+                    self._store_row_to_wiki(r, source="lexical")
+                    for r in self._normalize_rows(rows)
+                ]
+            except Exception as exc:  # noqa: BLE001
+                self.logger.warning("WikiStore FTS search failed: %s", exc)
+
+        vector_results: list[WikiSearchResult] = []
+        if want_vector and self._embedder is not None:
+            try:
+                embedding = await self._embedder(query)
+                rows = await self._store.search_vector(embedding, limit=top_k)
+                vector_results = [
+                    self._store_row_to_wiki(r, source="vector")
+                    for r in self._normalize_rows(rows)
+                ]
+            except Exception as exc:  # noqa: BLE001
+                self.logger.warning("WikiStore vector search failed: %s", exc)
+
+        # When only one leg produced results, give it full weight so
+        # scores stay meaningful in [0, 1].
+        if lexical_results and not vector_results:
+            lex_weight = 1.0
+        elif vector_results and not lexical_results:
+            vec_weight = 1.0
+
+        merged = self._merge_groups(
+            [(lexical_results, lex_weight), (vector_results, vec_weight)]
+        )
+        return merged[:top_k]
+
+    @staticmethod
+    def _normalize_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Min-max normalise raw store scores into [0, 1] per group.
+
+        Raw scores (``-bm25`` or cosine) are unbounded / signed, but
+        :class:`WikiSearchResult` enforces ``score ∈ [0, 1]`` — so the
+        normalisation must happen before model construction.
+        """
+        if not rows:
+            return []
+        scores = [float(r.get("score") or 0.0) for r in rows]
+        min_s, max_s = min(scores), max(scores)
+        span = max_s - min_s
+        out = []
+        for row, raw in zip(rows, scores):
+            item = dict(row)
+            item["score"] = (raw - min_s) / span if span > 0 else 1.0
+            out.append(item)
+        return out
+
+    @staticmethod
+    def _store_row_to_wiki(
+        row: dict[str, Any], source: str
+    ) -> WikiSearchResult:
+        """Convert a WikiStore result row to a :class:`WikiSearchResult`."""
+        raw_category = row.get("category")
+        try:
+            category = WikiPageCategory(raw_category) if raw_category else None
+        except ValueError:
+            category = None
+        return WikiSearchResult(
+            node_id=str(row.get("concept_id") or row.get("node_id") or ""),
+            title=str(row.get("title") or ""),
+            score=min(max(float(row.get("score") or 0.0), 0.0), 1.0),
+            source=source,
+            snippet=str(row.get("summary") or ""),
+            category=category,
+        )
 
     async def find_related(
         self,
@@ -130,6 +249,8 @@ class WikiCombinedSearch:
         Returns:
             A list of neighbour node dicts.  Returns an empty list on error.
         """
+        if self._store is not None:
+            return await self._find_related_store(page_id, depth=depth)
         try:
             gn_method = getattr(self._gi, "get_neighborhood", None)
             if callable(gn_method):
@@ -153,6 +274,47 @@ class WikiCombinedSearch:
                 page_id,
                 depth,
                 exc,
+            )
+            return []
+
+    async def _find_related_store(
+        self,
+        page_id: str,
+        depth: int = 2,
+    ) -> list[dict[str, Any]]:
+        """BFS over the WikiStore edges table up to ``depth`` hops.
+
+        Args:
+            page_id: Seed concept_id.
+            depth: Maximum number of hops from the seed.
+
+        Returns:
+            Neighbour dicts (each includes ``concept_id``, ``rel``,
+            ``direction``, ``hops``, and page stub fields when the
+            target is a known page).  Empty list on error.
+        """
+        try:
+            seen: set[str] = {page_id}
+            frontier = [page_id]
+            related: list[dict[str, Any]] = []
+            for hop in range(1, max(1, depth) + 1):
+                next_frontier: list[str] = []
+                for cid in frontier:
+                    for item in await self._store.neighbors(cid):
+                        target = str(item.get("concept_id") or "")
+                        if not target or target in seen:
+                            continue
+                        seen.add(target)
+                        item["hops"] = hop
+                        related.append(item)
+                        next_frontier.append(target)
+                frontier = next_frontier
+                if not frontier:
+                    break
+            return related
+        except Exception as exc:  # noqa: BLE001
+            self.logger.warning(
+                "find_related(%s) via WikiStore failed: %s", page_id, exc
             )
             return []
 
@@ -268,21 +430,33 @@ class WikiCombinedSearch:
         """
         pi_weight = weights.get("pageindex", 0.6)
         gi_weight = weights.get("graphindex", 0.4)
+        return self._merge_groups(
+            [(pi_results, pi_weight), (gi_results, gi_weight)]
+        )
 
-        # Normalise each group and apply weight
-        weighted_pi = self._apply_weight(pi_results, pi_weight)
-        weighted_gi = self._apply_weight(gi_results, gi_weight)
+    def _merge_groups(
+        self,
+        groups: list[tuple[list[WikiSearchResult], float]],
+    ) -> list[WikiSearchResult]:
+        """Weight, deduplicate, and sort result groups.
 
-        # Merge, keeping highest-scored duplicate by node_id
+        Each group is min-max normalised and multiplied by its weight;
+        when the same ``node_id`` appears in several groups the entry
+        with the higher weighted score is kept.
+
+        Args:
+            groups: ``(results, weight)`` pairs.
+
+        Returns:
+            Deduplicated list sorted by weighted score (descending).
+        """
         seen: dict[str, WikiSearchResult] = {}
-        for result in weighted_pi + weighted_gi:
-            existing = seen.get(result.node_id)
-            if existing is None or result.score > existing.score:
-                seen[result.node_id] = result
-
-        # Sort descending by weighted score
-        merged = sorted(seen.values(), key=lambda r: r.score, reverse=True)
-        return merged
+        for results, weight in groups:
+            for result in self._apply_weight(results, weight):
+                existing = seen.get(result.node_id)
+                if existing is None or result.score > existing.score:
+                    seen[result.node_id] = result
+        return sorted(seen.values(), key=lambda r: r.score, reverse=True)
 
     def _apply_weight(
         self,

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/sources.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/sources.py
@@ -1,13 +1,21 @@
 """Source collection manager for the LLM Wiki feature (FEAT-260).
 
 Implements the "Raw Sources" layer of Karpathy's 3-layer architecture.
-Tracks ingested source documents via a JSON manifest persisted to
-``.manifest.json`` inside the wiki's sources directory.
+Tracks ingested source documents in the ``sources`` table of the wiki's
+single-file SQLite retrieval plane (``wiki.db`` — see
+:mod:`parrot.knowledge.wiki.store`), replacing the legacy
+``.manifest.json`` file.  A legacy manifest found on first open is
+migrated into the database automatically and renamed to
+``.manifest.json.bak``.
 
 Staleness detection reuses the same mtime + SHA-1 pattern as
-``SQLitePersistence.is_stale()`` in ``graphindex/persist_sqlite.py``,
-but stores state in a plain JSON file rather than SQLite so the
-manifest remains human-readable without a database dependency.
+``SQLitePersistence.is_stale()`` in ``graphindex/persist_sqlite.py``.
+
+The public API is synchronous (callers off-load to a thread pool via
+``asyncio.to_thread``), so this module uses the stdlib ``sqlite3``
+driver with short-lived per-call connections — WAL mode makes this safe
+alongside the async :class:`~parrot.knowledge.wiki.store.WikiStore`
+connections on the same file.
 """
 
 from __future__ import annotations
@@ -15,12 +23,14 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import sqlite3
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from parrot.knowledge.wiki.models import SourceManifestEntry
+from parrot.knowledge.wiki.store import WIKI_SCHEMA_SQL
 
 
 class SourceCollectionManager:
@@ -28,8 +38,8 @@ class SourceCollectionManager:
 
     Attributes:
         sources_dir: Directory where raw source files live.
-        manifest_path: Path to the ``.manifest.json`` file that tracks
-            all ingested sources.
+        db_path: Path of the shared ``wiki.db`` SQLite file.
+        manifest_path: Legacy ``.manifest.json`` location (migration only).
         logger: Standard Python logger.
 
     Example::
@@ -44,26 +54,38 @@ class SourceCollectionManager:
 
     _MANIFEST_FILENAME: str = ".manifest.json"
 
-    def __init__(self, sources_dir: Path) -> None:
-        """Initialise the manager and load the existing manifest.
+    def __init__(
+        self,
+        sources_dir: Path,
+        db_path: Optional[Path] = None,
+    ) -> None:
+        """Initialise the manager, the schema, and migrate legacy data.
 
         Args:
             sources_dir: Root directory for raw source documents.
                 Created automatically if it does not exist.
+            db_path: Optional explicit path of the wiki database.  When
+                omitted, defaults to ``<sources_dir>/../wiki.db`` — the
+                same file used by :class:`WikiStore`.
         """
         self.sources_dir: Path = Path(sources_dir)
         self.sources_dir.mkdir(parents=True, exist_ok=True)
+        self.db_path: Path = (
+            Path(db_path) if db_path else self.sources_dir.parent / "wiki.db"
+        )
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self.manifest_path: Path = self.sources_dir / self._MANIFEST_FILENAME
         self.logger: logging.Logger = logging.getLogger(__name__)
-        self._manifest: dict[str, SourceManifestEntry] = {}
-        self._load_manifest()
+        with self._connect() as conn:
+            conn.executescript(WIKI_SCHEMA_SQL)
+        self._migrate_json_manifest()
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
 
     def add_source(self, path: Path) -> SourceManifestEntry:
-        """Register a new source file in the manifest.
+        """Register a new source file in the sources table.
 
         Computes the SHA-1 hash and mtime of the file at registration
         time.  If the source is already tracked (by URI), the existing
@@ -83,30 +105,24 @@ class SourceCollectionManager:
             raise FileNotFoundError(f"Source file not found: {path}")
 
         source_uri = str(path)
-        # Re-use existing ID if the file was already tracked
         existing_id = self._find_id_by_uri(source_uri)
         source_id = existing_id or self._generate_source_id(source_uri)
-
-        file_hash = self._compute_hash(path)
-        mtime = path.stat().st_mtime
-        ingested_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
         entry = SourceManifestEntry(
             source_id=source_id,
             source_uri=source_uri,
-            file_hash=file_hash,
-            mtime=mtime,
-            ingested_at=ingested_at,
+            file_hash=self._compute_hash(path),
+            mtime=path.stat().st_mtime,
+            ingested_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             pages_generated=[],
             status="ingested",
         )
-        self._manifest[source_id] = entry
-        self._save_manifest()
+        self._upsert(entry)
         self.logger.debug(
             "Source added: source_id=%s uri=%s hash=%s",
             source_id,
             source_uri,
-            file_hash,
+            entry.file_hash,
         )
         return entry
 
@@ -115,9 +131,13 @@ class SourceCollectionManager:
 
         Returns:
             A list of :class:`SourceManifestEntry` objects, one per
-            registered source.  Order is insertion order (Python 3.7+).
+            registered source, in insertion (rowid) order.
         """
-        return list(self._manifest.values())
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM sources ORDER BY rowid"
+            ).fetchall()
+        return [self._row_to_entry(row) for row in rows]
 
     def get_source(self, source_id: str) -> Optional[SourceManifestEntry]:
         """Retrieve a single source entry by its ID.
@@ -129,7 +149,11 @@ class SourceCollectionManager:
         Returns:
             The :class:`SourceManifestEntry`, or ``None`` if not found.
         """
-        return self._manifest.get(source_id)
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM sources WHERE source_id = ?", (source_id,)
+            ).fetchone()
+        return self._row_to_entry(row) if row else None
 
     def is_stale(self, source_id: str) -> bool:
         """Determine whether a tracked source has changed since last ingest.
@@ -142,13 +166,13 @@ class SourceCollectionManager:
             source_id: The stable source identifier to check.
 
         Returns:
-            ``True`` when the source is missing from the manifest, the
+            ``True`` when the source is missing from the table, the
             underlying file no longer exists, or the file content / mtime
             has changed.  ``False`` otherwise.
         """
-        entry = self._manifest.get(source_id)
+        entry = self.get_source(source_id)
         if entry is None:
-            self.logger.debug("is_stale: source_id=%s not in manifest", source_id)
+            self.logger.debug("is_stale: source_id=%s not tracked", source_id)
             return True
 
         path = Path(entry.source_uri)
@@ -165,10 +189,8 @@ class SourceCollectionManager:
             current_hash = self._compute_hash(path)
             stale = current_hash != entry.file_hash
             self.logger.debug(
-                "is_stale: source_id=%s mtime_changed=%s hash_changed=%s stale=%s",
+                "is_stale: source_id=%s mtime_changed=True hash_changed=%s",
                 source_id,
-                True,
-                stale,
                 stale,
             )
             return stale
@@ -182,7 +204,7 @@ class SourceCollectionManager:
         pages_generated: list[str],
         status: str = "ingested",
     ) -> Optional[SourceManifestEntry]:
-        """Update the manifest after a successful ingest run.
+        """Update the sources table after a successful ingest run.
 
         Args:
             source_id: The source to update.
@@ -193,7 +215,7 @@ class SourceCollectionManager:
             The updated :class:`SourceManifestEntry`, or ``None`` if
             ``source_id`` is not tracked.
         """
-        entry = self._manifest.get(source_id)
+        entry = self.get_source(source_id)
         if entry is None:
             self.logger.warning(
                 "mark_ingested: source_id=%s not found", source_id
@@ -212,30 +234,94 @@ class SourceCollectionManager:
                 pages_generated=pages_generated,
                 status=status,
             )
-            self._manifest[source_id] = entry
-            self._save_manifest()
+            self._upsert(entry)
         return entry
 
     def remove_source(self, source_id: str) -> bool:
-        """Remove a source from the manifest.
+        """Remove a source from the sources table.
 
         Args:
             source_id: The stable source identifier to remove.
 
         Returns:
             ``True`` if the entry existed and was removed; ``False`` if
-            ``source_id`` was not present in the manifest.
+            ``source_id`` was not present.
         """
-        if source_id not in self._manifest:
-            return False
-        del self._manifest[source_id]
-        self._save_manifest()
-        self.logger.debug("Source removed: source_id=%s", source_id)
-        return True
+        with self._connect() as conn:
+            cur = conn.execute(
+                "DELETE FROM sources WHERE source_id = ?", (source_id,)
+            )
+        removed = cur.rowcount > 0
+        if removed:
+            self.logger.debug("Source removed: source_id=%s", source_id)
+        return removed
+
+    def find_by_uri(self, source_uri: str) -> Optional[str]:
+        """Look up an existing source ID by URI (public API).
+
+        Args:
+            source_uri: The URI to search for.
+
+        Returns:
+            The matching source_id, or ``None`` if not tracked.
+        """
+        return self._find_id_by_uri(source_uri)
 
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
+
+    def _connect(self) -> sqlite3.Connection:
+        """Open a short-lived connection to the shared wiki database.
+
+        Per-call connections keep the sync API thread-safe when invoked
+        via ``asyncio.to_thread`` (sqlite3 connections have thread
+        affinity); WAL mode allows concurrency with async WikiStore
+        connections on the same file.
+        """
+        conn = sqlite3.connect(str(self.db_path))
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _upsert(self, entry: SourceManifestEntry) -> None:
+        """Insert or replace one sources row from a manifest entry."""
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO sources"
+                " (source_id, source_uri, file_hash, mtime, ingested_at,"
+                "  pages_generated, status)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?)"
+                " ON CONFLICT(source_id) DO UPDATE SET"
+                "  source_uri=excluded.source_uri, file_hash=excluded.file_hash,"
+                "  mtime=excluded.mtime, ingested_at=excluded.ingested_at,"
+                "  pages_generated=excluded.pages_generated, status=excluded.status",
+                (
+                    entry.source_id,
+                    entry.source_uri,
+                    entry.file_hash,
+                    entry.mtime,
+                    entry.ingested_at,
+                    json.dumps(entry.pages_generated),
+                    entry.status,
+                ),
+            )
+
+    @staticmethod
+    def _row_to_entry(row: sqlite3.Row) -> SourceManifestEntry:
+        """Convert a sources row into a :class:`SourceManifestEntry`."""
+        try:
+            pages = json.loads(row["pages_generated"] or "[]")
+        except (json.JSONDecodeError, TypeError):
+            pages = []
+        return SourceManifestEntry(
+            source_id=row["source_id"],
+            source_uri=row["source_uri"],
+            file_hash=row["file_hash"],
+            mtime=row["mtime"],
+            ingested_at=row["ingested_at"],
+            pages_generated=pages,
+            status=row["status"],
+        )
 
     def _compute_hash(self, path: Path) -> str:
         """Compute the SHA-1 hex digest of a file.
@@ -269,80 +355,47 @@ class SourceCollectionManager:
         uid = uuid.uuid5(uuid.NAMESPACE_URL, source_uri)
         return f"src-{uid.hex[:12]}"
 
-    def find_by_uri(self, source_uri: str) -> Optional[str]:
-        """Look up an existing source ID by URI (public API).
-
-        Args:
-            source_uri: The URI to search for.
-
-        Returns:
-            The matching source_id, or ``None`` if not tracked.
-        """
-        return self._find_id_by_uri(source_uri)
-
     def _find_id_by_uri(self, source_uri: str) -> Optional[str]:
-        """Look up an existing source ID by URI (internal implementation).
+        """Look up an existing source ID by URI (internal implementation)."""
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT source_id FROM sources WHERE source_uri = ?",
+                (source_uri,),
+            ).fetchone()
+        return row["source_id"] if row else None
 
-        Args:
-            source_uri: The URI to search for.
+    def _migrate_json_manifest(self) -> None:
+        """One-time migration of a legacy ``.manifest.json`` into SQLite.
 
-        Returns:
-            The matching source_id, or ``None`` if not tracked.
-        """
-        for sid, entry in self._manifest.items():
-            if entry.source_uri == source_uri:
-                return sid
-        return None
-
-    def _load_manifest(self) -> None:
-        """Load the JSON manifest from disk into ``self._manifest``.
-
-        Silently initialises an empty manifest when the file does not
-        exist or contains invalid JSON.
+        Existing rows win — a JSON entry is only imported when its
+        ``source_id`` is not already in the table.  The legacy file is
+        renamed to ``.manifest.json.bak`` afterwards so migration never
+        repeats (and the original data is preserved).
         """
         if not self.manifest_path.exists():
-            self.logger.debug(
-                "No existing manifest at %s; starting fresh", self.manifest_path
-            )
             return
-
         try:
-            raw: dict = json.loads(self.manifest_path.read_text(encoding="utf-8"))
-            self._manifest = {
-                sid: SourceManifestEntry(**data)
-                for sid, data in raw.items()
-            }
-            self.logger.debug(
-                "Loaded manifest with %d source(s) from %s",
-                len(self._manifest),
-                self.manifest_path,
+            raw: dict[str, Any] = json.loads(
+                self.manifest_path.read_text(encoding="utf-8")
             )
-        except (json.JSONDecodeError, KeyError, ValueError) as exc:
+            imported = 0
+            for sid, data in raw.items():
+                entry = SourceManifestEntry(**data)
+                if self.get_source(sid) is None:
+                    self._upsert(entry)
+                    imported += 1
+            self.manifest_path.rename(
+                self.manifest_path.with_suffix(".json.bak")
+            )
+            self.logger.info(
+                "Migrated %d legacy manifest entrie(s) from %s into %s",
+                imported,
+                self.manifest_path,
+                self.db_path,
+            )
+        except (json.JSONDecodeError, KeyError, ValueError, OSError) as exc:
             self.logger.warning(
-                "Could not parse manifest at %s: %s — starting fresh",
+                "Could not migrate legacy manifest at %s: %s",
                 self.manifest_path,
                 exc,
             )
-            self._manifest = {}
-
-    def _save_manifest(self) -> None:
-        """Persist the in-memory manifest to the JSON file.
-
-        Serialises each :class:`SourceManifestEntry` via
-        ``model_dump()``.  The file is written atomically via a
-        temporary sibling to avoid partial writes.
-        """
-        data = {
-            sid: entry.model_dump() for sid, entry in self._manifest.items()
-        }
-        tmp_path = self.manifest_path.with_suffix(".json.tmp")
-        tmp_path.write_text(
-            json.dumps(data, indent=2, default=str),
-            encoding="utf-8",
-        )
-        tmp_path.replace(self.manifest_path)
-        self.logger.debug(
-            "Saved manifest with %d source(s) to %s",
-            len(data),
-            self.manifest_path,
-        )

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/sources.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/sources.py
@@ -1,21 +1,26 @@
 """Source collection manager for the LLM Wiki feature (FEAT-260).
 
 Implements the "Raw Sources" layer of Karpathy's 3-layer architecture.
-Tracks ingested source documents in the ``sources`` table of the wiki's
-single-file SQLite retrieval plane (``wiki.db`` — see
-:mod:`parrot.knowledge.wiki.store`), replacing the legacy
-``.manifest.json`` file.  A legacy manifest found on first open is
-migrated into the database automatically and renamed to
-``.manifest.json.bak``.
+Tracks ingested source documents in one of two backends, matching the
+wiki's ``storage_backend``:
+
+- ``"sqlite"`` (default) — the ``sources`` table of the wiki's
+  single-file SQLite retrieval plane (``wiki.db`` — see
+  :mod:`parrot.knowledge.wiki.store`).  A legacy ``.manifest.json``
+  found on first open is migrated into the database automatically and
+  renamed to ``.manifest.json.bak``.
+- ``"json"`` — a plain ``.manifest.json`` file in ``sources_dir``
+  (atomic tmp-file writes), used with the SQLite-free
+  ``InMemoryWikiStore`` backend.
 
 Staleness detection reuses the same mtime + SHA-1 pattern as
 ``SQLitePersistence.is_stale()`` in ``graphindex/persist_sqlite.py``.
 
 The public API is synchronous (callers off-load to a thread pool via
-``asyncio.to_thread``), so this module uses the stdlib ``sqlite3``
-driver with short-lived per-call connections — WAL mode makes this safe
-alongside the async :class:`~parrot.knowledge.wiki.store.WikiStore`
-connections on the same file.
+``asyncio.to_thread``); the sqlite mode uses short-lived per-call
+``sqlite3`` connections — WAL mode makes this safe alongside the async
+:class:`~parrot.knowledge.wiki.store.WikiStore` connections on the same
+file.
 """
 
 from __future__ import annotations
@@ -27,10 +32,9 @@ import sqlite3
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from parrot.knowledge.wiki.models import SourceManifestEntry
-from parrot.knowledge.wiki.store import WIKI_SCHEMA_SQL
 
 
 class SourceCollectionManager:
@@ -38,8 +42,11 @@ class SourceCollectionManager:
 
     Attributes:
         sources_dir: Directory where raw source files live.
-        db_path: Path of the shared ``wiki.db`` SQLite file.
-        manifest_path: Legacy ``.manifest.json`` location (migration only).
+        backend: ``"sqlite"`` (sources table in ``wiki.db``) or
+            ``"json"`` (``.manifest.json`` in ``sources_dir``).
+        db_path: Path of the shared ``wiki.db`` file (sqlite mode).
+        manifest_path: ``.manifest.json`` location (json-mode storage;
+            sqlite-mode legacy migration source).
         logger: Standard Python logger.
 
     Example::
@@ -58,27 +65,44 @@ class SourceCollectionManager:
         self,
         sources_dir: Path,
         db_path: Optional[Path] = None,
+        backend: Literal["sqlite", "json"] = "sqlite",
     ) -> None:
-        """Initialise the manager, the schema, and migrate legacy data.
+        """Initialise the manager's chosen persistence backend.
 
         Args:
             sources_dir: Root directory for raw source documents.
                 Created automatically if it does not exist.
-            db_path: Optional explicit path of the wiki database.  When
-                omitted, defaults to ``<sources_dir>/../wiki.db`` — the
-                same file used by :class:`WikiStore`.
+            db_path: Optional explicit path of the wiki database
+                (sqlite mode only).  When omitted, defaults to
+                ``<sources_dir>/../wiki.db`` — the same file used by
+                :class:`SQLiteWikiStore`.
+            backend: ``"sqlite"`` (default) or ``"json"``.
+
+        Raises:
+            ValueError: For an unknown ``backend`` value.
         """
+        if backend not in ("sqlite", "json"):
+            raise ValueError(
+                f"Unknown sources backend {backend!r} — expected 'sqlite' or 'json'"
+            )
         self.sources_dir: Path = Path(sources_dir)
         self.sources_dir.mkdir(parents=True, exist_ok=True)
+        self.backend: str = backend
         self.db_path: Path = (
             Path(db_path) if db_path else self.sources_dir.parent / "wiki.db"
         )
-        self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self.manifest_path: Path = self.sources_dir / self._MANIFEST_FILENAME
         self.logger: logging.Logger = logging.getLogger(__name__)
-        with self._connect() as conn:
-            conn.executescript(WIKI_SCHEMA_SQL)
-        self._migrate_json_manifest()
+        self._manifest: dict[str, SourceManifestEntry] = {}
+        if backend == "sqlite":
+            from parrot.knowledge.wiki.store import WIKI_SCHEMA_SQL
+
+            self.db_path.parent.mkdir(parents=True, exist_ok=True)
+            with self._connect() as conn:
+                conn.executescript(WIKI_SCHEMA_SQL)
+            self._migrate_json_manifest()
+        else:
+            self._load_manifest()
 
     # ------------------------------------------------------------------
     # Public API
@@ -131,8 +155,10 @@ class SourceCollectionManager:
 
         Returns:
             A list of :class:`SourceManifestEntry` objects, one per
-            registered source, in insertion (rowid) order.
+            registered source, in insertion order.
         """
+        if self.backend == "json":
+            return list(self._manifest.values())
         with self._connect() as conn:
             rows = conn.execute(
                 "SELECT * FROM sources ORDER BY rowid"
@@ -149,6 +175,8 @@ class SourceCollectionManager:
         Returns:
             The :class:`SourceManifestEntry`, or ``None`` if not found.
         """
+        if self.backend == "json":
+            return self._manifest.get(source_id)
         with self._connect() as conn:
             row = conn.execute(
                 "SELECT * FROM sources WHERE source_id = ?", (source_id,)
@@ -247,6 +275,13 @@ class SourceCollectionManager:
             ``True`` if the entry existed and was removed; ``False`` if
             ``source_id`` was not present.
         """
+        if self.backend == "json":
+            if source_id not in self._manifest:
+                return False
+            del self._manifest[source_id]
+            self._save_manifest()
+            self.logger.debug("Source removed: source_id=%s", source_id)
+            return True
         with self._connect() as conn:
             cur = conn.execute(
                 "DELETE FROM sources WHERE source_id = ?", (source_id,)
@@ -284,7 +319,11 @@ class SourceCollectionManager:
         return conn
 
     def _upsert(self, entry: SourceManifestEntry) -> None:
-        """Insert or replace one sources row from a manifest entry."""
+        """Insert or replace one source entry in the active backend."""
+        if self.backend == "json":
+            self._manifest[entry.source_id] = entry
+            self._save_manifest()
+            return
         with self._connect() as conn:
             conn.execute(
                 "INSERT INTO sources"
@@ -357,6 +396,11 @@ class SourceCollectionManager:
 
     def _find_id_by_uri(self, source_uri: str) -> Optional[str]:
         """Look up an existing source ID by URI (internal implementation)."""
+        if self.backend == "json":
+            for sid, entry in self._manifest.items():
+                if entry.source_uri == source_uri:
+                    return sid
+            return None
         with self._connect() as conn:
             row = conn.execute(
                 "SELECT source_id FROM sources WHERE source_uri = ?",
@@ -399,3 +443,58 @@ class SourceCollectionManager:
                 self.manifest_path,
                 exc,
             )
+
+    # ------------------------------------------------------------------
+    # JSON-backend persistence (storage_backend="memory" wikis)
+    # ------------------------------------------------------------------
+
+    def _load_manifest(self) -> None:
+        """Load the JSON manifest from disk into ``self._manifest``.
+
+        Silently initialises an empty manifest when the file does not
+        exist or contains invalid JSON.
+        """
+        if not self.manifest_path.exists():
+            self.logger.debug(
+                "No existing manifest at %s; starting fresh", self.manifest_path
+            )
+            return
+        try:
+            raw: dict = json.loads(self.manifest_path.read_text(encoding="utf-8"))
+            self._manifest = {
+                sid: SourceManifestEntry(**data) for sid, data in raw.items()
+            }
+            self.logger.debug(
+                "Loaded manifest with %d source(s) from %s",
+                len(self._manifest),
+                self.manifest_path,
+            )
+        except (json.JSONDecodeError, KeyError, ValueError) as exc:
+            self.logger.warning(
+                "Could not parse manifest at %s: %s — starting fresh",
+                self.manifest_path,
+                exc,
+            )
+            self._manifest = {}
+
+    def _save_manifest(self) -> None:
+        """Persist the in-memory manifest to the JSON file.
+
+        Serialises each :class:`SourceManifestEntry` via
+        ``model_dump()``.  The file is written atomically via a
+        temporary sibling to avoid partial writes.
+        """
+        data = {
+            sid: entry.model_dump() for sid, entry in self._manifest.items()
+        }
+        tmp_path = self.manifest_path.with_suffix(".json.tmp")
+        tmp_path.write_text(
+            json.dumps(data, indent=2, default=str),
+            encoding="utf-8",
+        )
+        tmp_path.replace(self.manifest_path)
+        self.logger.debug(
+            "Saved manifest with %d source(s) to %s",
+            len(data),
+            self.manifest_path,
+        )

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/store.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/store.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import logging
 import re
 import struct
+from abc import ABC, abstractmethod
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from pathlib import Path
@@ -202,7 +203,199 @@ class WikiPageRecord(BaseModel):
     token_count: int = Field(default=0, ge=0)
 
 
-class WikiStore:
+def rank_by_cosine(
+    embedding: list[float],
+    candidates: list[tuple[dict[str, Any], list[float]]],
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    """Rank candidate stubs by cosine similarity to a query vector.
+
+    Shared by every backend — brute-force in-process scan, appropriate
+    at wiki scale (10³–10⁴ pages).  Candidates whose vector dimension
+    does not match the query are skipped.
+
+    Args:
+        embedding: Query vector.
+        candidates: ``(stub_dict, vector)`` pairs.
+        limit: Maximum results.
+
+    Returns:
+        Stub dicts with a ``score`` key in [-1, 1], best first.
+    """
+    if not candidates:
+        return []
+
+    import numpy as np
+
+    query_vec = np.asarray(embedding, dtype=np.float32)
+    q_norm = float(np.linalg.norm(query_vec))
+    if q_norm == 0.0:
+        return []
+
+    scored: list[dict[str, Any]] = []
+    for stub, vector in candidates:
+        vec = np.asarray(vector, dtype=np.float32)
+        if vec.shape != query_vec.shape:
+            continue
+        denom = q_norm * float(np.linalg.norm(vec))
+        score = float(np.dot(query_vec, vec) / denom) if denom else 0.0
+        item = dict(stub)
+        item["score"] = score
+        scored.append(item)
+    scored.sort(key=lambda r: r["score"], reverse=True)
+    return scored[:limit]
+
+
+class BaseWikiStore(ABC):
+    """Contract for wiki retrieval-plane backends.
+
+    Every consumer (``wiki/search.py``, ``wiki/ingest.py``,
+    ``wiki/toolkit.py``, ``wiki/export.py``) talks only to this
+    surface, so backends are interchangeable via
+    :func:`create_wiki_store`:
+
+    - :class:`SQLiteWikiStore` — single-file ``wiki.db`` (FTS5/BM25).
+    - :class:`InMemoryWikiStore` — RAM indexes persisted as an OKF
+      markdown bundle directory (``wiki/file_store.py``).
+
+    ``search_fts`` is the lexical-search entry point on all backends
+    (the name predates the second backend; semantics are
+    backend-defined lexical ranking, not necessarily SQLite FTS).
+    """
+
+    # -- write -----------------------------------------------------------
+    @abstractmethod
+    async def upsert_pages(self, pages: list[WikiPageRecord]) -> int: ...
+
+    @abstractmethod
+    async def add_edges(self, edges: list[tuple[str, str, str]]) -> int: ...
+
+    @abstractmethod
+    async def replace_source_slice(
+        self,
+        source_id: str,
+        pages: list[WikiPageRecord],
+        edges: Optional[list[tuple[str, str, str]]] = None,
+    ) -> dict[str, Any]: ...
+
+    @abstractmethod
+    async def delete_page(self, concept_id: str) -> bool: ...
+
+    @abstractmethod
+    async def upsert_embedding(
+        self, concept_id: str, vector: list[float], model: str = ""
+    ) -> None: ...
+
+    # -- read ------------------------------------------------------------
+    @abstractmethod
+    async def get_page(
+        self, concept_id: str, include_body: bool = True
+    ) -> Optional[dict[str, Any]]: ...
+
+    @abstractmethod
+    async def list_pages(
+        self, category: Optional[str] = None, limit: int = 100
+    ) -> list[dict[str, Any]]: ...
+
+    @abstractmethod
+    async def search_fts(
+        self, query: str, category: Optional[str] = None, limit: int = 10
+    ) -> list[dict[str, Any]]: ...
+
+    @abstractmethod
+    async def search_vector(
+        self, embedding: list[float], limit: int = 10
+    ) -> list[dict[str, Any]]: ...
+
+    @abstractmethod
+    async def neighbors(
+        self,
+        concept_id: str,
+        rel: Optional[str] = None,
+        direction: str = "both",
+    ) -> list[dict[str, Any]]: ...
+
+    @abstractmethod
+    async def dump_pages(self) -> list[dict[str, Any]]: ...
+
+    @abstractmethod
+    async def dump_edges(self) -> list[dict[str, Any]]: ...
+
+    @abstractmethod
+    async def stats(self) -> dict[str, Any]: ...
+
+    # -- lint --------------------------------------------------------------
+    @abstractmethod
+    async def orphan_sources(self) -> list[str]: ...
+
+    @abstractmethod
+    async def broken_edges(self) -> list[dict[str, Any]]: ...
+
+    @abstractmethod
+    async def missing_bodies(self) -> list[str]: ...
+
+    # -- shared concrete behaviour ----------------------------------------
+
+    async def rebuild_from_tree(
+        self,
+        tree: dict[str, Any],
+        content_loader: Optional[Callable[[str], Optional[str]]] = None,
+        source_id: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Rebuild page rows from a PageIndex tree (derived-plane refresh).
+
+        Backend-agnostic: walks every node once and calls
+        :meth:`upsert_pages`.  Page identity prefers ``concept_id``
+        (assigned by ``splice_subtree``) and falls back to ``node_id``.
+        Bodies are loaded through ``content_loader`` (typically
+        ``NodeContentStore.loader_for(tree_name)``).
+
+        Args:
+            tree: PageIndex tree dict (``{"structure": [...]}``).
+            content_loader: ``node_id -> markdown`` callable, or ``None``
+                to store summary-only rows.
+            source_id: Optional source id stamped on every rebuilt page.
+
+        Returns:
+            ``{"pages_written": N}``
+        """
+        from parrot.knowledge.pageindex.utils import get_nodes
+
+        structure = tree.get("structure", tree)
+        nodes = get_nodes(structure)
+        pages: list[WikiPageRecord] = []
+        for node in nodes:
+            node_id = str(node.get("node_id") or "")
+            concept_id = str(node.get("concept_id") or node_id)
+            if not concept_id:
+                continue
+            body = ""
+            if content_loader is not None:
+                for key in (concept_id, node_id):
+                    if not key:
+                        continue
+                    loaded = content_loader(key)
+                    if loaded:
+                        body = loaded
+                        break
+            summary = str(node.get("summary") or "")
+            pages.append(
+                WikiPageRecord(
+                    concept_id=concept_id,
+                    node_id=node_id or None,
+                    title=str(node.get("title") or concept_id),
+                    category=str(node.get("category") or node.get("type") or "concept").lower(),
+                    summary=summary,
+                    body=body,
+                    source_id=source_id,
+                    token_count=estimate_tokens(body or summary),
+                )
+            )
+        written = await self.upsert_pages(pages)
+        return {"pages_written": written}
+
+
+class SQLiteWikiStore(BaseWikiStore):
     """Async single-file SQLite retrieval plane for one wiki.
 
     Args:
@@ -577,24 +770,10 @@ class WikiStore:
                 " FROM embeddings e JOIN pages p ON p.concept_id = e.concept_id"
             ) as cur:
                 rows = await cur.fetchall()
-        if not rows:
-            return []
 
-        import numpy as np
-
-        query_vec = np.asarray(embedding, dtype=np.float32)
-        q_norm = float(np.linalg.norm(query_vec))
-        if q_norm == 0.0:
-            return []
-
-        scored: list[dict[str, Any]] = []
+        candidates: list[tuple[dict[str, Any], list[float]]] = []
         for row in rows:
-            vec = np.frombuffer(row["vector"], dtype=np.float32)
-            if vec.shape != query_vec.shape:
-                continue
-            denom = q_norm * float(np.linalg.norm(vec))
-            score = float(np.dot(query_vec, vec) / denom) if denom else 0.0
-            item = {
+            stub = {
                 k: row[k]
                 for k in (
                     "concept_id",
@@ -606,10 +785,8 @@ class WikiStore:
                     "token_count",
                 )
             }
-            item["score"] = score
-            scored.append(item)
-        scored.sort(key=lambda r: r["score"], reverse=True)
-        return scored[:limit]
+            candidates.append((stub, _unpack_vector(row["vector"])))
+        return rank_by_cosine(embedding, candidates, limit=limit)
 
     async def neighbors(
         self,
@@ -735,63 +912,45 @@ class WikiStore:
             ) as cur:
                 return [row["concept_id"] for row in await cur.fetchall()]
 
-    # ------------------------------------------------------------------
-    # Rebuild
-    # ------------------------------------------------------------------
 
-    async def rebuild_from_tree(
-        self,
-        tree: dict[str, Any],
-        content_loader: Optional[Callable[[str], Optional[str]]] = None,
-        source_id: Optional[str] = None,
-    ) -> dict[str, Any]:
-        """Rebuild page rows from a PageIndex tree (derived-plane refresh).
+# Backwards-compatible alias — the SQLite plane was the only backend
+# before the pluggable-store refactor.
+WikiStore = SQLiteWikiStore
 
-        Walks every node once; page identity prefers ``concept_id``
-        (assigned by ``splice_subtree``) and falls back to ``node_id``.
-        Bodies are loaded through ``content_loader`` (typically
-        ``NodeContentStore.loader_for(tree_name)``).
 
-        Args:
-            tree: PageIndex tree dict (``{"structure": [...]}``).
-            content_loader: ``node_id -> markdown`` callable, or ``None``
-                to store summary-only rows.
-            source_id: Optional source id stamped on every rebuilt page.
+def create_wiki_store(
+    storage_dir: str | Path,
+    wiki_name: str = "",
+    backend: str = "sqlite",
+) -> BaseWikiStore:
+    """Instantiate the configured wiki retrieval-plane backend.
 
-        Returns:
-            ``{"pages_written": N}``
-        """
-        from parrot.knowledge.pageindex.utils import get_nodes
+    Selection is explicit (``WikiConfig.storage_backend``) — there is no
+    silent fallback: a broken/unavailable backend is a hard error.
 
-        structure = tree.get("structure", tree)
-        nodes = get_nodes(structure)
-        pages: list[WikiPageRecord] = []
-        for node in nodes:
-            node_id = str(node.get("node_id") or "")
-            concept_id = str(node.get("concept_id") or node_id)
-            if not concept_id:
-                continue
-            body = ""
-            if content_loader is not None:
-                for key in (concept_id, node_id):
-                    if not key:
-                        continue
-                    loaded = content_loader(key)
-                    if loaded:
-                        body = loaded
-                        break
-            summary = str(node.get("summary") or "")
-            pages.append(
-                WikiPageRecord(
-                    concept_id=concept_id,
-                    node_id=node_id or None,
-                    title=str(node.get("title") or concept_id),
-                    category=str(node.get("category") or node.get("type") or "concept").lower(),
-                    summary=summary,
-                    body=body,
-                    source_id=source_id,
-                    token_count=estimate_tokens(body or summary),
-                )
-            )
-        written = await self.upsert_pages(pages)
-        return {"pages_written": written}
+    Args:
+        storage_dir: Wiki storage root.  ``sqlite`` uses
+            ``{storage_dir}/wiki.db``; ``memory`` uses the OKF bundle
+            directory ``{storage_dir}/pages/``.
+        wiki_name: Wiki name recorded by the backend.
+        backend: ``"sqlite"`` (single-file SQLite plane) or
+            ``"memory"`` (in-memory indexes + OKF markdown directory).
+
+    Returns:
+        A :class:`BaseWikiStore` implementation.
+
+    Raises:
+        ValueError: For an unknown ``backend`` value.
+    """
+    storage_dir = Path(storage_dir)
+    if backend == "sqlite":
+        return SQLiteWikiStore(storage_dir / "wiki.db", wiki_name=wiki_name)
+    if backend == "memory":
+        # Imported lazily — file_store imports export helpers which
+        # import this module.
+        from parrot.knowledge.wiki.file_store import InMemoryWikiStore
+
+        return InMemoryWikiStore(storage_dir / "pages", wiki_name=wiki_name)
+    raise ValueError(
+        f"Unknown wiki storage backend {backend!r} — expected 'sqlite' or 'memory'"
+    )

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/store.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/store.py
@@ -1,0 +1,775 @@
+"""WikiStore — single-file SQLite retrieval plane for the LLM Wiki.
+
+Machine-first knowledge storage (follow-up to FEAT-260): every wiki
+query is answered from indexed SQL — no YAML/markdown parsing, no tree
+walks, and no dual-toolkit fan-out at retrieval time.
+
+Design (mirrors ``graphindex/persist_sqlite.py`` patterns):
+
+- One ``wiki.db`` per wiki (WAL journal mode, ``aiosqlite``).
+- ``pages`` — page bodies live IN the database, keyed by stable
+  ``concept_id`` (volatile PageIndex ``node_id`` kept as a secondary
+  column).  ``category`` and edge ``rel`` are open strings — no enum
+  ceremony in the machine plane.
+- ``edges`` — typed relations (``summarizes``, ``references``, …).
+- ``sources`` — absorbs the former ``.manifest.json`` manifest
+  (SHA-1 + mtime staleness detection).
+- ``pages_fts`` — FTS5/BM25 lexical index over title/summary/body.
+- ``embeddings`` — optional per-page vectors for cosine re-ranking.
+- ``meta`` — schema version + wiki name.
+
+The store is a *derived* retrieval plane: PageIndex remains the
+authoring/structuring engine, and the database can always be rebuilt
+from a PageIndex tree via :meth:`WikiStore.rebuild_from_tree`.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import struct
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, AsyncIterator, Callable, Optional
+
+import aiosqlite
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = "1"
+
+# Shared between WikiStore (async) and SourceCollectionManager (sync
+# sqlite3 connection to the same file) — WAL mode allows both.
+WIKI_SCHEMA_SQL = """
+PRAGMA journal_mode = WAL;
+
+CREATE TABLE IF NOT EXISTS meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sources (
+    source_id       TEXT PRIMARY KEY,
+    source_uri      TEXT NOT NULL UNIQUE,
+    file_hash       TEXT NOT NULL,
+    mtime           REAL NOT NULL,
+    ingested_at     TEXT NOT NULL,
+    pages_generated TEXT NOT NULL DEFAULT '[]',
+    status          TEXT NOT NULL DEFAULT 'ingested'
+);
+
+CREATE TABLE IF NOT EXISTS pages (
+    concept_id  TEXT PRIMARY KEY,
+    node_id     TEXT,
+    title       TEXT NOT NULL,
+    category    TEXT NOT NULL DEFAULT 'concept',
+    summary     TEXT NOT NULL DEFAULT '',
+    body        TEXT NOT NULL DEFAULT '',
+    source_id   TEXT,
+    token_count INTEGER NOT NULL DEFAULT 0,
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_pages_category ON pages(category);
+CREATE INDEX IF NOT EXISTS idx_pages_source   ON pages(source_id);
+CREATE INDEX IF NOT EXISTS idx_pages_node     ON pages(node_id);
+
+CREATE TABLE IF NOT EXISTS edges (
+    src        TEXT NOT NULL,
+    dst        TEXT NOT NULL,
+    rel        TEXT NOT NULL DEFAULT 'references',
+    provenance TEXT NOT NULL DEFAULT 'extracted',
+    PRIMARY KEY (src, dst, rel)
+);
+CREATE INDEX IF NOT EXISTS idx_edges_rel_src ON edges(rel, src);
+CREATE INDEX IF NOT EXISTS idx_edges_dst     ON edges(dst);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS pages_fts USING fts5(
+    concept_id UNINDEXED, title, summary, body, tokenize = 'unicode61'
+);
+
+CREATE TABLE IF NOT EXISTS embeddings (
+    concept_id TEXT PRIMARY KEY,
+    vector     BLOB NOT NULL,
+    model      TEXT NOT NULL DEFAULT ''
+);
+"""
+
+_FTS_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
+
+
+def _now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string."""
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+00:00")
+
+
+_TOKEN_ENCODER: Any = None  # resolved lazily; False = unavailable
+
+
+def _get_token_encoder() -> Any:
+    """Load and cache the tiktoken encoder once per process.
+
+    ``tiktoken.get_encoding`` may hit the network on first use — caching
+    the result (or the failure) keeps ``estimate_tokens`` O(text) and
+    prevents repeated download attempts in offline environments.
+    """
+    global _TOKEN_ENCODER
+    if _TOKEN_ENCODER is None:
+        try:
+            import tiktoken
+
+            _TOKEN_ENCODER = tiktoken.get_encoding("cl100k_base")
+        except Exception:  # noqa: BLE001 — tokenizer optional
+            _TOKEN_ENCODER = False
+    return _TOKEN_ENCODER
+
+
+def estimate_tokens(text: str) -> int:
+    """Cheap deterministic token estimate for budget accounting.
+
+    Uses ``tiktoken`` (``cl100k_base``) when available, falling back to
+    the ``len(text) // 4`` heuristic.  The result is stored per page so
+    context packing can budget without re-tokenising at query time.
+
+    Args:
+        text: Text to measure.
+
+    Returns:
+        Estimated token count (>= 0).
+    """
+    if not text:
+        return 0
+    enc = _get_token_encoder()
+    if enc:
+        try:
+            return len(enc.encode(text, disallowed_special=()))
+        except Exception:  # noqa: BLE001
+            pass
+    return max(1, len(text) // 4)
+
+
+def _fts_query(query: str) -> str:
+    """Build a safe FTS5 MATCH expression from free-form user text.
+
+    Extracts word tokens and joins them with ``OR`` so partial matches
+    still rank (BM25 handles precision).  All FTS5 operators/quotes in
+    the raw query are discarded — user input can never inject syntax.
+
+    Args:
+        query: Free-form natural-language query.
+
+    Returns:
+        FTS5 MATCH expression, or ``""`` when no tokens survive.
+    """
+    tokens = _FTS_TOKEN_RE.findall(query)
+    return " OR ".join(f'"{t}"' for t in tokens)
+
+
+def _pack_vector(vector: list[float]) -> bytes:
+    """Serialise an embedding vector to a float32 blob."""
+    return struct.pack(f"<{len(vector)}f", *vector)
+
+
+def _unpack_vector(blob: bytes) -> list[float]:
+    """Deserialise a float32 blob back to a list of floats."""
+    count = len(blob) // 4
+    return list(struct.unpack(f"<{count}f", blob))
+
+
+class WikiPageRecord(BaseModel):
+    """A single wiki page row in the retrieval plane.
+
+    Attributes:
+        concept_id: Stable page identity (primary key, link target).
+        node_id: Volatile PageIndex node id (secondary lookup only).
+        title: Page title.
+        category: Open-string category (e.g. ``"summary"``, ``"entity"``).
+        summary: Short summary used for stubs and FTS.
+        body: Full markdown body (lives in the DB — no sidecar reads).
+        source_id: Originating source id (``sources.source_id``).
+        token_count: Estimated token cost of the body.
+    """
+
+    concept_id: str = Field(..., min_length=1)
+    node_id: Optional[str] = None
+    title: str = ""
+    category: str = "concept"
+    summary: str = ""
+    body: str = ""
+    source_id: Optional[str] = None
+    token_count: int = Field(default=0, ge=0)
+
+
+class WikiStore:
+    """Async single-file SQLite retrieval plane for one wiki.
+
+    Args:
+        db_path: Path of the ``wiki.db`` file.  Parent directories are
+            created automatically.
+        wiki_name: Optional wiki name recorded in the ``meta`` table.
+
+    Example::
+
+        store = WikiStore(storage_dir / "wiki.db", wiki_name="my-wiki")
+        await store.upsert_pages([WikiPageRecord(concept_id="intro", ...)])
+        hits = await store.search_fts("neural networks", limit=5)
+    """
+
+    def __init__(self, db_path: str | Path, wiki_name: str = "") -> None:
+        self._db_path = Path(db_path)
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._wiki_name = wiki_name
+        self.logger = logging.getLogger(__name__)
+
+    @property
+    def db_path(self) -> Path:
+        """Path of the underlying SQLite file."""
+        return self._db_path
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @asynccontextmanager
+    async def _connect(self) -> AsyncIterator[aiosqlite.Connection]:
+        """Open the database, ensure schema, and yield a connection.
+
+        The caller is responsible for committing before exiting.
+        """
+        async with aiosqlite.connect(str(self._db_path)) as conn:
+            conn.row_factory = aiosqlite.Row
+            await conn.executescript(WIKI_SCHEMA_SQL)
+            await conn.execute(
+                "INSERT OR IGNORE INTO meta (key, value) VALUES (?, ?)",
+                ("schema_version", SCHEMA_VERSION),
+            )
+            if self._wiki_name:
+                await conn.execute(
+                    "INSERT OR IGNORE INTO meta (key, value) VALUES (?, ?)",
+                    ("wiki_name", self._wiki_name),
+                )
+            await conn.commit()
+            yield conn
+
+    async def _upsert_pages_conn(
+        self,
+        conn: aiosqlite.Connection,
+        pages: list[WikiPageRecord],
+    ) -> None:
+        """Upsert page rows + FTS entries on an open connection."""
+        now = _now_iso()
+        await conn.executemany(
+            "INSERT INTO pages"
+            " (concept_id, node_id, title, category, summary, body,"
+            "  source_id, token_count, created_at, updated_at)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            " ON CONFLICT(concept_id) DO UPDATE SET"
+            "  node_id=excluded.node_id, title=excluded.title,"
+            "  category=excluded.category, summary=excluded.summary,"
+            "  body=excluded.body, source_id=excluded.source_id,"
+            "  token_count=excluded.token_count, updated_at=excluded.updated_at",
+            [
+                (
+                    p.concept_id,
+                    p.node_id,
+                    p.title,
+                    p.category,
+                    p.summary,
+                    p.body,
+                    p.source_id,
+                    p.token_count or estimate_tokens(p.body),
+                    now,
+                    now,
+                )
+                for p in pages
+            ],
+        )
+        await conn.executemany(
+            "DELETE FROM pages_fts WHERE concept_id = ?",
+            [(p.concept_id,) for p in pages],
+        )
+        await conn.executemany(
+            "INSERT INTO pages_fts (concept_id, title, summary, body)"
+            " VALUES (?, ?, ?, ?)",
+            [(p.concept_id, p.title, p.summary, p.body) for p in pages],
+        )
+
+    async def _insert_edges_conn(
+        self,
+        conn: aiosqlite.Connection,
+        edges: list[tuple[str, str, str]],
+    ) -> None:
+        """Insert (src, dst, rel) edge tuples on an open connection."""
+        await conn.executemany(
+            "INSERT OR REPLACE INTO edges (src, dst, rel) VALUES (?, ?, ?)",
+            edges,
+        )
+
+    # ------------------------------------------------------------------
+    # Write API
+    # ------------------------------------------------------------------
+
+    async def upsert_pages(self, pages: list[WikiPageRecord]) -> int:
+        """Insert or update wiki pages (and their FTS index rows).
+
+        Args:
+            pages: Page records to write.
+
+        Returns:
+            Number of pages written.
+        """
+        if not pages:
+            return 0
+        async with self._connect() as conn:
+            await self._upsert_pages_conn(conn, pages)
+            await conn.commit()
+        return len(pages)
+
+    async def add_edges(self, edges: list[tuple[str, str, str]]) -> int:
+        """Insert typed edges.
+
+        Args:
+            edges: ``(src, dst, rel)`` tuples; ``rel`` is an open string.
+
+        Returns:
+            Number of edges written.
+        """
+        if not edges:
+            return 0
+        async with self._connect() as conn:
+            await self._insert_edges_conn(conn, edges)
+            await conn.commit()
+        return len(edges)
+
+    async def replace_source_slice(
+        self,
+        source_id: str,
+        pages: list[WikiPageRecord],
+        edges: Optional[list[tuple[str, str, str]]] = None,
+    ) -> dict[str, Any]:
+        """Atomically replace all pages/edges derived from one source.
+
+        Deletes existing pages whose ``source_id`` matches (plus their
+        FTS rows, embeddings, and any edges touching them), then inserts
+        the replacements — so re-ingest never accumulates duplicates.
+
+        Args:
+            source_id: Source whose derived pages are being replaced.
+            pages: Replacement page records.
+            edges: Optional replacement ``(src, dst, rel)`` edges.
+
+        Returns:
+            ``{"pages_deleted": N, "pages_written": M, "edges_written": K}``
+        """
+        edges = edges or []
+        async with self._connect() as conn:
+            async with conn.execute(
+                "SELECT concept_id FROM pages WHERE source_id = ?",
+                (source_id,),
+            ) as cur:
+                old_ids = [row["concept_id"] for row in await cur.fetchall()]
+
+            if old_ids:
+                await conn.executemany(
+                    "DELETE FROM pages_fts WHERE concept_id = ?",
+                    [(cid,) for cid in old_ids],
+                )
+                await conn.executemany(
+                    "DELETE FROM embeddings WHERE concept_id = ?",
+                    [(cid,) for cid in old_ids],
+                )
+                await conn.executemany(
+                    "DELETE FROM edges WHERE src = ? OR dst = ?",
+                    [(cid, cid) for cid in old_ids],
+                )
+                await conn.execute(
+                    "DELETE FROM pages WHERE source_id = ?", (source_id,)
+                )
+
+            await self._upsert_pages_conn(conn, pages)
+            await self._insert_edges_conn(conn, edges)
+            await conn.commit()
+
+        self.logger.debug(
+            "replace_source_slice: source=%s deleted=%d written=%d",
+            source_id,
+            len(old_ids),
+            len(pages),
+        )
+        return {
+            "pages_deleted": len(old_ids),
+            "pages_written": len(pages),
+            "edges_written": len(edges),
+        }
+
+    async def delete_page(self, concept_id: str) -> bool:
+        """Delete a page and its FTS row, embeddings, and edges.
+
+        Args:
+            concept_id: Page identity to delete.
+
+        Returns:
+            ``True`` when a page row was actually deleted.
+        """
+        async with self._connect() as conn:
+            cur = await conn.execute(
+                "DELETE FROM pages WHERE concept_id = ?", (concept_id,)
+            )
+            deleted = cur.rowcount > 0
+            await conn.execute(
+                "DELETE FROM pages_fts WHERE concept_id = ?", (concept_id,)
+            )
+            await conn.execute(
+                "DELETE FROM embeddings WHERE concept_id = ?", (concept_id,)
+            )
+            await conn.execute(
+                "DELETE FROM edges WHERE src = ? OR dst = ?",
+                (concept_id, concept_id),
+            )
+            await conn.commit()
+        return deleted
+
+    async def upsert_embedding(
+        self,
+        concept_id: str,
+        vector: list[float],
+        model: str = "",
+    ) -> None:
+        """Store (or replace) the embedding vector for a page.
+
+        Args:
+            concept_id: Page the vector belongs to.
+            vector: Embedding as a list of floats (stored as float32).
+            model: Identifier of the embedding model used.
+        """
+        async with self._connect() as conn:
+            await conn.execute(
+                "INSERT OR REPLACE INTO embeddings (concept_id, vector, model)"
+                " VALUES (?, ?, ?)",
+                (concept_id, _pack_vector(vector), model),
+            )
+            await conn.commit()
+
+    # ------------------------------------------------------------------
+    # Read API
+    # ------------------------------------------------------------------
+
+    async def get_page(
+        self, concept_id: str, include_body: bool = True
+    ) -> Optional[dict[str, Any]]:
+        """Fetch a single page by ``concept_id`` (falls back to ``node_id``).
+
+        Args:
+            concept_id: Stable page identity — for convenience a volatile
+                PageIndex ``node_id`` is also accepted.
+            include_body: When ``False`` the body column is omitted
+                (cheaper for stub-only reads).
+
+        Returns:
+            Page row as a dict, or ``None`` when not found.
+        """
+        cols = (
+            "concept_id, node_id, title, category, summary, source_id,"
+            " token_count, created_at, updated_at"
+        )
+        if include_body:
+            cols += ", body"
+        async with self._connect() as conn:
+            for key_col in ("concept_id", "node_id"):
+                async with conn.execute(
+                    f"SELECT {cols} FROM pages WHERE {key_col} = ? LIMIT 1",  # noqa: S608
+                    (concept_id,),
+                ) as cur:
+                    row = await cur.fetchone()
+                if row:
+                    return dict(row)
+        return None
+
+    async def list_pages(
+        self,
+        category: Optional[str] = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """List page stubs (no bodies), optionally filtered by category.
+
+        Args:
+            category: Exact category pre-filter (open string).
+            limit: Maximum rows returned.
+
+        Returns:
+            List of stub dicts ordered by ``updated_at`` (newest first).
+        """
+        sql = (
+            "SELECT concept_id, node_id, title, category, summary,"
+            " source_id, token_count, updated_at FROM pages"
+        )
+        params: tuple[Any, ...] = ()
+        if category is not None:
+            sql += " WHERE category = ?"
+            params = (category,)
+        sql += " ORDER BY updated_at DESC LIMIT ?"
+        params += (limit,)
+        async with self._connect() as conn:
+            async with conn.execute(sql, params) as cur:
+                return [dict(row) for row in await cur.fetchall()]
+
+    async def search_fts(
+        self,
+        query: str,
+        category: Optional[str] = None,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        """BM25 lexical search over title/summary/body.
+
+        Args:
+            query: Free-form natural-language query (sanitised before
+                reaching FTS5 — no operator injection).
+            category: Optional exact category pre-filter (deterministic
+                gate applied before ranking).
+            limit: Maximum results.
+
+        Returns:
+            Stub dicts with a ``score`` key (higher is better; scores
+            are ``-bm25`` and NOT normalised — callers normalise).
+        """
+        match_expr = _fts_query(query)
+        if not match_expr:
+            return []
+        sql = (
+            "SELECT p.concept_id, p.node_id, p.title, p.category, p.summary,"
+            " p.source_id, p.token_count, -bm25(pages_fts) AS score"
+            " FROM pages_fts JOIN pages p ON p.concept_id = pages_fts.concept_id"
+            " WHERE pages_fts MATCH ?"
+        )
+        params: tuple[Any, ...] = (match_expr,)
+        if category is not None:
+            sql += " AND p.category = ?"
+            params += (category,)
+        sql += " ORDER BY bm25(pages_fts) LIMIT ?"
+        params += (limit,)
+        async with self._connect() as conn:
+            async with conn.execute(sql, params) as cur:
+                return [dict(row) for row in await cur.fetchall()]
+
+    async def search_vector(
+        self,
+        embedding: list[float],
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        """Cosine-similarity search over stored page embeddings.
+
+        Brute-force in-process scan — appropriate at wiki scale (10³–10⁴
+        pages) and keeps the store dependency-free.
+
+        Args:
+            embedding: Query vector.
+            limit: Maximum results.
+
+        Returns:
+            Stub dicts with a ``score`` key in [-1, 1] (cosine).
+        """
+        async with self._connect() as conn:
+            async with conn.execute(
+                "SELECT e.concept_id, e.vector, p.node_id, p.title,"
+                " p.category, p.summary, p.source_id, p.token_count"
+                " FROM embeddings e JOIN pages p ON p.concept_id = e.concept_id"
+            ) as cur:
+                rows = await cur.fetchall()
+        if not rows:
+            return []
+
+        import numpy as np
+
+        query_vec = np.asarray(embedding, dtype=np.float32)
+        q_norm = float(np.linalg.norm(query_vec))
+        if q_norm == 0.0:
+            return []
+
+        scored: list[dict[str, Any]] = []
+        for row in rows:
+            vec = np.frombuffer(row["vector"], dtype=np.float32)
+            if vec.shape != query_vec.shape:
+                continue
+            denom = q_norm * float(np.linalg.norm(vec))
+            score = float(np.dot(query_vec, vec) / denom) if denom else 0.0
+            item = {
+                k: row[k]
+                for k in (
+                    "concept_id",
+                    "node_id",
+                    "title",
+                    "category",
+                    "summary",
+                    "source_id",
+                    "token_count",
+                )
+            }
+            item["score"] = score
+            scored.append(item)
+        scored.sort(key=lambda r: r["score"], reverse=True)
+        return scored[:limit]
+
+    async def neighbors(
+        self,
+        concept_id: str,
+        rel: Optional[str] = None,
+        direction: str = "both",
+    ) -> list[dict[str, Any]]:
+        """Return edge-adjacent pages/targets of a concept.
+
+        Args:
+            concept_id: Seed page identity.
+            rel: Optional exact relation filter (open string).
+            direction: ``"out"``, ``"in"``, or ``"both"``.
+
+        Returns:
+            Dicts with ``concept_id``, ``rel``, ``direction`` and — when
+            the target is a known page — its ``title``/``summary`` stub.
+        """
+        clauses: list[tuple[str, str]] = []
+        if direction in ("out", "both"):
+            clauses.append(("src", "dst"))
+        if direction in ("in", "both"):
+            clauses.append(("dst", "src"))
+
+        results: list[dict[str, Any]] = []
+        async with self._connect() as conn:
+            for anchor, other in clauses:
+                sql = (
+                    f"SELECT e.{other} AS concept_id, e.rel,"  # noqa: S608
+                    " p.title, p.category, p.summary, p.token_count"
+                    f" FROM edges e LEFT JOIN pages p ON p.concept_id = e.{other}"
+                    f" WHERE e.{anchor} = ?"
+                )
+                params: tuple[Any, ...] = (concept_id,)
+                if rel is not None:
+                    sql += " AND e.rel = ?"
+                    params += (rel,)
+                async with conn.execute(sql, params) as cur:
+                    for row in await cur.fetchall():
+                        item = dict(row)
+                        item["direction"] = "out" if anchor == "src" else "in"
+                        results.append(item)
+        return results
+
+    async def stats(self) -> dict[str, Any]:
+        """Aggregate counters for the wiki (single fast query set).
+
+        Returns:
+            ``{"pages": N, "edges": M, "sources": S, "embeddings": E,
+            "total_tokens": T, "categories": {...}}``
+        """
+        async with self._connect() as conn:
+            out: dict[str, Any] = {}
+            for key, sql in (
+                ("pages", "SELECT COUNT(*) FROM pages"),
+                ("edges", "SELECT COUNT(*) FROM edges"),
+                ("sources", "SELECT COUNT(*) FROM sources"),
+                ("embeddings", "SELECT COUNT(*) FROM embeddings"),
+                ("total_tokens", "SELECT COALESCE(SUM(token_count), 0) FROM pages"),
+            ):
+                async with conn.execute(sql) as cur:
+                    row = await cur.fetchone()
+                    out[key] = row[0] if row else 0
+            async with conn.execute(
+                "SELECT category, COUNT(*) AS n FROM pages GROUP BY category"
+            ) as cur:
+                out["categories"] = {
+                    row["category"]: row["n"] for row in await cur.fetchall()
+                }
+        return out
+
+    # ------------------------------------------------------------------
+    # Lint API (fast SQL checks)
+    # ------------------------------------------------------------------
+
+    async def orphan_sources(self) -> list[str]:
+        """Sources that produced no pages (zero rows in ``pages``)."""
+        async with self._connect() as conn:
+            async with conn.execute(
+                "SELECT s.source_id FROM sources s"
+                " LEFT JOIN pages p ON p.source_id = s.source_id"
+                " WHERE p.concept_id IS NULL"
+            ) as cur:
+                return [row["source_id"] for row in await cur.fetchall()]
+
+    async def broken_edges(self) -> list[dict[str, Any]]:
+        """Edges whose destination is neither a page nor a source."""
+        async with self._connect() as conn:
+            async with conn.execute(
+                "SELECT e.src, e.dst, e.rel FROM edges e"
+                " WHERE e.dst NOT IN (SELECT concept_id FROM pages)"
+                " AND e.dst NOT IN (SELECT source_id FROM sources)"
+            ) as cur:
+                return [dict(row) for row in await cur.fetchall()]
+
+    async def missing_bodies(self) -> list[str]:
+        """Pages with an empty body (stub rows without content)."""
+        async with self._connect() as conn:
+            async with conn.execute(
+                "SELECT concept_id FROM pages WHERE body = ''"
+            ) as cur:
+                return [row["concept_id"] for row in await cur.fetchall()]
+
+    # ------------------------------------------------------------------
+    # Rebuild
+    # ------------------------------------------------------------------
+
+    async def rebuild_from_tree(
+        self,
+        tree: dict[str, Any],
+        content_loader: Optional[Callable[[str], Optional[str]]] = None,
+        source_id: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Rebuild page rows from a PageIndex tree (derived-plane refresh).
+
+        Walks every node once; page identity prefers ``concept_id``
+        (assigned by ``splice_subtree``) and falls back to ``node_id``.
+        Bodies are loaded through ``content_loader`` (typically
+        ``NodeContentStore.loader_for(tree_name)``).
+
+        Args:
+            tree: PageIndex tree dict (``{"structure": [...]}``).
+            content_loader: ``node_id -> markdown`` callable, or ``None``
+                to store summary-only rows.
+            source_id: Optional source id stamped on every rebuilt page.
+
+        Returns:
+            ``{"pages_written": N}``
+        """
+        from parrot.knowledge.pageindex.utils import get_nodes
+
+        structure = tree.get("structure", tree)
+        nodes = get_nodes(structure)
+        pages: list[WikiPageRecord] = []
+        for node in nodes:
+            node_id = str(node.get("node_id") or "")
+            concept_id = str(node.get("concept_id") or node_id)
+            if not concept_id:
+                continue
+            body = ""
+            if content_loader is not None:
+                for key in (concept_id, node_id):
+                    if not key:
+                        continue
+                    loaded = content_loader(key)
+                    if loaded:
+                        body = loaded
+                        break
+            summary = str(node.get("summary") or "")
+            pages.append(
+                WikiPageRecord(
+                    concept_id=concept_id,
+                    node_id=node_id or None,
+                    title=str(node.get("title") or concept_id),
+                    category=str(node.get("category") or node.get("type") or "concept").lower(),
+                    summary=summary,
+                    body=body,
+                    source_id=source_id,
+                    token_count=estimate_tokens(body or summary),
+                )
+            )
+        written = await self.upsert_pages(pages)
+        return {"pages_written": written}

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/store.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/store.py
@@ -654,6 +654,28 @@ class WikiStore:
                         results.append(item)
         return results
 
+    async def dump_pages(self) -> list[dict[str, Any]]:
+        """Return every page row WITH bodies (bulk export path).
+
+        Returns:
+            Full page dicts ordered by ``concept_id``.
+        """
+        async with self._connect() as conn:
+            async with conn.execute(
+                "SELECT concept_id, node_id, title, category, summary, body,"
+                " source_id, token_count, created_at, updated_at"
+                " FROM pages ORDER BY concept_id"
+            ) as cur:
+                return [dict(row) for row in await cur.fetchall()]
+
+    async def dump_edges(self) -> list[dict[str, Any]]:
+        """Return every edge row (bulk export path)."""
+        async with self._connect() as conn:
+            async with conn.execute(
+                "SELECT src, dst, rel FROM edges ORDER BY src, dst, rel"
+            ) as cur:
+                return [dict(row) for row in await cur.fetchall()]
+
     async def stats(self) -> dict[str, Any]:
         """Aggregate counters for the wiki (single fast query set).
 

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/toolkit.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/toolkit.py
@@ -463,9 +463,10 @@ class LLMWikiToolkit(AbstractToolkit):
                 wiki_name, markdown, doc_name=title
             )
             if isinstance(pi_result, dict):
-                page_id = str(
-                    pi_result.get("node_id") or pi_result.get("id") or ""
-                )
+                # PageIndexToolkit.insert_markdown() contract:
+                # {"tree_name", "new_node_ids"}
+                new_ids = pi_result.get("new_node_ids") or []
+                page_id = str(new_ids[0]) if new_ids else None
         except Exception as exc:  # noqa: BLE001
             self.logger.warning("create_page PageIndex insert failed: %s", exc)
 

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/toolkit.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/toolkit.py
@@ -22,6 +22,11 @@ from pathlib import Path
 from typing import Any, Optional
 
 from parrot.knowledge.wiki.bookkeeper import WikiBookkeeper
+from parrot.knowledge.wiki.context import (
+    DEFAULT_BUDGET_TOKENS,
+    pack_results,
+    truncate_to_tokens,
+)
 from parrot.knowledge.wiki.ingest import IngestReport, WikiIngestOrchestrator
 from parrot.knowledge.wiki.models import (
     WikiConfig,
@@ -179,8 +184,8 @@ class LLMWikiToolkit(AbstractToolkit):
         results = await self._search.search(
             question, mode=mode, top_k=10, tree_name=wiki_name
         )
-        context_snippets = [r.snippet for r in results if r.snippet]
-        answer = self._synthesise_answer(question, context_snippets)
+        packed = pack_results(results, budget_tokens=DEFAULT_BUDGET_TOKENS)
+        answer = self._synthesise_answer(question, packed.text)
 
         filed_page_id: Optional[str] = None
         if file_answer:
@@ -451,22 +456,32 @@ class LLMWikiToolkit(AbstractToolkit):
         self,
         wiki_name: str,
         page_id: str,
+        max_tokens: Optional[int] = None,
     ) -> dict[str, Any]:
         """Read the full content of a wiki page by its ID.
+
+        Progressive disclosure: search returns compact stubs with each
+        page's token cost; call this only for pages worth their tokens,
+        optionally capping the spend with ``max_tokens``.
 
         Args:
             wiki_name: Wiki name containing the page.
             page_id: Stable ``concept_id`` of the page (a volatile
                 PageIndex ``node_id`` is also accepted).
+            max_tokens: Optional ceiling on returned content tokens —
+                the body is deterministically truncated when over.
 
         Returns:
             Dict with keys: page_id, title, category, summary, content,
-            token_count, source_id.  Returns ``{"error": "not_found"}``
-            when the page does not exist.
+            token_count, truncated, source_id.  Returns
+            ``{"error": "not_found"}`` when the page does not exist.
         """
         page = await self._store.get_page(page_id)
         if page is None:
             return {"error": "not_found", "page_id": page_id}
+        content, truncated = truncate_to_tokens(
+            page.get("body", ""), max_tokens
+        )
         return {
             "page_id": page["concept_id"],
             "node_id": page.get("node_id"),
@@ -474,8 +489,9 @@ class LLMWikiToolkit(AbstractToolkit):
             "title": page.get("title", ""),
             "category": page.get("category", ""),
             "summary": page.get("summary", ""),
-            "content": page.get("body", ""),
+            "content": content,
             "token_count": page.get("token_count", 0),
+            "truncated": truncated,
             "source_id": page.get("source_id"),
         }
 
@@ -742,6 +758,74 @@ class LLMWikiToolkit(AbstractToolkit):
         )
         return [r.model_dump() for r in results]
 
+    async def search_compact(
+        self,
+        wiki_name: str,
+        query: str,
+        budget_tokens: int = DEFAULT_BUDGET_TOKENS,
+        mode: str = "combined",
+    ) -> dict[str, Any]:
+        """Search and return token-budgeted compact stubs (preferred).
+
+        Each stub carries the page id, title, lead sentence, score, and
+        the token cost of reading the full page — so the caller can
+        decide what to ``read_page`` next without paying for bodies
+        up front.
+
+        Args:
+            wiki_name: Wiki name to search.
+            query: Natural-language search query.
+            budget_tokens: Hard token ceiling for the packed context.
+            mode: ``"combined"``, ``"lexical"``, or ``"vector"``.
+
+        Returns:
+            Dict with keys: context (packed text), stubs, tokens_used,
+            results_packed, total_available, truncated.
+        """
+        results = await self._search.search(
+            query, mode=mode, top_k=25, tree_name=wiki_name
+        )
+        packed = pack_results(results, budget_tokens=budget_tokens)
+        return {
+            "context": packed.text,
+            "stubs": packed.stubs,
+            "tokens_used": packed.tokens_used,
+            "results_packed": packed.results_packed,
+            "total_available": packed.total_available,
+            "truncated": packed.truncated,
+        }
+
+    async def expand(
+        self,
+        wiki_name: str,
+        page_id: str,
+        rel: Optional[str] = None,
+        budget_tokens: int = DEFAULT_BUDGET_TOKENS,
+    ) -> dict[str, Any]:
+        """Progressively disclose a page's graph neighbourhood as stubs.
+
+        Args:
+            wiki_name: Wiki name.
+            page_id: Seed page ``concept_id``.
+            rel: Optional exact relation filter (e.g. ``"summarizes"``,
+                ``"references"``).
+            budget_tokens: Token ceiling for the packed stubs.
+
+        Returns:
+            Dict with keys: page_id, context, stubs, tokens_used,
+            total_available, truncated.
+        """
+        neighbours = await self._store.neighbors(page_id, rel=rel)
+        packed = pack_results(neighbours, budget_tokens=budget_tokens)
+        return {
+            "page_id": page_id,
+            "context": packed.text,
+            "stubs": packed.stubs,
+            "tokens_used": packed.tokens_used,
+            "total_available": packed.total_available,
+            "truncated": packed.truncated,
+        }
+
     async def find_related(
         self,
         wiki_name: str,
@@ -856,25 +940,25 @@ class LLMWikiToolkit(AbstractToolkit):
     def _synthesise_answer(
         self,
         question: str,
-        snippets: list[str],
+        packed_context: str,
     ) -> str:
-        """Synthesise an answer from search result snippets.
+        """Synthesise an answer from token-budgeted packed context.
 
-        This is a lightweight placeholder: it concatenates the top
-        snippets with attribution markers.  In production, replace with an
-        LLM completion call using the bot's configured adapter.
+        This is a lightweight placeholder: it returns the packed stub
+        block with an attribution header.  In production, replace with
+        an LLM completion call using the bot's configured adapter — the
+        packed context is already budgeted for direct prompt inclusion.
 
         Args:
             question: The original question.
-            snippets: List of content snippets from search results.
+            packed_context: Compact stub block from :func:`pack_results`.
 
         Returns:
             A synthesised answer string.
         """
-        if not snippets:
+        if not packed_context:
             return (
                 f"No relevant wiki pages found for: {question!r}. "
                 "Try ingesting more sources first."
             )
-        joined = "\n\n".join(snippets[:5])
-        return f"Based on the wiki knowledge base:\n\n{joined}"
+        return f"Based on the wiki knowledge base:\n\n{packed_context}"

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/toolkit.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/toolkit.py
@@ -37,7 +37,7 @@ from parrot.knowledge.wiki.search import WikiCombinedSearch
 from parrot.knowledge.wiki.sources import SourceCollectionManager
 from parrot.knowledge.wiki.store import (
     WikiPageRecord,
-    WikiStore,
+    create_wiki_store,
     estimate_tokens,
 )
 from parrot.tools.toolkit import AbstractToolkit
@@ -95,16 +95,23 @@ class LLMWikiToolkit(AbstractToolkit):
         self._okf = okf_toolkit
         self._config = config
 
-        # Initialise helper components.  The WikiStore SQLite plane
-        # (storage_dir/wiki.db) is the retrieval backend; the sources
-        # registry shares the same database file.
-        self._store = WikiStore(
-            config.storage_dir / "wiki.db", wiki_name=config.wiki_name
+        # Initialise helper components.  The WikiStore plane is the
+        # retrieval backend — SQLite (storage_dir/wiki.db) or the
+        # in-memory + OKF-bundle-directory backend, per config.
+        self._store = create_wiki_store(
+            config.storage_dir,
+            wiki_name=config.wiki_name,
+            backend=config.storage_backend,
         )
         sources_dir = config.storage_dir / "sources"
-        self._sources = SourceCollectionManager(
-            sources_dir, db_path=self._store.db_path
-        )
+        if config.storage_backend == "sqlite":
+            self._sources = SourceCollectionManager(
+                sources_dir, db_path=config.storage_dir / "wiki.db"
+            )
+        else:
+            self._sources = SourceCollectionManager(
+                sources_dir, backend="json"
+            )
         self._bookkeeper = WikiBookkeeper()
         self._search = WikiCombinedSearch(
             pageindex_toolkit,

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/toolkit.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/toolkit.py
@@ -29,6 +29,11 @@ from parrot.knowledge.wiki.models import (
 )
 from parrot.knowledge.wiki.search import WikiCombinedSearch
 from parrot.knowledge.wiki.sources import SourceCollectionManager
+from parrot.knowledge.wiki.store import (
+    WikiPageRecord,
+    WikiStore,
+    estimate_tokens,
+)
 from parrot.tools.toolkit import AbstractToolkit
 
 
@@ -84,9 +89,16 @@ class LLMWikiToolkit(AbstractToolkit):
         self._okf = okf_toolkit
         self._config = config
 
-        # Initialise helper components
+        # Initialise helper components.  The WikiStore SQLite plane
+        # (storage_dir/wiki.db) is the retrieval backend; the sources
+        # registry shares the same database file.
+        self._store = WikiStore(
+            config.storage_dir / "wiki.db", wiki_name=config.wiki_name
+        )
         sources_dir = config.storage_dir / "sources"
-        self._sources = SourceCollectionManager(sources_dir)
+        self._sources = SourceCollectionManager(
+            sources_dir, db_path=self._store.db_path
+        )
         self._bookkeeper = WikiBookkeeper()
         self._search = WikiCombinedSearch(
             pageindex_toolkit,
@@ -98,6 +110,8 @@ class LLMWikiToolkit(AbstractToolkit):
             graphindex_toolkit,
             self._sources,
             self._bookkeeper,
+            store=self._store,
+            sync_graph=config.sync_graph,
         )
         self.logger: logging.Logger = logging.getLogger(__name__)
 
@@ -260,13 +274,12 @@ class LLMWikiToolkit(AbstractToolkit):
 
             {storage_dir}/
             ├── sources/         # raw source documents
-            ├── wiki/            # wiki markdown pages (by category)
-            │   ├── entities/
-            │   ├── concepts/
-            │   ├── summaries/
-            │   └── comparisons/
+            ├── wiki.db          # SQLite retrieval plane (pages/edges/FTS)
             ├── index.md         # auto-generated content catalog
             └── log.md           # append-only operation log
+
+        Page content lives in ``wiki.db`` (machine plane), not in
+        per-category markdown directories.
 
         Args:
             wiki_name: Human-readable wiki name.
@@ -278,10 +291,6 @@ class LLMWikiToolkit(AbstractToolkit):
         storage_dir = self._config.storage_dir
         directories = [
             storage_dir / "sources",
-            storage_dir / "wiki" / "entities",
-            storage_dir / "wiki" / "concepts",
-            storage_dir / "wiki" / "summaries",
-            storage_dir / "wiki" / "comparisons",
         ]
         created: list[str] = []
         for d in directories:
@@ -454,7 +463,9 @@ class LLMWikiToolkit(AbstractToolkit):
         Returns:
             Dict with keys: page_id, title, category, status.
         """
-        # Build markdown with YAML-like frontmatter comment
+        # Markdown kept for the PageIndex authoring plane; the category
+        # lives as a real column in the WikiStore (the HTML comment is
+        # retained only for backwards compatibility of stored markdown).
         markdown = f"# {title}\n\n<!-- category: {category} -->\n\n{content}"
 
         page_id: Optional[str] = None
@@ -470,18 +481,42 @@ class LLMWikiToolkit(AbstractToolkit):
         except Exception as exc:  # noqa: BLE001
             self.logger.warning("create_page PageIndex insert failed: %s", exc)
 
-        # Sync to GraphIndex
+        if not page_id:
+            page_id = f"page-{title[:40].lower().replace(' ', '-')}"
+
+        # Write to the WikiStore retrieval plane: category as a column,
+        # body in the DB, related_pages as typed edges.
         try:
-            gi_result = await self._gi.create_node(
-                kind="wiki_page",
+            record = WikiPageRecord(
+                concept_id=page_id,
+                node_id=page_id,
                 title=title,
+                category=category,
                 summary=content[:300],
-                domain_tags={"wiki": wiki_name, "category": category},
+                body=content,
+                token_count=estimate_tokens(content),
             )
-            if isinstance(gi_result, dict) and not page_id:
-                page_id = gi_result.get("node_id")
+            await self._store.upsert_pages([record])
+            if related_pages:
+                await self._store.add_edges(
+                    [(page_id, str(rp), "references") for rp in related_pages]
+                )
         except Exception as exc:  # noqa: BLE001
-            self.logger.warning("create_page GraphIndex create_node failed: %s", exc)
+            self.logger.warning("create_page WikiStore upsert failed: %s", exc)
+
+        # Optional GraphIndex mirror (off by default).
+        if self._config.sync_graph:
+            try:
+                await self._gi.create_node(
+                    kind="wiki_page",
+                    title=title,
+                    summary=content[:300],
+                    domain_tags={"wiki": wiki_name, "category": category},
+                )
+            except Exception as exc:  # noqa: BLE001
+                self.logger.warning(
+                    "create_page GraphIndex create_node failed: %s", exc
+                )
 
         await asyncio.to_thread(
             self._bookkeeper.log_operation,
@@ -490,9 +525,10 @@ class LLMWikiToolkit(AbstractToolkit):
             f"title: {title!r}, category: {category}",
         )
         return {
-            "page_id": page_id or f"page-{title[:20].lower().replace(' ', '-')}",
+            "page_id": page_id,
             "title": title,
             "category": category,
+            "related_pages": list(related_pages or []),
             "status": "created",
         }
 

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/toolkit.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/toolkit.py
@@ -845,6 +845,45 @@ class LLMWikiToolkit(AbstractToolkit):
         return await self._search.find_related(page_id, depth=depth)
 
     # ------------------------------------------------------------------
+    # OKF export boundary
+    # ------------------------------------------------------------------
+
+    async def export_okf(
+        self,
+        wiki_name: str,
+        output_dir: str,
+    ) -> dict[str, Any]:
+        """Export the wiki as an OKF v0.1 markdown bundle (interchange).
+
+        The wiki's internal store is machine-first SQLite; this tool
+        lazily projects it into Open Knowledge Format — one markdown
+        file per page with YAML frontmatter (``type`` from the page
+        category, ``relates_to`` from the edges table), grouped in
+        category directories with a root ``index.md``.
+
+        Args:
+            wiki_name: Wiki to export.
+            output_dir: Destination directory for the bundle.
+
+        Returns:
+            Export report dict: files_written, categories,
+            index_generated, output_dir.
+        """
+        from parrot.knowledge.wiki.export import export_okf_bundle
+
+        self._config_for(wiki_name)
+        report = await export_okf_bundle(
+            self._store, Path(output_dir), wiki_name=wiki_name
+        )
+        await asyncio.to_thread(
+            self._bookkeeper.log_operation,
+            self._config.storage_dir,
+            "EXPORT_OKF",
+            f"output_dir: {output_dir}, files: {report.files_written}",
+        )
+        return report.model_dump()
+
+    # ------------------------------------------------------------------
     # Bookkeeping
     # ------------------------------------------------------------------
 

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/toolkit.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/toolkit.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from pathlib import Path
 from typing import Any, Optional
 
 from parrot.knowledge.wiki.bookkeeper import WikiBookkeeper
@@ -104,6 +105,7 @@ class LLMWikiToolkit(AbstractToolkit):
             pageindex_toolkit,
             graphindex_toolkit,
             config.search_weights,
+            store=self._store,
         )
         self._ingest_orch = WikiIngestOrchestrator(
             pageindex_toolkit,
@@ -231,23 +233,50 @@ class LLMWikiToolkit(AbstractToolkit):
         except Exception as exc:  # noqa: BLE001
             self.logger.warning("OKF lint failed: %s", exc)
 
-        # Wiki-specific checks
+        # Wiki-specific checks — answered from the SQLite plane.
+        # Orphans: sources with zero derived pages (SQL join); falls back
+        # to the registry's pages_generated when the pages table is empty
+        # for that source but ids were recorded (e.g. store sync skipped).
         all_sources = self._sources.list_sources()
+        recorded = {
+            s.source_id for s in all_sources if s.pages_generated
+        }
         orphan_sources = [
-            s.source_id for s in all_sources if not s.pages_generated
+            sid
+            for sid in await self._store.orphan_sources()
+            if sid not in recorded
         ]
         # is_stale does file I/O (stat + optional hash) — offload to thread pool
         stale_sources: list[str] = []
         for s in all_sources:
             if await asyncio.to_thread(self._sources.is_stale, s.source_id):
                 stale_sources.append(s.source_id)
-        uncovered_sources: list[str] = []  # future: scan source_dir for new files
+
+        # Uncovered: files present in source_dir but never registered.
+        uncovered_sources: list[str] = []
+        source_dir = self._config.source_dir
+        if source_dir and Path(source_dir).is_dir():
+            tracked_uris = {s.source_uri for s in all_sources}
+            for candidate in sorted(Path(source_dir).rglob("*")):
+                if candidate.is_file() and str(candidate.resolve()) not in tracked_uris:
+                    uncovered_sources.append(str(candidate))
+
+        # Cross-reference issues: broken edges + pages without bodies.
+        cross_ref_issues: list[dict[str, Any]] = [
+            {"kind": "broken_edge", **edge}
+            for edge in await self._store.broken_edges()
+        ]
+        cross_ref_issues.extend(
+            {"kind": "missing_body", "concept_id": cid}
+            for cid in await self._store.missing_bodies()
+        )
 
         report = WikiLintReport(
             okf_report=okf_result,
             orphan_sources=orphan_sources,
             stale_sources=stale_sources,
             uncovered_sources=uncovered_sources,
+            cross_ref_issues=cross_ref_issues,
         )
 
         await asyncio.to_thread(
@@ -401,16 +430,19 @@ class LLMWikiToolkit(AbstractToolkit):
 
         Args:
             wiki_name: Wiki name to browse.
-            category: Optional WikiPageCategory value to filter by.
-            search: Optional search query to filter results.
+            category: Optional category value to filter by (exact match).
+            search: Optional search query — when given, results come
+                from FTS ranking instead of the recency listing.
 
         Returns:
-            List of page summary dicts from PageIndex search.
+            List of page stub dicts (no bodies — use ``read_page``).
         """
-        query = search or (category or wiki_name)
         try:
-            raw = await self._pi.search(wiki_name, query, top_k=20)
-            return raw if isinstance(raw, list) else []
+            if search:
+                return await self._store.search_fts(
+                    search, category=category, limit=20
+                )
+            return await self._store.list_pages(category=category, limit=20)
         except Exception as exc:  # noqa: BLE001
             self.logger.warning("browse_pages failed: %s", exc)
             return []
@@ -424,20 +456,27 @@ class LLMWikiToolkit(AbstractToolkit):
 
         Args:
             wiki_name: Wiki name containing the page.
-            page_id: Node ID of the page to read.
+            page_id: Stable ``concept_id`` of the page (a volatile
+                PageIndex ``node_id`` is also accepted).
 
         Returns:
-            Dict with keys: page_id, content, metadata.  Returns
-            ``{"error": "not_found"}`` when the page does not exist.
+            Dict with keys: page_id, title, category, summary, content,
+            token_count, source_id.  Returns ``{"error": "not_found"}``
+            when the page does not exist.
         """
-        # PageIndex node content retrieval via search is the available API
+        page = await self._store.get_page(page_id)
+        if page is None:
+            return {"error": "not_found", "page_id": page_id}
         return {
-            "page_id": page_id,
+            "page_id": page["concept_id"],
+            "node_id": page.get("node_id"),
             "wiki_name": wiki_name,
-            "note": (
-                "Full page content retrieval requires PageIndex node reader; "
-                "use search() to locate pages by content."
-            ),
+            "title": page.get("title", ""),
+            "category": page.get("category", ""),
+            "summary": page.get("summary", ""),
+            "content": page.get("body", ""),
+            "token_count": page.get("token_count", 0),
+            "source_id": page.get("source_id"),
         }
 
     async def create_page(
@@ -570,23 +609,50 @@ class LLMWikiToolkit(AbstractToolkit):
     ) -> dict[str, Any]:
         """Delete a wiki page.
 
+        Deletes the page from the WikiStore retrieval plane (row, FTS
+        entry, embeddings, and edges) and best-effort removes the
+        corresponding node from the PageIndex tree.
+
         Args:
             wiki_name: Wiki name containing the page.
-            page_id: Node ID of the page to delete.
+            page_id: Stable ``concept_id`` (or PageIndex ``node_id``).
 
         Returns:
-            Dict with keys: page_id, status, message.
+            Dict with keys: page_id, status, message.  ``status`` is
+            ``"not_found"`` when the page does not exist.
         """
+        page = await self._store.get_page(page_id, include_body=False)
+        if page is None:
+            return {
+                "page_id": page_id,
+                "status": "not_found",
+                "message": "No such page in the wiki store.",
+            }
+
+        deleted = await self._store.delete_page(page["concept_id"])
+
+        # Best-effort removal from the PageIndex authoring plane.
+        node_id = page.get("node_id")
+        if node_id:
+            try:
+                await self._pi.delete_node(wiki_name, node_id)
+            except Exception as exc:  # noqa: BLE001
+                self.logger.warning(
+                    "delete_page: PageIndex delete_node(%s) failed: %s",
+                    node_id,
+                    exc,
+                )
+
         await asyncio.to_thread(
             self._bookkeeper.log_operation,
             self._config_for(wiki_name).storage_dir,
             "DELETE_PAGE",
-            f"page_id: {page_id}",
+            f"page_id: {page['concept_id']}",
         )
         return {
-            "page_id": page_id,
-            "status": "deleted",
-            "message": "Page marked for deletion (physical removal pending).",
+            "page_id": page["concept_id"],
+            "status": "deleted" if deleted else "not_found",
+            "message": "Page removed from wiki store.",
         }
 
     # ------------------------------------------------------------------

--- a/packages/ai-parrot/tests/knowledge/pageindex/test_okf_ontology.py
+++ b/packages/ai-parrot/tests/knowledge/pageindex/test_okf_ontology.py
@@ -52,8 +52,9 @@ class TestConceptType:
         assert ConceptType.CONTROL.value == "Control"
 
     def test_all_values_count(self):
-        """FEAT-239 extended to 16 values (11 original + 5 graph-native)."""
-        assert len(list(ConceptType)) == 16
+        """11 original + 5 graph-native (FEAT-239) + 5 wiki (FEAT-260)
+        + OTHER (FEAT-216 open-vocabulary fallback) = 22."""
+        assert len(list(ConceptType)) == 22
 
     def test_case_sensitive_values(self):
         """Values use Title-Case as per spec."""
@@ -93,8 +94,9 @@ class TestRelationType:
         assert RelationType.REFERENCES.value == "references"
 
     def test_all_values_count(self):
-        """FEAT-239 extended to 12 values (8 original + 4 graph edge kinds)."""
-        assert len(list(RelationType)) == 12
+        """8 original + 4 graph edge kinds (FEAT-239) + extends (FEAT-240)
+        + summarizes/contradicts (FEAT-260) = 15."""
+        assert len(list(RelationType)) == 15
 
     def test_str_enum_equality(self):
         """str, Enum values compare equal to plain strings."""

--- a/packages/ai-parrot/tests/knowledge/pageindex/test_toolkit.py
+++ b/packages/ai-parrot/tests/knowledge/pageindex/test_toolkit.py
@@ -1098,8 +1098,8 @@ def test_set_okf_toolkit_registers_tools(toolkit: PageIndexToolkit, tmp_path: Pa
     all_tools = toolkit.get_tools()
     # Should have the standard toolkit tools + 6 OKF tools.
     assert len(all_tools) > len(toolkit.__class__.mro())  # at least some tools
-    # OKF toolkit returns 6 tools.
-    assert len(okf_tk.get_tools()) == 6
+    # OKF toolkit returns 9 tools (6 read tools + FEAT-216 lint/export/import).
+    assert len(okf_tk.get_tools()) == 9
 
 
 @pytest.mark.asyncio

--- a/tests/knowledge/wiki/conftest.py
+++ b/tests/knowledge/wiki/conftest.py
@@ -91,8 +91,19 @@ def mock_pi():
         {"node_id": "n1", "title": "Neural Networks", "score": 0.9, "summary": "A neural network is..."},
         {"node_id": "n2", "title": "Deep Learning", "score": 0.7, "summary": "Deep learning extends..."},
     ])
-    pi.insert_markdown = AsyncMock(return_value={"node_id": "m1", "status": "ok"})
-    pi.insert_content = AsyncMock(return_value={"nodes_added": 3, "tree_name": "test-wiki"})
+    # Real PageIndexToolkit contract: insert_markdown returns
+    # {"tree_name", "new_node_ids"}; insert_content adds "title"/"summary".
+    pi.insert_markdown = AsyncMock(
+        return_value={"tree_name": "test-wiki", "new_node_ids": ["m1"]}
+    )
+    pi.insert_content = AsyncMock(
+        return_value={
+            "tree_name": "test-wiki",
+            "new_node_ids": ["n1", "n2", "n3"],
+            "title": "Neural Networks",
+            "summary": "A neural network is a computational model.",
+        }
+    )
     pi.create_tree = AsyncMock(return_value={"tree_name": "test-wiki"})
     pi.delete_tree = AsyncMock(return_value={"status": "deleted"})
     return pi

--- a/tests/knowledge/wiki/test_context.py
+++ b/tests/knowledge/wiki/test_context.py
@@ -1,0 +1,160 @@
+"""Tests for token-efficient context packing (wiki/context.py)."""
+
+import pytest
+
+from parrot.knowledge.wiki.context import (
+    PackedContext,
+    first_sentence,
+    pack_results,
+    stub_line,
+    truncate_to_tokens,
+)
+from parrot.knowledge.wiki.models import WikiSearchResult
+from parrot.knowledge.wiki.store import WikiPageRecord
+
+
+def _result(i: int, **kw) -> dict:
+    return {
+        "concept_id": kw.pop("concept_id", f"page-{i}"),
+        "title": kw.pop("title", f"Title {i}"),
+        "summary": kw.pop("summary", f"First sentence of page {i}. Second sentence."),
+        "score": kw.pop("score", 1.0 - i * 0.05),
+        "token_count": kw.pop("token_count", 500),
+        **kw,
+    }
+
+
+class TestFirstSentence:
+    def test_takes_lead_sentence(self):
+        assert first_sentence("Hello world. More text.") == "Hello world."
+
+    def test_caps_length(self):
+        lead = first_sentence("x" * 1000)
+        assert len(lead) <= 240
+        assert lead.endswith("…")
+
+    def test_collapses_whitespace(self):
+        assert first_sentence("a\n  b\t c.") == "a b c."
+
+    def test_empty(self):
+        assert first_sentence("   ") == ""
+
+
+class TestStubLine:
+    def test_format(self):
+        line = stub_line(_result(1))
+        assert line.startswith("- [page-1] Title 1 — First sentence of page 1.")
+        assert "score=0.95" in line
+        assert "~500tok" in line
+
+    def test_minimal_result(self):
+        line = stub_line({"concept_id": "x"})
+        assert line == "- [x] x"
+
+
+class TestPackResults:
+    def test_all_fit(self):
+        packed = pack_results([_result(i) for i in range(3)], budget_tokens=1000)
+        assert isinstance(packed, PackedContext)
+        assert packed.results_packed == 3
+        assert packed.total_available == 3
+        assert packed.truncated is False
+        assert packed.text.count("\n") == 2
+
+    def test_budget_cuts_off(self):
+        packed = pack_results([_result(i) for i in range(50)], budget_tokens=100)
+        assert 0 < packed.results_packed < 50
+        assert packed.truncated is True
+        assert packed.tokens_used <= 100
+
+    def test_accepts_models(self):
+        results = [
+            WikiSearchResult(
+                node_id="n1", title="T", score=0.9, source="lexical", snippet="S."
+            )
+        ]
+        packed = pack_results(results, budget_tokens=200)
+        assert packed.results_packed == 1
+        assert "[n1]" in packed.text
+
+    def test_dedupes_ids(self):
+        packed = pack_results(
+            [_result(1), _result(1)], budget_tokens=1000
+        )
+        assert packed.results_packed == 1
+
+    def test_single_oversized_stub_still_included(self):
+        packed = pack_results([_result(1)], budget_tokens=1)
+        assert packed.results_packed == 1
+        assert packed.truncated is True
+
+    def test_empty_input(self):
+        packed = pack_results([], budget_tokens=100)
+        assert packed.results_packed == 0
+        assert packed.text == ""
+        assert packed.truncated is False
+
+
+class TestTruncateToTokens:
+    def test_no_limit(self):
+        text, truncated = truncate_to_tokens("hello", None)
+        assert text == "hello" and truncated is False
+
+    def test_under_limit(self):
+        text, truncated = truncate_to_tokens("hello world", 100)
+        assert text == "hello world" and truncated is False
+
+    def test_over_limit(self):
+        long_text = "word " * 2000
+        text, truncated = truncate_to_tokens(long_text, 50)
+        assert truncated is True
+        assert len(text) < len(long_text)
+        assert text.endswith("[…truncated]")
+
+
+class TestToolkitProgressiveDisclosure:
+    """search_compact / read_page(max_tokens) / expand via the toolkit."""
+
+    @pytest.mark.asyncio
+    async def test_search_compact_returns_budgeted_stubs(self, wiki_toolkit):
+        await wiki_toolkit.create_page(
+            "test-wiki",
+            "Neural Networks",
+            "A neural network is a computational model. " * 30,
+        )
+        result = await wiki_toolkit.search_compact(
+            "test-wiki", "neural networks", budget_tokens=300
+        )
+        assert result["results_packed"] >= 1
+        assert result["tokens_used"] <= 300
+        assert "[m1]" in result["context"]
+        stub = result["stubs"][0]
+        assert stub["token_count"] > 0  # cost of reading the full page
+
+    @pytest.mark.asyncio
+    async def test_read_page_max_tokens_truncates(self, wiki_toolkit):
+        await wiki_toolkit.create_page(
+            "test-wiki", "Big Page", "Lots of content here. " * 500
+        )
+        full = await wiki_toolkit.read_page("test-wiki", "m1")
+        assert full["truncated"] is False
+        capped = await wiki_toolkit.read_page("test-wiki", "m1", max_tokens=50)
+        assert capped["truncated"] is True
+        assert len(capped["content"]) < len(full["content"])
+
+    @pytest.mark.asyncio
+    async def test_expand_returns_neighbour_stubs(self, wiki_toolkit):
+        await wiki_toolkit.create_page("test-wiki", "Seed", "Seed body.")
+        # second insert would reuse mock id m1 → give the related page
+        # its own id directly in the store
+        await wiki_toolkit._store.upsert_pages(  # noqa: SLF001 — test shortcut
+            [
+                WikiPageRecord(
+                    concept_id="rel-1", title="Related", summary="Related page."
+                )
+            ]
+        )
+        await wiki_toolkit._store.add_edges([("m1", "rel-1", "references")])
+        result = await wiki_toolkit.expand("test-wiki", "m1", rel="references")
+        assert result["total_available"] == 1
+        assert "[rel-1]" in result["context"]

--- a/tests/knowledge/wiki/test_export.py
+++ b/tests/knowledge/wiki/test_export.py
@@ -1,0 +1,156 @@
+"""Tests for the OKF v0.1 export boundary (wiki/export.py)."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from parrot.knowledge.wiki.export import (
+    WikiExportReport,
+    _category_dir,
+    _okf_type,
+    export_okf_bundle,
+)
+from parrot.knowledge.wiki.store import WikiPageRecord, WikiStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> WikiStore:
+    return WikiStore(tmp_path / "wiki.db", wiki_name="export-wiki")
+
+
+async def _seed(store: WikiStore) -> None:
+    await store.upsert_pages(
+        [
+            WikiPageRecord(
+                concept_id="neural-networks",
+                node_id="0001",
+                title="Neural Networks",
+                category="summary",
+                summary="Computational models inspired by the brain.",
+                body="# Neural Networks\n\nFull body here.",
+            ),
+            WikiPageRecord(
+                concept_id="deep-learning",
+                node_id="0002",
+                title="Deep Learning",
+                category="entity",
+                summary="Extends neural networks.",
+                body="# Deep Learning\n\nMore body.",
+            ),
+        ]
+    )
+    await store.add_edges(
+        [("deep-learning", "neural-networks", "references")]
+    )
+
+
+def _parse_front(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n")
+    _, front, body = text.split("---\n", 2)
+    return yaml.safe_load(front), body
+
+
+class TestHelpers:
+    def test_okf_type_known_categories(self):
+        assert _okf_type("summary") == "Wiki Summary"
+        assert _okf_type("entity") == "Wiki Entity"
+        assert _okf_type("concept") == "Concept"
+
+    def test_okf_type_open_fallback(self):
+        assert _okf_type("answer") == "Answer"
+        assert _okf_type("custom-thing") == "Custom-Thing"
+
+    def test_category_dir(self):
+        assert _category_dir("summary") == "summaries"
+        assert _category_dir("entity") == "entities"
+        assert _category_dir("concept") == "concepts"
+        assert _category_dir("synthesis") == "synthesis"
+
+
+class TestExportBundle:
+    @pytest.mark.asyncio
+    async def test_bundle_layout(self, store: WikiStore, tmp_path: Path):
+        await _seed(store)
+        out = tmp_path / "bundle"
+        report = await export_okf_bundle(store, out, wiki_name="export-wiki")
+        assert isinstance(report, WikiExportReport)
+        assert report.files_written == 2
+        assert report.index_generated is True
+        assert (out / "index.md").exists()
+        assert (out / "summaries" / "neural-networks.md").exists()
+        assert (out / "entities" / "deep-learning.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_frontmatter_is_okf_conformant(
+        self, store: WikiStore, tmp_path: Path
+    ):
+        await _seed(store)
+        out = tmp_path / "bundle"
+        await export_okf_bundle(store, out, wiki_name="export-wiki")
+        front, body = _parse_front(out / "summaries" / "neural-networks.md")
+        # OKF v0.1: `type` is the only required field
+        assert front["type"] == "Wiki Summary"
+        assert front["title"] == "Neural Networks"
+        assert front["id"] == "neural-networks"
+        assert front["tags"] == ["summary"]
+        assert "Full body here." in body
+
+    @pytest.mark.asyncio
+    async def test_relates_to_from_edges(self, store: WikiStore, tmp_path: Path):
+        await _seed(store)
+        out = tmp_path / "bundle"
+        await export_okf_bundle(store, out, wiki_name="export-wiki")
+        front, _ = _parse_front(out / "entities" / "deep-learning.md")
+        assert front["relates_to"] == [
+            {"concept": "neural-networks", "rel": "references"}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_index_lists_pages(self, store: WikiStore, tmp_path: Path):
+        await _seed(store)
+        out = tmp_path / "bundle"
+        await export_okf_bundle(store, out, wiki_name="export-wiki")
+        index = (out / "index.md").read_text(encoding="utf-8")
+        assert index.startswith("# export-wiki")
+        assert "[Neural Networks](summaries/neural-networks.md)" in index
+        assert "[Deep Learning](entities/deep-learning.md)" in index
+
+    @pytest.mark.asyncio
+    async def test_empty_store_exports_index_only(
+        self, store: WikiStore, tmp_path: Path
+    ):
+        out = tmp_path / "bundle"
+        report = await export_okf_bundle(store, out, wiki_name="empty")
+        assert report.files_written == 0
+        assert (out / "index.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_bundle_reimportable_by_okf_parser(
+        self, store: WikiStore, tmp_path: Path
+    ):
+        """The exported files must parse with the shared OKF frontmatter
+        parser — producer/consumer independence at the boundary."""
+        from parrot.knowledge.okf.frontmatter import parse_frontmatter
+
+        await _seed(store)
+        out = tmp_path / "bundle"
+        await export_okf_bundle(store, out, wiki_name="export-wiki")
+        parsed = parse_frontmatter(
+            (out / "summaries" / "neural-networks.md").read_text(encoding="utf-8")
+        )
+        assert parsed.type.value == "Wiki Summary"
+        assert parsed.id == "neural-networks"
+
+
+class TestToolkitExport:
+    @pytest.mark.asyncio
+    async def test_wiki_export_okf_tool(self, wiki_toolkit, tmp_path: Path):
+        await wiki_toolkit.create_page(
+            "test-wiki", "Some Page", "Body content.", category="summary"
+        )
+        out = tmp_path / "okf-out"
+        result = await wiki_toolkit.export_okf("test-wiki", str(out))
+        assert result["files_written"] == 1
+        assert (out / "index.md").exists()

--- a/tests/knowledge/wiki/test_export.py
+++ b/tests/knowledge/wiki/test_export.py
@@ -7,8 +7,8 @@ import yaml
 
 from parrot.knowledge.wiki.export import (
     WikiExportReport,
-    _category_dir,
-    _okf_type,
+    category_dir,
+    okf_type,
     export_okf_bundle,
 )
 from parrot.knowledge.wiki.store import WikiPageRecord, WikiStore
@@ -54,19 +54,19 @@ def _parse_front(path: Path) -> dict:
 
 class TestHelpers:
     def test_okf_type_known_categories(self):
-        assert _okf_type("summary") == "Wiki Summary"
-        assert _okf_type("entity") == "Wiki Entity"
-        assert _okf_type("concept") == "Concept"
+        assert okf_type("summary") == "Wiki Summary"
+        assert okf_type("entity") == "Wiki Entity"
+        assert okf_type("concept") == "Concept"
 
     def test_okf_type_open_fallback(self):
-        assert _okf_type("answer") == "Answer"
-        assert _okf_type("custom-thing") == "Custom-Thing"
+        assert okf_type("answer") == "Answer"
+        assert okf_type("custom-thing") == "Custom-Thing"
 
     def test_category_dir(self):
-        assert _category_dir("summary") == "summaries"
-        assert _category_dir("entity") == "entities"
-        assert _category_dir("concept") == "concepts"
-        assert _category_dir("synthesis") == "synthesis"
+        assert category_dir("summary") == "summaries"
+        assert category_dir("entity") == "entities"
+        assert category_dir("concept") == "concepts"
+        assert category_dir("synthesis") == "synthesis"
 
 
 class TestExportBundle:

--- a/tests/knowledge/wiki/test_file_store.py
+++ b/tests/knowledge/wiki/test_file_store.py
@@ -1,0 +1,255 @@
+"""Backend-specific tests for InMemoryWikiStore (OKF file directory).
+
+The generic behavioural contract is covered by the parametrized suite
+in ``test_store.py``; this file pins what is unique to the file
+backend: durability across instances, OKF-conformance of the on-disk
+bundle, frontmatter edge round-trips, and the factory/config wiring.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from parrot.knowledge.wiki.file_store import InMemoryWikiStore
+from parrot.knowledge.wiki.models import WikiConfig
+from parrot.knowledge.wiki.store import (
+    SQLiteWikiStore,
+    WikiPageRecord,
+    create_wiki_store,
+)
+
+
+@pytest.fixture
+def bundle_dir(tmp_path: Path) -> Path:
+    return tmp_path / "pages"
+
+
+def _page(cid: str, **kw) -> WikiPageRecord:
+    defaults = {
+        "concept_id": cid,
+        "title": kw.pop("title", cid.title()),
+        "category": kw.pop("category", "summary"),
+        "summary": kw.pop("summary", f"Summary of {cid}"),
+        "body": kw.pop("body", f"# {cid}\n\nBody of {cid}."),
+    }
+    defaults.update(kw)
+    return WikiPageRecord(**defaults)
+
+
+def _read_front(path: Path) -> tuple[dict, str]:
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), f"no frontmatter in {path}"
+    _, front_raw, body = text.split("---\n", 2)
+    return yaml.safe_load(front_raw), body
+
+
+class TestFactory:
+    def test_sqlite_backend(self, tmp_path: Path):
+        store = create_wiki_store(tmp_path, backend="sqlite")
+        assert isinstance(store, SQLiteWikiStore)
+
+    def test_memory_backend(self, tmp_path: Path):
+        store = create_wiki_store(tmp_path, backend="memory")
+        assert isinstance(store, InMemoryWikiStore)
+        assert store.bundle_dir == tmp_path / "pages"
+
+    def test_unknown_backend_is_hard_error(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="Unknown wiki storage backend"):
+            create_wiki_store(tmp_path, backend="magnetic-tape")
+
+    def test_config_rejects_unknown_backend(self, tmp_path: Path):
+        with pytest.raises(Exception):
+            WikiConfig(
+                wiki_name="w", storage_dir=tmp_path, storage_backend="nope"
+            )
+
+
+class TestBundleOnDisk:
+    """The storage directory must be a valid OKF bundle at all times."""
+
+    @pytest.mark.asyncio
+    async def test_page_file_layout_and_frontmatter(self, bundle_dir: Path):
+        store = InMemoryWikiStore(bundle_dir, wiki_name="w")
+        await store.upsert_pages(
+            [_page("neural-networks", category="summary", node_id="0001",
+                   source_id="src-1")]
+        )
+        path = bundle_dir / "summaries" / "neural-networks.md"
+        assert path.exists()
+        front, body = _read_front(path)
+        # OKF v0.1 required field + queryable fields
+        assert front["type"] == "Wiki Summary"
+        assert front["id"] == "neural-networks"
+        assert front["title"] == "Neural-Networks"
+        # machine fields ride along (OKF tolerates unknown keys)
+        assert front["node_id"] == "0001"
+        assert front["source_id"] == "src-1"
+        assert front["token_count"] > 0
+        assert "Body of neural-networks." in body
+
+    @pytest.mark.asyncio
+    async def test_index_md_regenerated(self, bundle_dir: Path):
+        store = InMemoryWikiStore(bundle_dir, wiki_name="my-wiki")
+        await store.upsert_pages([_page("a"), _page("b")])
+        index = (bundle_dir / "index.md").read_text(encoding="utf-8")
+        assert index.startswith("# my-wiki")
+        assert "summaries/a.md" in index and "summaries/b.md" in index
+        await store.delete_page("b")
+        index = (bundle_dir / "index.md").read_text(encoding="utf-8")
+        assert "summaries/b.md" not in index
+
+    @pytest.mark.asyncio
+    async def test_edges_round_trip_via_relates_to(self, bundle_dir: Path):
+        store = InMemoryWikiStore(bundle_dir, wiki_name="w")
+        await store.upsert_pages([_page("a"), _page("b")])
+        await store.add_edges([("a", "b", "references")])
+        front, _ = _read_front(bundle_dir / "summaries" / "a.md")
+        assert front["relates_to"] == [{"concept": "b", "rel": "references"}]
+
+    @pytest.mark.asyncio
+    async def test_delete_removes_file(self, bundle_dir: Path):
+        store = InMemoryWikiStore(bundle_dir, wiki_name="w")
+        await store.upsert_pages([_page("a")])
+        path = bundle_dir / "summaries" / "a.md"
+        assert path.exists()
+        await store.delete_page("a")
+        assert not path.exists()
+
+    @pytest.mark.asyncio
+    async def test_category_change_moves_file(self, bundle_dir: Path):
+        store = InMemoryWikiStore(bundle_dir, wiki_name="w")
+        await store.upsert_pages([_page("a", category="summary")])
+        await store.upsert_pages([_page("a", category="entity")])
+        assert not (bundle_dir / "summaries" / "a.md").exists()
+        assert (bundle_dir / "entities" / "a.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_slash_concept_id_flattened(self, bundle_dir: Path):
+        store = InMemoryWikiStore(bundle_dir, wiki_name="w")
+        await store.upsert_pages([_page("guides/getting-started")])
+        assert (bundle_dir / "summaries" / "guides--getting-started.md").exists()
+
+
+class TestPersistenceAcrossInstances:
+    """A brand-new instance must rebuild all indexes from the bundle."""
+
+    @pytest.mark.asyncio
+    async def test_pages_edges_survive_reload(self, bundle_dir: Path):
+        first = InMemoryWikiStore(bundle_dir, wiki_name="w")
+        await first.upsert_pages(
+            [
+                _page("nn", title="Neural Networks",
+                      body="A neural network is a computational model."),
+                _page("dl", title="Deep Learning", category="entity"),
+            ]
+        )
+        await first.add_edges([("dl", "nn", "references")])
+        await first.upsert_embedding("nn", [1.0, 0.0], model="m")
+
+        second = InMemoryWikiStore(bundle_dir, wiki_name="w")
+        page = await second.get_page("nn")
+        assert page is not None
+        assert page["body"].startswith("A neural network")
+        assert page["category"] == "summary"
+        hits = await second.search_fts("neural computational")
+        assert hits and hits[0]["concept_id"] == "nn"
+        out = await second.neighbors("dl", direction="out")
+        assert [n["concept_id"] for n in out] == ["nn"]
+        inbound = await second.neighbors("nn", direction="in")
+        assert [n["concept_id"] for n in inbound] == ["dl"]
+        vec_hits = await second.search_vector([1.0, 0.0])
+        assert vec_hits and vec_hits[0]["concept_id"] == "nn"
+
+    @pytest.mark.asyncio
+    async def test_open_string_category_survives_reload(self, bundle_dir: Path):
+        """Categories outside the OKF WIKI_* vocabulary (e.g. 'answer')
+        must load back intact — no closed-enum crash."""
+        first = InMemoryWikiStore(bundle_dir, wiki_name="w")
+        await first.upsert_pages([_page("q1", category="answer")])
+        second = InMemoryWikiStore(bundle_dir, wiki_name="w")
+        page = await second.get_page("q1")
+        assert page is not None and page["category"] == "answer"
+
+    @pytest.mark.asyncio
+    async def test_unparseable_file_skipped(self, bundle_dir: Path):
+        bundle_dir.mkdir(parents=True, exist_ok=True)
+        (bundle_dir / "garbage.md").write_text("no frontmatter here")
+        store = InMemoryWikiStore(bundle_dir, wiki_name="w")
+        assert (await store.stats())["pages"] == 0
+
+    @pytest.mark.asyncio
+    async def test_embeddings_sidecar_is_json(self, bundle_dir: Path):
+        store = InMemoryWikiStore(bundle_dir, wiki_name="w")
+        await store.upsert_pages([_page("a")])
+        await store.upsert_embedding("a", [0.5, 0.5], model="mini")
+        raw = json.loads(
+            (bundle_dir / ".embeddings.json").read_text(encoding="utf-8")
+        )
+        assert raw["a"]["model"] == "mini"
+
+
+class TestToolkitMemoryBackend:
+    """LLMWikiToolkit on storage_backend='memory' — no wiki.db anywhere."""
+
+    @pytest.fixture
+    def mem_toolkit(self, tmp_path, mock_pi, mock_gi, mock_okf):
+        from parrot.knowledge.wiki.toolkit import LLMWikiToolkit
+
+        config = WikiConfig(
+            wiki_name="test-wiki",
+            storage_dir=tmp_path / "wiki-storage",
+            storage_backend="memory",
+        )
+        return LLMWikiToolkit(mock_pi, mock_gi, mock_okf, config)
+
+    @pytest.mark.asyncio
+    async def test_full_cycle_without_sqlite(self, mem_toolkit, tmp_path):
+        storage = tmp_path / "wiki-storage"
+        await mem_toolkit.create_wiki("test-wiki")
+
+        created = await mem_toolkit.create_page(
+            "test-wiki", "Neural Networks",
+            "A neural network is a computational model.",
+            category="summary",
+        )
+        assert created["status"] == "created"
+
+        results = await mem_toolkit.search("test-wiki", "neural network")
+        assert results and results[0]["source"] == "lexical"
+
+        page = await mem_toolkit.read_page("test-wiki", created["page_id"])
+        assert "computational model" in page["content"]
+
+        lint = await mem_toolkit.lint("test-wiki")
+        assert "orphan_sources" in lint
+
+        out = tmp_path / "okf-out"
+        export = await mem_toolkit.export_okf("test-wiki", str(out))
+        assert export["files_written"] == 1
+
+        deleted = await mem_toolkit.delete_page(
+            "test-wiki", created["page_id"]
+        )
+        assert deleted["status"] == "deleted"
+
+        # The whole cycle ran without creating any SQLite database.
+        assert not list(storage.rglob("*.db"))
+        # Sources registry is the JSON manifest.
+        assert mem_toolkit._sources.backend == "json"  # noqa: SLF001
+
+    @pytest.mark.asyncio
+    async def test_ingest_source_memory_backend(
+        self, mem_toolkit, tmp_path, sample_source
+    ):
+        report = await mem_toolkit.ingest_source(
+            "test-wiki", str(sample_source)
+        )
+        assert report["status"] == "ok"
+        assert report["pages_created"] == 3
+        # manifest file exists, wiki.db does not
+        assert (
+            tmp_path / "wiki-storage" / "sources" / ".manifest.json"
+        ).exists()
+        assert not (tmp_path / "wiki-storage" / "wiki.db").exists()

--- a/tests/knowledge/wiki/test_ingest.py
+++ b/tests/knowledge/wiki/test_ingest.py
@@ -172,12 +172,17 @@ class TestWikiIngestOrchestrator:
     @pytest.mark.asyncio
     async def test_ingest_creates_graph_node(
         self,
-        orchestrator: WikiIngestOrchestrator,
+        mock_pi,
         mock_gi,
+        source_manager: SourceCollectionManager,
+        bookkeeper: WikiBookkeeper,
         sample_source: Path,
         wiki_config: WikiConfig,
     ):
-        """create_node is called on GraphIndexToolkit."""
+        """With sync_graph=True, create_node is called on GraphIndexToolkit."""
+        orchestrator = WikiIngestOrchestrator(
+            mock_pi, mock_gi, source_manager, bookkeeper, sync_graph=True
+        )
         await orchestrator.ingest(str(sample_source), wiki_config)
         mock_gi.create_node.assert_called_once()
         call_kwargs = mock_gi.create_node.call_args[1] if mock_gi.create_node.call_args[1] else {}
@@ -189,13 +194,33 @@ class TestWikiIngestOrchestrator:
     @pytest.mark.asyncio
     async def test_ingest_graph_nodes_created(
         self,
-        orchestrator: WikiIngestOrchestrator,
+        mock_pi,
+        mock_gi,
+        source_manager: SourceCollectionManager,
+        bookkeeper: WikiBookkeeper,
         sample_source: Path,
         wiki_config: WikiConfig,
     ):
-        """graph_nodes_created >= 1 after successful ingest."""
+        """graph_nodes_created >= 1 when sync_graph=True."""
+        orchestrator = WikiIngestOrchestrator(
+            mock_pi, mock_gi, source_manager, bookkeeper, sync_graph=True
+        )
         report = await orchestrator.ingest(str(sample_source), wiki_config)
         assert report.graph_nodes_created >= 1
+
+    @pytest.mark.asyncio
+    async def test_ingest_graph_sync_off_by_default(
+        self,
+        orchestrator: WikiIngestOrchestrator,
+        mock_gi,
+        sample_source: Path,
+        wiki_config: WikiConfig,
+    ):
+        """GraphIndex is NOT touched by default — WikiStore is the plane."""
+        report = await orchestrator.ingest(str(sample_source), wiki_config)
+        assert report.status == "ok"
+        assert report.graph_nodes_created == 0
+        mock_gi.create_node.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_ingest_updates_manifest(
@@ -276,7 +301,9 @@ class TestWikiIngestOrchestrator:
         gi = MagicMock()
         gi.create_node = AsyncMock(side_effect=RuntimeError("GI down"))
 
-        orch = WikiIngestOrchestrator(pi, gi, source_manager, bookkeeper)
+        orch = WikiIngestOrchestrator(
+            pi, gi, source_manager, bookkeeper, sync_graph=True
+        )
         report = await orch.ingest(str(sample_source), wiki_config)
         assert report.status == "ok"
         assert report.graph_nodes_created == 0  # failed, but not fatal
@@ -291,3 +318,68 @@ class TestWikiIngestOrchestrator:
         """duration_ms is a positive float after ingest."""
         report = await orchestrator.ingest(str(sample_source), wiki_config)
         assert report.duration_ms >= 0.0
+
+
+class TestIngestWikiStoreSync:
+    """Ingest writes pages + provenance edges into the WikiStore plane."""
+
+    @pytest.fixture
+    def store(self, tmp_path: Path):
+        from parrot.knowledge.wiki.store import WikiStore
+
+        return WikiStore(tmp_path / "wiki.db", wiki_name="test-wiki")
+
+    @pytest.fixture
+    def store_orchestrator(
+        self, mock_pi, mock_gi, source_manager, bookkeeper, store
+    ) -> WikiIngestOrchestrator:
+        return WikiIngestOrchestrator(
+            mock_pi, mock_gi, source_manager, bookkeeper, store=store
+        )
+
+    @pytest.mark.asyncio
+    async def test_ingest_upserts_pages_into_store(
+        self,
+        store_orchestrator: WikiIngestOrchestrator,
+        store,
+        sample_source: Path,
+        wiki_config: WikiConfig,
+    ):
+        report = await store_orchestrator.ingest(str(sample_source), wiki_config)
+        assert report.status == "ok"
+        stats = await store.stats()
+        assert stats["pages"] == 3  # one per new_node_id from the mock
+
+    @pytest.mark.asyncio
+    async def test_ingest_records_summarizes_edges(
+        self,
+        store_orchestrator: WikiIngestOrchestrator,
+        store,
+        sample_source: Path,
+        wiki_config: WikiConfig,
+    ):
+        report = await store_orchestrator.ingest(str(sample_source), wiki_config)
+        page = await store.get_page("0001")
+        assert page is not None
+        out = await store.neighbors("0001", rel="summarizes", direction="out")
+        assert len(out) == 1
+        assert out[0]["concept_id"] == report.source_id
+
+    @pytest.mark.asyncio
+    async def test_reingest_does_not_duplicate_pages(
+        self,
+        store_orchestrator: WikiIngestOrchestrator,
+        store,
+        source_manager: SourceCollectionManager,
+        sample_source: Path,
+        wiki_config: WikiConfig,
+    ):
+        """G9 regression: re-ingest replaces the source slice atomically."""
+        report = await store_orchestrator.ingest(str(sample_source), wiki_config)
+        # Force staleness so the second ingest is not skipped
+        sample_source.write_text(sample_source.read_text() + "\nMore.")
+        report2 = await store_orchestrator.ingest(str(sample_source), wiki_config)
+        assert report2.status == "ok"
+        assert report.source_id == report2.source_id
+        stats = await store.stats()
+        assert stats["pages"] == 3  # replaced, not accumulated

--- a/tests/knowledge/wiki/test_ingest.py
+++ b/tests/knowledge/wiki/test_ingest.py
@@ -33,8 +33,15 @@ def sample_source(tmp_path: Path) -> Path:
 def mock_pi():
     """Mock PageIndexToolkit."""
     pi = MagicMock()
+    # Real PageIndexToolkit.insert_content contract (FEAT-238):
+    # {"tree_name", "new_node_ids", "title", "summary"}
     pi.insert_content = AsyncMock(
-        return_value={"nodes_added": 3, "tree_name": "test-wiki"}
+        return_value={
+            "tree_name": "test-wiki",
+            "new_node_ids": ["0001", "0002", "0003"],
+            "title": "Neural Networks",
+            "summary": "A neural network is a computational model.",
+        }
     )
     pi.create_tree = AsyncMock(return_value={"tree_name": "test-wiki"})
     return pi
@@ -129,6 +136,24 @@ class TestWikiIngestOrchestrator:
         """Successful ingest produces status='ok'."""
         report = await orchestrator.ingest(str(sample_source), wiki_config)
         assert report.status == "ok"
+
+    @pytest.mark.asyncio
+    async def test_ingest_records_generated_page_ids(
+        self,
+        orchestrator: WikiIngestOrchestrator,
+        source_manager: SourceCollectionManager,
+        sample_source: Path,
+        wiki_config: WikiConfig,
+    ):
+        """Regression (G1): the real insert_content contract returns
+        ``new_node_ids`` — ingest must count them as pages_created and
+        record them in the manifest so sources do not lint as orphans."""
+        report = await orchestrator.ingest(str(sample_source), wiki_config)
+        assert report.pages_created == 3
+        entry = source_manager.get_source(report.source_id)
+        assert entry is not None
+        # PageIndex node ids MUST be present (graph node id may be appended)
+        assert {"0001", "0002", "0003"}.issubset(set(entry.pages_generated))
 
     @pytest.mark.asyncio
     async def test_ingest_calls_insert_content(
@@ -246,7 +271,7 @@ class TestWikiIngestOrchestrator:
         """GraphIndex failure is logged but ingest still succeeds."""
         pi = MagicMock()
         pi.insert_content = AsyncMock(
-            return_value={"nodes_added": 2, "tree_name": "test-wiki"}
+            return_value={"tree_name": "test-wiki", "new_node_ids": ["0001", "0002"]}
         )
         gi = MagicMock()
         gi.create_node = AsyncMock(side_effect=RuntimeError("GI down"))

--- a/tests/knowledge/wiki/test_integration.py
+++ b/tests/knowledge/wiki/test_integration.py
@@ -67,9 +67,17 @@ def _make_pi_mock(
         ]
     )
     pi.insert_content = AsyncMock(
-        return_value=insert_content_result or {"nodes_added": 3, "tree_name": "test-wiki"}
+        return_value=insert_content_result
+        or {
+            "tree_name": "test-wiki",
+            "new_node_ids": ["0001", "0002", "0003"],
+            "title": "Neural Networks",
+            "summary": "A neural network is a computational model.",
+        }
     )
-    pi.insert_markdown = AsyncMock(return_value={"node_id": "pi-page-1", "status": "ok"})
+    pi.insert_markdown = AsyncMock(
+        return_value={"tree_name": "test-wiki", "new_node_ids": ["pi-page-1"]}
+    )
     pi.create_tree = AsyncMock(return_value={"tree_name": "test-wiki"})
     pi.delete_tree = AsyncMock(return_value={"status": "deleted"})
     return pi

--- a/tests/knowledge/wiki/test_integration.py
+++ b/tests/knowledge/wiki/test_integration.py
@@ -208,16 +208,17 @@ class TestEndToEnd:
         assert "sources" in query_result
         assert query_result["question"] == "What is a neural network?"
 
-        # The synthesised answer is built from snippet content returned by search;
-        # the mock returns "A neural network is a computational model." as the snippet.
+        # The synthesised answer is built from snippets served by the
+        # WikiStore plane, which recorded the ingested pages' summaries.
         answer = query_result["answer"]
         assert "neural network" in answer.lower() or "computational model" in answer.lower(), (
             f"Answer did not reference source content: {answer!r}"
         )
 
-        # Verify that both backends were called (combined mode)
-        pi.search.assert_called_once()
-        gi.search_hybrid.assert_called_once()
+        # Retrieval is answered from wiki.db — the toolkits are NOT
+        # fanned out to at query time.
+        pi.search.assert_not_called()
+        gi.search_hybrid.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_ingest_reingest_cycle(
@@ -370,24 +371,19 @@ class TestEndToEnd:
         # --- Assert: results non-empty ---
         assert len(search_results) > 0, "Combined search returned no results"
 
-        # --- Assert: results come from both backends ---
+        # --- Assert: results are served by the WikiStore plane ---
         sources_seen = {r["source"] for r in search_results}
-        assert "pageindex" in sources_seen, (
-            f"No pageindex results in combined search: {sources_seen}"
+        assert sources_seen <= {"lexical", "vector"}, (
+            f"Unexpected result sources: {sources_seen}"
         )
-        assert "graphindex" in sources_seen, (
-            f"No graphindex results in combined search: {sources_seen}"
-        )
+        pi.search.assert_not_called()
+        gi.search_hybrid.assert_not_called()
 
         # --- Assert: results are sorted descending by score ---
         scores = [r["score"] for r in search_results]
         assert scores == sorted(scores, reverse=True), (
             f"Results are not sorted by score (desc): {scores}"
         )
-
-        # --- Assert: both backends were actually called ---
-        pi.search.assert_called()
-        gi.search_hybrid.assert_called()
 
     @pytest.mark.asyncio
     async def test_lint_reports_issues(

--- a/tests/knowledge/wiki/test_sources.py
+++ b/tests/knowledge/wiki/test_sources.py
@@ -205,3 +205,46 @@ class TestSourceCollectionManager:
         assert not new_dir.exists()
         SourceCollectionManager(new_dir)
         assert new_dir.exists()
+
+
+class TestJsonBackend:
+    """SourceCollectionManager with backend='json' (memory-backend wikis)."""
+
+    def test_manifest_file_exists_after_add(
+        self, sources_dir: Path, sample_source: Path
+    ):
+        mgr = SourceCollectionManager(sources_dir, backend="json")
+        mgr.add_source(sample_source)
+        assert (sources_dir / ".manifest.json").exists()
+        assert not mgr.db_path.exists()  # no wiki.db in json mode
+
+    def test_persistence_across_managers(
+        self, sources_dir: Path, sample_source: Path
+    ):
+        first = SourceCollectionManager(sources_dir, backend="json")
+        entry = first.add_source(sample_source)
+        first.mark_ingested(entry.source_id, pages_generated=["0001"])
+
+        second = SourceCollectionManager(sources_dir, backend="json")
+        reloaded = second.get_source(entry.source_id)
+        assert reloaded is not None
+        assert reloaded.pages_generated == ["0001"]
+        assert second.find_by_uri(entry.source_uri) == entry.source_id
+
+    def test_remove_source(self, sources_dir: Path, sample_source: Path):
+        mgr = SourceCollectionManager(sources_dir, backend="json")
+        entry = mgr.add_source(sample_source)
+        assert mgr.remove_source(entry.source_id) is True
+        assert mgr.get_source(entry.source_id) is None
+        assert mgr.remove_source("nope") is False
+
+    def test_is_stale_json_mode(self, sources_dir: Path, sample_source: Path):
+        mgr = SourceCollectionManager(sources_dir, backend="json")
+        entry = mgr.add_source(sample_source)
+        assert mgr.is_stale(entry.source_id) is False
+        sample_source.write_text("changed content")
+        assert mgr.is_stale(entry.source_id) is True
+
+    def test_unknown_backend_rejected(self, sources_dir: Path):
+        with pytest.raises(ValueError, match="Unknown sources backend"):
+            SourceCollectionManager(sources_dir, backend="parquet")

--- a/tests/knowledge/wiki/test_sources.py
+++ b/tests/knowledge/wiki/test_sources.py
@@ -119,13 +119,40 @@ class TestSourceCollectionManager:
         assert len(sources) == 1
         assert sources[0].source_uri == str(sample_source.resolve())
 
-    def test_manifest_file_exists_after_add(
+    def test_registry_db_exists_after_add(
         self, sources_dir: Path, sample_source: Path
     ):
-        """A .manifest.json file is created after the first add_source."""
+        """The shared wiki.db registry is created after the first add_source."""
         mgr = SourceCollectionManager(sources_dir)
         mgr.add_source(sample_source)
-        assert (sources_dir / ".manifest.json").exists()
+        assert mgr.db_path.exists()
+        assert mgr.db_path == sources_dir.parent / "wiki.db"
+
+    def test_legacy_json_manifest_migrated(
+        self, sources_dir: Path, sample_source: Path
+    ):
+        """A legacy .manifest.json is imported into SQLite and renamed."""
+        import json
+
+        sources_dir.mkdir(parents=True, exist_ok=True)
+        legacy_entry = {
+            "src-legacy000001": {
+                "source_id": "src-legacy000001",
+                "source_uri": str(sample_source),
+                "file_hash": "deadbeef" * 5,
+                "mtime": 1.0,
+                "ingested_at": "2026-01-01T00:00:00Z",
+                "pages_generated": ["0001"],
+                "status": "ingested",
+            }
+        }
+        (sources_dir / ".manifest.json").write_text(json.dumps(legacy_entry))
+        mgr = SourceCollectionManager(sources_dir)
+        entry = mgr.get_source("src-legacy000001")
+        assert entry is not None
+        assert entry.pages_generated == ["0001"]
+        assert not (sources_dir / ".manifest.json").exists()
+        assert (sources_dir / ".manifest.json.bak").exists()
 
     def test_mark_ingested_updates_pages(
         self, sources_dir: Path, sample_source: Path

--- a/tests/knowledge/wiki/test_store.py
+++ b/tests/knowledge/wiki/test_store.py
@@ -1,7 +1,12 @@
-"""Tests for WikiStore — the SQLite retrieval plane (machine-first wiki).
+"""Tests for the wiki retrieval plane — run against EVERY backend.
 
-All tests use a real on-disk SQLite database under ``tmp_path`` — no
-mocks: the retrieval plane is fast enough to test for real.
+The ``store`` fixture is parametrized over both `BaseWikiStore`
+implementations (SQLite plane and in-memory + OKF file directory), so
+the whole behavioural contract — CRUD, lexical/vector search, edges,
+source-slice replacement, lint queries, tree rebuild — is pinned
+identically for each.  All tests use real on-disk state under
+``tmp_path`` — no mocks: the retrieval plane is fast enough to test
+for real.
 """
 
 from pathlib import Path
@@ -9,17 +14,20 @@ from pathlib import Path
 import pytest
 
 from parrot.knowledge.wiki.store import (
+    BaseWikiStore,
     WikiPageRecord,
-    WikiStore,
+    create_wiki_store,
     estimate_tokens,
     _fts_query,
 )
 
 
-@pytest.fixture
-def store(tmp_path: Path) -> WikiStore:
-    """Fresh WikiStore backed by a tmp_path wiki.db."""
-    return WikiStore(tmp_path / "wiki.db", wiki_name="test-wiki")
+@pytest.fixture(params=["sqlite", "memory"])
+def store(tmp_path: Path, request: pytest.FixtureRequest) -> BaseWikiStore:
+    """Fresh store of each backend, rooted at tmp_path."""
+    return create_wiki_store(
+        tmp_path, wiki_name="test-wiki", backend=request.param
+    )
 
 
 def _page(cid: str, **kw) -> WikiPageRecord:
@@ -60,7 +68,7 @@ class TestPagesCrud:
     """Page upsert / get / list / delete round-trips."""
 
     @pytest.mark.asyncio
-    async def test_upsert_and_get(self, store: WikiStore):
+    async def test_upsert_and_get(self, store: BaseWikiStore):
         await store.upsert_pages([_page("intro", node_id="0001")])
         page = await store.get_page("intro")
         assert page is not None
@@ -69,23 +77,23 @@ class TestPagesCrud:
         assert page["token_count"] > 0  # auto-computed
 
     @pytest.mark.asyncio
-    async def test_get_by_node_id_fallback(self, store: WikiStore):
+    async def test_get_by_node_id_fallback(self, store: BaseWikiStore):
         await store.upsert_pages([_page("intro", node_id="0001")])
         page = await store.get_page("0001")
         assert page is not None and page["concept_id"] == "intro"
 
     @pytest.mark.asyncio
-    async def test_get_without_body(self, store: WikiStore):
+    async def test_get_without_body(self, store: BaseWikiStore):
         await store.upsert_pages([_page("intro")])
         page = await store.get_page("intro", include_body=False)
         assert page is not None and "body" not in page
 
     @pytest.mark.asyncio
-    async def test_get_missing(self, store: WikiStore):
+    async def test_get_missing(self, store: BaseWikiStore):
         assert await store.get_page("nope") is None
 
     @pytest.mark.asyncio
-    async def test_upsert_is_idempotent(self, store: WikiStore):
+    async def test_upsert_is_idempotent(self, store: BaseWikiStore):
         await store.upsert_pages([_page("intro")])
         await store.upsert_pages([_page("intro", title="Updated")])
         page = await store.get_page("intro")
@@ -94,7 +102,7 @@ class TestPagesCrud:
         assert stats["pages"] == 1
 
     @pytest.mark.asyncio
-    async def test_list_pages_category_filter(self, store: WikiStore):
+    async def test_list_pages_category_filter(self, store: BaseWikiStore):
         await store.upsert_pages(
             [_page("a", category="entity"), _page("b", category="summary")]
         )
@@ -103,7 +111,7 @@ class TestPagesCrud:
         assert "body" not in entities[0]  # stubs only
 
     @pytest.mark.asyncio
-    async def test_delete_page_cleans_everything(self, store: WikiStore):
+    async def test_delete_page_cleans_everything(self, store: BaseWikiStore):
         await store.upsert_pages([_page("a"), _page("b")])
         await store.add_edges([("a", "b", "references")])
         await store.upsert_embedding("a", [0.1, 0.2], model="m")
@@ -115,7 +123,7 @@ class TestPagesCrud:
         assert all(h["concept_id"] != "a" for h in hits)
 
     @pytest.mark.asyncio
-    async def test_delete_missing_returns_false(self, store: WikiStore):
+    async def test_delete_missing_returns_false(self, store: BaseWikiStore):
         assert await store.delete_page("nope") is False
 
 
@@ -123,7 +131,7 @@ class TestSearchFts:
     """BM25 lexical search behavior."""
 
     @pytest.mark.asyncio
-    async def test_search_finds_relevant_page(self, store: WikiStore):
+    async def test_search_finds_relevant_page(self, store: BaseWikiStore):
         await store.upsert_pages(
             [
                 _page("nn", title="Neural Networks",
@@ -137,7 +145,7 @@ class TestSearchFts:
         assert "score" in hits[0]
 
     @pytest.mark.asyncio
-    async def test_search_category_prefilter(self, store: WikiStore):
+    async def test_search_category_prefilter(self, store: BaseWikiStore):
         await store.upsert_pages(
             [
                 _page("nn-sum", category="summary", body="neural networks summary"),
@@ -148,11 +156,11 @@ class TestSearchFts:
         assert [h["concept_id"] for h in hits] == ["nn-ent"]
 
     @pytest.mark.asyncio
-    async def test_search_empty_query(self, store: WikiStore):
+    async def test_search_empty_query(self, store: BaseWikiStore):
         assert await store.search_fts("***") == []
 
     @pytest.mark.asyncio
-    async def test_search_injection_safe(self, store: WikiStore):
+    async def test_search_injection_safe(self, store: BaseWikiStore):
         await store.upsert_pages([_page("a")])
         # Must not raise despite FTS syntax in the query
         assert isinstance(await store.search_fts('"; DROP TABLE pages; --'), list)
@@ -162,7 +170,7 @@ class TestVectorSearch:
     """Cosine search over the embeddings table."""
 
     @pytest.mark.asyncio
-    async def test_vector_ranking(self, store: WikiStore):
+    async def test_vector_ranking(self, store: BaseWikiStore):
         await store.upsert_pages([_page("a"), _page("b")])
         await store.upsert_embedding("a", [1.0, 0.0], model="m")
         await store.upsert_embedding("b", [0.0, 1.0], model="m")
@@ -171,11 +179,11 @@ class TestVectorSearch:
         assert hits[0]["score"] > hits[1]["score"]
 
     @pytest.mark.asyncio
-    async def test_vector_empty_store(self, store: WikiStore):
+    async def test_vector_empty_store(self, store: BaseWikiStore):
         assert await store.search_vector([1.0, 0.0]) == []
 
     @pytest.mark.asyncio
-    async def test_vector_dimension_mismatch_skipped(self, store: WikiStore):
+    async def test_vector_dimension_mismatch_skipped(self, store: BaseWikiStore):
         await store.upsert_pages([_page("a")])
         await store.upsert_embedding("a", [1.0, 0.0, 0.0], model="m")
         assert await store.search_vector([1.0, 0.0]) == []
@@ -185,7 +193,7 @@ class TestEdgesAndNeighbors:
     """Typed edges with open-string relations."""
 
     @pytest.mark.asyncio
-    async def test_neighbors_out_in_both(self, store: WikiStore):
+    async def test_neighbors_out_in_both(self, store: BaseWikiStore):
         await store.upsert_pages([_page("a"), _page("b")])
         await store.add_edges([("a", "b", "summarizes")])
         out = await store.neighbors("a", direction="out")
@@ -197,7 +205,7 @@ class TestEdgesAndNeighbors:
         assert len(both) == 1
 
     @pytest.mark.asyncio
-    async def test_neighbors_rel_filter(self, store: WikiStore):
+    async def test_neighbors_rel_filter(self, store: BaseWikiStore):
         await store.upsert_pages([_page("a"), _page("b"), _page("c")])
         await store.add_edges(
             [("a", "b", "summarizes"), ("a", "c", "references")]
@@ -206,7 +214,7 @@ class TestEdgesAndNeighbors:
         assert [h["concept_id"] for h in hits] == ["c"]
 
     @pytest.mark.asyncio
-    async def test_open_string_relation(self, store: WikiStore):
+    async def test_open_string_relation(self, store: BaseWikiStore):
         """rel is an open string — no enum gate in the machine plane."""
         await store.upsert_pages([_page("a"), _page("b")])
         await store.add_edges([("a", "b", "totally-custom-rel")])
@@ -218,7 +226,7 @@ class TestReplaceSourceSlice:
     """Re-ingest must never accumulate duplicates (fixes G9)."""
 
     @pytest.mark.asyncio
-    async def test_replace_deletes_old_slice(self, store: WikiStore):
+    async def test_replace_deletes_old_slice(self, store: BaseWikiStore):
         p1 = [_page("old-1", source_id="src-1"), _page("old-2", source_id="src-1")]
         await store.replace_source_slice("src-1", p1, [("old-1", "old-2", "references")])
         p2 = [_page("new-1", source_id="src-1")]
@@ -232,7 +240,7 @@ class TestReplaceSourceSlice:
         assert stats["edges"] == 0  # old edges cleaned up
 
     @pytest.mark.asyncio
-    async def test_replace_is_idempotent(self, store: WikiStore):
+    async def test_replace_is_idempotent(self, store: BaseWikiStore):
         pages = [_page("p-1", source_id="src-1")]
         await store.replace_source_slice("src-1", pages)
         await store.replace_source_slice("src-1", pages)
@@ -240,7 +248,7 @@ class TestReplaceSourceSlice:
         assert stats["pages"] == 1
 
     @pytest.mark.asyncio
-    async def test_replace_leaves_other_sources_alone(self, store: WikiStore):
+    async def test_replace_leaves_other_sources_alone(self, store: BaseWikiStore):
         await store.replace_source_slice("src-1", [_page("a", source_id="src-1")])
         await store.replace_source_slice("src-2", [_page("b", source_id="src-2")])
         await store.replace_source_slice("src-1", [_page("a2", source_id="src-1")])
@@ -251,19 +259,19 @@ class TestLintQueries:
     """Fast SQL lint checks."""
 
     @pytest.mark.asyncio
-    async def test_broken_edges(self, store: WikiStore):
+    async def test_broken_edges(self, store: BaseWikiStore):
         await store.upsert_pages([_page("a")])
         await store.add_edges([("a", "ghost", "references")])
         broken = await store.broken_edges()
         assert len(broken) == 1 and broken[0]["dst"] == "ghost"
 
     @pytest.mark.asyncio
-    async def test_missing_bodies(self, store: WikiStore):
+    async def test_missing_bodies(self, store: BaseWikiStore):
         await store.upsert_pages([_page("a", body=""), _page("b")])
         assert await store.missing_bodies() == ["a"]
 
     @pytest.mark.asyncio
-    async def test_stats(self, store: WikiStore):
+    async def test_stats(self, store: BaseWikiStore):
         await store.upsert_pages([_page("a", category="entity"), _page("b")])
         stats = await store.stats()
         assert stats["pages"] == 2
@@ -275,7 +283,7 @@ class TestRebuildFromTree:
     """Derived-plane rebuild from a PageIndex tree."""
 
     @pytest.mark.asyncio
-    async def test_rebuild(self, store: WikiStore):
+    async def test_rebuild(self, store: BaseWikiStore):
         tree = {
             "structure": [
                 {
@@ -308,7 +316,7 @@ class TestRebuildFromTree:
         assert child["source_id"] == "src-1"
 
     @pytest.mark.asyncio
-    async def test_rebuild_without_loader(self, store: WikiStore):
+    async def test_rebuild_without_loader(self, store: BaseWikiStore):
         tree = {"structure": [{"node_id": "0000", "title": "T", "summary": "s", "nodes": []}]}
         report = await store.rebuild_from_tree(tree)
         assert report["pages_written"] == 1

--- a/tests/knowledge/wiki/test_store.py
+++ b/tests/knowledge/wiki/test_store.py
@@ -1,0 +1,316 @@
+"""Tests for WikiStore — the SQLite retrieval plane (machine-first wiki).
+
+All tests use a real on-disk SQLite database under ``tmp_path`` — no
+mocks: the retrieval plane is fast enough to test for real.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from parrot.knowledge.wiki.store import (
+    WikiPageRecord,
+    WikiStore,
+    estimate_tokens,
+    _fts_query,
+)
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> WikiStore:
+    """Fresh WikiStore backed by a tmp_path wiki.db."""
+    return WikiStore(tmp_path / "wiki.db", wiki_name="test-wiki")
+
+
+def _page(cid: str, **kw) -> WikiPageRecord:
+    """Shorthand page-record builder."""
+    defaults = {
+        "concept_id": cid,
+        "node_id": kw.pop("node_id", None),
+        "title": kw.pop("title", cid.replace("-", " ").title()),
+        "category": kw.pop("category", "concept"),
+        "summary": kw.pop("summary", f"Summary of {cid}"),
+        "body": kw.pop("body", f"# {cid}\n\nBody of {cid}."),
+    }
+    defaults.update(kw)
+    return WikiPageRecord(**defaults)
+
+
+class TestHelpers:
+    """Unit tests for module-level helpers."""
+
+    def test_estimate_tokens_empty(self):
+        assert estimate_tokens("") == 0
+
+    def test_estimate_tokens_positive(self):
+        assert estimate_tokens("hello world " * 50) > 0
+
+    def test_fts_query_strips_operators(self):
+        """FTS operators and quotes in user input cannot inject syntax."""
+        expr = _fts_query('neural OR "networks" NEAR(bad) *')
+        # Every token is individually quoted
+        assert '"neural"' in expr and '"networks"' in expr
+        assert "NEAR(" not in expr and "*" not in expr
+
+    def test_fts_query_empty(self):
+        assert _fts_query("!!! ***") == ""
+
+
+class TestPagesCrud:
+    """Page upsert / get / list / delete round-trips."""
+
+    @pytest.mark.asyncio
+    async def test_upsert_and_get(self, store: WikiStore):
+        await store.upsert_pages([_page("intro", node_id="0001")])
+        page = await store.get_page("intro")
+        assert page is not None
+        assert page["node_id"] == "0001"
+        assert page["body"].startswith("# intro")
+        assert page["token_count"] > 0  # auto-computed
+
+    @pytest.mark.asyncio
+    async def test_get_by_node_id_fallback(self, store: WikiStore):
+        await store.upsert_pages([_page("intro", node_id="0001")])
+        page = await store.get_page("0001")
+        assert page is not None and page["concept_id"] == "intro"
+
+    @pytest.mark.asyncio
+    async def test_get_without_body(self, store: WikiStore):
+        await store.upsert_pages([_page("intro")])
+        page = await store.get_page("intro", include_body=False)
+        assert page is not None and "body" not in page
+
+    @pytest.mark.asyncio
+    async def test_get_missing(self, store: WikiStore):
+        assert await store.get_page("nope") is None
+
+    @pytest.mark.asyncio
+    async def test_upsert_is_idempotent(self, store: WikiStore):
+        await store.upsert_pages([_page("intro")])
+        await store.upsert_pages([_page("intro", title="Updated")])
+        page = await store.get_page("intro")
+        assert page["title"] == "Updated"
+        stats = await store.stats()
+        assert stats["pages"] == 1
+
+    @pytest.mark.asyncio
+    async def test_list_pages_category_filter(self, store: WikiStore):
+        await store.upsert_pages(
+            [_page("a", category="entity"), _page("b", category="summary")]
+        )
+        entities = await store.list_pages(category="entity")
+        assert [p["concept_id"] for p in entities] == ["a"]
+        assert "body" not in entities[0]  # stubs only
+
+    @pytest.mark.asyncio
+    async def test_delete_page_cleans_everything(self, store: WikiStore):
+        await store.upsert_pages([_page("a"), _page("b")])
+        await store.add_edges([("a", "b", "references")])
+        await store.upsert_embedding("a", [0.1, 0.2], model="m")
+        assert await store.delete_page("a") is True
+        assert await store.get_page("a") is None
+        assert await store.neighbors("b") == []
+        # FTS must not find the deleted page
+        hits = await store.search_fts("Body of a")
+        assert all(h["concept_id"] != "a" for h in hits)
+
+    @pytest.mark.asyncio
+    async def test_delete_missing_returns_false(self, store: WikiStore):
+        assert await store.delete_page("nope") is False
+
+
+class TestSearchFts:
+    """BM25 lexical search behavior."""
+
+    @pytest.mark.asyncio
+    async def test_search_finds_relevant_page(self, store: WikiStore):
+        await store.upsert_pages(
+            [
+                _page("nn", title="Neural Networks",
+                      body="A neural network is a computational model."),
+                _page("cooking", title="Cooking Pasta",
+                      body="Boil water and add salt."),
+            ]
+        )
+        hits = await store.search_fts("neural network model")
+        assert hits and hits[0]["concept_id"] == "nn"
+        assert "score" in hits[0]
+
+    @pytest.mark.asyncio
+    async def test_search_category_prefilter(self, store: WikiStore):
+        await store.upsert_pages(
+            [
+                _page("nn-sum", category="summary", body="neural networks summary"),
+                _page("nn-ent", category="entity", body="neural networks entity"),
+            ]
+        )
+        hits = await store.search_fts("neural", category="entity")
+        assert [h["concept_id"] for h in hits] == ["nn-ent"]
+
+    @pytest.mark.asyncio
+    async def test_search_empty_query(self, store: WikiStore):
+        assert await store.search_fts("***") == []
+
+    @pytest.mark.asyncio
+    async def test_search_injection_safe(self, store: WikiStore):
+        await store.upsert_pages([_page("a")])
+        # Must not raise despite FTS syntax in the query
+        assert isinstance(await store.search_fts('"; DROP TABLE pages; --'), list)
+
+
+class TestVectorSearch:
+    """Cosine search over the embeddings table."""
+
+    @pytest.mark.asyncio
+    async def test_vector_ranking(self, store: WikiStore):
+        await store.upsert_pages([_page("a"), _page("b")])
+        await store.upsert_embedding("a", [1.0, 0.0], model="m")
+        await store.upsert_embedding("b", [0.0, 1.0], model="m")
+        hits = await store.search_vector([1.0, 0.1])
+        assert hits[0]["concept_id"] == "a"
+        assert hits[0]["score"] > hits[1]["score"]
+
+    @pytest.mark.asyncio
+    async def test_vector_empty_store(self, store: WikiStore):
+        assert await store.search_vector([1.0, 0.0]) == []
+
+    @pytest.mark.asyncio
+    async def test_vector_dimension_mismatch_skipped(self, store: WikiStore):
+        await store.upsert_pages([_page("a")])
+        await store.upsert_embedding("a", [1.0, 0.0, 0.0], model="m")
+        assert await store.search_vector([1.0, 0.0]) == []
+
+
+class TestEdgesAndNeighbors:
+    """Typed edges with open-string relations."""
+
+    @pytest.mark.asyncio
+    async def test_neighbors_out_in_both(self, store: WikiStore):
+        await store.upsert_pages([_page("a"), _page("b")])
+        await store.add_edges([("a", "b", "summarizes")])
+        out = await store.neighbors("a", direction="out")
+        assert len(out) == 1 and out[0]["concept_id"] == "b"
+        assert out[0]["rel"] == "summarizes"
+        inbound = await store.neighbors("b", direction="in")
+        assert len(inbound) == 1 and inbound[0]["concept_id"] == "a"
+        both = await store.neighbors("a", direction="both")
+        assert len(both) == 1
+
+    @pytest.mark.asyncio
+    async def test_neighbors_rel_filter(self, store: WikiStore):
+        await store.upsert_pages([_page("a"), _page("b"), _page("c")])
+        await store.add_edges(
+            [("a", "b", "summarizes"), ("a", "c", "references")]
+        )
+        hits = await store.neighbors("a", rel="references", direction="out")
+        assert [h["concept_id"] for h in hits] == ["c"]
+
+    @pytest.mark.asyncio
+    async def test_open_string_relation(self, store: WikiStore):
+        """rel is an open string — no enum gate in the machine plane."""
+        await store.upsert_pages([_page("a"), _page("b")])
+        await store.add_edges([("a", "b", "totally-custom-rel")])
+        hits = await store.neighbors("a", rel="totally-custom-rel")
+        assert len(hits) == 1
+
+
+class TestReplaceSourceSlice:
+    """Re-ingest must never accumulate duplicates (fixes G9)."""
+
+    @pytest.mark.asyncio
+    async def test_replace_deletes_old_slice(self, store: WikiStore):
+        p1 = [_page("old-1", source_id="src-1"), _page("old-2", source_id="src-1")]
+        await store.replace_source_slice("src-1", p1, [("old-1", "old-2", "references")])
+        p2 = [_page("new-1", source_id="src-1")]
+        report = await store.replace_source_slice("src-1", p2)
+        assert report["pages_deleted"] == 2
+        assert report["pages_written"] == 1
+        assert await store.get_page("old-1") is None
+        assert await store.get_page("new-1") is not None
+        stats = await store.stats()
+        assert stats["pages"] == 1
+        assert stats["edges"] == 0  # old edges cleaned up
+
+    @pytest.mark.asyncio
+    async def test_replace_is_idempotent(self, store: WikiStore):
+        pages = [_page("p-1", source_id="src-1")]
+        await store.replace_source_slice("src-1", pages)
+        await store.replace_source_slice("src-1", pages)
+        stats = await store.stats()
+        assert stats["pages"] == 1
+
+    @pytest.mark.asyncio
+    async def test_replace_leaves_other_sources_alone(self, store: WikiStore):
+        await store.replace_source_slice("src-1", [_page("a", source_id="src-1")])
+        await store.replace_source_slice("src-2", [_page("b", source_id="src-2")])
+        await store.replace_source_slice("src-1", [_page("a2", source_id="src-1")])
+        assert await store.get_page("b") is not None
+
+
+class TestLintQueries:
+    """Fast SQL lint checks."""
+
+    @pytest.mark.asyncio
+    async def test_broken_edges(self, store: WikiStore):
+        await store.upsert_pages([_page("a")])
+        await store.add_edges([("a", "ghost", "references")])
+        broken = await store.broken_edges()
+        assert len(broken) == 1 and broken[0]["dst"] == "ghost"
+
+    @pytest.mark.asyncio
+    async def test_missing_bodies(self, store: WikiStore):
+        await store.upsert_pages([_page("a", body=""), _page("b")])
+        assert await store.missing_bodies() == ["a"]
+
+    @pytest.mark.asyncio
+    async def test_stats(self, store: WikiStore):
+        await store.upsert_pages([_page("a", category="entity"), _page("b")])
+        stats = await store.stats()
+        assert stats["pages"] == 2
+        assert stats["categories"] == {"entity": 1, "concept": 1}
+        assert stats["total_tokens"] > 0
+
+
+class TestRebuildFromTree:
+    """Derived-plane rebuild from a PageIndex tree."""
+
+    @pytest.mark.asyncio
+    async def test_rebuild(self, store: WikiStore):
+        tree = {
+            "structure": [
+                {
+                    "node_id": "0000",
+                    "concept_id": "hipaa",
+                    "title": "HIPAA",
+                    "summary": "Overview",
+                    "nodes": [
+                        {
+                            "node_id": "0001",
+                            "concept_id": "hipaa/safeguards",
+                            "title": "Safeguards",
+                            "summary": "Admin safeguards",
+                            "nodes": [],
+                        }
+                    ],
+                }
+            ]
+        }
+        bodies = {"hipaa": "# HIPAA\n\nfull text", "0001": "# Safeguards"}
+        report = await store.rebuild_from_tree(
+            tree, content_loader=bodies.get, source_id="src-1"
+        )
+        assert report["pages_written"] == 2
+        root = await store.get_page("hipaa")
+        assert root["body"] == "# HIPAA\n\nfull text"
+        child = await store.get_page("hipaa/safeguards")
+        # body found via node_id fallback in the loader
+        assert child["body"] == "# Safeguards"
+        assert child["source_id"] == "src-1"
+
+    @pytest.mark.asyncio
+    async def test_rebuild_without_loader(self, store: WikiStore):
+        tree = {"structure": [{"node_id": "0000", "title": "T", "summary": "s", "nodes": []}]}
+        report = await store.rebuild_from_tree(tree)
+        assert report["pages_written"] == 1
+        page = await store.get_page("0000")  # falls back to node_id identity
+        assert page is not None and page["body"] == ""

--- a/tests/knowledge/wiki/test_toolkit.py
+++ b/tests/knowledge/wiki/test_toolkit.py
@@ -103,10 +103,13 @@ class TestLLMWikiToolkitCreateWiki:
         wiki_toolkit: LLMWikiToolkit,
         wiki_config: WikiConfig,
     ):
-        """create_wiki creates the expected directory structure."""
+        """create_wiki creates the sources dir and the wiki.db plane."""
         await wiki_toolkit.create_wiki("my-wiki")
         assert (wiki_config.storage_dir / "sources").exists()
-        assert (wiki_config.storage_dir / "wiki").exists()
+        # Page content lives in the SQLite retrieval plane, not in
+        # per-category markdown directories.
+        assert (wiki_config.storage_dir / "wiki.db").exists()
+        assert not (wiki_config.storage_dir / "wiki").exists()
 
     @pytest.mark.asyncio
     async def test_create_wiki_writes_index(

--- a/tests/knowledge/wiki/test_toolkit.py
+++ b/tests/knowledge/wiki/test_toolkit.py
@@ -208,12 +208,19 @@ class TestLLMWikiToolkitSearch:
         assert isinstance(results, list)
 
     @pytest.mark.asyncio
-    async def test_search_calls_backends(
+    async def test_search_answered_from_store(
         self, wiki_toolkit: LLMWikiToolkit, mock_pi, mock_gi
     ):
-        """search (combined mode) queries both PageIndex and GraphIndex."""
-        await wiki_toolkit.search("test-wiki", "deep learning", mode="combined")
-        assert mock_pi.search.called or mock_gi.search_hybrid.called
+        """search is answered by the WikiStore plane — no toolkit fan-out."""
+        await wiki_toolkit.create_page(
+            "test-wiki", "Deep Learning", "Deep learning extends neural nets."
+        )
+        results = await wiki_toolkit.search(
+            "test-wiki", "deep learning", mode="combined"
+        )
+        assert results and results[0]["source"] == "lexical"
+        mock_pi.search.assert_not_called()
+        mock_gi.search_hybrid.assert_not_called()
 
 
 class TestLLMWikiToolkitSources:

--- a/tests/knowledge/wiki/test_toolkit.py
+++ b/tests/knowledge/wiki/test_toolkit.py
@@ -26,8 +26,12 @@ def mock_pi():
     pi.search = AsyncMock(return_value=[
         {"node_id": "n1", "title": "Page 1", "score": 0.9, "summary": "Snippet 1"},
     ])
-    pi.insert_markdown = AsyncMock(return_value={"node_id": "m1", "status": "ok"})
-    pi.insert_content = AsyncMock(return_value={"nodes_added": 2, "tree_name": "test-wiki"})
+    pi.insert_markdown = AsyncMock(
+        return_value={"tree_name": "test-wiki", "new_node_ids": ["m1"]}
+    )
+    pi.insert_content = AsyncMock(
+        return_value={"tree_name": "test-wiki", "new_node_ids": ["0001", "0002"]}
+    )
     pi.create_tree = AsyncMock(return_value={"tree_name": "test-wiki"})
     return pi
 


### PR DESCRIPTION
## Summary

Implements the retrieval plane for the LLM Wiki (FEAT-260), replacing YAML/markdown parsing at query time with indexed SQL and in-memory RAM backends. The wiki now answers every search, read, and edge query from a single-file SQLite database or an in-memory store persisted as an OKF markdown bundle — no toolkit fan-out, no tree walks at retrieval time.

## Key Changes

### New Retrieval Plane (`wiki/store.py`)
- **`BaseWikiStore`** — abstract contract for all backends (CRUD, lexical/vector search, edges, source-slice replacement)
- **`SQLiteWikiStore`** — single-file `wiki.db` with WAL mode, FTS5/BM25 lexical indexing, optional embeddings, and schema versioning
- **`InMemoryWikiStore`** (`wiki/file_store.py`) — RAM-indexed backend persisted as an OKF v0.1 markdown bundle directory; TF-IDF postings, prefix tree, adjacency lists
- **`create_wiki_store()`** factory — instantiates the configured backend (sqlite/memory) with automatic schema initialization
- Helper functions: `estimate_tokens()` (tiktoken + fallback heuristic), `_fts_query()` (safe FTS5 expression builder), `rank_by_cosine()` (brute-force vector scoring)

### OKF Export Boundary (`wiki/export.py`)
- **`export_okf_bundle()`** — lazily generates OKF v0.1 markdown from the SQLite plane at export time (never read back on retrieval path)
- Category → OKF ConceptType mapping (WIKI_SUMMARY, WIKI_ENTITY, etc.)
- Frontmatter generation with machine fields (node_id, source_id, token_count) alongside OKF fields

### Token-Efficient Context Packing (`wiki/context.py`)
- **`PackedContext`** — budgeted, LLM-ready packing of search results (stubs with identity, title, lead sentence, score, token cost)
- **`pack_results()`** — fits results under an explicit token budget; `first_sentence()` extracts lead text; `truncate_to_tokens()` caps full bodies
- All accounting uses per-page `token_count` stored at ingest time — no re-tokenization at query time

### Integration Points
- **`WikiToolkit`** — wired to use the store for all retrieval; `WikiCombinedSearch` now queries the plane directly (lexical + vector) instead of toolkit fan-out
- **`WikiIngestOrchestrator`** — upserts generated pages into the store via `replace_source_slice()` (atomic source-level replacement, no duplicates on re-ingest); optionally syncs a `wiki_page` node to GraphIndex
- **`SourceCollectionManager`** — dual backend: sqlite mode (sources table in wiki.db) with legacy `.manifest.json` migration, or json mode (plain `.manifest.json` for the in-memory backend)
- **`WikiConfig`** — new `storage_backend` field (sqlite/memory) and `sync_graph` flag

### Test Coverage
- **`test_store.py`** — parametrized suite covering both backends identically (CRUD, search, edges, source-slice replacement, tree rebuild)
- **`test_file_store.py`** — backend-specific tests for OKF durability, frontmatter round-trips, factory wiring
- **`test_export.py`** — OKF bundle generation and conformance
- **`test_context.py`** — token packing, sentence extraction, budget enforcement
- Updated `test_ingest.py`, `test_sources.py`, `test_integration.py` to match new contracts

### Schema & Persistence
- **SQLite schema** — `meta`, `sources`, `pages`, `edges`, `pages_fts` (FTS5), `embeddings` tables with appropriate indexes
- **WAL mode** — allows concurrent async (`aiosqlite`) and sync (`sqlite3`) access from

https://claude.ai/code/session_018YrhgCod24ziZU7gHKMJAk