### PR TITLE
feat(graphindex): durable agent graph memory — provenance schema + GraphPublisher + toolkit write-through

### DIFF
--- a/packages/ai-parrot-tools/src/parrot_tools/graphindex/toolkit.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/graphindex/toolkit.py
@@ -1165,6 +1165,104 @@ class GraphIndexToolkit(AbstractToolkit):
             )
         return result
 
+    async def extract_knowledge(self, text: str, source_uri: str = "") -> dict:
+        """Extract typed entities/relations from text into the graph.
+
+        Runs a schema-constrained LLM extraction, deduplicates entities
+        against the existing graph (additive alias merges — nothing is
+        destroyed), publishes ONE audited commit, and mirrors the new
+        nodes/edges into the in-memory graph so they are immediately
+        searchable.
+
+        Requires both a ``client`` (LLM) and a ``publisher`` (durable
+        plane) on the toolkit.
+
+        Args:
+            text: Free text to extract knowledge from.
+            source_uri: Citation URI recorded on the extracted items.
+
+        Returns:
+            ``{entities, relations, commit_id, node_ids}`` or
+            ``{"error": ...}``.
+        """
+        if self.client is None:
+            return {"error": "extract_knowledge: no LLM client configured"}
+        if self.publisher is None:
+            return {"error": "extract_knowledge: no durable graph plane configured"}
+        try:
+            from parrot.knowledge.graphindex.extractors.llm import (
+                LLMGraphExtractor,
+            )
+
+            extractor = LLMGraphExtractor(self.client, self.publisher)
+            result = await extractor.extract_and_publish(
+                text,
+                source_uri=source_uri,
+                agent_id=self.agent_id,
+                run_id=self.run_id,
+            )
+        except Exception as exc:  # noqa: BLE001 — never raise into the LLM
+            return {"error": f"extract_knowledge: {exc}"}
+
+        # Mirror committed nodes/edges into the in-memory graph (only
+        # possible when the write dependencies are wired).
+        if not self._write_supported:
+            return {
+                "entities": len(result.extracted.entities),
+                "relations": len(result.extracted.relations),
+                "nodes_written": len(result.update.nodes),
+                "edges_written": len(result.update.edges),
+                "node_ids": [n.node_id for n in result.update.nodes],
+                "commit_id": result.receipt.commit_id,
+                "persisted": True,
+                "note": "in-memory graph not updated (no assembler/embedder)",
+            }
+        for node in result.update.nodes:
+            if node.node_id in self.node_map:
+                # Alias merge on an existing node — refresh the payload.
+                try:
+                    self.assembler.add_node(node)
+                except Exception:  # noqa: BLE001
+                    pass
+                continue
+            try:
+                rust_idx = self.assembler.add_node(node)
+            except Exception as exc:  # noqa: BLE001
+                self.logger.warning(
+                    "extract_knowledge: in-memory add failed for %s: %s",
+                    node.node_id,
+                    exc,
+                )
+                continue
+            self.node_map[node.node_id] = rust_idx
+            try:
+                await self.embedder.embed_nodes([node])
+            except Exception as exc:  # noqa: BLE001
+                self.logger.warning(
+                    "extract_knowledge: embed failed for %s: %s",
+                    node.node_id,
+                    exc,
+                )
+            if node.node_id not in self.node_id_list:
+                self.node_id_list.append(node.node_id)
+            self.nodes.append(node)
+        for edge in result.update.edges:
+            try:
+                self.assembler.add_edge(edge)
+            except Exception:  # noqa: BLE001
+                pass
+        self._invalidate_community_cache()
+
+        return {
+            "entities": len(result.extracted.entities),
+            "relations": len(result.extracted.relations),
+            "nodes_written": len(result.update.nodes),
+            "edges_written": len(result.update.edges),
+            "node_ids": [n.node_id for n in result.update.nodes],
+            "commit_id": result.receipt.commit_id,
+            "persisted": True,
+        }
+
     # ==================================================================
     # READ tools — signal + community surface (FEAT-190 / FEAT-191)
     # ==================================================================

--- a/packages/ai-parrot-tools/src/parrot_tools/graphindex/toolkit.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/graphindex/toolkit.py
@@ -31,6 +31,15 @@ Tool surface:
   # WRITE
   create_concept, create_node, link_nodes, unlink_nodes,
   attach_summary, tag_node, merge_nodes
+
+  # DURABLE MEMORY (requires publisher=GraphPublisher)
+  graph_history, revert_write
+
+When a ``GraphPublisher`` is injected, every write tool ALSO persists
+its mutation as an audited, revertible commit stamped with the agent's
+identity and run — the graph becomes durable cross-session memory
+("the agent forgets, the graph does not"). Persistence failures never
+fail the tool call; they surface as ``persist_warning`` in the result.
 """
 
 from __future__ import annotations
@@ -90,7 +99,19 @@ class GraphIndexToolkit(AbstractToolkit):
             authoritative).
         signal_config: Optional :class:`SignalRelevanceConfig` (FEAT-190).
             Defaults to the library's default config when not supplied.
+        publisher: Optional ``GraphPublisher`` — when supplied, every
+            write tool ALSO persists its mutation durably as an audited
+            commit (write-through). Without it, writes stay in-memory
+            only (legacy behavior). Persistence failures never fail the
+            tool call; they surface as a ``persist_warning`` key.
+        agent_id: Stable identifier stamped onto persisted writes.
+        run_id: Optional run/session identifier linking persisted writes
+            to the execution that produced them. Mutable — set per ask.
     """
+
+    # Reverting another agent's (or one's own) committed write is the one
+    # destructive operation that warrants human confirmation (FEAT-235).
+    confirming_tools: frozenset = frozenset({"revert_write"})
 
     def __init__(
         self,
@@ -103,6 +124,9 @@ class GraphIndexToolkit(AbstractToolkit):
         embedder: Optional["GraphIndexEmbedder"] = None,
         nodes: Optional[list["UniversalNode"]] = None,
         signal_config: Optional["SignalRelevanceConfig"] = None,
+        publisher: Optional[Any] = None,
+        agent_id: str = "agent",
+        run_id: Optional[str] = None,
     ) -> None:
         super().__init__()
         self.graph = graph
@@ -114,6 +138,9 @@ class GraphIndexToolkit(AbstractToolkit):
         self.embedder = embedder
         self.nodes = nodes if nodes is not None else []
         self.signal_config = signal_config
+        self.publisher = publisher
+        self.agent_id = agent_id
+        self.run_id = run_id
         self._community_cache: Optional[Any] = None
         self._analytics_cache: Optional[Any] = None  # FEAT-215
         self._encoder_warning_emitted = False
@@ -146,6 +173,78 @@ class GraphIndexToolkit(AbstractToolkit):
             if n.node_id == node_id:
                 return n
         return None
+
+    def _model_from_graph(self, node_id: str) -> Optional["UniversalNode"]:
+        """Best-effort ``UniversalNode`` for persistence.
+
+        Prefers the authoritative model in ``self.nodes``; falls back to
+        rebuilding one from the rustworkx payload dict.
+        """
+        node = self._node_by_id(node_id)
+        if node is not None:
+            return node
+        idx = self.node_map.get(node_id)
+        if idx is None:
+            return None
+        payload = self.graph[idx]
+        if not isinstance(payload, dict):
+            return None
+        from parrot.knowledge.graphindex.schema import UniversalNode
+        try:
+            return UniversalNode(
+                node_id=payload["node_id"],
+                kind=payload["kind"],
+                title=payload.get("title", payload["node_id"]),
+                source_uri=payload.get("source_uri") or f"agent://{payload['kind']}/{payload['node_id']}",
+                content_ref=payload.get("content_ref"),
+                summary=payload.get("summary"),
+                embedding_ref=payload.get("embedding_ref"),
+                domain_tags=payload.get("domain_tags") or {},
+                parent_id=payload.get("parent_id"),
+                provenance=payload.get("provenance", "extracted"),
+            )
+        except Exception:  # noqa: BLE001 — persistence is best-effort
+            return None
+
+    async def _persist_write(
+        self,
+        op: str,
+        nodes: Optional[list["UniversalNode"]] = None,
+        edges: Optional[list] = None,
+        removed_edges: Optional[list[tuple[str, str, str]]] = None,
+        removed_nodes: Optional[list[str]] = None,
+        reason: Optional[str] = None,
+        source: Optional[str] = None,
+    ) -> dict:
+        """Write-through a mutation to the durable graph plane.
+
+        Returns a dict to merge into the tool result:
+        ``{}`` when no publisher is configured (legacy in-memory mode),
+        ``{"persisted": True, "commit_id": ...}`` on success, or
+        ``{"persisted": False, "persist_warning": ...}`` on failure —
+        the in-memory mutation is kept either way (never-raise contract).
+        """
+        if self.publisher is None:
+            return {}
+        from parrot.knowledge.graphindex.schema import GraphUpdate
+        try:
+            update = GraphUpdate(
+                nodes=list(nodes or []),
+                edges=list(edges or []),
+                removed_edges=list(removed_edges or []),
+                removed_nodes=list(removed_nodes or []),
+                agent_id=self.agent_id,
+                run_id=self.run_id,
+                asserted_by=f"agent:{self.agent_id}",
+                source=source,
+                reason=reason,
+                op=op,
+            )
+            receipt = await self.publisher.publish(update)
+            return {"persisted": True, "commit_id": receipt.commit_id}
+        except Exception as exc:  # noqa: BLE001 — degrade, don't fail the tool
+            self.logger.warning("%s: durable persist failed: %s", op, exc)
+            return {"persisted": False, "persist_warning": str(exc)}
 
 
     # ------------------------------------------------------------------
@@ -640,12 +739,14 @@ class GraphIndexToolkit(AbstractToolkit):
 
         self.nodes.append(node)
         self._invalidate_community_cache()
-        return {
+        result = {
             "node_id": node_id,
             "kind": kind_enum.value,
             "title": node.title,
             "status": "created",
         }
+        result.update(await self._persist_write("create_node", nodes=[node]))
+        return result
 
     async def link_nodes(
         self,
@@ -694,12 +795,14 @@ class GraphIndexToolkit(AbstractToolkit):
             return {"error": f"link_nodes: assembler rejected: {exc}"}
 
         self._invalidate_community_cache()
-        return {
+        result = {
             "source_id": source_id,
             "target_id": target_id,
             "kind": kind_enum.value,
             "status": "linked",
         }
+        result.update(await self._persist_write("link_nodes", edges=[edge]))
+        return result
 
     async def unlink_nodes(
         self,
@@ -720,6 +823,7 @@ class GraphIndexToolkit(AbstractToolkit):
             return {"error": "unlink_nodes: unknown source_id or target_id"}
 
         removed = 0
+        removed_triples: list[tuple[str, str, str]] = []
         for s, t in ((src_idx, tgt_idx), (tgt_idx, src_idx)):
             for _eidx, payload in list(self._edges_between(s, t)):
                 if kind is not None and payload.get("kind") != kind:
@@ -727,6 +831,11 @@ class GraphIndexToolkit(AbstractToolkit):
                 try:
                     self.graph.remove_edge(s, t)
                     removed += 1
+                    removed_triples.append((
+                        payload.get("source_id"),
+                        payload.get("target_id"),
+                        payload.get("kind"),
+                    ))
                 except Exception:
                     pass
                 # Also clean the assembler's edge_index_map entry.
@@ -747,12 +856,16 @@ class GraphIndexToolkit(AbstractToolkit):
             }
 
         self._invalidate_community_cache()
-        return {
+        result = {
             "source_id": source_id,
             "target_id": target_id,
             "removed": removed,
             "status": "unlinked",
         }
+        result.update(
+            await self._persist_write("unlink_nodes", removed_edges=removed_triples)
+        )
+        return result
 
     def _edges_between(self, src_idx: int, tgt_idx: int):
         """Yield (edge_index, payload) for every edge from src to tgt."""
@@ -791,7 +904,13 @@ class GraphIndexToolkit(AbstractToolkit):
                 )
 
         self._invalidate_community_cache()
-        return {"node_id": node_id, "summary": summary, "status": "updated"}
+        result = {"node_id": node_id, "summary": summary, "status": "updated"}
+        model = self._model_from_graph(node_id)
+        if model is not None:
+            result.update(
+                await self._persist_write("attach_summary", nodes=[model])
+            )
+        return result
 
     async def tag_node(self, node_id: str, key: str, value: Any) -> dict:
         """Shallow-merge a single key/value into the node's ``domain_tags``."""
@@ -814,7 +933,11 @@ class GraphIndexToolkit(AbstractToolkit):
             node.domain_tags[key] = value
 
         self._invalidate_community_cache()
-        return {"node_id": node_id, "key": key, "value": value, "status": "tagged"}
+        result = {"node_id": node_id, "key": key, "value": value, "status": "tagged"}
+        model = self._model_from_graph(node_id)
+        if model is not None:
+            result.update(await self._persist_write("tag_node", nodes=[model]))
+        return result
 
     async def merge_nodes(
         self,
@@ -841,6 +964,18 @@ class GraphIndexToolkit(AbstractToolkit):
         dup_idx = self.node_map[duplicate_id]
         canonical_idx = self.node_map[canonical_id]
 
+        # Capture the duplicate's identity before any mutation so the
+        # merge stays additive and inspectable (alias retention).
+        dup_payload = self.graph[dup_idx]
+        dup_title = (
+            dup_payload.get("title") if isinstance(dup_payload, dict) else None
+        )
+        dup_aliases: list[str] = []
+        if isinstance(dup_payload, dict):
+            tags = dup_payload.get("domain_tags") or {}
+            if isinstance(tags, dict):
+                dup_aliases = [str(a) for a in tags.get("aliases", [])]
+
         # Collect every (other_id, payload, direction) before we mutate.
         out_edges: list[dict] = list(
             payload for _s, _t, payload in self.graph.out_edges(dup_idx)
@@ -851,6 +986,7 @@ class GraphIndexToolkit(AbstractToolkit):
 
         existing_keys = self._existing_edge_keys(canonical_idx)
         redirected = 0
+        redirected_edges: list = []
 
         from parrot.knowledge.graphindex.schema import (
             EdgeKind, Provenance, UniversalEdge,
@@ -875,6 +1011,7 @@ class GraphIndexToolkit(AbstractToolkit):
                 self.assembler.add_edge(edge)
                 existing_keys.add(key)
                 redirected += 1
+                redirected_edges.append(edge)
             except Exception as exc:  # noqa: BLE001
                 self.logger.warning("merge_nodes: out-edge redirect failed: %s", exc)
 
@@ -897,6 +1034,7 @@ class GraphIndexToolkit(AbstractToolkit):
                 self.assembler.add_edge(edge)
                 existing_keys.add(key)
                 redirected += 1
+                redirected_edges.append(edge)
             except Exception as exc:  # noqa: BLE001
                 self.logger.warning("merge_nodes: in-edge redirect failed: %s", exc)
 
@@ -915,13 +1053,47 @@ class GraphIndexToolkit(AbstractToolkit):
             pass
         self.nodes = [n for n in self.nodes if n.node_id != duplicate_id]
 
+        # Additive alias retention: the canonical node keeps the merged
+        # duplicate's title (and its aliases) in domain_tags['aliases'],
+        # so the merge is inspectable and no surface form is lost.
+        new_aliases = [a for a in ([dup_title] if dup_title else []) + dup_aliases]
+        canonical_payload = self.graph[canonical_idx]
+        if new_aliases and isinstance(canonical_payload, dict):
+            tags = canonical_payload.setdefault("domain_tags", {})
+            if isinstance(tags, dict):
+                merged = list(tags.get("aliases", [])) + new_aliases
+                tags["aliases"] = sorted({str(a) for a in merged})
+        canonical_model = self._node_by_id(canonical_id)
+        if new_aliases and canonical_model is not None:
+            merged = list(canonical_model.domain_tags.get("aliases", [])) + new_aliases
+            canonical_model.domain_tags["aliases"] = sorted({str(a) for a in merged})
+
         self._invalidate_community_cache()
-        return {
+        result = {
             "canonical_id": canonical_id,
             "duplicate_id": duplicate_id,
             "redirected_edges": redirected,
+            "aliases_added": new_aliases,
             "status": "merged",
         }
+        persist_nodes = []
+        model = self._model_from_graph(canonical_id)
+        if model is not None:
+            persist_nodes.append(model)
+        result.update(
+            await self._persist_write(
+                "merge_nodes",
+                nodes=persist_nodes,
+                edges=redirected_edges,
+                removed_nodes=[duplicate_id],
+                reason=(
+                    f"merged {duplicate_id!r}"
+                    + (f" ({dup_title})" if dup_title else "")
+                    + f" into {canonical_id!r}"
+                ),
+            )
+        )
+        return result
 
     def _existing_edge_keys(self, node_idx: int) -> set[tuple]:
         """Return the set of ``(source_id, target_id, kind)`` triples
@@ -940,6 +1112,58 @@ class GraphIndexToolkit(AbstractToolkit):
         import hashlib
         raw = f"{kind}::{title}::{summary}".encode("utf-8")
         return hashlib.sha1(raw).hexdigest()[:16]
+
+    async def graph_history(
+        self,
+        run_id: Optional[str] = None,
+        limit: int = 20,
+    ) -> list[dict]:
+        """List durable graph write commits, newest first.
+
+        Every persisted write (create_node, link_nodes, merge_nodes, ...)
+        is recorded as an audited commit carrying the agent, run, and
+        rationale that produced it.
+
+        Args:
+            run_id: Only show commits from this run/session.
+            limit: Maximum commits returned.
+
+        Returns:
+            Commit summaries, or a single-element list with an ``error``
+            key when no durable plane is configured.
+        """
+        if self.publisher is None:
+            return [{"error": "graph_history: no durable graph plane configured"}]
+        try:
+            return await self.publisher.list_commits(run_id=run_id, limit=limit)
+        except Exception as exc:  # noqa: BLE001
+            return [{"error": f"graph_history: {exc}"}]
+
+    async def revert_write(self, commit_id: str) -> dict:
+        """Revert a durable graph write commit (restore its pre-images).
+
+        The revert is refused when later commits touched the same nodes
+        or edges. NOTE: the revert applies to the durable plane; the
+        in-memory view refreshes on the next toolkit load.
+
+        Args:
+            commit_id: The commit to revert (see ``graph_history``).
+
+        Returns:
+            ``{"status": "reverted", ...}`` or ``{"error": ...}``.
+        """
+        if self.publisher is None:
+            return {"error": "revert_write: no durable graph plane configured"}
+        try:
+            result = await self.publisher.revert_commit(commit_id)
+        except Exception as exc:  # noqa: BLE001
+            return {"error": f"revert_write: {exc}"}
+        if "error" not in result:
+            result["note"] = (
+                "durable plane reverted; reload the toolkit to refresh the"
+                " in-memory graph"
+            )
+        return result
 
     # ==================================================================
     # READ tools — signal + community surface (FEAT-190 / FEAT-191)

--- a/packages/ai-parrot-tools/src/parrot_tools/graphindex/toolkit.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/graphindex/toolkit.py
@@ -1165,6 +1165,41 @@ class GraphIndexToolkit(AbstractToolkit):
             )
         return result
 
+    async def ground_claim(self, claim: str) -> dict:
+        """Check whether the graph evidences a claim (grounding layer).
+
+        Resolves the claim's entities, looks for supporting edge paths,
+        and returns either cited evidence (stable edge ids) or a
+        structured revise instruction listing the missing evidence.
+        Contradicting relations touching the entities are surfaced.
+
+        Args:
+            claim: Natural-language claim to check.
+
+        Returns:
+            A grounding result dict (``decision``: ``grounded`` |
+            ``revise``) or ``{"error": ...}``.
+        """
+        try:
+            from parrot.knowledge.graphindex.grounding import GroundingEvaluator
+            from parrot.knowledge.graphindex.retriever import (
+                GraphExpandedRetriever,
+            )
+
+            if self.embedder is None:
+                return {"error": "ground_claim: no embedder configured"}
+            retriever = GraphExpandedRetriever(
+                graph=self.graph,
+                nodes=self.nodes,
+                embedder=self.embedder,
+                signal_config=self.signal_config,
+            )
+            evaluator = GroundingEvaluator(retriever, client=self.client)
+            result = await evaluator.ground_claim(claim)
+            return result.model_dump()
+        except Exception as exc:  # noqa: BLE001 — never raise into the LLM
+            return {"error": f"ground_claim: {exc}"}
+
     async def extract_knowledge(self, text: str, source_uri: str = "") -> dict:
         """Extract typed entities/relations from text into the graph.
 

--- a/packages/ai-parrot-tools/tests/graphindex/test_toolkit_persistence.py
+++ b/packages/ai-parrot-tools/tests/graphindex/test_toolkit_persistence.py
@@ -1,0 +1,169 @@
+"""Tests for GraphIndexToolkit durable write-through (graph memory).
+
+Covers the publisher-wired toolkit built by
+``parrot.knowledge.graphindex.factory.build_graph_memory_toolkit``:
+  - writes persist across a fresh factory reload (cross-session memory)
+  - graceful degradation when persistence fails (persist_warning)
+  - legacy parity: no publisher → identical result shape, no persistence keys
+  - graph_history / revert_write tool surface
+  - merge_nodes alias retention on the durable plane
+"""
+from __future__ import annotations
+
+import pytest
+
+from parrot.knowledge.graphindex.factory import build_graph_memory_toolkit
+from parrot_tools.graphindex.toolkit import GraphIndexToolkit
+
+
+@pytest.fixture
+def db_dir(tmp_path):
+    return tmp_path / "graph_memory"
+
+
+class _FailingPublisher:
+    """Publisher double whose publish always raises."""
+
+    async def publish(self, update):
+        raise RuntimeError("disk on fire")
+
+
+class TestWriteThrough:
+    async def test_create_concept_returns_commit(self, db_dir):
+        tk = await build_graph_memory_toolkit(db_dir=db_dir, agent_id="ag")
+        result = await tk.create_concept("EventBus", "pubsub hub")
+        assert result["status"] == "created"
+        assert result["persisted"] is True
+        assert result["commit_id"]
+
+    async def test_writes_survive_reload(self, db_dir):
+        tk = await build_graph_memory_toolkit(db_dir=db_dir, agent_id="ag")
+        r1 = await tk.create_concept("EventBus", "publish subscribe hub")
+        r2 = await tk.create_concept("OrderService", "emits order events")
+        await tk.link_nodes(r2["node_id"], r1["node_id"], "references")
+
+        tk2 = await build_graph_memory_toolkit(db_dir=db_dir, agent_id="ag")
+        assert tk2.graph.num_nodes() == 2
+        assert tk2.graph.num_edges() == 1
+        assert {n.node_id for n in tk2.nodes} == {r1["node_id"], r2["node_id"]}
+
+    async def test_unlink_survives_reload(self, db_dir):
+        tk = await build_graph_memory_toolkit(db_dir=db_dir, agent_id="ag")
+        r1 = await tk.create_concept("A", "a")
+        r2 = await tk.create_concept("B", "b")
+        await tk.link_nodes(r1["node_id"], r2["node_id"], "references")
+        result = await tk.unlink_nodes(r1["node_id"], r2["node_id"])
+        assert result["status"] == "unlinked"
+        assert result["persisted"] is True
+
+        tk2 = await build_graph_memory_toolkit(db_dir=db_dir, agent_id="ag")
+        assert tk2.graph.num_edges() == 0
+
+    async def test_attach_summary_and_tag_survive_reload(self, db_dir):
+        tk = await build_graph_memory_toolkit(db_dir=db_dir, agent_id="ag")
+        r = await tk.create_concept("A", "initial")
+        await tk.attach_summary(r["node_id"], "improved summary")
+        await tk.tag_node(r["node_id"], "reviewed", True)
+
+        tk2 = await build_graph_memory_toolkit(db_dir=db_dir, agent_id="ag")
+        node = [n for n in tk2.nodes if n.node_id == r["node_id"]][0]
+        assert node.summary == "improved summary"
+        assert node.domain_tags["reviewed"] is True
+
+    async def test_merge_nodes_alias_retention_durable(self, db_dir):
+        tk = await build_graph_memory_toolkit(db_dir=db_dir, agent_id="ag")
+        canonical = await tk.create_concept("EventBus", "pubsub hub")
+        dup = await tk.create_concept("Event Bus", "the pubsub hub (dup)")
+        other = await tk.create_concept("Consumer", "listens to events")
+        await tk.link_nodes(dup["node_id"], other["node_id"], "references")
+
+        result = await tk.merge_nodes(canonical["node_id"], dup["node_id"])
+        assert result["status"] == "merged"
+        assert "Event Bus" in result["aliases_added"]
+        assert result["persisted"] is True
+
+        tk2 = await build_graph_memory_toolkit(db_dir=db_dir, agent_id="ag")
+        assert {n.node_id for n in tk2.nodes} == {
+            canonical["node_id"], other["node_id"],
+        }
+        node = [n for n in tk2.nodes if n.node_id == canonical["node_id"]][0]
+        assert "Event Bus" in node.domain_tags["aliases"]
+        # Redirected edge survives.
+        assert tk2.graph.num_edges() == 1
+
+    async def test_assertion_metadata_stamped(self, db_dir):
+        tk = await build_graph_memory_toolkit(
+            db_dir=db_dir, agent_id="ag", run_id="run-7"
+        )
+        r = await tk.create_concept("A", "a")
+        tk2 = await build_graph_memory_toolkit(db_dir=db_dir, agent_id="ag")
+        node = [n for n in tk2.nodes if n.node_id == r["node_id"]][0]
+        assert node.assertion.asserted_by == "agent:ag"
+        assert node.assertion.run_id == "run-7"
+
+
+class TestDegradation:
+    async def test_persist_failure_keeps_in_memory_write(self, db_dir):
+        tk = await build_graph_memory_toolkit(db_dir=db_dir, agent_id="ag")
+        tk.publisher = _FailingPublisher()
+        result = await tk.create_concept("A", "a")
+        assert result["status"] == "created"
+        assert result["persisted"] is False
+        assert "disk on fire" in result["persist_warning"]
+        # In-memory state still mutated.
+        assert tk.graph.num_nodes() == 1
+
+    async def test_no_publisher_legacy_parity(self, db_dir):
+        tk = await build_graph_memory_toolkit(db_dir=db_dir, agent_id="ag")
+        tk.publisher = None
+        result = await tk.create_concept("A", "a")
+        assert result["status"] == "created"
+        assert "persisted" not in result
+        assert "commit_id" not in result
+
+
+class TestHistoryAndRevert:
+    async def test_graph_history_lists_commits(self, db_dir):
+        tk = await build_graph_memory_toolkit(
+            db_dir=db_dir, agent_id="ag", run_id="r1"
+        )
+        await tk.create_concept("A", "a")
+        tk.run_id = "r2"
+        await tk.create_concept("B", "b")
+        history = await tk.graph_history()
+        assert len(history) == 2
+        assert {h["run_id"] for h in history} == {"r1", "r2"}
+        filtered = await tk.graph_history(run_id="r2")
+        assert len(filtered) == 1
+
+    async def test_revert_write_restores_durable_plane(self, db_dir):
+        tk = await build_graph_memory_toolkit(db_dir=db_dir, agent_id="ag")
+        result = await tk.create_concept("A", "a")
+        revert = await tk.revert_write(result["commit_id"])
+        assert revert["status"] == "reverted"
+
+        tk2 = await build_graph_memory_toolkit(db_dir=db_dir, agent_id="ag")
+        assert tk2.graph.num_nodes() == 0
+
+    async def test_history_and_revert_without_publisher(self, db_dir):
+        tk = await build_graph_memory_toolkit(db_dir=db_dir, agent_id="ag")
+        tk.publisher = None
+        assert "error" in (await tk.graph_history())[0]
+        assert "error" in await tk.revert_write("whatever")
+
+    async def test_revert_write_is_confirming_tool(self):
+        assert "revert_write" in GraphIndexToolkit.confirming_tools
+
+
+class TestFactory:
+    async def test_blank_dir_starts_empty(self, db_dir):
+        tk = await build_graph_memory_toolkit(db_dir=db_dir)
+        assert tk.graph.num_nodes() == 0
+        assert await tk.graph_history() == []
+
+    async def test_cross_session_search_finds_nodes(self, db_dir):
+        tk = await build_graph_memory_toolkit(db_dir=db_dir, agent_id="ag")
+        await tk.create_concept("EventBus", "publish subscribe hub for events")
+        tk2 = await build_graph_memory_toolkit(db_dir=db_dir, agent_id="ag")
+        found = await tk2.find_node("publish subscribe events")
+        assert found.get("title") == "EventBus"

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/__init__.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/__init__.py
@@ -19,6 +19,10 @@ from parrot.knowledge.graphindex.schema import (
     EdgeKind,
     UniversalNode,
     UniversalEdge,
+    AssertionMeta,
+    GraphUpdate,
+    CommitReceipt,
+    stable_edge_id,
     SourceConfig,
     GraphProjectionReport,
     BuildResult,
@@ -66,6 +70,14 @@ __all__ = [
     "GraphProjectionReport",
     "BuildResult",
     "IngestResult",
+    "AssertionMeta",
+    "GraphUpdate",
+    "CommitReceipt",
+    "stable_edge_id",
+    "GraphPublisher",
+    "build_graph_memory_toolkit",
+    "HashingGraphEmbedder",
+    "make_stub_tenant_context",
     "SignalRelevance",
     "SignalRelevanceConfig",
     "compute_pairwise_signals",
@@ -96,7 +108,17 @@ __all__ = [
 # stack (aiohttp, navigator, embeddings). Import it lazily (PEP 562) so that
 # ``import parrot.knowledge.graphindex`` — and the local-first CLI / pure graph
 # modules — stay lightweight and usable without those heavyweight dependencies.
-_LAZY_ATTRS = {"GraphIndexLoader": "parrot.knowledge.graphindex.loader"}
+_LAZY_ATTRS = {
+    "GraphIndexLoader": "parrot.knowledge.graphindex.loader",
+    # GraphPublisher is lazy so the publish path stays optional for
+    # consumers that only need the read-side schema/persistence symbols.
+    "GraphPublisher": "parrot.knowledge.graphindex.publish",
+    # The factory returns a GraphIndexToolkit from the sibling
+    # ai-parrot-tools distribution (imported lazily inside the call).
+    "build_graph_memory_toolkit": "parrot.knowledge.graphindex.factory",
+    "HashingGraphEmbedder": "parrot.knowledge.graphindex.factory",
+    "make_stub_tenant_context": "parrot.knowledge.graphindex.factory",
+}
 
 
 def __getattr__(name: str):

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/__init__.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/__init__.py
@@ -78,6 +78,10 @@ __all__ = [
     "build_graph_memory_toolkit",
     "HashingGraphEmbedder",
     "make_stub_tenant_context",
+    "GraphContextBuilder",
+    "ContextBuildConfig",
+    "GraphContext",
+    "GraphMemoryMixin",
     "SignalRelevance",
     "SignalRelevanceConfig",
     "compute_pairwise_signals",
@@ -118,6 +122,10 @@ _LAZY_ATTRS = {
     "build_graph_memory_toolkit": "parrot.knowledge.graphindex.factory",
     "HashingGraphEmbedder": "parrot.knowledge.graphindex.factory",
     "make_stub_tenant_context": "parrot.knowledge.graphindex.factory",
+    "GraphContextBuilder": "parrot.knowledge.graphindex.context_builder",
+    "ContextBuildConfig": "parrot.knowledge.graphindex.context_builder",
+    "GraphContext": "parrot.knowledge.graphindex.context_builder",
+    "GraphMemoryMixin": "parrot.knowledge.graphindex.mixin",
 }
 
 

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/__init__.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/__init__.py
@@ -82,6 +82,8 @@ __all__ = [
     "ContextBuildConfig",
     "GraphContext",
     "GraphMemoryMixin",
+    "GroundingEvaluator",
+    "GroundingResult",
     "SignalRelevance",
     "SignalRelevanceConfig",
     "compute_pairwise_signals",
@@ -126,6 +128,8 @@ _LAZY_ATTRS = {
     "ContextBuildConfig": "parrot.knowledge.graphindex.context_builder",
     "GraphContext": "parrot.knowledge.graphindex.context_builder",
     "GraphMemoryMixin": "parrot.knowledge.graphindex.mixin",
+    "GroundingEvaluator": "parrot.knowledge.graphindex.grounding",
+    "GroundingResult": "parrot.knowledge.graphindex.grounding",
 }
 
 

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/context_builder.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/context_builder.py
@@ -1,0 +1,388 @@
+"""Task-scoped context construction from a knowledge graph.
+
+Implements the paper's graph-grounded context recipe: resolve the
+entities a task mentions, expand a bounded neighbourhood over allowed
+edge types, prefer recent verified (asserted) claims, surface conflicts
+explicitly, and serialize everything within a token budget — with a
+stable, citable id attached to every relation so downstream evaluators
+can check answers edge-by-edge instead of trusting free-form prose.
+
+The builder is a thin composition over :class:`GraphExpandedRetriever`
+(which already provides seeded search, decayed multi-hop expansion, and
+budgeting) — the deltas here are entity seeding, edge-kind filtering,
+assertion-aware ranking, conflict surfacing, and citation serialization.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional
+
+from pydantic import BaseModel, Field
+
+from parrot.knowledge.graphindex.retriever import (
+    BudgetConfig,
+    ExpansionConfig,
+    GraphExpandedRetriever,
+    ScoredNode,
+)
+from parrot.knowledge.graphindex.schema import stable_edge_id
+
+if TYPE_CHECKING:  # pragma: no cover — typing only
+    from parrot.knowledge.graphindex.schema import UniversalNode
+
+logger = logging.getLogger(__name__)
+
+#: Minimum title length considered for entity resolution by mention.
+_MIN_ENTITY_TITLE = 3
+
+
+def _estimate_tokens(text: str) -> int:
+    """Cheap token estimate (≈4 chars/token) — good enough for budgeting."""
+    return max(1, len(text) // 4)
+
+
+class ContextBuildConfig(BaseModel):
+    """Configuration for graph context construction.
+
+    Args:
+        allowed_edge_kinds: Restrict expansion (and cited relations) to
+            these edge kinds. ``None`` allows every kind.
+        max_hops: Neighbourhood radius around resolved/seeded entities.
+        max_tokens: Serialization budget for the final context text.
+        seed_top_k: Seed-search breadth before expansion.
+        include_conflicts: Surface ambiguous/contradicting relations in a
+            dedicated section instead of hiding them.
+        prefer_asserted: Boost nodes carrying assertion metadata (agent/
+            human-verified claims) above same-scored extracted nodes.
+        max_entities: Cap on entity mentions resolved from the task text.
+    """
+
+    allowed_edge_kinds: Optional[list[str]] = None
+    max_hops: int = Field(default=2, ge=1, le=4)
+    max_tokens: int = Field(default=4000, ge=200)
+    seed_top_k: int = Field(default=8, ge=1)
+    include_conflicts: bool = True
+    prefer_asserted: bool = True
+    max_entities: int = Field(default=10, ge=1)
+
+
+class GraphContext(BaseModel):
+    """Serialized, citable graph context for one task.
+
+    Args:
+        text: Markdown context ready for prompt injection.
+        entities: ``node_id`` of every entity resolved from the task.
+        node_ids: Every node included in the context.
+        cited_edge_ids: Stable edge ids (see :func:`stable_edge_id`)
+            attached to the serialized relations, for citation.
+        conflicts: Stable edge ids of surfaced conflict relations.
+        budget_used: Estimated tokens consumed by ``text``.
+        truncated: Whether the budget cut content.
+    """
+
+    text: str
+    entities: list[str] = Field(default_factory=list)
+    node_ids: list[str] = Field(default_factory=list)
+    cited_edge_ids: list[str] = Field(default_factory=list)
+    conflicts: list[str] = Field(default_factory=list)
+    budget_used: int = 0
+    truncated: bool = False
+
+
+class GraphContextBuilder:
+    """Build task-specific, token-budgeted context from a graph.
+
+    Args:
+        retriever: A :class:`GraphExpandedRetriever` over the graph.
+        entity_resolver: Optional resolver with an async
+            ``extract_and_resolve(text)`` API; when absent, entities are
+            resolved by (case-insensitive) title mention matching —
+            dependency-free and adequate for agent-memory graphs.
+    """
+
+    def __init__(
+        self,
+        retriever: GraphExpandedRetriever,
+        entity_resolver: Optional[object] = None,
+    ) -> None:
+        self.retriever = retriever
+        self.entity_resolver = entity_resolver
+        self.logger = logging.getLogger(__name__)
+
+    # ------------------------------------------------------------------
+    # Step 1 — entity resolution
+    # ------------------------------------------------------------------
+
+    async def _resolve_entities(
+        self, task: str, config: ContextBuildConfig
+    ) -> list[str]:
+        """Resolve task-mentioned entities to graph node ids."""
+        if self.entity_resolver is not None:
+            try:
+                resolved = await self.entity_resolver.extract_and_resolve(task)
+                ids = [
+                    str(getattr(e, "node_id", None) or e.get("node_id"))
+                    for e in (resolved or [])
+                ]
+                return [i for i in ids if i][: config.max_entities]
+            except Exception as exc:  # noqa: BLE001 — fall back to mentions
+                self.logger.debug(
+                    "entity resolver failed (%s); using mention matching", exc
+                )
+        task_lower = task.lower()
+        matches: list[tuple[int, str]] = []
+        for node in self.retriever.nodes:
+            title = (node.title or "").strip()
+            if len(title) < _MIN_ENTITY_TITLE:
+                continue
+            candidates = [title.lower()]
+            aliases = node.domain_tags.get("aliases") or []
+            candidates += [str(a).lower() for a in aliases if a]
+            for cand in candidates:
+                if cand and cand in task_lower:
+                    matches.append((len(cand), node.node_id))
+                    break
+        # Longest mentions first — most specific entities win the cap.
+        matches.sort(reverse=True)
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for _, node_id in matches:
+            if node_id not in seen:
+                seen.add(node_id)
+                ordered.append(node_id)
+        return ordered[: config.max_entities]
+
+    # ------------------------------------------------------------------
+    # Step 2+3 — retrieval and assertion-aware ranking
+    # ------------------------------------------------------------------
+
+    def _node_meta(self, node_id: str) -> Optional["UniversalNode"]:
+        for node in self.retriever.nodes:
+            if node.node_id == node_id:
+                return node
+        return None
+
+    def _rank(
+        self, nodes: list[ScoredNode], config: ContextBuildConfig
+    ) -> list[ScoredNode]:
+        """Order candidates; asserted (verified) claims first when enabled."""
+
+        def sort_key(sn: ScoredNode) -> tuple:
+            meta = self._node_meta(sn.node_id)
+            asserted = bool(meta is not None and meta.assertion is not None)
+            asserted_at = (
+                meta.assertion.asserted_at
+                if asserted and meta.assertion.asserted_at
+                else ""
+            )
+            if config.prefer_asserted:
+                return (asserted, sn.combined_score, asserted_at)
+            return (sn.combined_score, asserted, asserted_at)
+
+        return sorted(nodes, key=sort_key, reverse=True)
+
+    # ------------------------------------------------------------------
+    # Step 4 — relations among included nodes
+    # ------------------------------------------------------------------
+
+    def _relations(
+        self, node_ids: list[str], config: ContextBuildConfig
+    ) -> tuple[list[dict], list[dict]]:
+        """Collect (relations, conflicts) among the included nodes.
+
+        A relation is a conflict when its provenance is ``ambiguous`` or
+        its kind is ``contradicts``.
+        """
+        included = set(node_ids)
+        allowed = (
+            set(config.allowed_edge_kinds) if config.allowed_edge_kinds else None
+        )
+        graph = self.retriever.graph
+        titles: dict[str, str] = {}
+        for node in self.retriever.nodes:
+            titles[node.node_id] = node.title
+
+        relations: list[dict] = []
+        conflicts: list[dict] = []
+        seen: set[str] = set()
+        for idx in graph.node_indices():
+            payload = graph[idx]
+            if not isinstance(payload, dict):
+                continue
+            src = payload.get("node_id")
+            if src not in included:
+                continue
+            for _s, t, edge in graph.out_edges(idx):
+                if not isinstance(edge, dict):
+                    continue
+                dst = edge.get("target_id")
+                kind = edge.get("kind")
+                if dst not in included or not kind:
+                    continue
+                is_conflict = (
+                    edge.get("provenance") == "ambiguous" or kind == "contradicts"
+                )
+                if allowed is not None and kind not in allowed and not is_conflict:
+                    continue
+                edge_id = stable_edge_id(src, dst, kind)
+                if edge_id in seen:
+                    continue
+                seen.add(edge_id)
+                entry = {
+                    "edge_id": edge_id,
+                    "src": src,
+                    "dst": dst,
+                    "kind": kind,
+                    "src_title": titles.get(src, src),
+                    "dst_title": titles.get(dst, dst),
+                    "provenance": edge.get("provenance", "extracted"),
+                }
+                if is_conflict:
+                    conflicts.append(entry)
+                else:
+                    relations.append(entry)
+        return relations, conflicts
+
+    # ------------------------------------------------------------------
+    # Step 5 — serialization within budget
+    # ------------------------------------------------------------------
+
+    async def build(
+        self,
+        task: str,
+        config: Optional[ContextBuildConfig] = None,
+    ) -> GraphContext:
+        """Build the serialized graph context for a task.
+
+        Args:
+            task: The task/question the context should ground.
+            config: Optional build configuration.
+
+        Returns:
+            A :class:`GraphContext` with citable relations.
+        """
+        config = config or ContextBuildConfig()
+
+        entity_ids = await self._resolve_entities(task, config)
+
+        result = await self.retriever.search(
+            task,
+            seed_top_k=config.seed_top_k,
+            expansion=ExpansionConfig(
+                max_hops=config.max_hops,
+                allowed_edge_kinds=config.allowed_edge_kinds,
+            ),
+            budget=BudgetConfig(max_tokens=config.max_tokens),
+        )
+        candidates = {sn.node_id: sn for sn in result.nodes}
+        # Force-include resolved entities even when seed search missed them.
+        for node_id in entity_ids:
+            if node_id not in candidates:
+                meta = self._node_meta(node_id)
+                if meta is None:
+                    continue
+                candidates[node_id] = ScoredNode(
+                    node_id=node_id,
+                    title=meta.title,
+                    kind=str(meta.kind.value)
+                    if hasattr(meta.kind, "value")
+                    else str(meta.kind),
+                    search_score=1.0,
+                    combined_score=1.0,
+                    is_seed=True,
+                    source_uri=meta.source_uri,
+                    summary=meta.summary,
+                )
+
+        ranked = self._rank(list(candidates.values()), config)
+
+        # Serialize greedily within budget.
+        header = f"## Graph context\n\nTask: {task.strip()[:160]}\n"
+        lines: list[str] = [header]
+        budget_used = _estimate_tokens(header)
+        truncated = False
+        included: list[str] = []
+
+        if entity_ids:
+            entity_lines = ["\n### Entities in this task\n"]
+            for node_id in entity_ids:
+                meta = self._node_meta(node_id)
+                if meta is not None:
+                    entity_lines.append(f"- {meta.title} [{node_id}]\n")
+            block = "".join(entity_lines)
+            lines.append(block)
+            budget_used += _estimate_tokens(block)
+
+        lines.append("\n### Knowledge\n")
+        for sn in ranked:
+            meta = self._node_meta(sn.node_id)
+            attribution = ""
+            if meta is not None and meta.assertion is not None:
+                attribution = (
+                    f" (asserted by {meta.assertion.asserted_by}"
+                    f"{' @ ' + meta.assertion.asserted_at if meta.assertion.asserted_at else ''})"
+                )
+            summary = (sn.summary or "").strip().replace("\n", " ")
+            line = (
+                f"- [{sn.node_id}] {sn.title} ({sn.kind};"
+                f" score {sn.combined_score:.2f}){attribution}"
+                + (f" — {summary[:200]}" if summary else "")
+                + "\n"
+            )
+            cost = _estimate_tokens(line)
+            if budget_used + cost > config.max_tokens:
+                truncated = True
+                break
+            lines.append(line)
+            budget_used += cost
+            included.append(sn.node_id)
+
+        relations, conflicts = self._relations(included, config)
+        cited: list[str] = []
+        if relations:
+            rel_header = "\n### Relations (cite by edge id)\n"
+            lines.append(rel_header)
+            budget_used += _estimate_tokens(rel_header)
+            for rel in relations:
+                line = (
+                    f"- [edge:{rel['edge_id']}] {rel['src_title']}"
+                    f" -{rel['kind']}-> {rel['dst_title']}\n"
+                )
+                cost = _estimate_tokens(line)
+                if budget_used + cost > config.max_tokens:
+                    truncated = True
+                    break
+                lines.append(line)
+                budget_used += cost
+                cited.append(rel["edge_id"])
+
+        conflict_ids: list[str] = []
+        if conflicts and config.include_conflicts:
+            conflict_header = "\n### Conflicts / uncertain claims\n"
+            lines.append(conflict_header)
+            budget_used += _estimate_tokens(conflict_header)
+            for rel in conflicts:
+                line = (
+                    f"- [edge:{rel['edge_id']}] {rel['src_title']}"
+                    f" -{rel['kind']}-> {rel['dst_title']}"
+                    f" (provenance={rel['provenance']})\n"
+                )
+                cost = _estimate_tokens(line)
+                if budget_used + cost > config.max_tokens:
+                    truncated = True
+                    break
+                lines.append(line)
+                budget_used += cost
+                conflict_ids.append(rel["edge_id"])
+                cited.append(rel["edge_id"])
+
+        return GraphContext(
+            text="".join(lines),
+            entities=entity_ids,
+            node_ids=included,
+            cited_edge_ids=cited,
+            conflicts=conflict_ids,
+            budget_used=budget_used,
+            truncated=truncated,
+        )

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/extractors/__init__.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/extractors/__init__.py
@@ -1,12 +1,16 @@
 """GraphIndex extractors sub-package.
 
-Four parallel extractors feed UniversalNode/UniversalEdge instances
-into the pipeline:
+Five extractors feed UniversalNode/UniversalEdge instances into the
+pipeline:
 
 - ``code.CodeExtractor``         — tree-sitter Python parsing
 - ``odoo_code.OdooCodeExtractor`` — Odoo-aware extension of CodeExtractor (FEAT-240)
 - ``loader.LoaderExtractor``     — ai-parrot-loaders + PageIndex integration
 - ``skill.SkillExtractor``       — SKILL.md frontmatter parsing
+- ``llm.LLMGraphExtractor``      — schema-constrained LLM extraction of
+  typed entities/relations from free text (imported lazily below — it
+  is the only extractor with no heavyweight parser dependency, but its
+  publish path pulls the persistence stack).
 """
 
 from parrot.knowledge.graphindex.extractors.code import CodeExtractor
@@ -19,4 +23,26 @@ __all__ = [
     "LoaderExtractor",
     "OdooCodeExtractor",
     "SkillExtractor",
+    "LLMGraphExtractor",
+    "ExtractedGraph",
+    "ExtractedEntity",
+    "ExtractedRelation",
 ]
+
+_LAZY_ATTRS = {
+    "LLMGraphExtractor": "parrot.knowledge.graphindex.extractors.llm",
+    "ExtractedGraph": "parrot.knowledge.graphindex.extractors.llm",
+    "ExtractedEntity": "parrot.knowledge.graphindex.extractors.llm",
+    "ExtractedRelation": "parrot.knowledge.graphindex.extractors.llm",
+}
+
+
+def __getattr__(name: str):
+    """Resolve lazily-exported attributes on first access (PEP 562)."""
+    module_path = _LAZY_ATTRS.get(name)
+    if module_path is not None:
+        import importlib
+
+        module = importlib.import_module(module_path)
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/extractors/llm.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/extractors/llm.py
@@ -1,0 +1,343 @@
+"""LLM-typed knowledge extraction into the graph (schema-constrained).
+
+Replaces a classical NER/relation pipeline with one structured-output
+call: the Pydantic schema is the only "training data". Extracted
+entities are deduplicated against the existing graph (exact, alias, and
+fuzzy title matching), merges are additive and inspectable (canonical
+nodes keep aliases + a merge rationale), and everything lands in ONE
+audited, revertible commit attributed to the extracting agent/run.
+
+The other extractors in this package are structural (tree-sitter, file
+headings); this one turns free text — conversation notes, documents,
+decisions — into typed nodes and edges.
+"""
+
+from __future__ import annotations
+
+import difflib
+import hashlib
+import logging
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+from parrot.knowledge.graphindex.publish import GraphPublisher
+from parrot.knowledge.graphindex.schema import (
+    CommitReceipt,
+    EdgeKind,
+    GraphUpdate,
+    NodeKind,
+    Provenance,
+    UniversalEdge,
+    UniversalNode,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Fuzzy title-similarity threshold for entity deduplication.
+_FUZZY_THRESHOLD = 0.88
+
+_EXTRACTION_PROMPT = """Extract a typed knowledge graph from the text below.
+
+Rules:
+- entities: the distinct things the text is about (concepts, components,
+  services, people, policies). Use short canonical names; put variant
+  names in aliases. kind is one of: concept, document, symbol, skill.
+- relations: subject-predicate-object links BETWEEN the entities you
+  extracted (use the exact entity names as source/target). kind is one
+  of: references, contains, defines, mentions, explains, extends.
+- Give each entity a one-sentence summary grounded in the text.
+- confidence in [0, 1]: how directly the text supports the item.
+- Do NOT invent entities or relations not supported by the text.
+
+Text:
+---
+{text}
+---
+"""
+
+
+class ExtractedEntity(BaseModel):
+    """A typed entity extracted from free text.
+
+    Args:
+        name: Short canonical name.
+        kind: Node kind string (validated against ``NodeKind``; unknown
+            kinds fall back to ``concept``).
+        summary: One-sentence description grounded in the source text.
+        aliases: Variant surface forms seen in the text.
+        confidence: Extraction confidence in [0, 1].
+    """
+
+    name: str
+    kind: str = "concept"
+    summary: str = ""
+    aliases: list[str] = Field(default_factory=list)
+    confidence: float = Field(default=0.8, ge=0.0, le=1.0)
+
+
+class ExtractedRelation(BaseModel):
+    """A typed relation between two extracted entities.
+
+    Args:
+        source: Name of the subject entity (must match an entity name).
+        target: Name of the object entity.
+        kind: Edge kind string (validated against ``EdgeKind``; unknown
+            kinds fall back to ``references``).
+        rationale: Short justification quoted/paraphrased from the text.
+        confidence: Extraction confidence in [0, 1].
+    """
+
+    source: str
+    target: str
+    kind: str = "references"
+    rationale: str = ""
+    confidence: float = Field(default=0.8, ge=0.0, le=1.0)
+
+
+class ExtractedGraph(BaseModel):
+    """The structured-output contract for one extraction call."""
+
+    entities: list[ExtractedEntity] = Field(default_factory=list)
+    relations: list[ExtractedRelation] = Field(default_factory=list)
+
+
+class ExtractionPublishResult(BaseModel):
+    """Outcome of :meth:`LLMGraphExtractor.extract_and_publish`.
+
+    Args:
+        receipt: The recorded commit.
+        extracted: The raw LLM extraction.
+        update: The deduplicated update that was committed (post-merge
+            nodes and resolved edges) — callers can mirror it into an
+            in-memory graph.
+    """
+
+    receipt: CommitReceipt
+    extracted: ExtractedGraph
+    update: GraphUpdate
+
+
+def _mint_node_id(kind: str, title: str, summary: str) -> str:
+    """Deterministic node id (same recipe as the toolkit's write tools)."""
+    raw = f"{kind}::{title}::{summary}".encode("utf-8")
+    return hashlib.sha1(raw).hexdigest()[:16]
+
+
+class LLMGraphExtractor:
+    """Extract typed knowledge from text and publish it durably.
+
+    Args:
+        client: An ``AbstractClient`` (uses its provider-native
+            structured output via ``invoke(output_type=...)``).
+        publisher: Optional :class:`GraphPublisher`; required for
+            :meth:`extract_and_publish`.
+    """
+
+    def __init__(
+        self,
+        client: Any,
+        publisher: Optional[GraphPublisher] = None,
+    ) -> None:
+        self.client = client
+        self.publisher = publisher
+        self.logger = logging.getLogger(__name__)
+
+    async def extract(self, text: str) -> ExtractedGraph:
+        """Run the schema-constrained extraction call.
+
+        Args:
+            text: Free text to extract from.
+
+        Returns:
+            The parsed :class:`ExtractedGraph`.
+        """
+        result = await self.client.invoke(
+            _EXTRACTION_PROMPT.format(text=text),
+            output_type=ExtractedGraph,
+            system_prompt=(
+                "You are a precise knowledge-graph extraction engine. "
+                "Return only what the text supports."
+            ),
+        )
+        output = getattr(result, "output", result)
+        if isinstance(output, ExtractedGraph):
+            return output
+        if isinstance(output, dict):
+            return ExtractedGraph(**output)
+        raise TypeError(
+            f"extraction returned unsupported type {type(output).__name__}"
+        )
+
+    # ------------------------------------------------------------------
+    # Dedup + publish
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _match_existing(
+        entity: ExtractedEntity,
+        existing: list[UniversalNode],
+    ) -> Optional[UniversalNode]:
+        """Find the canonical node an extracted entity refers to.
+
+        Blocking order: exact title match (case-insensitive) → alias
+        match → fuzzy title similarity above :data:`_FUZZY_THRESHOLD`.
+        """
+        name = entity.name.strip().lower()
+        surfaces = {name} | {a.strip().lower() for a in entity.aliases if a}
+        best: Optional[UniversalNode] = None
+        best_ratio = 0.0
+        for node in existing:
+            title = node.title.strip().lower()
+            node_aliases = {
+                str(a).strip().lower()
+                for a in (node.domain_tags.get("aliases") or [])
+            }
+            if title in surfaces or (node_aliases & surfaces):
+                return node
+            ratio = difflib.SequenceMatcher(None, name, title).ratio()
+            if ratio > best_ratio:
+                best_ratio = ratio
+                best = node
+        if best is not None and best_ratio >= _FUZZY_THRESHOLD:
+            return best
+        return None
+
+    async def extract_and_publish(
+        self,
+        text: str,
+        source_uri: str,
+        agent_id: str = "agent",
+        run_id: Optional[str] = None,
+    ) -> tuple[CommitReceipt, ExtractedGraph]:
+        """Extract, dedup against the existing graph, and commit.
+
+        Matched entities are merged ADDITIVELY: the canonical node keeps
+        its identity and gains the new surface forms in
+        ``domain_tags['aliases']`` plus a ``merge_rationale`` entry — no
+        node is ever destroyed by extraction, and the whole batch is one
+        revertible commit.
+
+        Args:
+            text: Free text to extract from.
+            source_uri: Citation URI for the extracted knowledge.
+            agent_id: Agent identity for attribution.
+            run_id: Optional run/session id for lineage.
+
+        Returns:
+            An :class:`ExtractionPublishResult` with the commit receipt,
+            the raw extraction, and the committed update.
+
+        Raises:
+            RuntimeError: When no publisher is configured.
+        """
+        if self.publisher is None:
+            raise RuntimeError(
+                "extract_and_publish requires a GraphPublisher"
+            )
+
+        extracted = await self.extract(text)
+
+        existing_nodes, _ = await self.publisher.persistence.load_graph(
+            self.publisher.ctx
+        )
+
+        name_to_id: dict[str, str] = {}
+        upserts: dict[str, UniversalNode] = {}
+        for entity in extracted.entities:
+            if not entity.name.strip():
+                continue
+            try:
+                kind = NodeKind(entity.kind)
+            except ValueError:
+                kind = NodeKind.CONCEPT
+
+            canonical = self._match_existing(entity, existing_nodes)
+            if canonical is not None:
+                # Additive alias merge on the canonical node.
+                aliases = {
+                    str(a) for a in (canonical.domain_tags.get("aliases") or [])
+                }
+                new_surfaces = {
+                    s
+                    for s in [entity.name, *entity.aliases]
+                    if s and s.strip().lower() != canonical.title.strip().lower()
+                }
+                added = sorted(new_surfaces - aliases)
+                if added:
+                    canonical.domain_tags["aliases"] = sorted(aliases | new_surfaces)
+                    rationales = list(
+                        canonical.domain_tags.get("merge_rationale") or []
+                    )
+                    rationales.append(
+                        f"aliases {added} from extraction of {source_uri}"
+                    )
+                    canonical.domain_tags["merge_rationale"] = rationales
+                    upserts[canonical.node_id] = canonical
+                name_to_id[entity.name.strip().lower()] = canonical.node_id
+                for alias in entity.aliases:
+                    name_to_id.setdefault(alias.strip().lower(), canonical.node_id)
+                continue
+
+            node_id = _mint_node_id(kind.value, entity.name.strip(), entity.summary)
+            tags: dict[str, Any] = {}
+            if entity.aliases:
+                tags["aliases"] = sorted({str(a) for a in entity.aliases})
+            node = UniversalNode(
+                node_id=node_id,
+                kind=kind,
+                title=entity.name.strip(),
+                source_uri=source_uri or f"agent://{kind.value}/{node_id}",
+                summary=entity.summary,
+                domain_tags=tags,
+                provenance=Provenance.ASSERTED,
+            )
+            upserts[node_id] = node
+            existing_nodes.append(node)  # visible to later dedup passes
+            name_to_id[entity.name.strip().lower()] = node_id
+            for alias in entity.aliases:
+                name_to_id.setdefault(alias.strip().lower(), node_id)
+
+        edges: list[UniversalEdge] = []
+        skipped_relations: list[str] = []
+        seen_edges: set[tuple[str, str, str]] = set()
+        for relation in extracted.relations:
+            src = name_to_id.get(relation.source.strip().lower())
+            tgt = name_to_id.get(relation.target.strip().lower())
+            if src is None or tgt is None or src == tgt:
+                skipped_relations.append(
+                    f"{relation.source} -{relation.kind}-> {relation.target}"
+                )
+                continue
+            try:
+                kind = EdgeKind(relation.kind)
+            except ValueError:
+                kind = EdgeKind.REFERENCES
+            key = (src, tgt, kind.value)
+            if key in seen_edges:
+                continue
+            seen_edges.add(key)
+            edges.append(
+                UniversalEdge(source_id=src, target_id=tgt, kind=kind)
+            )
+        if skipped_relations:
+            self.logger.warning(
+                "extract_and_publish: %d relations skipped (unresolvable): %s",
+                len(skipped_relations),
+                "; ".join(skipped_relations[:5]),
+            )
+
+        update = GraphUpdate(
+            nodes=list(upserts.values()),
+            edges=edges,
+            agent_id=agent_id,
+            run_id=run_id,
+            asserted_by=f"agent:{agent_id}",
+            source=source_uri,
+            reason=f"LLM extraction from {source_uri or 'text'}",
+            op="extract_knowledge",
+        )
+        receipt = await self.publisher.publish(update)
+        return ExtractionPublishResult(
+            receipt=receipt, extracted=extracted, update=update
+        )

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/factory.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/factory.py
@@ -1,0 +1,254 @@
+"""Factory for persistent, write-enabled graph memory toolkits.
+
+Productizes the load → assemble → embed → publish loop so an agent (or a
+mixin) can open its durable knowledge graph in one call::
+
+    toolkit = await build_graph_memory_toolkit(
+        db_dir=Path("~/.parrot/agents/my-agent/graph_memory"),
+        agent_id="my-agent",
+    )
+
+The returned ``GraphIndexToolkit`` has every write tool wired for
+write-through persistence (via :class:`GraphPublisher`), so knowledge the
+agent files survives process restarts — "the agent forgets, the graph
+does not".
+
+``GraphIndexToolkit`` lives in the sibling ``ai-parrot-tools``
+distribution; it is imported lazily inside the factory (mirroring
+``ToolInterface._capture_knowledge_toolkit``) so ``ai-parrot`` core keeps
+no hard dependency on it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional
+
+import numpy as np
+
+from parrot.knowledge.graphindex.assemble import GraphAssembler
+from parrot.knowledge.graphindex.publish import GraphPublisher
+from parrot.knowledge.graphindex.persist_sqlite import SQLitePersistence
+from parrot.knowledge.graphindex.schema import UniversalNode
+from parrot.knowledge.ontology.schema import MergedOntology, TenantContext
+
+if TYPE_CHECKING:  # pragma: no cover — typing only
+    from parrot_tools.graphindex.toolkit import GraphIndexToolkit
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DIMENSION = 256
+
+
+def make_stub_tenant_context(tenant_id: str) -> TenantContext:
+    """Build a minimal :class:`TenantContext` for local graph planes.
+
+    The ontology is a stub (same pattern as the flowtask component) —
+    full hydration is only needed for ArangoDB/ontology deployments.
+
+    Args:
+        tenant_id: Tenant identifier for the graph plane.
+
+    Returns:
+        A ``TenantContext`` suitable for ``SQLitePersistence``.
+    """
+    ontology = MergedOntology.model_construct(
+        name="graphindex",
+        version="1.0",
+        entities={},
+        relations={},
+        traversal_patterns={},
+        layers=[],
+        merge_timestamp=None,
+    )
+    return TenantContext(
+        tenant_id=tenant_id,
+        arango_db=f"db_{tenant_id}",
+        pgvector_schema=f"schema_{tenant_id}",
+        ontology=ontology,
+    )
+
+
+def _embed_text(text: str, dim: int) -> np.ndarray:
+    """Hash tokens into a normalised bag-of-tokens vector.
+
+    Deterministic ACROSS PROCESSES (bucket derivation uses SHA-1, never
+    Python's salted ``hash()``) — a hard requirement for persistent
+    memory, where nodes embedded in one session must stay findable from
+    queries encoded in the next.
+
+    Args:
+        text: Text to embed.
+        dim: Vector dimension.
+
+    Returns:
+        L2-normalised ``(dim,)`` float32 vector.
+    """
+    vec = np.zeros(dim, dtype=np.float32)
+    for tok in text.lower().split():
+        tok = tok.strip(".,;:!?()[]{}\"'`")
+        if not tok:
+            continue
+        digest = hashlib.sha1(tok.encode("utf-8")).digest()
+        bucket = int.from_bytes(digest[:4], "big") % dim
+        vec[bucket] += 1.0
+    norm = float(np.linalg.norm(vec))
+    if norm > 0:
+        vec /= norm
+    return vec
+
+
+class _HashingModel:
+    """Minimal ``model`` object exposing the ``encode`` the toolkit calls."""
+
+    def __init__(self, dim: int) -> None:
+        self.dim = dim
+
+    def encode(self, texts: list[str]) -> np.ndarray:
+        """Encode texts into a ``(len(texts), dim)`` float32 matrix."""
+        if not texts:
+            return np.zeros((0, self.dim), dtype=np.float32)
+        return np.vstack([_embed_text(t, self.dim) for t in texts]).astype(
+            np.float32
+        )
+
+
+class HashingGraphEmbedder:
+    """Deterministic, offline embedder compatible with ``GraphIndexToolkit``.
+
+    Implements the subset of the ``GraphIndexEmbedder`` API the toolkit
+    uses: ``model.encode``, ``index`` (the shared FAISS index), an
+    internal ``_node_id_map`` (FAISS position → node_id) and
+    ``embed_nodes``. Used as the zero-dependency fallback when no real
+    embedding model is configured — lexical bag-of-tokens vectors are
+    enough for ``find_node``/``search_hybrid`` over agent memory.
+
+    Args:
+        dimension: Embedding vector dimension.
+    """
+
+    def __init__(self, dimension: int = DEFAULT_DIMENSION) -> None:
+        from parrot.utils.faiss_logging import quiet_faiss_loader
+
+        quiet_faiss_loader()
+        import faiss
+
+        self.dimension = dimension
+        self.model = _HashingModel(dimension)
+        self.index = faiss.IndexFlatL2(dimension)
+        self._node_id_map: list[str] = []
+        self._vectors: dict[str, np.ndarray] = {}
+
+    async def embed_nodes(
+        self, nodes: list[UniversalNode], batch_size: int = 64
+    ) -> list[UniversalNode]:
+        """Embed (or re-embed) nodes, keeping FAISS positions stable.
+
+        New node ids are appended; an already-embedded node id has its
+        vector refreshed in place. The FAISS index is rebuilt in the
+        same object (``reset`` + ``add``) so shared references stay
+        valid and positions remain aligned with ``node_id_list``.
+
+        Args:
+            nodes: Nodes to embed.
+            batch_size: Unused (single batch); kept for API parity.
+
+        Returns:
+            The same nodes with ``embedding_ref`` populated.
+        """
+        if not nodes:
+            return nodes
+        texts = [f"{n.summary or ''} {n.title or ''}".strip() for n in nodes]
+        vecs = self.model.encode(texts)
+        for i, node in enumerate(nodes):
+            if node.node_id not in self._vectors:
+                self._node_id_map.append(node.node_id)
+            self._vectors[node.node_id] = vecs[i]
+        self.index.reset()
+        ordered = np.vstack([self._vectors[nid] for nid in self._node_id_map])
+        self.index.add(ordered.astype(np.float32))
+        for node in nodes:
+            node.embedding_ref = f"faiss:{self._node_id_map.index(node.node_id)}"
+        return nodes
+
+
+async def build_graph_memory_toolkit(
+    db_dir: Path | str,
+    tenant_id: str = "default",
+    agent_id: str = "agent",
+    run_id: Optional[str] = None,
+    embedder: Optional[Any] = None,
+    client: Optional[Any] = None,
+    dimension: int = DEFAULT_DIMENSION,
+) -> "GraphIndexToolkit":
+    """Open (or create) a persistent graph memory and return its toolkit.
+
+    Loads the durable graph plane from ``db_dir``, assembles the
+    in-memory rustworkx graph, embeds the loaded nodes, and wires a
+    :class:`GraphPublisher` so every toolkit write persists as an
+    audited, revertible commit.
+
+    Args:
+        db_dir: Directory holding the per-tenant SQLite graph plane.
+        tenant_id: Tenant identifier (one ``<tenant_id>.db`` per tenant).
+        agent_id: Stable agent identity stamped onto writes.
+        run_id: Optional run/session id stamped onto writes (mutable on
+            the returned toolkit — set per ask).
+        embedder: Optional embedder implementing the
+            ``GraphIndexEmbedder`` surface. Defaults to the deterministic
+            offline :class:`HashingGraphEmbedder`.
+        client: Optional ``AbstractClient`` for ``explain()``.
+        dimension: Vector dimension for the default embedder.
+
+    Returns:
+        A write-enabled, persistence-backed ``GraphIndexToolkit``.
+    """
+    # Lazy import — keeps ai-parrot core free of a hard dependency on
+    # the ai-parrot-tools distribution (same seam as ToolInterface).
+    from parrot_tools.graphindex.toolkit import GraphIndexToolkit
+
+    ctx = make_stub_tenant_context(tenant_id)
+    persistence = SQLitePersistence(Path(db_dir))
+    publisher = GraphPublisher(persistence, ctx)
+
+    nodes, edges = await persistence.load_graph(ctx)
+
+    assembler = GraphAssembler(tenant_id=tenant_id)
+    for node in nodes:
+        assembler.add_node(node)
+    skipped_edges = 0
+    for edge in edges:
+        if assembler.add_edge(edge) is None:
+            skipped_edges += 1
+    if skipped_edges:
+        logger.warning(
+            "build_graph_memory_toolkit: %d edges skipped (missing endpoints)",
+            skipped_edges,
+        )
+
+    embedder = embedder or HashingGraphEmbedder(dimension=dimension)
+    if nodes:
+        await embedder.embed_nodes(nodes)
+
+    toolkit = GraphIndexToolkit(
+        graph=assembler.graph,
+        faiss_index=embedder.index,
+        node_map=dict(assembler._node_index_map),
+        node_id_list=list(embedder._node_id_map),
+        client=client,
+        assembler=assembler,
+        embedder=embedder,
+        nodes=nodes,
+        publisher=publisher,
+        agent_id=agent_id,
+        run_id=run_id,
+    )
+    logger.info(
+        "build_graph_memory_toolkit: tenant %r — %d nodes, %d edges loaded",
+        tenant_id,
+        len(nodes),
+        len(edges),
+    )
+    return toolkit

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/factory.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/factory.py
@@ -173,6 +173,32 @@ class HashingGraphEmbedder:
             node.embedding_ref = f"faiss:{self._node_id_map.index(node.node_id)}"
         return nodes
 
+    def get_embedding(self, node_id: str) -> Optional[np.ndarray]:
+        """Return the stored vector for a node id, or ``None``."""
+        return self._vectors.get(node_id)
+
+    async def search_similar(
+        self, query: str, top_k: int = 10
+    ) -> list[tuple[str, float]]:
+        """FAISS L2 search over the embedded nodes.
+
+        Args:
+            query: Natural-language query text.
+            top_k: Maximum results.
+
+        Returns:
+            ``(node_id, distance)`` pairs, closest first.
+        """
+        if self.index.ntotal == 0:
+            return []
+        vec = self.model.encode([query])
+        distances, positions = self.index.search(vec, min(top_k, self.index.ntotal))
+        results: list[tuple[str, float]] = []
+        for pos, dist in zip(positions[0], distances[0]):
+            if 0 <= pos < len(self._node_id_map):
+                results.append((self._node_id_map[pos], float(dist)))
+        return results
+
 
 async def build_graph_memory_toolkit(
     db_dir: Path | str,

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/grounding.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/grounding.py
@@ -1,0 +1,358 @@
+"""Grounding evaluator — check claims against graph evidence.
+
+Implements the paper's grounding layer: instead of a free-form critique,
+a claim is checked for supporting *paths* in the knowledge graph. When
+support exists, the result cites the exact edges (stable ids); when it
+does not, the result is a structured revise instruction listing the
+missing evidence — actionable feedback an agent can act on
+(add the missing relation, find a source, or weaken the claim).
+
+Example revise contract::
+
+    {
+      "decision": "revise",
+      "claim": "Vendor X supplied the component in Incident Y",
+      "reason": "No supported path between 'Vendor X' and 'Incident Y'",
+      "required_evidence": [
+        "A path connecting 'Vendor X' and 'Incident Y' (e.g. a"
+        " supported_by/references relation)"
+      ]
+    }
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import deque
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+from parrot.knowledge.graphindex.context_builder import GraphContextBuilder
+from parrot.knowledge.graphindex.retriever import GraphExpandedRetriever
+from parrot.knowledge.graphindex.schema import stable_edge_id
+
+logger = logging.getLogger(__name__)
+
+
+class GroundingJudgement(BaseModel):
+    """Structured output of the optional LLM semantic check.
+
+    Args:
+        supported: Whether the cited paths actually support the claim
+            semantically (connectivity alone can be coincidental).
+        reason: One-sentence justification.
+        confidence: Judgement confidence in [0, 1].
+    """
+
+    supported: bool
+    reason: str = ""
+    confidence: float = Field(default=0.7, ge=0.0, le=1.0)
+
+
+class GroundingResult(BaseModel):
+    """Outcome of grounding one claim against the graph.
+
+    Args:
+        decision: ``"grounded"`` when supporting paths exist (and the
+            optional LLM judgement agrees); ``"revise"`` otherwise.
+        claim: The claim that was checked.
+        reason: Human-readable explanation of the decision.
+        entities: Resolved ``node_id`` of each claim entity found in the
+            graph.
+        unresolved_entities: Claim terms that could not be resolved
+            (only populated when resolution found nothing for them).
+        supported_paths: One list of stable edge ids per supporting
+            path (citable evidence).
+        contradictions: Stable edge ids of ``contradicts`` relations
+            touching the claim's entities.
+        required_evidence: When revising — the specific missing
+            entities/relations that would ground the claim.
+        confidence: Support confidence in [0, 1].
+    """
+
+    decision: Literal["grounded", "revise"]
+    claim: str
+    reason: str
+    entities: list[str] = Field(default_factory=list)
+    unresolved_entities: list[str] = Field(default_factory=list)
+    supported_paths: list[list[str]] = Field(default_factory=list)
+    contradictions: list[str] = Field(default_factory=list)
+    required_evidence: list[str] = Field(default_factory=list)
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+
+
+_JUDGEMENT_PROMPT = """Claim: {claim}
+
+Evidence paths found in a knowledge graph (each line is one relation):
+{paths}
+
+Question: do these relations, taken together, actually SUPPORT the claim
+semantically? Connectivity alone is not support — the relation kinds and
+directions must be consistent with what the claim states.
+"""
+
+
+class GroundingEvaluator:
+    """Check claims for edge-level support in a knowledge graph.
+
+    Args:
+        retriever: A :class:`GraphExpandedRetriever` over the graph
+            (supplies the graph, node models, and entity surface forms).
+        client: Optional ``AbstractClient``; when present, a structured
+            LLM judgement confirms that found paths semantically support
+            the claim (path existence alone can be coincidental).
+        max_hops: Maximum path length considered supporting evidence.
+    """
+
+    def __init__(
+        self,
+        retriever: GraphExpandedRetriever,
+        client: Optional[Any] = None,
+        max_hops: int = 2,
+    ) -> None:
+        self.retriever = retriever
+        self.client = client
+        self.max_hops = max_hops
+        self._builder = GraphContextBuilder(retriever)
+        self.logger = logging.getLogger(__name__)
+
+    # ------------------------------------------------------------------
+    # Graph helpers
+    # ------------------------------------------------------------------
+
+    def _adjacency(self) -> dict[str, list[tuple[str, str, str, str]]]:
+        """Undirected adjacency: node_id → [(other, src, dst, kind)]."""
+        adj: dict[str, list[tuple[str, str, str, str]]] = {}
+        graph = self.retriever.graph
+        for idx in graph.node_indices():
+            payload = graph[idx]
+            if not isinstance(payload, dict):
+                continue
+            for _s, _t, edge in graph.out_edges(idx):
+                if not isinstance(edge, dict):
+                    continue
+                src = edge.get("source_id")
+                dst = edge.get("target_id")
+                kind = edge.get("kind")
+                if not src or not dst or not kind:
+                    continue
+                adj.setdefault(src, []).append((dst, src, dst, kind))
+                adj.setdefault(dst, []).append((src, src, dst, kind))
+        return adj
+
+    def _find_path(
+        self,
+        adj: dict[str, list[tuple[str, str, str, str]]],
+        start: str,
+        goal: str,
+    ) -> Optional[list[tuple[str, str, str]]]:
+        """BFS for the shortest undirected path within ``max_hops``.
+
+        ``contradicts`` edges never count as supporting evidence.
+
+        Returns:
+            List of ``(src, dst, kind)`` triples, or ``None``.
+        """
+        if start == goal:
+            return []
+        queue: deque[tuple[str, list[tuple[str, str, str]]]] = deque(
+            [(start, [])]
+        )
+        visited = {start}
+        while queue:
+            current, path = queue.popleft()
+            if len(path) >= self.max_hops:
+                continue
+            for other, src, dst, kind in adj.get(current, []):
+                if kind == "contradicts":
+                    continue
+                if other in visited:
+                    continue
+                new_path = path + [(src, dst, kind)]
+                if other == goal:
+                    return new_path
+                visited.add(other)
+                queue.append((other, new_path))
+        return None
+
+    def _contradictions_touching(self, node_ids: set[str]) -> list[str]:
+        """Stable edge ids of contradicts-edges incident on the entities."""
+        found: list[str] = []
+        graph = self.retriever.graph
+        for idx in graph.node_indices():
+            payload = graph[idx]
+            if not isinstance(payload, dict):
+                continue
+            for _s, _t, edge in graph.out_edges(idx):
+                if not isinstance(edge, dict):
+                    continue
+                if edge.get("kind") != "contradicts":
+                    continue
+                src, dst = edge.get("source_id"), edge.get("target_id")
+                if src in node_ids or dst in node_ids:
+                    found.append(stable_edge_id(src, dst, "contradicts"))
+        return sorted(set(found))
+
+    def _titles(self) -> dict[str, str]:
+        return {n.node_id: n.title for n in self.retriever.nodes}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def ground_claim(self, claim: str) -> GroundingResult:
+        """Ground a claim against the graph.
+
+        Args:
+            claim: Natural-language claim to check.
+
+        Returns:
+            A :class:`GroundingResult` — grounded with cited edge paths,
+            or a structured revise instruction.
+        """
+        from parrot.knowledge.graphindex.context_builder import (
+            ContextBuildConfig,
+        )
+
+        entity_ids = await self._builder._resolve_entities(
+            claim, ContextBuildConfig()
+        )
+        titles = self._titles()
+
+        if len(entity_ids) < 2:
+            resolved = [titles.get(e, e) for e in entity_ids]
+            return GroundingResult(
+                decision="revise",
+                claim=claim,
+                reason=(
+                    "Fewer than two claim entities resolve to graph nodes"
+                    f" (resolved: {resolved or 'none'}) — the graph cannot"
+                    " evidence a relationship."
+                ),
+                entities=entity_ids,
+                required_evidence=[
+                    "Graph nodes for the entities the claim mentions"
+                    " (file them via create_concept / remember, or check"
+                    " the entity names)."
+                ],
+            )
+
+        adj = self._adjacency()
+        supported_paths: list[list[str]] = []
+        missing_pairs: list[tuple[str, str]] = []
+        # Check consecutive-pair connectivity (anchor entity to the rest).
+        anchor = entity_ids[0]
+        for other in entity_ids[1:]:
+            path = self._find_path(adj, anchor, other)
+            if path is None:
+                missing_pairs.append((anchor, other))
+            else:
+                supported_paths.append(
+                    [stable_edge_id(s, d, k) for s, d, k in path]
+                )
+
+        contradictions = self._contradictions_touching(set(entity_ids))
+
+        if missing_pairs:
+            required = [
+                f"A source-backed path connecting {titles.get(a, a)!r} and"
+                f" {titles.get(b, b)!r} (within {self.max_hops} hops)"
+                for a, b in missing_pairs
+            ]
+            return GroundingResult(
+                decision="revise",
+                claim=claim,
+                reason=(
+                    "No supported path between "
+                    + "; ".join(
+                        f"{titles.get(a, a)!r} and {titles.get(b, b)!r}"
+                        for a, b in missing_pairs
+                    )
+                ),
+                entities=entity_ids,
+                supported_paths=supported_paths,
+                contradictions=contradictions,
+                required_evidence=required,
+            )
+
+        # Optional LLM semantic judgement over the found paths.
+        confidence = 0.6 if self.client is None else 0.0
+        reason = "Supporting paths found for every claim entity pair."
+        if self.client is not None:
+            try:
+                serialized = "\n".join(
+                    f"- path {i + 1}: {line}"
+                    for i, line in enumerate(
+                        self._serialize_paths(entity_ids, adj)
+                    )
+                )
+                result = await self.client.invoke(
+                    _JUDGEMENT_PROMPT.format(claim=claim, paths=serialized),
+                    output_type=GroundingJudgement,
+                    system_prompt=(
+                        "You are a strict evidence judge for a knowledge"
+                        " graph. Only mark supported=true when the relations"
+                        " genuinely entail the claim."
+                    ),
+                )
+                judgement = getattr(result, "output", result)
+                if isinstance(judgement, dict):
+                    judgement = GroundingJudgement(**judgement)
+                if not judgement.supported:
+                    return GroundingResult(
+                        decision="revise",
+                        claim=claim,
+                        reason=f"Paths exist but do not support the claim:"
+                        f" {judgement.reason}",
+                        entities=entity_ids,
+                        supported_paths=supported_paths,
+                        contradictions=contradictions,
+                        required_evidence=[
+                            "Relations whose kinds/directions match what the"
+                            " claim states (current paths are topologically"
+                            " connected but semantically insufficient)."
+                        ],
+                        confidence=judgement.confidence,
+                    )
+                confidence = judgement.confidence
+                reason = judgement.reason or reason
+            except Exception as exc:  # noqa: BLE001 — judge is optional
+                self.logger.warning("grounding judgement failed: %s", exc)
+                confidence = 0.6
+
+        if contradictions:
+            reason += (
+                f" NOTE: {len(contradictions)} contradicts-relation(s) touch"
+                " these entities — review before relying on the claim."
+            )
+
+        return GroundingResult(
+            decision="grounded",
+            claim=claim,
+            reason=reason,
+            entities=entity_ids,
+            supported_paths=supported_paths,
+            contradictions=contradictions,
+            confidence=confidence,
+        )
+
+    def _serialize_paths(
+        self,
+        entity_ids: list[str],
+        adj: dict[str, list[tuple[str, str, str, str]]],
+    ) -> list[str]:
+        """Human-readable path lines for the LLM judge."""
+        titles = self._titles()
+        lines: list[str] = []
+        anchor = entity_ids[0]
+        for other in entity_ids[1:]:
+            path = self._find_path(adj, anchor, other)
+            if not path:
+                continue
+            hops = " ; ".join(
+                f"{titles.get(s, s)} -{k}-> {titles.get(d, d)}"
+                for s, d, k in path
+            )
+            lines.append(hops)
+        return lines

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/mixin.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/mixin.py
@@ -1,0 +1,228 @@
+"""GraphMemoryMixin — persistent knowledge-graph memory for bots.
+
+Opt-in mixin (modeled on ``EpisodicMemoryMixin``) that gives any bot a
+durable, per-agent knowledge graph: writes made through the graph tools
+survive process restarts ("the agent forgets, the graph does not"), and
+task-relevant subgraph context can be injected before each ask.
+
+Usage::
+
+    class MyAgent(GraphMemoryMixin, BasicAgent):
+        enable_graph_memory = True
+
+    # inside the bot's configure():
+    await self._configure_graph_memory()
+
+The graph plane lives at ``AGENTS_DIR/{agent_id}/graph_memory`` by
+default (same convention as ``kb/``, ``skills/``, ``episodic_data``),
+overridable via ``graph_memory_path``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class GraphMemoryMixin:
+    """Mixin that adds persistent graph memory to bots.
+
+    Configuration attributes (override in subclass or set via kwargs):
+        enable_graph_memory: Master toggle for the mixin.
+        graph_memory_path: Directory of the SQLite graph plane; defaults
+            to ``AGENTS_DIR/{agent_id}/graph_memory``.
+        graph_memory_tenant: Tenant id inside the plane (one ``.db`` per
+            tenant).
+        graph_memory_inject_context: Whether ``_build_graph_context``
+            should produce pre-ask context.
+        graph_memory_context_tokens: Token budget for injected context.
+        graph_memory_dimension: Embedding dimension for the default
+            offline embedder.
+    """
+
+    enable_graph_memory: bool = False
+    graph_memory_path: Optional[str] = None
+    graph_memory_tenant: str = "default"
+    graph_memory_inject_context: bool = True
+    graph_memory_context_tokens: int = 4000
+    graph_memory_dimension: int = 256
+
+    _graph_memory_toolkit: Any = None
+
+    # ------------------------------------------------------------------
+    # Configuration
+    # ------------------------------------------------------------------
+
+    def _get_graph_agent_id(self) -> str:
+        """Agent identifier used for attribution and the storage path."""
+        return str(getattr(self, "name", None) or "agent")
+
+    def _resolve_graph_memory_path(self) -> Optional[str]:
+        """Resolve the graph plane directory.
+
+        Priority: explicit ``graph_memory_path`` >
+        ``AGENTS_DIR/{agent_id}/graph_memory`` (the framework-wide
+        per-agent data convention).
+
+        Returns:
+            Resolved path string, or ``None`` when no location is
+            configured and ``AGENTS_DIR`` is unavailable.
+        """
+        if self.graph_memory_path is not None:
+            return self.graph_memory_path
+        agents_dir = None
+        if hasattr(self, "_resolve_agents_dir"):
+            agents_dir = self._resolve_agents_dir()
+        if agents_dir is None:
+            try:
+                from parrot.conf import AGENTS_DIR
+            except Exception:  # noqa: BLE001 — conf stack optional in tests
+                return None
+            if AGENTS_DIR is None:
+                return None
+            agents_dir = Path(AGENTS_DIR)
+        return str(Path(agents_dir) / self._get_graph_agent_id() / "graph_memory")
+
+    async def _configure_graph_memory(self) -> None:
+        """Open (or create) the persistent graph and register its tools.
+
+        Call this from the bot's ``configure()``. Idempotent — repeated
+        calls (multi-configure hosts) neither rebuild the toolkit nor
+        re-register tools.
+        """
+        if not self.enable_graph_memory:
+            return
+        if self._graph_memory_toolkit is not None:
+            return
+
+        path = self._resolve_graph_memory_path()
+        if path is None:
+            logger.warning(
+                "GraphMemoryMixin: no storage path resolvable — set "
+                "graph_memory_path or configure AGENTS_DIR."
+            )
+            return
+
+        tool_manager = getattr(self, "tool_manager", None)
+        if tool_manager is not None and tool_manager.get_tool(
+            "graph_history"
+        ) is not None:
+            return
+
+        try:
+            from parrot.knowledge.graphindex.factory import (
+                build_graph_memory_toolkit,
+            )
+
+            toolkit = await build_graph_memory_toolkit(
+                db_dir=Path(path),
+                tenant_id=self.graph_memory_tenant,
+                agent_id=self._get_graph_agent_id(),
+                client=getattr(self, "_llm", None),
+                dimension=self.graph_memory_dimension,
+            )
+            self._graph_memory_toolkit = toolkit
+
+            # Register the tools and expose the toolkit on the bot's
+            # knowledge-toolkit slot (same seam ToolInterface uses).
+            if tool_manager is not None:
+                for tool in toolkit.get_tools():
+                    tool_manager.register_tool(tool)
+            if hasattr(self, "_capture_knowledge_toolkit"):
+                self._capture_knowledge_toolkit(toolkit)
+            elif getattr(self, "_graphindex_toolkit", None) is None:
+                self._graphindex_toolkit = toolkit
+
+            logger.info(
+                "Graph memory configured: %s (tenant=%s, %d nodes)",
+                path,
+                self.graph_memory_tenant,
+                toolkit.graph.num_nodes(),
+            )
+        except Exception as exc:  # noqa: BLE001 — memory is optional
+            logger.error("GraphMemoryMixin configuration failed: %s", exc)
+            self._graph_memory_toolkit = None
+
+    # ------------------------------------------------------------------
+    # Ask-flow hooks
+    # ------------------------------------------------------------------
+
+    def set_graph_memory_run(self, run_id: Optional[str]) -> None:
+        """Stamp subsequent graph writes with a run/session id."""
+        if self._graph_memory_toolkit is not None:
+            self._graph_memory_toolkit.run_id = run_id
+
+    async def _build_graph_context(self, query: str) -> Optional[str]:
+        """Build pre-ask context from the agent's graph memory.
+
+        Returns ``None`` when the mixin is disabled, unconfigured, the
+        graph is empty, or context injection is switched off — callers
+        can append the result to the system prompt unconditionally.
+
+        Args:
+            query: The user query/task to ground.
+
+        Returns:
+            Markdown context text, or ``None``.
+        """
+        if (
+            not self.enable_graph_memory
+            or not self.graph_memory_inject_context
+            or self._graph_memory_toolkit is None
+        ):
+            return None
+        toolkit = self._graph_memory_toolkit
+        if toolkit.graph.num_nodes() == 0:
+            return None
+        try:
+            from parrot.knowledge.graphindex.context_builder import (
+                ContextBuildConfig,
+                GraphContextBuilder,
+            )
+            from parrot.knowledge.graphindex.retriever import (
+                GraphExpandedRetriever,
+            )
+
+            retriever = GraphExpandedRetriever(
+                graph=toolkit.graph,
+                nodes=toolkit.nodes,
+                embedder=toolkit.embedder,
+                signal_config=toolkit.signal_config,
+            )
+            builder = GraphContextBuilder(retriever)
+            context = await builder.build(
+                query,
+                ContextBuildConfig(
+                    max_tokens=self.graph_memory_context_tokens,
+                ),
+            )
+            if not context.node_ids:
+                return None
+            return context.text
+        except Exception as exc:  # noqa: BLE001 — context is best-effort
+            logger.warning("GraphMemoryMixin context build failed: %s", exc)
+            return None
+
+    # ------------------------------------------------------------------
+    # Maintenance
+    # ------------------------------------------------------------------
+
+    async def flush_graph_memory(self) -> None:
+        """Delete the persisted graph plane for this agent's tenant.
+
+        Removes the tenant's ``.db`` file (and its WAL/SHM sidecars).
+        The in-memory toolkit is dropped so the next
+        ``_configure_graph_memory`` starts from a clean slate.
+        """
+        path = self._resolve_graph_memory_path()
+        if path:
+            base = Path(path)
+            for suffix in ("", "-wal", "-shm"):
+                target = base / f"{self.graph_memory_tenant}.db{suffix}"
+                if target.exists():
+                    target.unlink()
+                    logger.info("Graph memory flush: removed %s", target)
+        self._graph_memory_toolkit = None

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/persist_sqlite.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/persist_sqlite.py
@@ -17,12 +17,17 @@ import logging
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Optional
+
+import uuid
 
 import aiosqlite
 import orjson
 
 from parrot.knowledge.graphindex.schema import (
+    AssertionMeta,
+    CommitReceipt,
+    GraphUpdate,
     UniversalEdge,
     UniversalNode,
 )
@@ -50,7 +55,8 @@ CREATE TABLE IF NOT EXISTS nodes (
     content_ref   TEXT,
     embedding_ref TEXT,
     provenance    TEXT NOT NULL,
-    domain_tags   TEXT
+    domain_tags   TEXT,
+    assertion     TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_nodes_source_uri ON nodes(source_uri);
 CREATE INDEX IF NOT EXISTS idx_nodes_parent     ON nodes(parent_id);
@@ -63,6 +69,7 @@ CREATE TABLE IF NOT EXISTS edges (
     provenance  TEXT NOT NULL,
     confidence  REAL,
     source_uri  TEXT,
+    assertion   TEXT,
     PRIMARY KEY (source_id, target_id, kind)
 );
 CREATE INDEX IF NOT EXISTS idx_edges_kind       ON edges(kind, source_id);
@@ -71,7 +78,39 @@ CREATE INDEX IF NOT EXISTS idx_edges_source_uri ON edges(source_uri);
 CREATE VIRTUAL TABLE IF NOT EXISTS nodes_fts USING fts5(
     node_id UNINDEXED, title, summary, tokenize = 'unicode61'
 );
+
+CREATE TABLE IF NOT EXISTS graph_commits (
+    commit_id    TEXT PRIMARY KEY,
+    op           TEXT NOT NULL,
+    agent_id     TEXT,
+    run_id       TEXT,
+    asserted_by  TEXT NOT NULL,
+    reason       TEXT,
+    committed_at TEXT NOT NULL,
+    payload      TEXT NOT NULL,
+    reverted_at  TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_commits_run   ON graph_commits(run_id);
+CREATE INDEX IF NOT EXISTS idx_commits_agent ON graph_commits(agent_id);
+
+CREATE TABLE IF NOT EXISTS graph_commit_items (
+    commit_id  TEXT NOT NULL,
+    item_type  TEXT NOT NULL,
+    item_key   TEXT NOT NULL,
+    prior      TEXT,
+    PRIMARY KEY (commit_id, item_type, item_key)
+);
+CREATE INDEX IF NOT EXISTS idx_commit_items_key ON graph_commit_items(item_type, item_key);
 """
+
+# Columns added after the original FEAT-240 schema shipped.  ``CREATE TABLE
+# IF NOT EXISTS`` silently skips existing databases, so ``_migrate`` ALTERs
+# these in when missing (idempotent, no data rewrite).
+_MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = {
+    "nodes": [("assertion", "TEXT")],
+    "edges": [("assertion", "TEXT")],
+    "graph_commits": [("reverted_at", "TEXT")],
+}
 
 
 def _now_iso() -> str:
@@ -82,6 +121,18 @@ def _now_iso() -> str:
 def _tags_json(node: UniversalNode) -> str:
     """Serialize a node's domain_tags to a JSON string via orjson."""
     return orjson.dumps(node.domain_tags).decode()
+
+
+def _assertion_json(item: UniversalNode | UniversalEdge) -> str | None:
+    """Serialize a node/edge ``assertion`` to JSON, or ``None`` when absent."""
+    if item.assertion is None:
+        return None
+    return orjson.dumps(item.assertion.model_dump(exclude_none=True)).decode()
+
+
+def _edge_key(source_id: str, target_id: str, kind: str) -> str:
+    """Compose the canonical ``item_key`` string for an edge."""
+    return f"{source_id}|{target_id}|{kind}"
 
 
 class SQLitePersistence:
@@ -134,8 +185,28 @@ class SQLitePersistence:
         async with aiosqlite.connect(str(self._db_path(ctx))) as conn:
             conn.row_factory = aiosqlite.Row
             await conn.executescript(_SCHEMA_SQL)
+            await self._migrate(conn)
             await conn.commit()
             yield conn
+
+    async def _migrate(self, conn: aiosqlite.Connection) -> None:
+        """Add columns that post-date the original schema when missing.
+
+        ``CREATE TABLE IF NOT EXISTS`` never alters existing tables, so
+        databases created before the assertion/audit columns shipped are
+        upgraded here via idempotent ``ALTER TABLE ... ADD COLUMN``.
+
+        Args:
+            conn: Open database connection (schema already ensured).
+        """
+        for table, columns in _MIGRATION_COLUMNS.items():
+            async with conn.execute(f"PRAGMA table_info({table})") as cur:
+                existing = {row["name"] for row in await cur.fetchall()}
+            for name, col_type in columns:
+                if name not in existing:
+                    await conn.execute(
+                        f"ALTER TABLE {table} ADD COLUMN {name} {col_type}"
+                    )
 
     async def _upsert_files(
         self,
@@ -214,8 +285,8 @@ class SQLitePersistence:
             await conn.executemany(
                 "INSERT OR REPLACE INTO nodes"
                 " (node_id, kind, title, source_uri, parent_id, summary,"
-                "  content_ref, embedding_ref, provenance, domain_tags)"
-                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "  content_ref, embedding_ref, provenance, domain_tags, assertion)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 [
                     (
                         n.node_id,
@@ -228,6 +299,7 @@ class SQLitePersistence:
                         n.embedding_ref,
                         n.provenance.value,
                         _tags_json(n),
+                        _assertion_json(n),
                     )
                     for n in nodes
                 ],
@@ -235,8 +307,9 @@ class SQLitePersistence:
 
             await conn.executemany(
                 "INSERT OR REPLACE INTO edges"
-                " (source_id, target_id, kind, provenance, confidence, source_uri)"
-                " VALUES (?, ?, ?, ?, ?, ?)",
+                " (source_id, target_id, kind, provenance, confidence,"
+                "  source_uri, assertion)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?)",
                 [
                     (
                         e.source_id,
@@ -245,6 +318,7 @@ class SQLitePersistence:
                         e.provenance.value,
                         e.confidence,
                         None,
+                        _assertion_json(e),
                     )
                     for e in edges
                 ],
@@ -323,8 +397,8 @@ class SQLitePersistence:
             await conn.executemany(
                 "INSERT OR REPLACE INTO nodes"
                 " (node_id, kind, title, source_uri, parent_id, summary,"
-                "  content_ref, embedding_ref, provenance, domain_tags)"
-                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "  content_ref, embedding_ref, provenance, domain_tags, assertion)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 [
                     (
                         n.node_id,
@@ -337,6 +411,7 @@ class SQLitePersistence:
                         n.embedding_ref,
                         n.provenance.value,
                         _tags_json(n),
+                        _assertion_json(n),
                     )
                     for n in nodes
                 ],
@@ -354,12 +429,14 @@ class SQLitePersistence:
                     e.provenance.value,
                     e.confidence,
                     src_uri,
+                    _assertion_json(e),
                 ))
 
             await conn.executemany(
                 "INSERT OR REPLACE INTO edges"
-                " (source_id, target_id, kind, provenance, confidence, source_uri)"
-                " VALUES (?, ?, ?, ?, ?, ?)",
+                " (source_id, target_id, kind, provenance, confidence,"
+                "  source_uri, assertion)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?)",
                 edge_rows,
             )
 
@@ -427,3 +504,484 @@ class SQLitePersistence:
             if row["mtime"] != mtime:
                 return True
             return False
+
+    # ------------------------------------------------------------------
+    # Agent write path — GraphUpdate commits (durable graph memory)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _row_to_node(row: aiosqlite.Row) -> Optional[UniversalNode]:
+        """Rehydrate a ``UniversalNode`` from a nodes-table row.
+
+        Returns ``None`` (with a warning) when the row carries an enum
+        value unknown to this code version — forward compatibility with
+        databases written by newer versions.
+        """
+        try:
+            assertion = None
+            raw_assertion = row["assertion"] if "assertion" in row.keys() else None
+            if raw_assertion:
+                assertion = AssertionMeta(**orjson.loads(raw_assertion))
+            return UniversalNode(
+                node_id=row["node_id"],
+                kind=row["kind"],
+                title=row["title"],
+                source_uri=row["source_uri"],
+                parent_id=row["parent_id"],
+                summary=row["summary"],
+                content_ref=row["content_ref"],
+                embedding_ref=row["embedding_ref"],
+                provenance=row["provenance"],
+                domain_tags=orjson.loads(row["domain_tags"]) if row["domain_tags"] else {},
+                assertion=assertion,
+            )
+        except Exception as exc:  # noqa: BLE001 — skip-and-warn on unknown kinds
+            logger.warning(
+                "SQLitePersistence: skipping unreadable node row %r: %s",
+                row["node_id"] if "node_id" in row.keys() else "?",
+                exc,
+            )
+            return None
+
+    @staticmethod
+    def _row_to_edge(row: aiosqlite.Row) -> Optional[UniversalEdge]:
+        """Rehydrate a ``UniversalEdge`` from an edges-table row.
+
+        Returns ``None`` (with a warning) on unknown enum values.
+        """
+        try:
+            assertion = None
+            raw_assertion = row["assertion"] if "assertion" in row.keys() else None
+            if raw_assertion:
+                assertion = AssertionMeta(**orjson.loads(raw_assertion))
+            return UniversalEdge(
+                source_id=row["source_id"],
+                target_id=row["target_id"],
+                kind=row["kind"],
+                provenance=row["provenance"],
+                confidence=row["confidence"],
+                assertion=assertion,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "SQLitePersistence: skipping unreadable edge row (%r → %r): %s",
+                row["source_id"] if "source_id" in row.keys() else "?",
+                row["target_id"] if "target_id" in row.keys() else "?",
+                exc,
+            )
+            return None
+
+    async def load_graph(
+        self,
+        ctx: TenantContext,
+    ) -> tuple[list[UniversalNode], list[UniversalEdge]]:
+        """Load and rehydrate the full tenant graph as schema models.
+
+        Rows with enum values unknown to this code version are skipped
+        with a warning instead of raising, so an older library can still
+        open a database written by a newer one.
+
+        Args:
+            ctx: Tenant context.
+
+        Returns:
+            ``(nodes, edges)`` lists of validated models. Empty lists
+            when the database does not exist yet.
+        """
+        if not self._db_path(ctx).exists():
+            return [], []
+        nodes: list[UniversalNode] = []
+        edges: list[UniversalEdge] = []
+        async with self._connect(ctx) as conn:
+            async with conn.execute("SELECT * FROM nodes") as cur:
+                async for row in cur:
+                    node = self._row_to_node(row)
+                    if node is not None:
+                        nodes.append(node)
+            async with conn.execute("SELECT * FROM edges") as cur:
+                async for row in cur:
+                    edge = self._row_to_edge(row)
+                    if edge is not None:
+                        edges.append(edge)
+        return nodes, edges
+
+    async def apply_update(
+        self,
+        ctx: TenantContext,
+        update: GraphUpdate,
+    ) -> CommitReceipt:
+        """Apply a :class:`GraphUpdate` in one audited transaction.
+
+        Captures the pre-image of every touched row into
+        ``graph_commit_items`` (enabling :meth:`revert_commit`), upserts
+        nodes and edges, deletes ``removed_edges``, refreshes the FTS
+        rows for exactly the written nodes (never the whole index), and
+        records the commit with its full payload snapshot.
+
+        Args:
+            ctx: Tenant context.
+            update: The validated update batch to apply.
+
+        Returns:
+            A :class:`CommitReceipt` describing the recorded commit.
+        """
+        commit_id = uuid.uuid4().hex[:16]
+        committed_at = _now_iso()
+        warnings: list[str] = []
+
+        async with self._connect(ctx) as conn:
+            # --- capture pre-images -----------------------------------
+            node_keys = [(n.node_id, "node") for n in update.nodes] + [
+                (node_id, "node_removed") for node_id in update.removed_nodes
+            ]
+            for node_id, item_type in node_keys:
+                async with conn.execute(
+                    "SELECT * FROM nodes WHERE node_id = ?", (node_id,)
+                ) as cur:
+                    row = await cur.fetchone()
+                prior = orjson.dumps(dict(row)).decode() if row else None
+                await conn.execute(
+                    "INSERT OR REPLACE INTO graph_commit_items"
+                    " (commit_id, item_type, item_key, prior) VALUES (?, ?, ?, ?)",
+                    (commit_id, item_type, node_id, prior),
+                )
+            # Incident edges of removed nodes are implicitly removed —
+            # capture them so the removal is fully revertible.
+            implicit_removed: list[tuple[str, str, str]] = []
+            for node_id in update.removed_nodes:
+                async with conn.execute(
+                    "SELECT source_id, target_id, kind FROM edges"
+                    " WHERE source_id = ? OR target_id = ?",
+                    (node_id, node_id),
+                ) as cur:
+                    for row in await cur.fetchall():
+                        implicit_removed.append(
+                            (row["source_id"], row["target_id"], row["kind"])
+                        )
+            removed_edge_set = {
+                tuple(t) for t in update.removed_edges
+            } | set(implicit_removed)
+
+            edge_triples = [
+                (e.source_id, e.target_id, e.kind.value) for e in update.edges
+            ] + sorted(removed_edge_set)
+            for src, tgt, kind in edge_triples:
+                async with conn.execute(
+                    "SELECT * FROM edges WHERE source_id = ? AND target_id = ?"
+                    " AND kind = ?",
+                    (src, tgt, kind),
+                ) as cur:
+                    row = await cur.fetchone()
+                prior = orjson.dumps(dict(row)).decode() if row else None
+                item_type = (
+                    "edge_removed" if (src, tgt, kind) in removed_edge_set else "edge"
+                )
+                await conn.execute(
+                    "INSERT OR REPLACE INTO graph_commit_items"
+                    " (commit_id, item_type, item_key, prior) VALUES (?, ?, ?, ?)",
+                    (commit_id, item_type, _edge_key(src, tgt, kind), prior),
+                )
+
+            # --- apply writes -----------------------------------------
+            if update.nodes:
+                await conn.executemany(
+                    "INSERT OR REPLACE INTO nodes"
+                    " (node_id, kind, title, source_uri, parent_id, summary,"
+                    "  content_ref, embedding_ref, provenance, domain_tags,"
+                    "  assertion)"
+                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    [
+                        (
+                            n.node_id,
+                            n.kind.value,
+                            n.title,
+                            n.source_uri,
+                            n.parent_id,
+                            n.summary,
+                            n.content_ref,
+                            n.embedding_ref,
+                            n.provenance.value,
+                            _tags_json(n),
+                            _assertion_json(n),
+                        )
+                        for n in update.nodes
+                    ],
+                )
+                # Partial FTS refresh — only the nodes in this update.
+                await self._insert_nodes_fts(conn, update.nodes)
+            if update.edges:
+                await conn.executemany(
+                    "INSERT OR REPLACE INTO edges"
+                    " (source_id, target_id, kind, provenance, confidence,"
+                    "  source_uri, assertion)"
+                    " VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    [
+                        (
+                            e.source_id,
+                            e.target_id,
+                            e.kind.value,
+                            e.provenance.value,
+                            e.confidence,
+                            None,
+                            _assertion_json(e),
+                        )
+                        for e in update.edges
+                    ],
+                )
+            for src, tgt, kind in sorted(removed_edge_set):
+                await conn.execute(
+                    "DELETE FROM edges WHERE source_id = ? AND target_id = ?"
+                    " AND kind = ?",
+                    (src, tgt, kind),
+                )
+            for node_id in update.removed_nodes:
+                await conn.execute(
+                    "DELETE FROM nodes WHERE node_id = ?", (node_id,)
+                )
+                await conn.execute(
+                    "DELETE FROM nodes_fts WHERE node_id = ?", (node_id,)
+                )
+
+            # --- record the commit ------------------------------------
+            await conn.execute(
+                "INSERT INTO graph_commits"
+                " (commit_id, op, agent_id, run_id, asserted_by, reason,"
+                "  committed_at, payload)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    commit_id,
+                    update.op,
+                    update.agent_id,
+                    update.run_id,
+                    update.asserted_by,
+                    update.reason,
+                    committed_at,
+                    orjson.dumps(update.model_dump(mode="json")).decode(),
+                ),
+            )
+            await conn.commit()
+
+        logger.info(
+            "SQLitePersistence.apply_update: commit %s (%s) — %d nodes,"
+            " %d edges, %d removed",
+            commit_id,
+            update.op,
+            len(update.nodes),
+            len(update.edges),
+            len(update.removed_edges),
+        )
+        return CommitReceipt(
+            commit_id=commit_id,
+            op=update.op,
+            node_ids=[n.node_id for n in update.nodes] + list(update.removed_nodes),
+            edge_keys=[
+                (e.source_id, e.target_id, e.kind.value) for e in update.edges
+            ]
+            + sorted(removed_edge_set),
+            committed_at=committed_at,
+            warnings=warnings,
+        )
+
+    async def get_commit(
+        self,
+        ctx: TenantContext,
+        commit_id: str,
+    ) -> Optional[dict[str, Any]]:
+        """Return a recorded commit with its payload and items.
+
+        Args:
+            ctx: Tenant context.
+            commit_id: The commit to fetch.
+
+        Returns:
+            A dict with the commit row, decoded ``payload`` and its
+            ``items``, or ``None`` when unknown.
+        """
+        async with self._connect(ctx) as conn:
+            async with conn.execute(
+                "SELECT * FROM graph_commits WHERE commit_id = ?", (commit_id,)
+            ) as cur:
+                row = await cur.fetchone()
+            if row is None:
+                return None
+            commit = dict(row)
+            commit["payload"] = orjson.loads(commit["payload"])
+            async with conn.execute(
+                "SELECT item_type, item_key, prior FROM graph_commit_items"
+                " WHERE commit_id = ?",
+                (commit_id,),
+            ) as cur:
+                commit["items"] = [dict(r) for r in await cur.fetchall()]
+            return commit
+
+    async def list_commits(
+        self,
+        ctx: TenantContext,
+        run_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """List recorded commits, newest first.
+
+        Args:
+            ctx: Tenant context.
+            run_id: Optional filter on the producing run.
+            agent_id: Optional filter on the producing agent.
+            limit: Maximum rows returned.
+
+        Returns:
+            Commit rows (payload omitted for brevity) as dicts.
+        """
+        if not self._db_path(ctx).exists():
+            return []
+        clauses: list[str] = []
+        params: list[Any] = []
+        if run_id is not None:
+            clauses.append("run_id = ?")
+            params.append(run_id)
+        if agent_id is not None:
+            clauses.append("agent_id = ?")
+            params.append(agent_id)
+        where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+        params.append(int(limit))
+        async with self._connect(ctx) as conn:
+            async with conn.execute(
+                "SELECT commit_id, op, agent_id, run_id, asserted_by, reason,"
+                f" committed_at, reverted_at FROM graph_commits{where}"
+                " ORDER BY committed_at DESC, commit_id DESC LIMIT ?",
+                params,
+            ) as cur:
+                return [dict(r) for r in await cur.fetchall()]
+
+    async def revert_commit(
+        self,
+        ctx: TenantContext,
+        commit_id: str,
+    ) -> dict[str, Any]:
+        """Restore the pre-images captured by a commit.
+
+        Rows that had a pre-image are restored to it; rows created by the
+        commit (no pre-image) are deleted. The revert is refused when a
+        LATER commit touched any of the same item keys — reverting would
+        silently clobber the newer write.
+
+        Args:
+            ctx: Tenant context.
+            commit_id: The commit to revert.
+
+        Returns:
+            ``{"status": "reverted", ...}`` on success or
+            ``{"error": ...}`` on refusal/unknown commit.
+        """
+        async with self._connect(ctx) as conn:
+            async with conn.execute(
+                "SELECT committed_at, reverted_at FROM graph_commits"
+                " WHERE commit_id = ?",
+                (commit_id,),
+            ) as cur:
+                commit_row = await cur.fetchone()
+            if commit_row is None:
+                return {"error": f"revert_commit: unknown commit {commit_id!r}"}
+            if commit_row["reverted_at"]:
+                return {"error": f"revert_commit: {commit_id!r} already reverted"}
+
+            async with conn.execute(
+                "SELECT item_type, item_key, prior FROM graph_commit_items"
+                " WHERE commit_id = ?",
+                (commit_id,),
+            ) as cur:
+                items = [dict(r) for r in await cur.fetchall()]
+            if not items:
+                return {"error": f"revert_commit: commit {commit_id!r} has no items"}
+
+            # Refuse when a later commit touched any of the same keys.
+            # Ordering uses the commits table's implicit rowid — the
+            # ISO timestamp only has 1-second resolution.
+            conflicts: list[str] = []
+            for item in items:
+                item_key = item["item_key"]
+                async with conn.execute(
+                    "SELECT c.commit_id FROM graph_commit_items i"
+                    " JOIN graph_commits c ON c.commit_id = i.commit_id"
+                    " WHERE i.item_key = ? AND i.commit_id != ?"
+                    "  AND c.reverted_at IS NULL"
+                    "  AND c.rowid > (SELECT rowid FROM graph_commits"
+                    "                 WHERE commit_id = ?)",
+                    (item_key, commit_id, commit_id),
+                ) as cur:
+                    later = await cur.fetchall()
+                if later:
+                    conflicts.append(item_key)
+            if conflicts:
+                return {
+                    "error": "revert_commit: later commits touched the same items",
+                    "conflicts": sorted(set(conflicts)),
+                }
+
+            restored, deleted = 0, 0
+            for item in items:
+                prior = orjson.loads(item["prior"]) if item["prior"] else None
+                if item["item_type"] in ("node", "node_removed"):
+                    if prior is None:
+                        await conn.execute(
+                            "DELETE FROM nodes WHERE node_id = ?",
+                            (item["item_key"],),
+                        )
+                        await conn.execute(
+                            "DELETE FROM nodes_fts WHERE node_id = ?",
+                            (item["item_key"],),
+                        )
+                        deleted += 1
+                    else:
+                        columns = list(prior.keys())
+                        await conn.execute(
+                            f"INSERT OR REPLACE INTO nodes ({', '.join(columns)})"
+                            f" VALUES ({', '.join('?' for _ in columns)})",
+                            [prior[c] for c in columns],
+                        )
+                        await conn.execute(
+                            "INSERT OR REPLACE INTO nodes_fts"
+                            " (node_id, title, summary) VALUES (?, ?, ?)",
+                            (
+                                prior.get("node_id"),
+                                prior.get("title", ""),
+                                prior.get("summary") or "",
+                            ),
+                        )
+                        restored += 1
+                else:  # edge / edge_removed
+                    src, tgt, kind = item["item_key"].split("|", 2)
+                    if prior is None:
+                        await conn.execute(
+                            "DELETE FROM edges WHERE source_id = ?"
+                            " AND target_id = ? AND kind = ?",
+                            (src, tgt, kind),
+                        )
+                        deleted += 1
+                    else:
+                        columns = list(prior.keys())
+                        await conn.execute(
+                            f"INSERT OR REPLACE INTO edges ({', '.join(columns)})"
+                            f" VALUES ({', '.join('?' for _ in columns)})",
+                            [prior[c] for c in columns],
+                        )
+                        restored += 1
+
+            await conn.execute(
+                "UPDATE graph_commits SET reverted_at = ? WHERE commit_id = ?",
+                (_now_iso(), commit_id),
+            )
+            await conn.commit()
+
+        logger.info(
+            "SQLitePersistence.revert_commit: %s — %d restored, %d deleted",
+            commit_id,
+            restored,
+            deleted,
+        )
+        return {
+            "status": "reverted",
+            "commit_id": commit_id,
+            "restored": restored,
+            "deleted": deleted,
+        }

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/projection.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/projection.py
@@ -60,6 +60,11 @@ NODE_KIND_TO_CONCEPT_TYPE: dict[NodeKind, ConceptType] = {
     NodeKind.CONCEPT: ConceptType.CONCEPT_NODE,
     NodeKind.RATIONALE: ConceptType.RATIONALE,
     NodeKind.SKILL: ConceptType.SKILL,
+    # Wiki pages carry their real category in domain_tags; the OKF
+    # open-vocabulary fallback is the honest sidecar type here.
+    NodeKind.WIKI_PAGE: ConceptType.OTHER,
+    NodeKind.RUN: ConceptType.RUN,
+    NodeKind.CLAIM: ConceptType.CLAIM,
 }
 
 EDGE_KIND_TO_RELATION_TYPE: dict[EdgeKind, RelationType] = {
@@ -69,6 +74,10 @@ EDGE_KIND_TO_RELATION_TYPE: dict[EdgeKind, RelationType] = {
     EdgeKind.MENTIONS: RelationType.MENTIONS,
     EdgeKind.EXPLAINS: RelationType.EXPLAINS,
     EdgeKind.EXTENDS: RelationType.EXTENDS,
+    EdgeKind.PRODUCED: RelationType.PRODUCED,
+    EdgeKind.ABOUT: RelationType.ABOUT,
+    EdgeKind.SUPPORTED_BY: RelationType.SUPPORTED_BY,
+    EdgeKind.CONTRADICTS: RelationType.CONTRADICTS,
 }
 
 # ---------------------------------------------------------------------------

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/publish.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/publish.py
@@ -1,0 +1,149 @@
+"""GraphPublisher — the durable write path for agent graph memory.
+
+Implements the "publish pattern" for knowledge graphs used as persistent
+shared agent memory: workers submit a validated :class:`GraphUpdate`
+(nodes + edges + attribution), the publisher stamps assertion metadata
+onto every unattributed item, and the persistence backend applies the
+whole batch in one audited, revertible transaction.
+
+The publisher is duck-typed over its ``persistence`` dependency — any
+backend exposing ``apply_update`` / ``get_commit`` / ``list_commits`` /
+``revert_commit`` works (``SQLitePersistence`` today; the ArangoDB
+``GraphIndexPersistence`` can implement the same protocol later).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from parrot.knowledge.graphindex.schema import (
+    AssertionMeta,
+    CommitReceipt,
+    GraphUpdate,
+    Provenance,
+)
+from parrot.knowledge.ontology.schema import TenantContext
+
+logger = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string."""
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+00:00")
+
+
+class GraphPublisher:
+    """Validate, attribute, and durably commit agent graph writes.
+
+    Args:
+        persistence: Backend implementing the commit protocol
+            (``apply_update``, ``get_commit``, ``list_commits``,
+            ``revert_commit``). ``SQLitePersistence`` satisfies it.
+        ctx: Tenant context identifying the target graph.
+    """
+
+    def __init__(self, persistence: Any, ctx: TenantContext) -> None:
+        self.persistence = persistence
+        self.ctx = ctx
+        self.logger = logging.getLogger(__name__)
+
+    def _stamp(self, update: GraphUpdate) -> None:
+        """Stamp assertion metadata onto every unattributed node/edge.
+
+        Items that already carry an ``assertion`` keep it (extraction
+        pipelines may pre-attribute). Nodes/edges without one receive an
+        :class:`AssertionMeta` built from the update's attribution.
+
+        Provenance handling: agent-minted nodes (``agent://`` source
+        URIs) and non-INFERRED edges are marked ``Provenance.ASSERTED``.
+        Pipeline-extracted nodes an agent merely annotates keep their
+        original provenance — the assertion metadata alone records who
+        touched them. ``INFERRED`` items are never re-labeled (their
+        ``confidence`` semantics depend on it).
+
+        Args:
+            update: The update to stamp (mutated in place).
+        """
+        meta = AssertionMeta(
+            asserted_by=update.asserted_by,
+            asserted_at=_now_iso(),
+            agent_id=update.agent_id,
+            run_id=update.run_id,
+            source=update.source,
+        )
+        for node in update.nodes:
+            if node.assertion is None:
+                node.assertion = meta
+                if (
+                    node.provenance == Provenance.EXTRACTED
+                    and node.source_uri.startswith("agent://")
+                ):
+                    node.provenance = Provenance.ASSERTED
+        for edge in update.edges:
+            if edge.assertion is None:
+                edge.assertion = meta
+                if edge.provenance == Provenance.EXTRACTED:
+                    edge.provenance = Provenance.ASSERTED
+
+    async def publish(self, update: GraphUpdate) -> CommitReceipt:
+        """Stamp attribution onto the update and commit it durably.
+
+        Args:
+            update: The validated batch of graph writes.
+
+        Returns:
+            The :class:`CommitReceipt` recorded by the backend.
+        """
+        self._stamp(update)
+        receipt = await self.persistence.apply_update(self.ctx, update)
+        self.logger.info(
+            "GraphPublisher.publish: commit %s (%s) by %s",
+            receipt.commit_id,
+            update.op,
+            update.asserted_by,
+        )
+        return receipt
+
+    async def get_commit(self, commit_id: str) -> Optional[dict[str, Any]]:
+        """Fetch one recorded commit (payload + items) by id.
+
+        Args:
+            commit_id: The commit identifier.
+
+        Returns:
+            The commit dict, or ``None`` when unknown.
+        """
+        return await self.persistence.get_commit(self.ctx, commit_id)
+
+    async def list_commits(
+        self,
+        run_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """List recorded commits, newest first.
+
+        Args:
+            run_id: Optional filter on the producing run.
+            agent_id: Optional filter on the producing agent.
+            limit: Maximum rows returned.
+
+        Returns:
+            Commit summary dicts.
+        """
+        return await self.persistence.list_commits(
+            self.ctx, run_id=run_id, agent_id=agent_id, limit=limit
+        )
+
+    async def revert_commit(self, commit_id: str) -> dict[str, Any]:
+        """Revert a commit by restoring its captured pre-images.
+
+        Args:
+            commit_id: The commit to revert.
+
+        Returns:
+            ``{"status": "reverted", ...}`` or ``{"error": ...}``.
+        """
+        return await self.persistence.revert_commit(self.ctx, commit_id)

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/retriever.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/retriever.py
@@ -63,6 +63,10 @@ class ExpansionConfig(BaseModel):
         include_community_centroids: When ``True`` and a ``CommunitiesResult``
             is available, add the centroid node of each touched community to
             the result set if not already present.
+        allowed_edge_kinds: When set, expansion only traverses edges whose
+            ``kind`` is in this list (e.g. ``["references", "explains"]``).
+            ``None`` (default) traverses every edge — the pre-existing
+            behavior.
     """
 
     max_hops: int = Field(default=2, ge=1, le=4)
@@ -70,6 +74,7 @@ class ExpansionConfig(BaseModel):
     min_signal_threshold: float = Field(default=0.1, ge=0.0)
     max_expanded_nodes: int = Field(default=50, ge=1)
     include_community_centroids: bool = False
+    allowed_edge_kinds: Optional[list[str]] = None
 
 
 class BudgetConfig(BaseModel):
@@ -406,19 +411,40 @@ class GraphExpandedRetriever:
                 if parent_idx is None:
                     continue
 
+                allowed_kinds = (
+                    set(config.allowed_edge_kinds)
+                    if config.allowed_edge_kinds
+                    else None
+                )
+
+                def _edge_allowed(payload: Any) -> bool:
+                    if allowed_kinds is None:
+                        return True
+                    return (
+                        isinstance(payload, dict)
+                        and payload.get("kind") in allowed_kinds
+                    )
+
                 if parent_idx is not None:
                     out_neighbors = [
                         self.graph[t].get("node_id")
-                        for _s, t, _ in self.graph.out_edges(parent_idx)
-                        if isinstance(self.graph[t], dict)
+                        for _s, t, e in self.graph.out_edges(parent_idx)
+                        if isinstance(self.graph[t], dict) and _edge_allowed(e)
                     ]
                     in_neighbors = [
                         self.graph[s].get("node_id")
-                        for s, _t, _ in self.graph.in_edges(parent_idx)
-                        if isinstance(self.graph[s], dict)
+                        for s, _t, e in self.graph.in_edges(parent_idx)
+                        if isinstance(self.graph[s], dict) and _edge_allowed(e)
                     ]
                     all_adj = [nid for nid in (out_neighbors + in_neighbors) if nid]
-                    if len(all_adj) > 100:
+                    if allowed_kinds is not None:
+                        # Edge-kind filter active: the pool is always the
+                        # (filtered) adjacency, so expansion cannot leave
+                        # the allowed edge set via signal shortcuts.
+                        candidate_pool = all_adj[:100]
+                        if not candidate_pool:
+                            continue
+                    elif len(all_adj) > 100:
                         # Cap to first 100 neighbours to bound computation
                         candidate_pool = all_adj[:100]
 

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/schema.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/schema.py
@@ -23,11 +23,14 @@ class Provenance(str, Enum):
         INFERRED: Inferred via embedding similarity (cross-domain resolution).
         AMBIGUOUS: Extraction was attempted but produced uncertain results
             (e.g., dynamic code features, malformed input).
+        ASSERTED: Authored directly by an agent or human (persistent
+            graph memory writes). Attribution lives in ``AssertionMeta``.
     """
 
     EXTRACTED = "extracted"
     INFERRED = "inferred"
     AMBIGUOUS = "ambiguous"
+    ASSERTED = "asserted"
 
 
 class NodeKind(str, Enum):
@@ -73,6 +76,55 @@ class EdgeKind(str, Enum):
     EXTENDS = "extends"
 
 
+class AssertionMeta(BaseModel):
+    """Attribution metadata for an agent- or human-authored graph write.
+
+    Carried by nodes and edges whose knowledge was contributed directly
+    (``Provenance.ASSERTED``) rather than extracted from source material.
+    Keeping the assertion confidence here (instead of on
+    ``UniversalEdge.confidence``) avoids colliding with the
+    embedding-similarity semantics enforced by the edge validator.
+
+    Args:
+        asserted_by: Identity of the writer, e.g. ``"agent:<id>"``,
+            ``"human:<user>"`` or ``"cli:wikitoolkit"``.
+        asserted_at: ISO-8601 UTC timestamp of the write.
+        agent_id: Optional stable agent identifier.
+        run_id: Optional run/session identifier linking the write to the
+            execution that produced it (work-lineage audit).
+        source: Optional citation URI or page id supporting the assertion.
+        confidence: Optional self-reported confidence in [0, 1].
+    """
+
+    asserted_by: str
+    asserted_at: str
+    agent_id: Optional[str] = None
+    run_id: Optional[str] = None
+    source: Optional[str] = None
+    confidence: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+
+
+def stable_edge_id(source_id: str, target_id: str, kind: str) -> str:
+    """Return a stable, citable identifier for a graph edge.
+
+    The id is a SHA-1 prefix of ``"source::target::kind"`` so the same
+    logical edge always yields the same id — usable as a citation handle
+    in serialized graph context and grounding results.
+
+    Args:
+        source_id: ``node_id`` of the tail node.
+        target_id: ``node_id`` of the head node.
+        kind: Edge kind value (e.g. ``"references"``).
+
+    Returns:
+        A 12-character hex id.
+    """
+    import hashlib
+
+    raw = f"{source_id}::{target_id}::{kind}".encode("utf-8")
+    return hashlib.sha1(raw).hexdigest()[:12]
+
+
 class UniversalNode(BaseModel):
     """A node in the GraphIndex knowledge graph.
 
@@ -90,6 +142,9 @@ class UniversalNode(BaseModel):
             (e.g. ``{"symbol_type": "function"}``, ``{"flat": true}``).
         parent_id: Optional ``node_id`` of the logical parent node.
         provenance: How this node was created.
+        assertion: Attribution metadata when the node was authored by an
+            agent or human (``Provenance.ASSERTED``). ``None`` for
+            pipeline-extracted nodes.
     """
 
     node_id: str
@@ -102,6 +157,7 @@ class UniversalNode(BaseModel):
     domain_tags: dict = Field(default_factory=dict)
     parent_id: Optional[str] = None
     provenance: Provenance = Provenance.EXTRACTED
+    assertion: Optional[AssertionMeta] = None
 
 
 class UniversalEdge(BaseModel):
@@ -118,6 +174,10 @@ class UniversalEdge(BaseModel):
         provenance: How this edge was created.
         confidence: Cosine similarity score in [0, 1].  Required for
             ``INFERRED`` edges; must be ``None`` for others.
+        assertion: Attribution metadata when the edge was authored by an
+            agent or human (``Provenance.ASSERTED``). Assertion-level
+            confidence lives in ``AssertionMeta.confidence`` — it does
+            NOT interact with the similarity ``confidence`` field.
     """
 
     source_id: str
@@ -125,6 +185,7 @@ class UniversalEdge(BaseModel):
     kind: EdgeKind
     provenance: Provenance = Provenance.EXTRACTED
     confidence: Optional[float] = None
+    assertion: Optional[AssertionMeta] = None
 
     @model_validator(mode="after")
     def _validate_confidence_with_provenance(self) -> "UniversalEdge":
@@ -145,6 +206,63 @@ class UniversalEdge(BaseModel):
                 "confidence must be None when provenance is not INFERRED"
             )
         return self
+
+
+class GraphUpdate(BaseModel):
+    """A validated batch of graph writes published by an agent or human.
+
+    This is the unit of durable graph mutation (the "publish pattern"):
+    nodes and edges land in one transaction, and the update is recorded
+    as a commit linked to the run/agent that produced it so every write
+    is auditable and revertible.
+
+    Args:
+        nodes: Nodes to upsert.
+        edges: Edges to upsert.
+        removed_edges: ``(source_id, target_id, kind)`` triples to delete.
+        removed_nodes: ``node_id`` values to delete (e.g. the duplicate
+            side of a merge). Pre-images are captured so the removal is
+            revertible.
+        agent_id: Stable identifier of the writing agent.
+        run_id: Optional run/session identifier for work-lineage linkage.
+        asserted_by: Identity string stamped onto unattributed writes.
+        source: Optional citation URI supporting the whole update.
+        reason: Optional human-readable rationale (e.g. merge rationale).
+        op: Logical operation name (``create_node``, ``link_nodes``,
+            ``merge_nodes``, ``publish``, ...).
+    """
+
+    nodes: list[UniversalNode] = Field(default_factory=list)
+    edges: list[UniversalEdge] = Field(default_factory=list)
+    removed_edges: list[tuple[str, str, str]] = Field(default_factory=list)
+    removed_nodes: list[str] = Field(default_factory=list)
+    agent_id: str
+    run_id: Optional[str] = None
+    asserted_by: str
+    source: Optional[str] = None
+    reason: Optional[str] = None
+    op: str = "publish"
+
+
+class CommitReceipt(BaseModel):
+    """Outcome of a successfully applied :class:`GraphUpdate`.
+
+    Args:
+        commit_id: Unique identifier of the recorded commit.
+        op: Logical operation name copied from the update.
+        node_ids: ``node_id`` of every node upserted.
+        edge_keys: ``(source_id, target_id, kind)`` of every edge
+            upserted or removed.
+        committed_at: ISO-8601 UTC timestamp of the transaction.
+        warnings: Non-fatal issues encountered while applying the update.
+    """
+
+    commit_id: str
+    op: str
+    node_ids: list[str] = Field(default_factory=list)
+    edge_keys: list[tuple[str, str, str]] = Field(default_factory=list)
+    committed_at: str
+    warnings: list[str] = Field(default_factory=list)
 
 
 class SourceConfig(BaseModel):

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/schema.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/schema.py
@@ -44,6 +44,10 @@ class NodeKind(str, Enum):
         RATIONALE: Design rationale from docstring or tagged comment.
         SKILL: Skill definition parsed from a SKILL.md file.
         WIKI_PAGE: LLM-generated wiki page (FEAT-260 LLM Wiki).
+        RUN: An agent/crew execution (work lineage — links what a run
+            produced without collapsing lineage into domain knowledge).
+        CLAIM: A discrete assertion produced by a run, connectable to
+            the entities it is about and the sources supporting it.
     """
 
     DOCUMENT = "document"
@@ -53,6 +57,8 @@ class NodeKind(str, Enum):
     RATIONALE = "rationale"
     SKILL = "skill"
     WIKI_PAGE = "wiki_page"
+    RUN = "run"
+    CLAIM = "claim"
 
 
 class EdgeKind(str, Enum):
@@ -66,6 +72,11 @@ class EdgeKind(str, Enum):
         EXPLAINS: A rationale/docstring explains a symbol.
         EXTENDS: Odoo model inheritance — a class extends a canonical model
             node via ``_inherit`` or ``_inherits``. Added by FEAT-240.
+        PRODUCED: A run produced a claim/node (work lineage).
+        ABOUT: A claim is about an entity.
+        SUPPORTED_BY: A claim is supported by a source/page.
+        CONTRADICTS: Two claims/entities conflict — surfaced (never
+            hidden) by the context builder and grounding evaluator.
     """
 
     CONTAINS = "contains"
@@ -74,6 +85,10 @@ class EdgeKind(str, Enum):
     MENTIONS = "mentions"
     EXPLAINS = "explains"
     EXTENDS = "extends"
+    PRODUCED = "produced"
+    ABOUT = "about"
+    SUPPORTED_BY = "supported_by"
+    CONTRADICTS = "contradicts"
 
 
 class AssertionMeta(BaseModel):

--- a/packages/ai-parrot/src/parrot/knowledge/okf/ontology.py
+++ b/packages/ai-parrot/src/parrot/knowledge/okf/ontology.py
@@ -63,6 +63,10 @@ class ConceptType(str, Enum):
     WIKI_SYNTHESIS = "Wiki Synthesis"
     WIKI_OVERVIEW = "Wiki Overview"
 
+    # --- Work-lineage types (graph-knowledge-persistence) ---
+    RUN = "Run"
+    CLAIM = "Claim"
+
     # --- Open-vocabulary fallback (FEAT-216) ---
     # bundle.py maps unknown foreign OKF ``type`` values here on import;
     # the member was documented since FEAT-216 but never added, so any
@@ -102,6 +106,11 @@ class RelationType(str, Enum):
     # --- Wiki relation types (FEAT-260) ---
     SUMMARIZES = "summarizes"
     CONTRADICTS = "contradicts"
+
+    # --- Work-lineage relations (graph-knowledge-persistence) ---
+    PRODUCED = "produced"
+    ABOUT = "about"
+    SUPPORTED_BY = "supported_by"
 
 
 class RelatesTo(BaseModel):

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/claude_code/assets.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/claude_code/assets.py
@@ -85,9 +85,30 @@ Only fall back to Grep/Glob/Read (or shell search) once a clean query
 *and* a page/related follow-up have genuinely come up empty — and say
 so before you do. Consider `wikitoolkit build` if results look stale.
 
+**Saving knowledge (persistent memory).** The wiki is also your
+durable memory — what you save here survives this session and is
+found by future `wikitoolkit query` calls ("the agent forgets, the
+graph does not"). When you learn a durable fact, make a decision, or
+extract a lesson worth keeping, SAVE it:
+
+- `wikitoolkit remember "<fact>" --category [note|decision|lesson|concept]
+  [--title "<short title>"] [--link <page_id> --rel <relation>]` —
+  file new knowledge (idempotent: same title+category updates the
+  existing memory). Link it to the pages it is about.
+- `wikitoolkit note <page_id> "<text>"` — append an attributed,
+  dated note to an existing page.
+- `wikitoolkit link <src_id> <dst_id> --rel <relation>` — connect
+  two pages with a typed, asserted edge.
+- `wikitoolkit memories` — list saved memories;
+  `wikitoolkit audit` — the attributed write log.
+
+Save selectively: durable decisions, gotchas, and cross-file
+relationships — not session chatter. Every write is attributed and
+auditable.
+
 The `/parrotwiki` command wraps these (e.g. `/parrotwiki query how
-does ingest work`, `/parrotwiki --wiki` to export a human-readable
-markdown wiki).
+does ingest work`, `/parrotwiki remember <fact>`, `/parrotwiki --wiki`
+to export a human-readable markdown wiki).
 {CLAUDE_MD_END}
 """
 
@@ -97,7 +118,7 @@ markdown wiki).
 
 SLASH_COMMAND_MD = """---
 description: Query or maintain the repository LLM-wiki knowledge graph (wikitoolkit)
-argument-hint: [query <question> | page <id> | related <id> | status | build | --wiki [dir]]
+argument-hint: [query <question> | page <id> | related <id> | remember <fact> | note <id> <text> | link <a> <b> | memories | audit | status | build | --wiki [dir]]
 allowed-tools: Bash(wikitoolkit:*)
 ---
 
@@ -118,6 +139,17 @@ matching `wikitoolkit` command with Bash:
   neighbours connect.
 - `status` — run `wikitoolkit status` and report plane health.
 - `build` — run `wikitoolkit build` and report what changed.
+- `remember <fact>` — save durable knowledge: run
+  `wikitoolkit remember "<fact>" --category <note|decision|lesson|concept>`
+  (add `--title` for a short handle and `--link <page_id>` to connect
+  it to the pages it is about). Report the saved page id.
+- `note <id> <text>` — run `wikitoolkit note <id> "<text>"` to append
+  an attributed note to an existing page.
+- `link <a> <b>` — run `wikitoolkit link <a> <b> --rel <relation>`
+  to connect two pages (default relation `references`).
+- `memories` — run `wikitoolkit memories` and summarise what has
+  been saved.
+- `audit` — run `wikitoolkit audit` and summarise recent writes.
 - `--wiki [dir]` — build a human-readable markdown wiki from the
   graph: run `wikitoolkit export -o <dir>` (default `docs/wiki`) and
   list what was written.

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/cli.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/cli.py
@@ -1269,6 +1269,63 @@ def _sync_memory_to_graph(
         return None
 
 
+def _extract_into_graph(
+    root: Path,
+    config: WikiProjectConfig,
+    text: str,
+    source_uri: str,
+    asserted_by: str,
+    run_id: Optional[str],
+) -> Optional[dict[str, Any]]:
+    """Run LLM entity/relation extraction into the project graph plane.
+
+    Requires a ``WIKI_EXTRACT_LLM`` provider spec (env / .env, e.g.
+    ``anthropic:claude-haiku-4-5``). All heavyweight imports are lazy;
+    every failure degrades to ``None`` so the plain remember always
+    succeeds.
+
+    Returns:
+        Extraction summary dict, or ``None`` when unavailable/failed.
+    """
+    spec = _env_setting("WIKI_EXTRACT_LLM")
+    if not spec:
+        click.echo(
+            "[extract skipped: set WIKI_EXTRACT_LLM (e.g."
+            " 'anthropic:claude-haiku-4-5') to enable]"
+        )
+        return None
+    try:
+        from parrot.clients.factory import LLMFactory
+        from parrot.knowledge.graphindex.extractors.llm import LLMGraphExtractor
+        from parrot.knowledge.graphindex.factory import make_stub_tenant_context
+        from parrot.knowledge.graphindex.persist_sqlite import SQLitePersistence
+        from parrot.knowledge.graphindex.publish import GraphPublisher
+
+        client = LLMFactory.create(spec, model_args={"temperature": 0.0})
+        ctx = make_stub_tenant_context(config.wiki_name)
+        publisher = GraphPublisher(
+            SQLitePersistence(config.graph_path(root)), ctx
+        )
+        extractor = LLMGraphExtractor(client, publisher)
+        result = _run(
+            extractor.extract_and_publish(
+                text,
+                source_uri=source_uri,
+                agent_id=asserted_by.split(":", 1)[-1],
+                run_id=run_id,
+            )
+        )
+        return {
+            "entities": len(result.extracted.entities),
+            "relations": len(result.extracted.relations),
+            "nodes_written": len(result.update.nodes),
+            "commit_id": result.receipt.commit_id,
+        }
+    except Exception as exc:  # noqa: BLE001 — extraction is best-effort
+        click.echo(f"[extract failed: {exc}]")
+        return None
+
+
 @wiki.command()
 @click.argument("text")
 @path_option
@@ -1288,6 +1345,15 @@ def _sync_memory_to_graph(
 @click.option("--rel", default="references", help="Relation for --link edges.")
 @click.option("--source", "source_uri", default=None, help="Citation URI.")
 @click.option("--by", default=None, help="Identity asserting this memory.")
+@click.option(
+    "--extract",
+    "extract_",
+    is_flag=True,
+    help="Also run LLM entity/relation extraction over the text into the"
+    " project graph (requires sync_graph and a WIKI_EXTRACT_LLM provider"
+    " spec, e.g. 'anthropic:claude-haiku-4-5'; degrades to a plain"
+    " remember when unavailable).",
+)
 @click.option("--json", "as_json", is_flag=True, help="Emit raw JSON.")
 def remember(
     text: str,
@@ -1300,6 +1366,7 @@ def remember(
     rel: str,
     source_uri: Optional[str],
     by: Optional[str],
+    extract_: bool,
     as_json: bool,
 ) -> None:
     """Save a fact, decision, or lesson into the wiki (persistent memory).
@@ -1372,6 +1439,14 @@ def remember(
             linked, asserted_by, run_id,
         )
 
+    extraction: Optional[dict[str, Any]] = None
+    if extract_ and root is not None and config is not None:
+        extraction = _extract_into_graph(
+            root, config, text,
+            source_uri or f"wiki://{config.wiki_name}/{page_id}",
+            asserted_by, run_id,
+        )
+
     result = {
         "page_id": page_id,
         "title": resolved_title,
@@ -1383,6 +1458,8 @@ def remember(
     }
     if commit_id:
         result["graph_commit"] = commit_id
+    if extraction:
+        result["extraction"] = extraction
     if as_json:
         click.echo(json.dumps(result, indent=2))
         return
@@ -1396,6 +1473,12 @@ def remember(
         click.echo(f"  [skipped link: no page {target!r}]")
     if commit_id:
         click.echo(f"  graph commit: {commit_id}")
+    if extraction:
+        click.echo(
+            f"  extracted: {extraction.get('entities', 0)} entities,"
+            f" {extraction.get('relations', 0)} relations"
+            f" (commit {extraction.get('commit_id', '?')})"
+        )
 
 
 @wiki.command()

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/cli.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/cli.py
@@ -1692,6 +1692,76 @@ def audit(
             )
 
 
+@wiki.command()
+@click.argument("claim")
+@path_option
+@click.option("--json", "as_json", is_flag=True, help="Emit raw JSON.")
+def ground(
+    claim: str,
+    path_: Optional[str],
+    as_json: bool,
+) -> None:
+    """Check a claim against the project knowledge graph (grounding).
+
+    Requires the project graph plane (``.parrot/graph/``) created by
+    ``remember`` with ``sync_graph`` enabled or by ``--extract``.
+    Returns cited edge-level evidence, or a structured revise
+    instruction listing the missing evidence.
+    """
+    root, config = _resolve_project(path_)
+    graph_db = config.graph_path(root) / f"{config.wiki_name}.db"
+    if not graph_db.exists():
+        raise click.ClickException(
+            f"No graph plane at {graph_db}. Save graph-synced knowledge"
+            " first (enable sync_graph in .parrot/wiki.json, then"
+            " `wikitoolkit remember ...`)."
+        )
+    try:
+        from parrot.knowledge.graphindex.assemble import GraphAssembler
+        from parrot.knowledge.graphindex.factory import (
+            HashingGraphEmbedder,
+            make_stub_tenant_context,
+        )
+        from parrot.knowledge.graphindex.grounding import GroundingEvaluator
+        from parrot.knowledge.graphindex.persist_sqlite import SQLitePersistence
+        from parrot.knowledge.graphindex.retriever import GraphExpandedRetriever
+    except ImportError as exc:
+        raise click.ClickException(f"graphindex unavailable: {exc}") from exc
+
+    async def _ground() -> dict[str, Any]:
+        persistence = SQLitePersistence(config.graph_path(root))
+        ctx = make_stub_tenant_context(config.wiki_name)
+        nodes, edges = await persistence.load_graph(ctx)
+        assembler = GraphAssembler(tenant_id=config.wiki_name)
+        for node in nodes:
+            assembler.add_node(node)
+        for edge in edges:
+            assembler.add_edge(edge)
+        embedder = HashingGraphEmbedder()
+        if nodes:
+            await embedder.embed_nodes(nodes)
+        retriever = GraphExpandedRetriever(
+            graph=assembler.graph, nodes=nodes, embedder=embedder
+        )
+        result = await GroundingEvaluator(retriever).ground_claim(claim)
+        return result.model_dump()
+
+    data = _run(_ground())
+    if as_json:
+        click.echo(json.dumps(data, indent=2))
+        return
+    click.echo(f"Decision: {data['decision'].upper()}")
+    click.echo(f"Reason:   {data['reason']}")
+    if data.get("supported_paths"):
+        click.echo("Evidence paths (stable edge ids):")
+        for path in data["supported_paths"]:
+            click.echo(f"  - {' ; '.join(path)}")
+    if data.get("contradictions"):
+        click.echo(f"Contradictions: {', '.join(data['contradictions'])}")
+    for needed in data.get("required_evidence", []):
+        click.echo(f"Required: {needed}")
+
+
 @wiki.command(name="claude-hook", hidden=True)
 def claude_hook() -> None:
     """Claude Code PreToolUse hook runtime (reads stdin JSON).

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/cli.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/cli.py
@@ -1112,6 +1112,503 @@ def export(path_: Optional[str], output: str) -> None:
     )
 
 
+# --------------------------------------------------------------------------
+# Authoring / persistent-memory commands ("save things in the brain")
+# --------------------------------------------------------------------------
+
+def _authoring_identity(by: Optional[str]) -> str:
+    """Resolve who is asserting a write.
+
+    Precedence: explicit ``--by`` > ``CLAUDE_AGENT_ID`` /
+    ``PARROT_AGENT_ID`` env (prefixed ``agent:``) > the local user
+    (prefixed ``human:``).
+    """
+    import getpass
+    import os
+
+    if by:
+        return by
+    for env_name in ("CLAUDE_AGENT_ID", "PARROT_AGENT_ID"):
+        value = os.environ.get(env_name)
+        if value:
+            return f"agent:{value}"
+    try:
+        return f"human:{getpass.getuser()}"
+    except Exception:  # noqa: BLE001 — no user db in some containers
+        return "human:unknown"
+
+
+def _authoring_run_id() -> Optional[str]:
+    """Session/run identifier from the ambient environment, if any."""
+    import os
+
+    for env_name in ("CLAUDE_SESSION_ID", "PARROT_RUN_ID"):
+        value = os.environ.get(env_name)
+        if value:
+            return value
+    return None
+
+
+def _resolve_write_store(
+    path_: Optional[str],
+    store_opt: Optional[str],
+    backend_opt: Optional[str],
+) -> tuple[BaseWikiStore, Path, Optional[Path], Optional[WikiProjectConfig]]:
+    """Open a store for an authoring command, creating the plane lazily.
+
+    Same precedence as ``_resolve_read_store`` (``--store`` > ``--path``
+    project > ``WIKI_STORE`` env > auto-detected project), but a wiki
+    that was never built is initialised on first write instead of
+    aborting — remembering something must work from a blank slate.
+
+    Returns:
+        ``(store, storage_dir, root, config)`` — ``root``/``config`` are
+        ``None`` for ``--store`` targets (no project context).
+    """
+    store_override = store_opt
+    if not store_override and not path_:
+        store_override = _env_setting("WIKI_STORE")
+    if store_override:
+        backend = backend_opt or _env_setting("WIKI_STORE_BACKEND") or "sqlite"
+        storage_dir = Path(store_override).expanduser()
+        storage_dir.mkdir(parents=True, exist_ok=True)
+        return create_wiki_store(storage_dir, backend=backend), storage_dir, None, None
+    root, config = _resolve_project(path_)
+    return _open_store(root, config), config.storage_path(root), root, config
+
+
+def _sync_memory_to_graph(
+    root: Path,
+    config: WikiProjectConfig,
+    store: BaseWikiStore,
+    page_id: str,
+    title: str,
+    text: str,
+    links: list[tuple[str, str]],
+    asserted_by: str,
+    run_id: Optional[str],
+) -> Optional[str]:
+    """Mirror a remembered fact into the project's GraphIndex plane.
+
+    Publishes one audited commit containing a ``CONCEPT`` node for the
+    memory (plus stub nodes for linked wiki pages so no edge dangles)
+    into ``.parrot/graph/``. GraphIndex imports stay inside this
+    function so the wiki CLI works without the graphindex extra.
+
+    Returns:
+        The commit id, or ``None`` when sync failed/unavailable.
+    """
+    try:
+        from parrot.knowledge.graphindex.factory import make_stub_tenant_context
+        from parrot.knowledge.graphindex.persist_sqlite import SQLitePersistence
+        from parrot.knowledge.graphindex.publish import GraphPublisher
+        from parrot.knowledge.graphindex.schema import (
+            EdgeKind,
+            GraphUpdate,
+            NodeKind,
+            Provenance,
+            UniversalEdge,
+            UniversalNode,
+        )
+    except ImportError as exc:
+        click.echo(f"[graph sync skipped: graphindex unavailable — {exc}]")
+        return None
+
+    try:
+        ctx = make_stub_tenant_context(config.wiki_name)
+        persistence = SQLitePersistence(config.graph_path(root))
+        publisher = GraphPublisher(persistence, ctx)
+
+        nodes = [
+            UniversalNode(
+                node_id=page_id,
+                kind=NodeKind.CONCEPT,
+                title=title,
+                source_uri=f"wiki://{config.wiki_name}/{page_id}",
+                summary=text[:300],
+                provenance=Provenance.ASSERTED,
+            )
+        ]
+        edges = []
+        for target_id, rel in links:
+            target = _run(store.get_page(target_id, include_body=False))
+            if target is None:
+                continue
+            nodes.append(
+                UniversalNode(
+                    node_id=target_id,
+                    kind=NodeKind.CONCEPT,
+                    title=str(target.get("title") or target_id),
+                    source_uri=f"wiki://{config.wiki_name}/{target_id}",
+                    summary=str(target.get("summary") or "")[:300],
+                )
+            )
+            try:
+                kind = EdgeKind(rel)
+            except ValueError:
+                kind = EdgeKind.REFERENCES
+            edges.append(
+                UniversalEdge(source_id=page_id, target_id=target_id, kind=kind)
+            )
+        receipt = _run(
+            publisher.publish(
+                GraphUpdate(
+                    nodes=nodes,
+                    edges=edges,
+                    agent_id=asserted_by.split(":", 1)[-1],
+                    run_id=run_id,
+                    asserted_by=asserted_by,
+                    source=f"wiki://{config.wiki_name}/{page_id}",
+                    op="remember",
+                )
+            )
+        )
+        return receipt.commit_id
+    except Exception as exc:  # noqa: BLE001 — sync must never block the save
+        click.echo(f"[graph sync failed: {exc}]")
+        return None
+
+
+@wiki.command()
+@click.argument("text")
+@path_option
+@_store_options
+@click.option("--title", default=None, help="Short title (default: first line).")
+@click.option(
+    "--category",
+    default="note",
+    help="Memory category: note | decision | lesson | concept.",
+)
+@click.option(
+    "--link",
+    "links",
+    multiple=True,
+    help="Existing page id to link the memory to (repeatable).",
+)
+@click.option("--rel", default="references", help="Relation for --link edges.")
+@click.option("--source", "source_uri", default=None, help="Citation URI.")
+@click.option("--by", default=None, help="Identity asserting this memory.")
+@click.option("--json", "as_json", is_flag=True, help="Emit raw JSON.")
+def remember(
+    text: str,
+    path_: Optional[str],
+    store_opt: Optional[str],
+    backend_opt: Optional[str],
+    title: Optional[str],
+    category: str,
+    links: tuple[str, ...],
+    rel: str,
+    source_uri: Optional[str],
+    by: Optional[str],
+    as_json: bool,
+) -> None:
+    """Save a fact, decision, or lesson into the wiki (persistent memory).
+
+    The page id is a deterministic hash of title+category, so
+    re-remembering the same thing updates the existing memory instead of
+    duplicating it. With ``sync_graph`` enabled in ``.parrot/wiki.json``
+    the memory is also mirrored into the project's knowledge graph as an
+    audited commit.
+    """
+    import hashlib
+
+    store, storage_dir, root, config = _resolve_write_store(
+        path_, store_opt, backend_opt
+    )
+    asserted_by = _authoring_identity(by)
+    run_id = _authoring_run_id()
+
+    resolved_title = (title or text.strip().splitlines()[0][:80]).strip()
+    if not resolved_title:
+        raise click.ClickException("Cannot remember empty text.")
+    page_id = "mem-" + hashlib.sha1(
+        f"{resolved_title}::{category}".encode("utf-8")
+    ).hexdigest()[:12]
+
+    from parrot.knowledge.wiki.store import WikiPageRecord, estimate_tokens
+
+    existing = _run(store.get_page(page_id, include_body=False))
+    body = text if not source_uri else f"{text}\n\n> Source: {source_uri}"
+    _run(
+        store.upsert_pages([
+            WikiPageRecord(
+                concept_id=page_id,
+                node_id=page_id,
+                title=resolved_title,
+                category=category,
+                summary=text[:300],
+                body=body,
+                token_count=estimate_tokens(body),
+                origin="memory",
+                asserted_by=asserted_by,
+            )
+        ])
+    )
+
+    linked: list[tuple[str, str]] = []
+    skipped_links: list[str] = []
+    for target in links:
+        page = _run(store.get_page(target, include_body=False))
+        if page is None:
+            skipped_links.append(target)
+            continue
+        _run(store.add_edges([(page_id, page["concept_id"], rel, "asserted")]))
+        linked.append((page["concept_id"], rel))
+
+    from parrot.knowledge.wiki.bookkeeper import WikiBookkeeper
+
+    WikiBookkeeper().log_operation(
+        storage_dir,
+        "REMEMBER",
+        f"page_id: {page_id}, title: {resolved_title!r}, "
+        f"category: {category}, by: {asserted_by}"
+        + (f", run: {run_id}" if run_id else ""),
+    )
+
+    commit_id: Optional[str] = None
+    if root is not None and config is not None and config.sync_graph:
+        commit_id = _sync_memory_to_graph(
+            root, config, store, page_id, resolved_title, text,
+            linked, asserted_by, run_id,
+        )
+
+    result = {
+        "page_id": page_id,
+        "title": resolved_title,
+        "category": category,
+        "status": "updated" if existing else "created",
+        "asserted_by": asserted_by,
+        "linked": [t for t, _ in linked],
+        "skipped_links": skipped_links,
+    }
+    if commit_id:
+        result["graph_commit"] = commit_id
+    if as_json:
+        click.echo(json.dumps(result, indent=2))
+        return
+    click.echo(
+        f"{'Updated' if existing else 'Saved'} memory {page_id} "
+        f"({category}): {resolved_title!r}"
+    )
+    for target, rel_name in linked:
+        click.echo(f"  linked → {target} ({rel_name})")
+    for target in skipped_links:
+        click.echo(f"  [skipped link: no page {target!r}]")
+    if commit_id:
+        click.echo(f"  graph commit: {commit_id}")
+
+
+@wiki.command()
+@click.argument("page_id")
+@click.argument("text")
+@path_option
+@_store_options
+@click.option("--by", default=None, help="Identity asserting this note.")
+@click.option("--json", "as_json", is_flag=True, help="Emit raw JSON.")
+def note(
+    page_id: str,
+    text: str,
+    path_: Optional[str],
+    store_opt: Optional[str],
+    backend_opt: Optional[str],
+    by: Optional[str],
+    as_json: bool,
+) -> None:
+    """Append an attributed note to an existing wiki page."""
+    from datetime import datetime, timezone
+
+    store, storage_dir, _root, _config = _resolve_write_store(
+        path_, store_opt, backend_opt
+    )
+    page = _run(store.get_page(page_id, include_body=True))
+    if page is None:
+        raise click.ClickException(
+            f"Page {page_id!r} not found. Search first: wikitoolkit query \"...\""
+        )
+    asserted_by = _authoring_identity(by)
+    stamp = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+    body = str(page.get("body") or "")
+    body += f"\n\n> **Note ({stamp}, {asserted_by}):** {text}"
+
+    from parrot.knowledge.wiki.store import WikiPageRecord, estimate_tokens
+
+    _run(
+        store.upsert_pages([
+            WikiPageRecord(
+                concept_id=page["concept_id"],
+                node_id=page.get("node_id"),
+                title=page.get("title") or page["concept_id"],
+                category=page.get("category") or "concept",
+                summary=page.get("summary") or "",
+                body=body,
+                source_id=page.get("source_id"),
+                token_count=estimate_tokens(body),
+                origin=page.get("origin") or "ingest",
+                asserted_by=asserted_by,
+            )
+        ])
+    )
+    from parrot.knowledge.wiki.bookkeeper import WikiBookkeeper
+
+    WikiBookkeeper().log_operation(
+        storage_dir,
+        "NOTE",
+        f"page_id: {page['concept_id']}, by: {asserted_by}",
+    )
+    result = {"page_id": page["concept_id"], "status": "noted", "by": asserted_by}
+    if as_json:
+        click.echo(json.dumps(result, indent=2))
+    else:
+        click.echo(f"Noted on {page['concept_id']} (by {asserted_by}).")
+
+
+@wiki.command()
+@click.argument("src")
+@click.argument("dst")
+@path_option
+@_store_options
+@click.option("--rel", default="references", help="Edge relation.")
+@click.option("--by", default=None, help="Identity asserting this link.")
+@click.option("--json", "as_json", is_flag=True, help="Emit raw JSON.")
+def link(
+    src: str,
+    dst: str,
+    path_: Optional[str],
+    store_opt: Optional[str],
+    backend_opt: Optional[str],
+    rel: str,
+    by: Optional[str],
+    as_json: bool,
+) -> None:
+    """Connect two existing wiki pages with an asserted, typed edge."""
+    store, storage_dir, _root, _config = _resolve_write_store(
+        path_, store_opt, backend_opt
+    )
+    pages = {}
+    for label, cid in (("src", src), ("dst", dst)):
+        page = _run(store.get_page(cid, include_body=False))
+        if page is None:
+            raise click.ClickException(f"{label} page {cid!r} not found.")
+        pages[label] = page["concept_id"]
+    asserted_by = _authoring_identity(by)
+    _run(store.add_edges([(pages["src"], pages["dst"], rel, "asserted")]))
+
+    from parrot.knowledge.wiki.bookkeeper import WikiBookkeeper
+
+    WikiBookkeeper().log_operation(
+        storage_dir,
+        "LINK",
+        f"{pages['src']} -{rel}-> {pages['dst']}, by: {asserted_by}",
+    )
+    result = {
+        "src": pages["src"],
+        "dst": pages["dst"],
+        "rel": rel,
+        "status": "linked",
+        "by": asserted_by,
+    }
+    if as_json:
+        click.echo(json.dumps(result, indent=2))
+    else:
+        click.echo(f"Linked {pages['src']} -{rel}-> {pages['dst']}.")
+
+
+@wiki.command()
+@path_option
+@_store_options
+@click.option("--category", default=None, help="Filter by category.")
+@click.option("--limit", default=50, type=int, help="Maximum rows.")
+@click.option("--json", "as_json", is_flag=True, help="Emit raw JSON.")
+def memories(
+    path_: Optional[str],
+    store_opt: Optional[str],
+    backend_opt: Optional[str],
+    category: Optional[str],
+    limit: int,
+    as_json: bool,
+) -> None:
+    """List saved memories and agent-authored pages (newest first)."""
+    store, _storage_dir, _root, _config = _resolve_write_store(
+        path_, store_opt, backend_opt
+    )
+    rows = _run(
+        store.list_pages(
+            category=category, limit=limit, origin=["memory", "authored"]
+        )
+    )
+    if as_json:
+        click.echo(json.dumps(rows, indent=2, default=str))
+        return
+    if not rows:
+        click.echo("No memories saved yet. Save one: wikitoolkit remember \"...\"")
+        return
+    for row in rows:
+        click.echo(
+            f"{row['concept_id']}  [{row.get('category')}]"
+            f"  {row.get('title')!r}"
+            f"  — {row.get('asserted_by') or '?'} @ {row.get('updated_at')}"
+        )
+
+
+@wiki.command()
+@path_option
+@_store_options
+@click.option("--limit", default=30, type=int, help="Maximum entries per plane.")
+@click.option("--json", "as_json", is_flag=True, help="Emit raw JSON.")
+def audit(
+    path_: Optional[str],
+    store_opt: Optional[str],
+    backend_opt: Optional[str],
+    limit: int,
+    as_json: bool,
+) -> None:
+    """Show the wiki operation log and graph write commits (audit trail)."""
+    _store, storage_dir, root, config = _resolve_write_store(
+        path_, store_opt, backend_opt
+    )
+    from parrot.knowledge.wiki.bookkeeper import WikiBookkeeper
+
+    log_text = WikiBookkeeper().read_log(storage_dir, last_n=limit)
+
+    graph_commits: list[dict[str, Any]] = []
+    if root is not None and config is not None:
+        graph_db = config.graph_path(root) / f"{config.wiki_name}.db"
+        if graph_db.exists():
+            try:
+                from parrot.knowledge.graphindex.factory import (
+                    make_stub_tenant_context,
+                )
+                from parrot.knowledge.graphindex.persist_sqlite import (
+                    SQLitePersistence,
+                )
+
+                persistence = SQLitePersistence(config.graph_path(root))
+                ctx = make_stub_tenant_context(config.wiki_name)
+                graph_commits = _run(persistence.list_commits(ctx, limit=limit))
+            except Exception as exc:  # noqa: BLE001
+                click.echo(f"[graph audit unavailable: {exc}]")
+
+    if as_json:
+        click.echo(
+            json.dumps(
+                {"log": log_text.splitlines(), "graph_commits": graph_commits},
+                indent=2,
+                default=str,
+            )
+        )
+        return
+    click.echo("## Wiki operation log")
+    click.echo(log_text or "(empty)")
+    if graph_commits:
+        click.echo("\n## Graph write commits")
+        for c in graph_commits:
+            reverted = " [REVERTED]" if c.get("reverted_at") else ""
+            click.echo(
+                f"{c['commit_id']}  {c['op']}  by {c['asserted_by']}"
+                f"  @ {c['committed_at']}{reverted}"
+            )
+
+
 @wiki.command(name="claude-hook", hidden=True)
 def claude_hook() -> None:
     """Claude Code PreToolUse hook runtime (reads stdin JSON).

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/coding_agents.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/coding_agents.py
@@ -16,11 +16,13 @@ from typing import Any, TextIO
 NUDGE = (
     "This repository has an ai-parrot LLM-wiki. Before scanning source files, "
     "run `wikitoolkit query \"<focused question>\"`, then inspect a result "
-    "with `wikitoolkit page <id>` or `wikitoolkit related <id>`."
+    "with `wikitoolkit page <id>` or `wikitoolkit related <id>`. When you "
+    "learn a durable fact or decision, save it: "
+    "`wikitoolkit remember \"<fact>\" --category decision`."
 )
 SKILL = """---
 name: parrot-wiki
-description: Query the repository LLM-wiki before raw source scans.
+description: Query the repository LLM-wiki before raw source scans, and save durable knowledge into it.
 ---
 
 # Parrot Wiki
@@ -28,6 +30,14 @@ description: Query the repository LLM-wiki before raw source scans.
 Start codebase investigations with `wikitoolkit query \"<focused question>\"`,
 then use `wikitoolkit page <id>` and `wikitoolkit related <id>`. Fall back to
 raw search only after those paths are empty.
+
+The wiki is also persistent memory. When you learn a durable fact, make a
+decision, or extract a lesson worth keeping, save it with
+`wikitoolkit remember \"<fact>\" --category <note|decision|lesson|concept>`
+(add `--link <page_id>` to connect it to related pages). Annotate existing
+pages with `wikitoolkit note <id> \"<text>\"`, connect pages with
+`wikitoolkit link <a> <b> --rel <relation>`, and review saved knowledge via
+`wikitoolkit memories` / `wikitoolkit audit`.
 """
 
 _AGENTS = {

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/execution.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/execution.py
@@ -153,6 +153,7 @@ class ExecutionWikiRecorder:
         embedding_model: Any = None,
         body_max_chars: int = DEFAULT_BODY_MAX_CHARS,
         write_project_config: bool = True,
+        publisher: Any = None,
     ) -> None:
         self.storage_dir = Path(storage_dir)
         self.crew_name = crew_name
@@ -167,6 +168,11 @@ class ExecutionWikiRecorder:
         )
         # Last agent page per execution_id — source of the `follows` edge.
         self._last_agent_page: Dict[str, str] = {}
+        # Optional GraphPublisher — when present, runs are mirrored as
+        # RUN nodes in the knowledge graph and linked (run -produced->
+        # node) to every graph write carrying this run_id, connecting
+        # work lineage to domain knowledge without collapsing them.
+        self.publisher = publisher
         if write_project_config:
             self._write_project_config()
 
@@ -316,9 +322,107 @@ class ExecutionWikiRecorder:
                 token_count=estimate_tokens(body),
             )
             await self._store.upsert_pages([page])
+            await self._mirror_run_node(execution_id, method, task_text)
         except Exception as exc:  # noqa: BLE001
             self.logger.warning(
                 "Failed to record run start for '%s': %s", execution_id, exc
+            )
+
+    async def _mirror_run_node(
+        self,
+        execution_id: str,
+        method: str,
+        task_text: str,
+    ) -> None:
+        """Mirror the run as a RUN node in the knowledge graph.
+
+        No-op without a publisher; failure-tolerant like every recorder
+        path.
+        """
+        if self.publisher is None:
+            return
+        try:
+            from parrot.knowledge.graphindex.schema import (
+                GraphUpdate,
+                NodeKind,
+                Provenance,
+                UniversalNode,
+            )
+
+            node = UniversalNode(
+                node_id=f"run:{execution_id}",
+                kind=NodeKind.RUN,
+                title=f"{self.crew_name} run {execution_id}",
+                source_uri=f"wiki://crew:{self.crew_name}/run:{execution_id}",
+                summary=_clip(f"{method}: {task_text}".replace("\n", " "), 300),
+                provenance=Provenance.ASSERTED,
+            )
+            await self.publisher.publish(
+                GraphUpdate(
+                    nodes=[node],
+                    agent_id=self.crew_name,
+                    run_id=execution_id,
+                    asserted_by=f"crew:{self.crew_name}",
+                    op="record_run",
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            self.logger.warning(
+                "Failed to mirror run node for '%s': %s", execution_id, exc
+            )
+
+    async def _link_run_lineage(self, execution_id: str) -> None:
+        """Link ``(run) -produced-> (node)`` for the run's graph writes.
+
+        Finds every commit stamped with this ``run_id`` (skipping the
+        run-mirror commit itself) and links the run node to each node
+        those commits wrote — the paper's work-lineage/domain-knowledge
+        bridge. No-op without a publisher; failure-tolerant.
+        """
+        if self.publisher is None:
+            return
+        try:
+            from parrot.knowledge.graphindex.schema import (
+                EdgeKind,
+                GraphUpdate,
+                UniversalEdge,
+            )
+
+            run_node_id = f"run:{execution_id}"
+            commits = await self.publisher.list_commits(run_id=execution_id)
+            produced: list[str] = []
+            for commit in commits:
+                if commit.get("op") in ("record_run", "run_lineage"):
+                    continue
+                detail = await self.publisher.get_commit(commit["commit_id"])
+                if not detail:
+                    continue
+                for node in detail.get("payload", {}).get("nodes", []):
+                    node_id = node.get("node_id")
+                    if node_id and node_id != run_node_id:
+                        produced.append(node_id)
+            if not produced:
+                return
+            edges = [
+                UniversalEdge(
+                    source_id=run_node_id,
+                    target_id=node_id,
+                    kind=EdgeKind.PRODUCED,
+                )
+                for node_id in sorted(set(produced))
+            ]
+            await self.publisher.publish(
+                GraphUpdate(
+                    edges=edges,
+                    agent_id=self.crew_name,
+                    run_id=execution_id,
+                    asserted_by=f"crew:{self.crew_name}",
+                    op="run_lineage",
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            self.logger.warning(
+                "Failed to link run lineage for '%s': %s", execution_id, exc
             )
 
     async def record_agent_result(
@@ -497,6 +601,7 @@ class ExecutionWikiRecorder:
             await self._store.upsert_pages([page])
             await self._embed_pages([page])
             self._last_agent_page.pop(execution_id, None)
+            await self._link_run_lineage(execution_id)
         except Exception as exc:  # noqa: BLE001
             self.logger.warning(
                 "Failed to record run end for '%s': %s", execution_id, exc

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/file_store.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/file_store.py
@@ -347,6 +347,8 @@ class InMemoryWikiStore(BaseWikiStore):
                 "source_id",
                 "token_count",
                 "updated_at",
+                "origin",
+                "asserted_by",
             )
         }
 
@@ -374,6 +376,8 @@ class InMemoryWikiStore(BaseWikiStore):
                 "token_count": p.token_count or estimate_tokens(p.body),
                 "created_at": existing.get("created_at") or now,
                 "updated_at": now,
+                "origin": p.origin,
+                "asserted_by": p.asserted_by,
             }
             old_path = (
                 self._page_path(existing) if existing else None
@@ -386,13 +390,18 @@ class InMemoryWikiStore(BaseWikiStore):
         await self._persist_pages(rows)
         return len(rows)
 
-    async def add_edges(self, edges: list[tuple[str, str, str]]) -> int:
-        """Insert typed edges and re-persist affected source pages."""
+    async def add_edges(self, edges: list[tuple]) -> int:
+        """Insert typed edges and re-persist affected source pages.
+
+        Accepts ``(src, dst, rel)`` and ``(src, dst, rel, provenance)``
+        tuples; the in-memory index keeps only the typed triple.
+        """
         if not edges:
             return 0
         await self._ensure_loaded()
         touched: set[str] = set()
-        for src, dst, rel in edges:
+        for edge in edges:
+            src, dst, rel = edge[0], edge[1], edge[2]
             self._index_edge(src, dst, rel)
             touched.add(src)
         # relates_to lives in the source page's frontmatter
@@ -497,13 +506,15 @@ class InMemoryWikiStore(BaseWikiStore):
         self,
         category: Optional[str] = None,
         limit: int = 100,
+        origin: Optional[list[str]] = None,
     ) -> list[dict[str, Any]]:
-        """List page stubs, optionally filtered by category."""
+        """List page stubs, optionally filtered by category/origin."""
         await self._ensure_loaded()
         rows = [
             self._stub(p)
             for p in self._pages.values()
-            if category is None or p.get("category") == category
+            if (category is None or p.get("category") == category)
+            and (not origin or p.get("origin", "ingest") in origin)
         ]
         rows.sort(key=lambda r: str(r.get("updated_at") or ""), reverse=True)
         return rows[:limit]

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/project.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/project.py
@@ -53,6 +53,9 @@ class WikiProjectConfig(BaseModel):
         body_max_chars: Cap on stored page body length.
         max_file_kb: Files larger than this many KiB are skipped.
         claude: Claude Code integration settings.
+        sync_graph: When ``True``, authoring commands (``remember`` /
+            ``link``) also mirror their writes into the project's
+            GraphIndex plane (``.parrot/graph/``) as audited commits.
     """
 
     wiki_name: str = Field(default="codebase")
@@ -65,6 +68,11 @@ class WikiProjectConfig(BaseModel):
     claude: ClaudeIntegrationConfig = Field(
         default_factory=ClaudeIntegrationConfig
     )
+    sync_graph: bool = Field(default=False)
+
+    def graph_path(self, root: Path) -> Path:
+        """Directory of the project's GraphIndex plane (``.parrot/graph``)."""
+        return root / PARROT_DIR / "graph"
 
     def storage_path(self, root: Path) -> Path:
         """Resolve the wiki storage directory against the repo root."""

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/store.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/store.py
@@ -71,7 +71,9 @@ CREATE TABLE IF NOT EXISTS pages (
     source_id   TEXT,
     token_count INTEGER NOT NULL DEFAULT 0,
     created_at  TEXT NOT NULL,
-    updated_at  TEXT NOT NULL
+    updated_at  TEXT NOT NULL,
+    origin      TEXT NOT NULL DEFAULT 'ingest',
+    asserted_by TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_pages_category ON pages(category);
 CREATE INDEX IF NOT EXISTS idx_pages_source   ON pages(source_id);
@@ -97,6 +99,16 @@ CREATE TABLE IF NOT EXISTS embeddings (
     model      TEXT NOT NULL DEFAULT ''
 );
 """
+
+# Columns added after the original FEAT-260 schema shipped.  ``CREATE TABLE
+# IF NOT EXISTS`` silently skips existing databases, so ``_migrate`` ALTERs
+# these in when missing (idempotent, no data rewrite).
+_MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = {
+    "pages": [
+        ("origin", "TEXT NOT NULL DEFAULT 'ingest'"),
+        ("asserted_by", "TEXT"),
+    ],
+}
 
 _FTS_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
 
@@ -191,6 +203,11 @@ class WikiPageRecord(BaseModel):
         body: Full markdown body (lives in the DB — no sidecar reads).
         source_id: Originating source id (``sources.source_id``).
         token_count: Estimated token cost of the body.
+        origin: How the page came to exist — ``"ingest"`` (derived from
+            a source), ``"authored"`` (written by an agent tool), or
+            ``"memory"`` (saved via the ``remember`` authoring surface).
+        asserted_by: Identity of the writer for authored/memory pages,
+            e.g. ``"agent:<id>"`` or ``"human:<user>"``.
     """
 
     concept_id: str = Field(..., min_length=1)
@@ -201,6 +218,8 @@ class WikiPageRecord(BaseModel):
     body: str = ""
     source_id: Optional[str] = None
     token_count: int = Field(default=0, ge=0)
+    origin: str = "ingest"
+    asserted_by: Optional[str] = None
 
 
 def rank_by_cosine(
@@ -268,7 +287,7 @@ class BaseWikiStore(ABC):
     async def upsert_pages(self, pages: list[WikiPageRecord]) -> int: ...
 
     @abstractmethod
-    async def add_edges(self, edges: list[tuple[str, str, str]]) -> int: ...
+    async def add_edges(self, edges: list[tuple]) -> int: ...
 
     @abstractmethod
     async def replace_source_slice(
@@ -294,7 +313,10 @@ class BaseWikiStore(ABC):
 
     @abstractmethod
     async def list_pages(
-        self, category: Optional[str] = None, limit: int = 100
+        self,
+        category: Optional[str] = None,
+        limit: int = 100,
+        origin: Optional[list[str]] = None,
     ) -> list[dict[str, Any]]: ...
 
     @abstractmethod
@@ -434,6 +456,7 @@ class SQLiteWikiStore(BaseWikiStore):
         async with aiosqlite.connect(str(self._db_path)) as conn:
             conn.row_factory = aiosqlite.Row
             await conn.executescript(WIKI_SCHEMA_SQL)
+            await self._migrate(conn)
             await conn.execute(
                 "INSERT OR IGNORE INTO meta (key, value) VALUES (?, ?)",
                 ("schema_version", SCHEMA_VERSION),
@@ -446,6 +469,22 @@ class SQLiteWikiStore(BaseWikiStore):
             await conn.commit()
             yield conn
 
+    async def _migrate(self, conn: aiosqlite.Connection) -> None:
+        """Add columns that post-date the original schema when missing.
+
+        ``CREATE TABLE IF NOT EXISTS`` never alters existing tables, so
+        wiki databases created before the origin/asserted_by columns
+        shipped are upgraded here via idempotent ``ALTER TABLE``.
+        """
+        for table, columns in _MIGRATION_COLUMNS.items():
+            async with conn.execute(f"PRAGMA table_info({table})") as cur:
+                existing = {row["name"] for row in await cur.fetchall()}
+            for name, col_type in columns:
+                if name not in existing:
+                    await conn.execute(
+                        f"ALTER TABLE {table} ADD COLUMN {name} {col_type}"
+                    )
+
     async def _upsert_pages_conn(
         self,
         conn: aiosqlite.Connection,
@@ -456,13 +495,15 @@ class SQLiteWikiStore(BaseWikiStore):
         await conn.executemany(
             "INSERT INTO pages"
             " (concept_id, node_id, title, category, summary, body,"
-            "  source_id, token_count, created_at, updated_at)"
-            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            "  source_id, token_count, created_at, updated_at,"
+            "  origin, asserted_by)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
             " ON CONFLICT(concept_id) DO UPDATE SET"
             "  node_id=excluded.node_id, title=excluded.title,"
             "  category=excluded.category, summary=excluded.summary,"
             "  body=excluded.body, source_id=excluded.source_id,"
-            "  token_count=excluded.token_count, updated_at=excluded.updated_at",
+            "  token_count=excluded.token_count, updated_at=excluded.updated_at,"
+            "  origin=excluded.origin, asserted_by=excluded.asserted_by",
             [
                 (
                     p.concept_id,
@@ -475,6 +516,8 @@ class SQLiteWikiStore(BaseWikiStore):
                     p.token_count or estimate_tokens(p.body),
                     now,
                     now,
+                    p.origin,
+                    p.asserted_by,
                 )
                 for p in pages
             ],
@@ -492,12 +535,22 @@ class SQLiteWikiStore(BaseWikiStore):
     async def _insert_edges_conn(
         self,
         conn: aiosqlite.Connection,
-        edges: list[tuple[str, str, str]],
+        edges: list[tuple],
     ) -> None:
-        """Insert (src, dst, rel) edge tuples on an open connection."""
+        """Insert edge tuples on an open connection.
+
+        Accepts both ``(src, dst, rel)`` (provenance defaults to
+        ``'extracted'``) and ``(src, dst, rel, provenance)`` tuples —
+        the 4th element marks agent/human-authored edges ``'asserted'``.
+        """
+        rows = [
+            (e[0], e[1], e[2], e[3] if len(e) > 3 else "extracted")
+            for e in edges
+        ]
         await conn.executemany(
-            "INSERT OR REPLACE INTO edges (src, dst, rel) VALUES (?, ?, ?)",
-            edges,
+            "INSERT OR REPLACE INTO edges (src, dst, rel, provenance)"
+            " VALUES (?, ?, ?, ?)",
+            rows,
         )
 
     # ------------------------------------------------------------------
@@ -520,11 +573,13 @@ class SQLiteWikiStore(BaseWikiStore):
             await conn.commit()
         return len(pages)
 
-    async def add_edges(self, edges: list[tuple[str, str, str]]) -> int:
+    async def add_edges(self, edges: list[tuple]) -> int:
         """Insert typed edges.
 
         Args:
-            edges: ``(src, dst, rel)`` tuples; ``rel`` is an open string.
+            edges: ``(src, dst, rel)`` or ``(src, dst, rel, provenance)``
+                tuples; ``rel`` is an open string. A missing provenance
+                defaults to ``'extracted'``.
 
         Returns:
             Number of edges written.
@@ -690,7 +745,7 @@ class SQLiteWikiStore(BaseWikiStore):
         """
         cols = (
             "concept_id, node_id, title, category, summary, source_id,"
-            " token_count, created_at, updated_at"
+            " token_count, created_at, updated_at, origin, asserted_by"
         )
         if include_body:
             cols += ", body"
@@ -709,24 +764,36 @@ class SQLiteWikiStore(BaseWikiStore):
         self,
         category: Optional[str] = None,
         limit: int = 100,
+        origin: Optional[list[str]] = None,
     ) -> list[dict[str, Any]]:
-        """List page stubs (no bodies), optionally filtered by category.
+        """List page stubs (no bodies), optionally filtered.
 
         Args:
             category: Exact category pre-filter (open string).
             limit: Maximum rows returned.
+            origin: Optional origin filter, e.g. ``["memory", "authored"]``
+                to list only agent-saved knowledge.
 
         Returns:
             List of stub dicts ordered by ``updated_at`` (newest first).
         """
         sql = (
             "SELECT concept_id, node_id, title, category, summary,"
-            " source_id, token_count, updated_at FROM pages"
+            " source_id, token_count, updated_at, origin, asserted_by"
+            " FROM pages"
         )
+        clauses: list[str] = []
         params: tuple[Any, ...] = ()
         if category is not None:
-            sql += " WHERE category = ?"
-            params = (category,)
+            clauses.append("category = ?")
+            params += (category,)
+        if origin:
+            clauses.append(
+                f"origin IN ({', '.join('?' for _ in origin)})"
+            )
+            params += tuple(origin)
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
         sql += " ORDER BY updated_at DESC LIMIT ?"
         params += (limit,)
         async with self._connect() as conn:

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/toolkit.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/toolkit.py
@@ -78,6 +78,7 @@ class LLMWikiToolkit(AbstractToolkit):
         graphindex_toolkit: Any,
         okf_toolkit: Any,
         config: WikiConfig,
+        agent_id: str = "agent",
         **kwargs: Any,
     ) -> None:
         """Initialise the LLMWikiToolkit with composed dependencies.
@@ -87,6 +88,8 @@ class LLMWikiToolkit(AbstractToolkit):
             graphindex_toolkit: A ``GraphIndexToolkit`` instance for graph ops.
             okf_toolkit: An ``OKFToolkit`` instance for schema/lint ops.
             config: :class:`WikiConfig` for this wiki instance.
+            agent_id: Identity stamped (as ``agent:<id>``) onto pages the
+                agent authors via ``create_page`` / ``remember``.
             **kwargs: Forwarded to :class:`AbstractToolkit`.
         """
         super().__init__(**kwargs)
@@ -94,6 +97,7 @@ class LLMWikiToolkit(AbstractToolkit):
         self._gi = graphindex_toolkit
         self._okf = okf_toolkit
         self._config = config
+        self.agent_id = agent_id
 
         # Initialise helper components.  The WikiStore plane is the
         # retrieval backend — SQLite (storage_dir/wiki.db) or the
@@ -557,6 +561,8 @@ class LLMWikiToolkit(AbstractToolkit):
                 summary=content[:300],
                 body=content,
                 token_count=estimate_tokens(content),
+                origin="authored",
+                asserted_by=f"agent:{self.agent_id}",
             )
             await self._store.upsert_pages([record])
             if related_pages:
@@ -603,6 +609,10 @@ class LLMWikiToolkit(AbstractToolkit):
     ) -> dict[str, Any]:
         """Update the content of an existing wiki page.
 
+        Refreshes the WikiStore retrieval plane (row, FTS) so queries see
+        the new content immediately, and best-effort re-inserts the
+        markdown into the PageIndex authoring plane.
+
         Args:
             wiki_name: Wiki name containing the page.
             page_id: Node ID of the page to update.
@@ -610,12 +620,34 @@ class LLMWikiToolkit(AbstractToolkit):
             reason: Optional reason for the update (logged).
 
         Returns:
-            Dict with keys: page_id, status, reason.
+            Dict with keys: page_id, status, reason. ``status`` is
+            ``"not_found"`` when the page does not exist in the store.
         """
+        existing = await self._store.get_page(page_id, include_body=False)
+        if existing is None:
+            return {"page_id": page_id, "status": "not_found", "reason": reason}
+
+        # The WikiStore plane is the retrieval backend — update it first
+        # so FTS/queries never go stale (the pre-fix behavior only wrote
+        # the PageIndex tree, leaving this plane with the old body).
+        record = WikiPageRecord(
+            concept_id=existing["concept_id"],
+            node_id=existing.get("node_id"),
+            title=existing.get("title") or page_id,
+            category=existing.get("category") or "concept",
+            summary=content[:300],
+            body=content,
+            source_id=existing.get("source_id"),
+            token_count=estimate_tokens(content),
+            origin="authored",
+            asserted_by=f"agent:{self.agent_id}",
+        )
+        await self._store.upsert_pages([record])
+
         try:
             await self._pi.insert_markdown(wiki_name, content, doc_name=page_id)
         except Exception as exc:  # noqa: BLE001
-            self.logger.warning("update_page failed: %s", exc)
+            self.logger.warning("update_page PageIndex insert failed: %s", exc)
 
         await asyncio.to_thread(
             self._bookkeeper.log_operation,
@@ -624,6 +656,71 @@ class LLMWikiToolkit(AbstractToolkit):
             f"page_id: {page_id}, reason: {reason!r}",
         )
         return {"page_id": page_id, "status": "updated", "reason": reason}
+
+    async def remember(
+        self,
+        wiki_name: str,
+        text: str,
+        title: Optional[str] = None,
+        category: str = "note",
+        related_pages: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        """Save a fact, decision, or lesson into the wiki as durable memory.
+
+        The page id is a deterministic hash of the title/text, so
+        remembering the same thing twice updates the existing memory
+        instead of duplicating it. Links to related pages are recorded
+        as ``asserted`` edges.
+
+        Args:
+            wiki_name: Wiki to save the memory in.
+            text: The knowledge to remember (markdown allowed).
+            title: Optional short title; derived from the text when
+                omitted.
+            category: One of ``note``, ``decision``, ``lesson``,
+                ``concept`` (open string).
+            related_pages: Optional page ids to link the memory to.
+
+        Returns:
+            Dict with keys: page_id, title, category, status.
+        """
+        import hashlib
+
+        title = (title or text.strip().splitlines()[0][:80]).strip()
+        page_id = "mem-" + hashlib.sha1(
+            f"{title}::{category}".encode("utf-8")
+        ).hexdigest()[:12]
+
+        existing = await self._store.get_page(page_id, include_body=False)
+        record = WikiPageRecord(
+            concept_id=page_id,
+            node_id=page_id,
+            title=title,
+            category=category,
+            summary=text[:300],
+            body=text,
+            token_count=estimate_tokens(text),
+            origin="memory",
+            asserted_by=f"agent:{self.agent_id}",
+        )
+        await self._store.upsert_pages([record])
+        if related_pages:
+            await self._store.add_edges(
+                [(page_id, str(rp), "references", "asserted") for rp in related_pages]
+            )
+
+        await asyncio.to_thread(
+            self._bookkeeper.log_operation,
+            self._config_for(wiki_name).storage_dir,
+            "REMEMBER",
+            f"page_id: {page_id}, title: {title!r}, category: {category}",
+        )
+        return {
+            "page_id": page_id,
+            "title": title,
+            "category": category,
+            "status": "updated" if existing else "created",
+        }
 
     async def delete_page(
         self,

--- a/packages/ai-parrot/tests/knowledge/graphindex/test_context_builder.py
+++ b/packages/ai-parrot/tests/knowledge/graphindex/test_context_builder.py
@@ -1,0 +1,213 @@
+"""Tests for GraphContextBuilder and the GraphMemoryMixin.
+
+Uses the offline factory (deterministic hashing embedder + SQLite plane)
+so no model downloads or DBs are required.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from parrot.knowledge.graphindex.context_builder import (
+    ContextBuildConfig,
+    GraphContextBuilder,
+)
+from parrot.knowledge.graphindex.factory import build_graph_memory_toolkit
+from parrot.knowledge.graphindex.mixin import GraphMemoryMixin
+from parrot.knowledge.graphindex.retriever import (
+    ExpansionConfig,
+    GraphExpandedRetriever,
+)
+from parrot.knowledge.graphindex.schema import stable_edge_id
+
+
+async def _populated_toolkit(db_dir: Path):
+    """Toolkit with a small durable knowledge graph."""
+    tk = await build_graph_memory_toolkit(db_dir=db_dir, agent_id="ag")
+    bus = await tk.create_concept("EventBus", "publish subscribe hub for events")
+    svc = await tk.create_concept("OrderService", "emits order events onto the bus")
+    pol = await tk.create_concept("Deploy policy", "prod deploys need approval")
+    await tk.link_nodes(svc["node_id"], bus["node_id"], "references")
+    await tk.link_nodes(pol["node_id"], bus["node_id"], "mentions", confidence=0.4)
+    return tk, bus["node_id"], svc["node_id"], pol["node_id"]
+
+
+def _builder(tk) -> GraphContextBuilder:
+    retriever = GraphExpandedRetriever(
+        graph=tk.graph, nodes=tk.nodes, embedder=tk.embedder
+    )
+    return GraphContextBuilder(retriever)
+
+
+class TestContextBuilder:
+    async def test_entity_resolution_by_mention(self, tmp_path):
+        tk, bus_id, svc_id, _ = await _populated_toolkit(tmp_path)
+        ctx = await _builder(tk).build(
+            "How does OrderService publish to the EventBus?"
+        )
+        assert set(ctx.entities) == {bus_id, svc_id}
+
+    async def test_alias_mention_resolves(self, tmp_path):
+        tk, bus_id, _, _ = await _populated_toolkit(tmp_path)
+        await tk.tag_node(bus_id, "aliases", ["Message Hub"])
+        ctx = await _builder(tk).build("Where is the Message Hub configured?")
+        assert bus_id in ctx.entities
+
+    async def test_relations_carry_stable_edge_ids(self, tmp_path):
+        tk, bus_id, svc_id, _ = await _populated_toolkit(tmp_path)
+        ctx = await _builder(tk).build("OrderService and EventBus integration")
+        expected = stable_edge_id(svc_id, bus_id, "references")
+        assert expected in ctx.cited_edge_ids
+        assert f"[edge:{expected}]" in ctx.text
+
+    async def test_asserted_nodes_carry_attribution(self, tmp_path):
+        tk, _, _, _ = await _populated_toolkit(tmp_path)
+        ctx = await _builder(tk).build("EventBus knowledge")
+        assert "asserted by agent:ag" in ctx.text
+
+    async def test_budget_truncation(self, tmp_path):
+        tk, _, _, _ = await _populated_toolkit(tmp_path)
+        ctx = await _builder(tk).build(
+            "EventBus", ContextBuildConfig(max_tokens=200)
+        )
+        assert ctx.budget_used <= 200
+
+    async def test_edge_kind_filter_excludes_relations(self, tmp_path):
+        tk, bus_id, svc_id, pol_id = await _populated_toolkit(tmp_path)
+        ctx = await _builder(tk).build(
+            "OrderService EventBus Deploy policy",
+            ContextBuildConfig(allowed_edge_kinds=["references"]),
+        )
+        assert stable_edge_id(svc_id, bus_id, "references") in ctx.cited_edge_ids
+        assert stable_edge_id(pol_id, bus_id, "mentions") not in ctx.cited_edge_ids
+
+    async def test_conflicts_surfaced(self, tmp_path):
+        tk, bus_id, svc_id, _ = await _populated_toolkit(tmp_path)
+        # Force an ambiguous edge payload (conflict surface).
+        import rustworkx  # noqa: F401
+
+        src_idx = tk.node_map[bus_id]
+        for _s, _t, payload in tk.graph.out_edges(src_idx):
+            payload["provenance"] = "ambiguous"
+        ctx = await _builder(tk).build("EventBus OrderService Deploy policy")
+        # No outgoing edges from bus in fixture; add one and re-check via
+        # the svc->bus edge instead.
+        svc_idx = tk.node_map[svc_id]
+        for _s, _t, payload in tk.graph.out_edges(svc_idx):
+            payload["provenance"] = "ambiguous"
+        ctx = await _builder(tk).build("EventBus OrderService Deploy policy")
+        assert ctx.conflicts
+        assert "Conflicts / uncertain claims" in ctx.text
+
+
+class TestExpansionEdgeKindFilter:
+    async def test_expansion_respects_allowed_kinds(self, tmp_path):
+        tk, bus_id, svc_id, pol_id = await _populated_toolkit(tmp_path)
+        retriever = GraphExpandedRetriever(
+            graph=tk.graph, nodes=tk.nodes, embedder=tk.embedder
+        )
+        result = await retriever.search(
+            "publish subscribe hub for events",
+            seed_top_k=1,
+            expansion=ExpansionConfig(
+                max_hops=2, allowed_edge_kinds=["references"]
+            ),
+        )
+        ids = {n.node_id for n in result.nodes}
+        assert bus_id in ids
+        # pol is only reachable via a 'mentions' edge — must be excluded.
+        assert pol_id not in ids
+
+    async def test_expansion_default_traverses_all(self, tmp_path):
+        tk, bus_id, svc_id, pol_id = await _populated_toolkit(tmp_path)
+        retriever = GraphExpandedRetriever(
+            graph=tk.graph, nodes=tk.nodes, embedder=tk.embedder
+        )
+        result = await retriever.search(
+            "publish subscribe hub for events", seed_top_k=1
+        )
+        ids = {n.node_id for n in result.nodes}
+        assert pol_id in ids
+
+
+class _StubToolManager:
+    def __init__(self):
+        self.tools: dict[str, object] = {}
+
+    def get_tool(self, name):
+        return self.tools.get(name)
+
+    def register_tool(self, tool):
+        self.tools[tool.name] = tool
+
+
+class _MemoryBot(GraphMemoryMixin):
+    enable_graph_memory = True
+    name = "memo-agent"
+
+    def __init__(self, path: Path):
+        self.graph_memory_path = str(path)
+        self.tool_manager = _StubToolManager()
+
+
+class TestGraphMemoryMixin:
+    async def test_configure_registers_tools(self, tmp_path):
+        bot = _MemoryBot(tmp_path)
+        await bot._configure_graph_memory()
+        assert bot._graph_memory_toolkit is not None
+        assert bot.tool_manager.get_tool("graph_history") is not None
+        assert bot.tool_manager.get_tool("create_concept") is not None
+        # Exposed on the knowledge-toolkit slot too.
+        assert bot._graphindex_toolkit is bot._graph_memory_toolkit
+
+    async def test_configure_is_idempotent(self, tmp_path):
+        bot = _MemoryBot(tmp_path)
+        await bot._configure_graph_memory()
+        first = bot._graph_memory_toolkit
+        await bot._configure_graph_memory()
+        assert bot._graph_memory_toolkit is first
+
+    async def test_disabled_mixin_is_inert(self, tmp_path):
+        bot = _MemoryBot(tmp_path)
+        bot.enable_graph_memory = False
+        await bot._configure_graph_memory()
+        assert bot._graph_memory_toolkit is None
+        assert await bot._build_graph_context("anything") is None
+
+    async def test_memory_survives_restart_and_injects_context(self, tmp_path):
+        bot = _MemoryBot(tmp_path)
+        await bot._configure_graph_memory()
+        tk = bot._graph_memory_toolkit
+        await tk.create_concept("EventBus", "publish subscribe hub")
+
+        bot2 = _MemoryBot(tmp_path)
+        await bot2._configure_graph_memory()
+        context = await bot2._build_graph_context("Tell me about the EventBus")
+        assert context is not None
+        assert "EventBus" in context
+        assert "asserted by agent:memo-agent" in context
+
+    async def test_empty_graph_yields_no_context(self, tmp_path):
+        bot = _MemoryBot(tmp_path)
+        await bot._configure_graph_memory()
+        assert await bot._build_graph_context("anything") is None
+
+    async def test_run_id_stamping(self, tmp_path):
+        bot = _MemoryBot(tmp_path)
+        await bot._configure_graph_memory()
+        bot.set_graph_memory_run("run-42")
+        tk = bot._graph_memory_toolkit
+        await tk.create_concept("Fact", "something")
+        history = await tk.graph_history(run_id="run-42")
+        assert len(history) == 1
+
+    async def test_flush_clears_plane(self, tmp_path):
+        bot = _MemoryBot(tmp_path)
+        await bot._configure_graph_memory()
+        await bot._graph_memory_toolkit.create_concept("Fact", "x")
+        await bot.flush_graph_memory()
+        assert bot._graph_memory_toolkit is None
+
+        bot2 = _MemoryBot(tmp_path)
+        await bot2._configure_graph_memory()
+        assert bot2._graph_memory_toolkit.graph.num_nodes() == 0

--- a/packages/ai-parrot/tests/knowledge/graphindex/test_grounding.py
+++ b/packages/ai-parrot/tests/knowledge/graphindex/test_grounding.py
@@ -1,0 +1,183 @@
+"""Tests for the grounding evaluator and run→knowledge lineage linkage."""
+
+import pytest
+
+from parrot.knowledge.graphindex.factory import build_graph_memory_toolkit
+from parrot.knowledge.graphindex.grounding import (
+    GroundingEvaluator,
+    GroundingJudgement,
+)
+from parrot.knowledge.graphindex.retriever import GraphExpandedRetriever
+from parrot.knowledge.graphindex.schema import stable_edge_id
+
+
+async def _toolkit_with_graph(tmp_path):
+    tk = await build_graph_memory_toolkit(db_dir=tmp_path, agent_id="ag")
+    vendor = await tk.create_concept("Vendor X", "supplies pump components")
+    comp = await tk.create_concept("Component Z", "a hydraulic pump")
+    incident = await tk.create_concept("Incident Y", "pump failure event")
+    isolated = await tk.create_concept("Unrelated Topic", "nothing to do with it")
+    await tk.link_nodes(vendor["node_id"], comp["node_id"], "references")
+    await tk.link_nodes(comp["node_id"], incident["node_id"], "mentions", confidence=0.6)
+    return tk, vendor["node_id"], comp["node_id"], incident["node_id"], isolated["node_id"]
+
+
+def _evaluator(tk, client=None) -> GroundingEvaluator:
+    retriever = GraphExpandedRetriever(
+        graph=tk.graph, nodes=tk.nodes, embedder=tk.embedder
+    )
+    return GroundingEvaluator(retriever, client=client)
+
+
+class TestGroundClaim:
+    async def test_supported_claim_is_grounded_with_cited_edges(self, tmp_path):
+        tk, vendor, comp, incident, _ = await _toolkit_with_graph(tmp_path)
+        result = await _evaluator(tk).ground_claim(
+            "Vendor X supplied the Component Z involved in Incident Y"
+        )
+        assert result.decision == "grounded"
+        cited = {e for path in result.supported_paths for e in path}
+        assert stable_edge_id(vendor, comp, "references") in cited
+
+    async def test_unsupported_claim_returns_revise_contract(self, tmp_path):
+        tk, vendor, _, _, isolated = await _toolkit_with_graph(tmp_path)
+        result = await _evaluator(tk).ground_claim(
+            "Vendor X caused the Unrelated Topic"
+        )
+        assert result.decision == "revise"
+        assert result.required_evidence
+        assert "Vendor X" in result.reason
+        assert "Unrelated Topic" in result.reason
+
+    async def test_unknown_entities_revise(self, tmp_path):
+        tk, *_ = await _toolkit_with_graph(tmp_path)
+        result = await _evaluator(tk).ground_claim(
+            "The Flux Capacitor powers the Time Circuit"
+        )
+        assert result.decision == "revise"
+        assert result.required_evidence
+
+    async def test_contradictions_are_surfaced(self, tmp_path):
+        tk, vendor, comp, incident, _ = await _toolkit_with_graph(tmp_path)
+        await tk.link_nodes(incident["node_id"] if isinstance(incident, dict) else incident, vendor, "contradicts")
+        result = await _evaluator(tk).ground_claim(
+            "Vendor X supplied Component Z"
+        )
+        assert result.decision == "grounded"
+        assert result.contradictions
+        assert "contradicts" in result.reason or result.contradictions
+
+    async def test_contradicts_edges_never_support(self, tmp_path):
+        tk = await build_graph_memory_toolkit(db_dir=tmp_path, agent_id="ag")
+        a = await tk.create_concept("Claim A", "one side")
+        b = await tk.create_concept("Claim B", "other side")
+        await tk.link_nodes(a["node_id"], b["node_id"], "contradicts")
+        result = await _evaluator(tk).ground_claim("Claim A supports Claim B")
+        assert result.decision == "revise"
+
+    async def test_llm_judge_can_veto(self, tmp_path):
+        class _VetoClient:
+            async def invoke(self, prompt, *, output_type=None, **kw):
+                class _R:
+                    output = GroundingJudgement(
+                        supported=False, reason="direction mismatch"
+                    )
+                return _R()
+
+        tk, *_ = await _toolkit_with_graph(tmp_path)
+        result = await _evaluator(tk, client=_VetoClient()).ground_claim(
+            "Vendor X supplied Component Z"
+        )
+        assert result.decision == "revise"
+        assert "direction mismatch" in result.reason
+        assert result.supported_paths  # paths existed; semantics failed
+
+    async def test_llm_judge_confirms(self, tmp_path):
+        class _ConfirmClient:
+            async def invoke(self, prompt, *, output_type=None, **kw):
+                class _R:
+                    output = GroundingJudgement(
+                        supported=True, reason="entailed", confidence=0.9
+                    )
+                return _R()
+
+        tk, *_ = await _toolkit_with_graph(tmp_path)
+        result = await _evaluator(tk, client=_ConfirmClient()).ground_claim(
+            "Vendor X supplied Component Z"
+        )
+        assert result.decision == "grounded"
+        assert result.confidence == 0.9
+
+
+class TestToolkitGroundClaim:
+    async def test_ground_claim_tool(self, tmp_path):
+        tk, vendor, comp, *_ = await _toolkit_with_graph(tmp_path)
+        result = await tk.ground_claim("Vendor X supplied Component Z")
+        assert result["decision"] == "grounded"
+        assert result["supported_paths"]
+
+
+class TestRunLineage:
+    async def test_recorder_mirrors_run_and_links_produced(self, tmp_path):
+        from parrot.knowledge.graphindex.factory import make_stub_tenant_context
+        from parrot.knowledge.graphindex.persist_sqlite import SQLitePersistence
+        from parrot.knowledge.graphindex.publish import GraphPublisher
+        from parrot.knowledge.graphindex.schema import (
+            GraphUpdate,
+            NodeKind,
+            UniversalNode,
+        )
+        from parrot.knowledge.wiki.execution import ExecutionWikiRecorder
+
+        ctx = make_stub_tenant_context("crew-graph")
+        persistence = SQLitePersistence(tmp_path / "graph")
+        publisher = GraphPublisher(persistence, ctx)
+        recorder = ExecutionWikiRecorder(
+            storage_dir=tmp_path / "wiki",
+            crew_name="research-crew",
+            publisher=publisher,
+        )
+
+        await recorder.record_run_start(
+            "exec-1", "run_sequential", "investigate the pump failure"
+        )
+        # Simulate a knowledge write made during the run (same run_id).
+        await publisher.publish(
+            GraphUpdate(
+                nodes=[
+                    UniversalNode(
+                        node_id="claim-1",
+                        kind=NodeKind.CLAIM,
+                        title="Pump failed due to seal wear",
+                        source_uri="agent://claim/claim-1",
+                    )
+                ],
+                agent_id="research-crew",
+                run_id="exec-1",
+                asserted_by="crew:research-crew",
+            )
+        )
+        await recorder.record_run_end("exec-1", result="done")
+
+        nodes, edges = await persistence.load_graph(ctx)
+        by_id = {n.node_id: n for n in nodes}
+        assert by_id["run:exec-1"].kind.value == "run"
+        produced = [
+            (e.source_id, e.target_id)
+            for e in edges
+            if e.kind.value == "produced"
+        ]
+        assert ("run:exec-1", "claim-1") in produced
+        # The run node itself is never self-linked.
+        assert ("run:exec-1", "run:exec-1") not in produced
+
+    async def test_recorder_without_publisher_is_unchanged(self, tmp_path):
+        from parrot.knowledge.wiki.execution import ExecutionWikiRecorder
+
+        recorder = ExecutionWikiRecorder(
+            storage_dir=tmp_path / "wiki", crew_name="plain-crew"
+        )
+        await recorder.record_run_start("exec-2", "run_sequential", "task")
+        await recorder.record_run_end("exec-2", result="done")
+        page = await recorder.store.get_page("run:exec-2")
+        assert page is not None

--- a/packages/ai-parrot/tests/knowledge/graphindex/test_llm_extractor.py
+++ b/packages/ai-parrot/tests/knowledge/graphindex/test_llm_extractor.py
@@ -1,0 +1,219 @@
+"""Tests for LLM-typed graph extraction (stub client — no live LLM).
+
+Covers the ExtractedGraph contract, additive entity deduplication
+(exact/alias/fuzzy), relation resolution, durable publish + revert, and
+the toolkit's ``extract_knowledge`` in-memory mirror.
+"""
+
+import pytest
+
+from parrot.knowledge.graphindex.extractors.llm import (
+    ExtractedEntity,
+    ExtractedGraph,
+    ExtractedRelation,
+    LLMGraphExtractor,
+)
+from parrot.knowledge.graphindex.factory import (
+    build_graph_memory_toolkit,
+    make_stub_tenant_context,
+)
+from parrot.knowledge.graphindex.persist_sqlite import SQLitePersistence
+from parrot.knowledge.graphindex.publish import GraphPublisher
+from parrot.knowledge.graphindex.schema import Provenance
+
+
+class _StubInvokeResult:
+    def __init__(self, output):
+        self.output = output
+
+
+class _StubClient:
+    """AbstractClient double: invoke() returns a canned ExtractedGraph."""
+
+    def __init__(self, graph: ExtractedGraph):
+        self._graph = graph
+        self.calls: list[dict] = []
+
+    async def invoke(self, prompt, *, output_type=None, system_prompt=None, **kw):
+        self.calls.append({"prompt": prompt, "output_type": output_type})
+        return _StubInvokeResult(self._graph)
+
+
+def _sample_graph() -> ExtractedGraph:
+    return ExtractedGraph(
+        entities=[
+            ExtractedEntity(
+                name="EventBus",
+                kind="concept",
+                summary="publish subscribe hub",
+                aliases=["Message Bus"],
+            ),
+            ExtractedEntity(
+                name="OrderService",
+                kind="concept",
+                summary="emits order events",
+            ),
+        ],
+        relations=[
+            ExtractedRelation(
+                source="OrderService", target="EventBus", kind="references"
+            ),
+            ExtractedRelation(
+                source="OrderService", target="Ghost", kind="references"
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def publisher(tmp_path):
+    ctx = make_stub_tenant_context("t1")
+    return GraphPublisher(SQLitePersistence(tmp_path), ctx)
+
+
+class TestExtract:
+    async def test_extract_returns_graph(self, publisher):
+        extractor = LLMGraphExtractor(_StubClient(_sample_graph()), publisher)
+        graph = await extractor.extract("some text")
+        assert len(graph.entities) == 2
+        assert len(graph.relations) == 2
+
+    async def test_extract_uses_structured_output(self, publisher):
+        client = _StubClient(_sample_graph())
+        extractor = LLMGraphExtractor(client, publisher)
+        await extractor.extract("some text")
+        assert client.calls[0]["output_type"] is ExtractedGraph
+
+
+class TestExtractAndPublish:
+    async def test_publishes_nodes_and_resolved_relations(self, publisher):
+        extractor = LLMGraphExtractor(_StubClient(_sample_graph()), publisher)
+        result = await extractor.extract_and_publish(
+            "text", source_uri="doc://spec.md", agent_id="ag", run_id="r1"
+        )
+        assert len(result.update.nodes) == 2
+        # The Ghost relation is unresolvable and must be skipped.
+        assert len(result.update.edges) == 1
+
+        nodes, edges = await publisher.persistence.load_graph(publisher.ctx)
+        by_title = {n.title: n for n in nodes}
+        assert by_title["EventBus"].provenance is Provenance.ASSERTED
+        assert by_title["EventBus"].assertion.run_id == "r1"
+        assert by_title["EventBus"].domain_tags["aliases"] == ["Message Bus"]
+        assert len(edges) == 1
+        assert edges[0].source_id == by_title["OrderService"].node_id
+
+    async def test_dedup_fuzzy_merges_additively(self, publisher):
+        # Seed the graph with a canonical node.
+        first = LLMGraphExtractor(
+            _StubClient(
+                ExtractedGraph(
+                    entities=[
+                        ExtractedEntity(name="EventBus", summary="the hub")
+                    ]
+                )
+            ),
+            publisher,
+        )
+        await first.extract_and_publish("t", source_uri="a", agent_id="ag")
+
+        # Re-extract with a variant surface form → alias merge, no new node.
+        second = LLMGraphExtractor(
+            _StubClient(
+                ExtractedGraph(
+                    entities=[
+                        ExtractedEntity(
+                            name="Event Bus", summary="pubsub hub again"
+                        )
+                    ]
+                )
+            ),
+            publisher,
+        )
+        result = await second.extract_and_publish(
+            "t", source_uri="b", agent_id="ag"
+        )
+        nodes, _ = await publisher.persistence.load_graph(publisher.ctx)
+        assert len(nodes) == 1
+        node = nodes[0]
+        assert node.title == "EventBus"
+        assert "Event Bus" in node.domain_tags["aliases"]
+        assert any(
+            "Event Bus" in r for r in node.domain_tags["merge_rationale"]
+        )
+        assert result.update.nodes[0].node_id == node.node_id
+
+    async def test_dedup_by_alias(self, publisher):
+        await LLMGraphExtractor(
+            _StubClient(_sample_graph()), publisher
+        ).extract_and_publish("t", source_uri="a", agent_id="ag")
+        # "Message Bus" is an alias of EventBus.
+        result = await LLMGraphExtractor(
+            _StubClient(
+                ExtractedGraph(
+                    entities=[
+                        ExtractedEntity(name="Message Bus", summary="x")
+                    ]
+                )
+            ),
+            publisher,
+        ).extract_and_publish("t", source_uri="b", agent_id="ag")
+        nodes, _ = await publisher.persistence.load_graph(publisher.ctx)
+        titles = [n.title for n in nodes]
+        assert "Message Bus" not in titles  # merged, not created
+
+    async def test_unknown_kinds_fall_back(self, publisher):
+        graph = ExtractedGraph(
+            entities=[
+                ExtractedEntity(name="A", kind="hologram", summary="s"),
+                ExtractedEntity(name="B", kind="concept", summary="s"),
+            ],
+            relations=[
+                ExtractedRelation(source="A", target="B", kind="quantum-links")
+            ],
+        )
+        result = await LLMGraphExtractor(
+            _StubClient(graph), publisher
+        ).extract_and_publish("t", source_uri="a", agent_id="ag")
+        kinds = {n.kind.value for n in result.update.nodes}
+        assert kinds == {"concept"}
+        assert result.update.edges[0].kind.value == "references"
+
+    async def test_extraction_commit_is_revertible(self, publisher):
+        result = await LLMGraphExtractor(
+            _StubClient(_sample_graph()), publisher
+        ).extract_and_publish("t", source_uri="a", agent_id="ag")
+        revert = await publisher.revert_commit(result.receipt.commit_id)
+        assert revert["status"] == "reverted"
+        nodes, edges = await publisher.persistence.load_graph(publisher.ctx)
+        assert nodes == [] and edges == []
+
+    async def test_requires_publisher(self):
+        extractor = LLMGraphExtractor(_StubClient(_sample_graph()), None)
+        with pytest.raises(RuntimeError):
+            await extractor.extract_and_publish("t", source_uri="a")
+
+
+class TestToolkitExtractKnowledge:
+    async def test_extract_knowledge_mirrors_in_memory(self, tmp_path):
+        tk = await build_graph_memory_toolkit(
+            db_dir=tmp_path, agent_id="ag", run_id="r1"
+        )
+        tk.client = _StubClient(_sample_graph())
+        result = await tk.extract_knowledge("text", source_uri="doc://x")
+        assert result["persisted"] is True
+        assert result["entities"] == 2
+        assert result["edges_written"] == 1
+        assert tk.graph.num_nodes() == 2
+        assert tk.graph.num_edges() == 1
+        found = await tk.find_node("publish subscribe hub")
+        assert found.get("title") == "EventBus"
+
+        # And it is durable across a reload.
+        tk2 = await build_graph_memory_toolkit(db_dir=tmp_path, agent_id="ag")
+        assert tk2.graph.num_nodes() == 2
+
+    async def test_extract_knowledge_without_client(self, tmp_path):
+        tk = await build_graph_memory_toolkit(db_dir=tmp_path, agent_id="ag")
+        result = await tk.extract_knowledge("text")
+        assert "error" in result

--- a/packages/ai-parrot/tests/knowledge/graphindex/test_publish.py
+++ b/packages/ai-parrot/tests/knowledge/graphindex/test_publish.py
@@ -1,0 +1,379 @@
+"""Tests for the durable graph write path (GraphPublisher + apply_update).
+
+Covers the publish → load → revert cycle, assertion stamping, conflict
+refusal, node-removal (merge) semantics, and the ALTER-guard migration of
+databases created with the pre-assertion schema.
+"""
+
+import aiosqlite
+import pytest
+
+from parrot.knowledge.graphindex.persist_sqlite import SQLitePersistence
+from parrot.knowledge.graphindex.publish import GraphPublisher
+from parrot.knowledge.graphindex.schema import (
+    AssertionMeta,
+    EdgeKind,
+    GraphUpdate,
+    NodeKind,
+    Provenance,
+    UniversalEdge,
+    UniversalNode,
+    stable_edge_id,
+)
+from parrot.knowledge.ontology.schema import MergedOntology, TenantContext
+
+
+def make_ctx(tenant_id: str = "test-tenant") -> TenantContext:
+    """Create a minimal TenantContext for testing."""
+    fake_ontology = MergedOntology.model_construct(
+        name="test",
+        version="1.0",
+        entities={},
+        relations={},
+        traversal_patterns={},
+        layers=[],
+        merge_timestamp=None,
+    )
+    return TenantContext(
+        tenant_id=tenant_id,
+        arango_db=f"db_{tenant_id}",
+        pgvector_schema=f"schema_{tenant_id}",
+        ontology=fake_ontology,
+    )
+
+
+def make_node(node_id: str, title: str = "", **kwargs) -> UniversalNode:
+    """Create a minimal agent-authored node."""
+    return UniversalNode(
+        node_id=node_id,
+        kind=kwargs.pop("kind", NodeKind.CONCEPT),
+        title=title or f"Node {node_id}",
+        source_uri=kwargs.pop("source_uri", f"agent://concept/{node_id}"),
+        **kwargs,
+    )
+
+
+def make_edge(src: str, tgt: str, kind: EdgeKind = EdgeKind.REFERENCES) -> UniversalEdge:
+    """Create a minimal edge."""
+    return UniversalEdge(source_id=src, target_id=tgt, kind=kind)
+
+
+def make_update(**kwargs) -> GraphUpdate:
+    """Create a GraphUpdate with default attribution."""
+    kwargs.setdefault("agent_id", "test-agent")
+    kwargs.setdefault("asserted_by", "agent:test-agent")
+    return GraphUpdate(**kwargs)
+
+
+@pytest.fixture
+def ctx():
+    return make_ctx()
+
+
+@pytest.fixture
+def persistence(tmp_path):
+    return SQLitePersistence(tmp_path)
+
+
+@pytest.fixture
+def publisher(persistence, ctx):
+    return GraphPublisher(persistence, ctx)
+
+
+# =====================================================================
+# Schema models
+# =====================================================================
+
+
+class TestSchemaAdditions:
+    def test_provenance_has_asserted(self):
+        assert Provenance("asserted") is Provenance.ASSERTED
+
+    def test_node_assertion_default_none(self):
+        assert make_node("a").assertion is None
+
+    def test_edge_assertion_does_not_touch_confidence_validator(self):
+        meta = AssertionMeta(asserted_by="agent:x", asserted_at="2026-01-01T00:00:00+00:00")
+        edge = UniversalEdge(
+            source_id="a",
+            target_id="b",
+            kind=EdgeKind.REFERENCES,
+            provenance=Provenance.ASSERTED,
+            assertion=meta,
+        )
+        assert edge.confidence is None
+        # INFERRED still requires similarity confidence.
+        with pytest.raises(ValueError):
+            UniversalEdge(
+                source_id="a",
+                target_id="b",
+                kind=EdgeKind.MENTIONS,
+                provenance=Provenance.INFERRED,
+            )
+
+    def test_assertion_confidence_bounds(self):
+        with pytest.raises(ValueError):
+            AssertionMeta(
+                asserted_by="x", asserted_at="t", confidence=1.5,
+            )
+
+    def test_stable_edge_id_deterministic(self):
+        a = stable_edge_id("n1", "n2", "references")
+        b = stable_edge_id("n1", "n2", "references")
+        c = stable_edge_id("n2", "n1", "references")
+        assert a == b
+        assert a != c
+        assert len(a) == 12
+
+
+# =====================================================================
+# Publish / stamping
+# =====================================================================
+
+
+class TestPublish:
+    async def test_publish_persists_nodes_and_edges(self, publisher, persistence, ctx):
+        receipt = await publisher.publish(
+            make_update(
+                nodes=[make_node("a"), make_node("b")],
+                edges=[make_edge("a", "b")],
+                op="create_node",
+            )
+        )
+        assert receipt.op == "create_node"
+        assert set(receipt.node_ids) == {"a", "b"}
+        nodes, edges = await persistence.load_graph(ctx)
+        assert {n.node_id for n in nodes} == {"a", "b"}
+        assert [(e.source_id, e.target_id) for e in edges] == [("a", "b")]
+
+    async def test_publish_stamps_assertion_and_provenance(
+        self, publisher, persistence, ctx
+    ):
+        await publisher.publish(
+            make_update(nodes=[make_node("a")], run_id="run-9")
+        )
+        nodes, _ = await persistence.load_graph(ctx)
+        node = nodes[0]
+        assert node.provenance is Provenance.ASSERTED
+        assert node.assertion is not None
+        assert node.assertion.asserted_by == "agent:test-agent"
+        assert node.assertion.agent_id == "test-agent"
+        assert node.assertion.run_id == "run-9"
+
+    async def test_publish_preserves_extracted_provenance_of_pipeline_nodes(
+        self, publisher, persistence, ctx
+    ):
+        pipeline_node = make_node("mod", source_uri="src/module.py")
+        await publisher.publish(make_update(nodes=[pipeline_node]))
+        nodes, _ = await persistence.load_graph(ctx)
+        # Not agent-minted (no agent:// URI) → provenance untouched,
+        # but the write is still attributed.
+        assert nodes[0].provenance is Provenance.EXTRACTED
+        assert nodes[0].assertion is not None
+
+    async def test_publish_preserves_existing_assertion(
+        self, publisher, persistence, ctx
+    ):
+        meta = AssertionMeta(
+            asserted_by="human:reviewer", asserted_at="2026-01-01T00:00:00+00:00"
+        )
+        await publisher.publish(
+            make_update(nodes=[make_node("a", assertion=meta)])
+        )
+        nodes, _ = await persistence.load_graph(ctx)
+        assert nodes[0].assertion.asserted_by == "human:reviewer"
+
+    async def test_fts_partial_update_preserves_other_rows(
+        self, publisher, persistence, ctx
+    ):
+        await publisher.publish(
+            make_update(nodes=[make_node("a", title="Alpha topic")])
+        )
+        await publisher.publish(
+            make_update(nodes=[make_node("b", title="Beta topic")])
+        )
+        db = persistence._db_path(ctx)
+        async with aiosqlite.connect(str(db)) as conn:
+            async with conn.execute(
+                "SELECT node_id FROM nodes_fts WHERE nodes_fts MATCH 'Alpha'"
+            ) as cur:
+                rows = await cur.fetchall()
+        assert [r[0] for r in rows] == ["a"]
+
+
+# =====================================================================
+# Commit history
+# =====================================================================
+
+
+class TestCommitHistory:
+    async def test_list_commits_filters(self, publisher):
+        await publisher.publish(make_update(nodes=[make_node("a")], run_id="r1"))
+        await publisher.publish(make_update(nodes=[make_node("b")], run_id="r2"))
+        all_commits = await publisher.list_commits()
+        assert len(all_commits) == 2
+        r1_commits = await publisher.list_commits(run_id="r1")
+        assert len(r1_commits) == 1
+        assert r1_commits[0]["run_id"] == "r1"
+
+    async def test_get_commit_returns_payload_and_items(self, publisher):
+        receipt = await publisher.publish(
+            make_update(nodes=[make_node("a")], edges=[], reason="why not")
+        )
+        commit = await publisher.get_commit(receipt.commit_id)
+        assert commit["reason"] == "why not"
+        assert commit["payload"]["nodes"][0]["node_id"] == "a"
+        assert any(i["item_key"] == "a" for i in commit["items"])
+
+    async def test_get_commit_unknown_returns_none(self, publisher):
+        assert await publisher.get_commit("nope") is None
+
+
+# =====================================================================
+# Revert
+# =====================================================================
+
+
+class TestRevert:
+    async def test_revert_create_deletes_rows(self, publisher, persistence, ctx):
+        receipt = await publisher.publish(
+            make_update(nodes=[make_node("a")], edges=[])
+        )
+        result = await publisher.revert_commit(receipt.commit_id)
+        assert result["status"] == "reverted"
+        nodes, _ = await persistence.load_graph(ctx)
+        assert nodes == []
+
+    async def test_revert_update_restores_pre_image(
+        self, publisher, persistence, ctx
+    ):
+        await publisher.publish(make_update(nodes=[make_node("a", title="v1")]))
+        r2 = await publisher.publish(make_update(nodes=[make_node("a", title="v2")]))
+        await publisher.revert_commit(r2.commit_id)
+        nodes, _ = await persistence.load_graph(ctx)
+        assert nodes[0].title == "v1"
+
+    async def test_revert_merge_restores_duplicate_and_edges(
+        self, publisher, persistence, ctx
+    ):
+        await publisher.publish(
+            make_update(
+                nodes=[make_node("a"), make_node("b"), make_node("dup")],
+                edges=[make_edge("dup", "b")],
+            )
+        )
+        merge = await publisher.publish(
+            make_update(
+                edges=[make_edge("a", "b")],
+                removed_nodes=["dup"],
+                op="merge_nodes",
+            )
+        )
+        nodes, edges = await persistence.load_graph(ctx)
+        assert {n.node_id for n in nodes} == {"a", "b"}
+        result = await publisher.revert_commit(merge.commit_id)
+        assert result["status"] == "reverted"
+        nodes, edges = await persistence.load_graph(ctx)
+        assert {n.node_id for n in nodes} == {"a", "b", "dup"}
+        assert ("dup", "b") in [(e.source_id, e.target_id) for e in edges]
+        assert ("a", "b") not in [(e.source_id, e.target_id) for e in edges]
+
+    async def test_revert_refused_on_later_conflicting_commit(self, publisher):
+        r1 = await publisher.publish(make_update(nodes=[make_node("a")]))
+        await publisher.publish(make_update(nodes=[make_node("a", title="v2")]))
+        result = await publisher.revert_commit(r1.commit_id)
+        assert "error" in result
+        assert result["conflicts"] == ["a"]
+
+    async def test_revert_twice_refused(self, publisher):
+        r1 = await publisher.publish(make_update(nodes=[make_node("a")]))
+        assert (await publisher.revert_commit(r1.commit_id))["status"] == "reverted"
+        assert "error" in await publisher.revert_commit(r1.commit_id)
+
+    async def test_revert_unknown_commit(self, publisher):
+        assert "error" in await publisher.revert_commit("missing")
+
+    async def test_reverse_order_unwind(self, publisher, persistence, ctx):
+        r1 = await publisher.publish(make_update(nodes=[make_node("a", title="v1")]))
+        r2 = await publisher.publish(make_update(nodes=[make_node("a", title="v2")]))
+        assert (await publisher.revert_commit(r2.commit_id))["status"] == "reverted"
+        assert (await publisher.revert_commit(r1.commit_id))["status"] == "reverted"
+        nodes, _ = await persistence.load_graph(ctx)
+        assert nodes == []
+
+
+# =====================================================================
+# Migration of pre-assertion databases
+# =====================================================================
+
+_OLD_SCHEMA_SQL = """
+PRAGMA journal_mode = WAL;
+CREATE TABLE IF NOT EXISTS files (
+    source_uri  TEXT PRIMARY KEY,
+    mtime       REAL NOT NULL,
+    sha1        TEXT NOT NULL,
+    indexed_at  TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS nodes (
+    node_id       TEXT PRIMARY KEY,
+    kind          TEXT NOT NULL,
+    title         TEXT NOT NULL,
+    source_uri    TEXT NOT NULL,
+    parent_id     TEXT,
+    summary       TEXT,
+    content_ref   TEXT,
+    embedding_ref TEXT,
+    provenance    TEXT NOT NULL,
+    domain_tags   TEXT
+);
+CREATE TABLE IF NOT EXISTS edges (
+    source_id   TEXT NOT NULL,
+    target_id   TEXT NOT NULL,
+    kind        TEXT NOT NULL,
+    provenance  TEXT NOT NULL,
+    confidence  REAL,
+    source_uri  TEXT,
+    PRIMARY KEY (source_id, target_id, kind)
+);
+CREATE VIRTUAL TABLE IF NOT EXISTS nodes_fts USING fts5(
+    node_id UNINDEXED, title, summary, tokenize = 'unicode61'
+);
+"""
+
+
+class TestMigration:
+    async def test_old_schema_db_migrates_and_accepts_writes(
+        self, tmp_path, ctx
+    ):
+        # Build a DB file with the pre-assertion schema and a legacy row.
+        db_path = tmp_path / f"{ctx.tenant_id}.db"
+        async with aiosqlite.connect(str(db_path)) as conn:
+            await conn.executescript(_OLD_SCHEMA_SQL)
+            await conn.execute(
+                "INSERT INTO nodes (node_id, kind, title, source_uri, provenance)"
+                " VALUES ('legacy', 'concept', 'Legacy', 'x.py', 'extracted')"
+            )
+            await conn.commit()
+
+        persistence = SQLitePersistence(tmp_path)
+        publisher = GraphPublisher(persistence, ctx)
+        receipt = await publisher.publish(make_update(nodes=[make_node("new")]))
+        assert receipt.commit_id
+
+        nodes, _ = await persistence.load_graph(ctx)
+        by_id = {n.node_id: n for n in nodes}
+        assert by_id["legacy"].assertion is None
+        assert by_id["new"].assertion is not None
+
+    async def test_unknown_enum_rows_skipped_not_raised(self, tmp_path, ctx):
+        persistence = SQLitePersistence(tmp_path)
+        await persistence.persist_graph(ctx, [make_node("known")], [])
+        db_path = persistence._db_path(ctx)
+        async with aiosqlite.connect(str(db_path)) as conn:
+            await conn.execute(
+                "INSERT INTO nodes (node_id, kind, title, source_uri, provenance)"
+                " VALUES ('future', 'hologram', 'Future kind', 'x', 'extracted')"
+            )
+            await conn.commit()
+        nodes, _ = await persistence.load_graph(ctx)
+        assert {n.node_id for n in nodes} == {"known"}

--- a/packages/ai-parrot/tests/knowledge/graphindex/test_schema.py
+++ b/packages/ai-parrot/tests/knowledge/graphindex/test_schema.py
@@ -23,16 +23,25 @@ class TestProvenance:
 
 
 class TestNodeKind:
-    def test_all_six_values(self):
+    def test_all_values(self):
         kinds = {k.value for k in NodeKind}
-        assert kinds == {"document", "section", "symbol", "concept", "rationale", "skill"}
+        # FEAT-260 added "wiki_page"; graph-knowledge-persistence added
+        # the work-lineage kinds "run" and "claim".
+        assert kinds == {
+            "document", "section", "symbol", "concept", "rationale",
+            "skill", "wiki_page", "run", "claim",
+        }
 
 
 class TestEdgeKind:
-    def test_all_five_values(self):
+    def test_all_values(self):
         kinds = {k.value for k in EdgeKind}
-        # FEAT-240 (TASK-1571) added "extends" for Odoo model inheritance edges
-        assert kinds == {"contains", "references", "defines", "mentions", "explains", "extends"}
+        # FEAT-240 (TASK-1571) added "extends"; graph-knowledge-persistence
+        # added the lineage/grounding kinds.
+        assert kinds == {
+            "contains", "references", "defines", "mentions", "explains",
+            "extends", "produced", "about", "supported_by", "contradicts",
+        }
 
 
 class TestUniversalNode:

--- a/packages/ai-parrot/tests/knowledge/okf/test_ontology.py
+++ b/packages/ai-parrot/tests/knowledge/okf/test_ontology.py
@@ -44,8 +44,9 @@ class TestConceptType:
         assert ConceptType.DOCUMENT_NODE.value == "Document"
 
     def test_total_count(self) -> None:
-        """ConceptType must have exactly 16 values (11 existing + 5 new)."""
-        assert len(ConceptType) == 16
+        """ConceptType member count (11 pageindex + 5 FEAT-239 + 5 wiki
+        FEAT-260 + OTHER FEAT-216 + RUN/CLAIM lineage types)."""
+        assert len(ConceptType) == 24
 
     def test_string_round_trip(self) -> None:
         """ConceptType(value) must reconstruct the correct enum member."""
@@ -89,8 +90,9 @@ class TestRelationType:
         assert RelationType("extends") == RelationType.EXTENDS
 
     def test_total_count(self) -> None:
-        """RelationType must have exactly 13 values (8 existing + 4 FEAT-239 + 1 FEAT-240)."""
-        assert len(RelationType) == 13
+        """RelationType member count (8 existing + 4 FEAT-239 + 1 FEAT-240
+        + 2 wiki FEAT-260 + 3 lineage relations)."""
+        assert len(RelationType) == 18
 
     def test_string_round_trip(self) -> None:
         """RelationType(value) must reconstruct the correct enum member."""
@@ -172,4 +174,4 @@ class TestReExportCompat:
         from parrot.knowledge.pageindex.okf.ontology import ConceptType as CT
 
         assert CT.GUIDELINE.value == "Guideline"
-        assert len(CT) == 16
+        assert len(CT) == 24

--- a/packages/ai-parrot/tests/knowledge/pageindex/test_okf_ontology.py
+++ b/packages/ai-parrot/tests/knowledge/pageindex/test_okf_ontology.py
@@ -53,8 +53,8 @@ class TestConceptType:
 
     def test_all_values_count(self):
         """11 original + 5 graph-native (FEAT-239) + 5 wiki (FEAT-260)
-        + OTHER (FEAT-216 open-vocabulary fallback) = 22."""
-        assert len(list(ConceptType)) == 22
+        + OTHER (FEAT-216) + RUN/CLAIM work-lineage types = 24."""
+        assert len(list(ConceptType)) == 24
 
     def test_case_sensitive_values(self):
         """Values use Title-Case as per spec."""
@@ -95,8 +95,9 @@ class TestRelationType:
 
     def test_all_values_count(self):
         """8 original + 4 graph edge kinds (FEAT-239) + extends (FEAT-240)
-        + summarizes/contradicts (FEAT-260) = 15."""
-        assert len(list(RelationType)) == 15
+        + summarizes/contradicts (FEAT-260) + produced/about/supported_by
+        work-lineage relations = 18."""
+        assert len(list(RelationType)) == 18
 
     def test_str_enum_equality(self):
         """str, Enum values compare equal to plain strings."""

--- a/tests/knowledge/wiki/test_authoring.py
+++ b/tests/knowledge/wiki/test_authoring.py
@@ -1,0 +1,355 @@
+"""Tests for the wiki authoring / persistent-memory surface.
+
+Covers the ``remember`` / ``note`` / ``link`` / ``memories`` / ``audit``
+CLI commands, the origin/asserted_by store columns (+ migration of
+pre-existing databases), 4-tuple ``add_edges`` provenance, the
+``LLMWikiToolkit.update_page`` staleness regression, and the graph
+mirror behind ``sync_graph``.
+"""
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from parrot.knowledge.wiki.cli import wiki
+from parrot.knowledge.wiki.project import (
+    load_project_config,
+    save_project_config,
+)
+from parrot.knowledge.wiki.store import (
+    SQLiteWikiStore,
+    WikiPageRecord,
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A repo with a built (empty-ish) wiki plane."""
+    (tmp_path / "README.md").write_text("# Demo\n\nDemo.", encoding="utf-8")
+    runner = CliRunner()
+    result = runner.invoke(
+        wiki, ["build", "--path", str(tmp_path), "--no-git", "--no-graph"]
+    )
+    assert result.exit_code == 0, result.output
+    return tmp_path
+
+
+def _remember(runner, repo, text, *extra):
+    result = runner.invoke(
+        wiki, ["remember", text, "--path", str(repo), "--json", *extra]
+    )
+    assert result.exit_code == 0, result.output
+    return json.loads(result.output[result.output.index("{"):])
+
+
+# =====================================================================
+# Store: origin / asserted_by / provenance edges / migration
+# =====================================================================
+
+
+class TestStoreAuthoringColumns:
+    async def test_origin_and_asserted_by_round_trip(self, tmp_path):
+        store = SQLiteWikiStore(tmp_path / "wiki.db")
+        await store.upsert_pages([
+            WikiPageRecord(
+                concept_id="m1",
+                title="Fact",
+                origin="memory",
+                asserted_by="agent:x",
+            )
+        ])
+        page = await store.get_page("m1")
+        assert page["origin"] == "memory"
+        assert page["asserted_by"] == "agent:x"
+
+    async def test_default_origin_is_ingest(self, tmp_path):
+        store = SQLiteWikiStore(tmp_path / "wiki.db")
+        await store.upsert_pages([WikiPageRecord(concept_id="p1", title="T")])
+        page = await store.get_page("p1")
+        assert page["origin"] == "ingest"
+        assert page["asserted_by"] is None
+
+    async def test_list_pages_origin_filter(self, tmp_path):
+        store = SQLiteWikiStore(tmp_path / "wiki.db")
+        await store.upsert_pages([
+            WikiPageRecord(concept_id="src1", title="Ingested"),
+            WikiPageRecord(concept_id="m1", title="Memory", origin="memory"),
+            WikiPageRecord(concept_id="a1", title="Authored", origin="authored"),
+        ])
+        rows = await store.list_pages(origin=["memory", "authored"])
+        assert {r["concept_id"] for r in rows} == {"m1", "a1"}
+
+    async def test_add_edges_four_tuple_provenance(self, tmp_path):
+        store = SQLiteWikiStore(tmp_path / "wiki.db")
+        await store.upsert_pages([
+            WikiPageRecord(concept_id="a", title="A"),
+            WikiPageRecord(concept_id="b", title="B"),
+        ])
+        await store.add_edges([
+            ("a", "b", "references", "asserted"),
+            ("b", "a", "mentions"),
+        ])
+        with sqlite3.connect(tmp_path / "wiki.db") as conn:
+            rows = dict(
+                ((src, dst), prov)
+                for src, dst, prov in conn.execute(
+                    "SELECT src, dst, provenance FROM edges"
+                )
+            )
+        assert rows[("a", "b")] == "asserted"
+        assert rows[("b", "a")] == "extracted"
+
+    async def test_old_schema_db_migrates(self, tmp_path):
+        # Build a wiki.db WITHOUT the origin/asserted_by columns.
+        db = tmp_path / "wiki.db"
+        with sqlite3.connect(db) as conn:
+            conn.executescript(
+                """
+                CREATE TABLE pages (
+                    concept_id  TEXT PRIMARY KEY,
+                    node_id     TEXT,
+                    title       TEXT NOT NULL,
+                    category    TEXT NOT NULL DEFAULT 'concept',
+                    summary     TEXT NOT NULL DEFAULT '',
+                    body        TEXT NOT NULL DEFAULT '',
+                    source_id   TEXT,
+                    token_count INTEGER NOT NULL DEFAULT 0,
+                    created_at  TEXT NOT NULL,
+                    updated_at  TEXT NOT NULL
+                );
+                INSERT INTO pages (concept_id, title, created_at, updated_at)
+                VALUES ('legacy', 'Old page', 't', 't');
+                """
+            )
+        store = SQLiteWikiStore(db)
+        page = await store.get_page("legacy", include_body=False)
+        assert page["origin"] == "ingest"
+        await store.upsert_pages([
+            WikiPageRecord(concept_id="new", title="New", origin="memory")
+        ])
+        assert (await store.get_page("new"))["origin"] == "memory"
+
+
+# =====================================================================
+# CLI: remember / note / link / memories / audit
+# =====================================================================
+
+
+class TestRememberCommand:
+    def test_remember_creates_memory(self, runner, repo):
+        data = _remember(
+            runner, repo, "Always pin the CI runner version",
+            "--category", "lesson", "--by", "agent:tester",
+        )
+        assert data["status"] == "created"
+        assert data["page_id"].startswith("mem-")
+        assert data["asserted_by"] == "agent:tester"
+
+    def test_remember_is_idempotent(self, runner, repo):
+        first = _remember(runner, repo, "Fact one", "--title", "Fact")
+        second = _remember(runner, repo, "Fact one, refined", "--title", "Fact")
+        assert first["page_id"] == second["page_id"]
+        assert second["status"] == "updated"
+
+    def test_remember_found_by_query(self, runner, repo):
+        _remember(runner, repo, "The gateway retries thrice on 502", "--title", "Gateway retries")
+        result = runner.invoke(
+            wiki, ["query", "gateway retries 502", "--path", str(repo), "--json"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "Gateway retries" in result.output
+
+    def test_remember_links_to_existing_page(self, runner, repo):
+        first = _remember(runner, repo, "Base fact", "--title", "Base")
+        second = _remember(
+            runner, repo, "Derived fact", "--title", "Derived",
+            "--link", first["page_id"],
+        )
+        assert second["linked"] == [first["page_id"]]
+        related = runner.invoke(
+            wiki, ["related", second["page_id"], "--path", str(repo)]
+        )
+        assert first["page_id"] in related.output
+
+    def test_remember_skips_unknown_link(self, runner, repo):
+        data = _remember(
+            runner, repo, "Fact", "--title", "F", "--link", "no-such-page"
+        )
+        assert data["skipped_links"] == ["no-such-page"]
+
+    def test_env_identity_and_run_id(self, runner, repo, monkeypatch):
+        monkeypatch.setenv("CLAUDE_AGENT_ID", "cc-1")
+        monkeypatch.setenv("CLAUDE_SESSION_ID", "sess-9")
+        data = _remember(runner, repo, "Env fact", "--title", "EnvFact")
+        assert data["asserted_by"] == "agent:cc-1"
+        config = load_project_config(repo)
+        log = (config.storage_path(repo) / "log.md").read_text()
+        assert "agent:cc-1" in log
+        assert "sess-9" in log
+
+
+class TestNoteCommand:
+    def test_note_appends_attributed_blockquote(self, runner, repo):
+        data = _remember(runner, repo, "Original body", "--title", "Page")
+        result = runner.invoke(
+            wiki,
+            ["note", data["page_id"], "Watch out for tz handling",
+             "--path", str(repo), "--by", "human:rev"],
+        )
+        assert result.exit_code == 0, result.output
+        page = runner.invoke(
+            wiki, ["page", data["page_id"], "--path", str(repo), "--json"]
+        )
+        body = json.loads(page.output[page.output.index("{"):])["body"]
+        assert "Watch out for tz handling" in body
+        assert "human:rev" in body
+        assert "Original body" in body
+
+    def test_note_unknown_page_errors(self, runner, repo):
+        result = runner.invoke(
+            wiki, ["note", "missing-id", "text", "--path", str(repo)]
+        )
+        assert result.exit_code != 0
+        assert "not found" in result.output
+
+
+class TestLinkCommand:
+    def test_link_pages(self, runner, repo):
+        a = _remember(runner, repo, "A", "--title", "A")
+        b = _remember(runner, repo, "B", "--title", "B")
+        result = runner.invoke(
+            wiki,
+            ["link", a["page_id"], b["page_id"], "--rel", "explains",
+             "--path", str(repo), "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        config = load_project_config(repo)
+        with sqlite3.connect(config.db_path(repo)) as conn:
+            row = conn.execute(
+                "SELECT provenance FROM edges WHERE src = ? AND dst = ?"
+                " AND rel = 'explains'",
+                (a["page_id"], b["page_id"]),
+            ).fetchone()
+        assert row == ("asserted",)
+
+    def test_link_unknown_page_errors(self, runner, repo):
+        a = _remember(runner, repo, "A", "--title", "A")
+        result = runner.invoke(
+            wiki, ["link", a["page_id"], "ghost", "--path", str(repo)]
+        )
+        assert result.exit_code != 0
+
+
+class TestMemoriesAndAudit:
+    def test_memories_lists_only_authored(self, runner, repo):
+        _remember(runner, repo, "Fact", "--title", "OnlyMemory")
+        result = runner.invoke(wiki, ["memories", "--path", str(repo)])
+        assert result.exit_code == 0, result.output
+        assert "OnlyMemory" in result.output
+        # Ingested README page must not appear.
+        assert "README" not in result.output
+
+    def test_audit_shows_operations(self, runner, repo):
+        _remember(runner, repo, "Fact", "--title", "Audited")
+        result = runner.invoke(wiki, ["audit", "--path", str(repo)])
+        assert result.exit_code == 0, result.output
+        assert "REMEMBER" in result.output
+
+
+# =====================================================================
+# sync_graph mirror
+# =====================================================================
+
+
+class TestGraphSync:
+    def test_remember_mirrors_into_graph_plane(self, runner, repo):
+        config = load_project_config(repo)
+        config.sync_graph = True
+        save_project_config(repo, config)
+
+        data = _remember(runner, repo, "Graph-synced fact", "--title", "GraphFact")
+        assert "graph_commit" in data
+
+        graph_db = config.graph_path(repo) / f"{config.wiki_name}.db"
+        assert graph_db.exists()
+        with sqlite3.connect(graph_db) as conn:
+            titles = [
+                r[0] for r in conn.execute("SELECT title FROM nodes")
+            ]
+            commits = conn.execute(
+                "SELECT COUNT(*) FROM graph_commits"
+            ).fetchone()[0]
+        assert "GraphFact" in titles
+        assert commits == 1
+
+        audit = runner.invoke(wiki, ["audit", "--path", str(repo)])
+        assert "Graph write commits" in audit.output
+
+    def test_no_sync_by_default(self, runner, repo):
+        data = _remember(runner, repo, "Plain fact", "--title", "Plain")
+        assert "graph_commit" not in data
+        config = load_project_config(repo)
+        assert not (config.graph_path(repo)).exists()
+
+
+# =====================================================================
+# LLMWikiToolkit regression: update_page must refresh the store plane
+# =====================================================================
+
+
+class TestUpdatePageRegression:
+    @pytest.fixture
+    def toolkit(self, tmp_path):
+        from parrot.knowledge.wiki.models import WikiConfig
+        from parrot.knowledge.wiki.toolkit import LLMWikiToolkit
+
+        class _StubPI:
+            async def insert_markdown(self, *a, **k):
+                return {"tree_name": "t", "new_node_ids": []}
+
+        config = WikiConfig(
+            wiki_name="test-wiki", storage_dir=tmp_path / "wiki"
+        )
+        return LLMWikiToolkit(
+            pageindex_toolkit=_StubPI(),
+            graphindex_toolkit=None,
+            okf_toolkit=None,
+            config=config,
+        )
+
+    async def test_update_page_refreshes_store_and_fts(self, toolkit):
+        created = await toolkit.create_page(
+            "test-wiki", "My Page", "original searchable alpha content"
+        )
+        page_id = created["page_id"]
+        result = await toolkit.update_page(
+            "test-wiki", page_id, "completely new bravo content"
+        )
+        assert result["status"] == "updated"
+        page = await toolkit._store.get_page(page_id)
+        assert "bravo" in page["body"]
+        hits = await toolkit._store.search_fts("bravo")
+        assert any(h["concept_id"] == page_id for h in hits)
+        stale = await toolkit._store.search_fts("alpha")
+        assert not any(h["concept_id"] == page_id for h in stale)
+
+    async def test_update_page_not_found(self, toolkit):
+        result = await toolkit.update_page("test-wiki", "ghost", "content")
+        assert result["status"] == "not_found"
+
+    async def test_remember_tool_idempotent(self, toolkit):
+        first = await toolkit.remember("test-wiki", "A fact", title="Fact")
+        second = await toolkit.remember("test-wiki", "A better fact", title="Fact")
+        assert first["page_id"] == second["page_id"]
+        assert first["status"] == "created"
+        assert second["status"] == "updated"
+        page = await toolkit._store.get_page(first["page_id"])
+        assert page["origin"] == "memory"

--- a/tests/knowledge/wiki/test_schema_extensions.py
+++ b/tests/knowledge/wiki/test_schema_extensions.py
@@ -115,6 +115,7 @@ class TestNodeKindWikiPage:
         assert NodeKind.RATIONALE.value == "rationale"
         assert NodeKind.SKILL.value == "skill"
 
-    def test_seven_node_kinds(self):
-        """NodeKind now has exactly 7 members (6 original + WIKI_PAGE)."""
-        assert len(NodeKind) == 7
+    def test_node_kind_count(self):
+        """NodeKind members: 6 original + WIKI_PAGE (FEAT-260) + RUN/CLAIM
+        (graph-knowledge-persistence work-lineage kinds)."""
+        assert len(NodeKind) == 9


### PR DESCRIPTION
Phase 1 of the knowledge-graph-as-persistent-agent-memory feature
("the agent forgets, the graph does not"):

- schema.py: Provenance.ASSERTED, AssertionMeta (asserted_by/asserted_at/
  agent_id/run_id/source/confidence), assertion field on UniversalNode and
  UniversalEdge (all-optional, backward compatible; the confidence⇔INFERRED
  validator is untouched), GraphUpdate (incl. removed_edges/removed_nodes),
  CommitReceipt, stable_edge_id() citation helper.
- persist_sqlite.py: graph_commits + graph_commit_items audit tables with
  pre-image capture; ALTER-guard _migrate() upgrades pre-assertion DBs;
  apply_update() (single transaction, partial FTS refresh), load_graph()
  (skip-and-warn on unknown enum values), get_commit/list_commits/
  revert_commit (conflict refusal via commit rowid ordering).
- publish.py (new): GraphPublisher — stamps attribution onto unattributed
  writes and commits them durably; duck-typed persistence protocol.
- factory.py (new): build_graph_memory_toolkit() productizes the
  examples/knowledge_wiki glue — load → assemble → embed → publisher wiring;
  ships a process-stable HashingGraphEmbedder (SHA-1 buckets, never salted
  hash()) so persistent memory needs no model download.
- GraphIndexToolkit: optional publisher/agent_id/run_id; all 7 write tools
  write through durably (persist failures degrade to persist_warning, never
  fail the call); merge_nodes is now additive+inspectable (alias retention,
  revertible commit); new graph_history and revert_write tools
  (revert_write requires confirmation via confirming_tools).

Tests: test_publish.py (22) and test_toolkit_persistence.py (14) cover
publish/stamp/revert/conflict/migration and cross-session durability.