### PR TITLE
sdd: FEAT-324 spec + Presidio comparison for PII detection &amp; redaction

### DIFF
--- a/sdd/proposals/deterministic-groundedness-scoring.brainstorm.md
+++ b/sdd/proposals/deterministic-groundedness-scoring.brainstorm.md
@@ -1,0 +1,444 @@
+---
+# SDD flow type and base branch (FEAT-145).
+type: feature
+base_branch: dev
+---
+
+# Brainstorm: Deterministic Groundedness Scoring (Anti-Hallucination, Detection-Only)
+
+**Date**: 2026-07-22
+**Author**: Jesús Lara (with Claude Code research)
+**Status**: exploration
+**Recommended Option**: A
+
+> Candidate feature id: FEAT-325 (assigned at spec time; highest on main is
+> FEAT-323, FEAT-324 is the in-flight PII spec on this branch).
+> Companion docs: `pii-detection-redaction.brainstorm.md` / `.comparison.md`
+> (FEAT-324) — this feature reuses its catalog/engine machinery and seams.
+
+---
+
+## Problem Statement
+
+Agents compose their final answer *from* tool outputs — and sometimes invent
+or corrupt the very facts those tools returned: a transposed revenue figure,
+a ticket id that never existed, a date shifted by a month. Today AI-Parrot
+has no way to notice. The OpenAI Guardrails "Hallucination Detection" check
+(https://openai.github.io/openai-guardrails-python/ref/checks/hallucination_detection/)
+addresses this with an **LLM judge + FileSearch over an OpenAI vector
+store**: gpt-4.1-mini by default (ROC AUC 0.876; gpt-5-mini 0.934), **P50
+~7 s / P95 ~43 s per check**, extra FileSearch API cost, a vector store to
+build and maintain, degraded accuracy beyond ~11 MB of documents, and
+inherently non-deterministic verdicts.
+
+That profile cannot run in AI-Parrot's hot path, and it verifies against a
+*static* knowledge base — but in an agent framework the freshest ground
+truth for a turn is already in hand: **the turn's own tool outputs**. What's
+missing is a deterministic, sub-budget (<1000 ms) way to check the answer
+against that evidence and *score* it — detection only: no redaction, no
+blocking, no enforcement.
+
+## Constraints & Requirements
+
+- **Detection/scoring only** — never mutates or blocks the response; the
+  report is advisory (caller/UI/telemetry decide what to do).
+- **Deterministic**: same answer + same evidence → same score. No LLM, no
+  model download, no network call.
+- **Latency**: well under the 1000 ms budget per turn; target same order as
+  the FEAT-324 scanners (single-digit ms in Python, sub-ms with the Rust
+  engine later).
+- **Evidence = the turn's tool outputs** (already carried by
+  `AIMessage.tool_calls[].result` — verified below), not an external
+  knowledge base.
+- Per-agent opt-in via the established kwargs/policy convention; zero new
+  runtime dependencies.
+- Honest scope: verifies **hard-data atoms** only (numbers/amounts/percents,
+  dates, identifiers). Semantic/paraphrase hallucinations are explicitly out
+  of scope — this is a high-precision tripwire, not a truth oracle.
+
+---
+
+## Options Explored
+
+### Option A: Deterministic hard-data atom verification (evidence = turn's tool outputs)
+
+Extract "verifiable atoms" from the final answer — money amounts, percents,
+large/formatted numbers, dates, emails/URLs/ticket-style identifiers — via
+the same catalog+regex machinery as FEAT-324. Build an `EvidenceIndex` from
+the same atoms extracted from every `ToolCall.result` in the turn. Compare
+with normalization (`$1.24M` ≡ `1,243,500` within rounding; multi-format
+dates → ISO) and classify each answer atom:
+
+- `supported` — present in evidence (exact normalized match, or within a
+  **precision-aware rounding tolerance**: half a unit of the answer's last
+  stated significant digit, so `$1.24M` matches `$1,243,500` but a
+  fully-written `$1,234,500` demands exact equality);
+- `contradicted` — numerically close (same magnitude, ≤15% off) to an
+  evidence value but outside its stated precision → classic transposed/
+  corrupted digits, the strongest hallucination signal;
+- `unsupported` — no trace in evidence (invented id, email, figure).
+
+`score = supported / total_atoms`; an answer with no atoms scores 1.0 with
+a `no_factual_content` flag (nothing verifiable ≠ verified).
+
+✅ **Pros:**
+- Deterministic, explainable (every flagged atom is quotable), zero deps.
+- **Prototype validated** (Appendix A): 5/5 synthetic cases correct,
+  including the transposed-digits → `contradicted` case; p99 **2.37 ms**
+  for a 1 KB answer against 3×2 KB tool outputs — ~400× under budget,
+  ~3 000–18 000× faster than the Guardrails LLM judge.
+- Evidence is per-turn and always fresh — no vector store to maintain.
+- Reuses FEAT-324's catalog pattern, seams, and (later) Rust `RegexSet`
+  engine; extractors are data, not code.
+- High precision by construction: a hard atom absent from evidence is
+  near-certainly not grounded in it.
+
+❌ **Cons:**
+- Blind to paraphrased/semantic hallucinations and claims without hard data
+  (mitigated by the explicit `no_factual_content` flag).
+- Small bare integers (≤3 digits) are too noisy to verify and are skipped —
+  documented coverage gap.
+- Legitimate outside knowledge (e.g. the agent adds a well-known constant)
+  scores as `unsupported`; needs an allow-mechanism or tolerant reading of
+  mid scores.
+
+📊 **Effort:** Low–Medium (Python engine) — the hard parts (extraction,
+normalization, seams) are shared with FEAT-324.
+
+📦 **Libraries / Tools:**
+| Package | Purpose | Notes |
+|---|---|---|
+| stdlib `re`, `datetime` | extraction + normalization | zero new deps |
+| (later) `pii-rs`/Rust `RegexSet` | shared native scan pass | same crate as FEAT-324, optional |
+
+🔗 **Existing Code to Reuse:**
+- `models/basic.py:23` `ToolCall` — `result: Optional[Any]` (line 28)
+  already carries each tool's output through the turn.
+- `models/responses.py:72` `AIMessage` — `tool_calls: List[ToolCall]`,
+  `response`, and `metadata: Dict[str, Any]` (line 202) as report carrier.
+- FEAT-324 catalog/policy/engine patterns (`sdd/specs/pii-detection-redaction.spec.md`).
+- FEAT-176 lifecycle observers for telemetry emission.
+
+---
+
+### Option B: LLM-judge groundedness (Guardrails-style, self-hosted)
+
+Run a second LLM pass ("is this answer supported by these tool outputs?")
+per turn, prompt-only (no vector store — evidence inlined).
+
+✅ **Pros:**
+- Catches semantic/paraphrase hallucinations Option A cannot.
+- No FileSearch/vector-store maintenance (evidence inlined per turn).
+
+❌ **Cons:**
+- Seconds of added latency (Guardrails publishes P50 ~7 s / P95 ~43 s for
+  their variant) and per-turn token cost — breaks the ≤1000 ms budget.
+- Non-deterministic; verdicts drift with model/prompt versions.
+- Circular trust: an LLM auditing an LLM inherits the same failure class.
+
+📊 **Effort:** Medium (prompting, output parsing, eval harness)
+
+📦 **Libraries / Tools:**
+| Package | Purpose | Notes |
+|---|---|---|
+| existing `AbstractClient` | judge calls | any provider |
+
+🔗 **Existing Code to Reuse:**
+- `parrot/clients/` for the judge call; could live as an *offline/async*
+  evaluator later, complementary to Option A.
+
+---
+
+### Option C: N-gram / quoted-span overlap scoring
+
+Score lexical overlap: long n-grams and quoted spans of the answer must
+appear in tool outputs (ROUGE-style precision against evidence).
+
+✅ **Pros:**
+- Deterministic; catches invented *sentences*, not just atoms.
+
+❌ **Cons:**
+- Penalizes legitimate paraphrase heavily → noisy scores that erode trust
+  in the report; needs careful thresholds per language.
+- Much larger index cost per turn (all n-grams vs a handful of atoms).
+- Weak on the highest-value failure (a single corrupted digit changes one
+  token — invisible to n-gram overlap, decisive in Option A).
+
+📊 **Effort:** Medium
+
+📦 **Libraries / Tools:**
+| Package | Purpose | Notes |
+|---|---|---|
+| stdlib only | n-gram hashing | — |
+
+🔗 **Existing Code to Reuse:**
+- Same seams as Option A.
+
+---
+
+## Recommendation
+
+**Option A** is recommended because:
+
+- It is the only option that satisfies the constraint set as given —
+  deterministic, scoring-only, and orders of magnitude inside the 1000 ms
+  budget (measured p99 2.37 ms vs Guardrails' published P50 7 000 ms).
+- It targets the failure mode that matters most in a tool-using agent:
+  corruption or invention of the *hard facts the tools just returned* —
+  and the prototype proves the precision-aware tolerance cleanly separates
+  legitimate rounding (`$1.24M`) from digit transposition (`$1,234,500` →
+  `contradicted`).
+- Its blind spots are honest and bounded (`no_factual_content` flag), and
+  the catalog-driven extractor design leaves clean extension points for
+  Option C's n-grams as a future extractor kind, and Option B as an
+  *offline* complementary judge — neither is foreclosed.
+
+Trade-off accepted: this is a tripwire, not full hallucination coverage.
+The report says "these specific atoms are unsupported/contradicted", never
+"this answer is true".
+
+---
+
+## Feature Description
+
+### User-Facing Behavior
+
+- New bot kwargs (same convention as `enable_pii_protection`):
+  `enable_groundedness: bool = False`, `groundedness_policy: dict |
+  GroundednessPolicy` (`extractors` toggle per kind, `numeric_tolerance`
+  mode, `include_user_prompt_as_evidence: bool`, `min_alert_score`).
+- After each `ask()` (and at stream close), the `AIMessage` carries
+  `metadata["groundedness"] = GroundednessReport` with `score`,
+  `no_factual_content`, and the `supported` / `unsupported` /
+  `contradicted` atom lists (kind + raw text + best evidence candidate).
+- The same summary (score + counts, never full atom values) is emitted to
+  telemetry via the existing lifecycle observers.
+- Nothing is ever rewritten or blocked — consumers decide (UI badge,
+  logging, future auto-re-ask).
+
+### Internal Behavior
+
+- `parrot/security/groundedness/` (sibling to `pii/`): `extractors.py`
+  (catalog-driven atom extraction: money/percent/number/date/identifier,
+  with span de-overlap), `normalize.py` (numeric magnitude+suffix folding,
+  multi-format date → ISO, identifier lowercasing), `evidence.py`
+  (`EvidenceIndex`: exact hash-set per kind + numeric list for tolerance
+  checks, built once per turn from `AIMessage.tool_calls[].result`),
+  `scorer.py` (`GroundednessScorer.score()` with precision-aware
+  tolerance), `policy.py` (`GroundednessPolicy` Pydantic model).
+- **Seam**: end-of-turn only — in `get_response()` after the FEAT-324 PII
+  pass (scoring runs on the same text the user will see), and at
+  `ask_stream`'s final `AIMessage`. No per-chunk work: groundedness is a
+  whole-answer property.
+- Evidence uses the *scrubbed* tool outputs (post-PII); since answer and
+  evidence are scrubbed by the same catalog, redaction placeholders match
+  on both sides and do not distort the score.
+- Failure contract mirrors the scrubbers: any scorer exception logs a
+  warning and the response ships without a report — never breaks the turn.
+
+### Edge Cases & Error Handling
+
+- **No tool calls in the turn** → no evidence → report emitted with
+  `no_evidence: true` and score 1.0 (nothing checkable), distinct from
+  `no_factual_content`.
+- **Rounded answers**: precision-aware tolerance (half-unit of last stated
+  significant digit) accepts honest rounding, rejects digit corruption.
+- **Small integers (≤3 digits)** skipped by design (noise); documented.
+- **Structured tool results** (dicts/lists): serialized values traversed
+  recursively, same as the scrubbers traverse `ToolResult`.
+- **Unicode**: reuses FEAT-324's NFKC normalization pre-pass so fullwidth
+  digits can't dodge extraction.
+- **Huge evidence** (many/large tool outputs): index build is linear; cap
+  via `max_evidence_bytes` with a `evidence_truncated` flag on the report.
+
+---
+
+## Capabilities
+
+### New Capabilities
+- `groundedness-extractors`: catalog-driven hard-data atom extraction +
+  normalization (shared foundations with the FEAT-324 catalog).
+- `groundedness-scorer`: `EvidenceIndex` + precision-aware scoring +
+  `GroundednessReport` model.
+- `groundedness-reporting`: `AIMessage.metadata` attachment + telemetry
+  emission via lifecycle observers + bot kwargs/policy wiring.
+
+### Modified Capabilities
+- (none — FEAT-324 artifacts are reused read-only; if its spec lands first,
+  its engine protocol is the preferred extraction backend)
+
+---
+
+## Impact & Integration
+
+| Affected Component | Impact Type | Notes |
+|---|---|---|
+| `parrot/security/` | extends | new `groundedness/` subpackage |
+| `AbstractBot.get_response()` (`bots/abstract.py:3390`) | extends | score after PII pass, attach report to `AIMessage.metadata` |
+| `BaseBot.ask_stream()` final `AIMessage` (`bots/base.py:1846`) | extends | same scoring at stream close (whole-answer, no per-chunk cost) |
+| `AbstractBot.__init__` | extends | `enable_groundedness` / `groundedness_policy` kwargs |
+| `AIMessage` / `ToolCall` models | uses | `tool_calls[].result` as evidence; `metadata` as report carrier — no model changes |
+| Lifecycle observers (FEAT-176) | uses | telemetry emission (score + counts only) |
+| FEAT-324 catalog/engine | depends on (soft) | shares extraction machinery when present; stdlib fallback otherwise |
+
+No breaking changes; default off; zero new dependencies.
+
+---
+
+## Code Context
+
+### User-Provided Code
+
+(none — requirement provided as prose)
+
+### Verified Codebase References
+
+#### Classes & Signatures
+```python
+# packages/ai-parrot/src/parrot/models/basic.py:23
+class ToolCall(BaseModel):
+    id: str
+    name: str
+    arguments: Dict[str, Any]
+    result: Optional[Any] = None      # line 28 — the turn's evidence payload
+    error: Optional[str] = None
+    execution_time: Optional[float] = None
+
+# packages/ai-parrot/src/parrot/models/responses.py:72
+class AIMessage(BaseModel):
+    output: Any
+    response: Optional[str]
+    tool_calls: List[ToolCall]        # populated with results (see below)
+    metadata: Dict[str, Any]          # line 202 — report carrier
+
+# ToolCall.result is populated in the ask loop:
+#   clients/claude.py:584 and :766 — `tc.result = tool_result`
+#   (pattern repeated across provider clients; bedrock.py:728/1040 etc.)
+
+# End-of-turn seams (same as FEAT-324):
+#   bots/abstract.py:3390 — get_response() (non-streaming)
+#   bots/base.py:1846    — final AIMessage yield in ask_stream()
+
+# Observer-only telemetry (FEAT-176):
+#   core/events/lifecycle/events/invoke.py:34 — AfterInvokeEvent (metadata only)
+#   core/events/lifecycle/events/tool.py:30   — AfterToolCallEvent (metadata only)
+```
+
+#### Verified Imports
+```python
+from parrot.models.basic import ToolCall        # models/basic.py:23
+from parrot.models.responses import AIMessage   # models/responses.py:72
+```
+
+#### Key Attributes & Constants
+- `AIMessage.metadata: Dict[str, Any]` — `models/responses.py:202`.
+- Bot kwarg-toggle convention: `self.enable_tools` (`bots/abstract.py:~383-400`).
+- Policy-model template: `ObservabilityConfig` (`observability/config.py:18`).
+
+### Does NOT Exist (Anti-Hallucination)
+- ~~`parrot.security.groundedness`~~ — created by this feature.
+- ~~Text payloads on lifecycle events~~ — FEAT-176 events carry metadata
+  only (names/durations/sizes), by design; the scorer must read texts from
+  the `AIMessage`, not from events.
+- ~~A per-turn tool-output collector~~ — not needed: `AIMessage.tool_calls`
+  already aggregates `ToolCall.result` for the turn.
+- ~~Any existing groundedness/hallucination/factuality check in runtime~~ —
+  none found in `parrot/`.
+- ~~`parrot.security.pii` at implementation time~~ — FEAT-324 is spec'd,
+  not yet implemented; this feature must NOT import it until it lands
+  (stdlib extractor fallback first, shared engine as a follow-up).
+
+---
+
+## Parallelism Assessment
+
+- **Internal parallelism**: low — the three capabilities form a short
+  dependency chain (extractors → scorer → reporting); one worktree,
+  sequential tasks.
+- **Cross-feature independence**: file-disjoint from FEAT-324 code
+  (`groundedness/` vs `pii/`) but both touch `get_response()`/`ask_stream`
+  wiring — if implemented concurrently, land FEAT-324's seam hooks first
+  and chain after them.
+- **Recommended isolation**: per-spec (single worktree).
+- **Rationale**: small surface, strict ordering, shared seam with an
+  in-flight feature argues for sequential integration.
+
+---
+
+## Open Questions
+
+- [x] Numeric tolerance model — *Resolved in prototype round*:
+  precision-aware (half-unit of the answer's last stated significant
+  digit), NOT a fixed percentage; a fixed 2% swallowed digit
+  transpositions in testing (Appendix A, case b).
+- [ ] Should the user's prompt count as legitimate evidence (user states a
+  figure, agent echoes it)? Proposed default: yes, behind
+  `include_user_prompt_as_evidence=True`. — *Owner: Jesús*
+- [ ] Multi-locale numbers/dates (`1.234,5`, DD/MM vs MM/DD): v1 ships
+  en-US biased extractors; locale packs via catalog overlays later? —
+  *Owner: Jesús*
+- [ ] Telemetry alert threshold: emit score always, or only below
+  `min_alert_score` (default 0.8)? — *Owner: Jesús*
+- [ ] Small-integer gap: skip ≤3-digit bare numbers (current prototype) or
+  make the floor configurable per agent? — *Owner: Jesús*
+- [ ] Future: expose the scorer as a standalone evaluation tool (offline
+  batch over conversation logs) in addition to the runtime seam? —
+  *Owner: Jesús*
+
+---
+
+## Appendix A — Prototype validation & latency (reproducible)
+
+Stdlib-only prototype (~170 lines): extractors (money/percent/number/date/
+identifier with span de-overlap), magnitude+suffix normalization
+(`$1.24M` → 1 240 000), multi-format date → ISO, `EvidenceIndex`
+(exact set + numeric tolerance list), precision-aware scorer.
+
+Synthetic evidence: two tool outputs (sales query: `$1,243,500`, `4,812`
+orders, `2026-06-30`, `finance@acme.example.com`, `INV-2210`; inventory
+API: `312` units, `15%`, `06/28/2026`).
+
+| Case | Expectation | Result |
+|---|---|---|
+| (a) faithful answer | score 1.0, all atoms supported | ✅ 1.0 — money/date/number supported |
+| (b) transposed digits (`$1,234,500`) | flagged | ✅ 0.5 — money atom **contradicted** |
+| (c) invented id + email (`INV-9999`, other domain) | flagged | ✅ 0.0 — both **unsupported** |
+| (d) no hard data in answer | neutral | ✅ 1.0 + `no_factual_content: true` |
+| (e) rounded paraphrase (`$1.24M`, `312 units`) | supported | ✅ 1.0 — precision-aware tolerance |
+
+Latency (1 KB answer vs 3 × 2 KB tool outputs, 200 warm iterations,
+including per-call `EvidenceIndex` build — a per-turn cache would roughly
+halve it): **p50 1.81 ms, p95 1.95 ms, p99 2.37 ms** — ~400× under the
+1000 ms budget; Guardrails' LLM judge publishes P50 ~7 s / P95 ~43 s for
+its equivalent check (~3 000–18 000× slower).
+
+Design finding worth preserving: with a fixed 2% tolerance, case (b)
+scored `supported` — the transposition (`0.72%` off) hid inside the
+rounding allowance. The precision-aware rule (tolerance derived from the
+answer's own stated significant digits) fixed (b) without breaking (e).
+This is the recommended normative rule for the spec.
+
+```python
+# Core of the precision-aware tolerance (full script: ~170 lines, stdlib):
+def sig_digits(raw: str) -> int:
+    digits = re.sub(r"[^0-9]", "", raw).lstrip("0")
+    return max(len(digits), 1)
+
+def rel_tolerance(raw: str) -> float:
+    """Half a unit of the last stated significant digit:
+    '$1,234,500' (7 sig digits) -> ~5e-7 (exact match in practice)
+    '$1.24M'     (3 sig digits) -> 0.5%  (legitimate rounding passes)"""
+    return 0.5 * 10.0 ** (-(sig_digits(raw) - 1))
+
+# classification per answer atom vs EvidenceIndex:
+#   exact normalized match ................. supported
+#   |Δ|/ev <= rel_tolerance(stated) ........ supported   (honest rounding)
+#   |Δ|/ev <= 0.15 ......................... contradicted (corrupted digits)
+#   otherwise .............................. unsupported  (no trace)
+```
+
+## References
+
+- OpenAI Guardrails hallucination check: https://openai.github.io/openai-guardrails-python/ref/checks/hallucination_detection/
+- FEAT-324 spec (shared machinery): `sdd/specs/pii-detection-redaction.spec.md`
+- FEAT-324 comparison (latency methodology reused here): `sdd/proposals/pii-detection-redaction.comparison.md`

--- a/sdd/proposals/pii-detection-redaction.brainstorm.md
+++ b/sdd/proposals/pii-detection-redaction.brainstorm.md
@@ -458,8 +458,8 @@ from parrot.observability.context import current_agent_name  # bots/base.py:56 (
 - [ ] NER-class entities (person names, postal addresses) are not
   regex-detectable; `PIIEngine` Protocol is the extension point for a
   future `SpacyNerEngine` (spacy already in the `agents` extra) — confirm
-  out of scope for FEAT-319. — *Owner: Jesús*
+  out of scope for FEAT-324. — *Owner: Jesús*
   (Note: this feature was tentatively FEAT-316 when drafted; 316–318 were
-  taken by the eventbus migration, so the spec assigned FEAT-319.)
+  taken by the eventbus migration, so the spec assigned FEAT-324.)
 - [ ] Streaming UX: holdback window delays the last ≤128 chars of a
   stream — acceptable for AgentTalk/voice consumers? — *Owner: Jesús*

--- a/sdd/proposals/pii-detection-redaction.brainstorm.md
+++ b/sdd/proposals/pii-detection-redaction.brainstorm.md
@@ -458,6 +458,8 @@ from parrot.observability.context import current_agent_name  # bots/base.py:56 (
 - [ ] NER-class entities (person names, postal addresses) are not
   regex-detectable; `PIIEngine` Protocol is the extension point for a
   future `SpacyNerEngine` (spacy already in the `agents` extra) — confirm
-  out of scope for FEAT-316. — *Owner: Jesús*
+  out of scope for FEAT-319. — *Owner: Jesús*
+  (Note: this feature was tentatively FEAT-316 when drafted; 316–318 were
+  taken by the eventbus migration, so the spec assigned FEAT-319.)
 - [ ] Streaming UX: holdback window delays the last ≤128 chars of a
   stream — acceptable for AgentTalk/voice consumers? — *Owner: Jesús*

--- a/sdd/proposals/pii-detection-redaction.comparison.md
+++ b/sdd/proposals/pii-detection-redaction.comparison.md
@@ -1,7 +1,7 @@
-# Comparison: OpenAI Guardrails PII (Presidio + spaCy) vs FEAT-319 (Rust + catalog)
+# Comparison: OpenAI Guardrails PII (Presidio + spaCy) vs FEAT-324 (Rust + catalog)
 
 **Date**: 2026-07-22
-**Feature**: FEAT-319 (`sdd/specs/pii-detection-redaction.spec.md`)
+**Feature**: FEAT-324 (`sdd/specs/pii-detection-redaction.spec.md`)
 **Trigger**: review of https://openai.github.io/openai-guardrails-python/ref/checks/pii/
 **Latency budget under evaluation**: ≤ 1000 ms for detection + masking
 
@@ -31,7 +31,7 @@ Notable properties:
 
 ## 2. Architectural comparison
 
-| Dimension | OpenAI Guardrails (Presidio+spaCy) | FEAT-319 (this repo) |
+| Dimension | OpenAI Guardrails (Presidio+spaCy) | FEAT-324 (this repo) |
 |---|---|---|
 | Engine | Presidio analyzer; spaCy NLP pipeline runs on **every** `analyze()` call | Rust `pii-rs` (`RegexSet` one-pass DFA + validators + context scoring); pure-Python fallback, identical behavior |
 | Hard deps | `presidio-analyzer`, `presidio-anonymizer`, spaCy + `en_core_web_sm` model (init fails without it) | none in Python core; optional `ai-parrot[pii-native]` wheel |
@@ -41,7 +41,7 @@ Notable properties:
 | Actions | mask (input stage only) or block | allow / redact (mask strategies) / **reversible pseudonymize** with per-conversation restore |
 | Output-stage masking | **not supported** (block only) | primary use case: tool egress + final response are both mask-capable |
 | Streaming | none | sliding-window filter, holdback ≤ 128 chars, streaming ≡ non-streaming invariant |
-| Anti-bypass | Unicode normalization; optional encoded-PII scan | **adopted into FEAT-319 from this comparison** (see §5) |
+| Anti-bypass | Unicode normalization; optional encoded-PII scan | **adopted into FEAT-324 from this comparison** (see §5) |
 | At-rest posture | n/a (gateway-level check) | `enforce` mode persists scrubbed text in memory/observability on both ask paths |
 
 The output-stage limitation is decisive for our use case: AI-Parrot's two
@@ -53,7 +53,7 @@ to block-only.
 
 Environment: Linux container, Python 3.11.15, `presidio-analyzer 2.2.363`,
 `spacy 3.8.13`. 200 warm iterations per corpus; p50/p95/p99 via
-`time.perf_counter`. Corpora match the FEAT-319 benchmark gates: 1 KB clean
+`time.perf_counter`. Corpora match the FEAT-324 benchmark gates: 1 KB clean
 prose, 1 KB PII-dense (emails, phones, Luhn-valid cards, IPs, SSNs),
 10 KB mixed. Scripts in Appendix A.
 
@@ -85,7 +85,7 @@ differently, not a coverage gap in either direction).
 single-DFA pass plus GIL release is consistently reported at 10–33× over
 equivalent Python regex scanning (e.g. the argus-redact PyO3 engine's
 sub-ms "fast" mode). Applied to the measured prototype numbers, that puts
-the FEAT-319 native targets — p99 < 100 µs @ 1 KB clean, < 1 ms @ 10 KB —
+the FEAT-324 native targets — p99 < 100 µs @ 1 KB clean, < 1 ms @ 10 KB —
 inside the projected envelope with margin.
 
 ## 4. Reading the numbers against the ≤ 1000 ms budget
@@ -100,11 +100,11 @@ inside the projected envelope with margin.
   sliding window. A 20–50 ms engine inside the streaming loop turns a
   100-chunk response into seconds of added latency and starves
   time-to-first-token; at 0.1–1.7 ms (Python) or tens of µs (Rust,
-  projected) the same loop stays imperceptible. This is why FEAT-319 gates
+  projected) the same loop stays imperceptible. This is why FEAT-324 gates
   on p99 *per scan*, not per turn.
 - **Cold start matters for serverless/worker topologies**: 2.85 s of
   import+init (lower bound; the real model is bigger) vs effectively zero.
-- **detect_only telemetry mode** (FEAT-319) runs the same scan on every
+- **detect_only telemetry mode** (FEAT-324) runs the same scan on every
   output; a 30–50 ms engine makes "audit everything" expensive, a sub-2 ms
   one makes it free.
 
@@ -112,11 +112,11 @@ inside the projected envelope with margin.
 check for non-streaming input screening, but it cannot serve AI-Parrot's
 hot seams: it masks only at input stage, has no streaming story, and its
 per-scan cost composes badly even though a single call fits 1000 ms. The
-FEAT-319 design (catalog + Rust engine + Python fallback) meets the same
+FEAT-324 design (catalog + Rust engine + Python fallback) meets the same
 budget with two to three orders of magnitude of headroom — headroom that
 is what actually makes per-tool-call and per-chunk scrubbing viable.
 
-## 5. What we adopt from Guardrails (design changes to FEAT-319)
+## 5. What we adopt from Guardrails (design changes to FEAT-324)
 
 Two features are validated by this review and **incorporated into the spec
 (v0.2)**:
@@ -162,7 +162,7 @@ ran in this environment).
 ### corpus.py
 
 ```python
-"""Shared synthetic corpora for the PII latency benchmark (FEAT-319 baseline)."""
+"""Shared synthetic corpora for the PII latency benchmark (FEAT-324 baseline)."""
 
 CLEAN_1KB = (
     "The quarterly planning meeting covered roadmap priorities for the data "
@@ -263,7 +263,7 @@ if __name__ == "__main__":
 ### bench_prototype.py
 
 ```python
-"""FEAT-319 Phase-1 Python engine prototype (compiled stdlib re + Luhn)."""
+"""FEAT-324 Phase-1 Python engine prototype (compiled stdlib re + Luhn)."""
 import json, re, resource, statistics, sys, time
 
 PATTERNS = {
@@ -361,5 +361,5 @@ if __name__ == "__main__":
 - OpenAI Guardrails PII check: https://openai.github.io/openai-guardrails-python/ref/checks/pii/
 - Microsoft Presidio: https://microsoft.github.io/presidio/
 - argus-redact (PyO3 engine, sub-ms fast mode): https://pypi.org/project/argus-redact/
-- FEAT-319 spec: `sdd/specs/pii-detection-redaction.spec.md`
-- FEAT-319 brainstorm: `sdd/proposals/pii-detection-redaction.brainstorm.md`
+- FEAT-324 spec: `sdd/specs/pii-detection-redaction.spec.md`
+- FEAT-324 brainstorm: `sdd/proposals/pii-detection-redaction.brainstorm.md`

--- a/sdd/proposals/pii-detection-redaction.comparison.md
+++ b/sdd/proposals/pii-detection-redaction.comparison.md
@@ -1,0 +1,365 @@
+# Comparison: OpenAI Guardrails PII (Presidio + spaCy) vs FEAT-319 (Rust + catalog)
+
+**Date**: 2026-07-22
+**Feature**: FEAT-319 (`sdd/specs/pii-detection-redaction.spec.md`)
+**Trigger**: review of https://openai.github.io/openai-guardrails-python/ref/checks/pii/
+**Latency budget under evaluation**: ≤ 1000 ms for detection + masking
+
+---
+
+## 1. What the OpenAI Guardrails PII check is
+
+The `Contains PII` check in `openai-guardrails-python` wraps **Microsoft
+Presidio** (analyzer + anonymizer) with **spaCy `en_core_web_sm` as a hard
+requirement** — client initialization fails if the model is missing.
+Configuration surface:
+
+| Field | Default | Meaning |
+|---|---|---|
+| `entities` | required | Presidio entity list (+ custom `CVV`, `BIC_SWIFT`) |
+| `block` | `false` | `false` = mask with `<EMAIL_ADDRESS>`-style tokens; `true` = tripwire/block |
+| `detect_encoded_pii` | `false` | also scan Base64/URL-encoded/hex content; masks as `<ENTITY_ENCODED>` |
+
+Notable properties:
+- Unicode normalization to defeat fullwidth-character bypasses.
+- **Masking is only supported at the input (pre-flight) stage; in the output
+  stage the check can only block** — per its own docs, masking output "is not
+  supported and will not work as expected".
+- No streaming support, no reversible pseudonymization, no per-agent policy,
+  no user-extensible entity catalog (recognizers are code, not data).
+- No published latency numbers.
+
+## 2. Architectural comparison
+
+| Dimension | OpenAI Guardrails (Presidio+spaCy) | FEAT-319 (this repo) |
+|---|---|---|
+| Engine | Presidio analyzer; spaCy NLP pipeline runs on **every** `analyze()` call | Rust `pii-rs` (`RegexSet` one-pass DFA + validators + context scoring); pure-Python fallback, identical behavior |
+| Hard deps | `presidio-analyzer`, `presidio-anonymizer`, spaCy + `en_core_web_sm` model (init fails without it) | none in Python core; optional `ai-parrot[pii-native]` wheel |
+| Entity coverage | Presidio pattern recognizers **plus NER** (PERSON, LOCATION…) | structured PII only (regex+validator entities); NER explicitly out of scope (protocol leaves the door open for a `SpacyNerEngine`) |
+| Catalog | recognizers are code; config picks from a fixed list | data-driven YAML catalog; overlay/disable/re-score per entity `id` without code |
+| Policy model | global `entities` + `block` boolean | per-agent `PIIPolicy`: `off`/`detect_only`/`enforce`, `allow_entities`, per-entity actions, `min_score`, seam toggles |
+| Actions | mask (input stage only) or block | allow / redact (mask strategies) / **reversible pseudonymize** with per-conversation restore |
+| Output-stage masking | **not supported** (block only) | primary use case: tool egress + final response are both mask-capable |
+| Streaming | none | sliding-window filter, holdback ≤ 128 chars, streaming ≡ non-streaming invariant |
+| Anti-bypass | Unicode normalization; optional encoded-PII scan | **adopted into FEAT-319 from this comparison** (see §5) |
+| At-rest posture | n/a (gateway-level check) | `enforce` mode persists scrubbed text in memory/observability on both ask paths |
+
+The output-stage limitation is decisive for our use case: AI-Parrot's two
+interception points (tool egress before the LLM, final response before the
+user) are both *output* seams, exactly where the Guardrails check downgrades
+to block-only.
+
+## 3. Measured latency (empirical)
+
+Environment: Linux container, Python 3.11.15, `presidio-analyzer 2.2.363`,
+`spacy 3.8.13`. 200 warm iterations per corpus; p50/p95/p99 via
+`time.perf_counter`. Corpora match the FEAT-319 benchmark gates: 1 KB clean
+prose, 1 KB PII-dense (emails, phones, Luhn-valid cards, IPs, SSNs),
+10 KB mixed. Scripts in Appendix A.
+
+> **Important caveat — numbers below are a LOWER BOUND for Guardrails.**
+> `en_core_web_sm` cannot be downloaded in this sandbox (GitHub releases
+> blocked by network policy), so Presidio ran with a *blank* spaCy English
+> pipeline saved to disk. The five benchmarked entities are all Presidio
+> *pattern* recognizers (regex + context enhancement), which work without
+> NER. The real guardrails config additionally runs tok2vec/tagger/parser/NER
+> on every call, so production numbers are strictly worse than these, and its
+> memory sits near ~500 MB rather than the 147 MB measured here.
+
+| Metric | Presidio (lower bound) | Phase-1 Python prototype | Ratio |
+|---|---|---|---|
+| Import + cold init | 1.19 s + 1.66 s = **2.85 s** | ~0 (compiled regex) | — |
+| 1 KB clean — scan p50 / p99 | 1.01 / 1.12 ms | 0.108 / 0.157 ms | ~7× |
+| 1 KB PII-dense — scan p50 / p99 | 20.69 / 36.55 ms | 0.140 / 0.233 ms | **~150×** |
+| 10 KB mixed — scan p50 / p99 | 46.24 / 49.50 ms | 1.185 / 1.713 ms | ~29× |
+| 10 KB mixed — scan+mask p99 | 50.35 ms | 1.734 ms | ~29× |
+| Peak RSS | 147 MB (blank model) | 10.4 MB | ~14× |
+
+The Phase-1 prototype is ~40 lines of compiled stdlib `re` + a Luhn check —
+a deliberately conservative stand-in for `python_engine.py`. Detection
+parity on the corpora was equivalent (26 vs 24 hits on pii_1kb: the deltas
+are Presidio's phone-number recognizer scoring two low-confidence formats
+differently, not a coverage gap in either direction).
+
+**Rust projection** (crate not yet built): Rust `regex`'s `RegexSet`
+single-DFA pass plus GIL release is consistently reported at 10–33× over
+equivalent Python regex scanning (e.g. the argus-redact PyO3 engine's
+sub-ms "fast" mode). Applied to the measured prototype numbers, that puts
+the FEAT-319 native targets — p99 < 100 µs @ 1 KB clean, < 1 ms @ 10 KB —
+inside the projected envelope with margin.
+
+## 4. Reading the numbers against the ≤ 1000 ms budget
+
+- **A single isolated call fits the budget on both stacks.** Even
+  Presidio's worst measured case (50 ms @ 10 KB, lower bound) is 20× under
+  1000 ms. If the requirement were "one scan per user turn", either
+  approach passes.
+- **The budget is consumed per *seam invocation*, and invocations
+  compose.** One agent turn can mean N tool calls (each scrubbed) plus the
+  final response plus, in streaming, a rescan every ≥32 new chars of the
+  sliding window. A 20–50 ms engine inside the streaming loop turns a
+  100-chunk response into seconds of added latency and starves
+  time-to-first-token; at 0.1–1.7 ms (Python) or tens of µs (Rust,
+  projected) the same loop stays imperceptible. This is why FEAT-319 gates
+  on p99 *per scan*, not per turn.
+- **Cold start matters for serverless/worker topologies**: 2.85 s of
+  import+init (lower bound; the real model is bigger) vs effectively zero.
+- **detect_only telemetry mode** (FEAT-319) runs the same scan on every
+  output; a 30–50 ms engine makes "audit everything" expensive, a sub-2 ms
+  one makes it free.
+
+**Conclusion**: the Guardrails/Presidio stack is a reasonable *gateway*
+check for non-streaming input screening, but it cannot serve AI-Parrot's
+hot seams: it masks only at input stage, has no streaming story, and its
+per-scan cost composes badly even though a single call fits 1000 ms. The
+FEAT-319 design (catalog + Rust engine + Python fallback) meets the same
+budget with two to three orders of magnitude of headroom — headroom that
+is what actually makes per-tool-call and per-chunk scrubbing viable.
+
+## 5. What we adopt from Guardrails (design changes to FEAT-319)
+
+Two features are validated by this review and **incorporated into the spec
+(v0.2)**:
+
+1. **Unicode normalization pre-pass (mandatory, both engines)**: NFKC-fold
+   fullwidth/compatibility characters before matching so `ｊｏｈｎ＠ｅｘａｍｐｌｅ．ｃｏｍ`
+   cannot bypass the email pattern. Spans are mapped back to
+   original-text offsets so masking rewrites the untouched original.
+2. **`detect_encoded_pii` toggle on `PIIPolicy` (default off)**: decode
+   Base64/URL-encoded/hex candidates (stdlib) and scan the decoded text;
+   matches mask the *encoded* region as `<{ENTITY}_ENCODED>` (token format
+   borrowed from Guardrails). Python-side (Module 1), outside the Rust hot
+   path initially; the latency cost of enabling it is documented.
+
+Also validated (already in the design): placeholder-token masking style,
+and the decision to keep NER out of the hot path — Presidio's own
+architecture shows the NLP pipeline is where the milliseconds go.
+
+## 6. Methodology notes (honesty box)
+
+- Container-grade hardware; treat ratios as robust, absolute numbers as
+  indicative.
+- Synthetic corpora, 5 starter entities on both stacks; Presidio ran
+  pattern recognizers + context enhancement only (blank NLP pipeline) —
+  its numbers are a floor, not a typical.
+- The Rust engine does not exist yet; Rust figures are projections from
+  the prototype measurements and published PyO3-engine speedups, to be
+  replaced by real `tests/benchmarks/` results in Module 2 (the parity
+  corpus and gates are already specified).
+- Prototype masking is span-splice only (no pseudonym store, no policy
+  resolution); real Phase-1 overhead will be somewhat higher but bounded
+  by the same scan-dominated profile.
+
+---
+
+## Appendix A — Benchmark scripts (reproducible)
+
+Run with: `python3 -m venv v && v/bin/pip install presidio-analyzer
+presidio-anonymizer && v/bin/python -m spacy download en_core_web_sm`
+(use the real model where the network allows; the fallback below is what
+ran in this environment).
+
+### corpus.py
+
+```python
+"""Shared synthetic corpora for the PII latency benchmark (FEAT-319 baseline)."""
+
+CLEAN_1KB = (
+    "The quarterly planning meeting covered roadmap priorities for the data "
+    "platform team. Discussion focused on ingestion throughput, schema "
+    "evolution, and the migration of legacy batch jobs to the streaming "
+    "pipeline. Action items were assigned to the working groups and the "
+    "review cadence was set to biweekly. Attendees agreed that the current "
+    "architecture meets the projected load for the next two quarters, with "
+    "capacity headroom of roughly forty percent under peak conditions. "
+) * 3
+
+PII_1KB = (
+    "Customer record: John reachable at john.doe@example.com or "
+    "jane_smith@corp.example.org, phone (555) 123-4567 and 555-987-6543. "
+    "Payment card 4111 1111 1111 1111 (visa) on file, backup card "
+    "5500-0000-0000-0004. Server logged from 192.168.10.42 and 10.0.0.7. "
+    "SSN on record 123-45-6789. Contact billing at billing@example.net, "
+    "card cvv on separate channel, last login from 172.16.254.1, "
+    "alt phone 555.222.3333, secondary SSN 987-65-4321. "
+) * 2
+
+MIXED_10KB = (CLEAN_1KB + PII_1KB[:512] + CLEAN_1KB + CLEAN_1KB[:200]) * 3
+
+CORPORA = {
+    "clean_1kb": CLEAN_1KB[:1024],
+    "pii_1kb": PII_1KB[:1024],
+    "mixed_10kb": MIXED_10KB[:10240],
+}
+```
+
+### bench_presidio.py
+
+```python
+"""Presidio analyzer(+anonymizer) latency — OpenAI-Guardrails-style config."""
+import json, resource, statistics, sys, time
+
+ENTITIES = ["EMAIL_ADDRESS", "PHONE_NUMBER", "CREDIT_CARD", "IP_ADDRESS", "US_SSN"]
+N_WARM = 200
+
+def pctl(values, p):
+    values = sorted(values)
+    k = min(len(values) - 1, max(0, int(round(p / 100 * len(values) + 0.5)) - 1))
+    return values[k]
+
+def main():
+    from corpus import CORPORA
+    t0 = time.perf_counter()
+    from presidio_analyzer import AnalyzerEngine
+    from presidio_analyzer.nlp_engine import NlpEngineProvider
+    from presidio_anonymizer import AnonymizerEngine
+    import_s = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    # Guardrails uses en_core_web_sm. In sandboxes where the model download
+    # is blocked, fall back to a BLANK spaCy pipeline (pattern recognizers
+    # still work) — measured numbers are then a LOWER BOUND for guardrails.
+    import pathlib, spacy
+    blank_dir = pathlib.Path("blank_en_model")
+    if not blank_dir.exists():
+        spacy.blank("en").to_disk(blank_dir)
+    provider = NlpEngineProvider(nlp_configuration={
+        "nlp_engine_name": "spacy",
+        "models": [{"lang_code": "en", "model_name": str(blank_dir)}],
+    })
+    analyzer = AnalyzerEngine(nlp_engine=provider.create_engine())
+    anonymizer = AnonymizerEngine()
+    analyzer.analyze(text="warmup john@example.com", language="en", entities=ENTITIES)
+    init_s = time.perf_counter() - t0
+
+    results = {"import_s": round(import_s, 3), "cold_init_s": round(init_s, 3)}
+    for name, text in CORPORA.items():
+        analyze_ms, mask_ms = [], []
+        for _ in range(N_WARM):
+            t0 = time.perf_counter()
+            hits = analyzer.analyze(text=text, language="en", entities=ENTITIES)
+            t1 = time.perf_counter()
+            anonymizer.anonymize(text=text, analyzer_results=hits)
+            t2 = time.perf_counter()
+            analyze_ms.append((t1 - t0) * 1000)
+            mask_ms.append((t2 - t0) * 1000)
+        results[name] = {
+            "hits": len(hits),
+            "analyze_p50_ms": round(statistics.median(analyze_ms), 2),
+            "analyze_p95_ms": round(pctl(analyze_ms, 95), 2),
+            "analyze_p99_ms": round(pctl(analyze_ms, 99), 2),
+            "analyze_mask_p50_ms": round(statistics.median(mask_ms), 2),
+            "analyze_mask_p99_ms": round(pctl(mask_ms, 99), 2),
+        }
+    results["peak_rss_mb"] = round(
+        resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024, 1
+    )
+    json.dump(results, sys.stdout, indent=2); print()
+
+if __name__ == "__main__":
+    main()
+```
+
+### bench_prototype.py
+
+```python
+"""FEAT-319 Phase-1 Python engine prototype (compiled stdlib re + Luhn)."""
+import json, re, resource, statistics, sys, time
+
+PATTERNS = {
+    "email": re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"),
+    "phone_us": re.compile(r"\(?\b\d{3}\)?[-. ]\d{3}[-.]\d{4}\b"),
+    "credit_card": re.compile(r"\b(?:\d[ -]?){13,19}\b"),
+    "ipv4": re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b"),
+    "us_ssn": re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
+}
+MASKS = {k: f"<{k.upper()}>" for k in PATTERNS}
+N_WARM = 200
+
+def luhn(digits):
+    ds = [int(c) for c in digits if c.isdigit()]
+    if len(ds) < 13:
+        return False
+    total, parity = 0, len(ds) % 2
+    for i, d in enumerate(ds):
+        if i % 2 == parity:
+            d *= 2
+            if d > 9:
+                d -= 9
+        total += d
+    return total % 10 == 0
+
+def scan(text):
+    spans = []
+    for eid, rx in PATTERNS.items():
+        for m in rx.finditer(text):
+            if eid == "credit_card" and not luhn(m.group()):
+                continue
+            spans.append((eid, m.start(), m.end()))
+    return spans
+
+def mask(text, spans):
+    out, last = [], 0
+    for eid, start, end in sorted(spans, key=lambda s: s[1]):
+        if start < last:
+            continue
+        out.append(text[last:start]); out.append(MASKS[eid]); last = end
+    out.append(text[last:])
+    return "".join(out)
+
+def pctl(values, p):
+    values = sorted(values)
+    k = min(len(values) - 1, max(0, int(round(p / 100 * len(values) + 0.5)) - 1))
+    return values[k]
+
+def main():
+    from corpus import CORPORA
+    results = {}
+    for name, text in CORPORA.items():
+        scan_ms, mask_ms = [], []
+        for _ in range(N_WARM):
+            t0 = time.perf_counter(); spans = scan(text)
+            t1 = time.perf_counter(); mask(text, spans)
+            t2 = time.perf_counter()
+            scan_ms.append((t1 - t0) * 1000); mask_ms.append((t2 - t0) * 1000)
+        results[name] = {
+            "hits": len(spans),
+            "scan_p50_ms": round(statistics.median(scan_ms), 3),
+            "scan_p95_ms": round(pctl(scan_ms, 95), 3),
+            "scan_p99_ms": round(pctl(scan_ms, 99), 3),
+            "scan_mask_p50_ms": round(statistics.median(mask_ms), 3),
+            "scan_mask_p99_ms": round(pctl(mask_ms, 99), 3),
+        }
+    results["peak_rss_mb"] = round(
+        resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024, 1
+    )
+    json.dump(results, sys.stdout, indent=2); print()
+
+if __name__ == "__main__":
+    main()
+```
+
+### Raw results (this run)
+
+```json
+// bench_presidio.py (blank-model lower bound)
+{"import_s": 1.193, "cold_init_s": 1.66,
+ "clean_1kb": {"hits": 0, "analyze_p50_ms": 1.01, "analyze_p95_ms": 1.07, "analyze_p99_ms": 1.12, "analyze_mask_p50_ms": 1.02, "analyze_mask_p99_ms": 1.13},
+ "pii_1kb":  {"hits": 24, "analyze_p50_ms": 20.69, "analyze_p95_ms": 31.42, "analyze_p99_ms": 36.55, "analyze_mask_p50_ms": 21.13, "analyze_mask_p99_ms": 37.4},
+ "mixed_10kb": {"hits": 39, "analyze_p50_ms": 46.24, "analyze_p95_ms": 48.73, "analyze_p99_ms": 49.5, "analyze_mask_p50_ms": 47.1, "analyze_mask_p99_ms": 50.35},
+ "peak_rss_mb": 147.2}
+
+// bench_prototype.py
+{"clean_1kb": {"hits": 0, "scan_p50_ms": 0.108, "scan_p95_ms": 0.135, "scan_p99_ms": 0.157, "scan_mask_p50_ms": 0.108, "scan_mask_p99_ms": 0.158},
+ "pii_1kb":  {"hits": 26, "scan_p50_ms": 0.14, "scan_p95_ms": 0.18, "scan_p99_ms": 0.233, "scan_mask_p50_ms": 0.147, "scan_mask_p99_ms": 0.244},
+ "mixed_10kb": {"hits": 45, "scan_p50_ms": 1.185, "scan_p95_ms": 1.33, "scan_p99_ms": 1.713, "scan_mask_p50_ms": 1.202, "scan_mask_p99_ms": 1.734},
+ "peak_rss_mb": 10.4}
+```
+
+## References
+
+- OpenAI Guardrails PII check: https://openai.github.io/openai-guardrails-python/ref/checks/pii/
+- Microsoft Presidio: https://microsoft.github.io/presidio/
+- argus-redact (PyO3 engine, sub-ms fast mode): https://pypi.org/project/argus-redact/
+- FEAT-319 spec: `sdd/specs/pii-detection-redaction.spec.md`
+- FEAT-319 brainstorm: `sdd/proposals/pii-detection-redaction.brainstorm.md`

--- a/sdd/specs/deterministic-groundedness-scoring.spec.md
+++ b/sdd/specs/deterministic-groundedness-scoring.spec.md
@@ -1,0 +1,504 @@
+---
+type: feature
+base_branch: dev
+---
+
+# Feature Specification: Deterministic Groundedness Scoring (Anti-Hallucination, Detection-Only)
+
+**Feature ID**: FEAT-325
+**Date**: 2026-07-22
+**Author**: Jesús Lara (spec drafted with Claude Code)
+**Status**: draft
+**Target version**: 0.26.0
+
+> Source brainstorm: `sdd/proposals/deterministic-groundedness-scoring.brainstorm.md`
+> (Recommended Option A, prototype-validated). Companion feature: FEAT-324
+> (`sdd/specs/pii-detection-redaction.spec.md`) — shares seams and, later,
+> extraction machinery; neither depends on the other to ship.
+
+---
+
+## 1. Motivation & Business Requirements
+
+> Why does this feature exist? What problem does it solve?
+
+### Problem Statement
+
+Agents compose their final answer *from* tool outputs — and sometimes invent
+or corrupt the very facts those tools returned: a transposed revenue figure,
+a ticket id that never existed, a date shifted by a month. Today AI-Parrot
+has no way to notice. The OpenAI Guardrails "Hallucination Detection" check
+solves this with an **LLM judge + FileSearch over an OpenAI vector store**
+(gpt-4.1-mini default, ROC AUC 0.876; **P50 ~7 s / P95 ~43 s per check**,
+extra API cost, a vector store to maintain, degraded accuracy beyond ~11 MB,
+non-deterministic verdicts). That profile cannot run in the hot path — and
+it verifies against a *static* knowledge base, when the freshest ground
+truth for a turn is already in hand: **the turn's own tool outputs**.
+
+This feature adds a deterministic groundedness *scorer*: extract verifiable
+hard-data atoms from the agent's final answer, check each against the same
+atoms extracted from the turn's tool results, and emit a report. Detection
+only — no redaction, no blocking, no enforcement of any kind.
+
+### Goals
+
+- Score every final answer against the turn's tool outputs
+  (`AIMessage.tool_calls[].result`) — per-atom verdicts
+  `supported` / `contradicted` / `unsupported` plus an aggregate score.
+- **Deterministic**: same answer + same evidence → same report. No LLM, no
+  model download, no network call.
+- Latency far under the 1000 ms budget: gate p99 < 10 ms per turn
+  (prototype measured 2.4 ms for a 1 KB answer vs 3×2 KB of evidence,
+  including index build).
+- Scoring-only contract: the response text is **never** modified; the
+  report rides `AIMessage.metadata` and telemetry.
+- Per-agent opt-in via the established kwargs/policy convention; zero new
+  runtime dependencies (stdlib extractors).
+- Precision-aware numeric tolerance as the normative comparison rule
+  (resolved by prototype — see §2).
+
+### Non-Goals (explicitly out of scope)
+
+- Semantic/paraphrase hallucinations and claims without hard data — the
+  scorer flags them with `no_factual_content`, it does not judge them.
+- General truth verification: the report says "these atoms are unsupported
+  by this turn's evidence", never "this answer is true/false".
+- Any enforcement action (mask, block, re-ask). Consumers decide.
+- An in-line LLM judge (rejected as brainstorm Option B for the hot path:
+  seconds of latency, per-turn cost, non-determinism, circular trust). A
+  future *offline* judge is complementary, not part of this feature.
+- N-gram / quoted-span overlap scoring (brainstorm Option C) — a possible
+  future extractor kind; noisy on paraphrase and blind to single-digit
+  corruption, the highest-value failure here.
+
+---
+
+## 2. Architectural Design
+
+### Overview
+
+A new `parrot/security/groundedness/` subpackage (sibling to the planned
+FEAT-324 `pii/`) implements a three-stage, stdlib-only pipeline:
+
+1. **Extract** (`extractors.py` + `normalize.py`): pull hard-data atoms —
+   `money`, `percent`, `number` (formatted/large numerics), `date`,
+   `identifier` (emails, URLs, ticket/SKU-style codes) — from text, with
+   span de-overlap (a money hit is not re-counted as a bare number).
+   Normalization folds formats: `$1.24M` ≡ `1 240 000`; multi-format dates
+   → ISO-8601; identifiers case-folded; NFKC Unicode pre-pass.
+2. **Index** (`evidence.py`): build a per-turn `EvidenceIndex` from every
+   `ToolCall.result` on the outgoing `AIMessage` (values traversed
+   recursively for dict/list results) — an exact hash-set per atom kind
+   plus a numeric list for tolerance checks. Bounded by
+   `max_evidence_bytes` (report flags `evidence_truncated`).
+3. **Score** (`scorer.py`): classify each answer atom —
+   - `supported`: exact normalized match, **or** numeric match within the
+     **precision-aware tolerance**: half a unit of the answer's last
+     *stated* significant digit. A fully written `$1,234,500` (7 sig
+     digits) demands exact equality; a rounded `$1.24M` (3 sig digits)
+     tolerates ±0.5%. *Normative rule — a fixed 2% tolerance was tested
+     and rejected: it swallowed digit transpositions (0.72% delta).*
+   - `contradicted`: same-magnitude numeric (≤15% off an evidence value)
+     outside the stated precision — the classic transposed/corrupted-digit
+     signal, the strongest hallucination indicator.
+   - `unsupported`: no trace in evidence (invented id, email, figure).
+
+   `score = supported / total_atoms`; no atoms → score 1.0 with
+   `no_factual_content: true`; no tool calls → `no_evidence: true`.
+
+**Reporting** (never mutating): the `GroundednessReport` is attached to
+`AIMessage.metadata["groundedness"]` and a summary (score + per-verdict
+counts, **never atom values**) is emitted through the existing FEAT-176
+lifecycle observers. The single seam is end-of-turn — `get_response()` for
+non-streaming and the final `AIMessage` of `ask_stream` (groundedness is a
+whole-answer property; no per-chunk work). When FEAT-324 lands, scoring
+runs *after* the PII pass so answer and evidence are scrubbed by the same
+catalog and placeholders match on both sides.
+
+Failure contract mirrors the FEAT-252 scrubbers: any scorer exception logs
+a warning and the response ships without a report — never breaks the turn.
+
+### Component Diagram
+
+```
+                    ┌────────────────────────────────────────────┐
+AIMessage           │ end-of-turn seam                           │
+ ├─ tool_calls[]────┤► EvidenceIndex (per-kind sets + numerics)  │
+ │    .result       │            ▲                               │
+ └─ response ───────┤► extract_atoms() ──► GroundednessScorer    │
+                    │                          │                 │
+                    └──────────────────────────┼─────────────────┘
+                                               ▼
+                              GroundednessReport (score, supported,
+                              contradicted, unsupported, flags)
+                                   │                    │
+                                   ▼                    ▼
+                        AIMessage.metadata     FEAT-176 observers
+                        ["groundedness"]       (score + counts only)
+```
+
+### Integration Points
+
+| Existing Component | Integration Type | Notes |
+|---|---|---|
+| `AbstractBot.get_response()` (`bots/abstract.py:3390`) | extends | score + attach report before return (non-streaming) |
+| `BaseBot.ask_stream()` final `AIMessage` (`bots/base.py:1846`) | extends | same scoring at stream close; no per-chunk hook |
+| `AbstractBot.__init__` | extends | kwargs `enable_groundedness` / `groundedness_policy` (mirrors `enable_tools` convention, `bots/abstract.py:~383-400`) |
+| `AIMessage` / `ToolCall` models | uses | `tool_calls[].result` as evidence, `metadata` as report carrier — **no model changes** |
+| Lifecycle observers (FEAT-176) | uses (observer) | telemetry emission; no new event types |
+| FEAT-324 `parrot/security/pii/` | soft, future | when present, scoring runs after the PII pass; shared extraction engine is a follow-up — **no import of `parrot.security.pii` in this feature** |
+
+No breaking changes; default off; zero new dependencies.
+
+### Data Models
+
+```python
+# parrot/security/groundedness/ — design signatures (not implementation)
+class AtomKind(str, Enum):
+    MONEY = "money"
+    PERCENT = "percent"
+    NUMBER = "number"
+    DATE = "date"
+    IDENTIFIER = "identifier"
+
+class Atom(BaseModel):
+    kind: AtomKind
+    raw: str                  # as stated in the text
+    normalized: str | float   # comparison key
+    start: int                # char offsets in the answer
+    end: int
+
+class AtomVerdict(BaseModel):
+    atom: Atom
+    verdict: Literal["supported", "contradicted", "unsupported"]
+    nearest_evidence: Optional[str] = None   # raw evidence candidate (contradicted only)
+
+class GroundednessReport(BaseModel):
+    score: float                      # supported / total_atoms; 1.0 if none
+    total_atoms: int
+    supported: list[AtomVerdict]
+    contradicted: list[AtomVerdict]
+    unsupported: list[AtomVerdict]
+    no_factual_content: bool = False  # answer had no verifiable atoms
+    no_evidence: bool = False         # turn had no tool results
+    evidence_truncated: bool = False  # max_evidence_bytes hit
+    duration_ms: float
+
+class GroundednessPolicy(BaseModel):
+    """Per-agent groundedness policy. Scoring-only — there is no enforce mode.
+
+    Attributes:
+        enabled_kinds: Atom kinds to extract. Default: all five.
+        include_user_prompt_as_evidence: Treat the user's question as
+            legitimate evidence (agent echoing a user-stated figure).
+            Default True.
+        contradicted_band: Upper relative delta for "contradicted"
+            (same-magnitude) classification. Default 0.15.
+        min_alert_score: Below this, telemetry marks the turn flagged.
+            Default 0.8. Score is always emitted regardless.
+        max_evidence_bytes: Evidence-index input cap. Default 262_144.
+        min_number_digits: Bare integers shorter than this are skipped
+            (noise floor). Default 4.
+```
+
+### New Public Interfaces
+
+```python
+# parrot/security/groundedness/extractors.py
+def extract_atoms(text: str, policy: GroundednessPolicy) -> list[Atom]: ...
+
+# parrot/security/groundedness/evidence.py
+class EvidenceIndex:
+    @classmethod
+    def from_tool_calls(cls, tool_calls: list[ToolCall],
+                        policy: GroundednessPolicy,
+                        user_prompt: str | None = None) -> "EvidenceIndex": ...
+
+# parrot/security/groundedness/scorer.py
+class GroundednessScorer:
+    def score(self, answer_text: str,
+              evidence: EvidenceIndex) -> GroundednessReport: ...
+```
+
+New bot kwargs: `enable_groundedness: bool = False`,
+`groundedness_policy: dict | GroundednessPolicy | None`.
+
+---
+
+## 3. Module Breakdown
+
+> These map 1:1 to the brainstorm's capabilities; strict sequential chain.
+
+### Module 1: groundedness-extractors
+- **Path**: `parrot/security/groundedness/extractors.py`, `normalize.py`,
+  `models.py` (`Atom`, `AtomKind`), `__init__.py`
+- **Responsibility**: the five atom extractors with span de-overlap
+  (money/percent/date/identifier claim spans before bare numbers); NFKC
+  pre-pass; normalization (magnitude suffixes `k/M/B`, thousand/decimal
+  separators, common date formats → ISO, identifier case-folding);
+  significant-digit counting for the tolerance rule. Stdlib only
+  (`re`, `datetime`, `unicodedata`).
+- **Depends on**: nothing new.
+
+### Module 2: groundedness-scorer
+- **Path**: `parrot/security/groundedness/evidence.py`, `scorer.py`,
+  `policy.py` (`GroundednessPolicy`, `GroundednessReport`, `AtomVerdict`)
+- **Responsibility**: `EvidenceIndex.from_tool_calls()` (recursive value
+  traversal of `ToolCall.result` payloads, `max_evidence_bytes` cap,
+  optional user-prompt evidence); scorer with exact match →
+  precision-aware tolerance → contradicted band (≤`contradicted_band`) →
+  unsupported; report assembly with flags and timing.
+- **Depends on**: Module 1.
+
+### Module 3: groundedness-reporting
+- **Path**: wiring in `parrot/bots/abstract.py` (`__init__` kwargs +
+  `get_response()`) and `parrot/bots/base.py` (`ask_stream` final message)
+- **Responsibility**: policy coercion (dict → `GroundednessPolicy`);
+  end-of-turn scoring behind `enable_groundedness`; attach report to
+  `AIMessage.metadata["groundedness"]`; telemetry emission via existing
+  lifecycle observers (score + counts only — atom values never leave the
+  process through telemetry); non-fatal try/except contract; single INFO
+  log when a turn falls below `min_alert_score`.
+- **Depends on**: Module 2.
+
+---
+
+## 4. Test Specification
+
+### Unit Tests
+
+| Test | Module | Description |
+|---|---|---|
+| `test_extractors_per_kind` | M1 | Positive/negative corpora per atom kind; `min_number_digits` floor; NFKC (fullwidth digits extracted) |
+| `test_extractor_deoverlap` | M1 | `$1,243,500` yields one `money` atom, not money+number |
+| `test_normalize_numbers` | M1 | `$1.24M` ≡ `1,240,000` ≡ `1240000`; percents; sig-digit counting |
+| `test_normalize_dates` | M1 | `06/28/2026`, `June 28, 2026`, `2026-06-28` → same ISO key |
+| `test_evidence_index` | M2 | Built from `ToolCall.result` incl. dict/list payloads; `max_evidence_bytes` → `evidence_truncated`; user-prompt evidence toggle |
+| `test_scorer_canonical_cases` | M2 | The 5 prototype cases as canonical fixtures: faithful→1.0; transposed `$1,234,500` vs `$1,243,500`→`contradicted`; invented `INV-9999`/foreign email→`unsupported`; no hard data→`no_factual_content`; rounded `$1.24M`→`supported` |
+| `test_precision_tolerance` | M2 | Full-precision statement requires exact match; rounded statement passes within half-ULP of last sig digit; both against the same evidence value |
+| `test_determinism` | M2 | Same (answer, evidence) → byte-identical report across runs |
+| `test_no_evidence_turn` | M2 | Zero tool calls → `no_evidence: true`, score 1.0 |
+| `test_reporting_seam` | M3 | Bot stub: report present in `AIMessage.metadata`; **response text byte-identical with scoring on vs off**; scorer exception → warning + no report, turn succeeds |
+| `test_telemetry_no_values` | M3 | Emitted telemetry contains score/counts, never raw atom values (`caplog`/observer capture) |
+
+### Integration Tests
+
+| Test | Description |
+|---|---|
+| `test_ask_end_to_end` | Mock-LLM bot + PII-free stub tools → `ask()` returns report; verdicts match canonical expectations |
+| `test_ask_stream_end_to_end` | Same via `ask_stream`; report only on the final `AIMessage` |
+| `test_default_off` | Without `enable_groundedness`, no report, no scoring cost incurred |
+
+### Performance Benchmarks (`tests/benchmarks/`)
+
+| Benchmark | Gate |
+|---|---|
+| 1 KB answer vs 3×2 KB evidence (index built per call) | p99 < 10 ms (prototype: 2.4 ms) |
+| 4 KB answer vs 10 tools × 4 KB | p99 < 50 ms (informational ceiling) |
+
+### Test Data / Fixtures
+
+```python
+# tests/fixtures/groundedness/ — canonical corpus from the brainstorm
+# prototype (Appendix A): two tool outputs + five answer cases with
+# expected per-atom verdicts, stored as YAML.
+@pytest.fixture
+def groundedness_corpus() -> list[GroundednessCase]: ...
+
+@pytest.fixture
+def stub_bot_with_tools():  # mock LLM + tools returning the corpus evidence
+    ...
+```
+
+---
+
+## 5. Acceptance Criteria
+
+> This feature is complete when ALL of the following are true:
+
+- [ ] All unit + integration tests pass (`pytest tests/ -v`).
+- [ ] **Scoring-only invariant**: with groundedness enabled, the response
+      text delivered to the caller is byte-identical to scoring disabled —
+      the scorer never mutates, masks, or blocks.
+- [ ] **Determinism**: identical (answer, evidence) inputs produce
+      identical reports across runs and processes.
+- [ ] The five canonical prototype cases pass: faithful → 1.0; transposed
+      digits → `contradicted`; invented identifiers → `unsupported`; no
+      hard data → `no_factual_content`; rounded paraphrase → `supported`.
+- [ ] Precision-aware tolerance is the implemented comparison rule
+      (half-unit of the answer's last stated significant digit); a fixed
+      global percentage is not used.
+- [ ] Report attached to `AIMessage.metadata["groundedness"]` on both
+      `ask()` and `ask_stream()` paths; telemetry carries score + counts
+      and never atom values.
+- [ ] Default off (`enable_groundedness=False`); existing test suite
+      passes untouched; zero new runtime dependencies.
+- [ ] Benchmark gate met: p99 < 10 ms for 1 KB answer vs 3×2 KB evidence.
+- [ ] Scorer failure is non-fatal: exception → warning log, turn completes
+      without a report.
+- [ ] Documentation updated in `docs/` (report semantics + honest limits:
+      tripwire, not truth oracle).
+- [ ] No breaking changes to the existing public API.
+
+---
+
+## 6. Codebase Contract
+
+> **CRITICAL — Anti-Hallucination Anchor**
+> All references verified on 2026-07-22 on branch
+> `claude/pii-detection-ai-parrot-a48mat` (based on `origin/main`).
+> Paths relative to `packages/ai-parrot/src/parrot/`.
+
+### Verified Imports
+
+```python
+from parrot.models.basic import ToolCall        # models/basic.py:23
+from parrot.models.responses import AIMessage   # models/responses.py:72
+```
+
+### Existing Class Signatures
+
+```python
+# models/basic.py:23
+class ToolCall(BaseModel):
+    id: str
+    name: str
+    arguments: Dict[str, Any]
+    result: Optional[Any] = None      # line 28 — the turn's evidence payload
+    error: Optional[str] = None
+    execution_time: Optional[float] = None
+
+# models/responses.py:72
+class AIMessage(BaseModel):
+    output: Any
+    response: Optional[str]           # the final answer text
+    tool_calls: List[ToolCall]        # aggregated per turn
+    metadata: Dict[str, Any]          # line 202 — report carrier
+
+# ToolCall.result IS populated in the ask loop:
+#   clients/claude.py:584 and :766 — `tc.result = tool_result`
+#   (same pattern across provider clients, e.g. bedrock.py:728/1040)
+
+# End-of-turn seams:
+#   bots/abstract.py:3390 — def get_response(  (sync; all non-streaming paths)
+#   bots/base.py:1846    — final AIMessage yield in ask_stream()
+
+# Bot kwarg-toggle convention: self.enable_tools (bots/abstract.py:~383-400)
+# Policy-model template: ObservabilityConfig (observability/config.py:18)
+
+# FEAT-176 lifecycle events are METADATA-ONLY (no text payloads):
+#   core/events/lifecycle/events/invoke.py:34 — AfterInvokeEvent
+#   core/events/lifecycle/events/tool.py:30   — AfterToolCallEvent
+```
+
+### Integration Points
+
+| New Component | Connects To | Via | Verified At |
+|---|---|---|---|
+| `GroundednessScorer` | `AIMessage.tool_calls[].result` | evidence source | `models/basic.py:28`, `clients/claude.py:584` |
+| report attach | `AIMessage.metadata` | dict entry `"groundedness"` | `models/responses.py:202` |
+| non-streaming seam | `AbstractBot.get_response()` | score before return | `bots/abstract.py:3390` |
+| streaming seam | `ask_stream` final message | score before final yield | `bots/base.py:1846` |
+| telemetry | FEAT-176 observers | score + counts only | `core/events/lifecycle/events/*.py` |
+
+### Does NOT Exist (Anti-Hallucination)
+
+- ~~`parrot.security.groundedness`~~ — created by this feature.
+- ~~Text payloads on lifecycle events~~ — FEAT-176 events carry names/
+  durations/sizes only, by design; the scorer must read texts from the
+  `AIMessage`, never from events.
+- ~~A per-turn tool-output collector~~ — unnecessary:
+  `AIMessage.tool_calls` already aggregates `ToolCall.result`.
+- ~~Any existing groundedness/hallucination/factuality check in runtime~~.
+- ~~`parrot.security.pii`~~ — FEAT-324 is spec'd, **not implemented**.
+  This feature MUST NOT import it; extractors are stdlib-first, and a
+  shared native engine is an explicit follow-up once FEAT-324 lands.
+- ~~`AIMessage.groundedness` field~~ — the report lives inside the
+  existing `metadata` dict; no model changes.
+
+---
+
+## 7. Implementation Notes & Constraints
+
+### Patterns to Follow
+
+- Pydantic models for policy/report/atoms; Google-style docstrings; strict
+  type hints; `self.logger`, never print.
+- Scorer is deliberately **sync** (pure CPU, single-digit-ms budget;
+  `get_response()` is sync). Async only at the seam wiring.
+- Mirror the FEAT-252 scrubber failure contract: non-fatal try/except at
+  the seam; warnings, never raised into the turn.
+- Telemetry hygiene: score and counts only — atom raw values may contain
+  the very data (emails, ids) FEAT-324 exists to protect.
+- Kwargs coercion pattern: accept `dict | GroundednessPolicy | None`, as
+  the bots do for other structured configs.
+
+### Known Risks / Gotchas
+
+- **Legitimate outside knowledge scores `unsupported`** (agent adds a
+  well-known constant not present in evidence). Mitigation: the report is
+  advisory; consumers read `unsupported` as "verify", not "wrong";
+  `include_user_prompt_as_evidence` covers user-stated figures.
+- **Small-integer blindness**: bare integers < `min_number_digits` (default
+  4) are skipped as noise — a corrupted "3-digit count" goes unverified.
+  Documented; floor is per-agent configurable.
+- **en-US locale bias in v1** (decimal point, MM/DD dates). Locale packs
+  are an open question; misparse risk is bounded because both answer and
+  evidence pass through the *same* normalizer.
+- **Evidence explosion** on tool-heavy turns: linear index build, capped by
+  `max_evidence_bytes` with an explicit `evidence_truncated` flag —
+  a truncated index can only produce false `unsupported`, never false
+  `supported`.
+- **Coordination with FEAT-324**: both features wire `get_response()` /
+  `ask_stream`; if implemented concurrently, land FEAT-324's hooks first
+  and chain groundedness after the PII pass.
+
+### External Dependencies
+
+| Package | Version | Reason |
+|---|---|---|
+| — | — | **none** — stdlib only (`re`, `datetime`, `unicodedata`, `hashlib`) |
+
+---
+
+## Worktree Strategy
+
+- **Default isolation unit**: per-spec — one worktree, tasks sequential
+  (M1 → M2 → M3); the modules form a strict dependency chain with no
+  parallelizable seams.
+- **Cross-feature dependencies**: none blocking. File-disjoint from
+  FEAT-324 code (`groundedness/` vs `pii/`), but both touch the
+  `get_response()`/`ask_stream` wiring — serialize that integration
+  (FEAT-324 first if concurrent).
+
+---
+
+## 8. Open Questions
+
+> Carried forward from the brainstorm with resolution state; resolved
+> items are reflected in the spec body (§2, §4, §5).
+
+- [x] Numeric tolerance model — *Resolved in brainstorm prototype round*:
+  precision-aware (half-unit of the answer's last stated significant
+  digit), NOT a fixed percentage; a fixed 2% swallowed digit
+  transpositions in testing (§2 Overview, §5 criteria).
+- [ ] User prompt as evidence — proposed default **True**
+  (`include_user_prompt_as_evidence`); confirm during implementation
+  telemetry. — *Owner: Jesús*
+- [ ] Multi-locale numbers/dates (`1.234,5`, DD/MM): v1 ships en-US-biased
+  extractors; locale packs later? — *Owner: Jesús*
+- [ ] Telemetry alert threshold: `min_alert_score` proposed default 0.8
+  (score always emitted; threshold only marks the turn flagged). —
+  *Owner: Jesús*
+- [ ] Small-integer floor: `min_number_digits` proposed default 4,
+  per-agent configurable — right default? — *Owner: Jesús*
+- [ ] Offline batch evaluator (score historical conversation logs with the
+  same scorer) as a follow-up feature? — *Owner: Jesús*
+
+---
+
+## Revision History
+
+| Version | Date | Author | Change |
+|---|---|---|---|
+| 0.1 | 2026-07-22 | Jesús Lara / Claude Code | Initial draft from `deterministic-groundedness-scoring.brainstorm.md` (Option A, prototype-validated) |

--- a/sdd/specs/pii-detection-redaction.spec.md
+++ b/sdd/specs/pii-detection-redaction.spec.md
@@ -1,0 +1,610 @@
+---
+type: feature
+base_branch: dev
+---
+
+# Feature Specification: PII Detection & Redaction for Tool Outputs and Agent Responses
+
+**Feature ID**: FEAT-319
+**Date**: 2026-07-20
+**Author**: Jesús Lara (spec drafted with Claude Code)
+**Status**: draft
+**Target version**: 0.26.0
+
+> Source brainstorm: `sdd/proposals/pii-detection-redaction.brainstorm.md`
+> (Recommended Option A). Note: the brainstorm tentatively cited FEAT-316;
+> that id was taken by the eventbus migration — this feature is **FEAT-319**.
+
+---
+
+## 1. Motivation & Business Requirements
+
+> Why does this feature exist? What problem does it solve?
+
+### Problem Statement
+
+AI-Parrot agents surface text produced by tools (databases, CRMs, scrapers,
+file readers) and by the LLM itself. That text can contain personally
+identifiable information — emails, phone numbers, payment cards, national
+IDs, IP addresses — which today flows unfiltered into (a) the LLM context,
+(b) conversation memory, (c) observability backends, and (d) the end user's
+channel. The framework redacts **secrets** on tool egress (`OutputScrubber`,
+FEAT-252) but has **no personal-data detection at all**. Teams in regulated
+contexts (GDPR, PCI-DSS) need a low-latency, per-agent-configurable PII
+guardrail: some agents legitimately must return PII (an HR agent returning
+an employee email is not a leak), so "what counts as PII" must be an open
+catalog with per-entity and per-agent toggles.
+
+### Goals
+
+- Detect PII in tool outputs before they reach the LLM, and in the final
+  agent response before it reaches the user — including streaming.
+- Sub-millisecond scan for typical payloads (1–10 KB) via a native Rust
+  engine; a pure-Python fallback keeps `pip install ai-parrot` fully
+  functional with no native wheel.
+- Open catalog: entity definitions (regex + validator + scoring heuristics)
+  live in data, not code; per-entity enable/disable; per-agent `PIIPolicy`
+  with an `allow_entities` allowlist and `off`/`detect_only`/`enforce` modes.
+- Two actions: irreversible **redaction/masking** and **reversible
+  pseudonymization** (`<PII_EMAIL_1>` tokens; the LLM never sees the value,
+  the end user gets it restored).
+- Streaming support via a sliding-window filter with a bounded holdback.
+- When a policy is in `enforce` mode, conversation memory and observability
+  store **scrubbed text on both paths** (`ask()` and `ask_stream()`) —
+  PII-at-rest reduction is a goal, not a side effect.
+- Opt-in initially: `enable_pii_protection` defaults to `False`.
+
+### Non-Goals (explicitly out of scope)
+
+- NER-class entities (person names, postal addresses) — not regex-detectable;
+  the `PIIEngine` protocol is the extension point for a future
+  `SpacyNerEngine`.
+- PII split across formatting (a card number spanning table cells / JSON
+  keys) — span matching operates on contiguous text values; documented
+  limitation.
+- Adopting a third-party PII engine (argus-redact / worka-pii /
+  redact_core) — rejected as brainstorm Option B (adapter + supply-chain
+  cost at a security boundary; see the brainstorm for the full analysis).
+- Modifying the FEAT-252 secrets scrubber semantics — secrets stay
+  unconditional; `parrot/security/redaction.py` is not touched.
+
+---
+
+## 2. Architectural Design
+
+### Overview
+
+A new `parrot/security/pii/` subpackage provides a `PIIEngine` protocol
+(`scan(text) -> list[PIISpan]`) with two interchangeable implementations: a
+pure-Python engine (stdlib `re`, always installed) and a Rust engine
+(`pii-rs` crate, PyO3/maturin, packaged exactly like the existing `yaml-rs`
+crate and selected automatically when importable via the optional extra
+`ai-parrot[pii-native]`). The engine is *stateless per request* and holds the
+compiled catalog; instances are cached by catalog fingerprint.
+
+Everything cold stays in Python: catalog loading/merging (bundled
+`default_catalog.yaml` + user overlays merged by entity `id`), per-agent
+policy resolution, action application (mask strategies, token substitution),
+pseudonym token assignment, orchestration, and audit. The Rust crate owns
+only the hot path: `RegexSet` multi-pattern matching (one DFA pass — clean
+text exits in microseconds), checksum validators (Luhn, IBAN mod-97),
+context-word scoring (aho-corasick), and span overlap merging.
+
+`PIIScrubber` is a **sibling policy** to the FEAT-252 secrets scrubber,
+chained *after* the secrets pass inside the existing single tool-egress hook
+in `AbstractTool.execute()` — the "single seam" invariant is preserved, and
+the PII pass skips text already inside `***REDACTED***` markers. Per-agent
+policy is resolved through the `current_agent_name` ContextVar (FEAT-228)
+against a registry populated in `AbstractBot.__init__`. The final response
+is redacted or token-restored in `AbstractBot.get_response()`
+(non-streaming) and through a `StreamingPIIFilter` sliding window in
+`BaseBot.ask_stream()` (streaming).
+
+Resolved design decisions (carried from brainstorm + spec round):
+- Catalog regexes are validated at load time against the **Rust `regex`
+  syntax subset** (no lookaround/backreferences) so Python↔Rust parity is
+  permanent and testable.
+- Default posture is **opt-in** (`enable_pii_protection=False`);
+  `detect_only` mode (audit without rewriting) is the documented first step
+  of any rollout.
+- In `enforce` mode, memory and observability persist **scrubbed** text on
+  both `ask()` and `ask_stream()` paths.
+- `PseudonymStore` ships with an abstract interface and **two backends in
+  this feature**: in-memory (TTL/LRU) and encrypted Redis (AES-GCM via the
+  existing `credentials_utils` helpers over `navigator_session.vault.crypto`,
+  connection pattern per `RedisConversation`).
+
+### Component Diagram
+
+```
+                       ┌──────────────────────────────────────────────┐
+Tool.execute() ──────► │ FEAT-252 hook (tools/abstract.py:695-724)    │
+                       │  1. OutputScrubber (secrets, unconditional)  │
+                       │  2. PIIScrubber (policy-driven, NEW)         │──► ToolResult (clean)
+                       └───────────────┬──────────────────────────────┘        │
+                                       │ resolves policy via                    ▼
+                                       │ current_agent_name ContextVar     LLM context
+                                       ▼
+                       ┌──────────────────────────────┐
+                       │ PIIPolicy registry (per agent)│
+                       └───────────────┬──────────────┘
+                                       ▼
+      ┌──────────────┐   fingerprint   ┌─────────────────────────────┐
+      │ PIICatalog   │───────────────► │ get_engine() cache          │
+      │ (YAML merge) │                 │  ├─ RustPIIEngine (pii_rs)  │
+      └──────────────┘                 │  └─ PythonPIIEngine (re)    │
+                                       └─────────────────────────────┘
+
+LLM answer ──► get_response()  ──► PIIScrubber.redact / TokenMap.restore ──► user
+LLM stream ──► ask_stream()    ──► StreamingPIIFilter.feed()/flush()     ──► user
+                                       │
+                                       ▼
+                       ┌───────────────────────────────────┐
+                       │ AbstractPseudonymStore            │
+                       │  ├─ InMemoryPseudonymStore (TTL)  │
+                       │  └─ RedisPseudonymStore (AES-GCM) │
+                       └───────────────────────────────────┘
+```
+
+### Integration Points
+
+| Existing Component | Integration Type | Notes |
+|---|---|---|
+| `AbstractTool.execute()` egress hook (`tools/abstract.py:695-724`) | extends | PII pass chained after the secrets scrub; same non-fatal try/except contract |
+| `parrot/security/` package | extends | new `pii/` subpackage; `redaction.py` reused read-only (`_already_scrubbed` guard pattern), never modified |
+| `AbstractBot.__init__` (`bots/abstract.py`) | extends | new kwargs `enable_pii_protection` / `pii_policy`; registers policy in the per-agent registry |
+| `AbstractBot.get_response()` (`bots/abstract.py:3390`) | extends | redact (enforce+redact) or `TokenMap.restore()` (pseudonymize) on outgoing text |
+| `BaseBot.ask_stream()` (`bots/base.py:1772-1846`) | modifies | chunk yields wrapped through `StreamingPIIFilter`; final `AIMessage` carries filtered text |
+| Conversation memory / observability | modifies (behavioral) | in `enforce` mode both `ask()` and `ask_stream()` persist scrubbed text |
+| `parrot/memory/redis.py` (`RedisConversation`) | reuses pattern | `RedisPseudonymStore` follows its `redis.asyncio` + `REDIS_HISTORY_URL` + key-prefix conventions |
+| `parrot/security/credentials_utils.py` | uses | AES-GCM encrypt/decrypt for the Redis pseudonym payloads |
+| `packages/ai-parrot/pyproject.toml` | extends | optional extra `pii-native = ["parrot-pii-rs>=0.1"]` |
+| CI (cibuildwheel/maturin) | extends | wheel job for `pii-rs`, copying the `yaml-rs` matrix (cp311–314 manylinux x86_64) |
+| Lifecycle events (FEAT-176) | uses (observer) | detection counts attached to existing `AfterToolCallEvent`/`AfterInvokeEvent` observers; no new event types |
+
+No breaking changes: everything defaults off.
+
+### Data Models
+
+```python
+# parrot/security/pii/types.py — design signatures (not implementation)
+class PIIAction(str, Enum):
+    ALLOW = "allow"
+    REDACT = "redact"
+    PSEUDONYMIZE = "pseudonymize"
+
+class PIISpan(BaseModel):
+    entity_id: str        # catalog entity id, e.g. "credit_card"
+    start: int            # char offset (not bytes — UTF-8 safety)
+    end: int
+    score: float          # after validator/context boosts
+
+# parrot/security/pii/catalog.py
+class PIIPattern(BaseModel):
+    regex: str            # validated at load against the Rust `regex` subset
+    score: float          # base confidence
+
+class PIIMask(BaseModel):
+    strategy: Literal["fixed", "partial", "last4"] = "fixed"
+    placeholder: str      # e.g. "<CREDIT_CARD>"
+
+class PIIEntityDef(BaseModel):
+    id: str               # stable snake_case; used in tokens/policy/audit
+    name: str
+    locales: list[str] = ["any"]
+    severity: Literal["low", "medium", "high"]
+    enabled: bool = True
+    default_action: PIIAction = PIIAction.REDACT
+    max_len: int          # streaming holdback contribution
+    patterns: list[PIIPattern]
+    validator: Literal["none", "luhn", "mod97", "ip", "date"] = "none"
+    validator_boost: float = 0.0
+    context_words: list[str] = []
+    context_window: int = 40
+    context_boost: float = 0.0
+    mask: PIIMask
+
+class PIICatalog(BaseModel):
+    version: int
+    entities: list[PIIEntityDef]
+    # methods: load()/merge overlays by entity id, fingerprint() -> sha256,
+    #          set_enabled(entity_id, enabled) -> re-fingerprint
+
+# parrot/security/pii/policy.py
+class PIIPolicy(BaseModel):
+    mode: Literal["off", "detect_only", "enforce"] = "off"
+    allow_entities: set[str] = set()          # ids this agent may emit
+    entity_actions: dict[str, PIIAction] = {} # per-entity override
+    min_score: float = 0.5
+    locales: Optional[list[str]] = None
+    catalog_paths: list[Path] = []            # overlays; also PARROT_PII_CATALOG env
+    scrub_tool_outputs: bool = True
+    scrub_final_response: bool = True
+    scrub_streaming: bool = True
+    pseudonymize_default: bool = False
+```
+
+### New Public Interfaces
+
+```python
+# parrot/security/pii/engine.py
+class PIIEngine(Protocol):
+    """Scans text for PII spans. Holds the compiled catalog; sync (pure CPU)."""
+    def scan(self, text: str) -> list[PIISpan]: ...
+
+def get_engine(catalog: PIICatalog, prefer_native: bool = True) -> PIIEngine:
+    """Cached by catalog.fingerprint(); RustPIIEngine when pii_rs is
+    importable, else PythonPIIEngine (single INFO log on fallback)."""
+
+# parrot/security/pii/scrubber.py — mirrors OutputScrubber's call shape
+class PIIScrubber:
+    def scrub(self, value: Any, tool_name: str | None = None) -> Any: ...
+    def transform(
+        self, text: str, policy: PIIPolicy, token_map: "TokenMap | None"
+    ) -> "TransformResult": ...
+
+# parrot/security/pii/pseudonym.py
+class AbstractPseudonymStore(ABC):
+    """Per-conversation token maps, keyed (user_id, session_id).
+    The map IS PII: never logged; Redis backend stores AES-GCM ciphertext."""
+    async def get_map(self, user_id: str, session_id: str) -> "TokenMap": ...
+    async def save_map(self, user_id: str, session_id: str, m: "TokenMap") -> None: ...
+
+class InMemoryPseudonymStore(AbstractPseudonymStore): ...   # TTL + LRU
+class RedisPseudonymStore(AbstractPseudonymStore): ...      # encrypted payloads
+
+class TokenMap:
+    """(entity_id, normalized_value) -> '<PII_EMAIL_1>'; stable within a
+    conversation. restore(text) is best-effort (unknown tokens left literal,
+    WARNING logged)."""
+
+# parrot/security/pii/streaming.py
+class StreamingPIIFilter:
+    def feed(self, chunk: str) -> str: ...   # "" while withholding
+    def flush(self) -> str: ...
+
+# pii_rs (Rust crate, PyO3) — Python-visible surface
+# Engine(catalog_json: str); Engine.scan(text) -> list[Span]; Engine.fingerprint()
+```
+
+New bot kwargs (following the `enable_tools` convention):
+`enable_pii_protection: bool = False`, `pii_policy: dict | PIIPolicy | None`.
+
+---
+
+## 3. Module Breakdown
+
+> These map 1:1 to the brainstorm's capabilities and directly to Task
+> Artifacts.
+
+### Module 1: pii-catalog-engine
+- **Path**: `parrot/security/pii/` (`types.py`, `catalog.py`, `policy.py`,
+  `engine.py`, `python_engine.py`, `validators.py`, `scrubber.py`,
+  `data/default_catalog.yaml`, `__init__.py`) + seam integration in
+  `parrot/tools/abstract.py` and `parrot/bots/abstract.py`
+- **Responsibility**: catalog schema + loader/merger/fingerprint; `PIIPolicy`
+  + per-agent registry (resolved via `current_agent_name`); pure-Python
+  engine with enum validators; `PIIScrubber` chained after the secrets pass
+  at the tool seam; redact in `get_response()`; bot kwargs; starter entities
+  (`email`, `phone_us`, `credit_card` w/ Luhn, `ipv4`, `us_ssn`);
+  scrubbed-at-rest on both paths in `enforce`; `detect_only` mode; audit
+  logging (entity id + tool, never the value).
+- **Depends on**: nothing new (existing seams only).
+
+### Module 2: pii-rust-engine
+- **Path**: `parrot/pii-rs/` (Cargo.toml, own maturin `pyproject.toml`,
+  `src/lib.rs`, `src/engine.rs`, `src/validators.rs`, `src/merge.rs`) +
+  `parrot/security/pii/native_engine.py` + `pii-native` extra + CI wheels
+- **Responsibility**: `RegexSet` scan → per-match `find_iter` → validators +
+  context scoring (aho-corasick) → span merge; `Engine` pyclass compiled
+  once from catalog JSON, GIL released during matching; behavior-identical
+  drop-in behind `get_engine()`.
+- **Depends on**: Module 1 (protocol + corpus). Parallel with Module 3.
+
+### Module 3: pii-pseudonymization
+- **Path**: `parrot/security/pii/pseudonym.py` + restore wiring in
+  `bots/abstract.py` (`get_response()`)
+- **Responsibility**: `TokenMap` (stable `<PII_{ENTITY}_{n}>` tokens,
+  referential consistency), `AbstractPseudonymStore`, `InMemoryPseudonymStore`
+  (TTL/LRU, per-key `asyncio.Lock`), `RedisPseudonymStore` (AES-GCM payloads
+  via `credentials_utils`, `RedisConversation`-style keys/connection);
+  transform at the tool seam, restore at the response; best-effort restore.
+- **Depends on**: Module 1. Parallel with Module 2.
+
+### Module 4: pii-streaming-filter
+- **Path**: `parrot/security/pii/streaming.py` + hook in `bots/base.py`
+  (`ask_stream`)
+- **Responsibility**: sliding-window filter — holdback
+  `max(entity.max_len) + slack` capped at 128 chars, whitespace-preferring
+  cuts (markers/tokens never split), amortized rescan (≥32 new chars or
+  50 ms); `flush()` before the final `AIMessage`, which carries the filtered
+  full text; works with either engine, with or without Module 3.
+- **Depends on**: Module 1.
+
+---
+
+## 4. Test Specification
+
+### Unit Tests
+
+| Test | Module | Description |
+|---|---|---|
+| `test_catalog_schema_validation` | M1 | Valid/invalid entity defs; regex rejected if outside the Rust subset |
+| `test_catalog_overlay_merge` | M1 | Overlay by `id` disables/re-scores/replaces builtin entities; env var path |
+| `test_catalog_fingerprint_toggle` | M1 | `set_enabled` changes fingerprint → engine cache miss |
+| `test_python_engine_entities` | M1 | Positive/negative corpus per starter entity (Luhn-valid vs invalid cards, context boosts, `min_score`) |
+| `test_pii_scrubber_recursive` | M1 | dict/list/tuple/str traversal; idempotency `scrub(scrub(x)) == scrub(x)`; skips inside `***REDACTED***` |
+| `test_pii_policy_allow_entities` | M1 | Allowed entities pass through; `detect_only` audits without rewriting |
+| `test_tool_seam_integration` | M1 | Stub tool returning PII → scrubbed `ToolResult`; secrets pass runs first; scrub failure non-fatal |
+| `test_agent_policy_resolution` | M1 | Policy resolved via `current_agent_name`; unregistered agent → no PII pass |
+| `test_engine_parity` | M2 | Shared corpus through both engines → identical `(entity_id, start, end)` sets; `skipif` without `pii_rs` |
+| `test_token_map_roundtrip` | M3 | `restore(transform(x)) == x`; same value → same token; hallucinated token left literal + WARNING |
+| `test_pseudonym_stores` | M3 | TTL/LRU eviction; Redis backend stores only ciphertext; map never in logs (`caplog`) |
+| `test_streaming_boundaries` | M4 | Seeded random chunk splits → concatenated output == non-streaming scrub output; markers never split |
+
+### Integration Tests
+
+| Test | Description |
+|---|---|
+| `test_ask_end_to_end_redaction` | Bot with `enforce` policy + PII-emitting stub tool → response and memory contain no raw PII |
+| `test_ask_stream_end_to_end` | Streaming path: filtered chunks, filtered final `AIMessage`, scrubbed memory |
+| `test_pseudonymize_llm_blind` | LLM context receives tokens only; user response has restored values |
+| `test_scrubbed_at_rest_both_paths` | `enforce` mode: memory/observability text scrubbed on `ask()` AND `ask_stream()` |
+
+### Performance Benchmarks (`tests/benchmarks/`)
+
+| Benchmark | Gate |
+|---|---|
+| Native scan, 1 KB clean text | p99 < 100 µs |
+| Native scan, 10 KB mixed | p99 < 1 ms |
+| Python fallback, same corpora | informational (target: < 10× native) |
+| 100 KB pathological (many near-misses) | no quadratic blowup (documented ceiling) |
+
+### Test Data / Fixtures
+
+```python
+# tests/fixtures/pii_corpus/ — labeled YAML: text -> expected spans
+# Shared by unit, parity, streaming-fuzz, and benchmark suites.
+@pytest.fixture
+def pii_corpus() -> list[CorpusCase]: ...
+
+@pytest.fixture
+def pii_bot(policy: PIIPolicy):  # bot wired with a stub PII-emitting tool
+    ...
+```
+
+---
+
+## 5. Acceptance Criteria
+
+> This feature is complete when ALL of the following are true:
+
+- [ ] All unit + integration tests pass (`pytest tests/ -v`).
+- [ ] `pip install ai-parrot` alone (no native wheel) provides functional
+      PII redaction via the Python engine; fallback logs one INFO line.
+- [ ] With `ai-parrot[pii-native]` installed, `get_engine()` selects the
+      Rust engine automatically with zero behavior difference (parity suite
+      green on the shared corpus).
+- [ ] Native benchmark gates met: p99 < 100 µs @ 1 KB clean, < 1 ms @ 10 KB.
+- [ ] Default off: `enable_pii_protection=False`; no behavior change for
+      existing bots (full test suite passes untouched).
+- [ ] `detect_only` mode audits (entity id + tool name, never the value)
+      without rewriting any text.
+- [ ] Per-agent `allow_entities` lets a designated agent emit listed PII
+      while other agents' outputs are scrubbed.
+- [ ] Catalog overlays can disable, re-score, or replace builtin entities
+      and add new ones without code changes; invalid regex (outside the
+      Rust subset) is rejected at load time.
+- [ ] Secrets scrub (FEAT-252) still runs first and unconditionally;
+      `parrot/security/redaction.py` is unmodified.
+- [ ] Pseudonymization round-trip holds: LLM context contains only tokens;
+      user-facing response has restored values; unknown tokens degrade to
+      literals with a WARNING.
+- [ ] `RedisPseudonymStore` persists only AES-GCM ciphertext; token maps
+      never appear in logs.
+- [ ] Streaming invariant: concatenated streamed output equals the
+      non-streaming scrub of the same text; redaction markers/tokens are
+      never split across chunks; holdback ≤ 128 chars.
+- [ ] In `enforce` mode, memory and observability store scrubbed text on
+      both `ask()` and `ask_stream()` paths.
+- [ ] Documentation updated in `docs/` (enable/rollout guide:
+      off → detect_only → enforce).
+- [ ] No breaking changes to the existing public API.
+
+---
+
+## 6. Codebase Contract
+
+> **CRITICAL — Anti-Hallucination Anchor**
+> All references below were re-verified on 2026-07-20 on branch
+> `claude/pii-detection-ai-parrot-a48mat` (based on `origin/dev`).
+
+### Verified Imports
+
+```python
+from parrot.security.redaction import OutputScrubber, ScrubPolicy  # verified: tools/abstract.py:53 imports it this way (relative)
+from parrot.observability.context import current_agent_name  # verified: bots/base.py:56
+from parrot.memory.redis import RedisConversation  # verified: memory/redis.py:10
+from parrot.security.credentials_utils import encrypt_credential  # verified: security/credentials_utils.py:19
+from redis.asyncio import Redis  # verified: memory/redis.py:4
+```
+
+(Paths below are relative to `packages/ai-parrot/src/parrot/`.)
+
+### Existing Class Signatures
+
+```python
+# tools/abstract.py
+class ToolResult(BaseModel):  # line 88 — fields .result / .error / .metadata are what gets scrubbed
+def _default_scrubber():      # lines 59-65 — module-level OutputScrubber singleton, lazy init
+# FEAT-252 egress hook: lines 695-724 inside AbstractTool.execute();
+#   in-code comment: "This is the ONLY place scrubbing happens on the way out".
+#   Non-fatal try/except wraps the scrub (lines 700-724) — the PII pass MUST
+#   live inside this same block, after the secrets scrub.
+# AfterToolCallEvent emitted at line 728.
+
+# security/redaction.py
+@dataclass(frozen=True)
+class ScrubPolicy:            # lines 127-146: reason_tags, audit_log, allowlist, max_output_bytes=1 MiB
+def _already_scrubbed(text: str) -> bool:  # lines 122-124 — idempotency guard pattern to mirror
+class OutputScrubber:         # line 149 — scrub() recursive over str/dict/list/tuple; _audit logs tag+tool only
+
+# bots/abstract.py
+class AbstractBot:            # __init__ kwargs convention around lines 283-400 (e.g. self.enable_tools at ~383-400)
+    def get_response(         # line 3390 — sync; every non-streaming path funnels the AIMessage here
+
+# bots/base.py
+async def ask_stream(         # line 1566; chunks yielded at 1772-1773; final AIMessage at 1846
+# current_agent_name ContextVar set/reset at lines 196/220, 605/772, 964/1564, 1589 (FEAT-228)
+
+# memory/redis.py
+class RedisConversation(ConversationMemory):  # line 10
+    def __init__(self, redis_url=None, key_prefix="conversation", use_hash_storage=True)
+    # Redis.from_url(REDIS_HISTORY_URL, decode_responses=True, timeouts=5s, retry_on_timeout=True)
+    def _get_key(self, user_id, session_id, chatbot_id=None) -> str  # "prefix:chatbot:user:session"
+
+# security/credentials_utils.py
+def encrypt_credential(...)   # line 19 — AES-GCM via navigator_session.vault.crypto.encrypt_for_db
+# payload layout: [key_id 2B uint16 BE][nonce 12B][encrypted_payload + tag], base64-encoded
+```
+
+### Integration Points
+
+| New Component | Connects To | Via | Verified At |
+|---|---|---|---|
+| `PIIScrubber` | FEAT-252 egress hook | chained call after `_scrubber.scrub(...)` inside the same try/except | `tools/abstract.py:695-724` |
+| PIIPolicy registry | `current_agent_name` ContextVar | lookup at scrub time | `bots/base.py:56,1589` |
+| response redact/restore | `AbstractBot.get_response()` | text rewrite before return | `bots/abstract.py:3390` |
+| `StreamingPIIFilter` | `ask_stream` chunk loop | wrap `yield chunk` + flush before final `AIMessage` | `bots/base.py:1772-1773,1846` |
+| `RedisPseudonymStore` | Redis infra conventions | `redis.asyncio`, `REDIS_HISTORY_URL`, key-prefix scheme | `memory/redis.py:10-42` |
+| `RedisPseudonymStore` payloads | AES-GCM helpers | `encrypt_credential`/`decrypt_credential` | `security/credentials_utils.py:19+` |
+| `pii-rs` packaging | maturin/cibuildwheel wiring | copy `yaml-rs` model (own pyproject, dist, import-fallback) | `parrot/yaml-rs/`, core `pyproject.toml:608-622`, fallback pattern `outputs/formats/yaml.py:5-9` |
+| detection counters | lifecycle observers | attach to existing events, no new types | `tools/abstract.py:728`, `bots/base.py:1505,1838` |
+
+### Does NOT Exist (Anti-Hallucination)
+
+- ~~`parrot.security.pii`~~ — does not exist yet (this feature creates it).
+- ~~Any runtime personal-PII detection~~ — `redaction.py` covers only
+  secrets/credentials/infra (API keys, JWT, DSNs, env dumps, net topology).
+- ~~`presidio` / `scrubadub` / `phonenumbers` / `detect-secrets` deps~~ —
+  not in any package's `pyproject.toml`.
+- ~~An output-side middleware pipeline~~ — `bots/middleware.py`
+  (`PromptPipeline`) is input-only; there is no response-transform chain.
+- ~~Mutating lifecycle hooks~~ — FEAT-176 events and `_on_post_ask` /
+  `_post_response_memory_hook` are observer-only / fire-and-forget; they
+  cannot rewrite responses.
+- ~~aiohttp response-body middleware~~ — the only server middleware is A2A
+  auth; egress is per-handler.
+- ~~`cryptography`/`Fernet` direct dependency~~ — encryption goes through
+  `navigator_session.vault.crypto` helpers wrapped by
+  `security/credentials_utils.py`.
+- ~~FEAT-316 as this feature's id~~ — FEAT-316/317/318 belong to the
+  eventbus migration specs; this feature is FEAT-319.
+
+---
+
+## 7. Implementation Notes & Constraints
+
+### Patterns to Follow
+
+- Async-first throughout; `PIIEngine.scan` is deliberately sync (pure CPU,
+  sub-ms budget; `get_response()` is sync) — the Rust engine releases the
+  GIL internally for large inputs.
+- Pydantic models for catalog/policy/spans; Google-style docstrings; strict
+  type hints; `self.logger`, never print.
+- Mirror `OutputScrubber` exactly: recursive traversal, idempotency guard,
+  audit logs carry entity id + tool name and **never the value**, non-fatal
+  failure contract at the seam.
+- Bot config via the kwargs convention (`enable_tools` precedent); policy
+  shape modeled on `ObservabilityConfig` (`observability/config.py:18`).
+- Rust: pyo3 0.29 `Bound` API, `crate-type = ["cdylib"]`, release profile
+  `opt-level=3, lto=true` — copy `yaml-rs` verbatim as packaging template.
+- Validators are a **fixed enum implemented twice** (Python + Rust); a
+  catalog can never inject code.
+
+### Known Risks / Gotchas
+
+- **Regex parity**: Rust `regex` lacks lookaround/backrefs — enforced at
+  catalog load; the parity suite makes the constraint self-enforcing.
+- **False positives** (phones vs order numbers, SSN vs timestamps):
+  mitigated by context scoring + `min_score` + documented
+  `detect_only`-first rollout; residual risk accepted, revisit with
+  telemetry.
+- **Pseudonym map is itself PII**: in-memory backend evicts on TTL; Redis
+  backend stores ciphertext only; after eviction/restart, restore degrades
+  to literal tokens (logged) — documented limitation.
+- **Wheel coverage**: initial matrix manylinux x86_64 only (macOS/ARM get
+  the Python fallback, logged once); extending the matrix is a follow-up.
+- **Oversized payloads**: follow the `max_output_bytes` wholesale-action
+  precedent from `ScrubPolicy`.
+- **Streaming UX**: holdback delays at most the last ≤128 chars; confirm
+  acceptable for voice consumers (open question #9).
+
+### External Dependencies
+
+| Package | Version | Reason |
+|---|---|---|
+| `pyo3` (Rust) | 0.29 | crate bindings (same as `yaml-rs`) |
+| `regex` (Rust) | latest 1.x | `RegexSet` multi-pattern DFA |
+| `aho-corasick` (Rust) | transitive | context-word scanning |
+| `serde` / `serde_json` (Rust) | 1.x | catalog JSON → compiled engine |
+| `maturin` | ==1.9.6 (already in dev deps) | crate build backend |
+| — (Python core) | — | **no new Python runtime dependencies** |
+
+---
+
+## Worktree Strategy
+
+- **Default isolation unit**: mixed.
+- **Sequencing**: Module 1 first, sequentially, in one worktree — it freezes
+  the `PIIEngine` protocol, catalog schema, and seam integration everything
+  else builds on. After M1 merges: Module 2 (`pii-rust-engine`) and
+  Module 3 (`pii-pseudonymization`) are **parallelizable in separate
+  worktrees** (disjoint files: `pii-rs/` crate + `native_engine.py` vs
+  `pseudonym.py` + `get_response()` wiring). Module 4 follows M1 (touches
+  `bots/base.py` `ask_stream`; serialize with M3 only if M3's restore-wiring
+  lands in the same region).
+- **Cross-feature dependencies**: none blocking. Before cutting worktrees,
+  check in-flight specs touching `tools/abstract.py` / `bots/base.py`
+  (the eventbus migration FEAT-316/317/318 touches broker/event modules,
+  not these seams).
+
+---
+
+## 8. Open Questions
+
+> Carried forward from the brainstorm with their resolution state.
+> Resolved answers are reflected in the spec body (§1, §2, §3, §7).
+
+- [x] Regex-syntax parity: enforce the Rust `regex` subset from day 1 —
+  *Resolved in spec round*: yes; catalog validation rejects
+  lookaround/backrefs at load time (§2 Overview, §7 Risks).
+- [ ] False positives: are context scoring + `min_score` + `detect_only`
+  sufficient, or is a per-tool suppression list needed? — *Owner: Jesús*
+  (defer to implementation telemetry)
+- [x] Default posture — *Resolved in brainstorm/plan round*: opt-in
+  (`enable_pii_protection=False`); revisit default-on only after
+  `detect_only` telemetry (§1 Goals, §5).
+- [x] PII at rest — *Resolved in spec round*: in `enforce` mode, memory and
+  observability store scrubbed text on **both** `ask()` and `ask_stream()`
+  paths (§1 Goals, §5, integration table).
+- [x] Pseudonym store backend — *Resolved in spec round*: ship
+  `AbstractPseudonymStore` with in-memory (TTL/LRU) **and** encrypted-Redis
+  (AES-GCM via `credentials_utils`) backends in this feature (§3 Module 3).
+- [ ] Wheel matrix: manylinux x86_64 first; when to add macOS/ARM? —
+  *Owner: Jesús* (follow-up, fallback covers the gap)
+- [ ] PII split across formatting (table cells / JSON keys): document as
+  limitation only, or add a normalization pre-pass later? — *Owner: Jesús*
+- [x] NER-class entities — *Resolved in spec round*: out of scope for
+  FEAT-319; `PIIEngine` protocol is the extension point for a future
+  `SpacyNerEngine` (§1 Non-Goals).
+- [ ] Streaming UX for voice consumers (holdback ≤128 chars acceptable?) —
+  *Owner: Jesús*
+
+---
+
+## Revision History
+
+| Version | Date | Author | Change |
+|---|---|---|---|
+| 0.1 | 2026-07-20 | Jesús Lara / Claude Code | Initial draft from `pii-detection-redaction.brainstorm.md`; FEAT id corrected 316→319 |

--- a/sdd/specs/pii-detection-redaction.spec.md
+++ b/sdd/specs/pii-detection-redaction.spec.md
@@ -5,15 +5,16 @@ base_branch: dev
 
 # Feature Specification: PII Detection & Redaction for Tool Outputs and Agent Responses
 
-**Feature ID**: FEAT-319
+**Feature ID**: FEAT-324
 **Date**: 2026-07-20
 **Author**: Jesús Lara (spec drafted with Claude Code)
 **Status**: draft
 **Target version**: 0.26.0
 
 > Source brainstorm: `sdd/proposals/pii-detection-redaction.brainstorm.md`
-> (Recommended Option A). Note: the brainstorm tentatively cited FEAT-316;
-> that id was taken by the eventbus migration — this feature is **FEAT-319**.
+> (Recommended Option A). Id history: tentatively FEAT-316, then FEAT-319 —
+> both ranges were claimed by the eventbus workstream (FEAT-316–319) while
+> this spec was in flight; final id is **FEAT-324** (highest on main: 323).
 
 ---
 
@@ -534,7 +535,7 @@ def encrypt_credential(...)   # line 19 — AES-GCM via navigator_session.vault.
   `navigator_session.vault.crypto` helpers wrapped by
   `security/credentials_utils.py`.
 - ~~FEAT-316 as this feature's id~~ — FEAT-316/317/318 belong to the
-  eventbus migration specs; this feature is FEAT-319.
+  eventbus migration specs; this feature is FEAT-324.
 
 ---
 
@@ -631,7 +632,7 @@ def encrypt_credential(...)   # line 19 — AES-GCM via navigator_session.vault.
 - [ ] PII split across formatting (table cells / JSON keys): document as
   limitation only, or add a normalization pre-pass later? — *Owner: Jesús*
 - [x] NER-class entities — *Resolved in spec round*: out of scope for
-  FEAT-319; `PIIEngine` protocol is the extension point for a future
+  FEAT-324; `PIIEngine` protocol is the extension point for a future
   `SpacyNerEngine` (§1 Non-Goals).
 - [ ] Streaming UX for voice consumers (holdback ≤128 chars acceptable?) —
   *Owner: Jesús*
@@ -650,3 +651,4 @@ def encrypt_credential(...)   # line 19 — AES-GCM via navigator_session.vault.
 |---|---|---|---|
 | 0.1 | 2026-07-20 | Jesús Lara / Claude Code | Initial draft from `pii-detection-redaction.brainstorm.md`; FEAT id corrected 316→319 |
 | 0.2 | 2026-07-22 | Jesús Lara / Claude Code | Adopt Unicode normalization + `detect_encoded_pii` from the OpenAI-Guardrails comparison; add measured Presidio baseline (`pii-detection-redaction.comparison.md`) |
+| 0.3 | 2026-07-22 | Jesús Lara / Claude Code | Renumber FEAT-319 → FEAT-324 (id claimed by `eventbus-consolidation.spec.md` on main) |

--- a/sdd/specs/pii-detection-redaction.spec.md
+++ b/sdd/specs/pii-detection-redaction.spec.md
@@ -100,6 +100,17 @@ is redacted or token-restored in `AbstractBot.get_response()`
 (non-streaming) and through a `StreamingPIIFilter` sliding window in
 `BaseBot.ask_stream()` (streaming).
 
+Two anti-bypass measures are adopted from the OpenAI Guardrails PII check
+(comparison + measured baseline: `sdd/proposals/pii-detection-redaction.comparison.md`):
+a **mandatory Unicode normalization pre-pass** in both engines (NFKC folding
+of fullwidth/compatibility characters before matching, with spans mapped
+back to original-text offsets so masking always rewrites the untouched
+original), and an optional **encoded-PII detection** pass
+(`PIIPolicy.detect_encoded_pii`, default off): Base64/URL-encoded/hex
+candidates are decoded with stdlib codecs and scanned, and matches mask the
+*encoded* region with `<{ENTITY}_ENCODED>` tokens. Encoded-PII decoding runs
+Python-side (Module 1), outside the Rust hot path initially.
+
 Resolved design decisions (carried from brainstorm + spec round):
 - Catalog regexes are validated at load time against the **Rust `regex`
   syntax subset** (no lookaround/backreferences) so Python↔Rust parity is
@@ -109,6 +120,9 @@ Resolved design decisions (carried from brainstorm + spec round):
   of any rollout.
 - In `enforce` mode, memory and observability persist **scrubbed** text on
   both `ask()` and `ask_stream()` paths.
+- Unicode normalization is always-on (not policy-gated) — a bypassable
+  detector is worse than none; `detect_encoded_pii` is opt-in because its
+  decode+rescan cost is measurable.
 - `PseudonymStore` ships with an abstract interface and **two backends in
   this feature**: in-memory (TTL/LRU) and encrypted Redis (AES-GCM via the
   existing `credentials_utils` helpers over `navigator_session.vault.crypto`,
@@ -222,6 +236,7 @@ class PIIPolicy(BaseModel):
     scrub_final_response: bool = True
     scrub_streaming: bool = True
     pseudonymize_default: bool = False
+    detect_encoded_pii: bool = False          # scan Base64/URL/hex-decoded content
 ```
 
 ### New Public Interfaces
@@ -288,7 +303,10 @@ New bot kwargs (following the `enable_tools` convention):
   at the tool seam; redact in `get_response()`; bot kwargs; starter entities
   (`email`, `phone_us`, `credit_card` w/ Luhn, `ipv4`, `us_ssn`);
   scrubbed-at-rest on both paths in `enforce`; `detect_only` mode; audit
-  logging (entity id + tool, never the value).
+  logging (entity id + tool, never the value); **Unicode normalization
+  pre-pass** (NFKC fold, spans mapped back to original offsets) always-on;
+  **encoded-PII pass** (Base64/URL/hex decode + rescan, `<{ENTITY}_ENCODED>`
+  masking) behind `detect_encoded_pii`, default off.
 - **Depends on**: nothing new (existing seams only).
 
 ### Module 2: pii-rust-engine
@@ -340,6 +358,8 @@ New bot kwargs (following the `enable_tools` convention):
 | `test_engine_parity` | M2 | Shared corpus through both engines → identical `(entity_id, start, end)` sets; `skipif` without `pii_rs` |
 | `test_token_map_roundtrip` | M3 | `restore(transform(x)) == x`; same value → same token; hallucinated token left literal + WARNING |
 | `test_pseudonym_stores` | M3 | TTL/LRU eviction; Redis backend stores only ciphertext; map never in logs (`caplog`) |
+| `test_unicode_bypass` | M1 | Fullwidth/compatibility chars (e.g. `ｊｏｈｎ＠ｅｘａｍｐｌｅ．ｃｏｍ`) are detected; masked output rewrites the ORIGINAL text (offset-mapping correctness) |
+| `test_encoded_pii` | M1 | Base64/URL-encoded/hex PII detected when `detect_encoded_pii=True` → `<EMAIL_ENCODED>`-style masks; off by default |
 | `test_streaming_boundaries` | M4 | Seeded random chunk splits → concatenated output == non-streaming scrub output; markers never split |
 
 ### Integration Tests
@@ -359,6 +379,13 @@ New bot kwargs (following the `enable_tools` convention):
 | Native scan, 10 KB mixed | p99 < 1 ms |
 | Python fallback, same corpora | informational (target: < 10× native) |
 | 100 KB pathological (many near-misses) | no quadratic blowup (documented ceiling) |
+
+Measured baseline for context (Presidio/spaCy stack as used by OpenAI
+Guardrails; blank-model **lower bound**, see
+`sdd/proposals/pii-detection-redaction.comparison.md`): scan+mask p99 =
+1.13 ms @ 1 KB clean, 37.4 ms @ 1 KB PII-dense, 50.35 ms @ 10 KB mixed;
+cold init 2.85 s; 147 MB RSS. The Phase-1 Python prototype measured 0.16 /
+0.24 / 1.73 ms p99 on the same corpora at 10.4 MB RSS.
 
 ### Test Data / Fixtures
 
@@ -407,6 +434,14 @@ def pii_bot(policy: PIIPolicy):  # bot wired with a stub PII-emitting tool
       never split across chunks; holdback ≤ 128 chars.
 - [ ] In `enforce` mode, memory and observability store scrubbed text on
       both `ask()` and `ask_stream()` paths.
+- [ ] Unicode normalization is always active: the fullwidth-bypass test
+      passes and masked output rewrites original (un-normalized) text.
+- [ ] `detect_encoded_pii` detects Base64/URL/hex-encoded PII when enabled,
+      masks as `<{ENTITY}_ENCODED>`, and is off by default.
+- [ ] The comparative latency baseline vs Presidio/spaCy is checked into the
+      repo (`sdd/proposals/pii-detection-redaction.comparison.md`) and the
+      Rust engine beats the measured Presidio lower bound by ≥50× on the
+      10 KB corpus.
 - [ ] Documentation updated in `docs/` (enable/rollout guide:
       off → detect_only → enforce).
 - [ ] No breaking changes to the existing public API.
@@ -600,6 +635,12 @@ def encrypt_credential(...)   # line 19 — AES-GCM via navigator_session.vault.
   `SpacyNerEngine` (§1 Non-Goals).
 - [ ] Streaming UX for voice consumers (holdback ≤128 chars acceptable?) —
   *Owner: Jesús*
+- [x] Unicode-bypass hardening — *Resolved in comparison round (v0.2)*:
+  adopt a mandatory NFKC normalization pre-pass in both engines, spans
+  mapped back to original offsets (§2 Overview, §3 Module 1, §5).
+- [x] Encoded-PII detection (Base64/URL/hex) — *Resolved in comparison
+  round (v0.2)*: adopted as `PIIPolicy.detect_encoded_pii`, default off,
+  Python-side in Module 1, `<{ENTITY}_ENCODED>` masking (§2, §3, §5).
 
 ---
 
@@ -608,3 +649,4 @@ def encrypt_credential(...)   # line 19 — AES-GCM via navigator_session.vault.
 | Version | Date | Author | Change |
 |---|---|---|---|
 | 0.1 | 2026-07-20 | Jesús Lara / Claude Code | Initial draft from `pii-detection-redaction.brainstorm.md`; FEAT id corrected 316→319 |
+| 0.2 | 2026-07-22 | Jesús Lara / Claude Code | Adopt Unicode normalization + `detect_encoded_pii` from the OpenAI-Guardrails comparison; add measured Presidio baseline (`pii-detection-redaction.comparison.md`) |


### PR DESCRIPTION
## Summary

Follow-up to #1040 (merged brainstorm). This PR delivers the remaining SDD artifacts for the low-latency PII detection &amp; redaction feature, rebased onto latest `main`:

- **`sdd/specs/pii-detection-redaction.spec.md`** — formal spec (**FEAT-324**, v0.3): architecture (in-core Rust `pii-rs` engine via PyO3/maturin behind a `PIIEngine` protocol with a pure-Python fallback), data-driven YAML entity catalog, per-agent `PIIPolicy` (`off`/`detect_only`/`enforce`, `allow_entities`, per-entity actions), reversible pseudonymization with in-memory + encrypted-Redis stores, sliding-window streaming filter, 4-module breakdown with mixed worktree strategy, full test spec with latency gates, and a verified Codebase Contract.
- **`sdd/proposals/pii-detection-redaction.comparison.md`** — empirical + qualitative comparison against the OpenAI Guardrails PII check (Presidio + spaCy), evaluated against a ≤1000 ms budget. Measured (lower bound): Presidio scan+mask p99 50 ms @10 KB, 2.85 s cold init, 147 MB RSS vs the Phase-1 Python prototype at 1.7 ms p99 and 10 MB (~29–150×). Reproducible scripts included.
- **Spec v0.2 adoptions from the comparison**: mandatory NFKC Unicode normalization pre-pass (anti fullwidth-bypass, spans mapped to original offsets) and `PIIPolicy.detect_encoded_pii` (Base64/URL/hex decode + rescan, `&lt;ENTITY_ENCODED&gt;` masks, default off).
- **Brainstorm touch-up**: feature-id reference corrected.

## Feature-id note

The brainstorm tentatively used FEAT-316 and the spec initially FEAT-319; both ranges were claimed by the eventbus workstream while this was in flight. Final id: **FEAT-324** (highest on `main` is FEAT-323), renumbered consistently across all three documents.

## Next steps

1. Review the spec (Acceptance Criteria + Architectural Design) and mark `Status: approved`.
2. Run `/sdd-task sdd/specs/pii-detection-redaction.spec.md` to decompose into tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeqDJyFSV1CywVXnJEwgnq

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeqDJyFSV1CywVXnJEwgnq)_