### PR TITLE
Add ModelSwitchingMixin for dual-LLM fallback and contrastive modes

### DIFF
--- a/.agent/CONTEXT.md
+++ b/.agent/CONTEXT.md
@@ -51,6 +51,21 @@ of `Node` instances from `parrot/bots/flows/core/`.
 - Attach `on_node_event` listeners for lifecycle telemetry.
 Inherits `PersistenceMixin` (not `SynthesisMixin`).
 
+### ModelSwitchingMixin
+Location: `parrot/bots/mixins/model_switching.py`
+Dual-LLM model switching for any bot/agent (`class MyAgent(ModelSwitchingMixin, Agent)`).
+Configure a `secondary_llm` (same formats as `llm`: `"provider:model"`, client
+class/instance, or model_config dict) plus a `model_switch_mode`:
+- `fallback` — primary serves every call; on error the same call is retried
+  once on the secondary client (cross-provider failover, complementary to the
+  client-level same-provider `fallback_model`).
+- `contrastive` — both models answer concurrently; the merged `AIMessage`
+  carries a combined labeled output and `metadata['model_switching']`
+  attributes each answer (provider, model, usage, timing) to its model.
+Built on the `AbstractBot.get_client()` / `execute_llm_call()` hooks (same
+cooperative pattern as `IntentRouterMixin`). v1 limitation: `ask_stream`
+always uses the primary client.
+
 ### Loaders
 Location: `parrot/loaders/`
 Transform documents (PDF, HTML, DOCX, etc.) into text chunks for RAG.

--- a/packages/ai-parrot/src/parrot/bots/abstract.py
+++ b/packages/ai-parrot/src/parrot/bots/abstract.py
@@ -1120,6 +1120,43 @@ class AbstractBot(
     def llm(self, model):
         self._llm = model
 
+    def get_client(self) -> AbstractClient:
+        """Return the LLM client to use for the next call.
+
+        Default: the configured primary client (``self._llm``). This is the
+        cooperative-MRO terminal for client-selection mixins (e.g.
+        ``ModelSwitchingMixin``), which may override it to pick between
+        multiple configured clients.
+
+        Returns:
+            The :class:`AbstractClient` the caller should enter and invoke.
+        """
+        return self._llm
+
+    async def execute_llm_call(
+        self,
+        client: AbstractClient,
+        method: str = "ask",
+        **llm_kwargs: Any,
+    ) -> Any:
+        """Execute a single LLM call through an overridable hook.
+
+        Default implementation delegates straight to the client — behavior is
+        identical to the previous inline ``await client.ask(**llm_kwargs)``.
+        Mixins (e.g. ``ModelSwitchingMixin``) override this to add
+        cross-provider fallback or contrastive dual-model calls, chaining
+        ``super().execute_llm_call(...)`` for the primary call.
+
+        Args:
+            client: The already-entered LLM client (inside ``async with``).
+            method: Client coroutine to invoke (currently always ``"ask"``).
+            **llm_kwargs: Keyword arguments forwarded to the client method.
+
+        Returns:
+            The :class:`~parrot.models.responses.AIMessage` from the client.
+        """
+        return await getattr(client, method)(**llm_kwargs)
+
     def configure_conversation_memory(self) -> None:
         """Configure the unified conversation memory system."""
         try:

--- a/packages/ai-parrot/src/parrot/bots/base.py
+++ b/packages/ai-parrot/src/parrot/bots/base.py
@@ -415,7 +415,7 @@ class BaseBot(AbstractBot):
             )
 
             # Configure LLM if needed
-            llm = self._llm
+            llm = self.get_client()
             if (new_llm := kwargs.pop('llm', None)):
                 llm = self.configure_llm(
                     llm=new_llm,
@@ -451,7 +451,7 @@ class BaseBot(AbstractBot):
                     if max_tokens is not None:
                         llm_kwargs["max_tokens"] = max_tokens
 
-                    response = await client.ask(**llm_kwargs)
+                    response = await self.execute_llm_call(client, "ask", **llm_kwargs)
 
                     # Extract the vector-specific metadata
                     vector_info = vector_metadata.get('vector', {})
@@ -676,7 +676,7 @@ class BaseBot(AbstractBot):
             )
 
             # Configure LLM if needed
-            llm = self._llm
+            llm = self.get_client()
             if (new_llm := kwargs.pop('llm', None)):
                 llm = self.configure_llm(
                     llm=new_llm,
@@ -706,7 +706,7 @@ class BaseBot(AbstractBot):
                         output_type=response_model
                     )
 
-                response = await client.ask(**llm_kwargs)
+                response = await self.execute_llm_call(client, "ask", **llm_kwargs)
 
                 # Set conversation context info
                 response.set_conversation_context_info(
@@ -1239,7 +1239,7 @@ class BaseBot(AbstractBot):
             )
 
             # Configure LLM if needed
-            llm = self._llm
+            llm = self.get_client()
             if (new_llm := kwargs.pop('llm', None)):
                 llm = self.configure_llm(
                     llm=new_llm,
@@ -1300,7 +1300,7 @@ class BaseBot(AbstractBot):
                         llm_kwargs["structured_output"] = structured_output
 
                 phase_started = time.perf_counter()
-                response = await client.ask(**llm_kwargs)
+                response = await self.execute_llm_call(client, "ask", **llm_kwargs)
                 self.logger.info(
                     "[%s] ask timing: client.ask_ms=%.1f model=%s use_tools=%s",
                     self.name,

--- a/packages/ai-parrot/src/parrot/bots/mixins/__init__.py
+++ b/packages/ai-parrot/src/parrot/bots/mixins/__init__.py
@@ -3,8 +3,16 @@
 Provides optional mix-in classes that add capabilities to bots:
 - IntentRouterMixin: pre-RAG query routing with strategy cascade and HITL support.
 - IdentityMixin: file-based identity injection + hot reload (FEAT-321).
+- ModelSwitchingMixin: dual-LLM switching — cross-provider fallback on error
+  or contrastive dual-model answers with per-model attribution.
 """
 from .intent_router import IntentRouterMixin
 from .identity import IdentityMixin
+from .model_switching import ModelSwitchingMixin, ModelSwitchMode
 
-__all__ = ["IntentRouterMixin", "IdentityMixin"]
+__all__ = [
+    "IntentRouterMixin",
+    "IdentityMixin",
+    "ModelSwitchingMixin",
+    "ModelSwitchMode",
+]

--- a/packages/ai-parrot/src/parrot/bots/mixins/model_switching.py
+++ b/packages/ai-parrot/src/parrot/bots/mixins/model_switching.py
@@ -1,0 +1,460 @@
+"""
+ModelSwitchingMixin — dual-LLM model switching for AbstractBot.
+
+Adds the ability to configure a **secondary** LLM client next to the bot's
+primary one, and use it in one of two modes:
+
+- **fallback**: the primary client serves every call; when it raises, the
+  same call is retried once on the secondary client (cross-provider
+  failover — complementary to the client-level same-provider
+  ``fallback_model`` retries).
+- **contrastive**: both clients answer the same prompt concurrently and the
+  results are merged into a single :class:`~parrot.models.responses.AIMessage`
+  whose ``metadata['model_switching']`` attributes each answer to the model
+  that produced it.
+
+The mixin hooks the ``get_client()`` / ``execute_llm_call()`` extension
+points on :class:`~parrot.bots.abstract.AbstractBot` — the same cooperative
+pattern used by ``IntentRouterMixin`` (``_resolve_output_mode``) and
+``SkillRegistryMixin`` (``post_configure``).
+
+Usage::
+
+    from parrot.bots.agent import Agent
+    from parrot.bots.mixins import ModelSwitchingMixin, ModelSwitchMode
+
+    class ResearchAgent(ModelSwitchingMixin, Agent):
+        pass
+
+    agent = ResearchAgent(
+        llm="google:gemini-2.5-flash",
+        secondary_llm="anthropic:claude-sonnet-5",
+        model_switch_mode=ModelSwitchMode.CONTRASTIVE,
+    )
+
+Limitations (v1): only non-streaming calls (``ask``) are switched;
+``ask_stream`` always uses the primary client.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from enum import Enum
+from typing import Any, Dict, Optional, Union
+
+from ...clients.base import AbstractClient
+from ...exceptions import ConfigError
+from ...models.basic import CompletionUsage
+
+
+class ModelSwitchMode(str, Enum):
+    """How the secondary LLM client participates in a call."""
+
+    FALLBACK = "fallback"
+    CONTRASTIVE = "contrastive"
+
+
+class ModelSwitchingMixin:
+    """Mixin to add dual-LLM model switching to any bot or agent.
+
+    Mix in **before** the bot class so the MRO reaches this class first::
+
+        class MyAgent(ModelSwitchingMixin, Agent):
+            ...
+
+    Attributes:
+        enable_model_switching: Master switch. When ``False`` the mixin is a
+            pure passthrough. Default ``True``.
+        model_switch_mode: :class:`ModelSwitchMode` (or its string value)
+            selecting fallback or contrastive behavior. Default ``fallback``.
+        secondary_llm: Specification of the secondary client, in any format
+            :meth:`~parrot.bots.abstract.AbstractBot._resolve_llm_config`
+            accepts — ``"provider:model"`` string, ``AbstractClient``
+            subclass or instance, or a ``model_config`` dict. Default
+            ``None`` (switching disabled until provided).
+
+    The merged response always carries a ``metadata['model_switching']``
+    payload attributing which model produced what, e.g. for contrastive::
+
+        {
+            "mode": "contrastive",
+            "responses": [
+                {"role": "primary", "provider": "google", "model": "...",
+                 "output": "...", "usage": {...}, "response_time": 1.2},
+                {"role": "secondary", ...},
+            ],
+        }
+    """
+
+    # Configuration (overridable as class attrs or constructor kwargs)
+    enable_model_switching: bool = True
+    model_switch_mode: ModelSwitchMode = ModelSwitchMode.FALLBACK
+    secondary_llm: Union[str, dict, AbstractClient, None] = None
+
+    # Event emitted (via EventEmitterMixin) when a fallback switch happens.
+    EVENT_MODEL_SWITCHED = "model_switched"
+
+    # Runtime
+    _secondary_client: Optional[AbstractClient] = None
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Pop mixin kwargs, then continue the cooperative ``__init__`` chain."""
+        if "secondary_llm" in kwargs:
+            self.secondary_llm = kwargs.pop("secondary_llm")
+        if "model_switch_mode" in kwargs:
+            self.model_switch_mode = ModelSwitchMode(kwargs.pop("model_switch_mode"))
+        if "enable_model_switching" in kwargs:
+            self.enable_model_switching = bool(kwargs.pop("enable_model_switching"))
+        self._secondary_client = None
+        super().__init__(*args, **kwargs)
+
+    # ── Configuration ────────────────────────────────────────────────────
+
+    async def post_configure(self) -> None:
+        """Build the secondary client after base configuration completes.
+
+        Chains ``super().post_configure()`` first (documented contract of
+        :meth:`AbstractBot.post_configure`), then resolves
+        :attr:`secondary_llm` through the existing
+        :meth:`~parrot.interfaces.tools.ToolInterface.configure_llm` helper so
+        the secondary client gets the same tool sync and conversation memory
+        as the primary.
+
+        Raises:
+            ConfigError: If switching is enabled with a ``secondary_llm``
+                spec that cannot be resolved into a client.
+        """
+        await super().post_configure()
+        if not self.enable_model_switching or self.secondary_llm is None:
+            return
+        if self._secondary_client is not None:
+            return
+        try:
+            if isinstance(self.secondary_llm, dict):
+                self._secondary_client = self.configure_llm(
+                    model_config=self.secondary_llm
+                )
+            else:
+                self._secondary_client = self.configure_llm(llm=self.secondary_llm)
+        except Exception as exc:
+            raise ConfigError(
+                f"ModelSwitchingMixin: cannot resolve secondary_llm "
+                f"{self.secondary_llm!r}: {exc}"
+            ) from exc
+        self.logger.info(
+            "Model switching enabled (%s): primary=%s secondary=%s",
+            ModelSwitchMode(self.model_switch_mode).value,
+            self._client_label(getattr(self, "_llm", None)),
+            self._client_label(self._secondary_client),
+        )
+
+    # ── Policy hooks ─────────────────────────────────────────────────────
+
+    def should_switch_on(self, error: Exception) -> bool:
+        """Decide whether an error from the primary triggers the secondary.
+
+        Default: switch on any exception except ``asyncio.CancelledError``.
+        Override for finer control (e.g. only capacity errors).
+
+        Args:
+            error: The exception raised by the primary client's call.
+
+        Returns:
+            ``True`` to retry the call on the secondary client.
+        """
+        return not isinstance(error, asyncio.CancelledError)
+
+    # ── Core override ────────────────────────────────────────────────────
+
+    async def execute_llm_call(
+        self,
+        client: AbstractClient,
+        method: str = "ask",
+        **llm_kwargs: Any,
+    ) -> Any:
+        """Execute the LLM call with fallback or contrastive switching.
+
+        Passes straight through to the primary when switching is disabled,
+        no secondary client is configured, or the call is not an ``ask``.
+
+        Args:
+            client: The already-entered primary client.
+            method: Client coroutine name (only ``"ask"`` is switched).
+            **llm_kwargs: Keyword arguments for the client call.
+
+        Returns:
+            The (possibly merged/annotated) ``AIMessage``.
+        """
+        switching_active = (
+            self.enable_model_switching
+            and self._secondary_client is not None
+            and method == "ask"
+        )
+        if not switching_active:
+            return await super().execute_llm_call(client, method, **llm_kwargs)
+
+        # Normalize: subclasses may declare the mode as a plain string.
+        mode = ModelSwitchMode(self.model_switch_mode)
+        if mode is ModelSwitchMode.CONTRASTIVE:
+            return await self._contrastive_call(client, method, **llm_kwargs)
+        return await self._fallback_call(client, method, **llm_kwargs)
+
+    # ── Fallback mode ────────────────────────────────────────────────────
+
+    async def _fallback_call(
+        self,
+        client: AbstractClient,
+        method: str,
+        **llm_kwargs: Any,
+    ) -> Any:
+        """Primary first; on error, retry the same call once on the secondary."""
+        try:
+            response = await super().execute_llm_call(client, method, **llm_kwargs)
+        except asyncio.CancelledError:
+            raise
+        except Exception as primary_err:
+            if not self.should_switch_on(primary_err):
+                raise
+            primary_info = self._client_info(client)
+            self.logger.warning(
+                "Primary LLM %s failed (%s: %s) — switching to secondary %s",
+                self._client_label(client),
+                type(primary_err).__name__,
+                primary_err,
+                self._client_label(self._secondary_client),
+            )
+            try:
+                async with self._secondary_client as secondary:
+                    response = await getattr(secondary, method)(**llm_kwargs)
+            except Exception as secondary_err:
+                self.logger.error(
+                    "Secondary LLM %s also failed (%s: %s); raising primary error",
+                    self._client_label(self._secondary_client),
+                    type(secondary_err).__name__,
+                    secondary_err,
+                )
+                raise primary_err from secondary_err
+            self._annotate(response, {
+                "mode": ModelSwitchMode.FALLBACK.value,
+                "switched": True,
+                "primary": {
+                    **primary_info,
+                    "error_type": type(primary_err).__name__,
+                    "error": str(primary_err),
+                },
+                "served_by": self._response_info(response),
+            })
+            self._emit_switch_event(primary_err, response)
+            return response
+
+        self._annotate(response, {
+            "mode": ModelSwitchMode.FALLBACK.value,
+            "switched": False,
+            "served_by": self._response_info(response),
+        })
+        return response
+
+    # ── Contrastive mode ─────────────────────────────────────────────────
+
+    async def _contrastive_call(
+        self,
+        client: AbstractClient,
+        method: str,
+        **llm_kwargs: Any,
+    ) -> Any:
+        """Call primary and secondary concurrently and merge into one message."""
+        started = time.perf_counter()
+        primary_res, secondary_res = await asyncio.gather(
+            super().execute_llm_call(client, method, **llm_kwargs),
+            self._call_secondary(method, **llm_kwargs),
+            return_exceptions=True,
+        )
+        if isinstance(primary_res, asyncio.CancelledError):
+            raise primary_res
+        if isinstance(secondary_res, asyncio.CancelledError):
+            raise secondary_res
+
+        primary_failed = isinstance(primary_res, BaseException)
+        secondary_failed = isinstance(secondary_res, BaseException)
+
+        if primary_failed and secondary_failed:
+            self.logger.error(
+                "Contrastive call: both models failed (primary %s: %s / secondary %s: %s)",
+                self._client_label(client),
+                primary_res,
+                self._client_label(self._secondary_client),
+                secondary_res,
+            )
+            raise primary_res
+
+        entries = [
+            self._contrastive_entry("primary", client, primary_res),
+            self._contrastive_entry("secondary", self._secondary_client, secondary_res),
+        ]
+
+        if primary_failed or secondary_failed:
+            survivor = secondary_res if primary_failed else primary_res
+            self.logger.warning(
+                "Contrastive call: %s model failed — returning the surviving answer",
+                "primary" if primary_failed else "secondary",
+            )
+            self._annotate(survivor, {
+                "mode": ModelSwitchMode.CONTRASTIVE.value,
+                "responses": entries,
+            })
+            return survivor
+
+        # Both succeeded: primary AIMessage is the carrier so downstream
+        # post-processing (sources, memory, formatter) sees a normal message.
+        combined = self._combine_outputs(primary_res, secondary_res, **llm_kwargs)
+        if combined is not None:
+            primary_res.output = combined
+            primary_res.response = combined
+        self._aggregate_usage(primary_res, secondary_res)
+        if primary_res.response_time is not None:
+            primary_res.response_time = time.perf_counter() - started
+        self._annotate(primary_res, {
+            "mode": ModelSwitchMode.CONTRASTIVE.value,
+            "responses": entries,
+        })
+        return primary_res
+
+    async def _call_secondary(self, method: str, **llm_kwargs: Any) -> Any:
+        """Run one call on the secondary client, managing its own context."""
+        async with self._secondary_client as secondary:
+            return await getattr(secondary, method)(**llm_kwargs)
+
+    def _combine_outputs(
+        self,
+        primary: Any,
+        secondary: Any,
+        **llm_kwargs: Any,
+    ) -> Optional[str]:
+        """Build the combined labeled markdown output, or ``None`` to keep primary.
+
+        Structured-output calls and non-text outputs are not merged — the
+        primary output stays authoritative and the secondary answer remains
+        available in ``metadata['model_switching']``.
+        """
+        if llm_kwargs.get("structured_output") is not None:
+            return None
+        primary_text = self._response_text(primary)
+        secondary_text = self._response_text(secondary)
+        if primary_text is None or secondary_text is None:
+            return None
+        return (
+            f"### {primary.provider}:{primary.model} (primary)\n\n"
+            f"{primary_text}\n\n"
+            f"### {secondary.provider}:{secondary.model} (secondary)\n\n"
+            f"{secondary_text}"
+        )
+
+    def _contrastive_entry(
+        self,
+        role: str,
+        client: Optional[AbstractClient],
+        result: Any,
+    ) -> Dict[str, Any]:
+        """Build one attribution entry for the contrastive metadata payload."""
+        if isinstance(result, BaseException):
+            return {
+                "role": role,
+                **self._client_info(client),
+                "error_type": type(result).__name__,
+                "error": str(result),
+            }
+        usage = getattr(result, "usage", None)
+        return {
+            "role": role,
+            **self._response_info(result),
+            "output": self._response_text(result),
+            "usage": usage.model_dump() if usage is not None else None,
+            "response_time": getattr(result, "response_time", None),
+        }
+
+    @staticmethod
+    def _aggregate_usage(primary: Any, secondary: Any) -> None:
+        """Sum token counts of both calls into the carrier message's usage."""
+        p_usage = getattr(primary, "usage", None)
+        s_usage = getattr(secondary, "usage", None)
+        if not isinstance(p_usage, CompletionUsage) or not isinstance(s_usage, CompletionUsage):
+            return
+        p_usage.prompt_tokens += s_usage.prompt_tokens
+        p_usage.completion_tokens += s_usage.completion_tokens
+        p_usage.total_tokens += s_usage.total_tokens
+
+    # ── Helpers ──────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _response_text(response: Any) -> Optional[str]:
+        """Text of a response, or ``None`` when it is not plain text."""
+        output = getattr(response, "output", None)
+        return output if isinstance(output, str) else None
+
+    @staticmethod
+    def _client_info(client: Optional[AbstractClient]) -> Dict[str, Any]:
+        """Provider/model attribution for a client instance."""
+        if client is None:
+            return {"provider": None, "model": None}
+        return {
+            "provider": getattr(client, "client_name", None) or type(client).__name__,
+            "model": getattr(client, "model", None),
+        }
+
+    @staticmethod
+    def _response_info(response: Any) -> Dict[str, Any]:
+        """Provider/model attribution taken from an ``AIMessage``."""
+        return {
+            "provider": getattr(response, "provider", None),
+            "model": getattr(response, "model", None),
+        }
+
+    @staticmethod
+    def _client_label(client: Optional[AbstractClient]) -> str:
+        """Human-readable ``provider:model`` label for logging."""
+        if client is None:
+            return "<none>"
+        provider = getattr(client, "client_name", None) or type(client).__name__
+        model = getattr(client, "model", None)
+        return f"{provider}:{model}" if model else str(provider)
+
+    @staticmethod
+    def _annotate(response: Any, payload: Dict[str, Any]) -> None:
+        """Attach the model_switching payload to ``response.metadata``."""
+        metadata = getattr(response, "metadata", None)
+        if metadata is None:
+            try:
+                response.metadata = {"model_switching": payload}
+            except Exception:
+                return
+        else:
+            metadata["model_switching"] = payload
+
+    def _emit_switch_event(self, error: Exception, response: Any) -> None:
+        """Emit the bot-level model_switched event (best-effort)."""
+        trigger = getattr(self, "_trigger_event", None)
+        if callable(trigger):
+            trigger(
+                self.EVENT_MODEL_SWITCHED,
+                error=str(error),
+                error_type=type(error).__name__,
+                served_by=self._response_info(response),
+            )
+
+    # ── Lifecycle ────────────────────────────────────────────────────────
+
+    async def cleanup(self) -> None:
+        """Close the secondary client, then continue the cleanup chain."""
+        if self._secondary_client is not None:
+            close = getattr(self._secondary_client, "close", None)
+            if callable(close):
+                try:
+                    result = close()
+                    if asyncio.iscoroutine(result):
+                        await result
+                except Exception as exc:
+                    self.logger.error(
+                        "Error closing secondary LLM client: %s", exc
+                    )
+            self._secondary_client = None
+        await super().cleanup()

--- a/packages/ai-parrot/tests/bots/test_model_switching_mixin.py
+++ b/packages/ai-parrot/tests/bots/test_model_switching_mixin.py
@@ -1,0 +1,408 @@
+"""Unit tests for ModelSwitchingMixin.
+
+Mirrors the pattern used by test_identity_mixin.py: extract the REAL, unbound
+``AbstractBot.get_client`` / ``AbstractBot.execute_llm_call`` hooks and mix
+them into a minimal fake base class, so ModelSwitchingMixin is exercised
+against the actual framework logic it chains into (via ``super()``) rather
+than a hand-rolled stand-in. Fake LLM clients — no network.
+"""
+import asyncio
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from parrot.bots.mixins import ModelSwitchingMixin, ModelSwitchMode
+from parrot.models.basic import CompletionUsage
+from parrot.models.responses import AIMessage
+
+_RealAbstractBot = sys.modules["parrot.bots.abstract"].AbstractBot
+_get_client = _RealAbstractBot.get_client
+_execute_llm_call = _RealAbstractBot.execute_llm_call
+
+
+def make_message(text: str, provider: str, model: str, **kwargs) -> AIMessage:
+    """Build a minimal real AIMessage."""
+    return AIMessage(
+        input="question",
+        output=text,
+        response=text,
+        model=model,
+        provider=provider,
+        usage=CompletionUsage(
+            prompt_tokens=kwargs.pop("prompt_tokens", 10),
+            completion_tokens=kwargs.pop("completion_tokens", 5),
+            total_tokens=kwargs.pop("total_tokens", 15),
+        ),
+        **kwargs,
+    )
+
+
+class FakeClient:
+    """AbstractClient-shaped stub: async context manager + ask()."""
+
+    def __init__(self, name: str, model: str, *, answer=None, error=None):
+        self.client_name = name
+        self.model = model
+        self.answer = answer
+        self.error = error
+        self.ask_calls = []
+        self.entered = 0
+        self.exited = 0
+        self.closed = False
+
+    async def __aenter__(self):
+        self.entered += 1
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self.exited += 1
+        return False
+
+    async def ask(self, **kwargs):
+        self.ask_calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+        return self.answer
+
+    async def close(self):
+        self.closed = True
+
+
+class FakeBase:
+    """Minimal stand-in exposing the AbstractBot seams the mixin needs."""
+
+    # Real framework hooks — the mixin's super() chain lands here.
+    get_client = _get_client
+    execute_llm_call = _execute_llm_call
+
+    def __init__(self, **kwargs):
+        self.name = kwargs.pop("name", "TestBot")
+        self._llm = kwargs.pop("primary_client", None)
+        self.logger = MagicMock()
+        self.events_triggered = []
+        self.post_configure_chained = False
+        self.configure_llm_calls = []
+        self._configure_llm_result = kwargs.pop("configure_llm_result", None)
+
+    async def post_configure(self):
+        self.post_configure_chained = True
+
+    def configure_llm(self, **kwargs):
+        self.configure_llm_calls.append(kwargs)
+        if self._configure_llm_result is None:
+            raise ValueError("no secondary available")
+        return self._configure_llm_result
+
+    def _trigger_event(self, event_name, **kwargs):
+        self.events_triggered.append((event_name, kwargs))
+
+    async def cleanup(self):
+        self.base_cleanup_ran = True
+
+
+class SwitchingBot(ModelSwitchingMixin, FakeBase):
+    """Bot under test."""
+
+
+def make_bot(mode, primary, secondary, **kwargs):
+    bot = SwitchingBot(
+        primary_client=primary,
+        model_switch_mode=mode,
+        secondary_llm="stub:secondary" if secondary is not None else None,
+        **kwargs,
+    )
+    bot._secondary_client = secondary
+    return bot
+
+
+PRIMARY_OK = lambda: make_message("primary answer", "google", "gemini-x")  # noqa: E731
+SECONDARY_OK = lambda: make_message("secondary answer", "anthropic", "claude-y")  # noqa: E731
+
+
+# ── 1. Default hooks (no mixin) ─────────────────────────────────────────────
+
+class TestDefaultHooks:
+    def test_get_client_returns_primary(self):
+        primary = FakeClient("google", "gemini-x")
+        base = FakeBase(primary_client=primary)
+        assert base.get_client() is primary
+
+    @pytest.mark.asyncio
+    async def test_execute_llm_call_delegates_to_client(self):
+        msg = PRIMARY_OK()
+        primary = FakeClient("google", "gemini-x", answer=msg)
+        base = FakeBase(primary_client=primary)
+        result = await base.execute_llm_call(primary, "ask", prompt="hi")
+        assert result is msg
+        assert primary.ask_calls == [{"prompt": "hi"}]
+        # No annotation is added by the default hook
+        assert "model_switching" not in result.metadata
+
+
+# ── 2–5. Fallback mode ──────────────────────────────────────────────────────
+
+class TestFallbackMode:
+    @pytest.mark.asyncio
+    async def test_primary_success_no_switch(self):
+        primary = FakeClient("google", "gemini-x", answer=PRIMARY_OK())
+        secondary = FakeClient("anthropic", "claude-y", answer=SECONDARY_OK())
+        bot = make_bot(ModelSwitchMode.FALLBACK, primary, secondary)
+
+        result = await bot.execute_llm_call(primary, "ask", prompt="hi")
+
+        assert result.output == "primary answer"
+        ms = result.metadata["model_switching"]
+        assert ms["mode"] == "fallback"
+        assert ms["switched"] is False
+        assert ms["served_by"] == {"provider": "google", "model": "gemini-x"}
+        assert secondary.ask_calls == []
+
+    @pytest.mark.asyncio
+    async def test_primary_error_switches_to_secondary(self):
+        primary = FakeClient(
+            "google", "gemini-x", error=RuntimeError("provider down")
+        )
+        secondary = FakeClient("anthropic", "claude-y", answer=SECONDARY_OK())
+        bot = make_bot(ModelSwitchMode.FALLBACK, primary, secondary)
+
+        result = await bot.execute_llm_call(primary, "ask", prompt="hi")
+
+        assert result.output == "secondary answer"
+        ms = result.metadata["model_switching"]
+        assert ms["switched"] is True
+        assert ms["primary"]["provider"] == "google"
+        assert ms["primary"]["error_type"] == "RuntimeError"
+        assert "provider down" in ms["primary"]["error"]
+        assert ms["served_by"] == {"provider": "anthropic", "model": "claude-y"}
+        # Secondary context was entered and exited by the mixin
+        assert secondary.entered == 1
+        assert secondary.exited == 1
+        # Same kwargs forwarded
+        assert secondary.ask_calls == [{"prompt": "hi"}]
+        # Event emitted
+        assert bot.events_triggered
+        event_name, payload = bot.events_triggered[0]
+        assert event_name == ModelSwitchingMixin.EVENT_MODEL_SWITCHED
+        assert payload["error_type"] == "RuntimeError"
+
+    @pytest.mark.asyncio
+    async def test_both_fail_raises_primary_error(self):
+        primary_err = RuntimeError("primary down")
+        primary = FakeClient("google", "gemini-x", error=primary_err)
+        secondary = FakeClient(
+            "anthropic", "claude-y", error=ValueError("secondary down")
+        )
+        bot = make_bot(ModelSwitchMode.FALLBACK, primary, secondary)
+
+        with pytest.raises(RuntimeError, match="primary down") as excinfo:
+            await bot.execute_llm_call(primary, "ask", prompt="hi")
+        assert isinstance(excinfo.value.__cause__, ValueError)
+
+    @pytest.mark.asyncio
+    async def test_should_switch_on_veto(self):
+        class PickyBot(SwitchingBot):
+            def should_switch_on(self, error):
+                return False
+
+        primary = FakeClient("google", "gemini-x", error=RuntimeError("boom"))
+        secondary = FakeClient("anthropic", "claude-y", answer=SECONDARY_OK())
+        bot = PickyBot(
+            primary_client=primary,
+            model_switch_mode=ModelSwitchMode.FALLBACK,
+            secondary_llm="stub:secondary",
+        )
+        bot._secondary_client = secondary
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await bot.execute_llm_call(primary, "ask", prompt="hi")
+        assert secondary.ask_calls == []
+
+    @pytest.mark.asyncio
+    async def test_cancellation_never_switches(self):
+        primary = FakeClient(
+            "google", "gemini-x", error=asyncio.CancelledError()
+        )
+        secondary = FakeClient("anthropic", "claude-y", answer=SECONDARY_OK())
+        bot = make_bot(ModelSwitchMode.FALLBACK, primary, secondary)
+
+        with pytest.raises(asyncio.CancelledError):
+            await bot.execute_llm_call(primary, "ask", prompt="hi")
+        assert secondary.ask_calls == []
+
+
+# ── 6–7. Contrastive mode ───────────────────────────────────────────────────
+
+class TestContrastiveMode:
+    @pytest.mark.asyncio
+    async def test_both_succeed_combined_output(self):
+        primary = FakeClient("google", "gemini-x", answer=PRIMARY_OK())
+        secondary = FakeClient("anthropic", "claude-y", answer=SECONDARY_OK())
+        bot = make_bot(ModelSwitchMode.CONTRASTIVE, primary, secondary)
+
+        result = await bot.execute_llm_call(primary, "ask", prompt="hi")
+
+        # Combined labeled markdown
+        assert "### google:gemini-x (primary)" in result.output
+        assert "primary answer" in result.output
+        assert "### anthropic:claude-y (secondary)" in result.output
+        assert "secondary answer" in result.output
+        # Attribution metadata
+        ms = result.metadata["model_switching"]
+        assert ms["mode"] == "contrastive"
+        roles = {e["role"]: e for e in ms["responses"]}
+        assert roles["primary"]["provider"] == "google"
+        assert roles["primary"]["output"] == "primary answer"
+        assert roles["secondary"]["provider"] == "anthropic"
+        assert roles["secondary"]["output"] == "secondary answer"
+        assert roles["primary"]["usage"]["prompt_tokens"] == 10
+        # Both clients were actually called with the same kwargs
+        assert primary.ask_calls == [{"prompt": "hi"}]
+        assert secondary.ask_calls == [{"prompt": "hi"}]
+        # Aggregated usage on the carrier message
+        assert result.usage.prompt_tokens == 20
+        assert result.usage.completion_tokens == 10
+        assert result.usage.total_tokens == 30
+
+    @pytest.mark.asyncio
+    async def test_one_side_fails_returns_survivor(self):
+        primary = FakeClient("google", "gemini-x", error=RuntimeError("down"))
+        secondary = FakeClient("anthropic", "claude-y", answer=SECONDARY_OK())
+        bot = make_bot(ModelSwitchMode.CONTRASTIVE, primary, secondary)
+
+        result = await bot.execute_llm_call(primary, "ask", prompt="hi")
+
+        assert result.output == "secondary answer"
+        ms = result.metadata["model_switching"]
+        roles = {e["role"]: e for e in ms["responses"]}
+        assert roles["primary"]["error_type"] == "RuntimeError"
+        assert roles["secondary"]["output"] == "secondary answer"
+
+    @pytest.mark.asyncio
+    async def test_both_fail_raises_primary_error(self):
+        primary = FakeClient("google", "gemini-x", error=RuntimeError("p-down"))
+        secondary = FakeClient("anthropic", "claude-y", error=ValueError("s-down"))
+        bot = make_bot(ModelSwitchMode.CONTRASTIVE, primary, secondary)
+
+        with pytest.raises(RuntimeError, match="p-down"):
+            await bot.execute_llm_call(primary, "ask", prompt="hi")
+
+    @pytest.mark.asyncio
+    async def test_structured_output_keeps_primary_output(self):
+        primary = FakeClient("google", "gemini-x", answer=PRIMARY_OK())
+        secondary = FakeClient("anthropic", "claude-y", answer=SECONDARY_OK())
+        bot = make_bot(ModelSwitchMode.CONTRASTIVE, primary, secondary)
+
+        result = await bot.execute_llm_call(
+            primary, "ask", prompt="hi", structured_output=object()
+        )
+
+        # Output NOT rewritten for structured calls; attribution still present
+        assert result.output == "primary answer"
+        assert result.metadata["model_switching"]["mode"] == "contrastive"
+
+
+# ── 8. Passthrough ──────────────────────────────────────────────────────────
+
+class TestPassthrough:
+    @pytest.mark.asyncio
+    async def test_disabled_is_pure_passthrough(self):
+        primary = FakeClient("google", "gemini-x", answer=PRIMARY_OK())
+        secondary = FakeClient("anthropic", "claude-y", answer=SECONDARY_OK())
+        bot = make_bot(
+            ModelSwitchMode.FALLBACK, primary, secondary,
+            enable_model_switching=False,
+        )
+
+        result = await bot.execute_llm_call(primary, "ask", prompt="hi")
+        assert result.output == "primary answer"
+        assert "model_switching" not in result.metadata
+        assert secondary.ask_calls == []
+
+    @pytest.mark.asyncio
+    async def test_no_secondary_is_pure_passthrough(self):
+        primary = FakeClient("google", "gemini-x", answer=PRIMARY_OK())
+        bot = make_bot(ModelSwitchMode.FALLBACK, primary, None)
+
+        result = await bot.execute_llm_call(primary, "ask", prompt="hi")
+        assert result.output == "primary answer"
+        assert "model_switching" not in result.metadata
+
+    @pytest.mark.asyncio
+    async def test_non_ask_method_is_passthrough(self):
+        primary = FakeClient("google", "gemini-x", answer=PRIMARY_OK())
+        secondary = FakeClient("anthropic", "claude-y", error=RuntimeError("x"))
+        bot = make_bot(ModelSwitchMode.FALLBACK, primary, secondary)
+
+        async def other(**kwargs):
+            return "other-result"
+
+        primary.other = other
+        result = await bot.execute_llm_call(primary, "other", prompt="hi")
+        assert result == "other-result"
+        assert secondary.ask_calls == []
+
+    def test_get_client_still_returns_primary(self):
+        primary = FakeClient("google", "gemini-x")
+        secondary = FakeClient("anthropic", "claude-y")
+        bot = make_bot(ModelSwitchMode.FALLBACK, primary, secondary)
+        assert bot.get_client() is primary
+
+
+# ── 9. post_configure wiring + lifecycle ────────────────────────────────────
+
+class TestConfiguration:
+    @pytest.mark.asyncio
+    async def test_post_configure_builds_secondary_and_chains_super(self):
+        secondary = FakeClient("anthropic", "claude-y")
+        bot = SwitchingBot(
+            secondary_llm="anthropic:claude-y",
+            configure_llm_result=secondary,
+        )
+        await bot.post_configure()
+
+        assert bot.post_configure_chained is True
+        assert bot._secondary_client is secondary
+        assert bot.configure_llm_calls == [{"llm": "anthropic:claude-y"}]
+
+    @pytest.mark.asyncio
+    async def test_post_configure_dict_spec_uses_model_config(self):
+        secondary = FakeClient("anthropic", "claude-y")
+        spec = {"name": "anthropic", "model": "claude-y"}
+        bot = SwitchingBot(
+            secondary_llm=spec,
+            configure_llm_result=secondary,
+        )
+        await bot.post_configure()
+        assert bot.configure_llm_calls == [{"model_config": spec}]
+
+    @pytest.mark.asyncio
+    async def test_post_configure_resolution_failure_raises_config_error(self):
+        from parrot.exceptions import ConfigError
+
+        bot = SwitchingBot(secondary_llm="nope:nope")  # configure_llm raises
+        with pytest.raises(ConfigError):
+            await bot.post_configure()
+
+    @pytest.mark.asyncio
+    async def test_post_configure_noop_without_secondary(self):
+        bot = SwitchingBot()
+        await bot.post_configure()
+        assert bot.post_configure_chained is True
+        assert bot._secondary_client is None
+        assert bot.configure_llm_calls == []
+
+    def test_string_mode_kwarg_is_normalized(self):
+        bot = SwitchingBot(model_switch_mode="contrastive")
+        assert bot.model_switch_mode is ModelSwitchMode.CONTRASTIVE
+
+    @pytest.mark.asyncio
+    async def test_cleanup_closes_secondary_and_chains(self):
+        primary = FakeClient("google", "gemini-x")
+        secondary = FakeClient("anthropic", "claude-y")
+        bot = make_bot(ModelSwitchMode.FALLBACK, primary, secondary)
+
+        await bot.cleanup()
+        assert secondary.closed is True
+        assert bot._secondary_client is None
+        assert bot.base_cleanup_ran is True


### PR DESCRIPTION
## Summary

Introduces `ModelSwitchingMixin`, a cooperative mixin that adds dual-LLM model switching capabilities to any bot or agent. Supports two modes:
- **Fallback**: primary client serves all calls; on error, the same call is retried once on a secondary client (cross-provider failover)
- **Contrastive**: both clients answer concurrently; results are merged into a single message with per-model attribution in metadata

## Key Changes

- **New mixin class** (`parrot/bots/mixins/model_switching.py`):
  - `ModelSwitchingMixin` with configurable `secondary_llm`, `model_switch_mode`, and `enable_model_switching` attributes
  - `ModelSwitchMode` enum for `FALLBACK` and `CONTRASTIVE` modes
  - Hooks into `execute_llm_call()` extension point to intercept and modify LLM call behavior
  - Fallback mode: retries failed primary calls on secondary; emits `model_switched` event on switch
  - Contrastive mode: concurrent calls with merged labeled markdown output and aggregated token usage
  - Policy hook `should_switch_on(error)` for fine-grained control over fallback triggers
  - Lifecycle integration: `post_configure()` builds secondary client; `cleanup()` closes it

- **Framework extension points** (`parrot/bots/abstract.py`):
  - Added `get_client()` method: returns the LLM client to use (default: primary; overridable by mixins)
  - Added `execute_llm_call(client, method, **llm_kwargs)` method: executes a single LLM call through an overridable hook (default: delegates to client; mixins can wrap for fallback/contrastive behavior)

- **Integration** (`parrot/bots/base.py`):
  - Updated `_conversation_body()` to call `self.get_client()` instead of directly accessing `self._llm`
  - Updated LLM call to use `self.execute_llm_call()` instead of direct `await client.ask()`

- **Public API** (`parrot/bots/mixins/__init__.py`):
  - Exported `ModelSwitchingMixin` and `ModelSwitchMode`

- **Comprehensive test suite** (`tests/bots/test_model_switching_mixin.py`):
  - 408 lines of unit tests covering fallback mode (primary success, error switching, both fail, policy veto, cancellation handling)
  - Contrastive mode tests (both succeed with combined output, one side fails, both fail, structured output handling)
  - Passthrough tests (disabled, no secondary, non-ask methods)
  - Configuration and lifecycle tests (post_configure wiring, cleanup, mode normalization)
  - Uses real `AbstractBot` hooks mixed into minimal fake base to test actual framework integration

## Implementation Details

- **Cooperative MRO pattern**: Mixin chains `super()` calls to integrate with existing bot initialization and lifecycle
- **Metadata attribution**: Both modes attach `metadata['model_switching']` payload with mode, responses array, and per-model details (provider, model, output, usage, response_time, errors)
- **Concurrency**: Contrastive mode uses `asyncio.gather()` with `return_exceptions=True` to handle partial failures gracefully
- **Token aggregation**: Contrastive mode sums `CompletionUsage` from both calls into the carrier message
- **Structured output handling**: Contrastive mode preserves primary output for structured calls (no merging)
- **Streaming limitation**: v1 only switches non-streaming `ask` calls; `ask_stream` always uses primary
- **Error handling**: Fallback mode re-raises primary error if secondary also fails; contrastive mode raises primary if both fail
- **Cancellation safety**: `asyncio.CancelledError` never triggers fallback and is always re-raised immediately

https://claude.ai/code/session_0144it6zabP64v7YAJYieamH