### PR TITLE
feat(crew): execution wiki — record intermediate results + tool calls, searchable via LLM Wiki plane

### DIFF
--- a/packages/ai-parrot/src/parrot/bots/flows/core/storage/persistence.py
+++ b/packages/ai-parrot/src/parrot/bots/flows/core/storage/persistence.py
@@ -22,6 +22,10 @@ via a fifth, optional attribute:
 
 Also accessed via ``getattr`` with a safe default of ``True``, so hosts
 that have not been wired for per-agent persistence keep working unchanged.
+
+Hosts may also expose an optional ``self._execution_wiki`` (an
+``ExecutionWikiRecorder``) — ``aclose()`` closes it when present, again via
+``getattr`` so unwired hosts keep working unchanged.
 """
 from __future__ import annotations
 
@@ -203,6 +207,16 @@ class PersistenceMixin:
                 logger.warning("Failed to close result storage: %s", exc)
             finally:
                 self._result_storage = None  # type: ignore[attr-defined]
+
+        # Execution wiki recorder (optional host attribute — AgentCrew).
+        wiki = getattr(self, "_execution_wiki", None)
+        if wiki is not None:
+            try:
+                await wiki.aclose()
+            except Exception as exc:
+                logger.warning("Failed to close execution wiki: %s", exc)
+            finally:
+                self._execution_wiki = None  # type: ignore[attr-defined]
 
     async def __aenter__(self) -> "PersistenceMixin":
         """Enter the async context manager — returns self."""

--- a/packages/ai-parrot/src/parrot/bots/flows/crew/crew.py
+++ b/packages/ai-parrot/src/parrot/bots/flows/crew/crew.py
@@ -22,9 +22,11 @@ from typing import (
     TYPE_CHECKING,
 )
 from datetime import datetime
+from pathlib import Path
 
 if TYPE_CHECKING:
     from ....models.crew_definition import CrewDefinition
+    from ....knowledge.wiki.execution import ExecutionWikiRecorder
 from ....models.crew_definition import ExecutionMode
 import contextlib
 import asyncio
@@ -53,6 +55,8 @@ from ..core.result import (
     FlowResult,
     NodeExecutionInfo,
     NodeResult,
+    _serialise_result_value,
+    _serialise_tool_calls,
     build_node_metadata,
     determine_run_status,
 )
@@ -156,6 +160,8 @@ class AgentCrew(PersistenceMixin, SynthesisMixin):
         persist_results: bool = True,
         result_storage: Union[str, "ResultStorage", None] = None,
         persist_agent_results: bool = True,
+        enable_execution_wiki: bool = True,
+        execution_wiki_path: Union[str, "Path", None] = None,
         tenant: Optional[str] = None,
         generate_infographic: bool = False,
         result_agent_name: str = "result-agent",
@@ -174,6 +180,14 @@ class AgentCrew(PersistenceMixin, SynthesisMixin):
             persist_agent_results: Granular opt-out for per-agent incremental
                 persistence only (FEAT-306); has no effect when
                 ``persist_results`` is already ``False``.
+            enable_execution_wiki: Granular opt-out for the execution wiki —
+                a per-crew WikiStore SQLite plane recording the run, every
+                intermediate agent result, and every tool-call result as
+                searchable pages (BM25 + optional embeddings). Active only
+                when ``persist_results`` is also ``True``.
+            execution_wiki_path: Storage directory for the execution wiki
+                (holds ``wiki.db``). Defaults to
+                ``{cwd}/.parrot/crew_wiki/<crew-slug>``.
             tenant: Tenant identifier for multi-tenant isolation (FEAT-307).
                 Persisted on every saved execution (see ``_save_result()``
                 call sites in ``run_*``). Defaults to ``"global"`` when not
@@ -220,9 +234,11 @@ class AgentCrew(PersistenceMixin, SynthesisMixin):
             dimension=dimension,
             index_type=index_type
         )
-        # Register Retrieval Tool
+        # Register Retrieval Tool — wiki_provider resolves lazily because the
+        # execution wiki recorder is created on first use.
         self.retrieval_tool = ResultRetrievalTool(
-            self.execution_memory
+            self.execution_memory,
+            wiki_provider=self._ensure_execution_wiki,
         )
         if self._llm:
             try:
@@ -250,6 +266,11 @@ class AgentCrew(PersistenceMixin, SynthesisMixin):
         self._persist_tasks: set[asyncio.Task] = set()
         # Granular per-agent persistence opt-out (FEAT-306)
         self._persist_agent_results: bool = persist_agent_results
+        # Execution wiki — searchable plane of runs / intermediate results /
+        # tool-call results. Recorder is created lazily on first write.
+        self._enable_execution_wiki: bool = enable_execution_wiki
+        self._execution_wiki_path: Union[str, "Path", None] = execution_wiki_path
+        self._execution_wiki: Optional["ExecutionWikiRecorder"] = None
         # Tenant identifier for multi-tenant isolation (FEAT-307)
         self._tenant: str = tenant or "global"
 
@@ -377,6 +398,107 @@ class AgentCrew(PersistenceMixin, SynthesisMixin):
                     "Error in crew lifecycle hook %r: %s", hook, exc
                 )
 
+    def _ensure_execution_wiki(self) -> Optional["ExecutionWikiRecorder"]:
+        """Lazily resolve the per-crew execution wiki recorder.
+
+        Mirrors ``PersistenceMixin._ensure_result_storage``: the recorder is
+        created on first use and cached. Returns ``None`` (and disables
+        further attempts on construction failure) when the execution wiki is
+        inactive — either ``persist_results`` or ``enable_execution_wiki``
+        is ``False``.
+
+        Returns:
+            The shared ``ExecutionWikiRecorder``, or ``None`` when disabled.
+        """
+        if not (self._persist_results and self._enable_execution_wiki):
+            return None
+        if self._execution_wiki is None:
+            try:
+                from ....knowledge.wiki.execution import (
+                    ExecutionWikiRecorder,
+                    default_wiki_dir,
+                )
+
+                storage_dir = (
+                    Path(self._execution_wiki_path)
+                    if self._execution_wiki_path
+                    else default_wiki_dir(self.name)
+                )
+                self._execution_wiki = ExecutionWikiRecorder(
+                    storage_dir,
+                    self.name,
+                    embedding_model=self.embedding_model,
+                )
+            except Exception as exc:
+                self.logger.warning(
+                    "Execution wiki unavailable, disabling: %s", exc
+                )
+                self._enable_execution_wiki = False
+                return None
+        return self._execution_wiki
+
+    def _schedule_wiki_write(self, coro) -> None:
+        """Schedule a wiki write as a FIFO-chained, tracked background task.
+
+        Wiki writes must not run concurrently: SQLite allows a single
+        writer (concurrent tasks would trip "database is locked"), and the
+        run lifecycle depends on ordering (``record_run_end`` appends to
+        the page written by ``record_run_start``). Each write therefore
+        awaits the previously scheduled one — errors in the predecessor
+        are swallowed so the chain never stalls. Tasks join the standard
+        ``_persist_tasks`` set so ``aclose()`` drains them.
+        """
+        prev = getattr(self, '_wiki_write_chain', None)
+
+        async def _chained():
+            if prev is not None:
+                # wait() never propagates the predecessor's exception or
+                # cancellation, so a failed write cannot stall the chain.
+                await asyncio.wait([prev])
+            await coro
+
+        _task = asyncio.get_running_loop().create_task(_chained())
+        self._wiki_write_chain = _task
+        self._persist_tasks.add(_task)
+        _task.add_done_callback(self._persist_tasks.discard)
+
+    def _schedule_wiki_run_start(
+        self,
+        execution_id: str,
+        method: str,
+        task: Any,
+        user_id: Optional[str],
+        session_id: Optional[str],
+    ) -> None:
+        """Record the start of a run in the execution wiki (fire-and-forget)."""
+        wiki = self._ensure_execution_wiki()
+        if wiki is None:
+            return
+        self._schedule_wiki_write(
+            wiki.record_run_start(
+                execution_id,
+                method=method,
+                task=task,
+                user_id=user_id,
+                session_id=session_id,
+                tenant=getattr(self, '_tenant', 'global'),
+            )
+        )
+
+    def _schedule_wiki_run_end(
+        self,
+        execution_id: str,
+        result: Any,
+        method: str,
+    ) -> None:
+        """Record the completion of a run in the execution wiki (fire-and-forget)."""
+        wiki = self._ensure_execution_wiki()
+        if wiki is None:
+            return
+        self._schedule_wiki_write(
+            wiki.record_run_end(execution_id, result, method=method)
+        )
+
     def _schedule_agent_persist(
         self,
         agent_result: "NodeResult",
@@ -392,6 +514,12 @@ class AgentCrew(PersistenceMixin, SynthesisMixin):
         used for the final crew-level persist, so ``aclose()`` drains both
         planes of writes.
 
+        Also extracts the agent's intermediate tool-call records (name,
+        arguments, result, error, timing) from ``agent_result.ai_message``
+        so they are (a) stored on the persisted ``crew_agent_results``
+        document and (b) recorded as searchable ``tool_result`` pages in
+        the execution wiki alongside the ``agent_result`` page.
+
         Args:
             agent_result: The ``NodeResult`` that was just added to
                 ``execution_memory``.
@@ -400,6 +528,13 @@ class AgentCrew(PersistenceMixin, SynthesisMixin):
             user_id: User identifier propagated to the stored document.
             session_id: Session identifier propagated to the stored document.
         """
+        # AgentResponse nests the AIMessage under `.response` — check both.
+        _raw_message = agent_result.ai_message
+        _raw_tc = getattr(_raw_message, 'tool_calls', None)
+        if not _raw_tc:
+            _inner = getattr(_raw_message, 'response', None)
+            _raw_tc = getattr(_inner, 'tool_calls', None)
+        tool_calls = _serialise_result_value(_serialise_tool_calls(_raw_tc))
         _agent_task = asyncio.get_running_loop().create_task(
             self._save_agent_result(
                 agent_result,
@@ -407,10 +542,19 @@ class AgentCrew(PersistenceMixin, SynthesisMixin):
                 method=method,
                 user_id=user_id,
                 session_id=session_id,
+                tool_calls=tool_calls,
             )
         )
         self._persist_tasks.add(_agent_task)
         _agent_task.add_done_callback(self._persist_tasks.discard)
+
+        wiki = self._ensure_execution_wiki()
+        if wiki is not None:
+            self._schedule_wiki_write(
+                wiki.record_agent_result(
+                    execution_id, agent_result, tool_calls=tool_calls
+                )
+            )
 
     async def _finalize_infographic(self, result: FlowResult) -> None:
         """Populate ``result.infographic``; swallow+log on failure (FEAT-308).
@@ -673,6 +817,16 @@ class AgentCrew(PersistenceMixin, SynthesisMixin):
             "result_agent_name",
             getattr(crew_def, "result_agent_name", "result-agent"),
         )
+        # Execution wiki wiring — read from the definition, allow call-time
+        # overrides via kwargs (mirrors the infographic wiring above).
+        enable_execution_wiki = kwargs.pop(
+            "enable_execution_wiki",
+            getattr(crew_def, "enable_execution_wiki", True),
+        )
+        execution_wiki_path = kwargs.pop(
+            "execution_wiki_path",
+            getattr(crew_def, "execution_wiki_path", None),
+        )
         crew = cls(
             name=crew_def.name,
             agents=agents,
@@ -680,6 +834,8 @@ class AgentCrew(PersistenceMixin, SynthesisMixin):
             tenant=tenant,
             generate_infographic=generate_infographic,
             result_agent_name=result_agent_name,
+            enable_execution_wiki=enable_execution_wiki,
+            execution_wiki_path=execution_wiki_path,
             **kwargs,
         )
 
@@ -1282,6 +1438,7 @@ class AgentCrew(PersistenceMixin, SynthesisMixin):
                         node_name=node.agent.name,
                         task=agent_input,
                         result=output,
+                        ai_message=raw_response,
                         metadata={
                             'success': True,
                             'mode': 'flow',
@@ -1693,6 +1850,9 @@ class AgentCrew(PersistenceMixin, SynthesisMixin):
         # Crew-level execution id (FEAT-306) — links this run's per-agent
         # writes to the consolidated CrewExecutionDocument.
         execution_id = str(uuid.uuid4())
+        self._schedule_wiki_run_start(
+            execution_id, 'run_sequential', query, user_id, session_id
+        )
 
         # Initialize execution memory
         self.execution_memory = ExecutionMemory(
@@ -1823,6 +1983,7 @@ Current task: {current_input}"""
                     node_name=agent.name,
                     task=agent_input,
                     result=result,
+                    ai_message=response,
                     metadata={
                         'success': True,
                         'mode': 'sequential',
@@ -1986,6 +2147,7 @@ Current task: {current_input}"""
         )
         self._persist_tasks.add(_persist_task)
         _persist_task.add_done_callback(self._persist_tasks.discard)
+        self._schedule_wiki_run_end(execution_id, result, 'run_sequential')
 
         return result
 
@@ -2068,6 +2230,9 @@ Current task: {current_input}"""
         # to avoid shadowing the per-iteration `execution_id` local variable
         # used below (f"{agent_id}#iteration{n}", an ExecutionMemory node key).
         crew_execution_id = str(uuid.uuid4())
+        self._schedule_wiki_run_start(
+            crew_execution_id, 'run_loop', initial_task, user_id, session_id
+        )
 
         # Initialize execution memory
         self.execution_memory = ExecutionMemory(
@@ -2300,6 +2465,7 @@ Current task: {current_input}"""
                         node_name=agent.name,
                         task=agent_input,
                         result=result,
+                        ai_message=response,
                         metadata={
                             'success': True,
                             'mode': 'loop',
@@ -2498,6 +2664,7 @@ Current task: {current_input}"""
         )
         self._persist_tasks.add(_persist_task)
         _persist_task.add_done_callback(self._persist_tasks.discard)
+        self._schedule_wiki_run_end(crew_execution_id, result, 'run_loop')
 
         return result
 
@@ -2548,6 +2715,9 @@ Current task: {current_input}"""
         # Crew-level execution id (FEAT-306).
         execution_id = str(uuid.uuid4())
         original_query = tasks[0]['query'] if tasks else ""
+        self._schedule_wiki_run_start(
+            execution_id, 'run_parallel', original_query, user_id, session_id
+        )
 
         # initialize execution log
         self.execution_memory = ExecutionMemory(
@@ -2728,6 +2898,7 @@ Current task: {current_input}"""
                     node_name=agent_name,
                     task=_query,
                     result=extracted_result,
+                    ai_message=result,
                     metadata={
                         'success': True,
                         'mode': 'parallel',
@@ -2855,6 +3026,7 @@ Current task: {current_input}"""
         )
         self._persist_tasks.add(_persist_task)
         _persist_task.add_done_callback(self._persist_tasks.discard)
+        self._schedule_wiki_run_end(execution_id, result, 'run_parallel')
 
         return result
 
@@ -2927,6 +3099,9 @@ Current task: {current_input}"""
         user_id = user_id or 'crew_user'
         # Crew-level execution id (FEAT-306).
         execution_id = str(uuid.uuid4())
+        self._schedule_wiki_run_start(
+            execution_id, 'run_flow', initial_task, user_id, session_id
+        )
 
         # Initialize execution memory
         self.execution_memory = ExecutionMemory(
@@ -3120,6 +3295,7 @@ Current task: {current_input}"""
         )
         self._persist_tasks.add(_persist_task)
         _persist_task.add_done_callback(self._persist_tasks.discard)
+        self._schedule_wiki_run_end(execution_id, result, 'run_flow')
 
         return result
 
@@ -3398,21 +3574,65 @@ Create a clear, well-structured response."""
             "execution_order": self.execution_memory.execution_order
         }
 
+    @property
+    def execution_wiki(self) -> Optional["ExecutionWikiRecorder"]:
+        """The crew's execution wiki recorder (``None`` when disabled)."""
+        return self._ensure_execution_wiki()
+
+    async def search_execution(
+        self,
+        query: str,
+        top_k: int = 10,
+        category: Optional[str] = None,
+        execution_id: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Search the execution wiki — runs, intermediate agent results, and
+        tool-call results across ALL recorded runs of this crew.
+
+        Combines FTS5/BM25 lexical search with an embedding-cosine leg when
+        the crew was built with an ``embedding_model``.
+
+        Args:
+            query: Natural-language query.
+            top_k: Maximum merged results.
+            category: Optional filter — ``"crew_run"``, ``"agent_result"``,
+                or ``"tool_result"``.
+            execution_id: Optional filter to a single run.
+
+        Returns:
+            Result dicts (``concept_id``, ``title``, ``category``,
+            ``summary``, ``score`` in [0, 1], ...), best first. Empty list
+            when the execution wiki is disabled.
+        """
+        wiki = self._ensure_execution_wiki()
+        if wiki is None:
+            return []
+        return await wiki.search(
+            query,
+            top_k=top_k,
+            category=category,
+            execution_id=execution_id,
+        )
+
     def _build_ask_context(
         self,
         semantic_results: List[Tuple[str, NodeResult, float]],
         textual_context: Dict[str, Any],
-        question: str
+        question: str,
+        research_matches: Optional[List[Dict[str, Any]]] = None,
     ) -> Dict[str, Any]:
         """
         Construye el contexto combinado para el LLM principal.
 
         Integra resultados de búsqueda semántica (FAISS), contexto textual
-        del CrewResult, información de agentes disponibles, y metadata de ejecución.
+        del CrewResult, matches del execution wiki (BM25 sobre resultados
+        intermedios y tool calls), información de agentes disponibles, y
+        metadata de ejecución.
         """
         context = {
             'question': question,
             'semantic_matches': [],
+            'research_matches': research_matches or [],
             'crew_summary': {},
             'agents_available': [],
             'execution_metadata': {}
@@ -3489,7 +3709,9 @@ You have access to:
 
 1. **Execution History**: Detailed results from each agent's previous execution
 2. **Semantic Search**: Relevant content chunks from agent outputs based on similarity
-3. **Crew Metadata**: Execution times, status, and workflow information
+3. **Research Wiki**: Matches from the execution wiki — intermediate agent
+   results and raw tool-call results recorded across runs
+4. **Crew Metadata**: Execution times, status, and workflow information
 
 **IMPORTANT GUIDELINES:**
 
@@ -3598,6 +3820,36 @@ analyze, and present information in the most helpful way for the user.
                 "*No semantically similar content found. Answering based on crew summary.*",
                 ""
             ])
+
+        # 1b. Matches del execution wiki (BM25 sobre resultados intermedios
+        # y tool calls de todas las ejecuciones registradas)
+        if research_matches := context.get('research_matches'):
+            prompt_parts.extend([
+                "---",
+                "",
+                "# Research Wiki Matches (intermediate results & tool calls)",
+                ""
+            ])
+            for i, match in enumerate(research_matches, 1):
+                prompt_parts.extend([
+                    f"## Research Match {i}: {match.get('title', '')} "
+                    f"[{match.get('category', '')}] "
+                    f"(Score: {match.get('score', 0)})",
+                    f"**Page**: {match.get('concept_id', '')}",
+                ])
+                if match.get('summary'):
+                    prompt_parts.append(
+                        f"**Summary**: {self._coerce_prompt_text(match['summary'])}"
+                    )
+                if match.get('content'):
+                    prompt_parts.extend([
+                        "",
+                        "**Content**:",
+                        "```",
+                        self._coerce_prompt_text(match['content']),
+                        "```",
+                    ])
+                prompt_parts.append("")
 
         # 2. Resumen del crew (si existe)
         crew_summary = context.get('crew_summary', {})
@@ -3818,11 +4070,27 @@ analyze, and present information in the most helpful way for the user.
             crew_result=self.last_crew_result
         )
 
+        # 3b. Búsqueda en el execution wiki (BM25 sobre resultados
+        # intermedios y tool-call results de todas las ejecuciones).
+        research_matches = await self.search_execution(question, top_k=top_k)
+        # Hydrate the top matches' bodies so tool outputs are answerable.
+        wiki = self._ensure_execution_wiki()
+        if wiki is not None:
+            for match in research_matches[:3]:
+                page = await wiki.get_page(match.get('concept_id', ''))
+                if page and page.get('body'):
+                    body = str(page['body'])
+                    match['content'] = (
+                        body[:2000] + "\n... [truncated]"
+                        if len(body) > 2000 else body
+                    )
+
         # 4. Construir contexto combinado
         context = self._build_ask_context(
             semantic_results=semantic_results,
             textual_context=textual_context,
-            question=question
+            question=question,
+            research_matches=research_matches,
         )
 
         # 5. Construir prompts
@@ -3878,6 +4146,15 @@ analyze, and present information in the most helpful way for the user.
                     {result.agent_id for _, result, _ in semantic_results}
                 ),
                 'textual_context_used': bool(textual_context.get('relevant_logs')),
+                'research_matches_count': len(research_matches),
+                'research_matches': [
+                    {
+                        'concept_id': m.get('concept_id'),
+                        'category': m.get('category'),
+                        'score': m.get('score'),
+                    }
+                    for m in research_matches
+                ],
                 'reexecution_enabled': enable_agent_reexecution,
                 'crew_name': self.name,
             }

--- a/packages/ai-parrot/src/parrot/bots/flows/tools.py
+++ b/packages/ai-parrot/src/parrot/bots/flows/tools.py
@@ -7,7 +7,7 @@ rather than the old ``bots/flow/storage``.
 The original ``bots/flow/tools.py`` is NOT modified — it remains for any
 remaining consumers until they are migrated.
 """
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from parrot.tools.abstract import AbstractTool
 from .core.storage.memory import ExecutionMemory
@@ -17,32 +17,46 @@ class ResultRetrievalTool(AbstractTool):
     """Retrieval Tool for flows (AgentCrew, AgentsFlow).
 
     Allows agents to look up detailed execution results from the
-    ``ExecutionMemory`` of a running flow.  Supports three actions:
+    ``ExecutionMemory`` of a running flow.  Supports five actions:
 
     - ``list_agents``: List all agents with available results.
     - ``get_agent_result``: Retrieve the full result text for a specific agent.
     - ``search_results``: Semantic search across stored results (requires
         FAISS to be configured on the ``ExecutionMemory``).
+    - ``search_research``: BM25 (+ optional embedding) search across the
+        crew's execution wiki — runs, intermediate agent results, and raw
+        tool-call results from ALL recorded runs (requires an execution
+        wiki to be enabled on the crew).
+    - ``read_research_page``: Read one execution-wiki page in full by its
+        ``concept_id`` (progressive disclosure after ``search_research``).
 
     Args:
         memory: The ``ExecutionMemory`` instance to query.
+        wiki_provider: Optional zero-arg callable returning the crew's
+            ``ExecutionWikiRecorder`` (or ``None``). A callable — not the
+            recorder itself — because the recorder is created lazily by
+            the crew.
     """
 
     name = "execution_context_tool"
     description = (
         "Retrieve detailed execution results and context from agents. "
         "Use this tool when you need more specific details about what an agent "
-        "found than what is provided in the summary."
+        "found than what is provided in the summary. The 'search_research' "
+        "action searches the execution wiki: intermediate agent results and "
+        "raw tool-call results recorded across all previous runs."
     )
 
     def __init__(
         self,
         memory: ExecutionMemory,
         *args,
+        wiki_provider: Optional[Callable[[], Any]] = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self.memory = memory
+        self._wiki_provider = wiki_provider
 
     def get_schema(self) -> Dict[str, Any]:
         """Return the JSON schema for this tool's parameters.
@@ -58,10 +72,18 @@ class ResultRetrievalTool(AbstractTool):
                 "properties": {
                     "action": {
                         "type": "string",
-                        "enum": ["list_agents", "get_agent_result", "search_results"],
+                        "enum": [
+                            "list_agents",
+                            "get_agent_result",
+                            "search_results",
+                            "search_research",
+                            "read_research_page",
+                        ],
                         "description": (
                             "Action to perform: list available agents, "
-                            "get specific result, or search across results."
+                            "get specific result, search across results, "
+                            "search the execution wiki (intermediate results "
+                            "+ tool calls), or read a wiki page in full."
                         ),
                     },
                     "agent_id": {
@@ -73,7 +95,16 @@ class ResultRetrievalTool(AbstractTool):
                     "query": {
                         "type": "string",
                         "description": (
-                            "Search query (required for 'search_results')"
+                            "Search query (required for 'search_results' "
+                            "and 'search_research')"
+                        ),
+                    },
+                    "page_id": {
+                        "type": "string",
+                        "description": (
+                            "Execution-wiki page concept_id (required for "
+                            "'read_research_page'; returned by "
+                            "'search_research')"
                         ),
                     },
                 },
@@ -81,19 +112,32 @@ class ResultRetrievalTool(AbstractTool):
             },
         }
 
+    def _get_wiki(self) -> Any:
+        """Resolve the execution wiki recorder via the provider (or None)."""
+        if self._wiki_provider is None:
+            return None
+        try:
+            return self._wiki_provider()
+        except Exception:  # noqa: BLE001 — tool must degrade gracefully
+            return None
+
     async def _execute(
         self,
         action: str,
         agent_id: Optional[str] = None,
         query: Optional[str] = None,
+        page_id: Optional[str] = None,
     ) -> str:
         """Execute the requested retrieval action.
 
         Args:
-            action: One of ``list_agents``, ``get_agent_result``, or
-                ``search_results``.
+            action: One of ``list_agents``, ``get_agent_result``,
+                ``search_results``, ``search_research``, or
+                ``read_research_page``.
             agent_id: Required when ``action == 'get_agent_result'``.
-            query: Required when ``action == 'search_results'``.
+            query: Required when ``action`` is ``'search_results'`` or
+                ``'search_research'``.
+            page_id: Required when ``action == 'read_research_page'``.
 
         Returns:
             Human-readable string with the requested information.
@@ -126,5 +170,52 @@ class ResultRetrievalTool(AbstractTool):
                 )
 
             return "\n".join(output)
+
+        elif action == "search_research":
+            if not query:
+                return "Error: query is required for search_research"
+
+            wiki = self._get_wiki()
+            if wiki is None:
+                return (
+                    "Execution wiki is not available "
+                    "(disabled or not yet initialised)."
+                )
+            hits = await wiki.search(query, top_k=5)
+            if not hits:
+                return f"No research-wiki matches found for '{query}'"
+
+            output = []
+            for hit in hits:
+                output.append(
+                    f"[{hit.get('category')}] {hit.get('title')} "
+                    f"(Score: {hit.get('score', 0):.2f})\n"
+                    f"page_id: {hit.get('concept_id')}\n"
+                    f"{hit.get('summary', '')}\n---"
+                )
+            output.append(
+                "Use action 'read_research_page' with a page_id to read a "
+                "full page (including raw tool-call results)."
+            )
+            return "\n".join(output)
+
+        elif action == "read_research_page":
+            if not page_id:
+                return "Error: page_id is required for read_research_page"
+
+            wiki = self._get_wiki()
+            if wiki is None:
+                return (
+                    "Execution wiki is not available "
+                    "(disabled or not yet initialised)."
+                )
+            page = await wiki.get_page(page_id)
+            if not page:
+                return f"No research-wiki page found for '{page_id}'"
+            return (
+                f"# {page.get('title')} [{page.get('concept_id')}]\n"
+                f"category: {page.get('category')}\n\n"
+                f"{page.get('body', '')}"
+            )
 
         return f"Unknown action: {action}"

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/__init__.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/__init__.py
@@ -71,6 +71,8 @@ _EXPORT_MODULES: dict[str, str] = {
     # Context packing
     "PackedContext": "parrot.knowledge.wiki.context",
     "pack_results": "parrot.knowledge.wiki.context",
+    # Crew/flow execution recording (FEAT: execution wiki)
+    "ExecutionWikiRecorder": "parrot.knowledge.wiki.execution",
 }
 
 __all__ = list(_EXPORT_MODULES)

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/execution.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/execution.py
@@ -1,0 +1,681 @@
+"""ExecutionWikiRecorder — crew/flow execution content in the LLM Wiki plane.
+
+Records everything an :class:`~parrot.bots.flows.crew.crew.AgentCrew` run
+produces — the run itself, every intermediate per-agent result, and every
+intermediate tool-call result — as wiki pages + typed edges in a per-crew
+:class:`~parrot.knowledge.wiki.store.SQLiteWikiStore` (``wiki.db``), so the
+existing wiki search machinery (FTS5/BM25 + optional embedding cosine) can
+search *inside the research*, not just over final outputs.
+
+Page/edge mapping (categories and relations are open strings — the machine
+plane has no enum ceremony):
+
+=====================  ===================================  ==============
+Content                concept_id                           category
+=====================  ===================================  ==============
+Crew run               ``run:{execution_id}``               ``crew_run``
+Agent/tool-node result ``agent:{execution_id}:{node_id}``   ``agent_result``
+Tool call              ``tool:{execution_id}:{node_id}:N``  ``tool_result``
+=====================  ===================================  ==============
+
+Edges: ``run —contains→ agent``, ``agent —follows→ previous agent``,
+``agent —used_tool→ tool``.  Every page carries
+``source_id = "exec:{execution_id}"`` so a single run can be filtered.
+
+The store is the standard wiki.db schema, so the ``wikitoolkit`` CLI reads
+it directly (``wikitoolkit query "<q>" --store <storage_dir>`` or
+``--path <storage_dir>`` — the recorder writes a minimal
+``.parrot/wiki.json`` next to the database for the latter).
+
+All public record methods are failure-tolerant: they log and continue,
+never raising into the crew's execution path (mirrors
+``PersistenceMixin._save_result`` error handling).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+from datamodel.parsers.json import json_encoder  # pylint: disable=E0611 # noqa
+
+from parrot.knowledge.wiki.project import (
+    WikiProjectConfig,
+    save_project_config,
+)
+from parrot.knowledge.wiki.store import (
+    BaseWikiStore,
+    WikiPageRecord,
+    create_wiki_store,
+    estimate_tokens,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Cap on stored page body length (matches ``WikiProjectConfig.body_max_chars``).
+DEFAULT_BODY_MAX_CHARS = 16_000
+
+#: Default relative location of a crew's execution wiki.
+DEFAULT_WIKI_ROOT = Path(".parrot") / "crew_wiki"
+
+# Open-string page categories used by the execution wiki.
+CATEGORY_RUN = "crew_run"
+CATEGORY_AGENT = "agent_result"
+CATEGORY_TOOL = "tool_result"
+
+# Open-string edge relations used by the execution wiki.
+REL_CONTAINS = "contains"
+REL_FOLLOWS = "follows"
+REL_USED_TOOL = "used_tool"
+
+
+def crew_slug(name: str) -> str:
+    """Return a filesystem-safe slug for a crew name.
+
+    Args:
+        name: Human-readable crew name.
+
+    Returns:
+        Lower-cased slug with non-alphanumeric runs collapsed to ``-``.
+    """
+    slug = "".join(c if c.isalnum() else "-" for c in (name or "crew").lower())
+    slug = "-".join(part for part in slug.split("-") if part)
+    return slug or "crew"
+
+
+def default_wiki_dir(crew_name: str, base_dir: Optional[Path] = None) -> Path:
+    """Resolve the default storage directory for a crew's execution wiki.
+
+    Args:
+        crew_name: Crew name (slugified for the directory).
+        base_dir: Base directory; defaults to the current working directory.
+
+    Returns:
+        ``{base_dir}/.parrot/crew_wiki/{crew-slug}``.
+    """
+    base = base_dir or Path.cwd()
+    return base / DEFAULT_WIKI_ROOT / crew_slug(crew_name)
+
+
+def _clip(text: str, limit: int) -> str:
+    """Clip ``text`` to ``limit`` characters with an ellipsis marker."""
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "\n... [truncated]"
+
+
+def _to_json_text(value: Any, limit: int) -> str:
+    """Render an arbitrary value as bounded JSON-ish text (never raises)."""
+    try:
+        rendered = json_encoder(value)
+    except Exception:  # noqa: BLE001 — body building must never raise
+        rendered = str(value)
+    if not isinstance(rendered, str):
+        rendered = str(rendered)
+    return _clip(rendered, limit)
+
+
+def _tool_call_field(call: Any, key: str, default: Any = None) -> Any:
+    """Read ``key`` from a tool-call record (dict or object)."""
+    if isinstance(call, dict):
+        return call.get(key, default)
+    return getattr(call, key, default)
+
+
+class ExecutionWikiRecorder:
+    """Persist crew execution content into a WikiStore SQLite plane.
+
+    One recorder per crew: pages from every run accumulate in the same
+    ``wiki.db`` (tagged by ``execution_id``), enabling cross-run research
+    search.
+
+    Args:
+        storage_dir: Directory holding ``wiki.db`` (created on demand).
+        crew_name: Crew name recorded in the wiki ``meta`` table.
+        embedding_model: Optional embedding source for the vector search
+            leg.  Accepts an async ``text -> list[float]`` callable, a
+            SentenceTransformer-like object (sync ``.encode``), or a
+            parrot ``EmbeddingModel`` wrapper.  BM25-only when ``None``
+            or unusable.
+        body_max_chars: Cap applied to stored page bodies.
+        write_project_config: When ``True`` (default), write a minimal
+            ``.parrot/wiki.json`` inside ``storage_dir`` so
+            ``wikitoolkit ... --path <storage_dir>`` resolves the plane.
+    """
+
+    def __init__(
+        self,
+        storage_dir: str | Path,
+        crew_name: str,
+        embedding_model: Any = None,
+        body_max_chars: int = DEFAULT_BODY_MAX_CHARS,
+        write_project_config: bool = True,
+    ) -> None:
+        self.storage_dir = Path(storage_dir)
+        self.crew_name = crew_name
+        self.body_max_chars = body_max_chars
+        self.logger = logging.getLogger(f"parrot.wiki.execution.{crew_name}")
+        self._store: BaseWikiStore = create_wiki_store(
+            self.storage_dir, wiki_name=f"crew:{crew_name}"
+        )
+        self._embedder = self._build_embedder(embedding_model)
+        self._embedding_model_name = (
+            type(embedding_model).__name__ if embedding_model is not None else ""
+        )
+        # Last agent page per execution_id — source of the `follows` edge.
+        self._last_agent_page: Dict[str, str] = {}
+        if write_project_config:
+            self._write_project_config()
+
+    # ------------------------------------------------------------------
+    # Setup helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def store(self) -> BaseWikiStore:
+        """The underlying wiki retrieval-plane store."""
+        return self._store
+
+    def _write_project_config(self) -> None:
+        """Write ``.parrot/wiki.json`` inside the storage dir (best-effort).
+
+        Makes the execution wiki a self-contained wiki project so
+        ``wikitoolkit query|page|related --path <storage_dir>`` works
+        without extra flags.
+        """
+        try:
+            config = WikiProjectConfig(
+                wiki_name=f"crew:{self.crew_name}",
+                storage_dir=".",
+            )
+            save_project_config(self.storage_dir, config)
+        except Exception as exc:  # noqa: BLE001 — config is a convenience
+            self.logger.debug("Could not write wiki project config: %s", exc)
+
+    def _build_embedder(
+        self, embedding_model: Any
+    ) -> Optional[Callable[[str], Awaitable[List[float]]]]:
+        """Normalise the accepted embedding sources into an async callable.
+
+        Args:
+            embedding_model: See class docstring.
+
+        Returns:
+            Async ``text -> vector`` callable, or ``None`` (BM25-only).
+        """
+        if embedding_model is None:
+            return None
+
+        # Async callable — use directly.
+        if callable(embedding_model) and inspect.iscoroutinefunction(
+            embedding_model
+        ):
+            return embedding_model
+
+        # Parrot EmbeddingModel wrapper — unwrap to the raw library model.
+        raw = embedding_model
+        try:
+            from parrot.embeddings.base import EmbeddingModel
+
+            if isinstance(raw, EmbeddingModel):
+                raw = raw.model
+        except ImportError:
+            pass
+
+        encode = getattr(raw, "encode", None)
+        if not callable(encode):
+            self.logger.debug(
+                "Embedding model %r has no usable encode(); BM25-only.",
+                type(embedding_model).__name__,
+            )
+            return None
+
+        async def _encode(text: str) -> List[float]:
+            # Offload CPU-bound encode to a thread (same pattern as
+            # VectorStoreMixin._vectorize_result_async).
+            vector = await asyncio.to_thread(encode, text)
+            if hasattr(vector, "tolist"):
+                vector = vector.tolist()
+            # SentenceTransformer.encode("text") returns a 1-D vector; a
+            # list input would return 2-D — flatten defensively.
+            if vector and isinstance(vector[0], (list, tuple)):
+                vector = vector[0]
+            return [float(v) for v in vector]
+
+        return _encode
+
+    # ------------------------------------------------------------------
+    # Page-identity helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def run_page_id(execution_id: str) -> str:
+        """concept_id of a run page."""
+        return f"run:{execution_id}"
+
+    @staticmethod
+    def agent_page_id(execution_id: str, node_id: str) -> str:
+        """concept_id of an agent-result page."""
+        return f"agent:{execution_id}:{node_id}"
+
+    @staticmethod
+    def tool_page_id(execution_id: str, node_id: str, call_id: str) -> str:
+        """concept_id of a tool-call page."""
+        return f"tool:{execution_id}:{node_id}:{call_id}"
+
+    @staticmethod
+    def _source_id(execution_id: str) -> str:
+        """source_id tag shared by every page of one run."""
+        return f"exec:{execution_id}"
+
+    # ------------------------------------------------------------------
+    # Recording API (failure-tolerant — never raises into a run)
+    # ------------------------------------------------------------------
+
+    async def record_run_start(
+        self,
+        execution_id: str,
+        method: str,
+        task: Any,
+        user_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        tenant: Optional[str] = None,
+    ) -> None:
+        """Record the start of a crew run as a ``crew_run`` page.
+
+        Args:
+            execution_id: Crew-level execution id.
+            method: Execution method name (e.g. ``"run_sequential"``).
+            task: The initial task/prompt (any type; rendered as text).
+            user_id: Optional user identifier.
+            session_id: Optional session identifier.
+            tenant: Optional tenant identifier.
+        """
+        try:
+            task_text = _to_json_text(task, self.body_max_chars // 4)
+            body = (
+                f"# Crew Run {execution_id}\n\n"
+                f"- **Crew**: {self.crew_name}\n"
+                f"- **Method**: {method}\n"
+                f"- **Status**: running\n"
+                f"- **User**: {user_id or 'unknown'}\n"
+                f"- **Session**: {session_id or 'unknown'}\n"
+                f"- **Tenant**: {tenant or 'global'}\n\n"
+                f"## Task\n\n{task_text}\n"
+            )
+            page = WikiPageRecord(
+                concept_id=self.run_page_id(execution_id),
+                title=f"{self.crew_name} run {execution_id} ({method})",
+                category=CATEGORY_RUN,
+                summary=_clip(task_text.replace("\n", " "), 400),
+                body=body,
+                source_id=self._source_id(execution_id),
+                token_count=estimate_tokens(body),
+            )
+            await self._store.upsert_pages([page])
+        except Exception as exc:  # noqa: BLE001
+            self.logger.warning(
+                "Failed to record run start for '%s': %s", execution_id, exc
+            )
+
+    async def record_agent_result(
+        self,
+        execution_id: str,
+        node_result: Any,
+        tool_calls: Optional[List[Any]] = None,
+    ) -> None:
+        """Record one agent's intermediate result and its tool calls.
+
+        Writes the ``agent_result`` page, one ``tool_result`` page per
+        tool call, and the ``contains``/``follows``/``used_tool`` edges.
+
+        Args:
+            execution_id: Crew-level execution id linking pages to the run.
+            node_result: The per-agent execution record (``NodeResult`` —
+                anything exposing ``node_id``/``agent_id``, ``node_name``,
+                ``task``, and ``to_text()``).
+            tool_calls: Serialised tool-call records (dicts or ``ToolCall``
+                objects with ``id``/``name``/``arguments``/``result``/
+                ``error``/``execution_time``).
+        """
+        try:
+            node_id = (
+                getattr(node_result, "node_id", None)
+                or getattr(node_result, "agent_id", "unknown")
+            )
+            node_name = (
+                getattr(node_result, "node_name", None)
+                or getattr(node_result, "agent_name", node_id)
+            )
+            task = str(getattr(node_result, "task", "") or "")
+            if hasattr(node_result, "to_text"):
+                body = str(node_result.to_text())
+            else:
+                body = _to_json_text(node_result, self.body_max_chars)
+            body = _clip(body, self.body_max_chars)
+
+            agent_cid = self.agent_page_id(execution_id, node_id)
+            run_cid = self.run_page_id(execution_id)
+            pages = [
+                WikiPageRecord(
+                    concept_id=agent_cid,
+                    title=f"{node_name} — result ({execution_id})",
+                    category=CATEGORY_AGENT,
+                    summary=_clip(task.replace("\n", " "), 400),
+                    body=body,
+                    source_id=self._source_id(execution_id),
+                    token_count=estimate_tokens(body),
+                )
+            ]
+            edges: List[tuple] = [(run_cid, agent_cid, REL_CONTAINS)]
+            if prev := self._last_agent_page.get(execution_id):
+                if prev != agent_cid:
+                    edges.append((agent_cid, prev, REL_FOLLOWS))
+            self._last_agent_page[execution_id] = agent_cid
+
+            for index, call in enumerate(tool_calls or []):
+                page, edge = self._build_tool_call_page(
+                    execution_id, node_id, node_name, agent_cid, index, call
+                )
+                pages.append(page)
+                edges.append(edge)
+
+            await self._store.upsert_pages(pages)
+            await self._store.add_edges(edges)
+            await self._embed_pages(pages)
+        except Exception as exc:  # noqa: BLE001
+            self.logger.warning(
+                "Failed to record agent result for '%s': %s", execution_id, exc
+            )
+
+    def _build_tool_call_page(
+        self,
+        execution_id: str,
+        node_id: str,
+        node_name: str,
+        agent_cid: str,
+        index: int,
+        call: Any,
+    ) -> tuple:
+        """Build the page + ``used_tool`` edge for one tool call."""
+        call_id = str(_tool_call_field(call, "id", None) or index)
+        tool_name = str(_tool_call_field(call, "name", "unknown_tool"))
+        arguments = _tool_call_field(call, "arguments", {})
+        result = _tool_call_field(call, "result", None)
+        error = _tool_call_field(call, "error", None)
+        exec_time = _tool_call_field(call, "execution_time", None)
+
+        section_limit = self.body_max_chars // 2
+        parts = [
+            f"# Tool Call: {tool_name}",
+            "",
+            f"- **Agent**: {node_name} ({node_id})",
+            f"- **Execution**: {execution_id}",
+            f"- **Call id**: {call_id}",
+        ]
+        if exec_time is not None:
+            parts.append(f"- **Execution Time**: {exec_time}")
+        parts += ["", "## Arguments", "", _to_json_text(arguments, section_limit)]
+        if error is not None:
+            parts += ["", "## Error", "", _clip(str(error), section_limit)]
+        if result is not None:
+            parts += ["", "## Result", "", _to_json_text(result, section_limit)]
+        body = "\n".join(parts)
+
+        tool_cid = self.tool_page_id(execution_id, node_id, call_id)
+        page = WikiPageRecord(
+            concept_id=tool_cid,
+            title=f"{tool_name} — tool call by {node_name} ({execution_id})",
+            category=CATEGORY_TOOL,
+            summary=_clip(
+                f"{tool_name}({_to_json_text(arguments, 200)})".replace("\n", " "),
+                400,
+            ),
+            body=body,
+            source_id=self._source_id(execution_id),
+            token_count=estimate_tokens(body),
+        )
+        return page, (agent_cid, tool_cid, REL_USED_TOOL)
+
+    async def record_run_end(
+        self,
+        execution_id: str,
+        result: Any,
+        method: Optional[str] = None,
+    ) -> None:
+        """Record the completion of a crew run on its ``crew_run`` page.
+
+        Args:
+            execution_id: Crew-level execution id.
+            result: The final result — a ``FlowResult`` (``output``,
+                ``summary``, ``status``, ``total_time``) or any object
+                rendered as text.
+            method: Optional execution method name (kept from run start
+                when omitted).
+        """
+        try:
+            run_cid = self.run_page_id(execution_id)
+            existing = await self._store.get_page(run_cid, include_body=True)
+
+            output = getattr(result, "output", result)
+            summary = str(getattr(result, "summary", "") or "")
+            status = getattr(result, "status", "completed")
+            status = getattr(status, "value", status)
+            total_time = getattr(result, "total_time", None)
+
+            output_text = _to_json_text(output, self.body_max_chars // 2)
+            parts = [
+                str(existing.get("body") or "") if existing else "",
+                "\n## Final Output\n",
+                output_text,
+            ]
+            if summary:
+                parts += ["\n## Summary\n", _clip(summary, self.body_max_chars // 4)]
+            parts.append(f"\n- **Final Status**: {status}")
+            if total_time is not None:
+                parts.append(f"- **Total Time**: {total_time:.2f}s")
+            body = _clip("\n".join(parts), self.body_max_chars)
+
+            title = (
+                str(existing.get("title"))
+                if existing
+                else f"{self.crew_name} run {execution_id}"
+                + (f" ({method})" if method else "")
+            )
+            page = WikiPageRecord(
+                concept_id=run_cid,
+                title=title,
+                category=CATEGORY_RUN,
+                summary=_clip(output_text.replace("\n", " "), 400),
+                body=body,
+                source_id=self._source_id(execution_id),
+                token_count=estimate_tokens(body),
+            )
+            await self._store.upsert_pages([page])
+            await self._embed_pages([page])
+            self._last_agent_page.pop(execution_id, None)
+        except Exception as exc:  # noqa: BLE001
+            self.logger.warning(
+                "Failed to record run end for '%s': %s", execution_id, exc
+            )
+
+    async def _embed_pages(self, pages: List[WikiPageRecord]) -> None:
+        """Store embeddings for ``pages`` when an embedder is configured."""
+        if self._embedder is None:
+            return
+        for page in pages:
+            try:
+                text = f"{page.title}\n{page.summary}\n{page.body}"
+                vector = await self._embedder(text[: self.body_max_chars])
+                if vector:
+                    await self._store.upsert_embedding(
+                        page.concept_id,
+                        vector,
+                        model=self._embedding_model_name,
+                    )
+            except Exception as exc:  # noqa: BLE001
+                self.logger.debug(
+                    "Embedding failed for page '%s': %s", page.concept_id, exc
+                )
+
+    # ------------------------------------------------------------------
+    # Search / read API
+    # ------------------------------------------------------------------
+
+    async def search(
+        self,
+        query: str,
+        top_k: int = 10,
+        category: Optional[str] = None,
+        execution_id: Optional[str] = None,
+        lexical_weight: float = 0.6,
+        vector_weight: float = 0.4,
+    ) -> List[Dict[str, Any]]:
+        """Search the execution wiki (BM25 + optional embedding cosine).
+
+        Args:
+            query: Natural-language query.
+            top_k: Maximum merged results.
+            category: Optional exact category filter (``crew_run`` /
+                ``agent_result`` / ``tool_result``).
+            execution_id: Optional filter to a single run.
+            lexical_weight: Weight of the BM25 leg when both legs return.
+            vector_weight: Weight of the cosine leg when both legs return.
+
+        Returns:
+            Result dicts (``concept_id``, ``title``, ``category``,
+            ``summary``, ``source_id``, ``token_count``, ``score`` in
+            [0, 1], ``source`` = ``"lexical"``/``"vector"``), best first.
+        """
+        source_filter = (
+            self._source_id(execution_id) if execution_id else None
+        )
+
+        lexical: List[Dict[str, Any]] = []
+        try:
+            rows = await self._store.search_fts(
+                query, category=category, limit=top_k
+            )
+            lexical = self._tag(self._normalize(rows), "lexical")
+        except Exception as exc:  # noqa: BLE001
+            self.logger.warning("Execution wiki FTS search failed: %s", exc)
+
+        vector: List[Dict[str, Any]] = []
+        if self._embedder is not None:
+            try:
+                embedding = await self._embedder(query)
+                rows = await self._store.search_vector(embedding, limit=top_k)
+                if category is not None:
+                    rows = [r for r in rows if r.get("category") == category]
+                vector = self._tag(self._normalize(rows), "vector")
+            except Exception as exc:  # noqa: BLE001
+                self.logger.warning(
+                    "Execution wiki vector search failed: %s", exc
+                )
+
+        # A lone leg gets full weight so scores stay meaningful in [0, 1].
+        if lexical and not vector:
+            lexical_weight = 1.0
+        elif vector and not lexical:
+            vector_weight = 1.0
+
+        merged: Dict[str, Dict[str, Any]] = {}
+        for group, weight in ((lexical, lexical_weight), (vector, vector_weight)):
+            for row in group:
+                cid = str(row.get("concept_id") or "")
+                if source_filter and row.get("source_id") != source_filter:
+                    continue
+                row = {**row, "score": round(float(row["score"]) * weight, 4)}
+                kept = merged.get(cid)
+                if kept is None or row["score"] > kept["score"]:
+                    merged[cid] = row
+        results = sorted(
+            merged.values(), key=lambda r: r["score"], reverse=True
+        )
+        return results[:top_k]
+
+    @staticmethod
+    def _normalize(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Min-max normalise raw store scores into [0, 1]."""
+        if not rows:
+            return []
+        scores = [float(r.get("score") or 0.0) for r in rows]
+        min_s, max_s = min(scores), max(scores)
+        span = max_s - min_s
+        return [
+            {**row, "score": (raw - min_s) / span if span > 0 else 1.0}
+            for row, raw in zip(rows, scores)
+        ]
+
+    @staticmethod
+    def _tag(
+        rows: List[Dict[str, Any]], source: str
+    ) -> List[Dict[str, Any]]:
+        """Tag each row with the search leg that produced it."""
+        return [{**row, "source": source} for row in rows]
+
+    async def get_page(
+        self, concept_id: str, include_body: bool = True
+    ) -> Optional[Dict[str, Any]]:
+        """Read one execution-wiki page (progressive disclosure).
+
+        Args:
+            concept_id: Page identity (``run:...``/``agent:...``/``tool:...``).
+            include_body: When ``False`` the body column is omitted.
+
+        Returns:
+            Page dict or ``None`` when not found / on error.
+        """
+        try:
+            return await self._store.get_page(
+                concept_id, include_body=include_body
+            )
+        except Exception as exc:  # noqa: BLE001
+            self.logger.warning("get_page('%s') failed: %s", concept_id, exc)
+            return None
+
+    async def related(
+        self,
+        concept_id: str,
+        rel: Optional[str] = None,
+        direction: str = "both",
+    ) -> List[Dict[str, Any]]:
+        """Follow typed edges from a page (``contains``/``follows``/``used_tool``).
+
+        Args:
+            concept_id: Seed page identity.
+            rel: Optional exact relation filter.
+            direction: ``"out"``, ``"in"``, or ``"both"``.
+
+        Returns:
+            Neighbour dicts (empty on error).
+        """
+        try:
+            return await self._store.neighbors(
+                concept_id, rel=rel, direction=direction
+            )
+        except Exception as exc:  # noqa: BLE001
+            self.logger.warning("related('%s') failed: %s", concept_id, exc)
+            return []
+
+    async def stats(self) -> Dict[str, Any]:
+        """Plane statistics (page/edge counts etc.); empty dict on error."""
+        try:
+            return await self._store.stats()
+        except Exception as exc:  # noqa: BLE001
+            self.logger.warning("stats() failed: %s", exc)
+            return {}
+
+    async def aclose(self) -> None:
+        """Release the underlying store (no-op for the SQLite backend)."""
+        close = getattr(self._store, "close", None)
+        if callable(close):
+            try:
+                maybe = close()
+                if inspect.isawaitable(maybe):
+                    await maybe
+            except Exception as exc:  # noqa: BLE001
+                self.logger.warning("Failed to close execution wiki: %s", exc)

--- a/packages/ai-parrot/src/parrot/models/crew_definition.py
+++ b/packages/ai-parrot/src/parrot/models/crew_definition.py
@@ -163,6 +163,11 @@ class CrewDefinition(BaseModel):
         result_agent_name: Registered name of the ResultAgent used to author
             the infographic's executive-summary tab. Only relevant when
             ``generate_infographic`` is ``True``.
+        enable_execution_wiki: Opt-out for the searchable per-crew execution
+            wiki (runs + intermediate results + tool-call results). Wired
+            through to ``AgentCrew`` by ``from_definition``.
+        execution_wiki_path: Optional storage directory for the execution
+            wiki's ``wiki.db``.
         metadata: Arbitrary extra data attached to the definition.
         created_at: Timestamp when this definition was created.
         updated_at: Timestamp of the most recent update.
@@ -219,6 +224,22 @@ class CrewDefinition(BaseModel):
         description=(
             "Registered ResultAgent name used to author the infographic's "
             "executive-summary tab (only used when generate_infographic=True)"
+        )
+    )
+    enable_execution_wiki: bool = Field(
+        default=True,
+        description=(
+            "When True (default), the crew records runs, intermediate agent "
+            "results, and tool-call results into a searchable per-crew "
+            "execution wiki (WikiStore SQLite plane). Active only while "
+            "result persistence is enabled on the crew."
+        )
+    )
+    execution_wiki_path: Optional[str] = Field(
+        default=None,
+        description=(
+            "Storage directory for the execution wiki (holds wiki.db). "
+            "Defaults to {cwd}/.parrot/crew_wiki/<crew-slug>."
         )
     )
     metadata: Dict[str, Any] = Field(

--- a/tests/bots/flows/core/storage/test_execution_wiki_wiring.py
+++ b/tests/bots/flows/core/storage/test_execution_wiki_wiring.py
@@ -1,0 +1,314 @@
+"""AgentCrew wiring tests for the execution wiki.
+
+Verifies that crew runs record the run, per-agent intermediate results,
+and intermediate tool-call results into the per-crew WikiStore SQLite
+plane; that the persisted ``crew_agent_results`` documents now carry the
+serialised tool calls; and that the search surfaces (``search_execution``,
+``ResultRetrievalTool.search_research``, the ``ask()`` prompt section)
+are wired.
+
+Uses the same local stub-agent + fake-storage pattern as
+``test_crew_agent_persistence.py`` (FEAT-306), extended with tool-call
+records on the stub responses.
+"""
+from __future__ import annotations
+
+import types
+from collections import defaultdict
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from parrot.bots.flows.core.storage.backends import ResultStorage
+from parrot.bots.flows.crew.crew import AgentCrew
+from parrot.models.basic import ToolCall
+
+
+class _DummyToolManager:
+    """Minimal ToolManager stand-in for crew tests."""
+
+    def __init__(self) -> None:
+        self._tools: Dict[str, Any] = {}
+
+    def add_tool(self, tool: Any, tool_name: Optional[str] = None) -> None:
+        name = tool_name or getattr(tool, "name", str(tool))
+        self._tools[name] = tool
+
+    def get_tool(self, tool_name: Optional[str]) -> Any:
+        return self._tools.get(tool_name or "")
+
+    def list_tools(self) -> List[str]:
+        return list(self._tools.keys())
+
+
+class _DummyAgent:
+    """Deterministic agent stub whose responses carry tool-call records."""
+
+    is_configured: bool = True
+    EVENT_STATUS_CHANGED: str = "status_changed"
+    EVENT_TASK_STARTED: str = "task_started"
+    EVENT_TASK_COMPLETED: str = "task_completed"
+    EVENT_TASK_FAILED: str = "task_failed"
+
+    def __init__(
+        self,
+        name: str,
+        response: str = "ok",
+        tool_calls: Optional[List[ToolCall]] = None,
+    ) -> None:
+        self._name = name
+        self._response = response
+        self._tool_calls = tool_calls or []
+        self.tool_manager = _DummyToolManager()
+        self.description = f"Agent {name}"
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    async def invoke(self, prompt: str, **kwargs: Any) -> Any:
+        return await self.ask(question=prompt, **kwargs)
+
+    async def ask(
+        self, prompt: str = "", *, question: str = "", **kwargs: Any
+    ) -> types.SimpleNamespace:
+        effective_prompt = question or prompt
+        return types.SimpleNamespace(
+            content=f"{self._response}: {effective_prompt[:40]}",
+            tool_calls=list(self._tool_calls),
+        )
+
+    def add_event_listener(self, event: str, handler: Any) -> None:
+        """No-op for tests."""
+
+    def as_tool(self, **kwargs: Any) -> None:
+        return None
+
+    async def configure(self) -> None:
+        """No-op configure."""
+
+
+class _FakeStorage(ResultStorage):
+    """In-memory ResultStorage capturing save() calls, per-collection."""
+
+    def __init__(self) -> None:
+        self.docs: Dict[str, list] = defaultdict(list)
+
+    async def save(self, collection: str, document: dict) -> None:
+        self.docs[collection].append(document)
+
+    async def close(self) -> None:
+        pass
+
+
+def _searcher_tool_call() -> ToolCall:
+    return ToolCall(
+        id="tc-1",
+        name="web_search",
+        arguments={"query": "quokka population"},
+        result="the quokka census counted 14000 individuals",
+        execution_time=0.7,
+    )
+
+
+def _crew(tmp_path, **kwargs) -> AgentCrew:
+    agents = kwargs.pop("agents", None) or [
+        _DummyAgent("a1", "first", tool_calls=[_searcher_tool_call()]),
+        _DummyAgent("a2", "second"),
+    ]
+    return AgentCrew(
+        name="wikicrew",
+        agents=agents,
+        auto_configure=False,
+        result_storage=kwargs.pop("result_storage", _FakeStorage()),
+        execution_wiki_path=tmp_path / "crew_wiki",
+        **kwargs,
+    )
+
+
+class TestSequentialRecording:
+    @pytest.mark.asyncio
+    async def test_run_records_pages_and_tool_calls(self, tmp_path):
+        crew = _crew(tmp_path)
+        result = await crew.run_sequential("task", generate_summary=False)
+        wiki = crew.execution_wiki
+        await crew.aclose()
+
+        eid = result.metadata["execution_id"]
+        run_page = await wiki.get_page(f"run:{eid}")
+        assert run_page is not None
+        assert "run_sequential" in run_page["body"]
+        # Final output appended by record_run_end
+        assert "Final Output" in run_page["body"]
+
+        agent_page = await wiki.get_page(f"agent:{eid}:a1")
+        assert agent_page is not None
+        assert agent_page["category"] == "agent_result"
+
+        tool_page = await wiki.get_page(f"tool:{eid}:a1:tc-1")
+        assert tool_page is not None
+        assert "quokka census" in tool_page["body"]
+
+    @pytest.mark.asyncio
+    async def test_search_execution_finds_tool_result(self, tmp_path):
+        crew = _crew(tmp_path)
+        await crew.run_sequential("task", generate_summary=False)
+        await crew.aclose()
+
+        hits = await crew.search_execution("quokka census")
+        assert hits
+        assert hits[0]["category"] == "tool_result"
+
+    @pytest.mark.asyncio
+    async def test_agent_docs_carry_tool_calls(self, tmp_path):
+        storage = _FakeStorage()
+        crew = _crew(tmp_path, result_storage=storage)
+        await crew.run_sequential("task", generate_summary=False)
+        await crew.aclose()
+
+        docs = {d["node_id"]: d for d in storage.docs["crew_agent_results"]}
+        a1_calls = docs["a1"]["tool_calls"]
+        assert len(a1_calls) == 1
+        assert a1_calls[0]["name"] == "web_search"
+        assert "quokka census" in a1_calls[0]["result"]
+        assert docs["a2"]["tool_calls"] == []
+
+
+class TestOtherModesRecording:
+    @pytest.mark.asyncio
+    async def test_parallel_records_agent_and_tool_pages(self, tmp_path):
+        crew = _crew(tmp_path)
+        result = await crew.run_parallel(
+            tasks=[
+                {"agent_id": "a1", "query": "q1"},
+                {"agent_id": "a2", "query": "q2"},
+            ],
+            generate_summary=False,
+        )
+        wiki = crew.execution_wiki
+        await crew.aclose()
+
+        eid = result.metadata["execution_id"]
+        assert await wiki.get_page(f"run:{eid}") is not None
+        assert await wiki.get_page(f"agent:{eid}:a1") is not None
+        assert await wiki.get_page(f"tool:{eid}:a1:tc-1") is not None
+
+    @pytest.mark.asyncio
+    async def test_flow_records_agent_and_tool_pages(self, tmp_path):
+        a1 = _DummyAgent("a1", "first", tool_calls=[_searcher_tool_call()])
+        a2 = _DummyAgent("a2", "second")
+        crew = _crew(tmp_path, agents=[a1, a2])
+        crew.task_flow(a1, a2)
+        result = await crew.run_flow("start", generate_summary=False)
+        wiki = crew.execution_wiki
+        await crew.aclose()
+
+        eid = result.metadata["execution_id"]
+        assert await wiki.get_page(f"run:{eid}") is not None
+        assert await wiki.get_page(f"agent:{eid}:a1") is not None
+        assert await wiki.get_page(f"tool:{eid}:a1:tc-1") is not None
+
+    @pytest.mark.asyncio
+    async def test_loop_records_iteration_pages(self, tmp_path):
+        crew = _crew(
+            tmp_path,
+            agents=[_DummyAgent("a1", "ok", tool_calls=[_searcher_tool_call()])],
+        )
+        # Sidestep the pre-existing frozen-FSM reassignment bug in run_loop
+        # (see test_crew_agent_persistence.py::TestRunLoopWiring).
+        crew.workflow_graph = {}
+        result = await crew.run_loop(
+            "start", condition="", max_iterations=1, generate_summary=False,
+        )
+        wiki = crew.execution_wiki
+        await crew.aclose()
+
+        eid = result.metadata["execution_id"]
+        assert await wiki.get_page(f"run:{eid}") is not None
+        # Loop node ids are "<agent>#iteration<n>"
+        assert await wiki.get_page(f"agent:{eid}:a1#iteration1") is not None
+
+
+class TestGating:
+    @pytest.mark.asyncio
+    async def test_enable_execution_wiki_false_writes_nothing(self, tmp_path):
+        crew = _crew(tmp_path, enable_execution_wiki=False)
+        await crew.run_sequential("task", generate_summary=False)
+        await crew.aclose()
+
+        assert not (tmp_path / "crew_wiki").exists()
+        assert await crew.search_execution("anything") == []
+
+    @pytest.mark.asyncio
+    async def test_persist_results_false_writes_nothing(self, tmp_path):
+        crew = _crew(tmp_path, persist_results=False)
+        await crew.run_sequential("task", generate_summary=False)
+        await crew.aclose()
+
+        assert not (tmp_path / "crew_wiki").exists()
+
+    @pytest.mark.asyncio
+    async def test_aclose_clears_recorder(self, tmp_path):
+        crew = _crew(tmp_path)
+        await crew.run_sequential("task", generate_summary=False)
+        assert crew._execution_wiki is not None
+        await crew.aclose()
+        assert crew._execution_wiki is None
+
+
+class TestSearchSurfaces:
+    @pytest.mark.asyncio
+    async def test_retrieval_tool_search_research_and_read_page(self, tmp_path):
+        crew = _crew(tmp_path)
+        result = await crew.run_sequential("task", generate_summary=False)
+        await crew.aclose()
+
+        out = await crew.retrieval_tool._execute(
+            action="search_research", query="quokka census"
+        )
+        assert "tool_result" in out
+        eid = result.metadata["execution_id"]
+        assert f"tool:{eid}:a1:tc-1" in out
+
+        page_out = await crew.retrieval_tool._execute(
+            action="read_research_page", page_id=f"tool:{eid}:a1:tc-1"
+        )
+        assert "quokka census counted 14000" in page_out
+
+    @pytest.mark.asyncio
+    async def test_retrieval_tool_degrades_when_wiki_disabled(self, tmp_path):
+        crew = _crew(tmp_path, enable_execution_wiki=False)
+        out = await crew.retrieval_tool._execute(
+            action="search_research", query="anything"
+        )
+        assert "not available" in out
+
+    @pytest.mark.asyncio
+    async def test_ask_prompt_renders_research_section(self, tmp_path):
+        crew = _crew(tmp_path)
+        context = crew._build_ask_context(
+            semantic_results=[],
+            textual_context={},
+            question="what about quokkas?",
+            research_matches=[{
+                "concept_id": "tool:e1:a1:tc-1",
+                "title": "web_search — tool call by a1 (e1)",
+                "category": "tool_result",
+                "summary": "web_search({...})",
+                "score": 0.91,
+                "content": "the quokka census counted 14000 individuals",
+            }],
+        )
+        prompt = crew._build_ask_user_prompt("what about quokkas?", context)
+        assert "Research Wiki Matches" in prompt
+        assert "tool:e1:a1:tc-1" in prompt
+        assert "quokka census counted 14000" in prompt
+
+    @pytest.mark.asyncio
+    async def test_ask_prompt_without_research_matches_unchanged(self, tmp_path):
+        crew = _crew(tmp_path, enable_execution_wiki=False)
+        context = crew._build_ask_context(
+            semantic_results=[], textual_context={}, question="q?",
+        )
+        prompt = crew._build_ask_user_prompt("q?", context)
+        assert "Research Wiki Matches" not in prompt

--- a/tests/knowledge/wiki/test_execution_recorder.py
+++ b/tests/knowledge/wiki/test_execution_recorder.py
@@ -1,0 +1,249 @@
+"""Unit tests for ExecutionWikiRecorder (crew execution wiki).
+
+Drives the recorder against a real temp-dir SQLite plane — page/edge
+mapping, BM25 search over tool-call results, run lifecycle updates, and
+``wikitoolkit`` CLI compatibility. No LLM, no crew.
+"""
+from __future__ import annotations
+
+import types
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from parrot.knowledge.wiki.cli import wiki
+from parrot.knowledge.wiki.execution import (
+    CATEGORY_AGENT,
+    CATEGORY_RUN,
+    CATEGORY_TOOL,
+    REL_CONTAINS,
+    REL_FOLLOWS,
+    REL_USED_TOOL,
+    ExecutionWikiRecorder,
+    crew_slug,
+    default_wiki_dir,
+)
+
+
+def _node_result(node_id: str, node_name: str, task: str, text: str):
+    """Minimal NodeResult stand-in exposing the attrs the recorder reads."""
+    ns = types.SimpleNamespace(node_id=node_id, node_name=node_name, task=task)
+    ns.to_text = lambda: text
+    return ns
+
+
+def _flow_result(output: str, summary: str = "", status: str = "completed"):
+    return types.SimpleNamespace(
+        output=output, summary=summary, status=status, total_time=1.5
+    )
+
+
+@pytest.fixture
+def recorder(tmp_path: Path) -> ExecutionWikiRecorder:
+    return ExecutionWikiRecorder(tmp_path / "wiki", "Research Crew")
+
+
+class TestSlugHelpers:
+    def test_crew_slug_normalises(self):
+        assert crew_slug("My Research Crew!") == "my-research-crew"
+        assert crew_slug("") == "crew"
+
+    def test_default_wiki_dir(self, tmp_path):
+        path = default_wiki_dir("My Crew", base_dir=tmp_path)
+        assert path == tmp_path / ".parrot" / "crew_wiki" / "my-crew"
+
+
+class TestRecording:
+    @pytest.mark.asyncio
+    async def test_run_start_creates_run_page(self, recorder):
+        await recorder.record_run_start(
+            "e1", method="run_sequential", task="find solar prices",
+            user_id="u1", session_id="s1", tenant="acme",
+        )
+        page = await recorder.get_page("run:e1")
+        assert page is not None
+        assert page["category"] == CATEGORY_RUN
+        assert page["source_id"] == "exec:e1"
+        assert "find solar prices" in page["body"]
+        assert "run_sequential" in page["body"]
+
+    @pytest.mark.asyncio
+    async def test_agent_result_pages_and_edges(self, recorder):
+        await recorder.record_run_start("e1", method="run_flow", task="t")
+        await recorder.record_agent_result(
+            "e1",
+            _node_result("a1", "Agent One", "research task",
+                         "Monocrystalline panels cost $0.28/W"),
+            tool_calls=[{
+                "id": "c1", "name": "web_search",
+                "arguments": {"q": "panel prices"},
+                "result": "Price index says $0.28 per watt",
+                "execution_time": 0.4,
+            }],
+        )
+        await recorder.record_agent_result(
+            "e1",
+            _node_result("a2", "Agent Two", "summarize", "Summary text"),
+        )
+
+        agent_page = await recorder.get_page("agent:e1:a1")
+        assert agent_page["category"] == CATEGORY_AGENT
+        assert "Monocrystalline" in agent_page["body"]
+
+        tool_page = await recorder.get_page("tool:e1:a1:c1")
+        assert tool_page["category"] == CATEGORY_TOOL
+        assert "Price index says $0.28 per watt" in tool_page["body"]
+        assert "web_search" in tool_page["title"]
+
+        rels = await recorder.related("agent:e1:a1")
+        by_rel = {(r["rel"], r["direction"]) for r in rels}
+        assert (REL_CONTAINS, "in") in by_rel      # run contains agent
+        assert (REL_USED_TOOL, "out") in by_rel    # agent used tool
+        assert (REL_FOLLOWS, "in") in by_rel       # a2 follows a1
+
+    @pytest.mark.asyncio
+    async def test_run_end_appends_final_output(self, recorder):
+        await recorder.record_run_start("e1", method="run_parallel", task="t")
+        await recorder.record_run_end("e1", _flow_result("THE FINAL ANSWER"))
+        page = await recorder.get_page("run:e1")
+        assert "THE FINAL ANSWER" in page["body"]
+        assert "completed" in page["body"]
+
+    @pytest.mark.asyncio
+    async def test_record_methods_never_raise(self, recorder):
+        # Objects missing every expected attribute must not break a run.
+        await recorder.record_agent_result("e1", object())
+        await recorder.record_run_end("e1", object())
+
+
+class TestSearch:
+    @pytest.mark.asyncio
+    async def test_bm25_finds_tool_call_content(self, recorder):
+        await recorder.record_run_start("e1", method="run_flow", task="t")
+        await recorder.record_agent_result(
+            "e1",
+            _node_result("a1", "Agent One", "task", "agent body"),
+            tool_calls=[{
+                "id": "c1", "name": "db_query",
+                "arguments": {"sql": "select revenue"},
+                "result": "quarterly revenue was 42 million zorkmids",
+            }],
+        )
+        hits = await recorder.search("zorkmids revenue", top_k=5)
+        assert hits
+        assert hits[0]["concept_id"] == "tool:e1:a1:c1"
+        assert hits[0]["category"] == CATEGORY_TOOL
+        assert 0.0 <= hits[0]["score"] <= 1.0
+        assert hits[0]["source"] == "lexical"
+
+    @pytest.mark.asyncio
+    async def test_category_filter(self, recorder):
+        await recorder.record_agent_result(
+            "e1",
+            _node_result("a1", "Agent One", "task", "shared keyword aardvark"),
+            tool_calls=[{
+                "id": "c1", "name": "t", "arguments": {},
+                "result": "shared keyword aardvark",
+            }],
+        )
+        hits = await recorder.search("aardvark", category=CATEGORY_AGENT)
+        assert hits
+        assert all(h["category"] == CATEGORY_AGENT for h in hits)
+
+    @pytest.mark.asyncio
+    async def test_execution_id_filter(self, recorder):
+        for eid in ("e1", "e2"):
+            await recorder.record_agent_result(
+                eid, _node_result("a1", "Agent", "task", "wombat sighting"),
+            )
+        hits = await recorder.search("wombat", execution_id="e2")
+        assert hits
+        assert all(h["source_id"] == "exec:e2" for h in hits)
+
+    @pytest.mark.asyncio
+    async def test_empty_wiki_returns_empty(self, recorder):
+        assert await recorder.search("anything") == []
+
+
+class TestEmbedder:
+    @pytest.mark.asyncio
+    async def test_async_embedder_populates_vector_leg(self, tmp_path):
+        async def embed(text: str):
+            # Toy 2-d embedding: [has-cat, has-dog]
+            return [float("cat" in text), float("dog" in text)]
+
+        rec = ExecutionWikiRecorder(
+            tmp_path / "wiki", "c", embedding_model=embed
+        )
+        await rec.record_agent_result(
+            "e1", _node_result("a1", "A", "t", "a page about cat behaviour"),
+        )
+        stats = await rec.stats()
+        assert stats["embeddings"] == 1
+        hits = await rec.search("cat", top_k=3)
+        assert hits
+        assert any(h["source"] == "vector" for h in hits) or hits
+
+    def test_unusable_embedding_model_degrades_to_bm25(self, tmp_path):
+        rec = ExecutionWikiRecorder(
+            tmp_path / "wiki", "c", embedding_model=object()
+        )
+        assert rec._embedder is None
+
+
+class TestCliCompat:
+    """The execution wiki is a standard wiki.db — wikitoolkit reads it.
+
+    These tests are synchronous: the click commands call ``asyncio.run``
+    internally, which cannot run inside pytest-asyncio's event loop.
+    """
+
+    @staticmethod
+    def _populate(storage: Path) -> None:
+        import asyncio
+
+        async def _fill():
+            rec = ExecutionWikiRecorder(storage, "cli-crew")
+            await rec.record_agent_result(
+                "e1",
+                _node_result("a1", "Agent", "t", "body"),
+                tool_calls=[{
+                    "id": "c1", "name": "search", "arguments": {},
+                    "result": "the xylophone factory output doubled",
+                }],
+            )
+
+        asyncio.run(_fill())
+
+    def test_query_via_store_flag(self, tmp_path):
+        storage = tmp_path / "wiki"
+        self._populate(storage)
+        runner = CliRunner()
+        result = runner.invoke(
+            wiki, ["query", "xylophone factory", "--store", str(storage)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "tool:e1:a1:c1" in result.output
+
+    def test_query_via_path_uses_written_config(self, tmp_path):
+        storage = tmp_path / "wiki"
+        self._populate(storage)
+        # Recorder wrote {storage}/.parrot/wiki.json with storage_dir="."
+        assert (storage / ".parrot" / "wiki.json").exists()
+        runner = CliRunner()
+        result = runner.invoke(
+            wiki, ["query", "xylophone factory", "--path", str(storage)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "tool:e1:a1:c1" in result.output
+
+    def test_page_command_reads_tool_page(self, tmp_path):
+        storage = tmp_path / "wiki"
+        self._populate(storage)
+        runner = CliRunner()
+        result = runner.invoke(
+            wiki, ["page", "tool:e1:a1:c1", "--store", str(storage)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "xylophone factory" in result.output


### PR DESCRIPTION
## Summary

AgentCrew already persists execution results and can answer questions about them via `ask()`, but retrieval only covered **final per-agent results** — and intermediate tool-call results (already captured as `ToolCall.arguments/result/error/execution_time` by every LLM client) were discarded before persistence.

This PR records everything a crew run produces into a per-crew **execution wiki** built on the existing LLM Wiki plane (FEAT-260 `SQLiteWikiStore` — FTS5/BM25 + optional embedding cosine), so the existing wiki machinery can search *inside the research*:

| Content | Page (`concept_id`) | Category | Edges |
|---|---|---|---|
| Crew run | `run:{execution_id}` | `crew_run` | — |
| Intermediate agent / tool-node result | `agent:{execution_id}:{node_id}` | `agent_result` | `run —contains→ agent`, `agent —follows→ prev` |
| Intermediate tool-call result | `tool:{execution_id}:{node_id}:{call_id}` | `tool_result` | `agent —used_tool→ tool` |

One `wiki.db` per crew accumulates all runs (pages tagged by `execution_id`); default location `{cwd}/.parrot/crew_wiki/<crew-slug>` (already gitignored), overridable.

## Changes

- **New `ExecutionWikiRecorder`** (`parrot/knowledge/wiki/execution.py`): failure-tolerant async recorder wrapping `create_wiki_store`; records run start/end, agent results, and tool calls as pages + typed edges; BM25 (+ optional vector) `search()` with category / execution_id filters; `get_page()` / `related()` progressive disclosure; exported lazily from `parrot.knowledge.wiki`.
- **AgentCrew wiring** across all four run modes (sequential, parallel, flow, loop): `NodeResult` now carries the raw response (`ai_message`), and `_schedule_agent_persist` — the single choke point — extracts tool calls once, stores them on the persisted `crew_agent_results` documents **and** records them in the wiki. Wiki writes are FIFO-chained background tasks (single SQLite writer; run-start ordered before run-end) drained by `aclose()`.
- **Search surfaces**:
  - `crew.search_execution(query, category=..., execution_id=...)` public API;
  - `ask()` blends research-wiki matches (top bodies hydrated, tool outputs included) into its context alongside the existing FAISS leg, with match metadata on the response;
  - `ResultRetrievalTool` gains `search_research` / `read_research_page` actions so agents can query the research themselves;
  - **wikitoolkit CLI compatibility**: standard wiki.db schema + a written `.parrot/wiki.json`, so `wikitoolkit query|page|related --path <dir>` (or `--store <dir>`) reads the plane directly.
- **Config**: `enable_execution_wiki` (default `True`, gated by `persist_results`) and `execution_wiki_path` on `AgentCrew` and `CrewDefinition`, wired through `from_definition`.

## Tests

- 28 new tests: `tests/knowledge/wiki/test_execution_recorder.py` (15 — page/edge mapping, BM25 search over tool results, filters, embedder leg, CLI compat via click runner) and `tests/bots/flows/core/storage/test_execution_wiki_wiring.py` (13 — recording across all four run modes, tool_calls on persisted agent docs, gating, aclose, search surfaces, ask-prompt section).
- All 84 existing crew regression tests green (`test_crew_{sequential,parallel,loop,flow,final,tool_node,ask_prompt}_regression.py`), full `tests/knowledge/wiki` + `tests/bots/flows` suite: 474 passed; the 16 remaining failures in `tests/bots/flows/core/storage/` are pre-existing on this base (stale `parrot.bots.orchestration` imports, redis/postgres env tests) — verified identical before these changes via `git stash`.
- During testing this surfaced (and fixed) a real concurrency issue: unchained fire-and-forget writes raced each other ("database is locked", run-end beating run-start); the FIFO chain resolves it — verified stable across repeated runs.

## Notes

- Writes are fire-and-forget; `await crew.aclose()` (or `async with crew:`) guarantees everything lands.
- `AgentsFlow` can adopt the recorder later with minimal work — it lives in shared code and `PersistenceMixin.aclose()` already handles it via `getattr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyqieVgRTao5WU2WX4a9ka

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyqieVgRTao5WU2WX4a9ka)_