### PR TITLE
fix(wiki): drop redundant title and noise lead from query stubs

### DIFF
--- a/packages/ai-parrot/src/parrot/knowledge/wiki/context.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/context.py
@@ -24,6 +24,15 @@ from parrot.knowledge.wiki.store import estimate_tokens
 
 _SENTENCE_END_RE = re.compile(r"(?<=[.!?])\s")
 
+#: Leading ``<kind>:`` namespace of a page id.  Matched non-greedily and
+#: only at the start, so a path that itself contains a colon (e.g.
+#: ``file:docs/summaries/mod:parrot.skills.md``) keeps its inner one.
+_ID_PREFIX_RE = re.compile(r"^(?:file|dir|mod|pkg|doc|func|class|concept|page):")
+
+#: Leads carrying no information — typically a frontmatter delimiter
+#: captured as a page summary at ingest time.
+_NOISE_LEADS = frozenset({"---", "...", "-"})
+
 DEFAULT_BUDGET_TOKENS = 1200
 _MAX_LEAD_CHARS = 240
 
@@ -80,6 +89,13 @@ def stub_line(result: dict[str, Any]) -> str:
     The token figure is the cost of reading the FULL page via
     ``wiki_read`` — it lets the model budget its next move.
 
+    Both middle fields are elided when they carry nothing: a ``title``
+    that merely restates the id (every ``file:`` page stores its path as
+    its title) and a ``lead`` that is only a frontmatter delimiter are
+    dropped rather than rendered twice or rendered empty.  This is a
+    presentation concern only — :func:`pack_results` keeps the raw
+    ``title``/``lead`` in its structured ``stubs``.
+
     Args:
         result: Result dict with at least an id field; ``score``,
             ``snippet``/``summary``, and ``token_count`` are optional.
@@ -90,8 +106,10 @@ def stub_line(result: dict[str, Any]) -> str:
     rid = str(
         result.get("concept_id") or result.get("node_id") or result.get("page_id") or "?"
     )
-    title = str(result.get("title") or "").strip() or rid
+    title = str(result.get("title") or "").strip()
     lead = first_sentence(str(result.get("snippet") or result.get("summary") or ""))
+    if lead in _NOISE_LEADS:
+        lead = ""
     meta: list[str] = []
     score = result.get("score")
     if score is not None:
@@ -100,7 +118,11 @@ def stub_line(result: dict[str, Any]) -> str:
     if tokens:
         meta.append(f"~{int(tokens)}tok")
     suffix = f" ({', '.join(meta)})" if meta else ""
-    body = f"- [{rid}] {title}"
+    body = f"- [{rid}]"
+    # ``dir:`` titles carry a trailing slash the id does not — normalise it
+    # away so they count as duplicates rather than as added information.
+    if title and title.rstrip("/") not in (rid, _ID_PREFIX_RE.sub("", rid, count=1)):
+        body += f" {title}"
     if lead:
         body += f" — {lead}"
     return body + suffix

--- a/tests/knowledge/wiki/test_context.py
+++ b/tests/knowledge/wiki/test_context.py
@@ -49,7 +49,41 @@ class TestStubLine:
 
     def test_minimal_result(self):
         line = stub_line({"concept_id": "x"})
-        assert line == "- [x] x"
+        assert line == "- [x]"
+
+    def test_omits_title_that_only_repeats_the_id(self):
+        line = stub_line(
+            {
+                "concept_id": "file:parrot/tools/base.py",
+                "title": "parrot/tools/base.py",
+            }
+        )
+        assert line == "- [file:parrot/tools/base.py]"
+
+    def test_keeps_a_title_that_adds_information(self):
+        line = stub_line({"concept_id": "mem-3f32cf69", "title": "Graph sync gotcha"})
+        assert line == "- [mem-3f32cf69] Graph sync gotcha"
+
+    def test_strips_only_the_leading_id_prefix(self):
+        # The path itself contains a second ':' — de-duplication must not
+        # mistake it for the id prefix and mangle the comparison.
+        rid = "file:docs/parrot/summaries/mod:parrot.skills.md"
+        line = stub_line({"concept_id": rid, "title": rid.removeprefix("file:")})
+        assert line == f"- [{rid}]"
+
+    def test_omits_dir_title_that_only_adds_a_trailing_slash(self):
+        # repo_scan emits directory titles as "<relpath>/" against a
+        # "dir:<relpath>" id — the slash is not information.
+        line = stub_line({"concept_id": "dir:tests/knowledge", "title": "tests/knowledge/"})
+        assert line == "- [dir:tests/knowledge]"
+
+    def test_omits_pkg_title_that_only_repeats_the_id(self):
+        line = stub_line({"concept_id": "pkg:parrot.skills", "title": "parrot.skills"})
+        assert line == "- [pkg:parrot.skills]"
+
+    def test_drops_frontmatter_delimiter_lead(self):
+        line = stub_line({"concept_id": "x", "title": "Title", "summary": "---"})
+        assert line == "- [x] Title"
 
 
 class TestPackResults:


### PR DESCRIPTION
## Problem

`stub_line()` rendered every page path twice — once as the id, once as the title, which for `file:`/`dir:`/`pkg:` pages is that same id minus its namespace prefix. Pages whose summary captured a frontmatter delimiter also rendered a bare `— ---`.

```
- [file:sdd/specs/odoo-pageindex-documentation-agent.spec.md] sdd/specs/odoo-pageindex-documentation-agent.spec.md — --- (score=1.00, ~4223tok)
- [file:sdd/specs/odoo-pageindex-documentation-agent.spec.md] (score=1.00, ~4223tok)
```

## Change

Elide both fields when they carry nothing: a title that only restates the id (normalising the trailing slash `repo_scan` gives `dir:` titles) and a lead that is only a delimiter.

The id-prefix regex is anchored and non-greedy so a path containing its own colon — `file:docs/parrot/summaries/mod:parrot.skills.md` — keeps the inner one.

**Presentation only.** `pack_results` still stores the raw `title` and `lead` in its structured `stubs`, so `--json` and programmatic callers are unaffected. No consumer parses the rendered text: `cli.py:944` echoes it, `toolkit.py:199` feeds it to an LLM, `dev_loop/wiki_search.py` passes it through.

## Impact

**−30.8%** on `wikitoolkit query` output, measured across 8 queries (19373B → 13404B). `stub_line` is shared, so `related` and the MCP toolkit inherit the reduction.

The token budget is not the binding constraint here (measured p90 688 tok against a 1200 budget; `top_k=12` binds first), so the reduction materialises as fewer tokens rather than more results. Where a query *does* truncate, it becomes more coverage instead.

## Verification

- `tests/knowledge/` — 443 passed
- `ruff` — 4 findings, identical to the `dev` baseline; none introduced
- End-to-end diff of real `wikitoolkit query` output before/after

Six tests added, written before the implementation. One existing assertion changed: `test_minimal_result` went from `"- [x] x"` to `"- [x]"` — the redundancy being removed.

## Known residue (not in scope)

- JSON pages still render `{` as their lead.
- The `---` summaries are an **ingest-side** defect; this renderer only masks them, and the bad summary still feeds BM25 ranking.
- `docs/parrot/concepts/func:...stub_line.md` documents the old format until the next `wikitoolkit build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)