### PR TITLE
feat: Unified Adaptive Cards Builder (AC 1.5)

### DIFF
--- a/packages/ai-parrot-integrations/src/parrot/integrations/msagentsdk/cards.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/msagentsdk/cards.py
@@ -1,8 +1,12 @@
 """Deterministic Adaptive Card renderer for the Semantic UI Model (FEAT-303).
 
 Pure functions turning a :class:`~parrot.integrations.msagentsdk.semantic.
-SemanticUIResult` into Adaptive Card 1.4 JSON (plain ``dict``), plus a total
+SemanticUIResult` into Adaptive Card 1.5 JSON (plain ``dict``), plus a total
 plain-text fallback (:func:`render_text`) that never raises.
+
+Delegates to the shared :mod:`parrot.outputs.cards` builder for card
+construction (AC 1.5, native ``Table`` element).  This module remains the
+public API surface for the ``msagentsdk`` bridge.
 
 This module must be importable without ``microsoft_agents.*`` installed —
 cards are plain dicts here; wrapping them in SDK ``Activity`` objects is the
@@ -21,21 +25,22 @@ from parrot.integrations.msagentsdk.semantic import (
     TablePayload,
     UIAction,
 )
-
-# Allowed common-denominator Adaptive Card 1.4 element/action types
-# (spec §2/§7): TextBlock, ColumnSet, Column, FactSet, Container,
-# Action.Submit, Action.OpenUrl.
-
-_LEVEL_TO_COLOR = {
-    "success": "Good",
-    "warning": "Warning",
-    "error": "Attention",
-    "info": "Default",
-}
-
-
-class CardRenderError(Exception):
-    """Raised when a `SemanticUIResult` cannot be rendered within limits."""
+from parrot.outputs.cards import (
+    ActionOpenUrl,
+    ActionSubmit,
+    CardSpec,
+    DetailField,
+    DetailSection,
+    MetricEntry,
+    MetricsSection,
+    StatusSection,
+    TableSection,
+    TextSection,
+    build_attachment,
+)
+from parrot.outputs.cards import CardRenderError  # noqa: F401 — re-export
+from parrot.outputs.cards import render as _card_render
+from parrot.outputs.cards import render_text as _card_render_text
 
 
 class _DefaultFormatDict(dict):
@@ -58,178 +63,20 @@ def _safe_format(template: str, params: dict[str, Any]) -> str:
         return template
 
 
-def _no_results_card(message: str = "No results.") -> dict:
-    """Build a minimal "no results" status-style card body."""
-    return {
-        "type": "Container",
-        "items": [
-            {
-                "type": "TextBlock",
-                "text": message,
-                "wrap": True,
-                "color": _LEVEL_TO_COLOR["info"],
-            }
-        ],
-    }
-
-
-def _render_table(result: SemanticUIResult, *, max_table_rows: int) -> dict:
-    payload = result.payload
-    assert isinstance(payload, TablePayload)
-
-    body: list[dict] = [
-        {"type": "TextBlock", "text": result.title, "wrap": True, "weight": "Bolder"}
-    ]
-    if result.summary:
-        body.append({"type": "TextBlock", "text": result.summary, "wrap": True})
-
-    if not payload.columns or not payload.rows:
-        body.append(_no_results_card())
-        return {"type": "AdaptiveCard", "version": "1.4", "body": body, "actions": []}
-
-    rows = payload.rows[:max_table_rows]
-
-    # Every column uses width "stretch": separate ColumnSets lay out
-    # independently, and "auto" would size each set's columns to their own
-    # content — misaligning header and rows. Equal-stretch columns split the
-    # card width identically in every ColumnSet, so the grid stays aligned.
-    n_cols = len(payload.columns)
-    header_columns = [
-        {
-            "type": "Column",
-            "width": "stretch",
-            "items": [
-                {"type": "TextBlock", "text": col, "wrap": True, "weight": "Bolder"}
-            ],
-        }
-        for col in payload.columns
-    ]
-    body.append({"type": "ColumnSet", "columns": header_columns})
-
-    for row in rows:
-        # Ragged rows would change the column count and break alignment —
-        # normalize each row to exactly n_cols cells.
-        cells = [str(cell) for cell in row[:n_cols]]
-        cells += [""] * (n_cols - len(cells))
-        row_columns = [
-            {
-                "type": "Column",
-                "width": "stretch",
-                "items": [{"type": "TextBlock", "text": cell, "wrap": True}],
-            }
-            for cell in cells
-        ]
-        body.append({"type": "ColumnSet", "columns": row_columns})
-
-    total = payload.total_rows if payload.total_rows is not None else len(
-        payload.rows
-    )
-    if total > len(rows):
-        body.append(
-            {
-                "type": "TextBlock",
-                "text": f"Showing {len(rows)} of {total}",
-                "wrap": True,
-                "isSubtle": True,
-            }
-        )
-
-    return {"type": "AdaptiveCard", "version": "1.4", "body": body, "actions": []}
-
-
-def _render_metrics(result: SemanticUIResult, *, max_table_rows: int) -> dict:
-    payload = result.payload
-    assert isinstance(payload, MetricsPayload)
-
-    body: list[dict] = [
-        {"type": "TextBlock", "text": result.title, "wrap": True, "weight": "Bolder"}
-    ]
-    if result.summary:
-        body.append({"type": "TextBlock", "text": result.summary, "wrap": True})
-
-    if not payload.metrics:
-        body.append(_no_results_card())
-        return {"type": "AdaptiveCard", "version": "1.4", "body": body, "actions": []}
-
-    facts = []
-    for metric in payload.metrics:
-        value = metric.value
-        if metric.delta:
-            value = f"{value} ({metric.delta})"
-        facts.append({"title": metric.label, "value": value})
-
-    body.append({"type": "FactSet", "facts": facts})
-    return {"type": "AdaptiveCard", "version": "1.4", "body": body, "actions": []}
-
-
-def _render_detail(result: SemanticUIResult, *, max_table_rows: int) -> dict:
-    payload = result.payload
-    assert isinstance(payload, DetailPayload)
-
-    body: list[dict] = [
-        {"type": "TextBlock", "text": result.title, "wrap": True, "weight": "Bolder"}
-    ]
-    if result.summary:
-        body.append({"type": "TextBlock", "text": result.summary, "wrap": True})
-
-    if not payload.fields:
-        body.append(_no_results_card())
-        return {"type": "AdaptiveCard", "version": "1.4", "body": body, "actions": []}
-
-    facts = [{"title": field.label, "value": field.value} for field in payload.fields]
-    body.append({"type": "FactSet", "facts": facts})
-    return {"type": "AdaptiveCard", "version": "1.4", "body": body, "actions": []}
-
-
-def _render_status(result: SemanticUIResult, *, max_table_rows: int) -> dict:
-    payload = result.payload
-    assert isinstance(payload, StatusPayload)
-
-    items: list[dict] = [
-        {
-            "type": "TextBlock",
-            "text": payload.message,
-            "wrap": True,
-            "weight": "Bolder",
-            "color": _LEVEL_TO_COLOR[payload.level],
-        }
-    ]
-    if payload.details:
-        items.append({"type": "TextBlock", "text": payload.details, "wrap": True})
-
-    body: list[dict] = [
-        {"type": "TextBlock", "text": result.title, "wrap": True, "weight": "Bolder"}
-    ]
-    if result.summary:
-        body.append({"type": "TextBlock", "text": result.summary, "wrap": True})
-    body.append({"type": "Container", "items": items})
-
-    return {"type": "AdaptiveCard", "version": "1.4", "body": body, "actions": []}
-
-
-_RENDERERS = {
-    "table": _render_table,
-    "metrics": _render_metrics,
-    "detail": _render_detail,
-    "status": _render_status,
-}
-
-
-def _build_action(action: UIAction) -> dict:
-    """Build an Adaptive Card action dict from a `UIAction`.
+def _ui_action_to_ac_action(action: UIAction) -> ActionOpenUrl | ActionSubmit:
+    """Map a :class:`UIAction` to the shared builder's action model.
 
     ``prompt_template`` actions render as ``Action.Submit`` with a
     ``msteams.messageBack`` payload; ``url`` actions render as
     ``Action.OpenUrl``.
     """
     if action.url is not None:
-        return {"type": "Action.OpenUrl", "title": action.title, "url": action.url}
+        return ActionOpenUrl(title=action.title, url=action.url)
 
     filled_prompt = _safe_format(action.prompt_template or "", action.params)
-    return {
-        "type": "Action.Submit",
-        "title": action.title,
-        "data": {
+    return ActionSubmit(
+        title=action.title,
+        data={
             "msteams": {
                 "type": "messageBack",
                 "text": filled_prompt,
@@ -237,7 +84,82 @@ def _build_action(action: UIAction) -> dict:
             },
             "feat303_prompt": filled_prompt,
         },
-    }
+    )
+
+
+def _semantic_to_card_spec(
+    result: SemanticUIResult,
+    *,
+    max_table_rows: int = 15,
+) -> CardSpec:
+    """Map a :class:`SemanticUIResult` to a :class:`CardSpec`.
+
+    Translates each semantic payload type into the corresponding
+    :mod:`parrot.outputs.cards` section model, preserving full fidelity
+    with the original per-type renderers.
+
+    Args:
+        result: The semantic UI result to convert.
+        max_table_rows: Maximum table rows before truncation.
+
+    Returns:
+        A :class:`CardSpec` ready for :func:`parrot.outputs.cards.render`.
+
+    Raises:
+        CardRenderError: If the ``result_type`` is unknown.
+    """
+    payload = result.payload
+    sections: list = []
+
+    if isinstance(payload, TablePayload):
+        if not payload.columns or not payload.rows:
+            sections.append(StatusSection(level="info", message="No results."))
+        else:
+            sections.append(TableSection(
+                columns=payload.columns,
+                rows=payload.rows,
+                total_rows=payload.total_rows,
+                max_display_rows=max_table_rows,
+            ))
+    elif isinstance(payload, MetricsPayload):
+        if not payload.metrics:
+            sections.append(StatusSection(level="info", message="No results."))
+        else:
+            sections.append(MetricsSection(
+                metrics=[
+                    MetricEntry(label=m.label, value=m.value, delta=m.delta)
+                    for m in payload.metrics
+                ],
+            ))
+    elif isinstance(payload, DetailPayload):
+        if not payload.fields:
+            sections.append(StatusSection(level="info", message="No results."))
+        else:
+            sections.append(DetailSection(
+                fields=[
+                    DetailField(label=f.label, value=f.value)
+                    for f in payload.fields
+                ],
+            ))
+    elif isinstance(payload, StatusPayload):
+        sections.append(StatusSection(
+            level=payload.level,
+            message=payload.message,
+            details=payload.details,
+        ))
+    else:
+        raise CardRenderError(
+            f"unknown result_type {getattr(payload, 'result_type', '?')!r}"
+        )
+
+    actions = [_ui_action_to_ac_action(a) for a in result.actions]
+
+    return CardSpec(
+        title=result.title,
+        summary=result.summary,
+        sections=sections,
+        actions=actions,
+    )
 
 
 def render_card(
@@ -246,7 +168,7 @@ def render_card(
     max_table_rows: int = 15,
     max_card_bytes: int = 25_000,
 ) -> dict:
-    """Render a `SemanticUIResult` as Adaptive Card 1.4 JSON.
+    """Render a `SemanticUIResult` as Adaptive Card 1.5 JSON.
 
     Args:
         result: The semantic UI result to render.
@@ -265,21 +187,8 @@ def render_card(
             (unknown `result_type` at runtime, or the serialized card
             exceeds `max_card_bytes`).
     """
-    renderer = _RENDERERS.get(result.payload.result_type)
-    if renderer is None:
-        raise CardRenderError(
-            f"unknown result_type {result.payload.result_type!r}"
-        )
-
-    card = renderer(result, max_table_rows=max_table_rows)
-    card["actions"] = [_build_action(action) for action in result.actions]
-
-    serialized_size = len(json.dumps(card).encode("utf-8"))
-    if serialized_size > max_card_bytes:
-        raise CardRenderError(
-            f"card size {serialized_size} exceeds max_card_bytes={max_card_bytes}"
-        )
-    return card
+    spec = _semantic_to_card_spec(result, max_table_rows=max_table_rows)
+    return _card_render(spec, max_card_bytes=max_card_bytes)
 
 
 def render_text(result: SemanticUIResult) -> str:
@@ -349,7 +258,7 @@ def render_text(result: SemanticUIResult) -> str:
 
 
 def render_text_card(text: str) -> dict:
-    """Wrap a plain/markdown text string in a minimal Adaptive Card 1.4.
+    """Wrap a plain/markdown text string in a minimal Adaptive Card 1.5.
 
     Teams renders markdown inside a ``TextBlock`` when ``markdown`` style
     is used, giving proper formatting (bold, lists, tables, code blocks)
@@ -361,17 +270,8 @@ def render_text_card(text: str) -> dict:
     Returns:
         The Adaptive Card as a plain dict (``type``, ``version``, ``body``).
     """
-    return {
-        "type": "AdaptiveCard",
-        "version": "1.4",
-        "body": [
-            {
-                "type": "TextBlock",
-                "text": text,
-                "wrap": True,
-            },
-        ],
-    }
+    spec = CardSpec(sections=[TextSection(text=text)])
+    return _card_render(spec)
 
 
 def render_data_card(
@@ -385,7 +285,7 @@ def render_data_card(
 
     Used when the agent response carries structured tabular data (e.g.
     ``PandasAgentResponse`` with a ``data`` field) that should be rendered
-    as a ColumnSet-based table in Teams rather than discarded.
+    as a native Table element in Teams rather than discarded.
 
     Args:
         text: Explanation / summary text shown above the table.
@@ -396,54 +296,22 @@ def render_data_card(
     Returns:
         The Adaptive Card as a plain dict.
     """
-    body: list[dict] = []
+    sections: list = []
     if text:
-        body.append({"type": "TextBlock", "text": text, "wrap": True})
+        sections.append(TextSection(text=text))
 
     if not columns or not rows:
-        body.append({"type": "TextBlock", "text": "No data.", "wrap": True})
-        return {"type": "AdaptiveCard", "version": "1.4", "body": body}
+        sections.append(TextSection(text="No data."))
+    else:
+        sections.append(TableSection(
+            columns=columns,
+            rows=[[str(c) for c in row] for row in rows],
+            total_rows=len(rows),
+            max_display_rows=max_table_rows,
+        ))
 
-    display_rows = rows[:max_table_rows]
-    n_cols = len(columns)
-
-    header_columns = [
-        {
-            "type": "Column",
-            "width": "stretch",
-            "items": [
-                {"type": "TextBlock", "text": col, "wrap": True, "weight": "Bolder"}
-            ],
-        }
-        for col in columns
-    ]
-    body.append({"type": "ColumnSet", "columns": header_columns})
-
-    for row in display_rows:
-        cells = [str(cell) for cell in row[:n_cols]]
-        cells += [""] * (n_cols - len(cells))
-        row_columns = [
-            {
-                "type": "Column",
-                "width": "stretch",
-                "items": [{"type": "TextBlock", "text": cell, "wrap": True}],
-            }
-            for cell in cells
-        ]
-        body.append({"type": "ColumnSet", "columns": row_columns})
-
-    total = len(rows)
-    if total > len(display_rows):
-        body.append(
-            {
-                "type": "TextBlock",
-                "text": f"Showing {len(display_rows)} of {total}",
-                "wrap": True,
-                "isSubtle": True,
-            }
-        )
-
-    return {"type": "AdaptiveCard", "version": "1.4", "body": body}
+    spec = CardSpec(sections=sections)
+    return _card_render(spec)
 
 
 def build_card_attachment(card: dict) -> dict:
@@ -457,7 +325,4 @@ def build_card_attachment(card: dict) -> dict:
         `"application/vnd.microsoft.card.adaptive"` and `content` set to
         `card`.
     """
-    return {
-        "contentType": "application/vnd.microsoft.card.adaptive",
-        "content": card,
-    }
+    return build_attachment(card)

--- a/packages/ai-parrot-integrations/src/parrot/integrations/msagentsdk/cards.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/msagentsdk/cards.py
@@ -14,7 +14,6 @@ bridge's job (``agent.py``, TASK-1753).
 """
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from parrot.integrations.msagentsdk.semantic import (
@@ -40,7 +39,6 @@ from parrot.outputs.cards import (
 )
 from parrot.outputs.cards import CardRenderError  # noqa: F401 — re-export
 from parrot.outputs.cards import render as _card_render
-from parrot.outputs.cards import render_text as _card_render_text
 
 
 class _DefaultFormatDict(dict):

--- a/packages/ai-parrot-integrations/src/parrot/integrations/msteams/hitl_cards.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/msteams/hitl_cards.py
@@ -24,16 +24,16 @@ Policy-bound interactions can optionally include an "Escalar" action
 (``data.value == ESCALATE_OPTION_KEY``) when the channel's
 ``render_reject_button`` flag is ``True``.
 
-OQ-5 resolution — ``form_schema`` → ``Input.*`` mapping:
-  - ``"string"`` → ``Input.Text`` (single-line unless ``multiline: true``)
-  - ``"text"`` or ``"textarea"`` → ``Input.Text`` (multiline)
-  - ``"integer"`` or ``"number"`` → ``Input.Number``
-  - ``"boolean"`` → ``Input.Toggle``
-  - ``"choice"`` or ``"select"`` → ``Input.ChoiceSet`` (compact, single)
-  - ``"multi_choice"`` or ``"multi_select"`` → ``Input.ChoiceSet`` (multi)
-  - ``"date"`` → ``Input.Date``
-  - ``"time"`` → ``Input.Time``
-  - unknown / unrecognised → ``Input.Text`` (fallback)
+OQ-5 resolution -- ``form_schema`` -> ``Input.*`` mapping:
+  - ``"string"`` -> ``Input.Text`` (single-line unless ``multiline: true``)
+  - ``"text"`` or ``"textarea"`` -> ``Input.Text`` (multiline)
+  - ``"integer"`` or ``"number"`` -> ``Input.Number``
+  - ``"boolean"`` -> ``Input.Toggle``
+  - ``"choice"`` or ``"select"`` -> ``Input.ChoiceSet`` (compact, single)
+  - ``"multi_choice"`` or ``"multi_select"`` -> ``Input.ChoiceSet`` (multi)
+  - ``"date"`` -> ``Input.Date``
+  - ``"time"`` -> ``Input.Time``
+  - unknown / unrecognised -> ``Input.Text`` (fallback)
   Field ``required`` and ``placeholder`` keys are forwarded if present.
 """
 from __future__ import annotations
@@ -42,14 +42,44 @@ from typing import Any, Dict, List, Optional
 
 from parrot.human.channels.base import ESCALATE_OPTION_KEY, escalate_option
 from parrot.human.models import ChoiceOption, HumanInteraction, InteractionType
+from parrot.outputs.cards import (
+    ActionSubmit,
+    CardSpec,
+    FormFieldSpec,
+    InputChoice,
+    InputChoiceSet,
+    InputText,
+    RawElementsSection,
+    TextBlock,
+    render as render_card,
+)
+from parrot.outputs.cards.elements import ACElement
+from parrot.outputs.cards.sections import CardSection
+from parrot.outputs.cards.sections import FormSection as CardFormSection
 
 # Adaptive Card schema version targeted.
 _AC_VERSION = "1.5"
 _AC_SCHEMA = "http://adaptivecards.io/schemas/adaptive-card.json"
 
+# Map HITL schema field types to shared-builder field type strings.
+_HITL_TYPE_MAP: Dict[str, str] = {
+    "string": "text",
+    "text": "text_area",
+    "textarea": "text_area",
+    "integer": "integer",
+    "number": "number",
+    "boolean": "boolean",
+    "choice": "select",
+    "select": "select",
+    "multi_choice": "multi_select",
+    "multi_select": "multi_select",
+    "date": "date",
+    "time": "time",
+}
+
 
 class TeamsCardRenderer:
-    """Pure renderer: :class:`~parrot.human.models.HumanInteraction` → Adaptive Card dict.
+    """Pure renderer: :class:`~parrot.human.models.HumanInteraction` -> Adaptive Card dict.
 
     All methods are synchronous (no I/O).  The returned dict is JSON-
     serialisable and can be passed directly to ``CardFactory.adaptive_card``
@@ -57,14 +87,14 @@ class TeamsCardRenderer:
 
     Args:
         render_reject_button: When ``True``, policy-bound interactions receive
-            an "↑ Escalar" submit action.  Matches
+            an "escalate" submit action.  Matches
             ``TeamsHumanChannel.render_reject_button``.
     """
 
     def __init__(self, render_reject_button: bool = True) -> None:
         self._render_reject_button = render_reject_button
 
-    # ── Public API ─────────────────────────────────────────────────────────
+    # -- Public API ---------------------------------------------------------
 
     def render(
         self,
@@ -88,31 +118,24 @@ class TeamsCardRenderer:
         )
         policy_bound = interaction.policy is not None
 
-        body, actions = self._render_by_type(interaction)
+        sections, actions = self._render_by_type(interaction)
 
         if should_escalate and policy_bound:
             escalate = escalate_option()
             actions.append(
-                {
-                    "type": "Action.Submit",
-                    "title": escalate.label,
-                    "style": "destructive",
-                    "data": {
+                ActionSubmit(
+                    title=escalate.label,
+                    style="destructive",
+                    data={
                         "hitl": True,
                         "interaction_id": interaction.interaction_id,
                         "value": ESCALATE_OPTION_KEY,
                     },
-                }
+                )
             )
 
-        card: Dict[str, Any] = {
-            "type": "AdaptiveCard",
-            "$schema": _AC_SCHEMA,
-            "version": _AC_VERSION,
-            "body": body,
-            "actions": actions,
-        }
-        return card
+        spec = CardSpec(sections=sections, actions=actions)
+        return render_card(spec)
 
     def render_disabled(
         self,
@@ -133,41 +156,42 @@ class TeamsCardRenderer:
         Returns:
             An Adaptive Card dict in a greyed-out disabled style.
         """
-        return {
-            "type": "AdaptiveCard",
-            "$schema": _AC_SCHEMA,
-            "version": _AC_VERSION,
-            "body": [
-                {
-                    "type": "TextBlock",
-                    "text": f"Esta solicitud ha expirado o fue retirada ({reason}).",
-                    "wrap": True,
-                    "isSubtle": True,
-                    "color": "Warning",
-                },
-                {
-                    "type": "TextBlock",
-                    "text": f"ID: {interaction_id}",
-                    "wrap": True,
-                    "isSubtle": True,
-                    "size": "Small",
-                },
+        spec = CardSpec(
+            sections=[
+                RawElementsSection(elements=[
+                    TextBlock(
+                        text=(
+                            "Esta solicitud ha expirado o fue retirada"
+                            f" ({reason})."
+                        ),
+                        is_subtle=True,
+                        color="Warning",
+                    ),
+                    TextBlock(
+                        text=f"ID: {interaction_id}",
+                        is_subtle=True,
+                        size="Small",
+                    ),
+                ]),
             ],
-            "actions": [],
-        }
+        )
+        card = render_card(spec)
+        # Ensure actions key is present for backward compatibility.
+        card["actions"] = []
+        return card
 
-    # ── Internal renderers per InteractionType ─────────────────────────────
+    # -- Internal renderers per InteractionType -----------------------------
 
     def _render_by_type(
         self, interaction: HumanInteraction
-    ) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    ) -> tuple[List[CardSection], List[ActionSubmit]]:
         """Dispatch to the correct renderer by interaction type.
 
         Args:
             interaction: The interaction to render.
 
         Returns:
-            A tuple ``(body_elements, action_list)``.
+            A tuple ``(card_sections, action_list)``.
         """
         itype = interaction.interaction_type
         dispatch = {
@@ -181,29 +205,27 @@ class TeamsCardRenderer:
         renderer = dispatch.get(itype, self._render_free_text)
         return renderer(interaction)  # type: ignore[operator]
 
-    def _header_block(self, question: str) -> Dict[str, Any]:
+    def _header_block(self, question: str) -> TextBlock:
         """Build a header TextBlock for the card body.
 
         Args:
             question: The interaction question text.
 
         Returns:
-            An Adaptive Card TextBlock element.
+            A TextBlock element.
         """
-        return {
-            "type": "TextBlock",
-            "text": question,
-            "wrap": True,
-            "weight": "Bolder",
-            "size": "Medium",
-        }
+        return TextBlock(
+            text=question,
+            weight="Bolder",
+            size="Medium",
+        )
 
     def _submit_action(
         self,
         interaction_id: str,
         title: str = "Enviar",
         extra_data: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    ) -> ActionSubmit:
         """Build a generic ``Action.Submit`` with HITL correlation data.
 
         Args:
@@ -212,7 +234,7 @@ class TeamsCardRenderer:
             extra_data: Additional fields merged into ``data``.
 
         Returns:
-            An Adaptive Card ``Action.Submit`` element.
+            An ActionSubmit instance.
         """
         data: Dict[str, Any] = {
             "hitl": True,
@@ -220,31 +242,43 @@ class TeamsCardRenderer:
         }
         if extra_data:
             data.update(extra_data)
-        return {
-            "type": "Action.Submit",
-            "title": title,
-            "data": data,
-        }
+        return ActionSubmit(title=title, data=data)
+
+    def _choice_entries(
+        self, options: Optional[List[ChoiceOption]]
+    ) -> List[InputChoice]:
+        """Convert ChoiceOption list to InputChoice instances.
+
+        Args:
+            options: List of choice options from the interaction.
+
+        Returns:
+            List of InputChoice instances.
+        """
+        if not options:
+            return []
+        return [InputChoice(title=opt.label, value=opt.key) for opt in options]
 
     def _render_free_text(
         self, interaction: HumanInteraction
-    ) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
-        """FREE_TEXT → multiline Input.Text + Submit.
+    ) -> tuple[List[CardSection], List[ActionSubmit]]:
+        """FREE_TEXT -> multiline Input.Text + Submit.
 
         Args:
             interaction: The pending interaction.
 
         Returns:
-            ``(body_elements, actions)``.
+            ``(card_sections, actions)``.
         """
-        body = [
-            self._header_block(interaction.question),
-            {
-                "type": "Input.Text",
-                "id": "response_text",
-                "placeholder": "Escribe tu respuesta…",
-                "isMultiline": True,
-            },
+        sections: List[CardSection] = [
+            RawElementsSection(elements=[
+                self._header_block(interaction.question),
+                InputText(
+                    id="response_text",
+                    placeholder="Escribe tu respuesta…",
+                    is_multiline=True,
+                ),
+            ]),
         ]
         actions = [
             self._submit_action(
@@ -253,79 +287,67 @@ class TeamsCardRenderer:
                 extra_data={"field": "response_text"},
             )
         ]
-        return body, actions
+        return sections, actions
 
     def _render_approval(
         self, interaction: HumanInteraction
-    ) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
-        """APPROVAL → two Action.Submit buttons (Approve / Reject).
+    ) -> tuple[List[CardSection], List[ActionSubmit]]:
+        """APPROVAL -> two Action.Submit buttons (Approve / Reject).
 
         Args:
             interaction: The pending interaction.
 
         Returns:
-            ``(body_elements, actions)``.
+            ``(card_sections, actions)``.
         """
-        body = [self._header_block(interaction.question)]
-        actions = [
-            {
-                "type": "Action.Submit",
-                "title": "Aprobar",
-                "style": "positive",
-                "data": {
+        sections: List[CardSection] = [
+            RawElementsSection(elements=[
+                self._header_block(interaction.question),
+            ]),
+        ]
+        actions: List[ActionSubmit] = [
+            ActionSubmit(
+                title="Aprobar",
+                style="positive",
+                data={
                     "hitl": True,
                     "interaction_id": interaction.interaction_id,
                     "value": "approve",
                 },
-            },
-            {
-                "type": "Action.Submit",
-                "title": "Rechazar",
-                "style": "destructive",
-                "data": {
+            ),
+            ActionSubmit(
+                title="Rechazar",
+                style="destructive",
+                data={
                     "hitl": True,
                     "interaction_id": interaction.interaction_id,
                     "value": "reject",
                 },
-            },
+            ),
         ]
-        return body, actions
-
-    def _choice_entries(
-        self, options: Optional[List[ChoiceOption]]
-    ) -> List[Dict[str, str]]:
-        """Convert ChoiceOption list to Adaptive Card choice format.
-
-        Args:
-            options: List of choice options from the interaction.
-
-        Returns:
-            List of ``{"title": ..., "value": ...}`` dicts.
-        """
-        if not options:
-            return []
-        return [{"title": opt.label, "value": opt.key} for opt in options]
+        return sections, actions
 
     def _render_single_choice(
         self, interaction: HumanInteraction
-    ) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
-        """SINGLE_CHOICE → compact Input.ChoiceSet + Submit.
+    ) -> tuple[List[CardSection], List[ActionSubmit]]:
+        """SINGLE_CHOICE -> compact Input.ChoiceSet + Submit.
 
         Args:
             interaction: The pending interaction.
 
         Returns:
-            ``(body_elements, actions)``.
+            ``(card_sections, actions)``.
         """
-        body = [
-            self._header_block(interaction.question),
-            {
-                "type": "Input.ChoiceSet",
-                "id": "selected_option",
-                "style": "compact",
-                "isMultiSelect": False,
-                "choices": self._choice_entries(interaction.options),
-            },
+        sections: List[CardSection] = [
+            RawElementsSection(elements=[
+                self._header_block(interaction.question),
+                InputChoiceSet(
+                    id="selected_option",
+                    style="compact",
+                    is_multi_select=False,
+                    choices=self._choice_entries(interaction.options),
+                ),
+            ]),
         ]
         actions = [
             self._submit_action(
@@ -334,63 +356,71 @@ class TeamsCardRenderer:
                 extra_data={"field": "selected_option"},
             )
         ]
-        return body, actions
+        return sections, actions
 
     def _render_multi_choice(
         self, interaction: HumanInteraction
-    ) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
-        """MULTI_CHOICE → Input.ChoiceSet (isMultiSelect=true) + Submit.
+    ) -> tuple[List[CardSection], List[ActionSubmit]]:
+        """MULTI_CHOICE -> Input.ChoiceSet (isMultiSelect=true) + Submit.
 
         Args:
             interaction: The pending interaction.
 
         Returns:
-            ``(body_elements, actions)``.
+            ``(card_sections, actions)``.
         """
-        body = [
-            self._header_block(interaction.question),
-            {
-                "type": "Input.ChoiceSet",
-                "id": "selected_options",
-                "style": "expanded",
-                "isMultiSelect": True,
-                "choices": self._choice_entries(interaction.options),
-            },
+        sections: List[CardSection] = [
+            RawElementsSection(elements=[
+                self._header_block(interaction.question),
+                InputChoiceSet(
+                    id="selected_options",
+                    style="expanded",
+                    is_multi_select=True,
+                    choices=self._choice_entries(interaction.options),
+                ),
+            ]),
         ]
         actions = [
             self._submit_action(
                 interaction.interaction_id,
-                title="Confirmar selección",
+                title="Confirmar seleccion",
                 extra_data={"field": "selected_options"},
             )
         ]
-        return body, actions
+        return sections, actions
 
     def _render_form(
         self, interaction: HumanInteraction
-    ) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
-        """FORM → form_schema → Input.* fields + Submit.
+    ) -> tuple[List[CardSection], List[ActionSubmit]]:
+        """FORM -> form_schema -> FormSection with FormFieldSpec entries + Submit.
 
         OQ-5 resolution: maps each schema field's ``type`` to the
-        appropriate Adaptive Card ``Input.*`` element.  See module
+        appropriate shared-builder ``FormFieldSpec``.  See module
         docstring for the full mapping table.
 
         Args:
             interaction: The pending interaction (must have ``form_schema``).
 
         Returns:
-            ``(body_elements, actions)``.
+            ``(card_sections, actions)``.
         """
-        body: List[Dict[str, Any]] = [self._header_block(interaction.question)]
+        sections: List[CardSection] = [
+            RawElementsSection(elements=[
+                self._header_block(interaction.question),
+            ]),
+        ]
 
         schema = interaction.form_schema or {}
         properties = schema.get("properties", schema)  # support nested or flat
 
+        field_specs: List[FormFieldSpec] = []
         for field_name, field_def in properties.items():
             if not isinstance(field_def, dict):
                 continue
-            input_el = self._form_field_to_input(field_name, field_def)
-            body.append(input_el)
+            field_specs.append(self._form_field_to_spec(field_name, field_def))
+
+        if field_specs:
+            sections.append(CardFormSection(fields=field_specs))
 
         actions = [
             self._submit_action(
@@ -398,133 +428,76 @@ class TeamsCardRenderer:
                 title="Enviar formulario",
             )
         ]
-        return body, actions
+        return sections, actions
 
-    def _form_field_to_input(
+    def _form_field_to_spec(
         self, field_id: str, field_def: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        """Convert a single form-schema field to an Adaptive Card Input element.
+    ) -> FormFieldSpec:
+        """Convert a single form-schema field to a FormFieldSpec.
 
         Args:
             field_id: JSON key for the field (used as the Input ``id``).
             field_def: Field definition dict with at least ``type``.
 
         Returns:
-            An Adaptive Card ``Input.*`` element dict.
+            A FormFieldSpec for the shared card builder.
         """
         field_type = field_def.get("type", "string").lower()
         label = field_def.get("label", field_def.get("title", field_id))
         placeholder = field_def.get("placeholder", "")
         is_required = field_def.get("required", False)
 
-        # Label block
-        label_block: Dict[str, Any] = {
-            "type": "TextBlock",
-            "text": label + (" *" if is_required else ""),
-            "wrap": True,
-            "size": "Small",
-            "weight": "Bolder",
-        }
+        mapped_type = _HITL_TYPE_MAP.get(field_type, "text")
 
-        # Input element based on type mapping (OQ-5)
-        if field_type in ("text", "textarea"):
-            input_el: Dict[str, Any] = {
-                "type": "Input.Text",
-                "id": field_id,
-                "isMultiline": True,
-                "placeholder": placeholder,
-                "isRequired": is_required,
-            }
-        elif field_type in ("integer", "number"):
-            input_el = {
-                "type": "Input.Number",
-                "id": field_id,
-                "placeholder": placeholder or "0",
-                "isRequired": is_required,
-            }
-        elif field_type == "boolean":
-            input_el = {
-                "type": "Input.Toggle",
-                "id": field_id,
-                "title": label,
-                "valueOn": "true",
-                "valueOff": "false",
-                "isRequired": is_required,
-            }
-        elif field_type in ("choice", "select"):
-            choices = [
-                {"title": c if isinstance(c, str) else c.get("label", c.get("value", str(c))),
-                 "value": c if isinstance(c, str) else c.get("value", str(c))}
-                for c in field_def.get("choices", field_def.get("enum", []))
+        # Build options for choice types
+        options: List[InputChoice] | None = None
+        if mapped_type in ("select", "multi_select"):
+            raw_choices = field_def.get("choices", field_def.get("enum", []))
+            options = [
+                InputChoice(
+                    title=(
+                        c
+                        if isinstance(c, str)
+                        else c.get("label", c.get("value", str(c)))
+                    ),
+                    value=(
+                        c if isinstance(c, str) else c.get("value", str(c))
+                    ),
+                )
+                for c in raw_choices
             ]
-            input_el = {
-                "type": "Input.ChoiceSet",
-                "id": field_id,
-                "style": "compact",
-                "isMultiSelect": False,
-                "choices": choices,
-                "isRequired": is_required,
-            }
-        elif field_type in ("multi_choice", "multi_select"):
-            choices = [
-                {"title": c if isinstance(c, str) else c.get("label", c.get("value", str(c))),
-                 "value": c if isinstance(c, str) else c.get("value", str(c))}
-                for c in field_def.get("choices", field_def.get("enum", []))
-            ]
-            input_el = {
-                "type": "Input.ChoiceSet",
-                "id": field_id,
-                "style": "expanded",
-                "isMultiSelect": True,
-                "choices": choices,
-                "isRequired": is_required,
-            }
-        elif field_type == "date":
-            input_el = {
-                "type": "Input.Date",
-                "id": field_id,
-                "placeholder": placeholder or "YYYY-MM-DD",
-                "isRequired": is_required,
-            }
-        elif field_type == "time":
-            input_el = {
-                "type": "Input.Time",
-                "id": field_id,
-                "placeholder": placeholder or "HH:MM",
-                "isRequired": is_required,
-            }
-        else:
-            # Default: single-line Input.Text (covers "string" and unknowns)
-            input_el = {
-                "type": "Input.Text",
-                "id": field_id,
-                "isMultiline": False,
-                "placeholder": placeholder,
-                "isRequired": is_required,
-            }
 
-        return {"type": "Container", "items": [label_block, input_el]}
+        return FormFieldSpec(
+            field_id=field_id,
+            field_type=mapped_type,
+            label=label + (" *" if is_required else ""),
+            placeholder=placeholder,
+            required=is_required,
+            options=options,
+            is_multiline=mapped_type == "text_area",
+        )
 
     def _render_poll(
         self, interaction: HumanInteraction
-    ) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
-        """POLL → compact Input.ChoiceSet + Submit (mirrors SINGLE_CHOICE visually).
+    ) -> tuple[List[CardSection], List[ActionSubmit]]:
+        """POLL -> compact Input.ChoiceSet + Submit (mirrors SINGLE_CHOICE visually).
 
         Args:
             interaction: The pending interaction.
 
         Returns:
-            ``(body_elements, actions)``.
+            ``(card_sections, actions)``.
         """
-        body = [
-            self._header_block(interaction.question),
-            {
-                "type": "Input.ChoiceSet",
-                "id": "poll_choice",
-                "style": "expanded",
-                "isMultiSelect": False,
-                "choices": self._choice_entries(interaction.options),
-            },
+        sections: List[CardSection] = [
+            RawElementsSection(elements=[
+                self._header_block(interaction.question),
+                InputChoiceSet(
+                    id="poll_choice",
+                    style="expanded",
+                    is_multi_select=False,
+                    choices=self._choice_entries(interaction.options),
+                ),
+            ]),
         ]
         actions = [
             self._submit_action(
@@ -533,4 +506,4 @@ class TeamsCardRenderer:
                 extra_data={"field": "poll_choice"},
             )
         ]
-        return body, actions
+        return sections, actions

--- a/packages/ai-parrot-integrations/src/parrot/integrations/msteams/hitl_cards.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/msteams/hitl_cards.py
@@ -383,7 +383,7 @@ class TeamsCardRenderer:
         actions = [
             self._submit_action(
                 interaction.interaction_id,
-                title="Confirmar seleccion",
+                title="Confirmar selección",
                 extra_data={"field": "selected_options"},
             )
         ]

--- a/packages/ai-parrot-integrations/src/parrot/integrations/msteams/wrapper.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/msteams/wrapper.py
@@ -33,6 +33,17 @@ from .commands.jira_commands import register_jira_commands
 from .oauth_callback import MSTeamsOAuthNotifier
 from parrot.forms import FormSchema
 from parrot.forms import FormCache
+from parrot.outputs.cards import (
+    AutoCollapsePolicy,
+    CardSpec,
+    CodeSection,
+    ImageEntry,
+    ImageSection,
+    TableSection,
+    TextSection,
+    markdown_to_sections,
+    render,
+)
 from .voice import VoiceTranscriber, VoiceTranscriberConfig
 
 from typing import TYPE_CHECKING
@@ -1063,440 +1074,151 @@ class MSTeamsAgentWrapper(ActivityHandler, MessageHandler):
             return ""
         return parsed.text
 
-    def _build_adaptive_card(self, parsed: ParsedResponse) -> Dict[str, Any]:
-        """
-        Build an Adaptive Card from parsed response.
+    def _parsed_to_card_spec(self, parsed: ParsedResponse) -> CardSpec:
+        """Map a ParsedResponse to a CardSpec for the shared card builder.
 
-        Features:
-        - Text with markdown support (TextBlock wrap)
-        - Code blocks with monospace font
-        - Tables as FactSet or ColumnSet
-        - Images inline in card
+        Translates each ParsedResponse field into the corresponding
+        CardSection model from ``parrot.outputs.cards``.
 
         Args:
-            parsed: The parsed response content
+            parsed: The parsed response content.
 
         Returns:
-            Adaptive Card JSON structure
+            A CardSpec ready to be rendered via ``render()``.
         """
-        card_body = []
+        sections: list = []
 
-        # Add main text content
-        # Add main text content
+        # Main text content — markdown_to_sections splits text into
+        # TextSection / TableSection / CodeSection / ImageSection blocks.
         if parsed.text:
-            # Parse for markdown tables
-            content_elements = self._render_markdown_content(parsed.text)
-            card_body.extend(content_elements)
+            sections.extend(markdown_to_sections(parsed.text))
 
-        # Add code block if present
+        # Explicit code block from parsed response
         if parsed.has_code:
-            # Add separator
-            card_body.append({
-                "type": "TextBlock",
-                "text": f"**Code** ({parsed.code_language or 'text'}):",
-                "wrap": True,
-                "weight": "Bolder",
-                "spacing": "Medium"
-            })
+            label = f"**Code** ({parsed.code_language or 'text'}):"
+            sections.append(CodeSection(
+                code=parsed.code,
+                language=parsed.code_language,
+                label=label,
+                spacing="Medium",
+            ))
 
-            # Code in monospace TextBlock
-            card_body.append({
-                "type": "TextBlock",
-                "text": parsed.code,
-                "wrap": True,
-                "fontType": "Monospace",
-                "spacing": "Small"
-            })
-
-        # Add table if present
+        # Table data (pandas DataFrame)
         if parsed.has_table and parsed.table_data is not None:
             try:
                 df = parsed.table_data
-                columns = list(df.columns)
-
-                # Create header row
-                header_columns = [
-                    {
-                        "type": "Column",
-                        "width": "stretch",
-                        "items": [{
-                            "type": "TextBlock",
-                            "text": str(col),
-                            "weight": "Bolder",
-                            "wrap": True
-                        }]
-                    }
-                    for col in columns
+                columns = [str(c) for c in df.columns]
+                rows = [
+                    [str(val) for val in row.values]
+                    for _, row in df.head(20).iterrows()
                 ]
-
-                card_body.append({
-                    "type": "ColumnSet",
-                    "columns": header_columns,
-                    "spacing": "Medium"
-                })
-
-                # Add data rows (limit to 20 for card size)
-                for idx, (_, row) in enumerate(df.head(20).iterrows()):
-                    row_columns = [
-                        {
-                            "type": "Column",
-                            "width": "stretch",
-                            "items": [{
-                                "type": "TextBlock",
-                                "text": str(val),
-                                "wrap": True
-                            }]
-                        }
-                        for val in row.values
-                    ]
-                    card_body.append({
-                        "type": "ColumnSet",
-                        "columns": row_columns,
-                        "separator": idx == 0
-                    })
-
-                if len(df) > 20:
-                    card_body.append({
-                        "type": "TextBlock",
-                        "text": f"*... and {len(df) - 20} more rows*",
-                        "wrap": True,
-                        "isSubtle": True
-                    })
-
+                sections.append(TableSection(
+                    columns=columns,
+                    rows=rows,
+                    total_rows=len(df),
+                    max_display_rows=20,
+                    spacing="Medium",
+                ))
             except Exception:
-                # Fallback to markdown table
+                # Fallback to monospace markdown table
                 if parsed.table_markdown:
-                    card_body.append({
-                        "type": "TextBlock",
-                        "text": parsed.table_markdown,
-                        "wrap": True,
-                        "fontType": "Monospace"
-                    })
+                    sections.append(TextSection(
+                        text=parsed.table_markdown,
+                        role="monospace",
+                    ))
         elif parsed.table_markdown:
-            # If only markdown table available
-            card_body.append({
-                "type": "TextBlock",
-                "text": parsed.table_markdown,
-                "wrap": True,
-                "fontType": "Monospace"
-            })
+            sections.append(TextSection(
+                text=parsed.table_markdown,
+                role="monospace",
+            ))
 
-
-
-        # Add charts as images inline
+        # Charts as images
         if hasattr(parsed, 'charts') and parsed.charts:
             for chart in parsed.charts:
                 try:
-                    # Add chart title
-                    card_body.append({
-                        "type": "TextBlock",
-                        "text": f"📊 {chart.title}",
-                        "weight": "Bolder",
-                        "spacing": "Medium",
-                        "size": "Medium"
-                    })
-                    
-                    # Convert chart to base64 data URI
-                    data_uri = self._chart_to_data_uri(chart)
-                    
-                    # Add image element
-                    card_body.append({
-                        "type": "Image",
-                        "url": data_uri,
-                        "size": "Large",
-                        "horizontalAlignment": "Center",
-                        "spacing": "Small",
-                        "altText": f"Chart: {chart.title}"
-                    })
-                    
-                    # Add chart type info if available
-                    if chart.chart_type and chart.chart_type != "unknown":
-                        card_body.append({
-                            "type": "TextBlock",
-                            "text": f"*{chart.chart_type.replace('_', ' ').title()} Chart*",
-                            "isSubtle": True,
-                            "size": "Small",
-                            "horizontalAlignment": "Center"
-                        })
-                    
-                    self.logger.info("Added chart to Adaptive Card: %s", chart.title)
-                    
+                    data_uri = chart.to_data_uri()
+                    entries = [ImageEntry(
+                        url=data_uri,
+                        alt_text=f"Chart: {chart.title}",
+                        size="Large",
+                    )]
+                    sections.append(ImageSection(
+                        images=entries,
+                        spacing="Medium",
+                    ))
+                    self.logger.info("Added chart to card spec: %s", chart.title)
                 except Exception as e:
-                    self.logger.error("Failed to embed chart '%s': %s", chart.title, e)
-                    # Add error placeholder
-                    card_body.append({
-                        "type": "TextBlock",
-                        "text": f"⚠️ Chart '{chart.title}' could not be displayed",
-                        "color": "Warning",
-                        "wrap": True
-                    })
+                    self.logger.error(
+                        "Failed to embed chart '%s': %s", chart.title, e
+                    )
+                    sections.append(TextSection(
+                        text=f"Chart '{chart.title}' could not be displayed",
+                        color="Warning",
+                    ))
 
-        # Add images inline - handle URL images directly
-        media_added = False
-        for image_path in parsed.images[:3]:  # Limit to 3 images in card
+        # Images (URLs and local paths)
+        image_entries: list[ImageEntry] = []
+        for image_path in parsed.images[:3]:
             image_str = str(image_path) if hasattr(image_path, '__str__') else image_path
-            self.logger.debug("🖼️ Processing image: %s", image_str[:80] if isinstance(image_str, str) else image_str)
-            # Check if it's a URL (http/https) - can be displayed directly
             if isinstance(image_str, str) and image_str.startswith(('http://', 'https://')):
-                if not media_added:
-                    card_body.append({
-                        "type": "TextBlock",
-                        "text": "---",
-                        "spacing": "Medium"
-                    })
-                    media_added = True
-                card_body.append({
-                    "type": "Image",
-                    "url": image_str,
-                    "size": "Large",
-                    "horizontalAlignment": "Center",
-                    "spacing": "Medium",
-                    "altText": "Generated Image"
-                })
-                self.logger.info("✅ Added URL image to card")
+                image_entries.append(ImageEntry(
+                    url=image_str,
+                    alt_text="Generated Image",
+                    size="Large",
+                ))
             elif hasattr(image_path, 'name'):
-                # Local file path - show as text placeholder
-                card_body.append({
-                    "type": "TextBlock",
-                    "text": f"📷 Image: {image_path.name}",
-                    "wrap": True,
-                    "isSubtle": True
-                })
+                sections.append(TextSection(
+                    text=f"Image: {image_path.name}",
+                    is_subtle=True,
+                ))
 
-        # Add document mentions - handle base64 data URIs as inline images
+        # Documents that are base64 data URIs (inline images)
         for doc in parsed.documents[:5]:
             doc_str = str(doc) if hasattr(doc, '__str__') else doc
-            self.logger.debug("📄 Processing document: %s...", doc_str[:80] if isinstance(doc_str, str) else 'Path object')
-            # Check if it's a base64 data URI (image)
             if isinstance(doc_str, str) and doc_str.startswith('data:image/'):
-                if not media_added:
-                    card_body.append({
-                        "type": "TextBlock",
-                        "text": "---",
-                        "spacing": "Medium"
-                    })
-                    media_added = True
-                card_body.append({
-                    "type": "Image",
-                    "url": doc_str,
-                    "size": "Large",
-                    "horizontalAlignment": "Center",
-                    "spacing": "Medium",
-                    "altText": "Generated Chart"
-                })
-                self.logger.info("✅ Added base64 image to card (length: %s chars)", len(doc_str))
+                image_entries.append(ImageEntry(
+                    url=doc_str,
+                    alt_text="Generated Chart",
+                    size="Large",
+                ))
             elif hasattr(doc, 'name'):
-                # It's a Path object - show as document mention
-                card_body.append({
-                    "type": "TextBlock",
-                    "text": f"📎 Document: {doc.name}",
-                    "wrap": True,
-                    "isSubtle": True
-                })
+                sections.append(TextSection(
+                    text=f"Document: {doc.name}",
+                    is_subtle=True,
+                ))
             elif isinstance(doc_str, str) and not doc_str.startswith('data:'):
-                # Unknown string document
-                card_body.append({
-                    "type": "TextBlock",
-                    "text": f"📎 Document: {doc_str[:50]}...",
-                    "wrap": True,
-                    "isSubtle": True
-                })
+                sections.append(TextSection(
+                    text=f"Document: {doc_str[:50]}...",
+                    is_subtle=True,
+                ))
 
-        # Build the card
-        adaptive_card = {
-            "type": "AdaptiveCard",
-            "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-            "version": "1.4",
-            "body": card_body
-        }
+        if image_entries:
+            sections.append(ImageSection(
+                images=image_entries,
+                spacing="Medium",
+                separator=True,
+            ))
 
-        return adaptive_card
+        return CardSpec(
+            sections=sections,
+            auto_collapse=AutoCollapsePolicy(),
+        )
 
-    def _render_markdown_content(self, text: str) -> list[dict[str, Any]]:
+    def _build_adaptive_card(self, parsed: ParsedResponse) -> Dict[str, Any]:
+        """Build an Adaptive Card from parsed response.
+
+        Delegates to the shared card builder via ``_parsed_to_card_spec``
+        and ``render()``. Produces AC 1.5 JSON with native Table elements
+        and auto-collapse for oversized content.
+
+        Args:
+            parsed: The parsed response content.
+
+        Returns:
+            Adaptive Card JSON structure.
         """
-        Parse markdown text and convert tables to allowed Adaptive Card elements.
-        Splits text into TextBlocks and ColumnSets for tables.
-        """
-        elements = []
-        if not text:
-            return elements
-
-        # Regex to detect a markdown table row (starts and ends with pipe, at least one internal pipe)
-        # We use a lookahead to ensure we don't match simple pipes in text unless they look like table rows
-        table_row_pattern = re.compile(r'(?m)^.*\|.*\|.*$')
-
-        lines = text.split('\n')
-        current_text = []
-        table_lines = []
-
-        def flush_text():
-            if current_text:
-                txt = '\n'.join(current_text).strip()
-                if txt:
-                   # Check if the last part of the text looks like a started table on the same line
-                   # e.g. "Here is the data: | Col1 | Col2 |"
-                   last_line_match = re.search(r'(\|.*\|.*\|)', txt)
-                   if last_line_match and len(txt) > len(last_line_match.group(1)) + 5:
-                       # Split if meaningful text precedes the table part
-                       pre_text = txt[:last_line_match.start()].strip()
-                       table_part = txt[last_line_match.start():]
-                       if pre_text:
-                           elements.append({
-                               "type": "TextBlock",
-                               "text": pre_text,
-                               "wrap": True
-                           })
-                       # Treat the table part as the first line of a potential table
-                       table_lines.append(table_part)
-                   else:
-                       elements.append({
-                           "type": "TextBlock",
-                           "text": txt,
-                           "wrap": True
-                       })
-                current_text.clear()
-
-        def flush_table():
-            if table_lines:
-                # Need at least header and separator
-                if len(table_lines) >= 2:
-                     # Basic validation: second line should mimic separator |---|
-                     if set(table_lines[1].strip()) <= {'|', '-', ':', ' '}:
-                         table_element = self._markdown_table_to_adaptive(table_lines)
-                         if table_element:
-                             elements.append(table_element)
-                         else:
-                             # Fallback to monospace text
-                             elements.append({
-                                 "type": "TextBlock",
-                                 "text": '\n'.join(table_lines),
-                                 "wrap": True,
-                                 "fontType": "Monospace"
-                             })
-                     else:
-                        # Invalid table structure, revert to text
-                        elements.append({
-                            "type": "TextBlock",
-                            "text": '\n'.join(table_lines),
-                            "wrap": True
-                        })
-                else:
-                     elements.append({
-                         "type": "TextBlock",
-                         "text": '\n'.join(table_lines),
-                         "wrap": True
-                     })
-                table_lines.clear()
-
-        for line in lines:
-            stripped = line.strip()
-            # Check if line looks like a table row
-            if stripped.startswith('|') and stripped.endswith('|'):
-                flush_text()
-                table_lines.append(stripped)
-            else:
-                # Handle case where table is inline at end of text: "... text | Col | Col |"
-                # This is tricky because "Text | Pipe | Text" is valid text.
-                # Only assume it's a table start if subsequent lines confirm it (separator)
-                if table_lines:
-                    # Previous block was table, this line is NOT table -> flush table
-                    flush_table()
-                
-                # Check for inline table start
-                if '|' in stripped and stripped.endswith('|') and len(stripped.split('|')) > 2:
-                     # Check if it looks like a header row followed by separator in next line?
-                     # We can't know next line here easily without lookahead.
-                     # But we can try to split:
-                     match = re.search(r'(\|.*\|.*\|)$', stripped)
-                     if match:
-                         # Found a table-like structure at end of line.
-                         # Defer decision? No, let flush_text handle the splitting logic
-                         pass
-                
-                current_text.append(line)
-        
-        flush_table()
-        flush_text()
-        
-        return elements
-
-    def _markdown_table_to_adaptive(self, lines: list[str]) -> Optional[dict[str, Any]]:
-        """Convert markdown table lines to Adaptive Card ColumnSet."""
-        try:
-            # Parse header
-            header_line = lines[0].strip()[1:-1] # Remove leading/trailing |
-            headers = [h.strip() for h in header_line.split('|')]
-            
-            # Parse rows (skip separator at index 1)
-            rows = []
-            for line in lines[2:]:
-                row_line = line.strip()[1:-1]
-                vals = [v.strip() for v in row_line.split('|')]
-                # Pad with empty str if row is shorter
-                if len(vals) < len(headers):
-                    vals.extend([''] * (len(headers) - len(vals)))
-                rows.append(vals[:len(headers)])
-
-            container_items = []
-
-            # Create Header Row
-            header_columns = []
-            for h in headers:
-                header_columns.append({
-                    "type": "Column",
-                    "width": "stretch",
-                    "items": [{
-                        "type": "TextBlock",
-                        "text": h,
-                        "weight": "Bolder",
-                        "wrap": True
-                    }]
-                })
-            container_items.append({
-                "type": "ColumnSet",
-                "columns": header_columns,
-                "spacing": "Medium"
-            })
-
-            # Create Data Rows
-            for i, row in enumerate(rows):
-                # Limit to 15 rows to prevent card overflow
-                if i >= 15:
-                    container_items.append({
-                        "type": "TextBlock",
-                        "text": f"*... {len(rows)-15} more rows ...*",
-                        "isSubtle": True,
-                        "spacing": "Small"
-                    })
-                    break
-
-                row_columns = []
-                for val in row:
-                    row_columns.append({
-                        "type": "Column",
-                        "width": "stretch",
-                        "items": [{
-                            "type": "TextBlock",
-                            "text": val,
-                            "wrap": True
-                        }]
-                    })
-                
-                container_items.append({
-                    "type": "ColumnSet",
-                    "columns": row_columns,
-                    "separator": True if i == 0 else False,
-                    "spacing": "Small"
-                })
-
-            return {
-                "type": "Container",
-                "items": container_items,
-                "spacing": "Medium"
-            }
-        except Exception as e:
-            self.logger.warning("Error parsing markdown table: %s", e)
-            return None
+        spec = self._parsed_to_card_spec(parsed)
+        return render(spec)
 
     async def _send_parsed_response(
         self,

--- a/packages/ai-parrot-integrations/tests/unit/test_msagent_card_render.py
+++ b/packages/ai-parrot-integrations/tests/unit/test_msagent_card_render.py
@@ -18,7 +18,9 @@ from parrot.integrations.msagentsdk.semantic import (
     UIMetric,
 )
 
-ALLOWED_ELEMENTS = {"TextBlock", "ColumnSet", "Column", "FactSet", "Container"}
+ALLOWED_ELEMENTS = {
+    "TextBlock", "ColumnSet", "Column", "FactSet", "Container", "Table",
+}
 ALLOWED_ACTIONS = {"Action.Submit", "Action.OpenUrl"}
 
 
@@ -51,18 +53,25 @@ class TestRenderCard:
     def test_render_table_card(self, table_result):
         card = render_card(table_result)
         assert card["type"] == "AdaptiveCard"
-        assert card["version"] == "1.4"
+        assert card["version"] == "1.5"
 
-    def test_table_columns_align_across_rows(self, table_result):
-        # Header and every row must use the same column count and equal
-        # "stretch" widths — "auto" would let each ColumnSet size its
-        # columns independently, misaligning the grid.
+    def test_table_uses_native_table_element(self, table_result):
+        """The shared builder renders tables as native AC 1.5 Table elements
+        with equal-width column definitions and firstRowAsHeader=True."""
         card = render_card(table_result)
-        column_sets = [b for b in card["body"] if b["type"] == "ColumnSet"]
-        assert column_sets
-        for column_set in column_sets:
-            assert len(column_set["columns"]) == 2
-            assert all(c["width"] == "stretch" for c in column_set["columns"])
+        tables = [b for b in card["body"] if b.get("type") == "Table"]
+        assert tables
+        table = tables[0]
+        # 2 columns, equal width
+        assert len(table["columns"]) == 2
+        assert all(c["width"] == "1" for c in table["columns"])
+        # Header row + data rows
+        assert table["firstRowAsHeader"] is True
+        # Header cells carry bold weight
+        header_cells = table["rows"][0]["cells"]
+        assert all(
+            cell["items"][0]["weight"] == "Bolder" for cell in header_cells
+        )
 
     def test_table_ragged_rows_normalized(self):
         result = SemanticUIResult(
@@ -74,16 +83,21 @@ class TestRenderCard:
             ),
         )
         card = render_card(result)
-        column_sets = [b for b in card["body"] if b["type"] == "ColumnSet"]
-        # Header + 2 rows, all normalized to exactly 3 columns.
-        assert len(column_sets) == 3
-        assert all(len(cs["columns"]) == 3 for cs in column_sets)
+        tables = [b for b in card["body"] if b.get("type") == "Table"]
+        assert len(tables) == 1
+        table = tables[0]
+        # Header + 2 data rows
+        assert len(table["rows"]) == 3
+        # All rows normalized to exactly 3 cells
+        assert all(len(row["cells"]) == 3 for row in table["rows"])
+        # Short row padded with empty strings
         short_row_cells = [
-            c["items"][0]["text"] for c in column_sets[1]["columns"]
+            c["items"][0]["text"] for c in table["rows"][1]["cells"]
         ]
         assert short_row_cells == ["1", "", ""]
+        # Long row truncated to column count
         long_row_cells = [
-            c["items"][0]["text"] for c in column_sets[2]["columns"]
+            c["items"][0]["text"] for c in table["rows"][2]["cells"]
         ]
         assert long_row_cells == ["1", "2", "3"]
 
@@ -127,7 +141,7 @@ class TestRenderCard:
         card = render_card(table_result)
         found = set(_walk_types(card))
         assert found <= ALLOWED_ELEMENTS | ALLOWED_ACTIONS | {"AdaptiveCard"}
-        assert card["version"] == "1.4"
+        assert card["version"] == "1.5"
 
     def test_table_truncation(self, table_result):
         card = render_card(table_result, max_table_rows=15)

--- a/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/adaptive_cards.py
+++ b/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/adaptive_cards.py
@@ -27,6 +27,17 @@ from parrot.outputs.a2ui.renderers import (
     RendererCapabilities,
     register_a2ui_renderer,
 )
+from parrot.outputs.cards import (
+    CardSpec,
+    Column,
+    ColumnSet,
+    Container,
+    Image,
+    RawElementsSection,
+    TextBlock,
+    render as render_card,
+)
+from parrot.outputs.cards.elements import ACElement
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +61,7 @@ _HEADING_ROLES = {"heading", "subtitle", "label"}
     ),
 )
 class AdaptiveCardsRenderer(AbstractA2UIRenderer):
-    """Basic-tree → Adaptive Card JSON renderer (display subset, no actions)."""
+    """Basic-tree -> Adaptive Card JSON renderer (display subset, no actions)."""
 
     async def render(
         self,
@@ -61,26 +72,18 @@ class AdaptiveCardsRenderer(AbstractA2UIRenderer):
     ) -> RenderedArtifact:
         """Render an envelope to a baked Adaptive Card ``RenderedArtifact``."""
         baked_components = bake_envelope(envelope)
-        body: list[dict[str, Any]] = []
+        elements: list[ACElement] = []
         for bc in baked_components:
-            body.append(self._element_for_component(bc))
+            elements.append(self._element_for_component(bc))
 
         for link in deep_links or []:
             # Deep links are rendered as DISPLAY text (never Action.OpenUrl) in v1.
-            body.append(
-                {
-                    "type": "TextBlock",
-                    "text": f"{link.action_label}: {link.url}",
-                    "wrap": True,
-                }
+            elements.append(
+                TextBlock(text=f"{link.action_label}: {link.url}")
             )
 
-        card = {
-            "$schema": _AC_SCHEMA,
-            "type": "AdaptiveCard",
-            "version": _AC_VERSION,
-            "body": body,
-        }
+        spec = CardSpec(sections=[RawElementsSection(elements=elements)])
+        card = render_card(spec)
         content = json.dumps(card, sort_keys=True).encode("utf-8")
         return RenderedArtifact(
             artifact_id=f"{_SURFACE_NAME}-{envelope.surface_id}",
@@ -94,7 +97,7 @@ class AdaptiveCardsRenderer(AbstractA2UIRenderer):
 
     # -- internal mapping ---------------------------------------------------
 
-    def _element_for_component(self, comp: dict[str, Any]) -> dict[str, Any]:
+    def _element_for_component(self, comp: dict[str, Any]) -> ACElement:
         """Lower a baked component to a Basic tree and map it to an AC element."""
         name = comp["component"]
         try:
@@ -113,7 +116,7 @@ class AdaptiveCardsRenderer(AbstractA2UIRenderer):
         )
         return self._map_node(lowered)
 
-    def _map_node(self, node: BasicNode) -> dict[str, Any]:
+    def _map_node(self, node: BasicNode) -> ACElement:
         """Map a Basic Catalog node to an Adaptive Card display element."""
         component = node.component
         props = node.properties or {}
@@ -121,40 +124,39 @@ class AdaptiveCardsRenderer(AbstractA2UIRenderer):
         if component == "Text":
             role = props.get("role", "")
             text = props.get("text")
-            element: dict[str, Any] = {
-                "type": "TextBlock",
-                "text": "" if text is None else str(text),
-                "wrap": True,
-            }
+            kwargs: dict[str, Any] = {}
             if role in _TITLE_ROLES:
-                element["size"] = "Large"
-                element["weight"] = "Bolder"
+                kwargs["size"] = "Large"
+                kwargs["weight"] = "Bolder"
             elif role in _HEADING_ROLES:
-                element["weight"] = "Bolder"
-            return element
+                kwargs["weight"] = "Bolder"
+            return TextBlock(
+                text="" if text is None else str(text),
+                **kwargs,
+            )
 
         if component == "Image":
             src = str(props.get("src", ""))
-            return {"type": "Image", "url": src}
+            return Image(url=src)
 
         if component == "Row":
-            return {
-                "type": "ColumnSet",
-                "columns": [
-                    {"type": "Column", "items": [self._map_node(child)]}
+            return ColumnSet(
+                columns=[
+                    Column(items=[self._map_node(child)])
                     for child in node.children
                 ],
-            }
+            )
 
         if component in ("Column", "Card"):
-            container: dict[str, Any] = {
-                "type": "Container",
-                "items": [self._map_node(child) for child in node.children],
-            }
-            if component == "Card":
-                container["style"] = "emphasis"
-            return container
+            style = "Emphasis" if component == "Card" else None
+            return Container(
+                items=[self._map_node(child) for child in node.children],
+                style=style,
+            )
 
-        # Unmappable Basic element → deterministic fallback (never a silent drop).
-        logger.warning("A2UI adaptive_cards: unmapped Basic element %r; using fallback", component)
-        return {"type": "TextBlock", "text": component, "wrap": True}
+        # Unmappable Basic element -> deterministic fallback (never a silent drop).
+        logger.warning(
+            "A2UI adaptive_cards: unmapped Basic element %r; using fallback",
+            component,
+        )
+        return TextBlock(text=component)

--- a/packages/ai-parrot/src/parrot/forms/renderers/adaptive_card.py
+++ b/packages/ai-parrot/src/parrot/forms/renderers/adaptive_card.py
@@ -9,6 +9,24 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from parrot.outputs.cards import (
+    ActionSubmit,
+    CardSpec,
+    Column,
+    ColumnSet,
+    Container,
+    DetailField,
+    DetailSection,
+    InputChoice,
+    RawElementsSection,
+    TextBlock,
+    render as render_card,
+)
+from parrot.outputs.cards.elements import ACElement
+from parrot.outputs.cards.sections import CardSection
+from parrot.outputs.cards.sections import FormSection as CardFormSection
+from parrot.outputs.cards.sections import FormFieldSpec
+
 from ..schema import FormField, FormSchema, FormSection, FormSubsection, RenderedForm
 from ..style import LayoutType, StyleSchema
 from ..types import FieldType, LocalizedString
@@ -39,31 +57,6 @@ def _resolve(value: LocalizedString | None, locale: str = "en") -> str:
     if "en" in value:
         return value["en"]
     return next(iter(value.values()), "")
-
-
-# Map new FieldType to Adaptive Card input element type
-_FIELD_TYPE_MAPPING: dict[FieldType, str] = {
-    FieldType.TEXT: "Input.Text",
-    FieldType.TEXT_AREA: "Input.Text",
-    FieldType.NUMBER: "Input.Number",
-    FieldType.INTEGER: "Input.Number",
-    FieldType.BOOLEAN: "Input.Toggle",
-    FieldType.DATE: "Input.Date",
-    FieldType.DATETIME: "Input.Date",
-    FieldType.TIME: "Input.Time",
-    FieldType.SELECT: "Input.ChoiceSet",
-    FieldType.MULTI_SELECT: "Input.ChoiceSet",
-    FieldType.EMAIL: "Input.Text",
-    FieldType.URL: "Input.Text",
-    FieldType.PHONE: "Input.Text",
-    FieldType.PASSWORD: "Input.Text",
-    FieldType.COLOR: "Input.Text",
-    FieldType.HIDDEN: "Input.Text",
-    FieldType.GROUP: None,
-    FieldType.ARRAY: None,
-    FieldType.FILE: None,
-    FieldType.IMAGE: None,
-}
 
 
 class AdaptiveCardRenderer(AbstractFormRenderer):
@@ -131,27 +124,33 @@ class AdaptiveCardRenderer(AbstractFormRenderer):
         prefilled = prefilled or {}
         errors = errors or {}
 
-        body: list[dict[str, Any]] = []
+        sections: list[CardSection] = []
 
         # Header
         title = _resolve(form.title, locale)
-        body.append(self._build_header(title))
+        sections.append(RawElementsSection(elements=[
+            TextBlock(text=title, weight="Bolder", size="Large"),
+        ]))
 
         # Form description if present
         if form.description:
-            body.append({
-                "type": "TextBlock",
-                "text": _resolve(form.description, locale),
-                "isSubtle": True,
-                "wrap": True,
-                "spacing": "Small",
-            })
+            sections.append(RawElementsSection(elements=[
+                TextBlock(
+                    text=_resolve(form.description, locale),
+                    is_subtle=True,
+                    spacing="Small",
+                ),
+            ]))
 
         # Render all sections
         for i, section in enumerate(form.sections):
             if i > 0:
-                body.append({"type": "TextBlock", "text": " ", "separator": True})
-            body.extend(self._build_section_body(section, prefilled, errors, locale))
+                sections.append(RawElementsSection(elements=[
+                    TextBlock(text=" ", separator=True),
+                ]))
+            sections.extend(
+                self._build_section_cards(section, prefilled, errors, locale)
+            )
 
         # Actions
         submit_label = _resolve(style.submit_label, locale) or "Submit"
@@ -162,7 +161,13 @@ class AdaptiveCardRenderer(AbstractFormRenderer):
             cancel_label=cancel_label,
         )
 
-        card = self._wrap_card(body, actions)
+        spec = CardSpec(
+            sections=sections,
+            actions=actions,
+            version=self.version,
+            schema_url=self.SCHEMA_URL,
+        )
+        card = render_card(spec)
         return RenderedForm(
             content=card,
             content_type=self.CONTENT_TYPE,
@@ -203,23 +208,31 @@ class AdaptiveCardRenderer(AbstractFormRenderer):
         total = len(form.sections)
         is_last = section_index == total - 1
 
-        body: list[dict[str, Any]] = []
+        sections: list[CardSection] = []
 
         # Form title header
         form_title = _resolve(form.title, locale)
-        body.append(self._build_header(form_title, size="Medium"))
+        sections.append(RawElementsSection(elements=[
+            TextBlock(text=form_title, weight="Bolder", size="Medium"),
+        ]))
 
         # Progress indicator for multi-section forms
         if total > 1:
-            section_title = _resolve(section.title, locale) if section.title else None
-            body.append(self._build_progress_indicator(
-                current=section_index + 1,
-                total=total,
-                section_title=section_title,
-            ))
+            section_title = (
+                _resolve(section.title, locale) if section.title else None
+            )
+            sections.append(RawElementsSection(elements=[
+                self._build_progress_indicator(
+                    current=section_index + 1,
+                    total=total,
+                    section_title=section_title,
+                ),
+            ]))
 
         # Section body
-        body.extend(self._build_section_body(section, prefilled, errors, locale))
+        sections.extend(
+            self._build_section_cards(section, prefilled, errors, locale)
+        )
 
         # Wizard actions
         cancel_label = _resolve(style.cancel_label, locale) or "Cancel"
@@ -232,7 +245,13 @@ class AdaptiveCardRenderer(AbstractFormRenderer):
             cancel_label=cancel_label,
         )
 
-        card = self._wrap_card(body, actions)
+        spec = CardSpec(
+            sections=sections,
+            actions=actions,
+            version=self.version,
+            schema_url=self.SCHEMA_URL,
+        )
+        card = render_card(spec)
         return RenderedForm(
             content=card,
             content_type=self.CONTENT_TYPE,
@@ -257,59 +276,74 @@ class AdaptiveCardRenderer(AbstractFormRenderer):
         Returns:
             RenderedForm with summary confirmation card.
         """
-        body: list[dict[str, Any]] = []
+        sections: list[CardSection] = []
 
-        body.append(self._build_header("Confirm Submission", size="Medium"))
+        sections.append(RawElementsSection(elements=[
+            TextBlock(text="Confirm Submission", weight="Bolder", size="Medium"),
+        ]))
         form_title = _resolve(form.title, locale)
-        body.append({
-            "type": "TextBlock",
-            "text": form_title,
-            "weight": "Bolder",
-            "size": "Large",
-            "wrap": True,
-        })
+        sections.append(RawElementsSection(elements=[
+            TextBlock(text=form_title, weight="Bolder", size="Large"),
+        ]))
 
         if summary_text:
-            body.append({
-                "type": "Container",
-                "style": "emphasis",
-                "items": [{"type": "TextBlock", "text": summary_text, "wrap": True}],
-                "spacing": "Medium",
-            })
+            sections.append(RawElementsSection(elements=[
+                Container(
+                    style="Emphasis",
+                    items=[TextBlock(text=summary_text)],
+                    spacing="Medium",
+                ),
+            ]))
 
-        # Data as FactSet per section
+        # Data as FactSet per section via DetailSection
         for section in form.sections:
-            facts = []
+            facts: list[DetailField] = []
             for field in section.iter_fields():
                 value = form_data.get(field.field_id)
                 if value is not None:
                     label = _resolve(field.label, locale)
-                    facts.append({
-                        "title": f"{label}:",
-                        "value": self._format_value(field, value, locale),
-                    })
+                    facts.append(DetailField(
+                        label=f"{label}:",
+                        value=self._format_value(field, value, locale),
+                    ))
             if facts:
                 section_title = _resolve(section.title, locale) or ""
                 if section_title:
-                    body.append({
-                        "type": "TextBlock",
-                        "text": section_title,
-                        "weight": "Bolder",
-                        "spacing": "Medium",
-                        "separator": True,
-                    })
-                body.append({"type": "FactSet", "facts": facts})
+                    sections.append(RawElementsSection(elements=[
+                        TextBlock(
+                            text=section_title,
+                            weight="Bolder",
+                            spacing="Medium",
+                            separator=True,
+                        ),
+                    ]))
+                sections.append(DetailSection(fields=facts))
 
         actions = [
-            {"type": "Action.Submit", "title": "Confirm", "style": "positive",
-             "data": {"_action": "confirm", **form_data}},
-            {"type": "Action.Submit", "title": "Edit",
-             "data": {"_action": "edit", **form_data}},
-            {"type": "Action.Submit", "title": "Cancel", "style": "destructive",
-             "data": {"_action": "cancel"}, "associatedInputs": "none"},
+            ActionSubmit(
+                title="Confirm",
+                style="positive",
+                data={"_action": "confirm", **form_data},
+            ),
+            ActionSubmit(
+                title="Edit",
+                data={"_action": "edit", **form_data},
+            ),
+            ActionSubmit(
+                title="Cancel",
+                style="destructive",
+                data={"_action": "cancel"},
+                associated_inputs="None",
+            ),
         ]
 
-        card = self._wrap_card(body, actions)
+        spec = CardSpec(
+            sections=sections,
+            actions=actions,
+            version=self.version,
+            schema_url=self.SCHEMA_URL,
+        )
+        card = render_card(spec)
         return RenderedForm(content=card, content_type=self.CONTENT_TYPE)
 
     async def render_error(
@@ -331,92 +365,48 @@ class AdaptiveCardRenderer(AbstractFormRenderer):
         Returns:
             RenderedForm with error card.
         """
-        body: list[dict[str, Any]] = [
-            {
-                "type": "TextBlock",
-                "text": f"Error: {title}",
-                "weight": "Bolder",
-                "size": "Medium",
-                "color": "Attention",
-            },
-            {
-                "type": "TextBlock",
-                "text": "Please correct the following:",
-                "wrap": True,
-            },
+        elements: list[ACElement] = [
+            TextBlock(
+                text=f"Error: {title}",
+                weight="Bolder",
+                size="Medium",
+                color="Attention",
+            ),
+            TextBlock(text="Please correct the following:"),
         ]
 
         for error in errors:
-            body.append({
-                "type": "TextBlock",
-                "text": f"- {error}",
-                "color": "Attention",
-                "wrap": True,
-            })
+            elements.append(TextBlock(
+                text=f"- {error}",
+                color="Attention",
+            ))
 
-        actions = []
+        actions: list[ActionSubmit] = []
         if retry_action:
-            actions.append({
-                "type": "Action.Submit",
-                "title": "Try Again",
-                "data": {"_action": "retry"},
-            })
+            actions.append(ActionSubmit(
+                title="Try Again",
+                data={"_action": "retry"},
+            ))
 
-        card = self._wrap_card(body, actions)
+        spec = CardSpec(
+            sections=[RawElementsSection(elements=elements)],
+            actions=actions,
+            version=self.version,
+            schema_url=self.SCHEMA_URL,
+        )
+        card = render_card(spec)
         return RenderedForm(content=card, content_type=self.CONTENT_TYPE)
 
     # =========================================================================
     # Internal builders
     # =========================================================================
 
-    def _wrap_card(
-        self,
-        body: list[dict[str, Any]],
-        actions: list[dict[str, Any]] | None = None,
-    ) -> dict[str, Any]:
-        """Wrap body and actions into an Adaptive Card structure.
-
-        Args:
-            body: Card body elements.
-            actions: Card action buttons.
-
-        Returns:
-            Complete Adaptive Card dict.
-        """
-        card: dict[str, Any] = {
-            "type": "AdaptiveCard",
-            "$schema": self.SCHEMA_URL,
-            "version": self.version,
-            "body": body,
-        }
-        if actions:
-            card["actions"] = actions
-        return card
-
-    def _build_header(self, text: str, size: str = "Large") -> dict[str, Any]:
-        """Build a header TextBlock element.
-
-        Args:
-            text: Header text.
-            size: Font size (Large, Medium, etc.).
-
-        Returns:
-            TextBlock dict.
-        """
-        return {
-            "type": "TextBlock",
-            "text": text,
-            "weight": "Bolder",
-            "size": size,
-            "wrap": True,
-        }
-
     def _build_progress_indicator(
         self,
         current: int,
         total: int,
         section_title: str | None = None,
-    ) -> dict[str, Any]:
+    ) -> ColumnSet:
         """Build a wizard progress indicator ColumnSet.
 
         Args:
@@ -425,7 +415,7 @@ class AdaptiveCardRenderer(AbstractFormRenderer):
             section_title: Optional section title for the current step.
 
         Returns:
-            ColumnSet dict.
+            ColumnSet element.
         """
         indicators = []
         for i in range(1, total + 1):
@@ -441,34 +431,37 @@ class AdaptiveCardRenderer(AbstractFormRenderer):
         if section_title:
             step_text += f": {section_title}"
 
-        return {
-            "type": "ColumnSet",
-            "columns": [
-                {
-                    "type": "Column",
-                    "width": "auto",
-                    "items": [{"type": "TextBlock", "text": progress_text,
-                               "fontType": "Monospace", "size": "Small"}],
-                },
-                {
-                    "type": "Column",
-                    "width": "stretch",
-                    "items": [{"type": "TextBlock", "text": step_text,
-                               "size": "Small", "isSubtle": True,
-                               "horizontalAlignment": "Right"}],
-                },
+        return ColumnSet(
+            columns=[
+                Column(
+                    width="auto",
+                    items=[TextBlock(
+                        text=progress_text,
+                        font_type="Monospace",
+                        size="Small",
+                    )],
+                ),
+                Column(
+                    width="stretch",
+                    items=[TextBlock(
+                        text=step_text,
+                        size="Small",
+                        is_subtle=True,
+                        horizontal_alignment="Right",
+                    )],
+                ),
             ],
-            "spacing": "Small",
-        }
+            spacing="Small",
+        )
 
-    def _build_section_body(
+    def _build_section_cards(
         self,
         section: FormSection,
         prefilled: dict[str, Any],
         errors: dict[str, str],
         locale: str,
-    ) -> list[dict[str, Any]]:
-        """Build body elements for a form section.
+    ) -> list[CardSection]:
+        """Build card sections for a form section.
 
         Args:
             section: FormSection to render.
@@ -477,82 +470,94 @@ class AdaptiveCardRenderer(AbstractFormRenderer):
             locale: Locale for i18n.
 
         Returns:
-            List of Adaptive Card elements.
+            List of CardSection objects.
         """
-        elements: list[dict[str, Any]] = []
+        result: list[CardSection] = []
+        header_elements: list[ACElement] = []
 
         if section.title:
-            section_title = _resolve(section.title, locale)
-            elements.append({
-                "type": "TextBlock",
-                "text": section_title,
-                "weight": "Bolder",
-                "spacing": "Medium",
-            })
+            header_elements.append(TextBlock(
+                text=_resolve(section.title, locale),
+                weight="Bolder",
+                spacing="Medium",
+            ))
 
         if section.description:
-            elements.append({
-                "type": "TextBlock",
-                "text": _resolve(section.description, locale),
-                "isSubtle": True,
-                "wrap": True,
-                "spacing": "Small",
-            })
+            header_elements.append(TextBlock(
+                text=_resolve(section.description, locale),
+                is_subtle=True,
+                spacing="Small",
+            ))
+
+        if header_elements:
+            result.append(RawElementsSection(elements=header_elements))
 
         for item in section.fields:
             if isinstance(item, FormSubsection):
-                elements.extend(self._build_subsection(item, prefilled, errors, locale))
+                result.extend(
+                    self._build_subsection_cards(item, prefilled, errors, locale)
+                )
             else:
-                elements.extend(self._build_field(item, prefilled, errors, locale))
+                result.extend(
+                    self._build_field_cards(item, prefilled, errors, locale)
+                )
 
-        return elements
+        return result
 
-    def _build_subsection(
+    def _build_subsection_cards(
         self,
         subsection: FormSubsection,
         prefilled: dict[str, Any],
         errors: dict[str, str],
         locale: str,
-    ) -> list[dict[str, Any]]:
-        """Build Adaptive Card elements for a subsection container."""
-        items: list[dict[str, Any]] = []
+    ) -> list[CardSection]:
+        """Build card sections for a subsection container.
+
+        Args:
+            subsection: Subsection to render.
+            prefilled: Pre-filled values.
+            errors: Field error messages.
+            locale: Locale for i18n.
+
+        Returns:
+            List of CardSection objects.
+        """
+        result: list[CardSection] = []
+        header_elements: list[ACElement] = []
 
         if subsection.title:
-            items.append({
-                "type": "TextBlock",
-                "text": _resolve(subsection.title, locale),
-                "weight": "Bolder",
-                "size": "Default",
-                "spacing": "Medium",
-                "separator": True,
-            })
+            header_elements.append(TextBlock(
+                text=_resolve(subsection.title, locale),
+                weight="Bolder",
+                spacing="Medium",
+                separator=True,
+            ))
         if subsection.description:
-            items.append({
-                "type": "TextBlock",
-                "text": _resolve(subsection.description, locale),
-                "isSubtle": True,
-                "wrap": True,
-                "size": "Small",
-                "spacing": "None",
-            })
+            header_elements.append(TextBlock(
+                text=_resolve(subsection.description, locale),
+                is_subtle=True,
+                size="Small",
+                spacing="None",
+            ))
+
+        if header_elements:
+            result.append(RawElementsSection(elements=header_elements))
 
         for field in subsection.fields:
-            items.extend(self._build_field(field, prefilled, errors, locale))
+            result.extend(
+                self._build_field_cards(field, prefilled, errors, locale)
+            )
 
-        return [{
-            "type": "Container",
-            "items": items,
-            "spacing": "Medium",
-        }]
+        return result
 
-    def _build_field(
+    def _build_field_cards(
         self,
         field: FormField,
         prefilled: dict[str, Any],
         errors: dict[str, str],
         locale: str,
-    ) -> list[dict[str, Any]]:
-        """Build Adaptive Card elements for a single field.
+    ) -> list[CardSection]:
+        """Build card sections for a single form field.
 
         Args:
             field: FormField to render.
@@ -561,230 +566,130 @@ class AdaptiveCardRenderer(AbstractFormRenderer):
             locale: Locale for i18n.
 
         Returns:
-            List of elements (label, input, optional error).
+            List of CardSection objects (form field + optional error).
         """
-        elements: list[dict[str, Any]] = []
-        value = prefilled.get(field.field_id, field.default)
+        result: list[CardSection] = []
         error = errors.get(field.field_id)
 
-        # Label
-        label_text = _resolve(field.label, locale) or field.field_id.replace("_", " ").title()
-        if field.required:
-            label_text += " *"
+        if field.field_type == FieldType.GROUP and field.children:
+            # GROUP: recursively render children
+            for child in field.children:
+                result.extend(
+                    self._build_field_cards(child, prefilled, errors, locale)
+                )
+        else:
+            field_spec = self._build_field_spec(field, prefilled, locale)
+            if field_spec:
+                result.append(CardFormSection(fields=[field_spec]))
 
-        elements.append({
-            "type": "TextBlock",
-            "text": label_text,
-            "weight": "Bolder",
-            "size": "Default",
-            "spacing": "Medium",
-        })
-
-        # Description
-        if field.description:
-            elements.append({
-                "type": "TextBlock",
-                "text": _resolve(field.description, locale),
-                "isSubtle": True,
-                "size": "Small",
-                "wrap": True,
-                "spacing": "None",
-            })
-
-        # Input element
-        input_elem = self._build_input_element(field, value, locale)
-        if input_elem:
-            elements.append(input_elem)
-
-        # Error message
         if error:
-            elements.append({
-                "type": "TextBlock",
-                "text": f"Error: {error}",
-                "color": "Attention",
-                "size": "Small",
-                "spacing": "None",
-            })
+            result.append(RawElementsSection(elements=[
+                TextBlock(
+                    text=f"Error: {error}",
+                    color="Attention",
+                    size="Small",
+                    spacing="None",
+                ),
+            ]))
 
-        return elements
+        return result
 
-    def _build_input_element(
+    def _build_field_spec(
         self,
         field: FormField,
-        value: Any,
+        prefilled: dict[str, Any],
         locale: str,
-    ) -> dict[str, Any] | None:
-        """Build the Adaptive Card input element for a field.
+    ) -> FormFieldSpec | None:
+        """Build a FormFieldSpec from a FormField.
+
+        Maps the FormField's type, constraints, options, and prefilled value
+        into a shared-builder FormFieldSpec that the renderer can expand.
 
         Args:
             field: FormField definition.
-            value: Pre-filled value.
+            prefilled: Pre-filled values keyed by field_id.
             locale: Locale for i18n.
 
         Returns:
-            Adaptive Card input element dict, or None for unsupported types.
+            FormFieldSpec, or None for unsupported types.
         """
-        base: dict[str, Any] = {
-            "id": field.field_id,
-            "isRequired": field.required,
-        }
-
         ft = field.field_type
 
-        if ft in (FieldType.TEXT, FieldType.EMAIL, FieldType.URL, FieldType.PHONE,
-                  FieldType.COLOR, FieldType.HIDDEN, FieldType.PASSWORD):
-            elem: dict[str, Any] = {
-                **base,
-                "type": "Input.Text",
-                "placeholder": _resolve(field.placeholder, locale) if field.placeholder else "",
-                "value": str(value) if value is not None else "",
-            }
-            if ft == FieldType.EMAIL:
-                elem["style"] = "Email"
-            elif ft == FieldType.URL:
-                elem["style"] = "Url"
-            elif ft == FieldType.PASSWORD:
-                elem["style"] = "Password"
-            if field.constraints:
-                if field.constraints.max_length:
-                    elem["maxLength"] = field.constraints.max_length
-                if field.constraints.pattern:
-                    elem["regex"] = field.constraints.pattern
-            return elem
+        # Skip types with no input element mapping
+        if ft in (FieldType.ARRAY, FieldType.FILE, FieldType.IMAGE):
+            return None
 
-        elif ft == FieldType.TEXT_AREA:
-            return {
-                **base,
-                "type": "Input.Text",
-                "isMultiline": True,
-                "placeholder": _resolve(field.placeholder, locale) if field.placeholder else "",
-                "value": str(value) if value is not None else "",
-            }
+        value = prefilled.get(field.field_id, field.default)
 
-        elif ft in (FieldType.NUMBER, FieldType.INTEGER):
-            elem = {
-                **base,
-                "type": "Input.Number",
-                "placeholder": _resolve(field.placeholder, locale) if field.placeholder else "",
-            }
-            if value is not None:
-                elem["value"] = value
-            if field.constraints:
-                if field.constraints.min_value is not None:
-                    elem["min"] = field.constraints.min_value
-                if field.constraints.max_value is not None:
-                    elem["max"] = field.constraints.max_value
-            return elem
+        # Resolve label with required indicator
+        label_text = (
+            _resolve(field.label, locale)
+            or field.field_id.replace("_", " ").title()
+        )
+        if field.required:
+            label_text += " *"
 
-        elif ft == FieldType.BOOLEAN:
-            title = _resolve(field.description, locale) if field.description else _resolve(field.label, locale)
-            return {
-                **base,
-                "type": "Input.Toggle",
-                "title": title,
-                "value": "true" if value else "false",
-                "valueOn": "true",
-                "valueOff": "false",
-            }
+        field_type_str = ft.value  # e.g. "text", "text_area", "number"
 
-        elif ft == FieldType.DATE:
-            elem = {**base, "type": "Input.Date"}
-            if value:
-                elem["value"] = str(value)
-            return elem
+        # Build constraints dict from Pydantic model
+        constraints: dict[str, Any] | None = None
+        if field.constraints:
+            c: dict[str, Any] = {}
+            max_len = getattr(field.constraints, "max_length", None)
+            if max_len:
+                c["max_length"] = max_len
+            pattern = getattr(field.constraints, "pattern", None)
+            if pattern:
+                c["pattern"] = pattern
+            min_val = getattr(field.constraints, "min_value", None)
+            if min_val is not None:
+                c["min_value"] = min_val
+            max_val = getattr(field.constraints, "max_value", None)
+            if max_val is not None:
+                c["max_value"] = max_val
+            if c:
+                constraints = c
 
-        elif ft == FieldType.DATETIME:
-            elem = {**base, "type": "Input.Date"}
-            if value:
-                v = str(value)
-                elem["value"] = v.split("T")[0] if "T" in v else v
-            return elem
+        # Build options for choice types
+        options: list[InputChoice] | None = None
+        if ft in (FieldType.SELECT, FieldType.MULTI_SELECT) and field.options:
+            options = [
+                InputChoice(
+                    title=_resolve(opt.label, locale) or opt.value,
+                    value=opt.value,
+                )
+                for opt in field.options
+            ]
 
-        elif ft == FieldType.TIME:
-            elem = {**base, "type": "Input.Time"}
-            if value:
-                elem["value"] = str(value)
-            return elem
+        # Handle datetime → date value conversion
+        default = value
+        if ft == FieldType.DATETIME and value:
+            v = str(value)
+            default = v.split("T")[0] if "T" in v else v
 
-        elif ft == FieldType.SELECT:
-            choices = self._build_choices(field, locale)
-            elem = {
-                **base,
-                "type": "Input.ChoiceSet",
-                "style": "compact",
-                "choices": choices,
-            }
-            if value:
-                elem["value"] = str(value)
-            return elem
-
-        elif ft == FieldType.MULTI_SELECT:
-            choices = self._build_choices(field, locale)
-            elem = {
-                **base,
-                "type": "Input.ChoiceSet",
-                "isMultiSelect": True,
-                "style": "expanded",
-                "choices": choices,
-            }
-            if value:
-                if isinstance(value, list):
-                    elem["value"] = ",".join(str(v) for v in value)
-                else:
-                    elem["value"] = str(value)
-            return elem
-
-        # GROUP and ARRAY are rendered as sub-containers (simplified)
-        elif ft == FieldType.GROUP and field.children:
-            items: list[dict[str, Any]] = []
-            for child in field.children:
-                items.extend(self._build_field(child, {}, {}, locale))
-            return {
-                "type": "Container",
-                "items": items,
-                "spacing": "Small",
-            }
-
-        # Fallback for unsupported types
-        else:
-            logger.debug("No AC input element for field type %s, using text fallback", ft)
-            return {
-                **base,
-                "type": "Input.Text",
-                "placeholder": _resolve(field.placeholder, locale) if field.placeholder else "",
-                "value": str(value) if value is not None else "",
-            }
-
-    def _build_choices(
-        self,
-        field: FormField,
-        locale: str,
-    ) -> list[dict[str, str]]:
-        """Build choices array for Input.ChoiceSet.
-
-        Args:
-            field: FormField with options.
-            locale: Locale for i18n option labels.
-
-        Returns:
-            List of {title, value} dicts.
-        """
-        if not field.options:
-            return []
-        return [
-            {
-                "title": _resolve(opt.label, locale) or opt.value,
-                "value": opt.value,
-            }
-            for opt in field.options
-        ]
+        return FormFieldSpec(
+            field_id=field.field_id,
+            field_type=field_type_str,
+            label=label_text,
+            description=(
+                _resolve(field.description, locale) if field.description else None
+            ),
+            placeholder=(
+                _resolve(field.placeholder, locale) if field.placeholder else None
+            ),
+            required=field.required,
+            default=default,
+            options=options,
+            constraints=constraints,
+            is_multiline=ft == FieldType.TEXT_AREA,
+        )
 
     def _build_form_actions(
         self,
         show_cancel: bool = True,
         submit_label: str = "Submit",
         cancel_label: str = "Cancel",
-    ) -> list[dict[str, Any]]:
+    ) -> list[ActionSubmit]:
         """Build action buttons for a complete form.
 
         Args:
@@ -793,24 +698,22 @@ class AdaptiveCardRenderer(AbstractFormRenderer):
             cancel_label: Cancel button label.
 
         Returns:
-            List of Action.Submit dicts.
+            List of ActionSubmit instances.
         """
-        actions = [
-            {
-                "type": "Action.Submit",
-                "title": submit_label,
-                "style": "positive",
-                "data": {"_action": "submit"},
-            },
+        actions: list[ActionSubmit] = [
+            ActionSubmit(
+                title=submit_label,
+                style="positive",
+                data={"_action": "submit"},
+            ),
         ]
         if show_cancel:
-            actions.append({
-                "type": "Action.Submit",
-                "title": cancel_label,
-                "style": "destructive",
-                "data": {"_action": "cancel"},
-                "associatedInputs": "none",
-            })
+            actions.append(ActionSubmit(
+                title=cancel_label,
+                style="destructive",
+                data={"_action": "cancel"},
+                associated_inputs="None",
+            ))
         return actions
 
     def _build_wizard_actions(
@@ -821,7 +724,7 @@ class AdaptiveCardRenderer(AbstractFormRenderer):
         show_cancel: bool = True,
         show_skip: bool = False,
         cancel_label: str = "Cancel",
-    ) -> list[dict[str, Any]]:
+    ) -> list[ActionSubmit]:
         """Build action buttons for a wizard step.
 
         Args:
@@ -833,49 +736,44 @@ class AdaptiveCardRenderer(AbstractFormRenderer):
             cancel_label: Cancel button label.
 
         Returns:
-            List of Action.Submit dicts.
+            List of ActionSubmit instances.
         """
-        actions: list[dict[str, Any]] = []
+        actions: list[ActionSubmit] = []
 
         if not is_first and show_back:
-            actions.append({
-                "type": "Action.Submit",
-                "title": "Back",
-                "data": {"_action": "back"},
-                "associatedInputs": "none",
-            })
+            actions.append(ActionSubmit(
+                title="Back",
+                data={"_action": "back"},
+                associated_inputs="None",
+            ))
 
         if show_skip:
-            actions.append({
-                "type": "Action.Submit",
-                "title": "Skip",
-                "data": {"_action": "skip"},
-                "associatedInputs": "none",
-            })
+            actions.append(ActionSubmit(
+                title="Skip",
+                data={"_action": "skip"},
+                associated_inputs="None",
+            ))
 
         if show_cancel:
-            actions.append({
-                "type": "Action.Submit",
-                "title": cancel_label,
-                "style": "destructive",
-                "data": {"_action": "cancel"},
-                "associatedInputs": "none",
-            })
+            actions.append(ActionSubmit(
+                title=cancel_label,
+                style="destructive",
+                data={"_action": "cancel"},
+                associated_inputs="None",
+            ))
 
         if is_last:
-            actions.append({
-                "type": "Action.Submit",
-                "title": "Submit",
-                "style": "positive",
-                "data": {"_action": "submit"},
-            })
+            actions.append(ActionSubmit(
+                title="Submit",
+                style="positive",
+                data={"_action": "submit"},
+            ))
         else:
-            actions.append({
-                "type": "Action.Submit",
-                "title": "Next",
-                "style": "positive",
-                "data": {"_action": "next"},
-            })
+            actions.append(ActionSubmit(
+                title="Next",
+                style="positive",
+                data={"_action": "next"},
+            ))
 
         return actions
 

--- a/packages/ai-parrot/src/parrot/forms/renderers/adaptive_card.py
+++ b/packages/ai-parrot/src/parrot/forms/renderers/adaptive_card.py
@@ -615,9 +615,9 @@ class AdaptiveCardRenderer(AbstractFormRenderer):
         """
         ft = field.field_type
 
-        # Skip types with no input element mapping
+        # Unsupported types fall back to generic text input
         if ft in (FieldType.ARRAY, FieldType.FILE, FieldType.IMAGE):
-            return None
+            ft = FieldType.TEXT
 
         value = prefilled.get(field.field_id, field.default)
 

--- a/packages/ai-parrot/src/parrot/outputs/cards/__init__.py
+++ b/packages/ai-parrot/src/parrot/outputs/cards/__init__.py
@@ -1,1 +1,60 @@
-"""Unified Adaptive Card 1.5 builder."""
+"""Unified Adaptive Card 1.5 builder.
+
+Usage:
+    from parrot.outputs.cards import CardSpec, TableSection, render
+    spec = CardSpec(title="Report", sections=[TableSection(...)])
+    card_json = render(spec)
+"""
+from .actions import (
+    ACAction,
+    ActionOpenUrl,
+    ActionShowCard,
+    ActionSubmit,
+    ActionToggleVisibility,
+    TargetElement,
+)
+from .attachment import AC_CONTENT_TYPE, build_attachment, build_attachment_from_spec
+from .elements import (
+    ACElement,
+    Column,
+    ColumnSet,
+    Container,
+    Fact,
+    FactSet,
+    Image,
+    Table,
+    TableCell,
+    TableColumnDefinition,
+    TableRow,
+    TextBlock,
+)
+from .inputs import (
+    InputChoice,
+    InputChoiceSet,
+    InputDate,
+    InputNumber,
+    InputText,
+    InputTime,
+    InputToggle,
+)
+from .markdown import markdown_to_sections
+from .renderer import CardRenderError, render, render_text
+from .sections import (
+    CardSection,
+    CodeSection,
+    DetailField,
+    DetailSection,
+    FormFieldSpec,
+    FormSection,
+    ImageEntry,
+    ImageSection,
+    MetricEntry,
+    MetricsSection,
+    RawElementsSection,
+    StatusSection,
+    TableSection,
+    TextSection,
+    ToggleSection,
+)
+from .spec import CardSpec
+from .toggle import AutoCollapsePolicy, ToggleGroup

--- a/packages/ai-parrot/src/parrot/outputs/cards/__init__.py
+++ b/packages/ai-parrot/src/parrot/outputs/cards/__init__.py
@@ -1,0 +1,1 @@
+"""Unified Adaptive Card 1.5 builder."""

--- a/packages/ai-parrot/src/parrot/outputs/cards/actions.py
+++ b/packages/ai-parrot/src/parrot/outputs/cards/actions.py
@@ -1,0 +1,40 @@
+# packages/ai-parrot/src/parrot/outputs/cards/actions.py
+"""Pydantic models for AC 1.5 actions."""
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+
+class ACAction(BaseModel):
+    """Base for all Adaptive Card actions."""
+    action_type: str
+    title: str
+    style: Literal["default", "positive", "destructive"] | None = None
+
+
+class ActionSubmit(ACAction):
+    action_type: Literal["Action.Submit"] = "Action.Submit"
+    data: dict[str, Any] = {}
+    associated_inputs: Literal["Auto", "None"] | None = None
+
+
+class ActionOpenUrl(ACAction):
+    action_type: Literal["Action.OpenUrl"] = "Action.OpenUrl"
+    url: str
+
+
+class TargetElement(BaseModel):
+    element_id: str
+    is_visible: bool | None = None
+
+
+class ActionToggleVisibility(ACAction):
+    action_type: Literal["Action.ToggleVisibility"] = "Action.ToggleVisibility"
+    target_elements: list[TargetElement] = []
+
+
+class ActionShowCard(ACAction):
+    action_type: Literal["Action.ShowCard"] = "Action.ShowCard"
+    card: Any  # typed as CardSpec at runtime; Any avoids circular import

--- a/packages/ai-parrot/src/parrot/outputs/cards/attachment.py
+++ b/packages/ai-parrot/src/parrot/outputs/cards/attachment.py
@@ -1,0 +1,34 @@
+# packages/ai-parrot/src/parrot/outputs/cards/attachment.py
+"""Bot Framework attachment envelope helpers."""
+from __future__ import annotations
+
+from typing import Any
+
+AC_CONTENT_TYPE = "application/vnd.microsoft.card.adaptive"
+
+
+def build_attachment(card: dict[str, Any]) -> dict[str, Any]:
+    """Wrap a rendered Adaptive Card JSON payload in a Bot Framework attachment.
+
+    Args:
+        card: A JSON-serializable Adaptive Card payload (e.g. the output
+            of :func:`parrot.outputs.cards.renderer.render`).
+
+    Returns:
+        A Bot Framework attachment envelope with ``contentType`` set to
+        the Adaptive Card content type and ``content`` set to ``card``.
+    """
+    return {"contentType": AC_CONTENT_TYPE, "content": card}
+
+
+def build_attachment_from_spec(spec: Any) -> dict[str, Any]:
+    """Render a :class:`CardSpec` and wrap it in a Bot Framework attachment.
+
+    Args:
+        spec: The :class:`~parrot.outputs.cards.spec.CardSpec` to render.
+
+    Returns:
+        A Bot Framework attachment envelope wrapping the rendered card.
+    """
+    from .renderer import render
+    return build_attachment(render(spec))

--- a/packages/ai-parrot/src/parrot/outputs/cards/elements.py
+++ b/packages/ai-parrot/src/parrot/outputs/cards/elements.py
@@ -78,7 +78,8 @@ class Table(ACElement):
     vertical_cell_content_alignment: Literal["Top", "Center", "Bottom"] | None = None
 
 
-class Column(BaseModel):
+class Column(ACElement):
+    element_type: Literal["Column"] = "Column"
     width: str = "stretch"
     items: list[ACElement] = []
 

--- a/packages/ai-parrot/src/parrot/outputs/cards/elements.py
+++ b/packages/ai-parrot/src/parrot/outputs/cards/elements.py
@@ -1,0 +1,102 @@
+"""Pydantic models for AC 1.5 display elements."""
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel
+
+
+class ACElement(BaseModel):
+    """Base for all Adaptive Card elements."""
+    element_type: str
+
+
+class TextBlock(ACElement):
+    element_type: Literal["TextBlock"] = "TextBlock"
+    text: str
+    wrap: bool = True
+    weight: Literal["Default", "Bolder", "Lighter"] | None = None
+    size: Literal["Default", "Small", "Medium", "Large", "ExtraLarge"] | None = None
+    color: Literal["Default", "Dark", "Light", "Accent",
+                    "Good", "Warning", "Attention"] | None = None
+    font_type: Literal["Default", "Monospace"] | None = None
+    is_subtle: bool = False
+    horizontal_alignment: Literal["Left", "Center", "Right"] | None = None
+    spacing: Literal["None", "Small", "Default", "Medium",
+                     "Large", "ExtraLarge", "Padding"] | None = None
+    separator: bool = False
+    max_lines: int | None = None
+    id: str | None = None
+    is_visible: bool = True
+
+
+class Image(ACElement):
+    element_type: Literal["Image"] = "Image"
+    url: str
+    alt_text: str = ""
+    size: Literal["Auto", "Stretch", "Small", "Medium", "Large"] | None = None
+    horizontal_alignment: Literal["Left", "Center", "Right"] | None = None
+    spacing: Literal["None", "Small", "Default", "Medium",
+                     "Large", "ExtraLarge", "Padding"] | None = None
+    id: str | None = None
+    is_visible: bool = True
+
+
+class Fact(BaseModel):
+    title: str
+    value: str
+
+
+class FactSet(ACElement):
+    element_type: Literal["FactSet"] = "FactSet"
+    facts: list[Fact] = []
+
+
+class TableColumnDefinition(BaseModel):
+    width: str | int = "1"
+
+
+class TableCell(BaseModel):
+    items: list[ACElement] = []
+
+
+class TableRow(BaseModel):
+    cells: list[TableCell]
+    style: Literal["Default", "Accent", "Good",
+                    "Warning", "Attention"] | None = None
+
+
+class Table(ACElement):
+    element_type: Literal["Table"] = "Table"
+    columns: list[TableColumnDefinition]
+    rows: list[TableRow]
+    first_row_as_header: bool = True
+    show_grid_lines: bool = True
+    grid_style: Literal["Default", "Accent", "Good",
+                         "Warning", "Attention"] | None = None
+    horizontal_cell_content_alignment: Literal["Left", "Center", "Right"] | None = None
+    vertical_cell_content_alignment: Literal["Top", "Center", "Bottom"] | None = None
+
+
+class Column(BaseModel):
+    width: str = "stretch"
+    items: list[ACElement] = []
+
+
+class ColumnSet(ACElement):
+    element_type: Literal["ColumnSet"] = "ColumnSet"
+    columns: list[Column] = []
+    spacing: Literal["None", "Small", "Default", "Medium",
+                     "Large", "ExtraLarge", "Padding"] | None = None
+    separator: bool = False
+
+
+class Container(ACElement):
+    element_type: Literal["Container"] = "Container"
+    items: list[ACElement] = []
+    style: Literal["Default", "Emphasis", "Good", "Attention",
+                    "Warning", "Accent"] | None = None
+    spacing: Literal["None", "Small", "Default", "Medium",
+                     "Large", "ExtraLarge", "Padding"] | None = None
+    id: str | None = None
+    is_visible: bool = True

--- a/packages/ai-parrot/src/parrot/outputs/cards/elements.py
+++ b/packages/ai-parrot/src/parrot/outputs/cards/elements.py
@@ -1,7 +1,7 @@
 """Pydantic models for AC 1.5 display elements."""
 from __future__ import annotations
 
-from typing import Literal, Optional
+from typing import Literal
 
 from pydantic import BaseModel
 

--- a/packages/ai-parrot/src/parrot/outputs/cards/inputs.py
+++ b/packages/ai-parrot/src/parrot/outputs/cards/inputs.py
@@ -1,0 +1,82 @@
+# packages/ai-parrot/src/parrot/outputs/cards/inputs.py
+"""Pydantic models for AC 1.5 input elements."""
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+from .elements import ACElement
+
+
+class InputChoice(BaseModel):
+    title: str
+    value: str
+
+
+class InputText(ACElement):
+    element_type: Literal["Input.Text"] = "Input.Text"
+    id: str
+    placeholder: str = ""
+    value: str = ""
+    is_multiline: bool = False
+    max_length: int | None = None
+    regex: str | None = None
+    style: Literal["Text", "Email", "Url", "Tel", "Password"] | None = None
+    is_required: bool = False
+    label: str | None = None
+    error_message: str | None = None
+
+
+class InputNumber(ACElement):
+    element_type: Literal["Input.Number"] = "Input.Number"
+    id: str
+    placeholder: str = ""
+    value: float | int | None = None
+    min: float | int | None = None
+    max: float | int | None = None
+    is_required: bool = False
+    label: str | None = None
+    error_message: str | None = None
+
+
+class InputToggle(ACElement):
+    element_type: Literal["Input.Toggle"] = "Input.Toggle"
+    id: str
+    title: str
+    value: str = "false"
+    value_on: str = "true"
+    value_off: str = "false"
+    is_required: bool = False
+    label: str | None = None
+
+
+class InputDate(ACElement):
+    element_type: Literal["Input.Date"] = "Input.Date"
+    id: str
+    value: str | None = None
+    min: str | None = None
+    max: str | None = None
+    is_required: bool = False
+    label: str | None = None
+
+
+class InputTime(ACElement):
+    element_type: Literal["Input.Time"] = "Input.Time"
+    id: str
+    value: str | None = None
+    min: str | None = None
+    max: str | None = None
+    is_required: bool = False
+    label: str | None = None
+
+
+class InputChoiceSet(ACElement):
+    element_type: Literal["Input.ChoiceSet"] = "Input.ChoiceSet"
+    id: str
+    choices: list[InputChoice] = []
+    value: str | None = None
+    is_multi_select: bool = False
+    style: Literal["compact", "expanded", "filtered"] | None = None
+    is_required: bool = False
+    label: str | None = None

--- a/packages/ai-parrot/src/parrot/outputs/cards/markdown.py
+++ b/packages/ai-parrot/src/parrot/outputs/cards/markdown.py
@@ -1,0 +1,107 @@
+# packages/ai-parrot/src/parrot/outputs/cards/markdown.py
+"""Markdown text → list[CardSection] parser."""
+from __future__ import annotations
+
+import re
+
+from .sections import (
+    CardSection,
+    CodeSection,
+    ImageSection,
+    ImageEntry,
+    TableSection,
+    TextSection,
+)
+
+_IMAGE_RE = re.compile(r'^!\[([^\]]*)\]\(([^)]+)\)\s*$')
+_FENCE_OPEN_RE = re.compile(r'^```(\w*)\s*$')
+_FENCE_CLOSE_RE = re.compile(r'^```\s*$')
+_TABLE_ROW_RE = re.compile(r'^\|(.+)\|\s*$')
+_TABLE_SEP_RE = re.compile(r'^[\s|:-]+$')
+
+
+def markdown_to_sections(text: str) -> list[CardSection]:
+    """Parse markdown text into a list of CardSection instances.
+
+    Splits on structural boundaries (fenced code blocks, pipe tables,
+    standalone images) and groups everything else into TextSection
+    blocks, leaving inline markdown (bold, italic, links) intact.
+
+    Args:
+        text: Raw markdown text to parse.
+
+    Returns:
+        A list of CardSection instances (TextSection, TableSection,
+        CodeSection, ImageSection) in document order. Empty list if
+        `text` is empty or whitespace-only.
+    """
+    if not text or not text.strip():
+        return []
+
+    lines = text.split('\n')
+    sections: list[CardSection] = []
+    current_text: list[str] = []
+    i = 0
+
+    def flush_text():
+        if current_text:
+            joined = '\n'.join(current_text).strip()
+            if joined:
+                sections.append(TextSection(text=joined))
+            current_text.clear()
+
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+
+        # Fenced code block
+        fence_match = _FENCE_OPEN_RE.match(stripped)
+        if fence_match and not stripped.endswith('```'):
+            flush_text()
+            language = fence_match.group(1) or None
+            code_lines: list[str] = []
+            i += 1
+            while i < len(lines):
+                if _FENCE_CLOSE_RE.match(lines[i].strip()):
+                    break
+                code_lines.append(lines[i])
+                i += 1
+            sections.append(CodeSection(code='\n'.join(code_lines), language=language))
+            i += 1
+            continue
+
+        # Standalone image
+        img_match = _IMAGE_RE.match(stripped)
+        if img_match:
+            flush_text()
+            alt_text = img_match.group(1)
+            url = img_match.group(2)
+            sections.append(ImageSection(images=[ImageEntry(url=url, alt_text=alt_text)]))
+            i += 1
+            continue
+
+        # Pipe table
+        if _TABLE_ROW_RE.match(stripped):
+            # Look ahead for separator row
+            if (i + 1 < len(lines)
+                    and _TABLE_ROW_RE.match(lines[i + 1].strip())
+                    and _TABLE_SEP_RE.match(
+                        lines[i + 1].strip().strip('|').replace(' ', ''))):
+                flush_text()
+                header_line = stripped[1:-1]
+                headers = [h.strip() for h in header_line.split('|')]
+                i += 2  # skip header + separator
+                rows: list[list[str]] = []
+                while i < len(lines) and _TABLE_ROW_RE.match(lines[i].strip()):
+                    row_line = lines[i].strip()[1:-1]
+                    vals = [v.strip() for v in row_line.split('|')]
+                    rows.append(vals[:len(headers)])
+                    i += 1
+                sections.append(TableSection(columns=headers, rows=rows))
+                continue
+
+        current_text.append(line)
+        i += 1
+
+    flush_text()
+    return sections

--- a/packages/ai-parrot/src/parrot/outputs/cards/renderer.py
+++ b/packages/ai-parrot/src/parrot/outputs/cards/renderer.py
@@ -1,0 +1,560 @@
+# packages/ai-parrot/src/parrot/outputs/cards/renderer.py
+"""CardSpec → Adaptive Card 1.5 JSON renderer."""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from pydantic import BaseModel
+
+from .actions import (
+    ACAction,
+    ActionOpenUrl,
+    ActionShowCard,
+    ActionSubmit,
+    ActionToggleVisibility,
+    TargetElement,
+)
+from .elements import (
+    ACElement,
+    Column,
+    ColumnSet,
+    Container,
+    Fact,
+    FactSet,
+    Image,
+    Table,
+    TableCell,
+    TableColumnDefinition,
+    TableRow,
+    TextBlock,
+)
+from .inputs import (
+    InputChoiceSet,
+    InputDate,
+    InputNumber,
+    InputText,
+    InputTime,
+    InputToggle,
+)
+from .sections import (
+    CardSection,
+    CodeSection,
+    DetailSection,
+    FormFieldSpec,
+    FormSection,
+    ImageSection,
+    MetricsSection,
+    RawElementsSection,
+    StatusSection,
+    TableSection,
+    TextSection,
+    ToggleSection,
+)
+from .spec import CardSpec
+from .toggle import AutoCollapsePolicy, ToggleGroup
+
+logger = logging.getLogger(__name__)
+
+_LEVEL_TO_COLOR = {
+    "success": "Good",
+    "warning": "Warning",
+    "error": "Attention",
+    "info": "Default",
+}
+
+_FIELD_TYPE_TO_INPUT = {
+    "text": "Input.Text",
+    "text_area": "Input.Text",
+    "number": "Input.Number",
+    "integer": "Input.Number",
+    "boolean": "Input.Toggle",
+    "date": "Input.Date",
+    "datetime": "Input.Date",
+    "time": "Input.Time",
+    "select": "Input.ChoiceSet",
+    "multi_select": "Input.ChoiceSet",
+    "email": "Input.Text",
+    "url": "Input.Text",
+    "phone": "Input.Text",
+    "password": "Input.Text",
+    "color": "Input.Text",
+    "hidden": "Input.Text",
+}
+
+# snake_case → camelCase mapping for AC JSON serialization.
+# Only non-trivial mappings listed; the serializer handles
+# the generic snake→camel conversion for unlisted keys.
+_FIELD_RENAMES: dict[str, str] = {
+    "element_type": "type",
+    "action_type": "type",
+    "alt_text": "altText",
+    "font_type": "fontType",
+    "is_subtle": "isSubtle",
+    "is_visible": "isVisible",
+    "is_required": "isRequired",
+    "is_multiline": "isMultiline",
+    "is_multi_select": "isMultiSelect",
+    "horizontal_alignment": "horizontalAlignment",
+    "vertical_cell_content_alignment": "verticalCellContentAlignment",
+    "horizontal_cell_content_alignment": "horizontalCellContentAlignment",
+    "max_lines": "maxLines",
+    "max_length": "maxLength",
+    "first_row_as_header": "firstRowAsHeader",
+    "show_grid_lines": "showGridLines",
+    "grid_style": "gridStyle",
+    "error_message": "errorMessage",
+    "value_on": "valueOn",
+    "value_off": "valueOff",
+    "associated_inputs": "associatedInputs",
+    "target_elements": "targetElements",
+    "element_id": "elementId",
+    "schema_url": "$schema",
+}
+
+# Fields whose value must always be emitted even when it equals the
+# model's declared default — either because they carry structural data
+# (element_type, text, url, id, ...) or because their "default" value is
+# itself the semantically meaningful, expected-to-be-present state for AC
+# consumers (e.g. TextBlock.wrap defaults to True and Table.first_row_as_
+# header defaults to True, but both must still show up in the rendered
+# JSON).
+_ALWAYS_EMIT_FIELDS = frozenset({
+    "element_type", "text", "url", "id", "title", "facts",
+    "columns", "rows", "items", "cells", "choices",
+    "wrap", "first_row_as_header",
+})
+
+
+class CardRenderError(Exception):
+    """Raised when a CardSpec cannot be rendered within limits."""
+
+
+# ── Section expanders ─────────────────────────────────────────────────
+
+def _expand_text(section: TextSection) -> tuple[list[ACElement], list[ACAction]]:
+    kwargs: dict[str, Any] = {}
+    if section.role == "title":
+        kwargs.update(size="Large", weight="Bolder")
+    elif section.role in ("heading", "subtitle", "label"):
+        kwargs["weight"] = "Bolder"
+    elif section.role in ("code", "monospace"):
+        kwargs["font_type"] = "Monospace"
+    if section.color:
+        kwargs["color"] = section.color
+    if section.is_subtle:
+        kwargs["is_subtle"] = True
+    return [TextBlock(text=section.text, **kwargs)], []
+
+
+def _expand_table(section: TableSection) -> tuple[list[ACElement], list[ACAction]]:
+    n_cols = len(section.columns)
+    col_defs = [TableColumnDefinition(width="1") for _ in section.columns]
+
+    header_cells = [TableCell(items=[TextBlock(text=c, weight="Bolder")])
+                    for c in section.columns]
+    rows = [TableRow(cells=header_cells)]
+
+    display_rows = section.rows[:section.max_display_rows]
+    for row_data in display_rows:
+        cells_data = [str(c) for c in row_data[:n_cols]]
+        cells_data += [""] * (n_cols - len(cells_data))
+        rows.append(TableRow(cells=[
+            TableCell(items=[TextBlock(text=cell)]) for cell in cells_data
+        ]))
+
+    elements: list[ACElement] = [Table(
+        columns=col_defs,
+        rows=rows,
+        first_row_as_header=section.first_row_as_header,
+        show_grid_lines=section.show_grid_lines,
+    )]
+
+    total = section.total_rows if section.total_rows is not None else len(section.rows)
+    if total > len(display_rows):
+        elements.append(TextBlock(
+            text=f"Showing {len(display_rows)} of {total}",
+            is_subtle=True,
+        ))
+    return elements, []
+
+
+def _expand_metrics(section: MetricsSection) -> tuple[list[ACElement], list[ACAction]]:
+    facts = []
+    for m in section.metrics:
+        value = m.value
+        if m.delta:
+            value = f"{value} ({m.delta})"
+        facts.append(Fact(title=m.label, value=value))
+    return [FactSet(facts=facts)], []
+
+
+def _expand_detail(section: DetailSection) -> tuple[list[ACElement], list[ACAction]]:
+    facts = [Fact(title=f.label, value=f.value) for f in section.fields]
+    return [FactSet(facts=facts)], []
+
+
+def _expand_image(section: ImageSection) -> tuple[list[ACElement], list[ACAction]]:
+    elements = [
+        Image(url=img.url, alt_text=img.alt_text, size=img.size,
+              horizontal_alignment="Center")
+        for img in section.images
+    ]
+    return elements, []
+
+
+def _expand_code(section: CodeSection) -> tuple[list[ACElement], list[ACAction]]:
+    elements: list[ACElement] = []
+    if section.label:
+        elements.append(TextBlock(text=section.label, weight="Bolder", spacing="Medium"))
+    elements.append(TextBlock(text=section.code, font_type="Monospace", spacing="Small"))
+    return elements, []
+
+
+def _expand_status(section: StatusSection) -> tuple[list[ACElement], list[ACAction]]:
+    items: list[ACElement] = [
+        TextBlock(
+            text=section.message,
+            weight="Bolder",
+            color=_LEVEL_TO_COLOR.get(section.level, "Default"),
+        ),
+    ]
+    if section.details:
+        items.append(TextBlock(text=section.details))
+    return [Container(items=items)], []
+
+
+def _expand_toggle(section: ToggleSection) -> tuple[list[ACElement], list[ACAction]]:
+    tg = section.toggle
+    group_id = tg.group_id or "tg_0"
+    container_id = f"{group_id}_content"
+
+    container = Container(
+        id=container_id,
+        items=[_serialize_to_element(e) if not isinstance(e, ACElement) else e
+               for e in tg.content],
+        is_visible=tg.initially_visible,
+    )
+    action = ActionToggleVisibility(
+        title=tg.label_collapsed if not tg.initially_visible else tg.label_expanded,
+        target_elements=[TargetElement(element_id=container_id)],
+    )
+    return [container], [action]
+
+
+def _expand_form(section: FormSection) -> tuple[list[ACElement], list[ACAction]]:
+    elements: list[ACElement] = []
+    for field in section.fields:
+        elements.extend(_build_form_field(field))
+    return elements, []
+
+
+def _build_form_field(field: FormFieldSpec) -> list[ACElement]:
+    elements: list[ACElement] = []
+    input_type = _FIELD_TYPE_TO_INPUT.get(field.field_type, "Input.Text")
+
+    if input_type == "Input.Text":
+        kwargs: dict[str, Any] = {}
+        if field.field_type == "email":
+            kwargs["style"] = "Email"
+        elif field.field_type == "url":
+            kwargs["style"] = "Url"
+        elif field.field_type == "password":
+            kwargs["style"] = "Password"
+        if field.field_type == "text_area":
+            kwargs["is_multiline"] = True
+        elif field.is_multiline:
+            kwargs["is_multiline"] = True
+        if field.constraints and field.constraints.get("max_length"):
+            kwargs["max_length"] = field.constraints["max_length"]
+        if field.constraints and field.constraints.get("pattern"):
+            kwargs["regex"] = field.constraints["pattern"]
+        elements.append(InputText(
+            id=field.field_id,
+            label=field.label,
+            placeholder=field.placeholder or "",
+            value=str(field.default) if field.default is not None else "",
+            is_required=field.required,
+            **kwargs,
+        ))
+    elif input_type == "Input.Number":
+        kwargs = {}
+        if field.constraints:
+            if field.constraints.get("min_value") is not None:
+                kwargs["min"] = field.constraints["min_value"]
+            if field.constraints.get("max_value") is not None:
+                kwargs["max"] = field.constraints["max_value"]
+        elements.append(InputNumber(
+            id=field.field_id,
+            label=field.label,
+            placeholder=field.placeholder or "",
+            value=field.default,
+            is_required=field.required,
+            **kwargs,
+        ))
+    elif input_type == "Input.Toggle":
+        elements.append(InputToggle(
+            id=field.field_id,
+            title=field.description or field.label,
+            label=field.label,
+            value="true" if field.default else "false",
+            is_required=field.required,
+        ))
+    elif input_type == "Input.Date":
+        elements.append(InputDate(
+            id=field.field_id,
+            label=field.label,
+            value=str(field.default) if field.default else None,
+            is_required=field.required,
+        ))
+    elif input_type == "Input.Time":
+        elements.append(InputTime(
+            id=field.field_id,
+            label=field.label,
+            value=str(field.default) if field.default else None,
+            is_required=field.required,
+        ))
+    elif input_type == "Input.ChoiceSet":
+        choices = []
+        if field.options:
+            from .inputs import InputChoice
+            choices = [InputChoice(title=o.title, value=o.value) for o in field.options]
+        is_multi = field.field_type == "multi_select"
+        elements.append(InputChoiceSet(
+            id=field.field_id,
+            label=field.label,
+            choices=choices,
+            value=str(field.default) if field.default else None,
+            is_multi_select=is_multi,
+            style="expanded" if is_multi else "compact",
+            is_required=field.required,
+        ))
+    return elements
+
+
+def _expand_raw(section: RawElementsSection) -> tuple[list[ACElement], list[ACAction]]:
+    return list(section.elements), []
+
+
+_SECTION_EXPANDERS: dict[str, Any] = {
+    "text": _expand_text,
+    "table": _expand_table,
+    "metrics": _expand_metrics,
+    "detail": _expand_detail,
+    "image": _expand_image,
+    "code": _expand_code,
+    "status": _expand_status,
+    "toggle": _expand_toggle,
+    "form": _expand_form,
+    "raw": _expand_raw,
+}
+
+
+def _serialize_to_element(obj: Any) -> ACElement:
+    if isinstance(obj, ACElement):
+        return obj
+    return TextBlock(text=str(obj))
+
+
+# ── Serialization ─────────────────────────────────────────────────────
+
+def _snake_to_camel(name: str) -> str:
+    parts = name.split("_")
+    return parts[0] + "".join(p.capitalize() for p in parts[1:])
+
+
+def _serialize_element(element: ACElement) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for field_name, field_info in type(element).model_fields.items():
+        value = getattr(element, field_name)
+        if value is None:
+            continue
+        if (
+            field_name not in _ALWAYS_EMIT_FIELDS
+            and value == field_info.default
+        ):
+            continue
+        ac_key = _FIELD_RENAMES.get(field_name, _snake_to_camel(field_name))
+        if isinstance(value, list):
+            serialized_list = []
+            for item in value:
+                if isinstance(item, ACElement):
+                    serialized_list.append(_serialize_element(item))
+                elif isinstance(item, BaseModel):
+                    serialized_list.append(_serialize_model(item))
+                else:
+                    serialized_list.append(item)
+            if serialized_list or field_name in ("items", "columns", "rows",
+                                                  "cells", "facts", "choices"):
+                result[ac_key] = serialized_list
+        elif isinstance(value, ACElement):
+            result[ac_key] = _serialize_element(value)
+        elif isinstance(value, BaseModel):
+            result[ac_key] = _serialize_model(value)
+        else:
+            result[ac_key] = value
+    return result
+
+
+def _serialize_model(model: BaseModel) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for field_name in type(model).model_fields:
+        value = getattr(model, field_name)
+        if value is None:
+            continue
+        ac_key = _FIELD_RENAMES.get(field_name, _snake_to_camel(field_name))
+        if isinstance(value, list):
+            result[ac_key] = [
+                _serialize_element(v) if isinstance(v, ACElement)
+                else _serialize_model(v) if isinstance(v, BaseModel)
+                else v
+                for v in value
+            ]
+        elif isinstance(value, ACElement):
+            result[ac_key] = _serialize_element(value)
+        elif isinstance(value, BaseModel):
+            result[ac_key] = _serialize_model(value)
+        else:
+            result[ac_key] = value
+    return result
+
+
+def _serialize_action(action: ACAction) -> dict[str, Any]:
+    result: dict[str, Any] = {"type": action.action_type, "title": action.title}
+    if action.style and action.style != "default":
+        result["style"] = action.style
+    if isinstance(action, ActionSubmit):
+        if action.data:
+            result["data"] = action.data
+        if action.associated_inputs:
+            result["associatedInputs"] = action.associated_inputs
+    elif isinstance(action, ActionOpenUrl):
+        result["url"] = action.url
+    elif isinstance(action, ActionToggleVisibility):
+        result["targetElements"] = [
+            {"elementId": t.element_id, **({"isVisible": t.is_visible}
+                                            if t.is_visible is not None else {})}
+            for t in action.target_elements
+        ]
+    elif isinstance(action, ActionShowCard):
+        result["card"] = render(action.card)
+    return result
+
+
+# ── Public API ────────────────────────────────────────────────────────
+
+def render(spec: CardSpec, *, max_card_bytes: int = 28_000) -> dict[str, Any]:
+    """Render a :class:`CardSpec` into an Adaptive Card 1.5 JSON payload.
+
+    Args:
+        spec: The card specification to render.
+        max_card_bytes: Maximum allowed serialized card size in bytes.
+
+    Returns:
+        A JSON-serializable dict representing the Adaptive Card.
+
+    Raises:
+        CardRenderError: If the serialized card exceeds ``max_card_bytes``.
+    """
+    body: list[dict[str, Any]] = []
+    all_actions: list[ACAction] = list(spec.actions)
+
+    # Title and summary
+    if spec.title:
+        body.append(_serialize_element(TextBlock(
+            text=spec.title, weight="Bolder", size="Large",
+        )))
+    if spec.summary:
+        body.append(_serialize_element(TextBlock(text=spec.summary)))
+
+    # Expand sections
+    toggle_counter = 0
+    for section in spec.sections:
+        expander = _SECTION_EXPANDERS.get(section.section_type)
+        if expander is None:
+            logger.warning("Unknown section type: %s", section.section_type)
+            continue
+
+        if isinstance(section, ToggleSection) and section.toggle.group_id is None:
+            section.toggle.group_id = f"tg_{toggle_counter}"
+            toggle_counter += 1
+
+        elements, actions = expander(section)
+        for element in elements:
+            serialized = _serialize_element(element)
+            if section.separator and not body:
+                pass
+            elif section.separator:
+                serialized["separator"] = True
+            if section.spacing:
+                serialized["spacing"] = section.spacing
+            body.append(serialized)
+        all_actions.extend(actions)
+
+    card: dict[str, Any] = {
+        "$schema": spec.schema_url,
+        "type": "AdaptiveCard",
+        "version": spec.version,
+        "body": body,
+    }
+    if all_actions:
+        card["actions"] = [_serialize_action(a) for a in all_actions]
+
+    serialized_size = len(json.dumps(card).encode("utf-8"))
+    if serialized_size > max_card_bytes:
+        raise CardRenderError(
+            f"card size {serialized_size} exceeds max_card_bytes={max_card_bytes}"
+        )
+    return card
+
+
+def render_text(spec: CardSpec) -> str:
+    """Render a :class:`CardSpec` into a plain-text fallback representation.
+
+    Used by clients that cannot display Adaptive Cards. Never raises —
+    falls back to a generic message if rendering fails.
+
+    Args:
+        spec: The card specification to render.
+
+    Returns:
+        A plain-text summary of the card contents.
+    """
+    try:
+        lines: list[str] = []
+        if spec.title:
+            lines.append(f"**{spec.title}**")
+        if spec.summary:
+            lines.append(spec.summary)
+        for section in spec.sections:
+            if isinstance(section, TextSection):
+                lines.append(section.text)
+            elif isinstance(section, TableSection):
+                if section.columns:
+                    lines.append(" | ".join(section.columns))
+                    for row in section.rows[:section.max_display_rows]:
+                        lines.append(" | ".join(str(c) for c in row))
+            elif isinstance(section, MetricsSection):
+                for m in section.metrics:
+                    text = f"{m.label}: {m.value}"
+                    if m.delta:
+                        text += f" ({m.delta})"
+                    lines.append(text)
+            elif isinstance(section, DetailSection):
+                for f in section.fields:
+                    lines.append(f"{f.label}: {f.value}")
+            elif isinstance(section, StatusSection):
+                lines.append(f"[{section.level.upper()}] {section.message}")
+                if section.details:
+                    lines.append(section.details)
+            elif isinstance(section, CodeSection):
+                if section.label:
+                    lines.append(section.label)
+                lines.append(f"```{section.language or ''}\n{section.code}\n```")
+            elif isinstance(section, ImageSection):
+                for img in section.images:
+                    lines.append(f"[Image: {img.alt_text or img.url}]")
+        return "\n".join(lines)
+    except Exception:
+        return "Unable to render result."

--- a/packages/ai-parrot/src/parrot/outputs/cards/renderer.py
+++ b/packages/ai-parrot/src/parrot/outputs/cards/renderer.py
@@ -270,6 +270,8 @@ def _build_form_field(field: FormFieldSpec) -> list[ACElement]:
             kwargs["max_length"] = field.constraints["max_length"]
         if field.constraints and field.constraints.get("pattern"):
             kwargs["regex"] = field.constraints["pattern"]
+        if field.description:
+            elements.append(TextBlock(text=field.description, is_subtle=True, spacing="Small"))
         elements.append(InputText(
             id=field.field_id,
             label=field.label,
@@ -285,6 +287,8 @@ def _build_form_field(field: FormFieldSpec) -> list[ACElement]:
                 kwargs["min"] = field.constraints["min_value"]
             if field.constraints.get("max_value") is not None:
                 kwargs["max"] = field.constraints["max_value"]
+        if field.description:
+            elements.append(TextBlock(text=field.description, is_subtle=True, spacing="Small"))
         elements.append(InputNumber(
             id=field.field_id,
             label=field.label,
@@ -302,6 +306,8 @@ def _build_form_field(field: FormFieldSpec) -> list[ACElement]:
             is_required=field.required,
         ))
     elif input_type == "Input.Date":
+        if field.description:
+            elements.append(TextBlock(text=field.description, is_subtle=True, spacing="Small"))
         elements.append(InputDate(
             id=field.field_id,
             label=field.label,
@@ -309,6 +315,8 @@ def _build_form_field(field: FormFieldSpec) -> list[ACElement]:
             is_required=field.required,
         ))
     elif input_type == "Input.Time":
+        if field.description:
+            elements.append(TextBlock(text=field.description, is_subtle=True, spacing="Small"))
         elements.append(InputTime(
             id=field.field_id,
             label=field.label,
@@ -321,6 +329,8 @@ def _build_form_field(field: FormFieldSpec) -> list[ACElement]:
             from .inputs import InputChoice
             choices = [InputChoice(title=o.title, value=o.value) for o in field.options]
         is_multi = field.field_type == "multi_select"
+        if field.description:
+            elements.append(TextBlock(text=field.description, is_subtle=True, spacing="Small"))
         elements.append(InputChoiceSet(
             id=field.field_id,
             label=field.label,

--- a/packages/ai-parrot/src/parrot/outputs/cards/renderer.py
+++ b/packages/ai-parrot/src/parrot/outputs/cards/renderer.py
@@ -123,7 +123,7 @@ _FIELD_RENAMES: dict[str, str] = {
 _ALWAYS_EMIT_FIELDS = frozenset({
     "element_type", "text", "url", "id", "title", "facts",
     "columns", "rows", "items", "cells", "choices",
-    "wrap", "first_row_as_header",
+    "wrap", "first_row_as_header", "is_multi_select",
 })
 
 
@@ -481,14 +481,13 @@ def render(spec: CardSpec, *, max_card_bytes: int = 28_000) -> dict[str, Any]:
             toggle_counter += 1
 
         elements, actions = expander(section)
-        for element in elements:
+        for index, element in enumerate(elements):
             serialized = _serialize_element(element)
-            if section.separator and not body:
-                pass
-            elif section.separator:
-                serialized["separator"] = True
-            if section.spacing:
-                serialized["spacing"] = section.spacing
+            if index == 0:
+                if section.separator and body:
+                    serialized["separator"] = True
+                if section.spacing:
+                    serialized.setdefault("spacing", section.spacing)
             body.append(serialized)
         all_actions.extend(actions)
 

--- a/packages/ai-parrot/src/parrot/outputs/cards/renderer.py
+++ b/packages/ai-parrot/src/parrot/outputs/cards/renderer.py
@@ -18,8 +18,6 @@ from .actions import (
 )
 from .elements import (
     ACElement,
-    Column,
-    ColumnSet,
     Container,
     Fact,
     FactSet,
@@ -592,7 +590,11 @@ def render(spec: CardSpec, *, max_card_bytes: int = 28_000) -> dict[str, Any]:
             continue
 
         if isinstance(section, ToggleSection) and section.toggle.group_id is None:
-            section.toggle.group_id = f"tg_{toggle_counter}"
+            section = section.model_copy(
+                update={"toggle": section.toggle.model_copy(
+                    update={"group_id": f"tg_{toggle_counter}"}
+                )}
+            )
             toggle_counter += 1
 
         elements, actions = expander(section)

--- a/packages/ai-parrot/src/parrot/outputs/cards/renderer.py
+++ b/packages/ai-parrot/src/parrot/outputs/cards/renderer.py
@@ -357,6 +357,106 @@ def _serialize_to_element(obj: Any) -> ACElement:
     return TextBlock(text=str(obj))
 
 
+# ── Auto-collapse ─────────────────────────────────────────────────────
+
+def _apply_auto_collapse(
+    sections: list[CardSection],
+    policy: AutoCollapsePolicy,
+) -> list[CardSection]:
+    """Wrap oversized section content in auto-generated toggle groups.
+
+    Runs after the caller confirms auto-collapse is enabled and before
+    section expansion. Walks ``sections`` and, for any ``TableSection``,
+    ``TextSection``, or ``CodeSection`` whose content exceeds the
+    corresponding ``policy`` threshold, splits it into a truncated
+    preview section plus a ``ToggleSection`` holding the overflow.
+    Sections under threshold (or of other types) pass through unchanged.
+
+    Args:
+        sections: The card's sections, pre-expansion.
+        policy: Auto-collapse thresholds.
+
+    Returns:
+        A new list of sections with oversized ones replaced by a
+        preview + toggle pair.
+    """
+    result: list[CardSection] = []
+    counter = 0
+    for section in sections:
+        if (
+            isinstance(section, TableSection)
+            and len(section.rows) > policy.table_row_threshold
+        ):
+            threshold = policy.table_row_threshold
+            preview_rows = section.rows[:threshold]
+            overflow_rows = section.rows[threshold:]
+
+            preview = section.model_copy(update={
+                "rows": preview_rows,
+                "max_display_rows": threshold,
+                "total_rows": threshold,
+            })
+            overflow_section = TableSection(
+                columns=section.columns,
+                rows=overflow_rows,
+                max_display_rows=len(overflow_rows),
+                total_rows=len(overflow_rows),
+                first_row_as_header=section.first_row_as_header,
+                show_grid_lines=section.show_grid_lines,
+            )
+            overflow_elements, _ = _expand_table(overflow_section)
+            toggle = ToggleGroup(
+                content=overflow_elements,
+                label_collapsed=f"Show {len(overflow_rows)} more rows",
+                label_expanded="Hide extra rows",
+                group_id=f"tg_auto_{counter}",
+            )
+            counter += 1
+            result.append(preview)
+            result.append(ToggleSection(toggle=toggle))
+            continue
+
+        if (
+            isinstance(section, TextSection)
+            and len(section.text) > policy.text_char_threshold
+        ):
+            threshold = policy.text_char_threshold
+            preview_text = section.text[:threshold].rstrip() + "..."
+            preview = section.model_copy(update={"text": preview_text})
+            toggle = ToggleGroup(
+                content=[TextBlock(text=section.text)],
+                label_collapsed="Show full text",
+                label_expanded="Hide full text",
+                group_id=f"tg_auto_{counter}",
+            )
+            counter += 1
+            result.append(preview)
+            result.append(ToggleSection(toggle=toggle))
+            continue
+
+        if (
+            isinstance(section, CodeSection)
+            and len(section.code.splitlines()) > policy.code_line_threshold
+        ):
+            threshold = policy.code_line_threshold
+            lines = section.code.splitlines()
+            preview_code = "\n".join(lines[:threshold])
+            preview = section.model_copy(update={"code": preview_code})
+            toggle = ToggleGroup(
+                content=[TextBlock(text=section.code, font_type="Monospace")],
+                label_collapsed=f"Show all {len(lines)} lines",
+                label_expanded="Hide code",
+                group_id=f"tg_auto_{counter}",
+            )
+            counter += 1
+            result.append(preview)
+            result.append(ToggleSection(toggle=toggle))
+            continue
+
+        result.append(section)
+    return result
+
+
 # ── Serialization ─────────────────────────────────────────────────────
 
 def _snake_to_camel(name: str) -> str:
@@ -468,9 +568,14 @@ def render(spec: CardSpec, *, max_card_bytes: int = 28_000) -> dict[str, Any]:
     if spec.summary:
         body.append(_serialize_element(TextBlock(text=spec.summary)))
 
+    # Auto-collapse oversized sections before expansion
+    sections = spec.sections
+    if spec.auto_collapse is not None and spec.auto_collapse.enabled:
+        sections = _apply_auto_collapse(sections, spec.auto_collapse)
+
     # Expand sections
     toggle_counter = 0
-    for section in spec.sections:
+    for section in sections:
         expander = _SECTION_EXPANDERS.get(section.section_type)
         if expander is None:
             logger.warning("Unknown section type: %s", section.section_type)

--- a/packages/ai-parrot/src/parrot/outputs/cards/sections.py
+++ b/packages/ai-parrot/src/parrot/outputs/cards/sections.py
@@ -1,0 +1,111 @@
+# packages/ai-parrot/src/parrot/outputs/cards/sections.py
+"""Composable semantic sections for CardSpec."""
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+from .elements import ACElement
+from .inputs import InputChoice
+from .toggle import ToggleGroup
+
+
+class CardSection(BaseModel):
+    section_type: str
+    spacing: Literal["None", "Small", "Default", "Medium",
+                     "Large", "ExtraLarge", "Padding"] | None = None
+    separator: bool = False
+
+
+class TextSection(CardSection):
+    section_type: Literal["text"] = "text"
+    text: str
+    role: Literal["body", "title", "heading", "subtitle",
+                   "label", "code", "monospace"] = "body"
+    color: str | None = None
+    is_subtle: bool = False
+
+
+class TableSection(CardSection):
+    section_type: Literal["table"] = "table"
+    columns: list[str]
+    rows: list[list[str]]
+    total_rows: int | None = None
+    max_display_rows: int = 20
+    show_grid_lines: bool = True
+    first_row_as_header: bool = True
+
+
+class MetricEntry(BaseModel):
+    label: str
+    value: str
+    delta: str | None = None
+
+
+class MetricsSection(CardSection):
+    section_type: Literal["metrics"] = "metrics"
+    metrics: list[MetricEntry] = []
+
+
+class DetailField(BaseModel):
+    label: str
+    value: str
+
+
+class DetailSection(CardSection):
+    section_type: Literal["detail"] = "detail"
+    fields: list[DetailField] = []
+
+
+class ImageEntry(BaseModel):
+    url: str
+    alt_text: str = ""
+    size: Literal["Auto", "Stretch", "Small", "Medium", "Large"] = "Large"
+
+
+class ImageSection(CardSection):
+    section_type: Literal["image"] = "image"
+    images: list[ImageEntry] = []
+
+
+class CodeSection(CardSection):
+    section_type: Literal["code"] = "code"
+    code: str
+    language: str | None = None
+    label: str | None = None
+
+
+class StatusSection(CardSection):
+    section_type: Literal["status"] = "status"
+    level: Literal["success", "warning", "error", "info"] = "info"
+    message: str
+    details: str | None = None
+
+
+class ToggleSection(CardSection):
+    section_type: Literal["toggle"] = "toggle"
+    toggle: ToggleGroup
+
+
+class FormFieldSpec(BaseModel):
+    field_id: str
+    field_type: str
+    label: str
+    description: str | None = None
+    placeholder: str | None = None
+    required: bool = False
+    default: Any = None
+    options: list[InputChoice] | None = None
+    constraints: dict[str, Any] | None = None
+    is_multiline: bool = False
+
+
+class FormSection(CardSection):
+    section_type: Literal["form"] = "form"
+    fields: list[FormFieldSpec] = []
+
+
+class RawElementsSection(CardSection):
+    section_type: Literal["raw"] = "raw"
+    elements: list[ACElement] = []

--- a/packages/ai-parrot/src/parrot/outputs/cards/spec.py
+++ b/packages/ai-parrot/src/parrot/outputs/cards/spec.py
@@ -1,0 +1,19 @@
+# packages/ai-parrot/src/parrot/outputs/cards/spec.py
+"""CardSpec — top-level Adaptive Card specification."""
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from .actions import ACAction
+from .sections import CardSection
+from .toggle import AutoCollapsePolicy
+
+
+class CardSpec(BaseModel):
+    title: str | None = None
+    summary: str | None = None
+    sections: list[CardSection] = []
+    actions: list[ACAction] = []
+    auto_collapse: AutoCollapsePolicy | None = None
+    version: str = "1.5"
+    schema_url: str = "http://adaptivecards.io/schemas/adaptive-card.json"

--- a/packages/ai-parrot/src/parrot/outputs/cards/toggle.py
+++ b/packages/ai-parrot/src/parrot/outputs/cards/toggle.py
@@ -1,0 +1,23 @@
+# packages/ai-parrot/src/parrot/outputs/cards/toggle.py
+"""Toggle group and auto-collapse policy models."""
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from .elements import ACElement
+
+
+class ToggleGroup(BaseModel):
+    label_expanded: str = "Hide details"
+    label_collapsed: str = "Show details"
+    content: list[ACElement]
+    initially_visible: bool = False
+    group_id: str | None = None
+
+
+class AutoCollapsePolicy(BaseModel):
+    enabled: bool = True
+    table_row_threshold: int = 5
+    text_char_threshold: int = 500
+    code_line_threshold: int = 10
+    image_count_threshold: int = 2

--- a/packages/ai-parrot/tests/unit/outputs/cards/test_actions.py
+++ b/packages/ai-parrot/tests/unit/outputs/cards/test_actions.py
@@ -48,10 +48,6 @@ class TestActionToggleVisibility:
 
 
 class TestActionShowCard:
-    @pytest.mark.skip(
-        reason="CardSpec/TextSection land in Task 3 (spec.py/sections.py); "
-        "deferred per Task 2 brief."
-    )
     def test_inline_card(self):
         from parrot.outputs.cards.actions import ActionShowCard
         from parrot.outputs.cards.spec import CardSpec

--- a/packages/ai-parrot/tests/unit/outputs/cards/test_actions.py
+++ b/packages/ai-parrot/tests/unit/outputs/cards/test_actions.py
@@ -1,0 +1,65 @@
+# tests/unit/outputs/cards/test_actions.py
+"""Unit tests for AC action models."""
+import pytest
+from pydantic import ValidationError
+
+
+class TestActionSubmit:
+    def test_minimal(self):
+        from parrot.outputs.cards.actions import ActionSubmit
+        a = ActionSubmit(title="Submit")
+        assert a.action_type == "Action.Submit"
+        assert a.data == {}
+
+    def test_with_data_and_style(self):
+        from parrot.outputs.cards.actions import ActionSubmit
+        a = ActionSubmit(
+            title="Cancel",
+            style="destructive",
+            data={"_action": "cancel"},
+            associated_inputs="None",
+        )
+        assert a.style == "destructive"
+        assert a.associated_inputs == "None"
+
+
+class TestActionOpenUrl:
+    def test_minimal(self):
+        from parrot.outputs.cards.actions import ActionOpenUrl
+        a = ActionOpenUrl(title="Open", url="https://example.com")
+        assert a.action_type == "Action.OpenUrl"
+        assert a.url == "https://example.com"
+
+
+class TestActionToggleVisibility:
+    def test_toggle_targets(self):
+        from parrot.outputs.cards.actions import ActionToggleVisibility, TargetElement
+        a = ActionToggleVisibility(
+            title="Show details",
+            target_elements=[
+                TargetElement(element_id="detail_1"),
+                TargetElement(element_id="detail_2", is_visible=True),
+            ],
+        )
+        assert a.action_type == "Action.ToggleVisibility"
+        assert len(a.target_elements) == 2
+        assert a.target_elements[0].is_visible is None  # toggle mode
+        assert a.target_elements[1].is_visible is True   # explicit set
+
+
+class TestActionShowCard:
+    @pytest.mark.skip(
+        reason="CardSpec/TextSection land in Task 3 (spec.py/sections.py); "
+        "deferred per Task 2 brief."
+    )
+    def test_inline_card(self):
+        from parrot.outputs.cards.actions import ActionShowCard
+        from parrot.outputs.cards.spec import CardSpec
+        from parrot.outputs.cards.sections import TextSection
+        inner = CardSpec(
+            title="Details",
+            sections=[TextSection(text="More info here")],
+        )
+        a = ActionShowCard(title="Details", card=inner)
+        assert a.action_type == "Action.ShowCard"
+        assert a.card.title == "Details"

--- a/packages/ai-parrot/tests/unit/outputs/cards/test_attachment.py
+++ b/packages/ai-parrot/tests/unit/outputs/cards/test_attachment.py
@@ -1,0 +1,19 @@
+# packages/ai-parrot/tests/unit/outputs/cards/test_attachment.py
+"""Unit tests for attachment helper."""
+
+
+class TestBuildAttachment:
+    def test_wraps_card(self):
+        from parrot.outputs.cards.attachment import build_attachment
+        card = {"type": "AdaptiveCard", "version": "1.5", "body": []}
+        att = build_attachment(card)
+        assert att["contentType"] == "application/vnd.microsoft.card.adaptive"
+        assert att["content"] is card
+
+    def test_from_spec(self):
+        from parrot.outputs.cards.attachment import build_attachment_from_spec
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec(title="Test")
+        att = build_attachment_from_spec(spec)
+        assert att["contentType"] == "application/vnd.microsoft.card.adaptive"
+        assert att["content"]["type"] == "AdaptiveCard"

--- a/packages/ai-parrot/tests/unit/outputs/cards/test_elements.py
+++ b/packages/ai-parrot/tests/unit/outputs/cards/test_elements.py
@@ -1,0 +1,115 @@
+"""Unit tests for AC 1.5 element models."""
+import pytest
+from pydantic import ValidationError
+
+
+class TestTextBlock:
+    def test_minimal(self):
+        from parrot.outputs.cards.elements import TextBlock
+        tb = TextBlock(text="hello")
+        assert tb.element_type == "TextBlock"
+        assert tb.text == "hello"
+        assert tb.wrap is True
+        assert tb.is_visible is True
+
+    def test_all_properties(self):
+        from parrot.outputs.cards.elements import TextBlock
+        tb = TextBlock(
+            text="title",
+            weight="Bolder",
+            size="Large",
+            color="Good",
+            font_type="Monospace",
+            is_subtle=True,
+            horizontal_alignment="Center",
+            spacing="Medium",
+            separator=True,
+            max_lines=3,
+            id="tb1",
+            is_visible=False,
+        )
+        assert tb.weight == "Bolder"
+        assert tb.id == "tb1"
+        assert tb.is_visible is False
+
+    def test_invalid_weight_rejected(self):
+        from parrot.outputs.cards.elements import TextBlock
+        with pytest.raises(ValidationError):
+            TextBlock(text="x", weight="SuperBold")
+
+
+class TestImage:
+    def test_minimal(self):
+        from parrot.outputs.cards.elements import Image
+        img = Image(url="https://example.com/img.png")
+        assert img.element_type == "Image"
+        assert img.url == "https://example.com/img.png"
+        assert img.alt_text == ""
+
+    def test_data_uri(self):
+        from parrot.outputs.cards.elements import Image
+        img = Image(url="data:image/png;base64,abc123", alt_text="chart")
+        assert img.url.startswith("data:image/")
+
+
+class TestTable:
+    def test_structure(self):
+        from parrot.outputs.cards.elements import (
+            Table, TableColumnDefinition, TableRow, TableCell, TextBlock,
+        )
+        table = Table(
+            columns=[TableColumnDefinition(width="1"), TableColumnDefinition(width="2")],
+            rows=[
+                TableRow(cells=[
+                    TableCell(items=[TextBlock(text="a")]),
+                    TableCell(items=[TextBlock(text="b")]),
+                ]),
+            ],
+        )
+        assert table.element_type == "Table"
+        assert table.first_row_as_header is True
+        assert len(table.rows) == 1
+        assert len(table.rows[0].cells) == 2
+
+    def test_empty_table(self):
+        from parrot.outputs.cards.elements import Table
+        table = Table(columns=[], rows=[])
+        assert table.rows == []
+
+
+class TestContainer:
+    def test_with_children(self):
+        from parrot.outputs.cards.elements import Container, TextBlock
+        c = Container(
+            items=[TextBlock(text="inner")],
+            style="Emphasis",
+            id="c1",
+            is_visible=False,
+        )
+        assert c.element_type == "Container"
+        assert len(c.items) == 1
+        assert c.is_visible is False
+
+
+class TestColumnSet:
+    def test_with_columns(self):
+        from parrot.outputs.cards.elements import ColumnSet, Column, TextBlock
+        cs = ColumnSet(
+            columns=[
+                Column(width="stretch", items=[TextBlock(text="col1")]),
+                Column(width="auto", items=[TextBlock(text="col2")]),
+            ],
+        )
+        assert cs.element_type == "ColumnSet"
+        assert len(cs.columns) == 2
+
+
+class TestFactSet:
+    def test_facts(self):
+        from parrot.outputs.cards.elements import FactSet, Fact
+        fs = FactSet(facts=[
+            Fact(title="Revenue", value="$1M"),
+            Fact(title="Growth", value="+12%"),
+        ])
+        assert fs.element_type == "FactSet"
+        assert len(fs.facts) == 2

--- a/packages/ai-parrot/tests/unit/outputs/cards/test_init.py
+++ b/packages/ai-parrot/tests/unit/outputs/cards/test_init.py
@@ -1,0 +1,18 @@
+"""Smoke test for the public API re-exports of parrot.outputs.cards."""
+
+
+class TestPublicAPI:
+    def test_all_imports(self):
+        from parrot.outputs.cards import (
+            ACAction, ACElement, ActionOpenUrl, ActionShowCard,
+            ActionSubmit, ActionToggleVisibility, AutoCollapsePolicy,
+            CardRenderError, CardSpec, CodeSection, Container,
+            DetailField, DetailSection, FactSet, FormFieldSpec,
+            FormSection, Image, ImageEntry, ImageSection,
+            InputChoiceSet, InputText, MetricEntry, MetricsSection,
+            RawElementsSection, StatusSection, Table, TableSection,
+            TextBlock, TextSection, ToggleGroup, ToggleSection,
+            build_attachment, markdown_to_sections, render, render_text,
+        )
+        # All importable without error
+        assert CardSpec is not None

--- a/packages/ai-parrot/tests/unit/outputs/cards/test_inputs.py
+++ b/packages/ai-parrot/tests/unit/outputs/cards/test_inputs.py
@@ -1,0 +1,81 @@
+# tests/unit/outputs/cards/test_inputs.py
+"""Unit tests for AC input element models."""
+import pytest
+from pydantic import ValidationError
+
+
+class TestInputText:
+    def test_minimal(self):
+        from parrot.outputs.cards.inputs import InputText
+        inp = InputText(id="name")
+        assert inp.element_type == "Input.Text"
+        assert inp.is_multiline is False
+        assert inp.is_required is False
+
+    def test_email_style(self):
+        from parrot.outputs.cards.inputs import InputText
+        inp = InputText(id="email", style="Email", is_required=True, label="Email")
+        assert inp.style == "Email"
+        assert inp.label == "Email"
+
+    def test_multiline(self):
+        from parrot.outputs.cards.inputs import InputText
+        inp = InputText(id="notes", is_multiline=True, max_length=500)
+        assert inp.is_multiline is True
+        assert inp.max_length == 500
+
+
+class TestInputNumber:
+    def test_with_range(self):
+        from parrot.outputs.cards.inputs import InputNumber
+        inp = InputNumber(id="qty", min=1, max=100, value=5)
+        assert inp.element_type == "Input.Number"
+        assert inp.min == 1
+
+
+class TestInputToggle:
+    def test_defaults(self):
+        from parrot.outputs.cards.inputs import InputToggle
+        inp = InputToggle(id="agree", title="I agree")
+        assert inp.element_type == "Input.Toggle"
+        assert inp.value == "false"
+        assert inp.value_on == "true"
+
+
+class TestInputDate:
+    def test_minimal(self):
+        from parrot.outputs.cards.inputs import InputDate
+        inp = InputDate(id="dob")
+        assert inp.element_type == "Input.Date"
+        assert inp.value is None
+
+
+class TestInputTime:
+    def test_minimal(self):
+        from parrot.outputs.cards.inputs import InputTime
+        inp = InputTime(id="start_time")
+        assert inp.element_type == "Input.Time"
+
+
+class TestInputChoiceSet:
+    def test_single_select(self):
+        from parrot.outputs.cards.inputs import InputChoiceSet, InputChoice
+        inp = InputChoiceSet(
+            id="role",
+            choices=[InputChoice(title="Admin", value="admin"),
+                     InputChoice(title="User", value="user")],
+            style="compact",
+        )
+        assert inp.element_type == "Input.ChoiceSet"
+        assert inp.is_multi_select is False
+        assert len(inp.choices) == 2
+
+    def test_multi_select(self):
+        from parrot.outputs.cards.inputs import InputChoiceSet, InputChoice
+        inp = InputChoiceSet(
+            id="tags",
+            choices=[InputChoice(title="A", value="a")],
+            is_multi_select=True,
+            style="expanded",
+        )
+        assert inp.is_multi_select is True

--- a/packages/ai-parrot/tests/unit/outputs/cards/test_markdown.py
+++ b/packages/ai-parrot/tests/unit/outputs/cards/test_markdown.py
@@ -1,0 +1,66 @@
+"""Unit tests for the markdown-to-sections parser."""
+import pytest
+
+
+class TestMarkdownToSections:
+    def test_plain_text(self):
+        from parrot.outputs.cards.markdown import markdown_to_sections
+        from parrot.outputs.cards.sections import TextSection
+        result = markdown_to_sections("Hello world")
+        assert len(result) == 1
+        assert isinstance(result[0], TextSection)
+        assert result[0].text == "Hello world"
+
+    def test_pipe_table(self):
+        from parrot.outputs.cards.markdown import markdown_to_sections
+        from parrot.outputs.cards.sections import TableSection
+        md = "| Name | Age |\n| --- | --- |\n| Alice | 30 |\n| Bob | 25 |"
+        result = markdown_to_sections(md)
+        tables = [s for s in result if isinstance(s, TableSection)]
+        assert len(tables) == 1
+        assert tables[0].columns == ["Name", "Age"]
+        assert len(tables[0].rows) == 2
+        assert tables[0].rows[0] == ["Alice", "30"]
+
+    def test_text_then_table_then_text(self):
+        from parrot.outputs.cards.markdown import markdown_to_sections
+        from parrot.outputs.cards.sections import TableSection, TextSection
+        md = "Intro text\n\n| A | B |\n| - | - |\n| 1 | 2 |\n\nConclusion"
+        result = markdown_to_sections(md)
+        assert isinstance(result[0], TextSection)
+        assert isinstance(result[1], TableSection)
+        assert isinstance(result[2], TextSection)
+
+    def test_fenced_code_block(self):
+        from parrot.outputs.cards.markdown import markdown_to_sections
+        from parrot.outputs.cards.sections import CodeSection
+        md = "Before\n```python\nprint('hi')\n```\nAfter"
+        result = markdown_to_sections(md)
+        codes = [s for s in result if isinstance(s, CodeSection)]
+        assert len(codes) == 1
+        assert codes[0].code == "print('hi')"
+        assert codes[0].language == "python"
+
+    def test_image_reference(self):
+        from parrot.outputs.cards.markdown import markdown_to_sections
+        from parrot.outputs.cards.sections import ImageSection
+        md = "Text\n![Chart](https://example.com/chart.png)\nMore text"
+        result = markdown_to_sections(md)
+        images = [s for s in result if isinstance(s, ImageSection)]
+        assert len(images) == 1
+        assert images[0].images[0].url == "https://example.com/chart.png"
+        assert images[0].images[0].alt_text == "Chart"
+
+    def test_empty_string(self):
+        from parrot.outputs.cards.markdown import markdown_to_sections
+        result = markdown_to_sections("")
+        assert result == []
+
+    def test_inline_markdown_preserved(self):
+        from parrot.outputs.cards.markdown import markdown_to_sections
+        from parrot.outputs.cards.sections import TextSection
+        md = "This has **bold** and *italic* text"
+        result = markdown_to_sections(md)
+        assert len(result) == 1
+        assert isinstance(result[0], TextSection)
+        assert "**bold**" in result[0].text

--- a/packages/ai-parrot/tests/unit/outputs/cards/test_renderer.py
+++ b/packages/ai-parrot/tests/unit/outputs/cards/test_renderer.py
@@ -1,0 +1,279 @@
+"""Unit tests for the CardSpec renderer."""
+import json
+
+import pytest
+
+
+class TestRenderTextSection:
+    def test_simple_text(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import TextSection
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec(sections=[TextSection(text="Hello world")])
+        card = render(spec)
+        assert card["type"] == "AdaptiveCard"
+        assert card["version"] == "1.5"
+        assert card["$schema"] == "http://adaptivecards.io/schemas/adaptive-card.json"
+        body = card["body"]
+        assert len(body) == 1
+        assert body[0]["type"] == "TextBlock"
+        assert body[0]["text"] == "Hello world"
+        assert body[0]["wrap"] is True
+
+    def test_title_role(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import TextSection
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec(sections=[TextSection(text="Title", role="title")])
+        card = render(spec)
+        tb = card["body"][0]
+        assert tb["size"] == "Large"
+        assert tb["weight"] == "Bolder"
+
+    def test_monospace_role(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import TextSection
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec(sections=[TextSection(text="code", role="monospace")])
+        card = render(spec)
+        assert card["body"][0]["fontType"] == "Monospace"
+
+
+class TestRenderTableSection:
+    def test_native_table(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import TableSection
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec(sections=[TableSection(
+            columns=["Name", "Age"],
+            rows=[["Alice", "30"], ["Bob", "25"]],
+        )])
+        card = render(spec)
+        tables = [e for e in card["body"] if e["type"] == "Table"]
+        assert len(tables) == 1
+        table = tables[0]
+        assert table["firstRowAsHeader"] is True
+        assert len(table["columns"]) == 2
+        # Header row + 2 data rows
+        assert len(table["rows"]) == 3
+
+    def test_truncation_note(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import TableSection
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec(sections=[TableSection(
+            columns=["X"],
+            rows=[[str(i)] for i in range(30)],
+            total_rows=50,
+            max_display_rows=20,
+        )])
+        card = render(spec)
+        texts = [e for e in card["body"] if e["type"] == "TextBlock"]
+        assert any("50" in t["text"] for t in texts)
+
+    def test_ragged_rows_normalized(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import TableSection
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec(sections=[TableSection(
+            columns=["a", "b", "c"],
+            rows=[["1"], ["1", "2", "3", "4"]],
+        )])
+        card = render(spec)
+        table = [e for e in card["body"] if e["type"] == "Table"][0]
+        for row in table["rows"]:
+            assert len(row["cells"]) == 3
+
+
+class TestRenderMetricsSection:
+    def test_factset_output(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import MetricEntry, MetricsSection
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec(sections=[MetricsSection(metrics=[
+            MetricEntry(label="Rev", value="$1M", delta="+12%"),
+        ])])
+        card = render(spec)
+        factsets = [e for e in card["body"] if e["type"] == "FactSet"]
+        assert len(factsets) == 1
+        assert factsets[0]["facts"][0]["title"] == "Rev"
+        assert "+12%" in factsets[0]["facts"][0]["value"]
+
+
+class TestRenderDetailSection:
+    def test_factset_output(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import DetailField, DetailSection
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec(sections=[DetailSection(fields=[
+            DetailField(label="Status", value="Active"),
+        ])])
+        card = render(spec)
+        factsets = [e for e in card["body"] if e["type"] == "FactSet"]
+        assert factsets[0]["facts"][0]["value"] == "Active"
+
+
+class TestRenderImageSection:
+    def test_url_image(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import ImageEntry, ImageSection
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec(sections=[ImageSection(images=[
+            ImageEntry(url="https://example.com/chart.png", alt_text="chart"),
+        ])])
+        card = render(spec)
+        images = [e for e in card["body"] if e["type"] == "Image"]
+        assert len(images) == 1
+        assert images[0]["url"] == "https://example.com/chart.png"
+        assert images[0]["altText"] == "chart"
+
+
+class TestRenderCodeSection:
+    def test_monospace_block(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import CodeSection
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec(sections=[CodeSection(
+            code="print('hi')", language="python", label="Code (python):",
+        )])
+        card = render(spec)
+        texts = [e for e in card["body"] if e["type"] == "TextBlock"]
+        label = [t for t in texts if "Code" in t["text"]]
+        code = [t for t in texts if t.get("fontType") == "Monospace"]
+        assert len(label) == 1
+        assert len(code) == 1
+        assert code[0]["text"] == "print('hi')"
+
+
+class TestRenderStatusSection:
+    def test_colored_status(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import StatusSection
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec(sections=[StatusSection(
+            level="error", message="Failed", details="Timeout",
+        )])
+        card = render(spec)
+        container = [e for e in card["body"] if e["type"] == "Container"][0]
+        msg = container["items"][0]
+        assert msg["color"] == "Attention"
+        assert msg["text"] == "Failed"
+
+
+class TestRenderFormSection:
+    def test_input_elements(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import FormFieldSpec, FormSection
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec(sections=[FormSection(fields=[
+            FormFieldSpec(field_id="name", field_type="text", label="Name", required=True),
+            FormFieldSpec(field_id="age", field_type="number", label="Age"),
+        ])])
+        card = render(spec)
+        inputs = [e for e in card["body"] if e["type"].startswith("Input.")]
+        assert len(inputs) == 2
+        assert inputs[0]["type"] == "Input.Text"
+        assert inputs[0]["id"] == "name"
+        assert inputs[0]["isRequired"] is True
+        assert inputs[1]["type"] == "Input.Number"
+
+
+class TestRenderToggleSection:
+    def test_explicit_toggle(self):
+        from parrot.outputs.cards.elements import TextBlock
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import ToggleSection
+        from parrot.outputs.cards.spec import CardSpec
+        from parrot.outputs.cards.toggle import ToggleGroup
+        spec = CardSpec(sections=[ToggleSection(toggle=ToggleGroup(
+            content=[TextBlock(text="hidden content")],
+            group_id="detail",
+        ))])
+        card = render(spec)
+        containers = [e for e in card["body"] if e["type"] == "Container"]
+        assert any(c.get("id") == "detail_content" for c in containers)
+        assert any(c.get("isVisible") is False for c in containers)
+        toggle_actions = [a for a in card.get("actions", [])
+                         if a["type"] == "Action.ToggleVisibility"]
+        assert len(toggle_actions) == 1
+
+
+class TestRenderRawSection:
+    def test_passthrough(self):
+        from parrot.outputs.cards.elements import TextBlock
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import RawElementsSection
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec(sections=[RawElementsSection(
+            elements=[TextBlock(text="raw element", weight="Bolder")],
+        )])
+        card = render(spec)
+        assert card["body"][0]["type"] == "TextBlock"
+        assert card["body"][0]["weight"] == "Bolder"
+
+
+class TestRenderActions:
+    def test_submit_and_openurl(self):
+        from parrot.outputs.cards.actions import ActionOpenUrl, ActionSubmit
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec(actions=[
+            ActionSubmit(title="OK", data={"x": 1}),
+            ActionOpenUrl(title="Docs", url="https://docs.example.com"),
+        ])
+        card = render(spec)
+        assert len(card["actions"]) == 2
+        assert card["actions"][0]["type"] == "Action.Submit"
+        assert card["actions"][1]["type"] == "Action.OpenUrl"
+
+
+class TestRenderCardSpec:
+    def test_title_and_summary(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec(title="Report", summary="Q2 data")
+        card = render(spec)
+        texts = [e for e in card["body"] if e["type"] == "TextBlock"]
+        titles = [t for t in texts if t.get("weight") == "Bolder"]
+        assert any("Report" in t["text"] for t in titles)
+        assert any("Q2 data" in t["text"] for t in texts)
+
+    def test_omits_none_values(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import TextSection
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec(sections=[TextSection(text="clean")])
+        card = render(spec)
+        tb = card["body"][0]
+        assert "color" not in tb
+        assert "fontType" not in tb
+        assert "maxLines" not in tb
+        assert "id" not in tb
+
+    def test_size_guard(self):
+        from parrot.outputs.cards.renderer import CardRenderError, render
+        from parrot.outputs.cards.sections import TextSection
+        from parrot.outputs.cards.spec import CardSpec
+        huge = TextSection(text="x" * 30_000)
+        spec = CardSpec(sections=[huge])
+        with pytest.raises(CardRenderError):
+            render(spec, max_card_bytes=1_000)
+
+
+class TestRenderText:
+    def test_fallback(self):
+        from parrot.outputs.cards.renderer import render_text
+        from parrot.outputs.cards.sections import MetricEntry, MetricsSection, TextSection
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec(
+            title="Report",
+            sections=[
+                TextSection(text="Overview"),
+                MetricsSection(metrics=[MetricEntry(label="Rev", value="$1M")]),
+            ],
+        )
+        text = render_text(spec)
+        assert "Report" in text
+        assert "Overview" in text
+        assert "Rev" in text
+        assert "$1M" in text

--- a/packages/ai-parrot/tests/unit/outputs/cards/test_renderer.py
+++ b/packages/ai-parrot/tests/unit/outputs/cards/test_renderer.py
@@ -178,6 +178,87 @@ class TestRenderFormSection:
         assert inputs[1]["type"] == "Input.Number"
 
 
+class TestRenderFormFieldTypes:
+    def test_boolean_toggle(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import FormFieldSpec, FormSection
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec(sections=[FormSection(fields=[
+            FormFieldSpec(field_id="agree", field_type="boolean", label="Agree", description="I agree to terms"),
+        ])])
+        card = render(spec)
+        inputs = [e for e in card["body"] if e["type"] == "Input.Toggle"]
+        assert len(inputs) == 1
+        assert inputs[0]["id"] == "agree"
+
+    def test_date_input(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import FormFieldSpec, FormSection
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec(sections=[FormSection(fields=[
+            FormFieldSpec(field_id="dob", field_type="date", label="Date of Birth"),
+        ])])
+        card = render(spec)
+        inputs = [e for e in card["body"] if e["type"] == "Input.Date"]
+        assert len(inputs) == 1
+
+    def test_time_input(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import FormFieldSpec, FormSection
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec(sections=[FormSection(fields=[
+            FormFieldSpec(field_id="start", field_type="time", label="Start Time"),
+        ])])
+        card = render(spec)
+        inputs = [e for e in card["body"] if e["type"] == "Input.Time"]
+        assert len(inputs) == 1
+
+    def test_select_choiceset(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.inputs import InputChoice
+        from parrot.outputs.cards.sections import FormFieldSpec, FormSection
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec(sections=[FormSection(fields=[
+            FormFieldSpec(
+                field_id="role", field_type="select", label="Role",
+                options=[InputChoice(title="Admin", value="admin"),
+                         InputChoice(title="User", value="user")],
+            ),
+        ])])
+        card = render(spec)
+        inputs = [e for e in card["body"] if e["type"] == "Input.ChoiceSet"]
+        assert len(inputs) == 1
+        assert inputs[0]["isMultiSelect"] is False
+
+    def test_multi_select_choiceset(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.inputs import InputChoice
+        from parrot.outputs.cards.sections import FormFieldSpec, FormSection
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec(sections=[FormSection(fields=[
+            FormFieldSpec(
+                field_id="tags", field_type="multi_select", label="Tags",
+                options=[InputChoice(title="A", value="a")],
+            ),
+        ])])
+        card = render(spec)
+        inputs = [e for e in card["body"] if e["type"] == "Input.ChoiceSet"]
+        assert len(inputs) == 1
+        assert inputs[0]["isMultiSelect"] is True
+
+    def test_email_style(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import FormFieldSpec, FormSection
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec(sections=[FormSection(fields=[
+            FormFieldSpec(field_id="email", field_type="email", label="Email"),
+        ])])
+        card = render(spec)
+        inputs = [e for e in card["body"] if e["type"] == "Input.Text"]
+        assert len(inputs) == 1
+        assert inputs[0]["style"] == "Email"
+
+
 class TestRenderToggleSection:
     def test_explicit_toggle(self):
         from parrot.outputs.cards.elements import TextBlock

--- a/packages/ai-parrot/tests/unit/outputs/cards/test_renderer_auto_collapse.py
+++ b/packages/ai-parrot/tests/unit/outputs/cards/test_renderer_auto_collapse.py
@@ -1,0 +1,105 @@
+# packages/ai-parrot/tests/unit/outputs/cards/test_renderer_auto_collapse.py
+"""Unit tests for auto-collapse behavior in the renderer."""
+import pytest
+
+
+class TestAutoCollapseTable:
+    def test_table_exceeding_threshold_gets_toggle(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import TableSection
+        from parrot.outputs.cards.spec import CardSpec
+        from parrot.outputs.cards.toggle import AutoCollapsePolicy
+        spec = CardSpec(
+            sections=[TableSection(
+                columns=["X"],
+                rows=[[str(i)] for i in range(20)],
+                max_display_rows=20,
+            )],
+            auto_collapse=AutoCollapsePolicy(table_row_threshold=5),
+        )
+        card = render(spec)
+        # Should have a toggle action for the overflow
+        toggle_actions = [a for a in card.get("actions", [])
+                         if a["type"] == "Action.ToggleVisibility"]
+        assert len(toggle_actions) >= 1
+        # Should have a hidden container with the overflow rows
+        containers = [e for e in card["body"] if e.get("type") == "Container"
+                     and e.get("isVisible") is False]
+        assert len(containers) >= 1
+
+    def test_table_under_threshold_no_toggle(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import TableSection
+        from parrot.outputs.cards.spec import CardSpec
+        from parrot.outputs.cards.toggle import AutoCollapsePolicy
+        spec = CardSpec(
+            sections=[TableSection(columns=["X"], rows=[["1"], ["2"]])],
+            auto_collapse=AutoCollapsePolicy(table_row_threshold=5),
+        )
+        card = render(spec)
+        toggle_actions = [a for a in card.get("actions", [])
+                         if a["type"] == "Action.ToggleVisibility"]
+        assert len(toggle_actions) == 0
+
+
+class TestAutoCollapseText:
+    def test_long_text_gets_toggle(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import TextSection
+        from parrot.outputs.cards.spec import CardSpec
+        from parrot.outputs.cards.toggle import AutoCollapsePolicy
+        spec = CardSpec(
+            sections=[TextSection(text="word " * 200)],
+            auto_collapse=AutoCollapsePolicy(text_char_threshold=100),
+        )
+        card = render(spec)
+        toggle_actions = [a for a in card.get("actions", [])
+                         if a["type"] == "Action.ToggleVisibility"]
+        assert len(toggle_actions) >= 1
+
+    def test_short_text_no_toggle(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import TextSection
+        from parrot.outputs.cards.spec import CardSpec
+        from parrot.outputs.cards.toggle import AutoCollapsePolicy
+        spec = CardSpec(
+            sections=[TextSection(text="short")],
+            auto_collapse=AutoCollapsePolicy(text_char_threshold=100),
+        )
+        card = render(spec)
+        toggle_actions = [a for a in card.get("actions", [])
+                         if a["type"] == "Action.ToggleVisibility"]
+        assert len(toggle_actions) == 0
+
+
+class TestAutoCollapseCode:
+    def test_long_code_gets_toggle(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import CodeSection
+        from parrot.outputs.cards.spec import CardSpec
+        from parrot.outputs.cards.toggle import AutoCollapsePolicy
+        code = "\n".join(f"line {i}" for i in range(20))
+        spec = CardSpec(
+            sections=[CodeSection(code=code)],
+            auto_collapse=AutoCollapsePolicy(code_line_threshold=5),
+        )
+        card = render(spec)
+        toggle_actions = [a for a in card.get("actions", [])
+                         if a["type"] == "Action.ToggleVisibility"]
+        assert len(toggle_actions) >= 1
+
+
+class TestAutoCollapseDisabled:
+    def test_disabled_no_toggles(self):
+        from parrot.outputs.cards.renderer import render
+        from parrot.outputs.cards.sections import TextSection
+        from parrot.outputs.cards.spec import CardSpec
+        from parrot.outputs.cards.toggle import AutoCollapsePolicy
+        spec = CardSpec(
+            sections=[TextSection(text="word " * 200)],
+            auto_collapse=AutoCollapsePolicy(enabled=False),
+        )
+        card = render(spec)
+        toggle_actions = [a for a in card.get("actions", [])
+                         if a["type"] == "Action.ToggleVisibility"]
+        assert len(toggle_actions) == 0

--- a/packages/ai-parrot/tests/unit/outputs/cards/test_sections.py
+++ b/packages/ai-parrot/tests/unit/outputs/cards/test_sections.py
@@ -1,0 +1,123 @@
+# tests/unit/outputs/cards/test_sections.py
+"""Unit tests for section models and CardSpec."""
+
+
+class TestTextSection:
+    def test_defaults(self):
+        from parrot.outputs.cards.sections import TextSection
+        s = TextSection(text="hello")
+        assert s.section_type == "text"
+        assert s.role == "body"
+        assert s.is_subtle is False
+
+
+class TestTableSection:
+    def test_structure(self):
+        from parrot.outputs.cards.sections import TableSection
+        s = TableSection(
+            columns=["Name", "Age"],
+            rows=[["Alice", "30"], ["Bob", "25"]],
+            total_rows=100,
+        )
+        assert s.section_type == "table"
+        assert len(s.rows) == 2
+        assert s.max_display_rows == 20
+
+
+class TestMetricsSection:
+    def test_with_entries(self):
+        from parrot.outputs.cards.sections import MetricsSection, MetricEntry
+        s = MetricsSection(metrics=[
+            MetricEntry(label="Rev", value="$1M", delta="+12%"),
+        ])
+        assert s.section_type == "metrics"
+        assert s.metrics[0].delta == "+12%"
+
+
+class TestDetailSection:
+    def test_with_fields(self):
+        from parrot.outputs.cards.sections import DetailSection, DetailField
+        s = DetailSection(fields=[DetailField(label="Status", value="Active")])
+        assert s.section_type == "detail"
+
+
+class TestImageSection:
+    def test_with_entries(self):
+        from parrot.outputs.cards.sections import ImageSection, ImageEntry
+        s = ImageSection(images=[
+            ImageEntry(url="https://example.com/img.png", alt_text="chart"),
+        ])
+        assert s.section_type == "image"
+        assert s.images[0].size == "Large"
+
+
+class TestCodeSection:
+    def test_with_language(self):
+        from parrot.outputs.cards.sections import CodeSection
+        s = CodeSection(code="print('hi')", language="python", label="Code (python):")
+        assert s.section_type == "code"
+
+
+class TestStatusSection:
+    def test_defaults(self):
+        from parrot.outputs.cards.sections import StatusSection
+        s = StatusSection(message="All good")
+        assert s.section_type == "status"
+        assert s.level == "info"
+
+
+class TestToggleSection:
+    def test_wraps_toggle_group(self):
+        from parrot.outputs.cards.elements import TextBlock
+        from parrot.outputs.cards.sections import ToggleSection
+        from parrot.outputs.cards.toggle import ToggleGroup
+        tg = ToggleGroup(content=[TextBlock(text="hidden")])
+        s = ToggleSection(toggle=tg)
+        assert s.section_type == "toggle"
+
+
+class TestFormSection:
+    def test_with_fields(self):
+        from parrot.outputs.cards.sections import FormSection, FormFieldSpec
+        s = FormSection(fields=[
+            FormFieldSpec(field_id="name", field_type="text", label="Name", required=True),
+        ])
+        assert s.section_type == "form"
+        assert s.fields[0].required is True
+
+
+class TestRawElementsSection:
+    def test_passthrough(self):
+        from parrot.outputs.cards.elements import TextBlock
+        from parrot.outputs.cards.sections import RawElementsSection
+        s = RawElementsSection(elements=[TextBlock(text="raw")])
+        assert s.section_type == "raw"
+        assert len(s.elements) == 1
+
+
+class TestCardSpec:
+    def test_minimal(self):
+        from parrot.outputs.cards.spec import CardSpec
+        spec = CardSpec()
+        assert spec.version == "1.5"
+        assert spec.sections == []
+        assert spec.actions == []
+        assert spec.auto_collapse is None
+
+    def test_full(self):
+        from parrot.outputs.cards.actions import ActionSubmit
+        from parrot.outputs.cards.sections import TableSection, TextSection
+        from parrot.outputs.cards.spec import CardSpec
+        from parrot.outputs.cards.toggle import AutoCollapsePolicy
+        spec = CardSpec(
+            title="Report",
+            summary="Q2 summary",
+            sections=[
+                TextSection(text="Overview"),
+                TableSection(columns=["A"], rows=[["1"]]),
+            ],
+            actions=[ActionSubmit(title="OK")],
+            auto_collapse=AutoCollapsePolicy(table_row_threshold=10),
+        )
+        assert spec.title == "Report"
+        assert len(spec.sections) == 2

--- a/packages/ai-parrot/tests/unit/outputs/cards/test_toggle.py
+++ b/packages/ai-parrot/tests/unit/outputs/cards/test_toggle.py
@@ -1,0 +1,42 @@
+# tests/unit/outputs/cards/test_toggle.py
+"""Unit tests for toggle models."""
+
+
+class TestToggleGroup:
+    def test_defaults(self):
+        from parrot.outputs.cards.elements import TextBlock
+        from parrot.outputs.cards.toggle import ToggleGroup
+        tg = ToggleGroup(content=[TextBlock(text="hidden")])
+        assert tg.initially_visible is False
+        assert tg.label_collapsed == "Show details"
+        assert tg.label_expanded == "Hide details"
+        assert tg.group_id is None
+
+    def test_custom(self):
+        from parrot.outputs.cards.elements import TextBlock
+        from parrot.outputs.cards.toggle import ToggleGroup
+        tg = ToggleGroup(
+            content=[TextBlock(text="data")],
+            label_collapsed="Show 15 more rows",
+            label_expanded="Hide rows",
+            initially_visible=True,
+            group_id="table_overflow",
+        )
+        assert tg.group_id == "table_overflow"
+        assert tg.initially_visible is True
+
+
+class TestAutoCollapsePolicy:
+    def test_defaults(self):
+        from parrot.outputs.cards.toggle import AutoCollapsePolicy
+        p = AutoCollapsePolicy()
+        assert p.enabled is True
+        assert p.table_row_threshold == 5
+        assert p.text_char_threshold == 500
+        assert p.code_line_threshold == 10
+        assert p.image_count_threshold == 2
+
+    def test_disabled(self):
+        from parrot.outputs.cards.toggle import AutoCollapsePolicy
+        p = AutoCollapsePolicy(enabled=False)
+        assert p.enabled is False


### PR DESCRIPTION
## Summary

- **New shared card builder** at `parrot/outputs/cards/` — Pydantic-first, three-layer architecture (Elements → Sections → CardSpec → renderer) targeting Adaptive Cards 1.5 with native `Table` and `Action.ToggleVisibility`
- **Migrated 5 consumers** to the shared builder: msagentsdk/cards, msteams/wrapper, A2UI adaptive_cards, forms/adaptive_card, msteams/hitl_cards — net reduction of ~400 LOC across consumers
- **81 new unit tests** for the cards package, all 158 tests across cards + consumers pass with zero regressions
- Auto-collapse support (threshold-based wrapping in ToggleGroups), markdown-to-sections parser, attachment envelope helper

## Key design decisions

- Pure-function `render(CardSpec) → dict` — no side effects, no state
- `_FIELD_RENAMES` map + `_snake_to_camel` fallback for Python→JSON serialization
- `_ALWAYS_EMIT_FIELDS` for structural booleans that must appear even at default values
- 28KB size guard with `CardRenderError` for caller fallback

## Files

**New** (shared builder):
- `packages/ai-parrot/src/parrot/outputs/cards/` — elements, inputs, actions, toggle, sections, spec, renderer, markdown, attachment, `__init__`
- `packages/ai-parrot/tests/unit/outputs/cards/` — 10 test files, 81 tests

**Migrated consumers:**
- `packages/ai-parrot-integrations/src/parrot/integrations/msagentsdk/cards.py`
- `packages/ai-parrot-integrations/src/parrot/integrations/msteams/wrapper.py`
- `packages/ai-parrot-integrations/src/parrot/integrations/msteams/hitl_cards.py`
- `packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/adaptive_cards.py`
- `packages/ai-parrot/src/parrot/forms/renderers/adaptive_card.py`

## Test plan

- [x] 81 cards unit tests pass (elements, inputs, actions, toggle, sections, renderer, auto-collapse, markdown, attachment, init)
- [x] 51 integration tests pass (msagentsdk cards + HITL cards)
- [x] 8 A2UI renderer tests pass
- [x] 18 forms renderer tests pass
- [x] render() purity verified (no input mutation)
- [ ] Pre-existing e2e failure `test_plain_bot_unaffected` is unrelated (agent dispatch sends AC for plain-bot responses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)