### PR TITLE
feat(formdesigner): revision-chain contract for form submissions

### DIFF
--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/submissions.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/submissions.py
@@ -73,6 +73,14 @@ class FormSubmission(BaseModel):
         ip: Promoted metadata column — submitter IP address.
         user_agent: Promoted metadata column — submitter User-Agent header.
         locale: Promoted metadata column — BCP-47 locale (e.g. ``en-US``).
+        root_submission_id: Revision-chain anchor — the ``submission_id`` of
+            the first revision in the chain. Equals this record's own
+            ``submission_id`` on revision 1. ``None`` on legacy rows, which
+            readers treat as a single-revision chain.
+        revision: 1-based position within the revision chain. ``None`` on
+            legacy rows.
+        context: Optional per-revision audit context (free-form JSONB), e.g.
+            geofence status, GPS coordinates, and a post-visit flag.
     """
 
     submission_id: str = Field(
@@ -97,6 +105,9 @@ class FormSubmission(BaseModel):
     ip: str | None = None
     user_agent: str | None = None
     locale: str | None = None
+    root_submission_id: str | None = None
+    revision: int | None = None
+    context: dict[str, Any] | None = None
 
 
 class FormSubmissionStorage:
@@ -159,6 +170,8 @@ class FormSubmissionStorage:
         # Index name must be unique per schema; tie it to the table.
         idx_name = f"idx_{self._table}_form_id"
         validate_identifier(idx_name, kind="index")
+        root_idx_name = f"idx_{self._table}_root_submission_id"
+        validate_identifier(root_idx_name, kind="index")
         schema = self._resolve_schema(tenant)
         return f"""
         CREATE TABLE IF NOT EXISTS {qt} (
@@ -179,10 +192,15 @@ class FormSubmissionStorage:
             ip INET,
             user_agent TEXT,
             locale VARCHAR(35),
+            root_submission_id VARCHAR(255),
+            revision INTEGER,
+            context JSONB,
             created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
         );
         CREATE INDEX IF NOT EXISTS "{idx_name}"
             ON "{schema}"."{self._table}"(form_id);
+        CREATE INDEX IF NOT EXISTS "{root_idx_name}"
+            ON "{schema}"."{self._table}"(root_submission_id);
         """
 
     def _alter_table_sql(self, tenant: str | None) -> str:
@@ -193,6 +211,9 @@ class FormSubmissionStorage:
         is cheap on existing rows.
         """
         qt = self._qualified(tenant)
+        root_idx_name = f"idx_{self._table}_root_submission_id"
+        validate_identifier(root_idx_name, kind="index")
+        schema = self._resolve_schema(tenant)
         return f"""
         ALTER TABLE {qt}
             ADD COLUMN IF NOT EXISTS user_id VARCHAR(255),
@@ -201,7 +222,12 @@ class FormSubmissionStorage:
             ADD COLUMN IF NOT EXISTS submitted_at TIMESTAMPTZ,
             ADD COLUMN IF NOT EXISTS ip INET,
             ADD COLUMN IF NOT EXISTS user_agent TEXT,
-            ADD COLUMN IF NOT EXISTS locale VARCHAR(35);
+            ADD COLUMN IF NOT EXISTS locale VARCHAR(35),
+            ADD COLUMN IF NOT EXISTS root_submission_id VARCHAR(255),
+            ADD COLUMN IF NOT EXISTS revision INTEGER,
+            ADD COLUMN IF NOT EXISTS context JSONB;
+        CREATE INDEX IF NOT EXISTS "{root_idx_name}"
+            ON "{schema}"."{self._table}"(root_submission_id);
         """
 
     def _insert_sql(self, tenant: str | None) -> str:
@@ -211,10 +237,12 @@ class FormSubmissionStorage:
             submission_id, form_id, form_version, data,
             is_valid, forwarded, forward_status, forward_error,
             tenant, created_at,
-            user_id, username, org_id, submitted_at, ip, user_agent, locale
+            user_id, username, org_id, submitted_at, ip, user_agent, locale,
+            root_submission_id, revision, context
         ) VALUES (
             $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
-            $11, $12, $13, $14, $15, $16, $17
+            $11, $12, $13, $14, $15, $16, $17,
+            $18, $19, $20
         )
         """
 
@@ -260,6 +288,11 @@ class FormSubmissionStorage:
         effective_tenant = (
             tenant if tenant is not None else submission.tenant
         )
+        context_json = (
+            json.dumps(submission.context)
+            if submission.context is not None
+            else None
+        )
         async with self._pool.acquire() as conn:
             await conn.execute(
                 self._insert_sql(effective_tenant),
@@ -280,6 +313,9 @@ class FormSubmissionStorage:
                 submission.ip,
                 submission.user_agent,
                 submission.locale,
+                submission.root_submission_id,
+                submission.revision,
+                context_json,
             )
         self.logger.debug(
             "Stored submission %s for form %s in %s",
@@ -288,3 +324,107 @@ class FormSubmissionStorage:
             self._qualified(effective_tenant),
         )
         return submission.submission_id
+
+    # ------------------------------------------------------------------
+    # Read API (revision chain)
+    # ------------------------------------------------------------------
+
+    # Column list for reads — order is not significant (rows are accessed by
+    # name), but it enumerates every column mapped back onto ``FormSubmission``.
+    _SELECT_COLUMNS: str = (
+        "submission_id, form_id, form_version, data, is_valid, "
+        "forwarded, forward_status, forward_error, tenant, created_at, "
+        "user_id, username, org_id, submitted_at, ip, user_agent, locale, "
+        "root_submission_id, revision, context"
+    )
+
+    @staticmethod
+    def _row_to_submission(row: Any) -> FormSubmission:
+        """Map an ``asyncpg.Record`` back onto a :class:`FormSubmission`.
+
+        Handles the type gaps between the DB and the model: JSONB columns
+        (``data``, ``context``) come back as ``str`` unless a codec is set,
+        and ``INET`` (``ip``) comes back as an ``ipaddress`` object.
+        """
+
+        def _load_json(value: Any) -> Any:
+            if value is None or isinstance(value, (dict, list)):
+                return value
+            return json.loads(value)
+
+        ip = row["ip"]
+        return FormSubmission(
+            submission_id=row["submission_id"],
+            form_id=row["form_id"],
+            form_version=row["form_version"],
+            data=_load_json(row["data"]) or {},
+            is_valid=row["is_valid"],
+            forwarded=row["forwarded"],
+            forward_status=row["forward_status"],
+            forward_error=row["forward_error"],
+            tenant=row["tenant"],
+            created_at=row["created_at"],
+            user_id=row["user_id"],
+            username=row["username"],
+            org_id=row["org_id"],
+            submitted_at=row["submitted_at"],
+            ip=str(ip) if ip is not None else None,
+            user_agent=row["user_agent"],
+            locale=row["locale"],
+            root_submission_id=row["root_submission_id"],
+            revision=row["revision"],
+            context=_load_json(row["context"]),
+        )
+
+    async def get_submission(
+        self,
+        submission_id: str,
+        *,
+        tenant: str | None = None,
+    ) -> FormSubmission | None:
+        """Fetch a single submission by ``submission_id``.
+
+        Args:
+            submission_id: The unique submission identifier to look up.
+            tenant: Optional per-call tenant override (schema resolution).
+
+        Returns:
+            The matching :class:`FormSubmission`, or ``None`` if no row
+            exists.
+        """
+        qt = self._qualified(tenant)
+        sql = f"SELECT {self._SELECT_COLUMNS} FROM {qt} WHERE submission_id = $1"
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(sql, submission_id)
+        return self._row_to_submission(row) if row is not None else None
+
+    async def list_revisions(
+        self,
+        root_submission_id: str,
+        *,
+        tenant: str | None = None,
+    ) -> list[FormSubmission]:
+        """Return the full revision chain for a submission, oldest first.
+
+        The chain is every row sharing ``root_submission_id``, ordered by
+        ``revision ASC``. Legacy rows written before the revision-chain
+        columns existed have ``NULL`` ``root_submission_id``/``revision``
+        and are therefore single-revision chains reachable only via their
+        own ``submission_id`` (use :meth:`get_submission` for those).
+
+        Args:
+            root_submission_id: The chain anchor (revision 1's
+                ``submission_id``).
+            tenant: Optional per-call tenant override (schema resolution).
+
+        Returns:
+            The chain ordered by ``revision`` ascending (empty if none).
+        """
+        qt = self._qualified(tenant)
+        sql = (
+            f"SELECT {self._SELECT_COLUMNS} FROM {qt} "
+            "WHERE root_submission_id = $1 ORDER BY revision ASC"
+        )
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(sql, root_submission_id)
+        return [self._row_to_submission(row) for row in rows]

--- a/packages/parrot-formdesigner/tests/unit/test_submission_metadata_storage.py
+++ b/packages/parrot-formdesigner/tests/unit/test_submission_metadata_storage.py
@@ -50,7 +50,8 @@ class TestInitializeDDL:
 
 class TestStoreInsertsMetadata:
     @pytest.mark.asyncio
-    async def test_insert_has_seventeen_placeholders(self) -> None:
+    async def test_insert_has_twenty_placeholders(self) -> None:
+        """17 metadata columns + 3 revision-chain columns = 20 placeholders."""
         pool = _RecordingPool()
         storage = FormSubmissionStorage(pool=pool)
         await storage.store(
@@ -59,9 +60,9 @@ class TestStoreInsertsMetadata:
             )
         )
         sql, args = pool.conn.executed[0]
-        assert "$17" in sql
-        assert "$18" not in sql
-        assert len(args) == 17
+        assert "$20" in sql
+        assert "$21" not in sql
+        assert len(args) == 20
 
     @pytest.mark.asyncio
     async def test_insert_carries_metadata_values_in_order(self) -> None:

--- a/packages/parrot-formdesigner/tests/unit/test_submission_revisions.py
+++ b/packages/parrot-formdesigner/tests/unit/test_submission_revisions.py
@@ -1,0 +1,284 @@
+"""Tests for the FormSubmissionStorage revision-chain contract.
+
+Covers the additive revision-chain columns (``root_submission_id``,
+``revision``, ``context``), the ``store()`` INSERT threading them through,
+and the ``get_submission`` / ``list_revisions`` read API. Backward
+compatibility: legacy rows with NULL chain columns must still load, and
+``store()`` must remain insert-only.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from parrot_formdesigner.services.submissions import (
+    FormSubmission,
+    FormSubmissionStorage,
+)
+
+from .test_storage_schema_tenant import _RecordingConn, _RecordingPool
+
+
+# ---------------------------------------------------------------------------
+# A pool whose connection returns pre-seeded rows for reads
+# ---------------------------------------------------------------------------
+
+
+class _RowsConn(_RecordingConn):
+    """Recording connection that also returns seeded rows on reads."""
+
+    def __init__(self, *, row=None, rows=None) -> None:
+        super().__init__()
+        self._row = row
+        self._rows = rows or []
+
+    async def fetchrow(self, sql: str, *args):
+        self.fetched.append((sql, args))
+        return self._row
+
+    async def fetch(self, sql: str, *args):
+        self.fetched.append((sql, args))
+        return list(self._rows)
+
+
+class _RowsPool(_RecordingPool):
+    def __init__(self, *, row=None, rows=None) -> None:
+        super().__init__()
+        self.conn = _RowsConn(row=row, rows=rows)
+
+
+def _db_row(
+    submission_id: str,
+    *,
+    root_submission_id: str | None = None,
+    revision: int | None = None,
+    context: str | None = None,
+    data: str = '{"q1": "yes"}',
+) -> dict:
+    """A dict shaped like an asyncpg Record for the SELECT column set.
+
+    JSONB columns (``data``, ``context``) arrive as ``str`` and ``ip`` as
+    an object stringified by the mapper — mirrors real asyncpg behavior.
+    """
+    return {
+        "submission_id": submission_id,
+        "form_id": "f-1",
+        "form_version": "1.0",
+        "data": data,
+        "is_valid": True,
+        "forwarded": False,
+        "forward_status": None,
+        "forward_error": None,
+        "tenant": None,
+        "created_at": datetime(2026, 7, 21, tzinfo=timezone.utc),
+        "user_id": "u-1",
+        "username": "alice",
+        "org_id": 7,
+        "submitted_at": datetime(2026, 7, 21, tzinfo=timezone.utc),
+        "ip": "203.0.113.5",
+        "user_agent": "ParrotTest/1.0",
+        "locale": "en-US",
+        "root_submission_id": root_submission_id,
+        "revision": revision,
+        "context": context,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+
+class TestFormSubmissionRevisionFields:
+    def test_defaults_none(self) -> None:
+        sub = FormSubmission(
+            form_id="f", form_version="1.0", data={}, is_valid=True
+        )
+        assert sub.root_submission_id is None
+        assert sub.revision is None
+        assert sub.context is None
+
+    def test_roundtrip(self) -> None:
+        sub = FormSubmission(
+            form_id="f",
+            form_version="1.0",
+            data={},
+            is_valid=True,
+            root_submission_id="root-1",
+            revision=2,
+            context={"geofence_status": "outside", "post_visit": True},
+        )
+        restored = FormSubmission.model_validate(sub.model_dump())
+        assert restored.root_submission_id == "root-1"
+        assert restored.revision == 2
+        assert restored.context == {
+            "geofence_status": "outside",
+            "post_visit": True,
+        }
+
+
+# ---------------------------------------------------------------------------
+# DDL
+# ---------------------------------------------------------------------------
+
+
+class TestRevisionDDL:
+    @pytest.mark.asyncio
+    async def test_create_declares_revision_columns_and_index(self) -> None:
+        pool = _RecordingPool()
+        await FormSubmissionStorage(pool=pool).initialize()
+        create_sql = pool.conn.executed[0][0]
+        assert "root_submission_id VARCHAR(255)" in create_sql
+        assert "revision INTEGER" in create_sql
+        assert "context JSONB" in create_sql
+        assert "idx_form_data_root_submission_id" in create_sql
+
+    @pytest.mark.asyncio
+    async def test_alter_adds_revision_columns_and_index(self) -> None:
+        pool = _RecordingPool()
+        await FormSubmissionStorage(pool=pool).initialize()
+        alter_sql = pool.conn.executed[1][0]
+        assert "ADD COLUMN IF NOT EXISTS root_submission_id" in alter_sql
+        assert "ADD COLUMN IF NOT EXISTS revision" in alter_sql
+        assert "ADD COLUMN IF NOT EXISTS context" in alter_sql
+        assert "idx_form_data_root_submission_id" in alter_sql
+
+
+# ---------------------------------------------------------------------------
+# store() — insert-only, carries chain columns
+# ---------------------------------------------------------------------------
+
+
+class TestStoreRevisionColumns:
+    @pytest.mark.asyncio
+    async def test_store_carries_chain_values(self) -> None:
+        pool = _RecordingPool()
+        await FormSubmissionStorage(pool=pool).store(
+            FormSubmission(
+                form_id="f",
+                form_version="1.0",
+                data={},
+                is_valid=True,
+                submission_id="sub-1",
+                root_submission_id="sub-1",
+                revision=1,
+                context={"geofence_status": "ok"},
+            )
+        )
+        sql, args = pool.conn.executed[0]
+        # args (1-indexed): ... 18 root_submission_id, 19 revision, 20 context
+        assert args[17] == "sub-1"
+        assert args[18] == 1
+        assert json.loads(args[19]) == {"geofence_status": "ok"}
+        assert sql.strip().upper().startswith("INSERT INTO")
+
+    @pytest.mark.asyncio
+    async def test_store_nulls_context_when_unset(self) -> None:
+        pool = _RecordingPool()
+        await FormSubmissionStorage(pool=pool).store(
+            FormSubmission(
+                form_id="f", form_version="1.0", data={}, is_valid=True
+            )
+        )
+        _, args = pool.conn.executed[0]
+        assert args[17] is None  # root_submission_id
+        assert args[18] is None  # revision
+        assert args[19] is None  # context
+
+    @pytest.mark.asyncio
+    async def test_store_never_updates_or_deletes(self) -> None:
+        pool = _RecordingPool()
+        storage = FormSubmissionStorage(pool=pool)
+        await storage.store(
+            FormSubmission(
+                form_id="f", form_version="1.0", data={}, is_valid=True,
+                submission_id="sub-1", root_submission_id="sub-1", revision=1,
+            )
+        )
+        await storage.store(
+            FormSubmission(
+                form_id="f", form_version="1.0", data={}, is_valid=True,
+                submission_id="sub-2", root_submission_id="sub-1", revision=2,
+            )
+        )
+        for sql, _ in pool.conn.executed:
+            upper = sql.strip().upper()
+            assert "UPDATE" not in upper
+            assert "DELETE" not in upper
+
+
+# ---------------------------------------------------------------------------
+# Read API
+# ---------------------------------------------------------------------------
+
+
+class TestReadAPI:
+    @pytest.mark.asyncio
+    async def test_get_submission_returns_none_when_absent(self) -> None:
+        pool = _RowsPool(row=None)
+        result = await FormSubmissionStorage(pool=pool).get_submission("nope")
+        assert result is None
+        sql, args = pool.conn.fetched[0]
+        assert "WHERE submission_id = $1" in sql
+        assert args == ("nope",)
+
+    @pytest.mark.asyncio
+    async def test_get_submission_maps_row(self) -> None:
+        row = _db_row(
+            "sub-2",
+            root_submission_id="sub-1",
+            revision=2,
+            context='{"geofence_status": "outside", "post_visit": true}',
+        )
+        pool = _RowsPool(row=row)
+        sub = await FormSubmissionStorage(pool=pool).get_submission("sub-2")
+        assert sub is not None
+        assert sub.submission_id == "sub-2"
+        assert sub.root_submission_id == "sub-1"
+        assert sub.revision == 2
+        assert sub.data == {"q1": "yes"}  # JSONB str decoded
+        assert sub.context == {"geofence_status": "outside", "post_visit": True}
+        assert sub.ip == "203.0.113.5"  # INET stringified
+
+    @pytest.mark.asyncio
+    async def test_list_revisions_orders_by_revision_asc(self) -> None:
+        rows = [
+            _db_row("sub-1", root_submission_id="sub-1", revision=1),
+            _db_row("sub-2", root_submission_id="sub-1", revision=2),
+        ]
+        pool = _RowsPool(rows=rows)
+        chain = await FormSubmissionStorage(pool=pool).list_revisions("sub-1")
+        assert [s.revision for s in chain] == [1, 2]
+        sql, args = pool.conn.fetched[0]
+        assert "WHERE root_submission_id = $1" in sql
+        assert "ORDER BY revision ASC" in sql
+        assert args == ("sub-1",)
+
+    @pytest.mark.asyncio
+    async def test_list_revisions_empty(self) -> None:
+        pool = _RowsPool(rows=[])
+        chain = await FormSubmissionStorage(pool=pool).list_revisions("nope")
+        assert chain == []
+
+    @pytest.mark.asyncio
+    async def test_legacy_null_chain_row_loads(self) -> None:
+        """A pre-migration row (NULL root/revision/context) still maps."""
+        row = _db_row("legacy-1", root_submission_id=None, revision=None)
+        pool = _RowsPool(row=row)
+        sub = await FormSubmissionStorage(pool=pool).get_submission("legacy-1")
+        assert sub is not None
+        assert sub.root_submission_id is None
+        assert sub.revision is None
+        assert sub.context is None
+
+    @pytest.mark.asyncio
+    async def test_read_uses_tenant_override(self) -> None:
+        pool = _RowsPool(row=None)
+        await FormSubmissionStorage(pool=pool).get_submission(
+            "x", tenant="epson"
+        )
+        sql, _ = pool.conn.fetched[0]
+        assert '"epson"."form_data"' in sql


### PR DESCRIPTION
## What

Adds the **revision-chain contract** to `parrot-formdesigner` `FormSubmissionStorage`, enabling versioned form re-submission. All changes are **additive and backward compatible**.

This is the external prerequisite for FieldSync **FEAT-384 / NAV-9181** (Multi-Form Recap), spec §7. FieldSync consumes `parrot-formdesigner` as a git dependency; its `submit_form` service builds on the read API added here.

## Changes

- **`FormSubmission` model**: `+ root_submission_id`, `revision`, `context` (all optional, default `None`).
- **`form_data` DDL**: `+ root_submission_id VARCHAR(255)`, `revision INTEGER`, `context JSONB` — added via `_create_table_sql` (fresh tables) **and** `_alter_table_sql` (legacy tables, `ADD COLUMN IF NOT EXISTS`, nullable, no default → metadata-only on PG ≥ 11), plus an index on `root_submission_id`.
- **`_insert_sql` / `store()`**: thread the 3 new columns (17 → 20 placeholders); `context` serialized as JSON. `store()` **stays insert-only** — no UPDATE/DELETE.
- **Read API**: `get_submission(submission_id)` and `list_revisions(root_submission_id)` (ordered `revision ASC`). Legacy rows with NULL chain columns load as single-revision chains.

## Tests

- New `tests/unit/test_submission_revisions.py` (model defaults/roundtrip, DDL, insert-only store, read API, legacy NULL-chain, tenant override).
- Updated `test_submission_metadata_storage.py` placeholder count (17 → 20).
- `53 passed` across the submission suites. Unrelated collection errors elsewhere in `tests/unit` are `ModuleNotFoundError: 'parrot'` (optional `ai-parrot` dep not installed in the runner) — pre-existing, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)