### PR TITLE
feat: LLM Wiki CLI and Claude Code integration (FEAT-260)

### DIFF
--- a/docs/llm-wiki.md
+++ b/docs/llm-wiki.md
@@ -105,6 +105,9 @@ pytest examples/knowledge_wiki/ -v
 
 ## Read next
 
+- [WikiToolkit as Claude Code infrastructure](./wiki-claude-code.md) —
+  `wikitoolkit build` + `parrot claude install`: the wiki as a
+  codebase knowledge graph for coding assistants.
 - [PageIndex](./pageindex.md)
 - [Memory & Knowledge](./chapters/memory-knowledge.md)
 - [Parent-Child Retrieval](./parent-child-retrieval.md)

--- a/docs/wiki-claude-code.md
+++ b/docs/wiki-claude-code.md
@@ -1,0 +1,116 @@
+# WikiToolkit as Claude Code infrastructure
+
+> Install the LLM-Wiki knowledge graph (FEAT-260) as coding-assistant
+> infrastructure for the current repository — graphify-style. One
+> command builds a machine-first KB graph of the codebase; another
+> wires Claude Code to consult it before grepping raw files.
+
+## TL;DR
+
+```bash
+# 1. Generate the KB graph from the current repository (offline, no LLM)
+wikitoolkit build
+
+# 2. Install the Claude Code integration
+parrot claude install
+
+# 3. Ask scoped questions (what the assistant now does automatically)
+wikitoolkit query "where is the ingest pipeline implemented?"
+```
+
+## The retrieval plane
+
+`wikitoolkit build` scans the repository deterministically — no LLM,
+no embeddings, no network — and writes the FEAT-260 machine plane
+(SQLite FTS5/BM25 + typed edges) under `.parrot/wiki/`:
+
+- one **`file:<path>` page** per source file: extracted summary
+  (module docstring / first heading), a Python **API outline**
+  (classes, functions, docstrings via `ast`), and the content head
+  for lexical search;
+- one **`dir:<path>` overview page** per directory, listing children;
+- **`contains` edges** (directory → file) and **`references` edges**
+  between Python files derived from their imports (src-layouts
+  resolve correctly, e.g. `packages/x/src/pkg/mod.py` ⇒ `pkg.mod`).
+
+File discovery respects `.gitignore` (via `git ls-files`), skips
+binaries, lockfiles, and oversized files. Re-builds are incremental:
+sources are tracked with SHA-1 + mtime in the same SQLite plane, so
+unchanged files are skipped and deleted files are pruned.
+
+## CLI reference (`wikitoolkit` = `parrot wiki`)
+
+| Command | Purpose |
+| ------- | ------- |
+| `wikitoolkit build` | Generate/refresh the KB graph from the repo (`--force`, `--backend sqlite\|memory`, `--name`). |
+| `wikitoolkit query "<question>"` | Scoped question → ranked, token-budgeted page stubs (`--top-k`, `--budget`, `--json`). |
+| `wikitoolkit page <id>` | Read one page in full (`--max-tokens`). |
+| `wikitoolkit related <id>` | Follow typed edges (`--rel`, `--direction`). |
+| `wikitoolkit upsert [paths...] [--changed]` | Incrementally re-ingest files (used by the git hook). |
+| `wikitoolkit status` | Plane statistics + source staleness. |
+| `wikitoolkit export -o docs/wiki` | Export a human-readable markdown wiki (OKF bundle + index). |
+
+The repo config lives at `.parrot/wiki.json`
+(`parrot.knowledge.wiki.project.WikiProjectConfig`): wiki name,
+backend, include/exclude filters, body caps, and the Claude hook
+settings.
+
+## `parrot claude install`
+
+Wires the wiki into Claude Code for this repository. Every artifact
+is marker-based, idempotent, and reversible with
+`parrot claude uninstall`:
+
+1. **`.parrot/wiki.json`** — project config (created if missing).
+2. **`CLAUDE.md` managed section** — tells the assistant to prefer
+   scoped `wikitoolkit query "<question>"` calls over reading whole
+   reports or grepping raw files (delimited by
+   `<!-- parrot:wiki:begin/end -->`).
+3. **PreToolUse hook** in `.claude/settings.json` — before
+   search-style tool calls (`Grep|Glob|Read`), Claude Code runs
+   `wikitoolkit claude-hook`, which injects a non-blocking
+   `additionalContext` nudge toward the graph path. It never touches
+   the permission flow, throttles itself (default: one nudge per
+   300 s, `claude.nudge_cooldown_seconds`), only fires when a built
+   plane exists, and always exits 0 — a broken hook can never block a
+   session.
+4. **`/parrotwiki` slash command** (`.claude/commands/parrotwiki.md`)
+   — `query <question>`, `page <id>`, `related <id>`, `status`,
+   `build`, and `--wiki [dir]` to build a markdown wiki from the
+   graph (wraps `wikitoolkit export`).
+5. **git `post-commit` hook** — auto-upserts the wiki after every
+   commit (`wikitoolkit upsert --changed --quiet`). Chains politely
+   into an existing post-commit hook and is removed cleanly on
+   uninstall. Skip with `--no-git-hook`.
+6. **`.gitignore`** — adds `.parrot/` (skip with `--no-gitignore`).
+
+By default `install` also builds the plane on first run
+(`--no-build` to skip). `parrot claude status` shows what is
+installed.
+
+## How an assistant session flows
+
+1. You ask Claude Code: *"how does the wiki ingest pipeline work?"*
+2. Claude reaches for Grep → the PreToolUse hook injects the nudge.
+3. Claude runs `wikitoolkit query "wiki ingest pipeline"` and gets
+   ranked stubs (`file:...ingest.py`, `dir:...wiki`, ...) for a few
+   hundred tokens instead of several full files.
+4. `wikitoolkit page file:...ingest.py` gives the API outline and
+   content; `wikitoolkit related` walks imports.
+5. On `git commit`, the post-commit hook upserts changed files, so
+   the graph is already fresh for the next question.
+
+## Testing
+
+```bash
+pytest tests/knowledge/wiki/test_repo_scan.py \
+       tests/knowledge/wiki/test_cli.py \
+       tests/knowledge/wiki/test_claude_code.py -v
+```
+
+## Read next
+
+- [LLM Wiki](./llm-wiki.md) — the 3-layer architecture and agent-side
+  `LLMWikiToolkit`.
+- [PageIndex](./pageindex.md) — the writable page tree used by the
+  LLM ingest path.

--- a/packages/ai-parrot/pyproject.toml
+++ b/packages/ai-parrot/pyproject.toml
@@ -106,6 +106,8 @@ dependencies = [
 parrot = "parrot.cli:cli"
 # GraphIndex CLI — build an interactive knowledge graph from a code repo.
 parrot-graphindex = "parrot.knowledge.graphindex.cli:main"
+# LLM Wiki CLI — machine-first codebase KB for coding assistants (FEAT-260).
+wikitoolkit = "parrot.knowledge.wiki.cli:main"
 # parrot-fs moved to ai-parrot-server in FEAT-203
 
 [project.optional-dependencies]

--- a/packages/ai-parrot/src/parrot/cli/__init__.py
+++ b/packages/ai-parrot/src/parrot/cli/__init__.py
@@ -71,6 +71,8 @@ cli._lazy_commands = {
     "mcp": "parrot.mcp.cli",
     "autonomous": "parrot.autonomous.cli",
     "agent": "parrot.cli.agent_repl",
+    "wiki": "parrot.knowledge.wiki.cli",
+    "claude": "parrot.knowledge.wiki.claude_code.cli",
 }
 
 if __name__ == "__main__":

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/__init__.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/__init__.py
@@ -33,57 +33,74 @@ Public API::
         PackedContext,
         pack_results,
     )
+
+Exports are resolved lazily (PEP 562) so lightweight consumers — the
+``wikitoolkit`` CLI and the Claude Code integration hook — can import
+the retrieval plane (``store``/``search``/``context``/``export``)
+without pulling in the agent framework behind
+:class:`LLMWikiToolkit`.
 """
 
-from parrot.knowledge.wiki.bookkeeper import WikiBookkeeper
-from parrot.knowledge.wiki.context import PackedContext, pack_results
-from parrot.knowledge.wiki.ingest import IngestReport, WikiIngestOrchestrator
-from parrot.knowledge.wiki.models import (
-    SourceManifestEntry,
-    WikiConfig,
-    WikiLintReport,
-    WikiPageCategory,
-    WikiSearchResult,
-)
-from parrot.knowledge.wiki.file_store import InMemoryWikiStore
-from parrot.knowledge.wiki.search import WikiCombinedSearch
-from parrot.knowledge.wiki.sources import SourceCollectionManager
-from parrot.knowledge.wiki.store import (
-    BaseWikiStore,
-    SQLiteWikiStore,
-    WikiPageRecord,
-    WikiStore,
-    create_wiki_store,
-)
-from parrot.knowledge.wiki.toolkit import LLMWikiToolkit
-
-__all__ = [
+# Map of exported name -> defining submodule (lazy import targets).
+_EXPORT_MODULES: dict[str, str] = {
     # Toolkit (agent-facing)
-    "LLMWikiToolkit",
+    "LLMWikiToolkit": "parrot.knowledge.wiki.toolkit",
     # Configuration
-    "WikiConfig",
-    "WikiPageCategory",
+    "WikiConfig": "parrot.knowledge.wiki.models",
+    "WikiPageCategory": "parrot.knowledge.wiki.models",
     # Source tracking
-    "SourceManifestEntry",
-    "SourceCollectionManager",
+    "SourceManifestEntry": "parrot.knowledge.wiki.models",
+    "SourceCollectionManager": "parrot.knowledge.wiki.sources",
     # Search
-    "WikiSearchResult",
-    "WikiCombinedSearch",
+    "WikiSearchResult": "parrot.knowledge.wiki.models",
+    "WikiCombinedSearch": "parrot.knowledge.wiki.search",
     # Bookkeeping
-    "WikiBookkeeper",
+    "WikiBookkeeper": "parrot.knowledge.wiki.bookkeeper",
     # Ingest
-    "WikiIngestOrchestrator",
-    "IngestReport",
+    "WikiIngestOrchestrator": "parrot.knowledge.wiki.ingest",
+    "IngestReport": "parrot.knowledge.wiki.ingest",
     # Lint
-    "WikiLintReport",
+    "WikiLintReport": "parrot.knowledge.wiki.models",
     # Retrieval plane (machine-first, pluggable backends)
-    "BaseWikiStore",
-    "WikiStore",
-    "SQLiteWikiStore",
-    "InMemoryWikiStore",
-    "create_wiki_store",
-    "WikiPageRecord",
+    "BaseWikiStore": "parrot.knowledge.wiki.store",
+    "WikiStore": "parrot.knowledge.wiki.store",
+    "SQLiteWikiStore": "parrot.knowledge.wiki.store",
+    "InMemoryWikiStore": "parrot.knowledge.wiki.file_store",
+    "create_wiki_store": "parrot.knowledge.wiki.store",
+    "WikiPageRecord": "parrot.knowledge.wiki.store",
     # Context packing
-    "PackedContext",
-    "pack_results",
-]
+    "PackedContext": "parrot.knowledge.wiki.context",
+    "pack_results": "parrot.knowledge.wiki.context",
+}
+
+__all__ = list(_EXPORT_MODULES)
+
+
+def __getattr__(name: str):
+    """Resolve a public export lazily on first attribute access.
+
+    Args:
+        name: Attribute requested on the package.
+
+    Returns:
+        The resolved object from its defining submodule.
+
+    Raises:
+        AttributeError: If ``name`` is not a public wiki export.
+    """
+    module_path = _EXPORT_MODULES.get(name)
+    if module_path is None:
+        raise AttributeError(
+            f"module {__name__!r} has no attribute {name!r}"
+        )
+    import importlib
+
+    module = importlib.import_module(module_path)
+    value = getattr(module, name)
+    globals()[name] = value  # cache for subsequent lookups
+    return value
+
+
+def __dir__() -> list[str]:
+    """Expose lazy exports to :func:`dir`."""
+    return sorted(set(globals()) | set(__all__))

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/claude_code/__init__.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/claude_code/__init__.py
@@ -1,0 +1,30 @@
+"""Claude Code integration for the LLM Wiki (FEAT-260 follow-up).
+
+Installs the repository knowledge graph as coding-assistant
+infrastructure, graphify-style:
+
+- ``parrot claude install`` — writes a managed CLAUDE.md section, a
+  PreToolUse nudge hook, the ``/parrotwiki`` slash command, and an
+  optional git ``post-commit`` auto-upsert hook;
+- ``wikitoolkit claude-hook`` — the PreToolUse hook runtime that
+  nudges the assistant toward ``wikitoolkit query "<question>"``
+  before search-style tool calls.
+
+Modules:
+    assets: Managed file templates and markers.
+    installer: Idempotent install/uninstall/status operations.
+    hook: PreToolUse hook runtime (fast, dependency-light).
+    cli: ``parrot claude`` click command group.
+"""
+
+from parrot.knowledge.wiki.claude_code.installer import (
+    install_claude_integration,
+    integration_status,
+    uninstall_claude_integration,
+)
+
+__all__ = [
+    "install_claude_integration",
+    "uninstall_claude_integration",
+    "integration_status",
+]

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/claude_code/assets.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/claude_code/assets.py
@@ -1,0 +1,125 @@
+"""Managed file templates for the Claude Code wiki integration.
+
+Every artifact written by ``parrot claude install`` is delimited by
+markers (or identified by the hook command string) so installs are
+idempotent and ``parrot claude uninstall`` can remove exactly what was
+added without touching user content.
+"""
+
+from __future__ import annotations
+
+# --------------------------------------------------------------------------
+# Markers / identifiers
+# --------------------------------------------------------------------------
+
+#: Managed-block markers inside CLAUDE.md.
+CLAUDE_MD_BEGIN = "<!-- parrot:wiki:begin -->"
+CLAUDE_MD_END = "<!-- parrot:wiki:end -->"
+
+#: Hook command written into .claude/settings.json — also the needle
+#: used to find (and remove) our hook entries when merging settings.
+HOOK_COMMAND = "wikitoolkit claude-hook"
+
+#: Tool matcher for the PreToolUse nudge.
+HOOK_MATCHER = "Grep|Glob|Read"
+
+#: Managed-block markers inside .git/hooks/post-commit.
+GIT_HOOK_BEGIN = "# >>> parrot-wiki post-commit >>>"
+GIT_HOOK_END = "# <<< parrot-wiki post-commit <<<"
+
+#: Filename of the slash command (under .claude/commands/).
+SLASH_COMMAND_FILENAME = "parrotwiki.md"
+
+# --------------------------------------------------------------------------
+# CLAUDE.md managed section
+# --------------------------------------------------------------------------
+
+CLAUDE_MD_SECTION = f"""{CLAUDE_MD_BEGIN}
+## Codebase Knowledge Graph (LLM Wiki)
+
+This repository maintains a machine-first knowledge graph of the
+codebase (pages + typed edges over a local SQLite plane, built by
+`wikitoolkit build`). For questions about the codebase — where
+something lives, how modules relate, what a subsystem does — PREFER
+scoped wiki queries over reading whole files or grepping raw source:
+
+- `wikitoolkit query "<question>"` — token-budgeted, ranked page
+  stubs for a scoped question. Start here.
+- `wikitoolkit page <id>` — read one page in full (file summaries,
+  API outlines, content). Use the ids returned by `query`.
+- `wikitoolkit related <id>` — follow typed edges (`contains`,
+  `references`) to neighbouring files/modules.
+- `wikitoolkit status` — plane statistics and staleness.
+- `wikitoolkit build` — refresh the graph after large changes
+  (a git post-commit hook may already keep it fresh).
+
+The `/parrotwiki` command wraps these (e.g. `/parrotwiki query how
+does ingest work`, `/parrotwiki --wiki` to export a human-readable
+markdown wiki). Fall back to Grep/Glob/Read when the wiki has no
+answer, and consider `wikitoolkit build` if results look stale.
+{CLAUDE_MD_END}
+"""
+
+# --------------------------------------------------------------------------
+# /parrotwiki slash command
+# --------------------------------------------------------------------------
+
+SLASH_COMMAND_MD = """---
+description: Query or maintain the repository LLM-wiki knowledge graph (wikitoolkit)
+argument-hint: [query <question> | page <id> | related <id> | status | build | --wiki [dir]]
+allowed-tools: Bash(wikitoolkit:*)
+---
+
+# /parrotwiki — codebase knowledge graph
+
+Arguments: `$ARGUMENTS`
+
+This repository has an LLM-wiki knowledge base built from the source
+tree (see the "Codebase Knowledge Graph" section of CLAUDE.md).
+Interpret the arguments as one of the following actions and run the
+matching `wikitoolkit` command with Bash:
+
+- `query <question>` — run `wikitoolkit query "<question>"`. Read the
+  most promising results with `wikitoolkit page <id>` and answer the
+  question citing page ids. Prefer this over grepping raw files.
+- `page <id>` — run `wikitoolkit page <id>` and summarise it.
+- `related <id>` — run `wikitoolkit related <id>` and explain how the
+  neighbours connect.
+- `status` — run `wikitoolkit status` and report plane health.
+- `build` — run `wikitoolkit build` and report what changed.
+- `--wiki [dir]` — build a human-readable markdown wiki from the
+  graph: run `wikitoolkit export -o <dir>` (default `docs/wiki`) and
+  list what was written.
+- no arguments — run `wikitoolkit status` and briefly explain the
+  available actions above.
+
+If `wikitoolkit` reports the wiki is not built yet, run
+`wikitoolkit build` first, then retry the requested action.
+"""
+
+# --------------------------------------------------------------------------
+# git post-commit hook block
+# --------------------------------------------------------------------------
+
+GIT_HOOK_BLOCK = f"""{GIT_HOOK_BEGIN}
+# Keep the LLM-wiki knowledge graph in sync with the last commit.
+# Installed by `parrot claude install`; remove with `parrot claude uninstall`.
+wikitoolkit upsert --changed --quiet >/dev/null 2>&1 || true
+{GIT_HOOK_END}
+"""
+
+GIT_HOOK_NEW_FILE = f"""#!/bin/sh
+{GIT_HOOK_BLOCK}"""
+
+# --------------------------------------------------------------------------
+# PreToolUse nudge (emitted by the hook runtime)
+# --------------------------------------------------------------------------
+
+NUDGE_TEXT = (
+    "This repository has an LLM-wiki knowledge graph of the codebase. "
+    "Before scanning raw files, prefer a scoped query: "
+    "`wikitoolkit query \"<question>\"` returns ranked, token-budgeted "
+    "page stubs; follow up with `wikitoolkit page <id>` (full page) or "
+    "`wikitoolkit related <id>` (typed edges). Fall back to direct "
+    "Grep/Glob/Read when the wiki has no answer."
+)

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/claude_code/cli.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/claude_code/cli.py
@@ -1,0 +1,159 @@
+"""``parrot claude`` — install the LLM Wiki as Claude Code infrastructure.
+
+Subcommands:
+    install    Wire the repo's wiki into Claude Code (CLAUDE.md
+               section, PreToolUse nudge hook, /parrotwiki command,
+               git post-commit auto-upsert).
+    uninstall  Remove every managed artifact.
+    status     Show what is currently installed.
+    hook       PreToolUse hook runtime (reads stdin; used internally).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+import click
+
+from parrot.knowledge.wiki.claude_code.installer import (
+    install_claude_integration,
+    integration_status,
+    uninstall_claude_integration,
+)
+from parrot.knowledge.wiki.project import (
+    WikiConfigError,
+    find_project_root,
+    load_project_config,
+)
+
+
+
+
+#: Shared `--path` option — every command resolves the repo root the same way.
+path_option = click.option(
+    "--path", "path_", default=None, help="Repo root (default: auto-detect)."
+)
+
+def _resolve_root(path: Optional[str]) -> Path:
+    """Resolve the target repository root or abort with guidance."""
+    if path:
+        root = Path(path).resolve()
+        if not root.is_dir():
+            raise click.ClickException(f"Not a directory: {root}")
+        return root
+    found = find_project_root()
+    if found is None:
+        raise click.ClickException(
+            "No repository found upwards from here — run inside a git "
+            "repo or pass --path."
+        )
+    return found
+
+
+@click.group(name="claude")
+def claude() -> None:
+    """Claude Code integration for the repository LLM Wiki."""
+
+
+@claude.command()
+@path_option
+@click.option(
+    "--git-hook/--no-git-hook",
+    default=True,
+    show_default=True,
+    help="Install a git post-commit hook that upserts the wiki.",
+)
+@click.option(
+    "--gitignore/--no-gitignore",
+    default=True,
+    show_default=True,
+    help="Add .parrot/ to .gitignore.",
+)
+@click.option(
+    "--build/--no-build",
+    "build_now",
+    default=True,
+    show_default=True,
+    help="Build the wiki plane now if it does not exist yet.",
+)
+def install(
+    path_: Optional[str],
+    git_hook: bool,
+    gitignore: bool,
+    build_now: bool,
+) -> None:
+    """Install the wiki toolkit as Claude Code infrastructure.
+
+    Writes a small config plus assistant-facing wiring so Claude Code
+    consults the knowledge graph for codebase questions — preferring
+    scoped `wikitoolkit query "<question>"` calls over grepping raw
+    files — and keeps the graph fresh on every git commit.
+    """
+    root = _resolve_root(path_)
+    try:
+        config = load_project_config(root)
+        actions = install_claude_integration(
+            root, config, git_hook=git_hook, gitignore=gitignore
+        )
+    except (RuntimeError, WikiConfigError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    for action in actions:
+        click.echo(f"  ✓ {action}")
+
+    if build_now and not config.is_built(root):
+        click.echo("Building the wiki plane (first run)...")
+        from parrot.knowledge.wiki.cli import build as wiki_build
+
+        ctx = click.Context(wiki_build)
+        ctx.invoke(wiki_build, path_=str(root), quiet=True)
+
+    click.secho(
+        "Claude Code integration installed. Try: "
+        "`wikitoolkit query \"<question>\"` or /parrotwiki in Claude Code.",
+        fg="green",
+    )
+
+
+@claude.command()
+@path_option
+def uninstall(path_: Optional[str]) -> None:
+    """Remove the Claude Code integration (keeps the wiki plane)."""
+    root = _resolve_root(path_)
+    for action in uninstall_claude_integration(root):
+        click.echo(f"  ✓ {action}")
+
+
+@claude.command()
+@path_option
+@click.option("--json", "as_json", is_flag=True, help="Emit raw JSON.")
+def status(path_: Optional[str], as_json: bool) -> None:
+    """Show which integration pieces are installed."""
+    root = _resolve_root(path_)
+    info = integration_status(root)
+    if as_json:
+        click.echo(json.dumps(info, indent=2))
+        return
+    click.echo(f"Repository: {info['root']}")
+    labels = {
+        "config": ".parrot/wiki.json config",
+        "wiki_built": "wiki plane built",
+        "claude_md_section": "CLAUDE.md wiki section",
+        "pre_tool_use_hook": "PreToolUse nudge hook",
+        "slash_command": "/parrotwiki command",
+        "git_post_commit_hook": "git post-commit auto-upsert",
+    }
+    for key, label in labels.items():
+        mark = "✓" if info.get(key) else "✗"
+        click.echo(f"  {mark} {label}")
+
+
+@claude.command(hidden=True)
+def hook() -> None:
+    """PreToolUse hook runtime (reads the payload from stdin)."""
+    from parrot.knowledge.wiki.claude_code.hook import run_pre_tool_use_hook
+
+    sys.exit(run_pre_tool_use_hook())

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/claude_code/hook.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/claude_code/hook.py
@@ -1,0 +1,182 @@
+"""PreToolUse hook runtime for the Claude Code wiki integration.
+
+Invoked by Claude Code as ``wikitoolkit claude-hook`` before
+search-style tool calls (``Grep``/``Glob``/``Read``).  Reads the hook
+payload from stdin and — when the repository has a built wiki plane —
+emits a non-blocking JSON nudge (``hookSpecificOutput.additionalContext``)
+steering the assistant toward ``wikitoolkit query "<question>"``
+instead of scanning raw files.
+
+Design constraints:
+
+- **Never blocks**: no ``permissionDecision`` is emitted, so the
+  normal permission flow is untouched; the nudge is context only.
+- **Never breaks the session**: any error exits 0 silently.
+- **Throttled**: at most one nudge per cooldown window (default 300 s,
+  configurable via ``claude.nudge_cooldown_seconds`` in
+  ``.parrot/wiki.json``) so search-heavy turns are not spammed.
+- **Fast**: imports are dependency-light (stdlib + pydantic).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path, PurePosixPath
+from typing import Any, Optional, TextIO
+
+from parrot.knowledge.wiki.claude_code.assets import NUDGE_TEXT
+from parrot.knowledge.wiki.project import (
+    WikiProjectConfig,
+    find_project_root,
+    load_project_config,
+)
+from parrot.knowledge.wiki.repo_scan import CODE_SUFFIXES, DOC_SUFFIXES
+
+#: Prefix of the throttle stamp files, inside the wiki storage directory.
+STATE_FILENAME = "claude_hook_nudge"
+
+#: File suffixes for which a Read nudge makes sense — the same
+#: source/doc set the scanner turns into wiki pages.
+_READ_NUDGE_SUFFIXES = CODE_SUFFIXES | DOC_SUFFIXES
+
+
+def _should_nudge_read(tool_input: dict[str, Any]) -> bool:
+    """Only nudge Read calls that target source/doc files."""
+    file_path = str(tool_input.get("file_path") or "")
+    if not file_path:
+        return False
+    return PurePosixPath(file_path).suffix.lower() in _READ_NUDGE_SUFFIXES
+
+
+def _throttled(storage: Path, cooldown_seconds: int, now: float) -> bool:
+    """Atomically claim the nudge slot for the current cooldown window.
+
+    Claude Code fans out tool calls (and therefore hook processes) in
+    parallel, so a read-modify-write state file would let several
+    concurrent hooks all nudge at once. Instead, each cooldown window
+    is claimed by creating a per-window stamp file with
+    ``O_CREAT | O_EXCL`` — exactly one process wins the window.
+
+    Args:
+        storage: Wiki storage directory (holds the stamp files).
+        cooldown_seconds: Window length; ``0`` disables throttling.
+        now: Current time (injectable for tests).
+
+    Returns:
+        ``True`` when another nudge already claimed this window.
+    """
+    if cooldown_seconds <= 0:
+        return False
+    bucket = int(now // cooldown_seconds)
+    stamp = storage / f"{STATE_FILENAME}.{bucket}.stamp"
+    try:
+        storage.mkdir(parents=True, exist_ok=True)
+        fd = os.open(stamp, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        os.close(fd)
+    except FileExistsError:
+        return True
+    except OSError:
+        # Cannot persist throttle state — stay quiet rather than spam.
+        return True
+    # Best-effort cleanup of stale window stamps.
+    for old in storage.glob(f"{STATE_FILENAME}.*.stamp"):
+        if old != stamp:
+            try:
+                old.unlink()
+            except OSError:
+                pass
+    return False
+
+
+def build_nudge(
+    payload: dict[str, Any],
+    root: Optional[Path] = None,
+    config: Optional[WikiProjectConfig] = None,
+    now: Optional[float] = None,
+) -> Optional[dict[str, Any]]:
+    """Decide whether the hook payload deserves a wiki nudge.
+
+    Args:
+        payload: Parsed PreToolUse hook payload (``tool_name``,
+            ``tool_input``, ``cwd``...).
+        root: Repository root override (resolved from ``cwd`` when
+            omitted).
+        config: Project config override (loaded from ``root`` when
+            omitted).
+        now: Clock override for tests.
+
+    Returns:
+        The hook response JSON object, or ``None`` when no nudge
+        should be emitted.
+    """
+    if payload.get("hook_event_name") not in (None, "PreToolUse"):
+        return None
+    tool_name = str(payload.get("tool_name") or "")
+    tool_input = payload.get("tool_input") or {}
+    if not isinstance(tool_input, dict):
+        tool_input = {}
+
+    if root is None:
+        cwd = Path(str(payload.get("cwd") or Path.cwd()))
+        root = find_project_root(cwd)
+    if root is None:
+        return None
+    config = config or load_project_config(root)
+
+    if tool_name not in config.claude.nudge_tools:
+        return None
+    if not config.is_built(root):
+        return None
+    if tool_name == "Read" and not _should_nudge_read(tool_input):
+        return None
+
+    storage = config.storage_path(root)
+    if _throttled(
+        storage,
+        config.claude.nudge_cooldown_seconds,
+        time.time() if now is None else now,
+    ):
+        return None
+
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "additionalContext": NUDGE_TEXT,
+        },
+        "suppressOutput": True,
+    }
+
+
+def run_pre_tool_use_hook(
+    stdin: Optional[TextIO] = None,
+    stdout: Optional[TextIO] = None,
+) -> int:
+    """Entry point for ``wikitoolkit claude-hook`` / ``parrot claude hook``.
+
+    Reads the hook payload from stdin, prints the nudge JSON (if any)
+    to stdout, and always returns 0 so a misconfigured hook can never
+    block the assistant.
+
+    Args:
+        stdin: Input stream override for tests.
+        stdout: Output stream override for tests.
+
+    Returns:
+        Process exit code (always 0).
+    """
+    stdin = stdin or sys.stdin
+    stdout = stdout or sys.stdout
+    try:
+        payload = json.load(stdin)
+        if not isinstance(payload, dict):
+            return 0
+        response = build_nudge(payload)
+        if response is not None:
+            json.dump(response, stdout)
+            stdout.write("\n")
+    except Exception:  # noqa: BLE001 — a hook must never break the session
+        return 0
+    return 0

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/claude_code/installer.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/claude_code/installer.py
@@ -1,0 +1,427 @@
+"""Idempotent installer for the Claude Code wiki integration.
+
+``install_claude_integration`` wires the repository knowledge graph
+into Claude Code:
+
+1. persists ``.parrot/wiki.json`` (the config the hook reads);
+2. appends a managed section to ``CLAUDE.md`` telling the assistant to
+   prefer ``wikitoolkit query "<question>"`` over grepping raw files;
+3. merges a ``PreToolUse`` nudge hook into ``.claude/settings.json``
+   (matcher ``Grep|Glob|Read`` → ``wikitoolkit claude-hook``);
+4. writes the ``/parrotwiki`` slash command;
+5. optionally installs a chained git ``post-commit`` hook that runs
+   ``wikitoolkit upsert --changed`` after every commit;
+6. optionally git-ignores ``.parrot/``.
+
+Every step is marker-based and re-runnable; ``uninstall`` removes
+exactly the managed artifacts and nothing else.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import stat
+from pathlib import Path
+from typing import Any, Optional
+
+from parrot.knowledge.wiki.claude_code import assets
+from parrot.knowledge.wiki.project import (
+    WikiConfigError,
+    WikiProjectConfig,
+    config_path,
+    load_project_config,
+    save_project_config,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------------
+# Small marker-block helpers
+# --------------------------------------------------------------------------
+
+
+def _upsert_marker_block(
+    text: str, block: str, begin: str, end: str
+) -> str:
+    """Insert or replace a marker-delimited block inside ``text``."""
+    block = block.rstrip("\n")
+    if begin in text and end in text:
+        head, _, rest = text.partition(begin)
+        _, _, tail = rest.partition(end)
+        return f"{head}{block}{tail}"
+    if text and not text.endswith("\n"):
+        text += "\n"
+    separator = "\n" if text else ""
+    return f"{text}{separator}{block}\n"
+
+
+def _remove_marker_block(text: str, begin: str, end: str) -> str:
+    """Remove a marker-delimited block (markers included) from ``text``."""
+    if begin not in text or end not in text:
+        return text
+    head, _, rest = text.partition(begin)
+    _, _, tail = rest.partition(end)
+    head = head.rstrip(" \t").rstrip("\n")
+    if not head and not tail.strip():
+        return ""
+    return head + ("\n" + tail.lstrip("\n") if tail.strip() else "\n")
+
+
+# --------------------------------------------------------------------------
+# Individual install steps (each returns a human-readable action string)
+# --------------------------------------------------------------------------
+
+
+def _install_claude_md(root: Path) -> str:
+    """Write/refresh the managed CLAUDE.md section."""
+    path = root / "CLAUDE.md"
+    text = path.read_text(encoding="utf-8") if path.exists() else ""
+    updated = _upsert_marker_block(
+        text,
+        assets.CLAUDE_MD_SECTION,
+        assets.CLAUDE_MD_BEGIN,
+        assets.CLAUDE_MD_END,
+    )
+    if updated != text:
+        path.write_text(updated, encoding="utf-8")
+        return f"CLAUDE.md — wiki section {'updated' if text else 'created'}"
+    return "CLAUDE.md — wiki section already current"
+
+
+def _hook_entry() -> dict[str, Any]:
+    """Build the PreToolUse hook entry for settings.json."""
+    return {
+        "matcher": assets.HOOK_MATCHER,
+        "hooks": [
+            {
+                "type": "command",
+                "command": assets.HOOK_COMMAND,
+                "timeout": 10,
+            }
+        ],
+    }
+
+
+def _is_our_hook(entry: dict[str, Any]) -> bool:
+    """Whether a settings hook entry was installed by us."""
+    for hook in entry.get("hooks", []):
+        if assets.HOOK_COMMAND in str(hook.get("command", "")):
+            return True
+    return False
+
+
+def _load_settings(path: Path) -> Optional[dict[str, Any]]:
+    """Read a Claude settings.json file.
+
+    Args:
+        path: Settings file path.
+
+    Returns:
+        The parsed object, or ``None`` when the file does not exist.
+
+    Raises:
+        RuntimeError: When the file exists but is not valid JSON or is
+            not a JSON object — callers must not silently clobber it.
+    """
+    if not path.exists():
+        return None
+    try:
+        settings = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise RuntimeError(
+            f"Cannot parse {path} — fix or remove it first: {exc}"
+        ) from exc
+    if not isinstance(settings, dict):
+        raise RuntimeError(f"{path} is not a JSON object")
+    return settings
+
+
+def _write_settings(path: Path, settings: dict[str, Any]) -> None:
+    """Persist a settings object as pretty JSON."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+
+
+def _install_settings_hook(root: Path) -> str:
+    """Merge the PreToolUse nudge hook into .claude/settings.json."""
+    path = root / ".claude" / "settings.json"
+    settings = _load_settings(path) or {}
+
+    hooks = settings.get("hooks")
+    if hooks is None:
+        hooks = settings["hooks"] = {}
+    if not isinstance(hooks, dict):
+        raise RuntimeError(f"{path}: 'hooks' is not a JSON object")
+    pre = hooks.get("PreToolUse")
+    if pre is None:
+        pre = hooks["PreToolUse"] = []
+    if not isinstance(pre, list):
+        raise RuntimeError(f"{path}: 'hooks.PreToolUse' is not a list")
+
+    if any(isinstance(e, dict) and _is_our_hook(e) for e in pre):
+        return ".claude/settings.json — PreToolUse hook already installed"
+    pre.append(_hook_entry())
+    _write_settings(path, settings)
+    return ".claude/settings.json — PreToolUse wiki nudge hook added"
+
+
+def _install_slash_command(root: Path) -> str:
+    """Write the /parrotwiki slash command file."""
+    path = root / ".claude" / "commands" / assets.SLASH_COMMAND_FILENAME
+    existing = path.read_text(encoding="utf-8") if path.exists() else None
+    if existing == assets.SLASH_COMMAND_MD:
+        return ".claude/commands/parrotwiki.md — already current"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(assets.SLASH_COMMAND_MD, encoding="utf-8")
+    return (
+        ".claude/commands/parrotwiki.md — "
+        + ("updated" if existing is not None else "created")
+    )
+
+
+def _git_hook_path(root: Path) -> Optional[Path]:
+    """Locate .git/hooks/post-commit, or None when not a git repo."""
+    git_dir = root / ".git"
+    if git_dir.is_dir():
+        return git_dir / "hooks" / "post-commit"
+    if git_dir.is_file():  # worktree: `gitdir: <path>` pointer
+        try:
+            content = git_dir.read_text(encoding="utf-8").strip()
+        except OSError:
+            return None
+        if content.startswith("gitdir:"):
+            target = Path(content.split(":", 1)[1].strip())
+            if not target.is_absolute():
+                target = (root / target).resolve()
+            # Linked worktrees: git resolves hooks/ against the COMMON
+            # git dir (the `commondir` pointer), not the per-worktree
+            # gitdir — a hook written to the latter never runs.
+            commondir = target / "commondir"
+            if commondir.is_file():
+                try:
+                    rel = commondir.read_text(encoding="utf-8").strip()
+                except OSError:
+                    return None
+                target = (target / rel).resolve()
+            return target / "hooks" / "post-commit"
+    return None
+
+
+def _install_git_hook(root: Path) -> str:
+    """Install (or chain into) the git post-commit auto-upsert hook."""
+    hook_path = _git_hook_path(root)
+    if hook_path is None:
+        return "git hook — skipped (not a git repository)"
+    if hook_path.exists():
+        text = hook_path.read_text(encoding="utf-8")
+        if assets.GIT_HOOK_BEGIN in text:
+            return "git post-commit hook — already installed"
+        first_line = text.splitlines()[0] if text.strip() else ""
+        if first_line.startswith("#!") and "sh" not in first_line:
+            # Appending sh syntax to a python/node hook would break it.
+            return (
+                "git post-commit hook — skipped (existing hook is not a "
+                "shell script; add `wikitoolkit upsert --changed --quiet` "
+                "to it manually)"
+            )
+        if not text.endswith("\n"):
+            text += "\n"
+        hook_path.write_text(text + assets.GIT_HOOK_BLOCK, encoding="utf-8")
+        action = "git post-commit hook — chained into existing hook"
+    else:
+        hook_path.parent.mkdir(parents=True, exist_ok=True)
+        hook_path.write_text(assets.GIT_HOOK_NEW_FILE, encoding="utf-8")
+        action = "git post-commit hook — created"
+    mode = hook_path.stat().st_mode
+    hook_path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return action
+
+
+def _install_gitignore(root: Path) -> str:
+    """Ensure .parrot/ is git-ignored."""
+    path = root / ".gitignore"
+    text = path.read_text(encoding="utf-8") if path.exists() else ""
+    lines = {line.strip() for line in text.splitlines()}
+    if {".parrot/", ".parrot", "/.parrot/", "/.parrot"} & lines:
+        return ".gitignore — .parrot/ already ignored"
+    if text and not text.endswith("\n"):
+        text += "\n"
+    path.write_text(
+        text + "# parrot LLM-wiki state (local retrieval plane)\n.parrot/\n",
+        encoding="utf-8",
+    )
+    return ".gitignore — added .parrot/"
+
+
+# --------------------------------------------------------------------------
+# Public API
+# --------------------------------------------------------------------------
+
+
+def install_claude_integration(
+    root: Path,
+    config: Optional[WikiProjectConfig] = None,
+    git_hook: bool = True,
+    gitignore: bool = True,
+) -> list[str]:
+    """Install the wiki ↔ Claude Code integration into a repository.
+
+    Args:
+        root: Repository root.
+        config: Wiki project config; loaded/created when omitted.
+        git_hook: Install the git post-commit auto-upsert hook.
+        gitignore: Add ``.parrot/`` to .gitignore.
+
+    Returns:
+        Human-readable list of actions performed.
+    """
+    root = root.resolve()
+    config = config or load_project_config(root)
+    actions = [
+        f".parrot/wiki.json — config written "
+        f"(wiki '{config.wiki_name}', backend {config.backend})"
+        if not config_path(root).exists()
+        else ".parrot/wiki.json — config already present"
+    ]
+    save_project_config(root, config)
+
+    actions.append(_install_claude_md(root))
+    actions.append(_install_settings_hook(root))
+    actions.append(_install_slash_command(root))
+    if git_hook:
+        actions.append(_install_git_hook(root))
+    if gitignore:
+        actions.append(_install_gitignore(root))
+    return actions
+
+
+def uninstall_claude_integration(root: Path) -> list[str]:
+    """Remove every managed artifact written by the installer.
+
+    Leaves ``.parrot/wiki.json`` and the wiki plane itself in place —
+    only the Claude Code wiring is removed.
+
+    Args:
+        root: Repository root.
+
+    Returns:
+        Human-readable list of actions performed.
+    """
+    root = root.resolve()
+    actions: list[str] = []
+
+    claude_md = root / "CLAUDE.md"
+    if claude_md.exists():
+        text = claude_md.read_text(encoding="utf-8")
+        updated = _remove_marker_block(
+            text, assets.CLAUDE_MD_BEGIN, assets.CLAUDE_MD_END
+        )
+        if updated != text:
+            claude_md.write_text(updated, encoding="utf-8")
+            actions.append("CLAUDE.md — wiki section removed")
+
+    settings_path = root / ".claude" / "settings.json"
+    try:
+        settings = _load_settings(settings_path)
+    except RuntimeError:
+        settings = None
+    if isinstance(settings, dict):
+        hooks = settings.get("hooks")
+        pre = hooks.get("PreToolUse", []) if isinstance(hooks, dict) else []
+        if isinstance(pre, list):
+            kept = [
+                e for e in pre
+                if not (isinstance(e, dict) and _is_our_hook(e))
+            ]
+            if len(kept) != len(pre):
+                settings["hooks"]["PreToolUse"] = kept
+                if not kept:
+                    settings["hooks"].pop("PreToolUse")
+                if not settings["hooks"]:
+                    settings.pop("hooks")
+                _write_settings(settings_path, settings)
+                actions.append(
+                    ".claude/settings.json — PreToolUse hook removed"
+                )
+
+    command_path = root / ".claude" / "commands" / assets.SLASH_COMMAND_FILENAME
+    if command_path.exists():
+        command_path.unlink()
+        actions.append(".claude/commands/parrotwiki.md — removed")
+
+    hook_path = _git_hook_path(root)
+    if hook_path and hook_path.exists():
+        text = hook_path.read_text(encoding="utf-8")
+        if assets.GIT_HOOK_BEGIN in text:
+            updated = _remove_marker_block(
+                text, assets.GIT_HOOK_BEGIN, assets.GIT_HOOK_END
+            )
+            if updated.strip() in {"", "#!/bin/sh"}:
+                hook_path.unlink()
+                actions.append("git post-commit hook — removed")
+            else:
+                hook_path.write_text(updated, encoding="utf-8")
+                actions.append("git post-commit hook — wiki block removed")
+
+    if not actions:
+        actions.append("nothing to remove — integration not installed")
+    return actions
+
+
+def integration_status(root: Path) -> dict[str, Any]:
+    """Report which integration pieces are currently installed.
+
+    Args:
+        root: Repository root.
+
+    Returns:
+        Mapping of artifact name → bool (or detail string).
+    """
+    root = root.resolve()
+    try:
+        config = load_project_config(root)
+    except WikiConfigError:
+        # Status is read-only — report against defaults rather than fail.
+        config = WikiProjectConfig(wiki_name=root.name or "codebase")
+
+    claude_md = root / "CLAUDE.md"
+    claude_md_installed = (
+        claude_md.exists()
+        and assets.CLAUDE_MD_BEGIN in claude_md.read_text(encoding="utf-8")
+    )
+
+    settings_path = root / ".claude" / "settings.json"
+    hook_installed = False
+    try:
+        settings = _load_settings(settings_path)
+    except RuntimeError:
+        settings = None
+    if isinstance(settings, dict):
+        hooks = settings.get("hooks")
+        pre = hooks.get("PreToolUse", []) if isinstance(hooks, dict) else []
+        if isinstance(pre, list):
+            hook_installed = any(
+                isinstance(e, dict) and _is_our_hook(e) for e in pre
+            )
+
+    git_hook_file = _git_hook_path(root)
+    git_hook_installed = bool(
+        git_hook_file
+        and git_hook_file.exists()
+        and assets.GIT_HOOK_BEGIN
+        in git_hook_file.read_text(encoding="utf-8")
+    )
+
+    return {
+        "root": str(root),
+        "config": config_path(root).exists(),
+        "wiki_built": config.is_built(root),
+        "claude_md_section": claude_md_installed,
+        "pre_tool_use_hook": hook_installed,
+        "slash_command": (
+            root / ".claude" / "commands" / assets.SLASH_COMMAND_FILENAME
+        ).exists(),
+        "git_post_commit_hook": git_hook_installed,
+    }

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/cli.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/cli.py
@@ -1,0 +1,667 @@
+"""``wikitoolkit`` — machine-first CLI over the LLM Wiki retrieval plane.
+
+Gives agents (and humans) scoped, token-budgeted access to a codebase
+knowledge base built from the current repository — fully offline: the
+build path is deterministic (:mod:`parrot.knowledge.wiki.repo_scan`)
+and queries run on the SQLite FTS5/BM25 plane (FEAT-260).
+
+Exposed two ways:
+
+- ``wikitoolkit <command>`` — standalone console script, so coding
+  assistants can run ``wikitoolkit query "<question>"`` cheaply;
+- ``parrot wiki <command>`` — subcommand of the main parrot CLI.
+
+Commands:
+    build    Generate/refresh the KB graph from the repository.
+    upsert   Incrementally re-ingest specific/changed files.
+    query    Scoped question → token-budgeted context pack.
+    page     Read one wiki page (progressive disclosure).
+    related  Follow typed edges from a page.
+    status   Plane statistics + staleness report.
+    export   Export the wiki as a human-readable markdown bundle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path, PurePosixPath
+import subprocess
+from typing import Any, Optional
+
+import click
+
+from parrot.knowledge.wiki.context import (
+    DEFAULT_BUDGET_TOKENS,
+    pack_results,
+    truncate_to_tokens,
+)
+from parrot.knowledge.wiki.project import (
+    WikiConfigError,
+    WikiProjectConfig,
+    find_project_root,
+    load_project_config,
+    save_project_config,
+)
+from parrot.knowledge.wiki.repo_scan import (
+    is_wiki_relevant,
+    scan_repository,
+)
+from parrot.knowledge.wiki.sources import SourceCollectionManager
+from parrot.knowledge.wiki.store import BaseWikiStore, create_wiki_store
+
+
+# --------------------------------------------------------------------------
+# Shared helpers
+# --------------------------------------------------------------------------
+
+
+
+
+#: Shared `--path` option — every command resolves the repo root the same way.
+path_option = click.option(
+    "--path", "path_", default=None, help="Repo root (default: auto-detect)."
+)
+
+def _resolve_project(path: Optional[str]) -> tuple[Path, WikiProjectConfig]:
+    """Resolve the repo root + config, aborting with guidance if absent."""
+    if path:
+        root = Path(path).resolve()
+        if not root.is_dir():
+            raise click.ClickException(f"Not a directory: {root}")
+    else:
+        found = find_project_root()
+        if found is None:
+            raise click.ClickException(
+                "No wiki project found (no .parrot/wiki.json or .git "
+                "upwards from here). Run inside a repository or pass "
+                "--path."
+            )
+        root = found
+    try:
+        return root, load_project_config(root)
+    except WikiConfigError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+def _require_built(root: Path, config: WikiProjectConfig) -> BaseWikiStore:
+    """Open the store, aborting when the wiki was never built."""
+    if not config.is_built(root):
+        raise click.ClickException(
+            f"Wiki not built yet for {root}. "
+            "Run `wikitoolkit build` first."
+        )
+    return _open_store(root, config)
+
+
+def _open_store(root: Path, config: WikiProjectConfig) -> BaseWikiStore:
+    """Create the retrieval-plane store for a repo."""
+    storage = config.storage_path(root)
+    storage.mkdir(parents=True, exist_ok=True)
+    return create_wiki_store(
+        storage, wiki_name=config.wiki_name, backend=config.backend
+    )
+
+
+def _open_sources(root: Path, config: WikiProjectConfig) -> SourceCollectionManager:
+    """Create the source manifest manager matching the store backend."""
+    storage = config.storage_path(root)
+    if config.backend == "sqlite":
+        return SourceCollectionManager(
+            storage / "sources", db_path=storage / "wiki.db"
+        )
+    return SourceCollectionManager(storage / "sources", backend="json")
+
+
+def _normalize_scores(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Min-max normalise raw FTS scores into [0, 1] for packing."""
+    if not rows:
+        return rows
+    scores = [float(r.get("score", 0.0)) for r in rows]
+    lo, hi = min(scores), max(scores)
+    span = hi - lo
+    for row, score in zip(rows, scores):
+        row["score"] = 1.0 if span <= 0 else (score - lo) / span
+    return rows
+
+
+def _run(coro: Any) -> Any:
+    """Run an async store operation from a sync click command."""
+    return asyncio.run(coro)
+
+
+# --------------------------------------------------------------------------
+# Build / upsert pipeline
+# --------------------------------------------------------------------------
+
+
+async def _ingest_files(
+    store: BaseWikiStore,
+    sources: SourceCollectionManager,
+    root: Path,
+    scan: Any,
+    force: bool = False,
+) -> dict[str, int]:
+    """Ingest scanned file slices into the plane (incremental).
+
+    Unchanged files (same hash + mtime as the manifest) are skipped
+    unless ``force`` is set; changed/new files replace their previous
+    slice atomically so re-builds never accumulate duplicates (and
+    ``replace_source_slice`` preserves incoming edges to stable
+    concept ids). On a fresh, empty plane the per-slice path is
+    skipped in favour of one bulk ``upsert_pages``/``add_edges`` write.
+
+    Sync manifest I/O (hashing, SQLite writes) is offloaded via
+    ``asyncio.to_thread`` so the event loop is never blocked.
+    """
+    written = 0
+    unchanged = 0
+    edges_by_src: dict[str, list[tuple[str, str, str]]] = {}
+    for edge in scan.import_edges:
+        edges_by_src.setdefault(edge[0], []).append(edge)
+
+    stats = await store.stats()
+    fresh = int(stats.get("pages", 0)) == 0
+    bulk_records = []
+    bulk_edges: list[tuple[str, str, str]] = []
+
+    for fs in scan.files:
+        abs_path = root / fs.rel_path
+        uri = str(abs_path.resolve())
+        source_id = await asyncio.to_thread(sources.find_by_uri, uri)
+        if source_id is None:
+            entry = await asyncio.to_thread(sources.add_source, abs_path)
+            source_id = entry.source_id
+        elif not force and not await asyncio.to_thread(
+            sources.is_stale, source_id
+        ):
+            unchanged += 1
+            continue
+        fs.record.source_id = source_id
+        slice_edges = edges_by_src.get(fs.record.concept_id, [])
+        if fresh:
+            bulk_records.append(fs.record)
+            bulk_edges.extend(slice_edges)
+        else:
+            await store.replace_source_slice(
+                source_id, [fs.record], slice_edges
+            )
+        await asyncio.to_thread(
+            sources.mark_ingested, source_id, [fs.record.concept_id]
+        )
+        written += 1
+
+    if bulk_records:
+        await store.upsert_pages(bulk_records)
+    if bulk_edges:
+        await store.add_edges(bulk_edges)
+    return {"written": written, "unchanged": unchanged}
+
+
+async def _prune_removed(
+    store: BaseWikiStore,
+    sources: SourceCollectionManager,
+    root: Path,
+    scan: Any,
+) -> int:
+    """Drop pages/sources no longer in scan scope (full builds only).
+
+    Covers deleted files as well as files that fell out of scope
+    (newly ignored directories, changed suffix filters).
+    """
+    expected_files = {fs.record.concept_id for fs in scan.files}
+    expected_dirs = {r.concept_id for r in scan.dir_records}
+    expected_uris = {
+        str((root / fs.rel_path).resolve()) for fs in scan.files
+    }
+    removed = 0
+
+    for entry in await asyncio.to_thread(sources.list_sources):
+        if entry.source_uri not in expected_uris:
+            await store.replace_source_slice(entry.source_id, [], [])
+            await asyncio.to_thread(sources.remove_source, entry.source_id)
+            removed += 1
+
+    stubs = await store.list_pages(limit=1_000_000)
+    for stub in stubs:
+        cid = str(stub.get("concept_id", ""))
+        if cid.startswith("file:") and cid not in expected_files:
+            if await store.delete_page(cid):
+                removed += 1
+        elif cid.startswith("dir:") and cid not in expected_dirs:
+            if await store.delete_page(cid):
+                removed += 1
+    return removed
+
+
+# --------------------------------------------------------------------------
+# CLI group
+# --------------------------------------------------------------------------
+
+
+@click.group(name="wiki")
+def wiki() -> None:
+    """LLM Wiki — codebase knowledge base for agents (FEAT-260).
+
+    Build a machine-first knowledge graph of the current repository
+    and query it with scoped, token-budgeted questions instead of
+    grepping raw files.
+    """
+
+
+@wiki.command()
+@path_option
+@click.option("--name", default=None, help="Wiki name (default: repo directory name).")
+@click.option(
+    "--backend",
+    type=click.Choice(["sqlite", "memory"]),
+    default=None,
+    help="Retrieval-plane backend (default: sqlite).",
+)
+@click.option("--force", is_flag=True, help="Re-ingest every file, ignoring staleness.")
+@click.option("--no-git", is_flag=True, help="Do not use git for file discovery.")
+@click.option("--quiet", "-q", is_flag=True, help="Only print the final summary line.")
+def build(
+    path_: Optional[str],
+    name: Optional[str],
+    backend: Optional[str],
+    force: bool,
+    no_git: bool,
+    quiet: bool,
+) -> None:
+    """Generate (or refresh) the KB graph from the current repository.
+
+    Deterministic and offline: scans source files (respecting
+    .gitignore), extracts summaries/API outlines, and writes pages +
+    typed edges into the wiki retrieval plane under .parrot/wiki.
+    """
+    root, config = _resolve_project(path_)
+    if name:
+        config.wiki_name = name
+    if backend:
+        config.backend = backend  # type: ignore[assignment]
+
+    if not quiet:
+        click.echo(f"Scanning {root} ...")
+    scan = scan_repository(
+        root,
+        suffixes=config.include_suffixes or None,
+        exclude_dirs=config.exclude_dirs,
+        body_max_chars=config.body_max_chars,
+        max_file_bytes=config.max_file_kb * 1024,
+        use_git=not no_git,
+    )
+
+    async def _pipeline() -> dict[str, Any]:
+        store = _open_store(root, config)
+        sources = _open_sources(root, config)
+        counts = await _ingest_files(store, sources, root, scan, force=force)
+        await store.upsert_pages(scan.dir_records)
+        await store.add_edges(scan.dir_edges)
+        counts["removed"] = await _prune_removed(store, sources, root, scan)
+        counts["stats"] = await store.stats()
+        return counts
+
+    counts = _run(_pipeline())
+    save_project_config(root, config)
+
+    stats = counts["stats"]
+    click.echo(
+        f"Wiki '{config.wiki_name}' built at "
+        f"{config.storage_path(root)} — "
+        f"{counts['written']} ingested, {counts['unchanged']} unchanged, "
+        f"{counts['removed']} removed; "
+        f"{stats.get('pages', 0)} pages, {stats.get('edges', 0)} edges."
+    )
+    if scan.skipped and not quiet:
+        click.echo(f"Skipped {len(scan.skipped)} binary/oversized files.")
+
+
+def _changed_files_from_git(root: Path) -> list[str]:
+    """Relative paths touched by the last commit (post-commit hook).
+
+    Uses ``-z`` so paths with spaces/unicode are not C-quoted, and
+    ``--root`` so the very first commit of a repository also reports
+    its files.
+    """
+    try:
+        proc = subprocess.run(
+            [
+                "git", "-C", str(root), "diff-tree", "--no-commit-id",
+                "--name-only", "-z", "-r", "--root", "HEAD",
+            ],
+            capture_output=True,
+            timeout=30,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    out = proc.stdout.decode("utf-8", errors="replace")
+    return [p for p in out.split("\0") if p]
+
+
+@wiki.command()
+@click.argument("paths", nargs=-1)
+@path_option
+@click.option(
+    "--changed",
+    is_flag=True,
+    help="Upsert the files touched by the last git commit.",
+)
+@click.option("--quiet", "-q", is_flag=True, help="Suppress output (for git hooks).")
+def upsert(
+    paths: tuple[str, ...],
+    path_: Optional[str],
+    changed: bool,
+    quiet: bool,
+) -> None:
+    """Incrementally re-ingest specific files (or last-commit changes).
+
+    Used by the git post-commit hook installed via
+    `parrot claude install` to keep the wiki fresh. Deleted files have
+    their pages removed. Directory overview pages are refreshed by the
+    next full `wikitoolkit build`.
+    """
+    root, config = _resolve_project(path_)
+    if not config.is_built(root):
+        if not quiet:
+            click.echo("Wiki not built yet — run `wikitoolkit build` first.")
+        return
+
+    rel_paths = list(paths)
+    if changed:
+        rel_paths.extend(_changed_files_from_git(root))
+    if not rel_paths:
+        if not quiet:
+            click.echo("Nothing to upsert (no paths given).")
+        return
+
+    normalized: list[str] = []
+    for rel in rel_paths:
+        p = Path(rel)
+        if p.is_absolute():
+            try:
+                rel = p.resolve().relative_to(root).as_posix()
+            except ValueError:
+                continue
+        rel = PurePosixPath(rel).as_posix()
+        # Same selection filter as full discovery — the two paths must
+        # never disagree about what belongs in the wiki.
+        if is_wiki_relevant(
+            rel,
+            suffixes=config.include_suffixes or None,
+            exclude_dirs=config.exclude_dirs,
+        ):
+            normalized.append(rel)
+
+    existing = [rel for rel in normalized if (root / rel).is_file()]
+    deleted = [rel for rel in normalized if not (root / rel).is_file()]
+    if not existing and not deleted:
+        if not quiet:
+            click.echo("No wiki-relevant files in the given set.")
+        return
+
+    scan = scan_repository(
+        root,
+        suffixes=config.include_suffixes or None,
+        exclude_dirs=config.exclude_dirs,
+        body_max_chars=config.body_max_chars,
+        max_file_bytes=config.max_file_kb * 1024,
+        rel_paths=existing,
+    )
+
+    async def _pipeline() -> dict[str, int]:
+        store = _open_store(root, config)
+        sources = _open_sources(root, config)
+        counts = await _ingest_files(store, sources, root, scan, force=True)
+        removed = 0
+        for rel in deleted:
+            uri = str((root / rel).resolve())
+            source_id = await asyncio.to_thread(sources.find_by_uri, uri)
+            if source_id:
+                await store.replace_source_slice(source_id, [], [])
+                await asyncio.to_thread(sources.remove_source, source_id)
+                removed += 1
+        counts["removed"] = removed
+        return counts
+
+    counts = _run(_pipeline())
+    if not quiet:
+        click.echo(
+            f"Upserted {counts['written']} page(s), "
+            f"removed {counts['removed']}."
+        )
+
+
+@wiki.command()
+@click.argument("question")
+@path_option
+@click.option("--top-k", default=12, show_default=True, help="Max results to rank.")
+@click.option(
+    "--budget",
+    default=DEFAULT_BUDGET_TOKENS,
+    show_default=True,
+    help="Token budget for the packed context.",
+)
+@click.option("--category", default=None, help="Filter by page category.")
+@click.option("--json", "as_json", is_flag=True, help="Emit raw JSON results.")
+def query(
+    question: str,
+    path_: Optional[str],
+    top_k: int,
+    budget: int,
+    category: Optional[str],
+    as_json: bool,
+) -> None:
+    """Scoped question against the codebase KB (lexical BM25 search).
+
+    Returns a token-budgeted context pack of page stubs. Follow up
+    with `wikitoolkit page <id>` to read a full page, or
+    `wikitoolkit related <id>` to walk the graph.
+    """
+    root, config = _resolve_project(path_)
+    store = _require_built(root, config)
+    rows = _run(store.search_fts(question, category=category, limit=top_k))
+    rows = _normalize_scores(rows)
+
+    if as_json:
+        click.echo(json.dumps(rows, indent=2, default=str))
+        return
+    if not rows:
+        click.echo(
+            f"No wiki results for {question!r}. The wiki may be stale — "
+            "try `wikitoolkit build`, or fall back to code search."
+        )
+        return
+    packed = pack_results(rows, budget_tokens=budget)
+    click.echo(f"# Wiki results for: {question}\n")
+    click.echo(packed.text)
+    click.echo(
+        f"\n({packed.results_packed}/{packed.total_available} results, "
+        f"~{packed.tokens_used} tokens)"
+    )
+    click.echo(
+        "Next: `wikitoolkit page <id>` for a full page · "
+        "`wikitoolkit related <id>` for linked pages."
+    )
+
+
+@wiki.command()
+@click.argument("page_id")
+@path_option
+@click.option(
+    "--max-tokens",
+    default=None,
+    type=int,
+    help="Truncate the body to roughly this many tokens.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit raw JSON.")
+def page(
+    page_id: str,
+    path_: Optional[str],
+    max_tokens: Optional[int],
+    as_json: bool,
+) -> None:
+    """Read one wiki page in full (progressive disclosure)."""
+    root, config = _resolve_project(path_)
+    store = _require_built(root, config)
+    data = _run(store.get_page(page_id, include_body=True))
+    if data is None:
+        raise click.ClickException(
+            f"Page {page_id!r} not found. "
+            f"Search first: wikitoolkit query \"...\""
+        )
+    if as_json:
+        click.echo(json.dumps(data, indent=2, default=str))
+        return
+    body = str(data.get("body") or "")
+    truncated = False
+    if max_tokens is not None:
+        body, truncated = truncate_to_tokens(body, max_tokens)
+    click.echo(f"# {data.get('title')}  [{data.get('concept_id')}]")
+    click.echo(f"category: {data.get('category')}")
+    if data.get("summary"):
+        click.echo(f"summary: {data.get('summary')}\n")
+    click.echo(body)
+    if truncated:
+        click.echo("\n[... body truncated — re-run without --max-tokens]")
+
+
+@wiki.command()
+@click.argument("page_id")
+@path_option
+@click.option("--rel", default=None, help="Filter by edge relation (e.g. contains).")
+@click.option(
+    "--direction",
+    type=click.Choice(["out", "in", "both"]),
+    default="both",
+    show_default=True,
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit raw JSON.")
+def related(
+    page_id: str,
+    path_: Optional[str],
+    rel: Optional[str],
+    direction: str,
+    as_json: bool,
+) -> None:
+    """List pages linked to PAGE_ID by typed edges."""
+    root, config = _resolve_project(path_)
+    store = _require_built(root, config)
+    rows = _run(store.neighbors(page_id, rel=rel, direction=direction))
+    if as_json:
+        click.echo(json.dumps(rows, indent=2, default=str))
+        return
+    if not rows:
+        click.echo(f"No edges from {page_id!r}.")
+        return
+    for row in rows:
+        arrow = "→" if row.get("direction") == "out" else "←"
+        click.echo(
+            f"{arrow} [{row.get('concept_id')}] "
+            f"({row.get('rel')}) {row.get('title', '')}"
+        )
+
+
+@wiki.command()
+@path_option
+@click.option("--json", "as_json", is_flag=True, help="Emit raw JSON.")
+def status(path_: Optional[str], as_json: bool) -> None:
+    """Show wiki plane statistics and source staleness."""
+    root, config = _resolve_project(path_)
+    if not config.is_built(root):
+        click.echo(f"Wiki not built for {root} — run `wikitoolkit build`.")
+        return
+    store = _open_store(root, config)
+    sources = _open_sources(root, config)
+    stats = _run(store.stats())
+    entries = sources.list_sources()
+    stale = [e.source_id for e in entries if sources.is_stale(e.source_id)]
+    payload = {
+        "root": str(root),
+        "wiki_name": config.wiki_name,
+        "backend": config.backend,
+        "storage_dir": str(config.storage_path(root)),
+        "stats": stats,
+        "sources": len(entries),
+        "stale_sources": len(stale),
+    }
+    if as_json:
+        click.echo(json.dumps(payload, indent=2, default=str))
+        return
+    click.echo(f"Wiki      : {config.wiki_name} ({config.backend})")
+    click.echo(f"Root      : {root}")
+    click.echo(f"Storage   : {payload['storage_dir']}")
+    click.echo(
+        f"Plane     : {stats.get('pages', 0)} pages, "
+        f"{stats.get('edges', 0)} edges, "
+        f"~{stats.get('total_tokens', 0)} tokens"
+    )
+    click.echo(f"Categories: {stats.get('categories', {})}")
+    click.echo(f"Sources   : {len(entries)} tracked, {len(stale)} stale")
+    if stale:
+        click.echo("Run `wikitoolkit build` to refresh stale sources.")
+
+
+@wiki.command()
+@path_option
+@click.option(
+    "--output",
+    "-o",
+    default="docs/wiki",
+    show_default=True,
+    help="Output directory for the markdown bundle (relative to root).",
+)
+def export(path_: Optional[str], output: str) -> None:
+    """Export the wiki as a human-readable markdown bundle.
+
+    Writes one markdown file per page (YAML frontmatter + body) plus a
+    root index.md — the `--wiki` action of the /parrotwiki command.
+    """
+    from parrot.knowledge.wiki.export import export_okf_bundle
+
+    root, config = _resolve_project(path_)
+    store = _require_built(root, config)
+    out_dir = Path(output)
+    if not out_dir.is_absolute():
+        out_dir = root / out_dir
+    report = _run(
+        export_okf_bundle(store, out_dir, wiki_name=config.wiki_name)
+    )
+    # Exclude the export output from future scans, or the next build
+    # would ingest the wiki's own exported markdown back into itself.
+    try:
+        export_rel = out_dir.resolve().relative_to(root).as_posix()
+    except ValueError:
+        export_rel = None
+    if export_rel and export_rel not in config.exclude_dirs:
+        config.exclude_dirs.append(export_rel)
+        save_project_config(root, config)
+    click.echo(
+        f"Exported {report.files_written} pages to {out_dir} "
+        f"(index: {'yes' if report.index_generated else 'no'})."
+    )
+
+
+@wiki.command(name="claude-hook", hidden=True)
+def claude_hook() -> None:
+    """Claude Code PreToolUse hook runtime (reads stdin JSON).
+
+    Configured by `parrot claude install` in .claude/settings.json;
+    emits a non-blocking nudge toward `wikitoolkit query` before
+    search-style tool calls. Always exits 0.
+    """
+    import sys
+
+    from parrot.knowledge.wiki.claude_code.hook import run_pre_tool_use_hook
+
+    sys.exit(run_pre_tool_use_hook())
+
+
+def main() -> None:
+    """Console-script entry point for ``wikitoolkit``."""
+    wiki()
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/file_store.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/file_store.py
@@ -407,18 +407,34 @@ class InMemoryWikiStore(BaseWikiStore):
         pages: list[WikiPageRecord],
         edges: Optional[list[tuple[str, str, str]]] = None,
     ) -> dict[str, Any]:
-        """Atomically replace all pages/edges derived from one source."""
+        """Atomically replace all pages/edges derived from one source.
+
+        Incoming edges from other sources are preserved when the
+        replacement re-inserts the same stable ``concept_id`` (matching
+        the SQLite backend's contract).
+        """
         await self._ensure_loaded()
         old_ids = [
             cid
             for cid, page in self._pages.items()
             if page.get("source_id") == source_id
         ]
+        old_set = set(old_ids)
+        new_ids = {page.concept_id for page in pages}
+        preserved = [
+            (src, cid, rel)
+            for cid in old_ids
+            if cid in new_ids
+            for src, rel in self._in_edges.get(cid, [])
+            if src not in old_set
+        ]
         for cid in old_ids:
             await self.delete_page(cid)
         written = await self.upsert_pages(pages)
         if edges:
             await self.add_edges(edges)
+        if preserved:
+            await self.add_edges(preserved)
         return {
             "pages_deleted": len(old_ids),
             "pages_written": written,

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/project.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/project.py
@@ -1,0 +1,160 @@
+"""Per-repository wiki configuration for the ``wikitoolkit`` CLI.
+
+A repository that uses the LLM Wiki as its codebase knowledge plane
+carries a small JSON config at ``.parrot/wiki.json`` (relative to the
+repo root).  The config records where the retrieval plane lives and
+how the repo is scanned, and is what the Claude Code integration
+(``parrot claude install``) reads to find the wiki from hooks.
+
+All helpers here are dependency-light (stdlib + pydantic) so the
+PreToolUse hook can import them with minimal startup cost.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+#: Directory (relative to repo root) holding parrot project state.
+PARROT_DIR = ".parrot"
+
+#: Config filename inside :data:`PARROT_DIR`.
+CONFIG_FILENAME = "wiki.json"
+
+
+class ClaudeIntegrationConfig(BaseModel):
+    """Settings for the Claude Code integration.
+
+    Attributes:
+        nudge_cooldown_seconds: Minimum seconds between two hook
+            nudges, so search-heavy turns are not spammed.
+        nudge_tools: Tool names the PreToolUse nudge applies to.
+    """
+
+    nudge_cooldown_seconds: int = Field(default=300, ge=0)
+    nudge_tools: list[str] = Field(
+        default_factory=lambda: ["Grep", "Glob", "Read"]
+    )
+
+
+class WikiProjectConfig(BaseModel):
+    """Repository-level wiki configuration (``.parrot/wiki.json``).
+
+    Attributes:
+        wiki_name: Wiki identifier; defaults to the repo directory name.
+        storage_dir: Wiki storage directory, relative to the repo root.
+        backend: Retrieval-plane backend (``sqlite`` or ``memory``).
+        include_suffixes: File suffixes scanned into the wiki; empty
+            means the scanner defaults.
+        exclude_dirs: Extra directory names pruned during scans.
+        body_max_chars: Cap on stored page body length.
+        max_file_kb: Files larger than this many KiB are skipped.
+        claude: Claude Code integration settings.
+    """
+
+    wiki_name: str = Field(default="codebase")
+    storage_dir: str = Field(default=f"{PARROT_DIR}/wiki")
+    backend: Literal["sqlite", "memory"] = Field(default="sqlite")
+    include_suffixes: list[str] = Field(default_factory=list)
+    exclude_dirs: list[str] = Field(default_factory=list)
+    body_max_chars: int = Field(default=16_000, ge=1_000)
+    max_file_kb: int = Field(default=512, ge=1)
+    claude: ClaudeIntegrationConfig = Field(
+        default_factory=ClaudeIntegrationConfig
+    )
+
+    def storage_path(self, root: Path) -> Path:
+        """Resolve the wiki storage directory against the repo root."""
+        storage = Path(self.storage_dir)
+        return storage if storage.is_absolute() else root / storage
+
+    def db_path(self, root: Path) -> Path:
+        """Path of the SQLite retrieval plane (sqlite backend)."""
+        return self.storage_path(root) / "wiki.db"
+
+    def is_built(self, root: Path) -> bool:
+        """Whether the retrieval plane exists on disk for this repo."""
+        if self.backend == "sqlite":
+            return self.db_path(root).exists()
+        return (self.storage_path(root) / "pages").exists()
+
+
+def config_path(root: Path) -> Path:
+    """Return the config file path for a repo root."""
+    return root / PARROT_DIR / CONFIG_FILENAME
+
+
+def find_project_root(start: Optional[Path] = None) -> Optional[Path]:
+    """Walk upwards from ``start`` to the nearest configured repo root.
+
+    A directory is a wiki project root when it contains
+    ``.parrot/wiki.json``; as a fallback, the nearest ``.git`` root is
+    returned so ``wikitoolkit build`` can bootstrap a fresh repo.
+
+    Args:
+        start: Directory to start from (defaults to CWD).
+
+    Returns:
+        The project root, or ``None`` when neither marker is found.
+    """
+    current = (start or Path.cwd()).resolve()
+    git_root: Optional[Path] = None
+    for candidate in (current, *current.parents):
+        if config_path(candidate).exists():
+            return candidate
+        if git_root is None and (candidate / ".git").exists():
+            git_root = candidate
+    return git_root
+
+
+class WikiConfigError(ValueError):
+    """Raised when an existing ``.parrot/wiki.json`` cannot be used."""
+
+
+def load_project_config(root: Path) -> WikiProjectConfig:
+    """Load the repo's wiki config.
+
+    Args:
+        root: Repository root.
+
+    Returns:
+        Parsed config; defaults (with ``wiki_name`` set to the repo
+        directory name) when no config file exists.
+
+    Raises:
+        WikiConfigError: When a config file exists but is invalid —
+            silently substituting defaults would let the next
+            ``save_project_config`` clobber the user's settings.
+    """
+    path = config_path(root)
+    if path.exists():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            return WikiProjectConfig.model_validate(data)
+        except (OSError, ValueError) as exc:
+            raise WikiConfigError(
+                f"Invalid wiki config at {path} — fix or remove it: {exc}"
+            ) from exc
+    return WikiProjectConfig(wiki_name=root.name or "codebase")
+
+
+def save_project_config(root: Path, config: WikiProjectConfig) -> Path:
+    """Persist the wiki config to ``.parrot/wiki.json``.
+
+    Args:
+        root: Repository root.
+        config: Config to write.
+
+    Returns:
+        The path written.
+    """
+    path = config_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(config.model_dump(mode="json"), indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return path

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/repo_scan.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/repo_scan.py
@@ -1,0 +1,589 @@
+"""Deterministic codebase scanner for the LLM Wiki retrieval plane.
+
+Turns a source-code repository into :class:`WikiPageRecord` rows and
+typed edges for the machine-first WikiStore plane (FEAT-260) — fully
+offline: no LLM, no embeddings, no external parsers.
+
+Page model produced per repository:
+
+- one ``file:<relpath>`` page per scanned source file — title, an
+  extracted summary (module docstring / first heading / first line),
+  an API outline for Python files (classes, functions, docstrings via
+  :mod:`ast`), and the file content head for lexical (FTS5) search;
+- one ``dir:<relpath>`` overview page per directory, whose body lists
+  the children with their summaries;
+- ``contains`` edges directory → child, and ``references`` edges
+  between Python file pages derived from their import statements.
+
+Used by the ``wikitoolkit build`` / ``parrot wiki build`` CLI
+(:mod:`parrot.knowledge.wiki.cli`) and by the git ``post-commit``
+auto-upsert installed by ``parrot claude install``.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+import subprocess
+from pathlib import Path, PurePosixPath
+from typing import Iterable, Optional
+
+from pydantic import BaseModel, Field
+
+from parrot.knowledge.wiki.store import WikiPageRecord, estimate_tokens
+
+logger = logging.getLogger(__name__)
+
+# --------------------------------------------------------------------------
+# Defaults
+# --------------------------------------------------------------------------
+
+#: File suffixes treated as source code (category ``module``).
+CODE_SUFFIXES: frozenset[str] = frozenset({
+    ".py", ".pyx", ".pxd", ".pyi",
+    ".rs", ".go", ".java", ".kt", ".c", ".h", ".cpp", ".hpp",
+    ".js", ".jsx", ".ts", ".tsx", ".mjs",
+    ".sql", ".sh", ".bash",
+})
+
+#: File suffixes treated as documentation (category ``document``).
+DOC_SUFFIXES: frozenset[str] = frozenset({".md", ".rst", ".txt"})
+
+#: File suffixes treated as configuration (category ``config``).
+CONFIG_SUFFIXES: frozenset[str] = frozenset({
+    ".toml", ".yaml", ".yml", ".ini", ".cfg", ".json",
+})
+
+DEFAULT_SUFFIXES: frozenset[str] = CODE_SUFFIXES | DOC_SUFFIXES | CONFIG_SUFFIXES
+
+#: Directory names never descended into.
+DEFAULT_EXCLUDE_DIRS: frozenset[str] = frozenset({
+    ".git", ".hg", ".svn", "__pycache__",
+    ".venv", "venv", "node_modules", ".tox", "build", "dist", ".eggs",
+    ".idea", ".vscode", ".mypy_cache", ".pytest_cache", ".ruff_cache",
+    ".parrot", ".claude", ".worktrees", ".graphindex",
+})
+
+#: File basenames always skipped (lockfiles and similar noise).
+DEFAULT_EXCLUDE_NAMES: frozenset[str] = frozenset({
+    "package-lock.json", "yarn.lock", "pnpm-lock.yaml",
+    "uv.lock", "poetry.lock", "Cargo.lock",
+})
+
+#: Skip files larger than this many bytes (default 512 KiB).
+DEFAULT_MAX_FILE_BYTES = 512 * 1024
+
+#: Cap stored page bodies at this many characters (~4k tokens).
+DEFAULT_BODY_MAX_CHARS = 16_000
+
+_SUMMARY_MAX_CHARS = 240
+
+
+# --------------------------------------------------------------------------
+# Result containers
+# --------------------------------------------------------------------------
+
+
+class FileSlice(BaseModel):
+    """Everything scanned from a single source file.
+
+    Attributes:
+        rel_path: POSIX-style path relative to the repository root.
+        record: The wiki page record for the file (``source_id`` is
+            filled in later by the build pipeline).
+        imports: Dotted module names imported by the file (Python only),
+            used to derive cross-file ``references`` edges.
+    """
+
+    rel_path: str
+    record: WikiPageRecord
+    imports: list[str] = Field(default_factory=list)
+
+
+class RepoScan(BaseModel):
+    """Full result of scanning a repository.
+
+    Attributes:
+        root: Absolute repository root that was scanned.
+        files: One :class:`FileSlice` per scanned file, sorted by path.
+        dir_records: Directory overview pages (``dir:`` concept ids).
+        dir_edges: ``contains`` edges (dir → child dir/file pages).
+        import_edges: ``references`` edges between ``file:`` pages.
+        skipped: Relative paths skipped (too large / binary / unreadable).
+    """
+
+    root: Path
+    files: list[FileSlice] = Field(default_factory=list)
+    dir_records: list[WikiPageRecord] = Field(default_factory=list)
+    dir_edges: list[tuple[str, str, str]] = Field(default_factory=list)
+    import_edges: list[tuple[str, str, str]] = Field(default_factory=list)
+    skipped: list[str] = Field(default_factory=list)
+
+
+def is_wiki_relevant(
+    rel_path: str,
+    suffixes: Optional[Iterable[str]] = None,
+    exclude_dirs: Optional[Iterable[str]] = None,
+) -> bool:
+    """Whether a repository-relative path is in wiki scope.
+
+    Single source of truth for the selection filter, shared by full
+    discovery (:func:`discover_repo_files`) and incremental upserts so
+    the two paths can never disagree about what belongs in the wiki.
+
+    Args:
+        rel_path: POSIX-style path relative to the repository root.
+        suffixes: File suffixes to keep (defaults to
+            :data:`DEFAULT_SUFFIXES`).
+        exclude_dirs: Extra exclusions (merged with
+            :data:`DEFAULT_EXCLUDE_DIRS`): a bare name (``"vendor"``)
+            prunes any directory of that name; an entry containing
+            ``/`` (``"docs/wiki"``) prunes that root-relative path
+            prefix only.
+
+    Returns:
+        ``True`` when the file should be scanned into the wiki.
+    """
+    keep = frozenset(suffixes) if suffixes else DEFAULT_SUFFIXES
+    pruned_names = set(DEFAULT_EXCLUDE_DIRS)
+    pruned_paths: set[str] = set()
+    for entry in exclude_dirs or ():
+        entry = entry.strip("/")
+        if "/" in entry:
+            pruned_paths.add(entry)
+        elif entry:
+            pruned_names.add(entry)
+
+    p = PurePosixPath(rel_path)
+    if not p.parts:
+        return False
+    if any(part in pruned_names for part in p.parts):
+        return False
+    rel = p.as_posix()
+    if any(rel == pp or rel.startswith(pp + "/") for pp in pruned_paths):
+        return False
+    if p.parts[-1] in DEFAULT_EXCLUDE_NAMES:
+        return False
+    return p.suffix.lower() in keep
+
+
+def file_concept_id(rel_path: str) -> str:
+    """Return the stable concept id for a file page."""
+    return f"file:{PurePosixPath(rel_path)}"
+
+
+def dir_concept_id(rel_path: str) -> str:
+    """Return the stable concept id for a directory overview page."""
+    return f"dir:{PurePosixPath(rel_path) if rel_path else '.'}"
+
+
+# --------------------------------------------------------------------------
+# Discovery
+# --------------------------------------------------------------------------
+
+
+def discover_repo_files(
+    root: Path,
+    suffixes: Optional[Iterable[str]] = None,
+    exclude_dirs: Optional[Iterable[str]] = None,
+    use_git: bool = True,
+) -> list[str]:
+    """Enumerate candidate source files under ``root``.
+
+    Prefers ``git ls-files`` (tracked + untracked-but-not-ignored, so
+    ``.gitignore`` is respected) and falls back to a filesystem walk
+    with :data:`DEFAULT_EXCLUDE_DIRS` pruning when ``root`` is not a
+    git repository.
+
+    Args:
+        root: Repository root directory.
+        suffixes: File suffixes to keep (defaults to
+            :data:`DEFAULT_SUFFIXES`).
+        exclude_dirs: Directory names to prune (merged with defaults).
+        use_git: Set ``False`` to force the filesystem walk.
+
+    Returns:
+        Sorted list of POSIX-style relative paths.
+    """
+    root = root.resolve()
+    pruned = DEFAULT_EXCLUDE_DIRS | frozenset(exclude_dirs or ())
+
+    rel_paths: Optional[list[str]] = None
+    if use_git:
+        rel_paths = _git_ls_files(root)
+    if rel_paths is None:
+        rel_paths = _walk_files(root, pruned)
+
+    return sorted({
+        rel
+        for rel in rel_paths
+        if is_wiki_relevant(rel, suffixes=suffixes, exclude_dirs=exclude_dirs)
+    })
+
+
+def _git_ls_files(root: Path) -> Optional[list[str]]:
+    """List files via git (respecting .gitignore), or None if unavailable."""
+    try:
+        proc = subprocess.run(
+            [
+                "git", "-C", str(root), "ls-files", "-z",
+                "--cached", "--others", "--exclude-standard",
+            ],
+            capture_output=True,
+            timeout=30,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    out = proc.stdout.decode("utf-8", errors="replace")
+    return [p for p in out.split("\0") if p]
+
+
+def _walk_files(root: Path, pruned: frozenset[str]) -> list[str]:
+    """Filesystem fallback for :func:`discover_repo_files`."""
+    found: list[str] = []
+    stack = [root]
+    while stack:
+        current = stack.pop()
+        try:
+            entries = sorted(current.iterdir())
+        except OSError:
+            continue
+        for entry in entries:
+            if entry.is_dir():
+                if entry.name not in pruned and not entry.is_symlink():
+                    stack.append(entry)
+            elif entry.is_file():
+                found.append(entry.relative_to(root).as_posix())
+    return found
+
+
+# --------------------------------------------------------------------------
+# Per-file extraction
+# --------------------------------------------------------------------------
+
+
+def _first_line(text: str, limit: int = _SUMMARY_MAX_CHARS) -> str:
+    """Return the first non-empty line of ``text``, truncated."""
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped[:limit]
+    return ""
+
+
+def _category_for(rel_path: str) -> str:
+    """Map a file suffix to an open-string wiki category."""
+    suffix = PurePosixPath(rel_path).suffix.lower()
+    if suffix in DOC_SUFFIXES:
+        return "document"
+    if suffix in CONFIG_SUFFIXES:
+        return "config"
+    return "module"
+
+
+def _python_outline(source: str) -> tuple[str, list[str], list[str]]:
+    """Extract summary, API outline, and imports from Python source.
+
+    Args:
+        source: Raw Python source text.
+
+    Returns:
+        Tuple of ``(summary, outline_lines, imported_modules)``.  On a
+        syntax error every element degrades to empty.
+    """
+    try:
+        tree = ast.parse(source)
+    except (SyntaxError, ValueError):
+        return "", [], []
+
+    summary = _first_line(ast.get_docstring(tree) or "")
+    outline: list[str] = []
+    imports: list[str] = []
+
+    def _sig(node: ast.AST) -> str:
+        args = getattr(node, "args", None)
+        names = [a.arg for a in args.args] if args else []
+        return f"({', '.join(names)})"
+
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            imports.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            imports.append(node.module)
+        elif isinstance(node, ast.ClassDef):
+            doc = _first_line(ast.get_docstring(node) or "")
+            outline.append(f"class {node.name}: {doc}".rstrip(": "))
+            for item in node.body:
+                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    idoc = _first_line(ast.get_docstring(item) or "")
+                    outline.append(
+                        f"    def {item.name}{_sig(item)}: {idoc}".rstrip(": ")
+                    )
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            doc = _first_line(ast.get_docstring(node) or "")
+            outline.append(f"def {node.name}{_sig(node)}: {doc}".rstrip(": "))
+    return summary, outline, imports
+
+
+def _markdown_summary(content: str) -> str:
+    """Summary for a markdown/rst document: first heading or first line."""
+    for line in content.splitlines():
+        stripped = line.strip().lstrip("#").strip()
+        if stripped:
+            return stripped[:_SUMMARY_MAX_CHARS]
+    return ""
+
+
+def build_file_slice(
+    root: Path,
+    rel_path: str,
+    body_max_chars: int = DEFAULT_BODY_MAX_CHARS,
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
+) -> Optional[FileSlice]:
+    """Build the wiki page record for a single repository file.
+
+    Args:
+        root: Repository root.
+        rel_path: POSIX relative path of the file.
+        body_max_chars: Cap on the stored page body length.
+        max_file_bytes: Files larger than this are skipped.
+
+    Returns:
+        A :class:`FileSlice`, or ``None`` when the file is missing,
+        binary, or oversized.
+    """
+    path = root / rel_path
+    try:
+        if path.stat().st_size > max_file_bytes:
+            return None
+        data = path.read_bytes()
+    except OSError:
+        return None
+    if b"\0" in data[:1024]:
+        return None
+    content = data.decode("utf-8", errors="replace")
+
+    category = _category_for(rel_path)
+    suffix = PurePosixPath(rel_path).suffix.lower()
+    imports: list[str] = []
+    sections: list[str] = []
+
+    if suffix in {".py", ".pyi"}:
+        summary, outline, imports = _python_outline(content)
+        summary = summary or f"Python module {rel_path}"
+        if outline:
+            sections.append("## API outline\n" + "\n".join(outline))
+    elif suffix in DOC_SUFFIXES:
+        summary = _markdown_summary(content) or rel_path
+    else:
+        summary = _first_line(content) or rel_path
+
+    body_head = content[:body_max_chars]
+    truncated = len(content) > body_max_chars
+    sections.append(
+        "## Content" + (" (truncated)" if truncated else "") + "\n" + body_head
+    )
+    body = f"# {rel_path}\n\n" + "\n\n".join(sections)
+
+    record = WikiPageRecord(
+        concept_id=file_concept_id(rel_path),
+        node_id=rel_path,
+        title=rel_path,
+        category=category,
+        summary=summary,
+        body=body,
+        token_count=estimate_tokens(body),
+    )
+    return FileSlice(rel_path=rel_path, record=record, imports=imports)
+
+
+# --------------------------------------------------------------------------
+# Directory pages + import edges
+# --------------------------------------------------------------------------
+
+
+def build_dir_pages(
+    files: list[FileSlice],
+) -> tuple[list[WikiPageRecord], list[tuple[str, str, str]]]:
+    """Derive directory overview pages and ``contains`` edges.
+
+    Args:
+        files: Scanned file slices.
+
+    Returns:
+        Tuple ``(dir_records, edges)``; edges connect each directory
+        page to its child directory/file pages.
+    """
+    children: dict[str, set[tuple[str, str]]] = {}  # dir -> {(kind, rel)}
+    summaries: dict[str, str] = {
+        fs.rel_path: fs.record.summary for fs in files
+    }
+
+    for fs in files:
+        p = PurePosixPath(fs.rel_path)
+        parent = p.parent.as_posix()
+        parent = "" if parent == "." else parent
+        children.setdefault(parent, set()).add(("file", fs.rel_path))
+        # Register ancestor chain dir -> subdir
+        current = parent
+        while current:
+            up = PurePosixPath(current).parent.as_posix()
+            up = "" if up == "." else up
+            children.setdefault(up, set()).add(("dir", current))
+            current = up
+
+    records: list[WikiPageRecord] = []
+    edges: list[tuple[str, str, str]] = []
+    for dir_rel, kids in sorted(children.items()):
+        cid = dir_concept_id(dir_rel)
+        lines: list[str] = []
+        for kind, rel in sorted(kids):
+            child_cid = (
+                file_concept_id(rel) if kind == "file" else dir_concept_id(rel)
+            )
+            edges.append((cid, child_cid, "contains"))
+            label = summaries.get(rel, "") if kind == "file" else "directory"
+            lines.append(f"- [{child_cid}] {PurePosixPath(rel).name} — {label}")
+        title = dir_rel or "."
+        body = f"# Directory {title}\n\n" + "\n".join(lines)
+        records.append(
+            WikiPageRecord(
+                concept_id=cid,
+                node_id=f"dir/{title}",
+                title=f"{title}/",
+                category="overview",
+                summary=f"Directory overview of {title} "
+                        f"({len(kids)} entries)",
+                body=body,
+                token_count=estimate_tokens(body),
+            )
+        )
+    return records, edges
+
+
+def _module_index(rel_paths: Iterable[str]) -> dict[str, str]:
+    """Map importable dotted module names to relative file paths.
+
+    Handles both flat layouts (``pkg/mod.py`` → ``pkg.mod``) and src
+    layouts (``packages/x/src/pkg/mod.py`` → ``pkg.mod`` — everything
+    up to and including a ``src`` component is stripped).
+    """
+    index: dict[str, str] = {}
+    for rel in rel_paths:
+        p = PurePosixPath(rel)
+        if p.suffix not in {".py", ".pyi"}:
+            continue
+        parts = list(p.parts)
+        if "src" in parts:
+            parts = parts[parts.index("src") + 1:]
+        if not parts:
+            continue
+        parts[-1] = PurePosixPath(parts[-1]).stem
+        if parts[-1] == "__init__":
+            parts = parts[:-1]
+        if parts:
+            index.setdefault(".".join(parts), rel)
+    return index
+
+
+def build_import_edges(
+    files: list[FileSlice],
+    index_paths: Optional[Iterable[str]] = None,
+) -> list[tuple[str, str, str]]:
+    """Derive ``references`` edges between file pages from Python imports.
+
+    An import edge is emitted when an imported dotted module (or any
+    dotted prefix of it) resolves to another repository file.
+
+    Args:
+        files: Scanned file slices (edge sources).
+        index_paths: Relative paths used to build the import-target
+            index; defaults to the scanned files themselves.  Pass the
+            full repository file list on partial scans so imports still
+            resolve to files outside the scanned subset.
+
+    Returns:
+        Deduplicated ``(src_concept, dst_concept, "references")`` edges.
+    """
+    if index_paths is None:
+        index_paths = [fs.rel_path for fs in files]
+    index = _module_index(index_paths)
+    edges: set[tuple[str, str, str]] = set()
+    for fs in files:
+        src = file_concept_id(fs.rel_path)
+        for module in fs.imports:
+            parts = module.split(".")
+            target: Optional[str] = None
+            for depth in range(len(parts), 0, -1):
+                target = index.get(".".join(parts[:depth]))
+                if target:
+                    break
+            if target and target != fs.rel_path:
+                edges.add((src, file_concept_id(target), "references"))
+    return sorted(edges)
+
+
+# --------------------------------------------------------------------------
+# Top-level scan
+# --------------------------------------------------------------------------
+
+
+def scan_repository(
+    root: Path,
+    suffixes: Optional[Iterable[str]] = None,
+    exclude_dirs: Optional[Iterable[str]] = None,
+    body_max_chars: int = DEFAULT_BODY_MAX_CHARS,
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
+    use_git: bool = True,
+    rel_paths: Optional[Iterable[str]] = None,
+) -> RepoScan:
+    """Scan a repository into wiki page records and edges.
+
+    Args:
+        root: Repository root directory.
+        suffixes: File suffixes to include (defaults to
+            :data:`DEFAULT_SUFFIXES`).
+        exclude_dirs: Extra directory names to prune.
+        body_max_chars: Cap on stored page body length.
+        max_file_bytes: Skip files larger than this.
+        use_git: Prefer ``git ls-files`` for discovery.
+        rel_paths: Explicit relative paths to scan instead of running
+            discovery (used for incremental upserts).
+
+    Returns:
+        A fully populated :class:`RepoScan`.
+    """
+    root = root.resolve()
+    discovered = discover_repo_files(
+        root, suffixes=suffixes, exclude_dirs=exclude_dirs, use_git=use_git
+    )
+    if rel_paths is None:
+        targets = discovered
+    else:
+        targets = sorted({PurePosixPath(p).as_posix() for p in rel_paths})
+
+    scan = RepoScan(root=root)
+    for rel in targets:
+        fs = build_file_slice(
+            root,
+            rel,
+            body_max_chars=body_max_chars,
+            max_file_bytes=max_file_bytes,
+        )
+        if fs is None:
+            scan.skipped.append(rel)
+        else:
+            scan.files.append(fs)
+
+    scan.dir_records, scan.dir_edges = build_dir_pages(scan.files)
+    scan.import_edges = build_import_edges(scan.files, index_paths=discovered)
+    logger.info(
+        "Scanned %s: %d pages, %d dirs, %d import edges, %d skipped",
+        root,
+        len(scan.files),
+        len(scan.dir_records),
+        len(scan.import_edges),
+        len(scan.skipped),
+    )
+    return scan

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/store.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/store.py
@@ -548,6 +548,12 @@ class SQLiteWikiStore(BaseWikiStore):
         FTS rows, embeddings, and any edges touching them), then inserts
         the replacements — so re-ingest never accumulates duplicates.
 
+        Incoming edges from OTHER sources (e.g. a directory ``contains``
+        edge, or a ``references`` edge from an importing file) are
+        preserved when the replacement re-inserts the same stable
+        ``concept_id`` — the slice owns its outgoing edges, but links
+        pointing INTO it stay valid across a re-ingest.
+
         Args:
             source_id: Source whose derived pages are being replaced.
             pages: Replacement page records.
@@ -557,6 +563,7 @@ class SQLiteWikiStore(BaseWikiStore):
             ``{"pages_deleted": N, "pages_written": M, "edges_written": K}``
         """
         edges = edges or []
+        new_ids = {page.concept_id for page in pages}
         async with self._connect() as conn:
             async with conn.execute(
                 "SELECT concept_id FROM pages WHERE source_id = ?",
@@ -564,7 +571,23 @@ class SQLiteWikiStore(BaseWikiStore):
             ) as cur:
                 old_ids = [row["concept_id"] for row in await cur.fetchall()]
 
+            preserved: list[tuple[str, str, str]] = []
             if old_ids:
+                # Snapshot incoming edges whose target survives the
+                # replacement (same concept_id re-inserted below).
+                old_set = set(old_ids)
+                placeholders = ",".join("?" for _ in old_ids)
+                async with conn.execute(
+                    "SELECT src, dst, rel FROM edges"
+                    f" WHERE dst IN ({placeholders})",
+                    old_ids,
+                ) as cur:
+                    preserved = [
+                        (row["src"], row["dst"], row["rel"])
+                        for row in await cur.fetchall()
+                        if row["src"] not in old_set
+                        and row["dst"] in new_ids
+                    ]
                 await conn.executemany(
                     "DELETE FROM pages_fts WHERE concept_id = ?",
                     [(cid,) for cid in old_ids],
@@ -583,6 +606,8 @@ class SQLiteWikiStore(BaseWikiStore):
 
             await self._upsert_pages_conn(conn, pages)
             await self._insert_edges_conn(conn, edges)
+            if preserved:
+                await self._insert_edges_conn(conn, preserved)
             await conn.commit()
 
         self.logger.debug(

--- a/tests/knowledge/wiki/test_claude_code.py
+++ b/tests/knowledge/wiki/test_claude_code.py
@@ -1,0 +1,312 @@
+"""Tests for the Claude Code integration (installer + PreToolUse hook).
+
+Covers ``parrot claude install/uninstall/status`` semantics (managed
+markers, settings.json merging, git hook chaining) and the
+``wikitoolkit claude-hook`` runtime (nudge conditions, throttling,
+fail-silent guarantees). All offline against temp directories.
+"""
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from parrot.knowledge.wiki.claude_code import assets
+from parrot.knowledge.wiki.claude_code.hook import (
+    build_nudge,
+    run_pre_tool_use_hook,
+)
+from parrot.knowledge.wiki.claude_code.installer import (
+    install_claude_integration,
+    integration_status,
+    uninstall_claude_integration,
+)
+from parrot.knowledge.wiki.cli import wiki
+from parrot.knowledge.wiki.project import (
+    WikiProjectConfig,
+    load_project_config,
+    save_project_config,
+)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A fake repo with a .git dir (so the git hook installs)."""
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "mod.py").write_text(
+        '"""A module."""\nX = 1\n', encoding="utf-8"
+    )
+    return tmp_path
+
+
+def _built_repo(repo: Path) -> Path:
+    """Build the wiki plane inside the fake repo."""
+    result = CliRunner().invoke(
+        wiki, ["build", "--path", str(repo), "--no-git", "-q"]
+    )
+    assert result.exit_code == 0, result.output
+    return repo
+
+
+class TestInstaller:
+    def test_fresh_install_writes_all_artifacts(self, repo):
+        actions = install_claude_integration(repo)
+        assert len(actions) == 6
+
+        assert (repo / ".parrot" / "wiki.json").exists()
+        claude_md = (repo / "CLAUDE.md").read_text(encoding="utf-8")
+        assert assets.CLAUDE_MD_BEGIN in claude_md
+        assert 'wikitoolkit query' in claude_md
+
+        settings = json.loads(
+            (repo / ".claude" / "settings.json").read_text(encoding="utf-8")
+        )
+        entry = settings["hooks"]["PreToolUse"][0]
+        assert entry["matcher"] == assets.HOOK_MATCHER
+        assert entry["hooks"][0]["command"] == assets.HOOK_COMMAND
+
+        assert (repo / ".claude" / "commands" / "parrotwiki.md").exists()
+
+        hook = (repo / ".git" / "hooks" / "post-commit")
+        assert hook.exists()
+        assert "wikitoolkit upsert --changed" in hook.read_text()
+        assert hook.stat().st_mode & 0o111  # executable
+
+        gitignore = (repo / ".gitignore").read_text(encoding="utf-8")
+        assert ".parrot/" in gitignore
+
+    def test_install_is_idempotent(self, repo):
+        install_claude_integration(repo)
+        snapshot = {
+            p: p.read_text(encoding="utf-8")
+            for p in [
+                repo / "CLAUDE.md",
+                repo / ".claude" / "settings.json",
+                repo / ".claude" / "commands" / "parrotwiki.md",
+                repo / ".git" / "hooks" / "post-commit",
+                repo / ".gitignore",
+            ]
+        }
+        install_claude_integration(repo)
+        for path, before in snapshot.items():
+            assert path.read_text(encoding="utf-8") == before
+
+    def test_preserves_existing_claude_md(self, repo):
+        (repo / "CLAUDE.md").write_text(
+            "# My rules\n\nDo good work.\n", encoding="utf-8"
+        )
+        install_claude_integration(repo)
+        text = (repo / "CLAUDE.md").read_text(encoding="utf-8")
+        assert text.startswith("# My rules")
+        assert assets.CLAUDE_MD_BEGIN in text
+
+    def test_preserves_existing_settings_hooks(self, repo):
+        settings_dir = repo / ".claude"
+        settings_dir.mkdir()
+        (settings_dir / "settings.json").write_text(
+            json.dumps({
+                "permissions": {"allow": ["Bash(ls:*)"]},
+                "hooks": {"PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": "echo hi"}],
+                }]},
+            }),
+            encoding="utf-8",
+        )
+        install_claude_integration(repo)
+        settings = json.loads(
+            (settings_dir / "settings.json").read_text(encoding="utf-8")
+        )
+        assert settings["permissions"] == {"allow": ["Bash(ls:*)"]}
+        pre = settings["hooks"]["PreToolUse"]
+        assert len(pre) == 2
+        assert pre[0]["hooks"][0]["command"] == "echo hi"
+
+    def test_invalid_settings_json_aborts(self, repo):
+        settings_dir = repo / ".claude"
+        settings_dir.mkdir()
+        (settings_dir / "settings.json").write_text("{broken", encoding="utf-8")
+        with pytest.raises(RuntimeError):
+            install_claude_integration(repo)
+
+    def test_chains_into_existing_git_hook(self, repo):
+        hooks_dir = repo / ".git" / "hooks"
+        hooks_dir.mkdir(parents=True)
+        (hooks_dir / "post-commit").write_text(
+            "#!/bin/sh\necho existing\n", encoding="utf-8"
+        )
+        install_claude_integration(repo)
+        text = (hooks_dir / "post-commit").read_text(encoding="utf-8")
+        assert "echo existing" in text
+        assert assets.GIT_HOOK_BEGIN in text
+
+    def test_no_git_hook_option(self, repo):
+        install_claude_integration(repo, git_hook=False)
+        assert not (repo / ".git" / "hooks" / "post-commit").exists()
+
+    def test_uninstall_removes_only_ours(self, repo):
+        (repo / "CLAUDE.md").write_text("# Mine\n", encoding="utf-8")
+        hooks_dir = repo / ".git" / "hooks"
+        hooks_dir.mkdir(parents=True)
+        (hooks_dir / "post-commit").write_text(
+            "#!/bin/sh\necho existing\n", encoding="utf-8"
+        )
+        install_claude_integration(repo)
+        uninstall_claude_integration(repo)
+
+        text = (repo / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "# Mine" in text
+        assert assets.CLAUDE_MD_BEGIN not in text
+        settings = json.loads(
+            (repo / ".claude" / "settings.json").read_text(encoding="utf-8")
+        )
+        assert "hooks" not in settings
+        assert not (repo / ".claude" / "commands" / "parrotwiki.md").exists()
+        hook_text = (hooks_dir / "post-commit").read_text(encoding="utf-8")
+        assert "echo existing" in hook_text
+        assert assets.GIT_HOOK_BEGIN not in hook_text
+        # Config + plane are intentionally left in place.
+        assert (repo / ".parrot" / "wiki.json").exists()
+
+    def test_status_reflects_install_state(self, repo):
+        before = integration_status(repo)
+        assert not before["claude_md_section"]
+        install_claude_integration(repo)
+        after = integration_status(repo)
+        assert after["config"]
+        assert after["claude_md_section"]
+        assert after["pre_tool_use_hook"]
+        assert after["slash_command"]
+        assert after["git_post_commit_hook"]
+
+
+class TestHookNudge:
+    def _payload(self, repo: Path, tool: str, tool_input=None) -> dict:
+        return {
+            "hook_event_name": "PreToolUse",
+            "tool_name": tool,
+            "tool_input": tool_input or {},
+            "cwd": str(repo),
+        }
+
+    def test_nudges_grep_when_built(self, repo):
+        _built_repo(repo)
+        out = build_nudge(self._payload(repo, "Grep"), root=repo, now=1000.0)
+        assert out is not None
+        hso = out["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert "wikitoolkit query" in hso["additionalContext"]
+        # Non-blocking: never touches the permission flow.
+        assert "permissionDecision" not in hso
+
+    def test_no_nudge_when_not_built(self, repo):
+        save_project_config(repo, WikiProjectConfig(wiki_name="x"))
+        assert build_nudge(self._payload(repo, "Grep"), root=repo) is None
+
+    def test_no_nudge_for_unmatched_tool(self, repo):
+        _built_repo(repo)
+        assert build_nudge(self._payload(repo, "Bash"), root=repo) is None
+
+    def test_read_nudges_only_source_files(self, repo):
+        _built_repo(repo)
+        config = load_project_config(repo)
+        csv = self._payload(repo, "Read", {"file_path": "/tmp/data.csv"})
+        assert build_nudge(csv, root=repo, config=config, now=1000.0) is None
+        py = self._payload(repo, "Read", {"file_path": "/src/mod.py"})
+        assert (
+            build_nudge(py, root=repo, config=config, now=1000.0) is not None
+        )
+
+    def test_throttle_cooldown(self, repo):
+        _built_repo(repo)
+        first = build_nudge(self._payload(repo, "Grep"), root=repo, now=1000.0)
+        assert first is not None
+        second = build_nudge(self._payload(repo, "Grep"), root=repo, now=1010.0)
+        assert second is None  # inside the 300 s default cooldown
+        third = build_nudge(self._payload(repo, "Grep"), root=repo, now=1400.0)
+        assert third is not None
+
+    def test_wrong_event_ignored(self, repo):
+        _built_repo(repo)
+        payload = self._payload(repo, "Grep")
+        payload["hook_event_name"] = "PostToolUse"
+        assert build_nudge(payload, root=repo) is None
+
+
+class TestHookRuntime:
+    def test_runtime_emits_json(self, repo):
+        _built_repo(repo)
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Grep",
+            "tool_input": {"pattern": "x"},
+            "cwd": str(repo),
+        }
+        stdout = io.StringIO()
+        code = run_pre_tool_use_hook(
+            stdin=io.StringIO(json.dumps(payload)), stdout=stdout
+        )
+        assert code == 0
+        response = json.loads(stdout.getvalue())
+        assert response["suppressOutput"] is True
+        assert "additionalContext" in response["hookSpecificOutput"]
+
+    def test_runtime_never_fails_on_garbage(self):
+        for garbage in ["", "not json", "[1,2,3]", '"str"']:
+            code = run_pre_tool_use_hook(
+                stdin=io.StringIO(garbage), stdout=io.StringIO()
+            )
+            assert code == 0
+
+    def test_runtime_silent_outside_project(self, tmp_path):
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Grep",
+            "tool_input": {},
+            "cwd": str(tmp_path),
+        }
+        stdout = io.StringIO()
+        code = run_pre_tool_use_hook(
+            stdin=io.StringIO(json.dumps(payload)), stdout=stdout
+        )
+        assert code == 0
+        assert stdout.getvalue() == ""
+
+
+class TestClaudeCli:
+    def test_install_status_uninstall_cycle(self, repo):
+        from parrot.knowledge.wiki.claude_code.cli import claude
+
+        runner = CliRunner()
+        result = runner.invoke(
+            claude, ["install", "--path", str(repo), "--no-build"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "integration installed" in result.output
+
+        status = runner.invoke(
+            claude, ["status", "--path", str(repo), "--json"]
+        )
+        info = json.loads(status.output)
+        assert info["pre_tool_use_hook"] is True
+
+        result = runner.invoke(claude, ["uninstall", "--path", str(repo)])
+        assert result.exit_code == 0
+        info = json.loads(
+            runner.invoke(
+                claude, ["status", "--path", str(repo), "--json"]
+            ).output
+        )
+        assert info["pre_tool_use_hook"] is False
+
+    def test_install_builds_plane_by_default(self, repo):
+        from parrot.knowledge.wiki.claude_code.cli import claude
+
+        runner = CliRunner()
+        result = runner.invoke(claude, ["install", "--path", str(repo)])
+        assert result.exit_code == 0, result.output
+        config = load_project_config(repo)
+        assert config.is_built(repo)

--- a/tests/knowledge/wiki/test_cli.py
+++ b/tests/knowledge/wiki/test_cli.py
@@ -1,0 +1,238 @@
+"""Tests for the ``wikitoolkit`` / ``parrot wiki`` CLI.
+
+Drives the click commands end-to-end with ``CliRunner`` against temp
+repositories — real SQLite plane, no git dependency (``--no-git``),
+no LLM.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from parrot.knowledge.wiki.cli import wiki
+from parrot.knowledge.wiki.project import (
+    config_path,
+    load_project_config,
+)
+
+PY_STORE = '"""A tiny key-value store module."""\n\n\nclass Store:\n    """In-memory key-value store."""\n\n    def get(self, key):\n        """Fetch a value."""\n        return key\n'
+PY_UTIL = '"""Utility helpers."""\n\n\ndef helper(key):\n    """Return the key unchanged."""\n    return key\n'
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A small fake repository."""
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "store.py").write_text(PY_STORE, encoding="utf-8")
+    (tmp_path / "pkg" / "util.py").write_text(PY_UTIL, encoding="utf-8")
+    (tmp_path / "README.md").write_text(
+        "# Demo\n\nA demo project.", encoding="utf-8"
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _build(runner: CliRunner, repo: Path, *extra: str):
+    result = runner.invoke(
+        wiki, ["build", "--path", str(repo), "--no-git", *extra]
+    )
+    assert result.exit_code == 0, result.output
+    return result
+
+
+class TestBuild:
+    def test_build_creates_plane_and_config(self, runner, repo):
+        result = _build(runner, repo)
+        assert "built" in result.output
+        assert config_path(repo).exists()
+        config = load_project_config(repo)
+        assert config.wiki_name == repo.name
+        assert config.db_path(repo).exists()
+
+    def test_rebuild_is_incremental(self, runner, repo):
+        _build(runner, repo)
+        result = _build(runner, repo)
+        assert "0 ingested" in result.output
+        assert "3 unchanged" in result.output
+
+    def test_changed_file_reingested(self, runner, repo):
+        _build(runner, repo)
+        (repo / "pkg" / "util.py").write_text(
+            '"""Utility helpers v2."""\n', encoding="utf-8"
+        )
+        result = _build(runner, repo)
+        assert "1 ingested" in result.output
+
+    def test_deleted_file_pruned(self, runner, repo):
+        _build(runner, repo)
+        (repo / "pkg" / "util.py").unlink()
+        result = _build(runner, repo)
+        assert "removed" in result.output
+        page = runner.invoke(
+            wiki, ["page", "file:pkg/util.py", "--path", str(repo)]
+        )
+        assert page.exit_code != 0
+
+    def test_custom_name_and_backend(self, runner, repo):
+        _build(runner, repo, "--name", "kb", "--backend", "memory")
+        config = load_project_config(repo)
+        assert config.wiki_name == "kb"
+        assert config.backend == "memory"
+        result = runner.invoke(
+            wiki, ["query", "store", "--path", str(repo)]
+        )
+        assert result.exit_code == 0, result.output
+
+
+class TestQuery:
+    def test_query_returns_packed_stubs(self, runner, repo):
+        _build(runner, repo)
+        result = runner.invoke(
+            wiki, ["query", "key value store", "--path", str(repo)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "file:pkg/store.py" in result.output
+        assert "wikitoolkit page" in result.output  # follow-up hint
+
+    def test_query_json(self, runner, repo):
+        _build(runner, repo)
+        result = runner.invoke(
+            wiki,
+            ["query", "utility helpers", "--path", str(repo), "--json"],
+        )
+        assert result.exit_code == 0
+        rows = json.loads(result.output)
+        assert any(r["concept_id"] == "file:pkg/util.py" for r in rows)
+        assert all(0.0 <= r["score"] <= 1.0 for r in rows)
+
+    def test_query_without_build_fails_with_guidance(self, runner, repo):
+        result = runner.invoke(
+            wiki, ["query", "anything", "--path", str(repo)]
+        )
+        assert result.exit_code != 0
+        assert "wikitoolkit build" in result.output
+
+    def test_query_no_results_message(self, runner, repo):
+        _build(runner, repo)
+        result = runner.invoke(
+            wiki, ["query", "zzzqqqxyzzy", "--path", str(repo)]
+        )
+        assert result.exit_code == 0
+        assert "No wiki results" in result.output
+
+
+class TestPageAndRelated:
+    def test_page_full_read(self, runner, repo):
+        _build(runner, repo)
+        result = runner.invoke(
+            wiki, ["page", "file:pkg/store.py", "--path", str(repo)]
+        )
+        assert result.exit_code == 0
+        assert "In-memory key-value store" in result.output
+
+    def test_page_max_tokens_truncates(self, runner, repo):
+        _build(runner, repo)
+        result = runner.invoke(
+            wiki,
+            [
+                "page", "file:pkg/store.py",
+                "--path", str(repo), "--max-tokens", "5",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "truncated" in result.output
+
+    def test_related_shows_contains_edge(self, runner, repo):
+        _build(runner, repo)
+        result = runner.invoke(
+            wiki, ["related", "file:pkg/store.py", "--path", str(repo)]
+        )
+        assert result.exit_code == 0
+        assert "dir:pkg" in result.output
+        assert "contains" in result.output
+
+
+class TestUpsert:
+    def test_upsert_explicit_path(self, runner, repo):
+        _build(runner, repo)
+        (repo / "pkg" / "util.py").write_text(
+            '"""Utility helpers v2."""\n', encoding="utf-8"
+        )
+        result = runner.invoke(
+            wiki, ["upsert", "pkg/util.py", "--path", str(repo)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "Upserted 1" in result.output
+        page = runner.invoke(
+            wiki, ["page", "file:pkg/util.py", "--path", str(repo)]
+        )
+        assert "v2" in page.output
+
+    def test_upsert_preserves_incoming_edges(self, runner, repo):
+        _build(runner, repo)
+        (repo / "pkg" / "util.py").write_text(
+            '"""Utility helpers v3."""\n', encoding="utf-8"
+        )
+        runner.invoke(wiki, ["upsert", "pkg/util.py", "--path", str(repo)])
+        result = runner.invoke(
+            wiki,
+            ["related", "file:pkg/util.py", "--path", str(repo), "--json"],
+        )
+        rows = json.loads(result.output)
+        rels = {(r["concept_id"], r["rel"]) for r in rows}
+        assert ("dir:pkg", "contains") in rels
+
+    def test_upsert_deleted_file_removes_pages(self, runner, repo):
+        _build(runner, repo)
+        (repo / "pkg" / "util.py").unlink()
+        result = runner.invoke(
+            wiki, ["upsert", "pkg/util.py", "--path", str(repo)]
+        )
+        assert result.exit_code == 0
+        assert "removed 1" in result.output
+
+    def test_upsert_ignores_excluded_dirs(self, runner, repo):
+        _build(runner, repo)
+        state = repo / ".parrot" / "wiki.json"
+        assert state.exists()
+        result = runner.invoke(
+            wiki, ["upsert", ".parrot/wiki.json", "--path", str(repo)]
+        )
+        assert result.exit_code == 0
+        assert "No wiki-relevant files" in result.output
+
+    def test_upsert_before_build_is_noop(self, runner, tmp_path):
+        (tmp_path / "a.py").write_text("x = 1", encoding="utf-8")
+        result = runner.invoke(
+            wiki, ["upsert", "a.py", "--path", str(tmp_path)]
+        )
+        assert result.exit_code == 0
+        assert "not built" in result.output
+
+
+class TestStatusAndExport:
+    def test_status_json(self, runner, repo):
+        _build(runner, repo)
+        result = runner.invoke(
+            wiki, ["status", "--path", str(repo), "--json"]
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["stats"]["pages"] >= 3
+        assert payload["stale_sources"] == 0
+
+    def test_export_markdown_bundle(self, runner, repo):
+        _build(runner, repo)
+        result = runner.invoke(
+            wiki, ["export", "--path", str(repo), "-o", "docs/wiki"]
+        )
+        assert result.exit_code == 0, result.output
+        out = repo / "docs" / "wiki"
+        assert (out / "index.md").exists()
+        assert any(out.rglob("*store.py*"))

--- a/tests/knowledge/wiki/test_repo_scan.py
+++ b/tests/knowledge/wiki/test_repo_scan.py
@@ -1,0 +1,194 @@
+"""Tests for the deterministic repository scanner (repo_scan).
+
+All offline: temp directories, no git required (``use_git=False``),
+no LLM. Pins discovery filtering, per-file extraction (Python AST
+outline, markdown summary), directory overview pages, and import-edge
+derivation including src-layout resolution.
+"""
+
+from pathlib import Path
+
+from parrot.knowledge.wiki.repo_scan import (
+    DEFAULT_MAX_FILE_BYTES,
+    build_dir_pages,
+    build_file_slice,
+    dir_concept_id,
+    discover_repo_files,
+    file_concept_id,
+    scan_repository,
+)
+
+
+def _write(root: Path, rel: str, content: str) -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+PY_A = '"""Mod A does things."""\nfrom pkg.b import x\n\n\nclass Alpha:\n    """Alpha class."""\n\n    def run(self, arg):\n        """Run it."""\n        return arg\n\n\ndef helper():\n    """Top-level helper."""\n'
+PY_B = '"""Mod B."""\nx = 1\n'
+
+
+class TestDiscovery:
+    def test_filters_suffixes_and_dirs(self, tmp_path: Path):
+        _write(tmp_path, "pkg/a.py", PY_A)
+        _write(tmp_path, "README.md", "# Hello\n\nWorld.")
+        _write(tmp_path, "node_modules/x.js", "var x;")
+        _write(tmp_path, ".parrot/wiki.json", "{}")
+        _write(tmp_path, "image.png", "not really a png")
+        _write(tmp_path, "uv.lock", "lockfile")
+
+        found = discover_repo_files(tmp_path, use_git=False)
+        assert "pkg/a.py" in found
+        assert "README.md" in found
+        assert all("node_modules" not in f for f in found)
+        assert all(".parrot" not in f for f in found)
+        assert "image.png" not in found
+        assert "uv.lock" not in found
+
+    def test_extra_exclude_dirs(self, tmp_path: Path):
+        _write(tmp_path, "vendor/lib.py", "x = 1")
+        _write(tmp_path, "app.py", "y = 2")
+        found = discover_repo_files(
+            tmp_path, exclude_dirs=["vendor"], use_git=False
+        )
+        assert found == ["app.py"]
+
+    def test_deterministic_sorted(self, tmp_path: Path):
+        _write(tmp_path, "b.py", "x=1")
+        _write(tmp_path, "a.py", "x=1")
+        assert discover_repo_files(tmp_path, use_git=False) == [
+            "a.py", "b.py",
+        ]
+
+
+class TestFileSlice:
+    def test_python_outline_and_summary(self, tmp_path: Path):
+        _write(tmp_path, "pkg/a.py", PY_A)
+        fs = build_file_slice(tmp_path, "pkg/a.py")
+        assert fs is not None
+        rec = fs.record
+        assert rec.concept_id == "file:pkg/a.py"
+        assert rec.category == "module"
+        assert rec.summary == "Mod A does things."
+        assert "class Alpha: Alpha class." in rec.body
+        assert "def run(self, arg): Run it." in rec.body
+        assert "def helper(): Top-level helper." in rec.body
+        assert fs.imports == ["pkg.b"]
+        assert rec.token_count > 0
+
+    def test_markdown_summary(self, tmp_path: Path):
+        _write(tmp_path, "README.md", "# Project Title\n\nBody text.")
+        fs = build_file_slice(tmp_path, "README.md")
+        assert fs is not None
+        assert fs.record.category == "document"
+        assert fs.record.summary == "Project Title"
+
+    def test_config_category(self, tmp_path: Path):
+        _write(tmp_path, "settings.toml", "[tool]\nname = 'x'")
+        fs = build_file_slice(tmp_path, "settings.toml")
+        assert fs is not None
+        assert fs.record.category == "config"
+
+    def test_syntax_error_degrades_gracefully(self, tmp_path: Path):
+        _write(tmp_path, "bad.py", "def broken(:\n")
+        fs = build_file_slice(tmp_path, "bad.py")
+        assert fs is not None
+        assert fs.record.summary  # falls back, never empty
+        assert fs.imports == []
+
+    def test_binary_and_oversized_skipped(self, tmp_path: Path):
+        (tmp_path / "bin.py").write_bytes(b"\x00\x01\x02")
+        assert build_file_slice(tmp_path, "bin.py") is None
+        _write(tmp_path, "big.py", "x = 1\n" * 10)
+        assert build_file_slice(tmp_path, "big.py", max_file_bytes=10) is None
+        assert DEFAULT_MAX_FILE_BYTES > 10
+
+    def test_body_truncation(self, tmp_path: Path):
+        _write(tmp_path, "long.md", "word " * 5000)
+        fs = build_file_slice(tmp_path, "long.md", body_max_chars=100)
+        assert fs is not None
+        assert "(truncated)" in fs.record.body
+
+
+class TestDirPagesAndEdges:
+    def test_dir_pages_and_contains_edges(self, tmp_path: Path):
+        _write(tmp_path, "pkg/a.py", PY_A)
+        _write(tmp_path, "pkg/b.py", PY_B)
+        _write(tmp_path, "README.md", "# T")
+        scan = scan_repository(tmp_path, use_git=False)
+
+        dir_ids = {r.concept_id for r in scan.dir_records}
+        assert dir_concept_id("pkg") in dir_ids
+        assert dir_concept_id("") in dir_ids  # repo root
+        assert (
+            dir_concept_id("pkg"), file_concept_id("pkg/a.py"), "contains"
+        ) in scan.dir_edges
+        assert (
+            dir_concept_id(""), dir_concept_id("pkg"), "contains"
+        ) in scan.dir_edges
+
+    def test_dir_body_lists_children(self, tmp_path: Path):
+        _write(tmp_path, "pkg/a.py", PY_A)
+        files = [build_file_slice(tmp_path, "pkg/a.py")]
+        records, _ = build_dir_pages([f for f in files if f])
+        pkg = next(r for r in records if r.concept_id == "dir:pkg")
+        assert "file:pkg/a.py" in pkg.body
+        assert pkg.category == "overview"
+
+
+class TestImportEdges:
+    def test_flat_layout(self, tmp_path: Path):
+        _write(tmp_path, "pkg/a.py", PY_A)
+        _write(tmp_path, "pkg/b.py", PY_B)
+        scan = scan_repository(tmp_path, use_git=False)
+        assert (
+            file_concept_id("pkg/a.py"),
+            file_concept_id("pkg/b.py"),
+            "references",
+        ) in scan.import_edges
+
+    def test_src_layout_resolution(self, tmp_path: Path):
+        _write(
+            tmp_path,
+            "packages/lib/src/mypkg/mod.py",
+            '"""Target."""\nX = 1\n',
+        )
+        _write(tmp_path, "app.py", "from mypkg.mod import X\n")
+        scan = scan_repository(tmp_path, use_git=False)
+        assert (
+            file_concept_id("app.py"),
+            file_concept_id("packages/lib/src/mypkg/mod.py"),
+            "references",
+        ) in scan.import_edges
+
+    def test_package_prefix_fallback(self, tmp_path: Path):
+        _write(tmp_path, "pkg/__init__.py", '"""Pkg."""\n')
+        _write(tmp_path, "app.py", "import pkg.missing.deep\n")
+        scan = scan_repository(tmp_path, use_git=False)
+        # pkg.missing.deep has no file; falls back to the pkg package.
+        assert (
+            file_concept_id("app.py"),
+            file_concept_id("pkg/__init__.py"),
+            "references",
+        ) in scan.import_edges
+
+    def test_partial_scan_resolves_against_full_index(self, tmp_path: Path):
+        _write(tmp_path, "pkg/a.py", PY_A)
+        _write(tmp_path, "pkg/b.py", PY_B)
+        scan = scan_repository(
+            tmp_path, use_git=False, rel_paths=["pkg/a.py"]
+        )
+        assert [fs.rel_path for fs in scan.files] == ["pkg/a.py"]
+        # b.py was not scanned, but the import edge still resolves.
+        assert (
+            file_concept_id("pkg/a.py"),
+            file_concept_id("pkg/b.py"),
+            "references",
+        ) in scan.import_edges
+
+    def test_no_self_edges(self, tmp_path: Path):
+        _write(tmp_path, "pkg/__init__.py", "import pkg\n")
+        scan = scan_repository(tmp_path, use_git=False)
+        assert all(src != dst for src, dst, _ in scan.import_edges)

--- a/tests/knowledge/wiki/test_store.py
+++ b/tests/knowledge/wiki/test_store.py
@@ -254,6 +254,43 @@ class TestReplaceSourceSlice:
         await store.replace_source_slice("src-1", [_page("a2", source_id="src-1")])
         assert await store.get_page("b") is not None
 
+    @pytest.mark.asyncio
+    async def test_replace_preserves_incoming_edges_to_stable_ids(
+        self, store: BaseWikiStore
+    ):
+        """Incoming edges from other sources survive a re-ingest.
+
+        A directory 'contains' edge (or an importer's 'references'
+        edge) points INTO a page whose concept_id is stable across
+        re-ingests — replacing the page's source slice must not drop it.
+        """
+        await store.replace_source_slice("src-1", [_page("a", source_id="src-1")])
+        await store.upsert_pages([_page("dir-x")])
+        await store.add_edges([("dir-x", "a", "contains")])
+
+        await store.replace_source_slice("src-1", [_page("a", source_id="src-1")])
+
+        incoming = await store.neighbors("a", direction="in")
+        assert [(n["concept_id"], n["rel"]) for n in incoming] == [
+            ("dir-x", "contains")
+        ]
+
+    @pytest.mark.asyncio
+    async def test_replace_drops_incoming_edges_to_removed_ids(
+        self, store: BaseWikiStore
+    ):
+        """Incoming edges are NOT preserved when the target id vanishes."""
+        await store.replace_source_slice("src-1", [_page("a", source_id="src-1")])
+        await store.upsert_pages([_page("dir-x")])
+        await store.add_edges([("dir-x", "a", "contains")])
+
+        # Re-ingest produces a different page id — the old edge target
+        # is gone, so the edge must be cleaned up (no dangling edges).
+        await store.replace_source_slice("src-1", [_page("a2", source_id="src-1")])
+
+        stats = await store.stats()
+        assert stats["edges"] == 0
+
 
 class TestLintQueries:
     """Fast SQL lint checks."""


### PR DESCRIPTION
## Summary

Implements the complete `wikitoolkit` CLI and Claude Code integration for the LLM Wiki retrieval plane (FEAT-260). This adds a machine-first, offline codebase knowledge graph that agents and humans can query with scoped, token-budgeted context instead of grepping raw files.

## Key Changes

### Core CLI (`parrot/knowledge/wiki/cli.py`)
- **`wikitoolkit build`** — Deterministically scans the repository and builds the SQLite FTS5/BM25 retrieval plane with typed edges (contains, references)
- **`wikitoolkit query`** — Scoped question → token-budgeted context pack (respects budget, normalizes scores, packs results)
- **`wikitoolkit page`** — Read individual wiki pages with progressive disclosure
- **`wikitoolkit related`** — Follow typed edges from a page
- **`wikitoolkit upsert`** — Incrementally re-ingest changed files (tracked via SHA-1 + mtime)
- **`wikitoolkit status`** — Plane statistics and staleness report
- **`wikitoolkit export`** — Export wiki as human-readable markdown bundle
- Shared helpers for project resolution, store creation, and async operations

### Repository Scanner (`parrot/knowledge/wiki/repo_scan.py`)
- **Deterministic file discovery** — Respects `.gitignore` via `git ls-files`, falls back to filesystem walk
- **Per-file extraction** — Python AST outline (classes, functions, docstrings), markdown summaries, content head for FTS
- **Directory overview pages** — One `dir:<path>` page per directory listing children with summaries
- **Import edge derivation** — `references` edges between Python files from import statements (src-layout aware)
- **Configurable filtering** — Suffix-based (code/doc/config), directory exclusions, file size limits
- **Incremental tracking** — Source manifest with SHA-1 + mtime to skip unchanged files on rebuild

### Claude Code Integration
- **Installer** (`parrot/knowledge/wiki/claude_code/installer.py`) — Idempotent, marker-based installation:
  - Writes/updates managed CLAUDE.md section
  - Merges PreToolUse nudge hook into `.claude/settings.json`
  - Creates `/parrotwiki` slash command
  - Optionally installs git `post-commit` hook for auto-upsert
  - Optionally adds `.parrot/` to `.gitignore`
- **PreToolUse Hook** (`parrot/knowledge/wiki/claude_code/hook.py`) — Runtime hook invoked before search-style tool calls:
  - Never blocks (no permission decision)
  - Never breaks the session (fail-silent)
  - Throttled (configurable cooldown, atomic window claiming)
  - Fast (lightweight imports)
  - Nudges toward `wikitoolkit query` instead of raw file scanning
- **CLI** (`parrot/knowledge/wiki/claude_code/cli.py`) — `parrot claude install/uninstall/status` commands
- **Assets** (`parrot/knowledge/wiki/claude_code/assets.py`) — Managed file templates with marker delimiters

### Project Configuration (`parrot/knowledge/wiki/project.py`)
- **WikiProjectConfig** — Repository-level config (`.parrot/wiki.json`):
  - Wiki name, storage directory, backend (sqlite/memory)
  - Include/exclude filters, body/file size limits
  - Claude integration settings (nudge cooldown, tool matcher)
- **Helpers** — Project root detection, config load/save, path resolution

### Store Enhancements
- **`replace_source_slice`** — Preserves incoming edges from other sources during re-ingest (so directory `contains` edges survive file updates)
- **Incremental upsert** — Bulk writes on fresh planes, per-slice atomic replacements on existing planes

### Documentation
- **`docs/wiki-claude-code.md`** — User guide for the Claude Code integration (TL;DR, retrieval plane model, installation, usage examples)

https://claude.ai/code/session_01BgtqvuJCLuSmUjxm2W8ZFr