### PR TITLE
feat(formdesigner): create forms without an LLM via POST /forms

### DIFF
--- a/packages/parrot-formdesigner/CHANGELOG.md
+++ b/packages/parrot-formdesigner/CHANGELOG.md
@@ -6,6 +6,34 @@ All notable changes to `parrot-formdesigner` will be documented in this file.
 
 ### Added
 
+- **No-LLM form creation**: `POST /api/v1/forms` is now dual-mode. A body
+  carrying `prompt` keeps the existing natural-language path
+  (`CreateFormTool`, 503 without an LLM client); any other body — including
+  an empty one — builds the `FormSchema` directly with no LLM involved and
+  returns `201` with the full schema. This closes the gap that forced the
+  form builder to go through the LLM (or `from-db` / `clone`) just to get a
+  canvas to work on: a "New form" button can `POST /forms` with `{}` and
+  then add controls with `PATCH /forms/{form_id}/operations`.
+  - Blank forms are seeded with one empty section (`section_1`) so
+    `add_field` has a target; pass `"sections": []` for none.
+  - `form_id` is taken from the body when valid (`FORM_ID_RE`, `409` when
+    taken) or derived from `title`, with a random suffix on collision so
+    clicking "New" repeatedly never fails.
+  - `version` (`"1.0"`), `published_version` (`None`) and `tenant`
+    (session-derived) are handler-controlled and ignored from the body.
+  - Mode selection is by key *presence*: `{"prompt": ""}` keeps its historical
+    `400 prompt is required` instead of creating a blank form.
+  - Duplicate detection consults storage, not just memory, and a lost
+    creation race answers `409` rather than a `201` for a form that was
+    never stored.
+- **`FormRegistry.contains(..., include_storage=True)`**: opt-in storage probe
+  for the memory-only membership check. Needed because the in-memory cache is
+  hydrated per tenant while `PostgresFormStorage.save()` upserts
+  (`ON CONFLICT ... DO UPDATE`) — a memory-only check would let a "new" form
+  silently overwrite a persisted one belonging to a non-hydrated tenant. A
+  storage error returns `True` ("cannot prove absence") so the caller refuses
+  to create rather than overwriting.
+
 - **FEAT-188 — Form Lifecycle Events**: declarative interceptor hooks
   (`onBeforeOpen`, `onSchemaLoaded`, `onBeforeSubmit`, `onAfterSubmit`,
   `onError`) per form. Register async handlers via

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/api/_utils.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/api/_utils.py
@@ -7,10 +7,21 @@ effects.
 
 from __future__ import annotations
 
+import re
+import uuid
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from aiohttp import web
+
+
+#: Accepted shape for a ``form_id`` supplied by a client. Deliberately
+#: narrower than "any string": form ids are interpolated into URLs
+#: (``/api/v1/forms/{form_id}``) and used as storage keys, so slashes,
+#: spaces, dots and path traversal sequences are rejected up-front.
+#: Anchored with ``\Z`` rather than ``$`` — ``$`` also matches just before a
+#: trailing newline, which would let ``"my-form\n"`` through.
+FORM_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}\Z")
 
 
 def _get_request_tenant(request: "web.Request") -> str | None:
@@ -99,6 +110,47 @@ def _loc_to_str(value: object) -> str | None:
     if not value:
         return None
     return str(value)
+
+
+def is_valid_form_id(value: object) -> bool:
+    """Return ``True`` when ``value`` is a safe, URL-embeddable form id.
+
+    Args:
+        value: Candidate form id (any type — non-strings return ``False``).
+
+    Returns:
+        ``True`` if the value matches :data:`FORM_ID_RE`.
+    """
+    return isinstance(value, str) and bool(FORM_ID_RE.match(value))
+
+
+def slugify_form_id(text: str) -> str:
+    """Derive a URL-safe ``form_id`` slug from free-form text.
+
+    Mirrors ``parrot_formdesigner.tools.create_form._slugify`` so the
+    manual (no-LLM) creation path and the natural-language path produce
+    ids of the same shape. Falls back to a random slug when ``text``
+    contains no usable characters.
+
+    Examples:
+        ``"Store Visit 2026"`` → ``"store-visit-2026"``
+        ``"¿Encuesta?"`` → ``"encuesta"``
+        ``"!!!"`` → ``"form-1a2b3c4d"``
+
+    Args:
+        text: Arbitrary human-entered text (typically the form title).
+
+    Returns:
+        A lowercase hyphenated slug of at most 50 characters, guaranteed
+        to match :data:`FORM_ID_RE`.
+    """
+    slug = text.lower().strip()
+    slug = re.sub(r"[^a-z0-9\s-]", "", slug)
+    slug = re.sub(r"[\s-]+", "-", slug).strip("-")
+    slug = slug[:50].strip("-")
+    if not is_valid_form_id(slug):
+        return f"form-{uuid.uuid4().hex[:8]}"
+    return slug
 
 
 def _bump_version(version: str) -> str:

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/api/handlers.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/api/handlers.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+import uuid
 from typing import TYPE_CHECKING, get_args
 
 from aiohttp import web
@@ -25,7 +26,14 @@ from ..services.csrf import issue_form_csrf_token, validate_form_csrf_token
 from ..services.event_dispatcher import apply_schema_overrides, dispatch
 from ..services.registry import FormAlreadyExistsError, FormRegistry
 from ..services.validators import FormValidator
-from ._utils import _bump_version, _deep_merge, _loc_to_str
+from ._utils import (
+    FORM_ID_RE,
+    _bump_version,
+    _deep_merge,
+    _loc_to_str,
+    is_valid_form_id,
+    slugify_form_id,
+)
 
 if TYPE_CHECKING:
     from parrot.clients.base import AbstractClient
@@ -72,6 +80,21 @@ class FormAPIHandler:
             but never blocks requests. Set to ``True`` only when nav-auth
             policies are fully configured. Consistent with ``Policy.enforcing=False``.
     """
+
+    #: ``FormSchema`` keys the manual creation path owns — a client cannot set
+    #: them through ``POST /forms``. Everything else in the body is passed
+    #: through to ``FormSchema.model_validate``.
+    _BLANK_FORM_RESERVED_KEYS = frozenset(
+        {
+            "prompt",
+            "form_id",
+            "title",
+            "version",
+            "published_version",
+            "created_at",
+            "tenant",
+        }
+    )
 
     def __init__(
         self,
@@ -743,9 +766,70 @@ class FormAPIHandler:
         )
 
     async def create_form(self, request: web.Request) -> web.Response:
-        """POST /api/v1/forms — Create a form from a natural language prompt."""
+        """POST /api/v1/forms — Create a form, with or without an LLM.
+
+        Two mutually exclusive modes, selected by the presence of ``prompt``
+        in the request body:
+
+        **Natural language** (``{"prompt": "..."}``) — delegates to
+        ``CreateFormTool``; requires a configured LLM client (503 otherwise).
+        Returns ``200`` with ``{"form_id", "title", "url"}``.
+
+        **Manual / blank** (no ``prompt``) — the form-builder path. Builds a
+        ``FormSchema`` straight from the body with no LLM involved, so a
+        "New form" button can POST an empty body and immediately start
+        adding controls via ``PATCH /forms/{form_id}/operations``. Returns
+        ``201`` with the full ``FormSchema`` JSON (mirroring ``clone_form``).
+
+        Manual-mode body (all keys optional):
+            form_id (str): Explicit id. Must match ``FORM_ID_RE``. When
+                omitted it is derived from ``title``, with a random suffix
+                appended if that slug is already taken.
+            title (str | dict): Form title. Defaults to ``"Untitled Form"``.
+            sections (list): Sections to seed. When the key is absent, a
+                single empty section (``section_id="section_1"``) is created
+                so ``add_field`` has a target. Pass ``[]`` explicitly for a
+                form with no sections at all.
+            Any other ``FormSchema`` field (``description``, ``form_type``,
+                ``metadata``, ``meta``, ``submit``, ``cancel_allowed``,
+                ``events``, ``is_public``, ``product_bindings``) is honoured.
+
+        ``version`` is always ``"1.0"``, ``published_version`` is always
+        ``None`` (publishing goes through ``POST /forms/{id}/publish``), and
+        ``tenant`` is taken from the session — never from the body.
+
+        Returns:
+            ``200``/``201`` on success; ``400`` on a malformed body or
+            invalid ``form_id``; ``409`` when the id is taken; ``422`` on
+            schema validation errors; ``503`` when ``prompt`` was sent but
+            no LLM client is configured.
+        """
         # FEAT-302: RBAC gate-keeping (shadow mode by default)
         await self._rbac_shadow_gate(request, "create_form")
+
+        # An empty body is a valid "give me a blank form" request, so read the
+        # raw payload instead of letting request.json() raise on b"".
+        raw = (await request.text()).strip()
+        if raw:
+            try:
+                body = json.loads(raw)
+            except (json.JSONDecodeError, ValueError):
+                return JSONResponse({"error": "Invalid JSON body"}, status=400)
+        else:
+            body = {}
+
+        if not isinstance(body, dict):
+            return JSONResponse(
+                {"error": "Request body must be a JSON object"}, status=400
+            )
+
+        # Mode selection is by KEY PRESENCE, not truthiness: a caller that sent
+        # "prompt" clearly wanted the LLM path, so an empty/null prompt stays
+        # the 400 it has always been instead of silently creating a blank form.
+        if "prompt" not in body:
+            # Manual (no-LLM) form-builder path.
+            return await self._create_blank_form(request, body)
+
         # _create_tool was initialised with the client available at construction
         # time. Check its client directly rather than calling _get_llm_client()
         # again, so the guard accurately reflects the tool's actual state.
@@ -754,10 +838,6 @@ class FormAPIHandler:
                 {"error": "No LLM client configured for form creation"},
                 status=503,
             )
-        try:
-            body = await request.json()
-        except (json.JSONDecodeError, ValueError):
-            return JSONResponse({"error": "Invalid JSON body"}, status=400)
 
         prompt = body.get("prompt")
         if not prompt:
@@ -792,6 +872,119 @@ class FormAPIHandler:
             "title": title,
             "url": f"{prefix}/forms/{form_id}",
         })
+
+    async def _create_blank_form(
+        self, request: web.Request, body: dict
+    ) -> web.Response:
+        """Create a form from an explicit (possibly empty) body — no LLM.
+
+        Backs the manual branch of :meth:`create_form`. Separated so the
+        natural-language path stays readable and so the no-LLM contract can
+        be unit-tested without a client.
+
+        Args:
+            request: Incoming HTTP request (session provides the tenant).
+            body: Already-parsed JSON object (``{}`` for a blank form).
+
+        Returns:
+            ``201`` with the full ``FormSchema`` JSON on success; ``400`` on
+            an invalid ``form_id``; ``409`` when the id is taken; ``422`` on
+            schema validation failure.
+        """
+        tenant = self._get_tenant(request)
+        title = body.get("title") or "Untitled Form"
+
+        explicit_id = body.get("form_id")
+        if explicit_id is not None:
+            if not is_valid_form_id(explicit_id):
+                return JSONResponse(
+                    {
+                        "error": (
+                            f"Invalid form_id {explicit_id!r}: must match "
+                            f"{FORM_ID_RE.pattern}"
+                        )
+                    },
+                    status=400,
+                )
+            form_id = explicit_id
+            # include_storage=True: a persisted form under a not-yet-hydrated
+            # tenant is absent from memory, and storage.save() upserts — so a
+            # memory-only check would let creation overwrite it.
+            if await self.registry.contains(
+                form_id, tenant=tenant, include_storage=True
+            ):
+                return JSONResponse(
+                    {"error": f"Form '{form_id}' already exists"}, status=409
+                )
+        else:
+            # Derived id: never 409 on a plain "New form" click — a taken
+            # slug gets a random suffix instead of rejecting the request.
+            form_id = slugify_form_id(_loc_to_str(title) or "form")
+            if await self.registry.contains(
+                form_id, tenant=tenant, include_storage=True
+            ):
+                form_id = f"{form_id[:50]}-{uuid.uuid4().hex[:6]}"
+
+        payload = {
+            key: value
+            for key, value in body.items()
+            if key not in self._BLANK_FORM_RESERVED_KEYS
+        }
+        payload["form_id"] = form_id
+        payload["title"] = title
+        payload["version"] = "1.0"
+        # published_version is immutable from the API surface — only
+        # FormVersionService.publish() may set it (parity with PUT/PATCH).
+        payload["published_version"] = None
+        # Tenant comes from the session, never from the body — prevents a
+        # caller from writing into another tenant's bucket.
+        payload["tenant"] = tenant
+        # A canvas needs at least one drop target for add_field. Callers that
+        # genuinely want zero sections pass "sections": [] explicitly.
+        if "sections" not in payload:
+            payload["sections"] = [{"section_id": "section_1", "fields": []}]
+
+        try:
+            form = FormSchema.model_validate(payload)
+        except ValidationError as exc:
+            return JSONResponse(
+                {"errors": exc.errors(include_url=False)}, status=422
+            )
+
+        schema_errors = self.validator.check_schema(form)
+        if schema_errors:
+            return JSONResponse({"errors": schema_errors}, status=422)
+
+        await self.registry.register(
+            form,
+            persist=self.registry.has_storage,
+            overwrite=False,
+            tenant=tenant,
+        )
+
+        # register(overwrite=False) is a silent no-op when the id was taken
+        # between the check above and this call. Confirm OUR object won the
+        # race — otherwise we would return 201 describing a form that was
+        # never stored, and the client's subsequent /operations calls would
+        # edit somebody else's form.
+        stored = await self.registry.get(form_id, tenant=tenant)
+        if stored is not form:
+            self.logger.warning(
+                "Create lost a concurrent race for form '%s' (tenant=%s)",
+                form_id,
+                tenant,
+            )
+            return JSONResponse(
+                {"error": f"Form '{form_id}' already exists"}, status=409
+            )
+
+        self.logger.info(
+            "Created form '%s' manually (tenant=%s, sections=%d)",
+            form_id,
+            tenant,
+            len(form.sections),
+        )
+        return JSONResponse(form.model_dump(mode="json"), status=201)
 
     async def edit_form(self, request: web.Request) -> web.Response:
         """POST /api/v1/forms/{form_id}/edit — Edit a form using natural language.

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/api/routes.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/api/routes.py
@@ -205,6 +205,9 @@ def setup_form_api(
 
     # CRUD + listing
     app.router.add_get(f"{bp}/forms", _wrap_auth(handler.list_forms))
+    # Dual-mode: a body with "prompt" creates via LLM (503 without a client);
+    # any other body — including an empty one — creates the form directly from
+    # the payload, which is the no-LLM form-builder path.
     app.router.add_post(f"{bp}/forms", _wrap_auth(handler.create_form))
     app.router.add_post(f"{bp}/forms/from-db", _wrap_auth(handler.load_from_db))
     app.router.add_get(f"{bp}/forms/{{form_id}}", _wrap_auth(handler.get_form))

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/registry.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/registry.py
@@ -665,19 +665,56 @@ class FormRegistry:
         async with self._lock:
             return list(self._forms.get(resolved, {}).keys())
 
-    async def contains(self, form_id: str, *, tenant: str | None = None) -> bool:
+    async def contains(
+        self,
+        form_id: str,
+        *,
+        tenant: str | None = None,
+        include_storage: bool = False,
+    ) -> bool:
         """Check if a form is registered under a specific tenant.
+
+        By default this is an in-memory lookup only.  Pass
+        ``include_storage=True`` to also probe the persistence backend — the
+        in-memory cache is hydrated per tenant (see :meth:`load_from_storage`),
+        so a persisted form belonging to a tenant that has not been hydrated
+        yet is invisible to the memory-only check.  Callers that use the answer
+        to decide whether creating a form would *clobber* an existing one MUST
+        pass ``include_storage=True``: ``PostgresFormStorage.save`` upserts
+        (``ON CONFLICT ... DO UPDATE``) and would silently overwrite.
+
+        A storage error is treated as "cannot prove absence" and returns
+        ``True`` — refusing to create is safer than overwriting.
 
         Args:
             form_id: Form identifier to check.
             tenant: Tenant scope.  ``None`` resolves to ``default_tenant``.
+            include_storage: Also query the storage backend when the form is
+                not in memory.
 
         Returns:
-            True if the form is registered under the resolved tenant.
+            True if the form is registered under the resolved tenant (or, with
+            ``include_storage=True``, persisted under it).
         """
         resolved = self._resolve_tenant(tenant)
         async with self._lock:
-            return form_id in self._forms.get(resolved, {})
+            if form_id in self._forms.get(resolved, {}):
+                return True
+
+        if not include_storage or self._storage is None:
+            return False
+
+        try:
+            return await self._storage.load(form_id, tenant=resolved) is not None
+        except Exception as exc:
+            self.logger.warning(
+                "contains(%s, tenant=%s): storage probe failed, assuming the "
+                "form exists to avoid an overwrite: %s",
+                form_id,
+                resolved,
+                exc,
+            )
+            return True
 
     async def clear(self, *, tenant: str | None = None) -> None:
         """Clear all registered forms for a specific tenant only.

--- a/packages/parrot-formdesigner/tests/unit/api/test_create_blank_form.py
+++ b/packages/parrot-formdesigner/tests/unit/api/test_create_blank_form.py
@@ -1,0 +1,498 @@
+"""Unit tests for the no-LLM branch of ``POST /api/v1/forms``.
+
+``FormAPIHandler.create_form`` is dual-mode: a body carrying ``prompt``
+goes to ``CreateFormTool`` (LLM), anything else builds the ``FormSchema``
+directly. These tests cover the manual branch — the one that backs a
+"New form" button in the form builder — plus the full
+create-blank → add-controls-on-the-canvas round trip via
+``PATCH /forms/{form_id}/operations``.
+
+All tests use mocked requests against a real ``FormRegistry``; no HTTP
+server and no LLM client are involved.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+
+from parrot_formdesigner.api.handlers import FormAPIHandler
+from parrot_formdesigner.api.operations import handle_operations
+from parrot_formdesigner.core.schema import FormSchema
+from parrot_formdesigner.services.registry import FormRegistry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_request(
+    *,
+    raw_body: str | None = None,
+    body: dict | list | None = None,
+    match_info: dict | None = None,
+    tenant: str = "t1",
+    app: dict | None = None,
+) -> MagicMock:
+    """Build a mocked aiohttp request for the create/operations handlers.
+
+    Args:
+        raw_body: Exact payload string. Takes precedence over ``body``; use
+            ``""`` to simulate a bodyless POST.
+        body: Object to JSON-encode as the payload.
+        match_info: Path parameters (e.g. ``{"form_id": "x"}``).
+        tenant: Program slug exposed through the mocked session.
+        app: Mapping used for ``request.app`` (needed by handle_operations).
+
+    Returns:
+        A ``MagicMock`` shaped like ``web.Request``.
+    """
+    if raw_body is None:
+        raw_body = "" if body is None else json.dumps(body)
+
+    req = MagicMock(spec=web.Request)
+    req.method = "POST"
+    req.match_info = match_info or {}
+    req.session = {"session": {"programs": [tenant]}}
+    req.headers = {}
+    req.text = AsyncMock(return_value=raw_body)
+
+    async def _json():
+        return json.loads(raw_body)
+
+    req.json = _json
+    req.app = app if app is not None else {}
+
+    user = MagicMock()
+    user.id = "test-user"
+    user.organizations = []
+    req.user = user
+    return req
+
+
+@pytest.fixture
+def registry() -> FormRegistry:
+    """Empty in-memory registry sealed to the ``t1`` tenant."""
+    return FormRegistry(require_tenant=False, default_tenant="t1")
+
+
+@pytest.fixture
+def handler(registry: FormRegistry) -> FormAPIHandler:
+    """Handler with NO LLM client — the manual path must not need one."""
+    return FormAPIHandler(registry=registry)
+
+
+async def _create(handler: FormAPIHandler, **kwargs) -> tuple[int, dict]:
+    """Call ``create_form`` and return ``(status, decoded body)``."""
+    resp = await handler.create_form(_make_request(**kwargs))
+    return resp.status, json.loads(resp.body.decode())
+
+
+# ---------------------------------------------------------------------------
+# Blank creation
+# ---------------------------------------------------------------------------
+
+
+async def test_empty_body_creates_blank_form(handler: FormAPIHandler) -> None:
+    """A bodyless POST is a valid "give me a blank form" request."""
+    status, form = await _create(handler)
+
+    assert status == 201
+    assert form["form_id"] == "untitled-form"
+    assert form["title"] == "Untitled Form"
+    assert form["version"] == "1.0"
+    assert form["published_version"] is None
+    assert form["tenant"] == "t1"
+    # One empty section so the canvas has an add_field target.
+    assert len(form["sections"]) == 1
+    assert form["sections"][0]["section_id"] == "section_1"
+    assert form["sections"][0]["fields"] == []
+
+
+async def test_blank_form_is_registered(
+    handler: FormAPIHandler, registry: FormRegistry
+) -> None:
+    """The new form is retrievable from the registry under the session tenant."""
+    _, form = await _create(handler, body={"title": "Store Visit"})
+
+    stored = await registry.get(form["form_id"], tenant="t1")
+    assert stored is not None
+    assert stored.form_id == "store-visit"
+
+
+async def test_no_llm_client_required(handler: FormAPIHandler) -> None:
+    """The manual path never hits the 503 LLM guard."""
+    assert handler._create_tool.client is None
+    status, _ = await _create(handler, body={"title": "No LLM Needed"})
+    assert status == 201
+
+
+async def test_title_derives_form_id(handler: FormAPIHandler) -> None:
+    status, form = await _create(handler, body={"title": "¡Encuesta Cliente 2026!"})
+    assert status == 201
+    assert form["form_id"] == "encuesta-cliente-2026"
+
+
+async def test_localized_title_derives_form_id(handler: FormAPIHandler) -> None:
+    status, form = await _create(
+        handler, body={"title": {"en": "Daily Report", "es": "Reporte Diario"}}
+    )
+    assert status == 201
+    assert form["form_id"] == "daily-report"
+    assert form["title"] == {"en": "Daily Report", "es": "Reporte Diario"}
+
+
+async def test_explicit_form_id_honoured(handler: FormAPIHandler) -> None:
+    status, form = await _create(
+        handler, body={"form_id": "my-custom-id", "title": "Whatever"}
+    )
+    assert status == 201
+    assert form["form_id"] == "my-custom-id"
+
+
+async def test_explicit_sections_honoured(handler: FormAPIHandler) -> None:
+    """``sections: []`` means "no sections" — the default is not applied."""
+    status, form = await _create(handler, body={"sections": []})
+    assert status == 201
+    assert form["sections"] == []
+
+
+async def test_seeded_sections_honoured(handler: FormAPIHandler) -> None:
+    status, form = await _create(
+        handler,
+        body={
+            "title": "Two Steps",
+            "sections": [
+                {"section_id": "step1", "title": "Step 1", "fields": []},
+                {"section_id": "step2", "fields": []},
+            ],
+        },
+    )
+    assert status == 201
+    assert [s["section_id"] for s in form["sections"]] == ["step1", "step2"]
+
+
+async def test_extra_schema_fields_pass_through(handler: FormAPIHandler) -> None:
+    status, form = await _create(
+        handler,
+        body={
+            "title": "Rich Blank",
+            "description": "Created by the builder",
+            "form_type": "survey",
+            "cancel_allowed": False,
+            "meta": {"builder": "canvas"},
+        },
+    )
+    assert status == 201
+    assert form["description"] == "Created by the builder"
+    assert form["form_type"] == "survey"
+    assert form["cancel_allowed"] is False
+    assert form["meta"] == {"builder": "canvas"}
+
+
+# ---------------------------------------------------------------------------
+# Reserved / controlled keys
+# ---------------------------------------------------------------------------
+
+
+async def test_version_and_published_version_are_controlled(
+    handler: FormAPIHandler,
+) -> None:
+    """A client cannot forge version state at creation time."""
+    status, form = await _create(
+        handler,
+        body={"title": "Forged", "version": "9.9", "published_version": "9.9"},
+    )
+    assert status == 201
+    assert form["version"] == "1.0"
+    assert form["published_version"] is None
+
+
+async def test_body_tenant_cannot_override_session(handler: FormAPIHandler) -> None:
+    """Tenant comes from the session — never from the body."""
+    status, form = await _create(
+        handler, body={"title": "Cross Tenant", "tenant": "other-tenant"}
+    )
+    assert status == 201
+    assert form["tenant"] == "t1"
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+async def test_duplicate_explicit_id_conflicts(handler: FormAPIHandler) -> None:
+    body = {"form_id": "dup", "title": "First"}
+    assert (await _create(handler, body=body))[0] == 201
+
+    status, payload = await _create(handler, body=body)
+    assert status == 409
+    assert "already exists" in payload["error"]
+
+
+async def test_duplicate_derived_id_gets_suffix(
+    handler: FormAPIHandler, registry: FormRegistry
+) -> None:
+    """Clicking "New" twice must not 409 — the derived slug is disambiguated."""
+    _, first = await _create(handler, body={"title": "Same Title"})
+    status, second = await _create(handler, body={"title": "Same Title"})
+
+    assert status == 201
+    assert first["form_id"] == "same-title"
+    assert second["form_id"] != first["form_id"]
+    assert second["form_id"].startswith("same-title-")
+    assert await registry.get(first["form_id"], tenant="t1") is not None
+    assert await registry.get(second["form_id"], tenant="t1") is not None
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "../etc/passwd",
+        "has space",
+        "with/slash",
+        "",
+        "a" * 65,
+        "-leading-dash",
+        "trailing-newline\n",
+        "embedded\nnewline",
+    ],
+)
+async def test_invalid_form_id_rejected(
+    handler: FormAPIHandler, bad_id: str
+) -> None:
+    status, payload = await _create(handler, body={"form_id": bad_id})
+    assert status == 400
+    assert "Invalid form_id" in payload["error"]
+
+
+async def test_malformed_json_rejected(handler: FormAPIHandler) -> None:
+    status, payload = await _create(handler, raw_body="{not json")
+    assert status == 400
+    assert payload["error"] == "Invalid JSON body"
+
+
+async def test_non_object_body_rejected(handler: FormAPIHandler) -> None:
+    status, payload = await _create(handler, body=["nope"])
+    assert status == 400
+    assert "JSON object" in payload["error"]
+
+
+async def test_invalid_schema_returns_422(handler: FormAPIHandler) -> None:
+    status, payload = await _create(
+        handler, body={"title": "Bad", "sections": [{"fields": []}]}
+    )
+    assert status == 422
+    assert "errors" in payload
+
+
+# ---------------------------------------------------------------------------
+# LLM branch regression
+# ---------------------------------------------------------------------------
+
+
+async def test_prompt_without_client_still_503(handler: FormAPIHandler) -> None:
+    """Sending ``prompt`` with no LLM configured keeps the pre-existing 503."""
+    status, payload = await _create(handler, body={"prompt": "a contact form"})
+    assert status == 503
+    assert "No LLM client" in payload["error"]
+
+
+@pytest.mark.parametrize("empty_prompt", ["", None, 0, []])
+async def test_empty_prompt_is_not_a_blank_form_request(
+    handler: FormAPIHandler, registry: FormRegistry, empty_prompt: object
+) -> None:
+    """Mode selection is by key presence: a falsy ``prompt`` is still LLM mode.
+
+    Sending ``prompt`` at all means the caller wanted the LLM path, so an
+    empty value must keep erroring instead of silently creating a blank form.
+    """
+    status, _ = await _create(handler, body={"prompt": empty_prompt})
+    assert status in (400, 503)
+    assert await registry.list_form_ids(tenant="t1") == []
+
+
+async def test_empty_prompt_with_client_is_400(registry: FormRegistry) -> None:
+    """With an LLM client configured, an empty prompt is the historical 400."""
+    handler = FormAPIHandler(registry=registry, client=MagicMock())
+    status, payload = await _create(handler, body={"prompt": ""})
+    assert status == 400
+    assert payload["error"] == "prompt is required"
+
+
+# ---------------------------------------------------------------------------
+# Storage-aware duplicate detection and race handling
+# ---------------------------------------------------------------------------
+
+
+async def test_persisted_form_not_in_memory_conflicts(
+    registry: FormRegistry,
+) -> None:
+    """A persisted form under a non-hydrated tenant must not be overwritten.
+
+    ``registry.get()`` is memory-only and ``PostgresFormStorage.save()``
+    upserts, so a memory-only duplicate check would let creation silently
+    replace an existing tenant form.
+    """
+    storage = MagicMock()
+    storage.load = AsyncMock(
+        return_value=FormSchema(
+            form_id="already-persisted",
+            title="Persisted",
+            sections=[],
+            tenant="t1",
+        )
+    )
+    storage.save = AsyncMock()
+    registry.set_storage(storage)
+
+    handler = FormAPIHandler(registry=registry)
+    status, payload = await _create(
+        handler, body={"form_id": "already-persisted", "title": "New One"}
+    )
+
+    assert status == 409
+    assert "already exists" in payload["error"]
+    storage.save.assert_not_awaited()
+
+
+async def test_derived_id_avoids_persisted_collision(
+    registry: FormRegistry,
+) -> None:
+    """A derived slug colliding with a persisted form gets a suffix, not a 409."""
+    storage = MagicMock()
+    storage.load = AsyncMock(
+        return_value=FormSchema(
+            form_id="daily-report", title="Old", sections=[], tenant="t1"
+        )
+    )
+    storage.save = AsyncMock()
+    registry.set_storage(storage)
+
+    handler = FormAPIHandler(registry=registry)
+    status, form = await _create(handler, body={"title": "Daily Report"})
+
+    assert status == 201
+    assert form["form_id"].startswith("daily-report-")
+    assert form["form_id"] != "daily-report"
+
+
+async def test_storage_probe_failure_refuses_to_overwrite(
+    registry: FormRegistry,
+) -> None:
+    """An unreachable storage backend must not be read as "id is free"."""
+    storage = MagicMock()
+    storage.load = AsyncMock(side_effect=RuntimeError("db down"))
+    storage.save = AsyncMock()
+    registry.set_storage(storage)
+
+    handler = FormAPIHandler(registry=registry)
+    status, _ = await _create(handler, body={"form_id": "unknown", "title": "X"})
+
+    assert status == 409
+    storage.save.assert_not_awaited()
+
+
+async def test_lost_creation_race_returns_409(
+    handler: FormAPIHandler, registry: FormRegistry, monkeypatch
+) -> None:
+    """If another writer wins between the check and register, answer 409.
+
+    ``register(overwrite=False)`` is a silent no-op on a taken id, so without
+    the post-register identity check the loser would return 201 for a form
+    that was never stored.
+    """
+    real_register = registry.register
+
+    async def _register_with_interloper(form, **kwargs):
+        # Simulate a concurrent creation landing first.
+        await real_register(
+            FormSchema(
+                form_id=form.form_id,
+                title="Interloper",
+                sections=[],
+                tenant="t1",
+            ),
+            tenant="t1",
+            overwrite=True,
+        )
+        return await real_register(form, **kwargs)
+
+    monkeypatch.setattr(registry, "register", _register_with_interloper)
+
+    status, payload = await _create(handler, body={"form_id": "raced"})
+    assert status == 409
+    assert "already exists" in payload["error"]
+
+    winner = await registry.get("raced", tenant="t1")
+    assert winner is not None
+    assert winner.title == "Interloper"
+
+
+# ---------------------------------------------------------------------------
+# The user story: new blank form → drop controls on the canvas
+# ---------------------------------------------------------------------------
+
+
+async def test_blank_form_then_add_controls_via_operations(
+    handler: FormAPIHandler, registry: FormRegistry
+) -> None:
+    """End-to-end manual flow: create blank, then add two fields and a section."""
+    _, blank = await _create(handler, body={"title": "Canvas Form"})
+    form_id = blank["form_id"]
+    section_id = blank["sections"][0]["section_id"]
+
+    ops_req = _make_request(
+        match_info={"form_id": form_id},
+        app={"form_registry": registry},
+        body={
+            "operations": [
+                {
+                    "op": "add_field",
+                    "section_id": section_id,
+                    "field": {
+                        "field_id": "full_name",
+                        "field_type": "text",
+                        "label": "Full Name",
+                        "required": True,
+                    },
+                },
+                {
+                    "op": "add_field",
+                    "section_id": section_id,
+                    "field": {
+                        "field_id": "visit_date",
+                        "field_type": "date",
+                        "label": "Visit Date",
+                    },
+                },
+                {
+                    "op": "add_section",
+                    "section": {"section_id": "notes", "fields": []},
+                },
+            ],
+        },
+    )
+    resp = await handle_operations(ops_req)
+    assert resp.status == 200
+
+    updated = json.loads(resp.body.decode())["form"]
+    assert [f["field_id"] for f in updated["sections"][0]["fields"]] == [
+        "full_name",
+        "visit_date",
+    ]
+    assert [s["section_id"] for s in updated["sections"]] == [section_id, "notes"]
+    # Version bumped off the 1.0 the blank form was created with.
+    assert updated["version"] == "1.1"
+
+    stored = await registry.get(form_id, tenant="t1")
+    assert stored is not None
+    assert [f.field_id for f in stored.iter_all_fields()] == [
+        "full_name",
+        "visit_date",
+    ]


### PR DESCRIPTION
## Problem

`POST /api/v1/forms` was LLM-only: it required a `prompt` in the body and
returned `503 No LLM client configured for form creation` without a client.

That left a form-builder UI with no way to get a blank canvas to work on.
`PUT /forms/{id}`, `PATCH /forms/{id}` and `PATCH /forms/{id}/operations` all
`404` on an unknown `form_id`, so the only LLM-free ways to bring a form into
existence were `POST /forms/from-db` (NetworkNinja definition) or cloning an
existing one. "New form → blank → drag controls" was not expressible.

## Change

`POST /api/v1/forms` is now dual-mode, selected by the **presence** of the
`prompt` key:

| Body | Path | Response |
|---|---|---|
| `{"prompt": "..."}` | `CreateFormTool` (LLM) — unchanged | `200 {form_id, title, url}` |
| anything else, incl. `{}` | `_create_blank_form` — no LLM | `201` + full `FormSchema` |

```bash
# 1. "New" → blank form (an empty body is enough)
curl -X POST /api/v1/forms -d '{}'
# → 201 {"form_id":"untitled-form","version":"1.0",
#        "sections":[{"section_id":"section_1","fields":[]}], ...}

# 2. Control catalog for the toolbar
curl /api/v1/form-controls

# 3. Drop controls on the canvas, one at a time or batched
curl -X PATCH /api/v1/forms/untitled-form/operations \
  -H 'If-Match: 1.0' \
  -d '{"operations":[{"op":"add_field","section_id":"section_1",
        "field":{"field_id":"full_name","field_type":"text","label":"Full Name"}}]}'
```

### Design decisions

- **Seeded section.** A blank form carries one empty section `section_1`,
  because `add_field` requires an existing `section_id` — without it the canvas
  would need an `add_section` round trip first. Pass `"sections": []` for none.
- **`form_id`.** Explicit when supplied and matching `FORM_ID_RE`
  (`400` on spaces, `/`, `..`, control characters; `409` when taken). Otherwise
  derived from `title`, with a random hex suffix on collision — so clicking
  "New" repeatedly never fails with a `409`.
- **Handler-controlled keys.** `version` is always `"1.0"`,
  `published_version` always `None` (publishing stays `POST /forms/{id}/publish`),
  and `tenant` always comes from the session, never the body — a caller cannot
  write into another tenant. Every other `FormSchema` field passes through.
- **Mode by key presence, not truthiness.** `{"prompt": ""}` keeps its
  historical `400 prompt is required` rather than silently creating a blank form.

### Storage-aware duplicate detection

`FormRegistry.get()` is memory-only, the in-memory cache is hydrated **per
tenant**, and `PostgresFormStorage.save()` upserts (`ON CONFLICT ... DO UPDATE`).
A memory-only existence check would therefore let a "new" form silently
**overwrite** a persisted form belonging to a tenant that has not been hydrated
yet — data loss.

This PR adds the opt-in `FormRegistry.contains(..., include_storage=True)`,
which probes storage when the form is not in memory and treats a storage error
as "cannot prove absence" (refusing to create beats overwriting).

It also verifies object identity after `register(overwrite=False)`: that call is
a **silent no-op** on a taken id, so the loser of a concurrent create would
otherwise receive a `201` describing a form that was never stored, and its
subsequent `/operations` calls would edit the winner's form.

## Testing

- 35 new tests in `tests/unit/api/test_create_blank_form.py`, including the full
  round trip (create blank → add 2 fields + 1 section via `/operations` → assert
  persistence), a mocked storage backend for the upsert-overwrite case, and a
  `monkeypatch`-simulated lost race.
- Unit suite: **1262 passed / 14 failed**. The 14 failures are pre-existing —
  verified against the same base with the change stashed (1227 passed, same 14).
  They are stale assertions unrelated to this change, e.g.
  `test_form_controls_endpoint` does not know about the
  `supported_effects`/`supported_operations`/`supported_operators` keys that
  TASK-1529 added on 2026-06-12, and several count `FieldType` against an
  outdated total.
- `ruff check` clean on all touched files.

## Reviewed against an independent adversarial pass

An independent review raised six findings. Four are fixed here (the
storage-overwrite bug, the create race, prompt truthiness, and a `$`-vs-`\Z`
regex anchor that let a trailing newline through). Two are real but
**pre-existing and out of scope**, flagged for a follow-up decision:

1. **`PATCH /forms/{id}/operations` does not pass through RBAC.**
   `handle_operations` never calls `_rbac_shadow_gate`, while `PUT`/`PATCH`
   enforce `update_form`/`patch_form`. Pre-existing since FEAT-152 and currently
   moot (RBAC defaults to shadow mode, log-only), but this PR makes
   `/operations` *the* recommended builder path, so the gap now matters more.
   Fixing it is not mechanical: `handle_operations` is a module-level function
   with no handler instance.
2. **A persistence failure still returns 2xx.** `FormRegistry.register()`
   catches storage exceptions, logs, and returns normally — so a `201` does not
   prove the form survived a restart. This is shared with `PUT`/`PATCH`/
   `/operations`; changing it alters `register()`'s contract for every caller,
   so this PR stays consistent with them rather than diverging.

## Notes

No migration and no breaking change: the `prompt` path keeps its exact status
codes and response shape, and `contains()` gains a defaulted keyword argument.

Developed with Spec Driven Development
