### PR TITLE
fix(wiki): never ingest a directory that is itself a wiki bundle

### DIFF
--- a/packages/ai-parrot/src/parrot/knowledge/wiki/cli.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/cli.py
@@ -44,6 +44,7 @@ from parrot.knowledge.wiki.project import (
     save_project_config,
 )
 from parrot.knowledge.wiki.repo_scan import (
+    is_inside_wiki_bundle,
     is_wiki_relevant,
     scan_repository,
 )
@@ -822,12 +823,15 @@ def upsert(
                 continue
         rel = PurePosixPath(rel).as_posix()
         # Same selection filter as full discovery — the two paths must
-        # never disagree about what belongs in the wiki.
+        # never disagree about what belongs in the wiki. The bundle
+        # guardrail is checked per path (ancestor walk) rather than by
+        # discovering every bundle in the repo, so a docs-only commit
+        # keeps its O(1) fast path.
         if is_wiki_relevant(
             rel,
             suffixes=config.include_suffixes or None,
             exclude_dirs=config.exclude_dirs,
-        ):
+        ) and not is_inside_wiki_bundle(root, rel):
             normalized.append(rel)
 
     existing = [rel for rel in normalized if (root / rel).is_file()]

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/repo_scan.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/repo_scan.py
@@ -70,6 +70,10 @@ DEFAULT_EXCLUDE_NAMES: frozenset[str] = frozenset({
     "uv.lock", "poetry.lock", "Cargo.lock",
 })
 
+#: Build-report basename written at the root of every exported wiki
+#: bundle — the marker that identifies a directory as *being* a wiki.
+WIKI_BUNDLE_MARKER = "wiki_stats.json"
+
 #: Skip files larger than this many bytes (default 512 KiB).
 DEFAULT_MAX_FILE_BYTES = 512 * 1024
 
@@ -182,6 +186,97 @@ def dir_concept_id(rel_path: str) -> str:
 # --------------------------------------------------------------------------
 
 
+def find_wiki_bundle_dirs(
+    root: Path,
+    exclude_dirs: Optional[Iterable[str]] = None,
+) -> list[str]:
+    """Locate exported wiki bundles nested inside ``root``.
+
+    A wiki must never ingest another wiki's export: those pages mirror
+    the repository's own files, so indexing them fills every result set
+    with near-duplicates of their own sources and buries the originals.
+    Bundles are recognised by the :data:`WIKI_BUNDLE_MARKER` build
+    report that ``build`` writes at the root of each export.
+
+    The build already excludes the export directory it is *currently*
+    configured to write; this finds the ones it is not — a bundle left
+    behind by an earlier configuration, or one vendored in from another
+    project.
+
+    A marker at ``root`` itself is ignored: the repository being scanned
+    may legitimately be a bundle, and pruning it would discover nothing.
+
+    Args:
+        root: Repository root directory.
+        exclude_dirs: Directory names pruned during the walk (merged
+            with :data:`DEFAULT_EXCLUDE_DIRS`); path-prefix entries
+            containing ``/`` are ignored here.
+
+    Returns:
+        Sorted root-relative POSIX paths of the bundle directories.
+    """
+    root = root.resolve()
+    pruned_names = set(DEFAULT_EXCLUDE_DIRS)
+    pruned_paths: set[str] = set()
+    for entry in (e.strip("/") for e in exclude_dirs or ()):
+        if not entry:
+            continue
+        if "/" in entry:
+            pruned_paths.add(entry)
+        else:
+            pruned_names.add(entry)
+
+    bundles: list[str] = []
+    stack = [root]
+    while stack:
+        current = stack.pop()
+        if current != root and (current / WIKI_BUNDLE_MARKER).is_file():
+            bundles.append(current.relative_to(root).as_posix())
+            continue  # a bundle is opaque — never descend into it
+        try:
+            entries = sorted(current.iterdir())
+        except OSError:
+            continue
+        for entry in entries:
+            if not entry.is_dir() or entry.is_symlink():
+                continue
+            if entry.name in pruned_names:
+                continue
+            rel = entry.relative_to(root).as_posix()
+            if any(rel == pp or rel.startswith(pp + "/") for pp in pruned_paths):
+                continue
+            stack.append(entry)
+    return sorted(bundles)
+
+
+def is_inside_wiki_bundle(root: Path, rel_path: str) -> bool:
+    """Whether ``rel_path`` sits inside a nested exported wiki bundle.
+
+    The ancestor-walk counterpart to :func:`find_wiki_bundle_dirs`, for
+    the incremental path. It answers the question for one file in
+    O(path depth) rather than O(repository), so the git post-commit
+    hook keeps its docs-only fast path instead of scanning the whole
+    tree on every commit.
+
+    A marker at ``root`` itself is ignored, matching
+    :func:`find_wiki_bundle_dirs`.
+
+    Args:
+        root: Repository root directory.
+        rel_path: POSIX-style path relative to ``root``.
+
+    Returns:
+        ``True`` when any ancestor directory below ``root`` carries the
+        :data:`WIKI_BUNDLE_MARKER`.
+    """
+    root = root.resolve()
+    parts = PurePosixPath(rel_path).parts
+    for depth in range(1, len(parts)):
+        if (root.joinpath(*parts[:depth]) / WIKI_BUNDLE_MARKER).is_file():
+            return True
+    return False
+
+
 def discover_repo_files(
     root: Path,
     suffixes: Optional[Iterable[str]] = None,
@@ -206,7 +301,11 @@ def discover_repo_files(
         Sorted list of POSIX-style relative paths.
     """
     root = root.resolve()
-    pruned = DEFAULT_EXCLUDE_DIRS | frozenset(exclude_dirs or ())
+    # Nested wiki bundles are pruned as path prefixes, whichever way the
+    # file list was obtained — git ls-files sees them too.
+    excluded = list(exclude_dirs or ())
+    excluded.extend(find_wiki_bundle_dirs(root, exclude_dirs=excluded))
+    pruned = DEFAULT_EXCLUDE_DIRS | frozenset(excluded)
 
     rel_paths: Optional[list[str]] = None
     if use_git:
@@ -217,7 +316,7 @@ def discover_repo_files(
     return sorted({
         rel
         for rel in rel_paths
-        if is_wiki_relevant(rel, suffixes=suffixes, exclude_dirs=exclude_dirs)
+        if is_wiki_relevant(rel, suffixes=suffixes, exclude_dirs=excluded)
     })
 
 

--- a/tests/knowledge/wiki/test_cli.py
+++ b/tests/knowledge/wiki/test_cli.py
@@ -289,6 +289,21 @@ class TestUpsert:
         assert result.exit_code == 0
         assert "No wiki-relevant files" in result.output
 
+    def test_upsert_ignores_a_nested_wiki_bundle(self, runner, repo):
+        # Incremental upsert must apply the same guardrail as a full
+        # build: a directory that is itself a wiki export is not content.
+        _build(runner, repo)
+        bundle = repo / "docs" / "legacy_wiki"
+        bundle.mkdir(parents=True, exist_ok=True)
+        (bundle / "wiki_stats.json").write_text("{}", encoding="utf-8")
+        (bundle / "index.md").write_text("# Legacy wiki\n", encoding="utf-8")
+
+        result = runner.invoke(
+            wiki, ["upsert", "docs/legacy_wiki/index.md", "--path", str(repo)]
+        )
+        assert result.exit_code == 0
+        assert "No wiki-relevant files" in result.output
+
     def test_upsert_before_build_is_noop(self, runner, tmp_path):
         (tmp_path / "a.py").write_text("x = 1", encoding="utf-8")
         result = runner.invoke(

--- a/tests/knowledge/wiki/test_repo_scan.py
+++ b/tests/knowledge/wiki/test_repo_scan.py
@@ -10,11 +10,14 @@ from pathlib import Path
 
 from parrot.knowledge.wiki.repo_scan import (
     DEFAULT_MAX_FILE_BYTES,
+    WIKI_BUNDLE_MARKER,
     build_dir_pages,
     build_file_slice,
     dir_concept_id,
     discover_repo_files,
     file_concept_id,
+    find_wiki_bundle_dirs,
+    is_inside_wiki_bundle,
     scan_repository,
 )
 
@@ -28,6 +31,74 @@ def _write(root: Path, rel: str, content: str) -> Path:
 
 PY_A = '"""Mod A does things."""\nfrom pkg.b import x\n\n\nclass Alpha:\n    """Alpha class."""\n\n    def run(self, arg):\n        """Run it."""\n        return arg\n\n\ndef helper():\n    """Top-level helper."""\n'
 PY_B = '"""Mod B."""\nx = 1\n'
+
+
+class TestWikiBundleGuardrail:
+    """A wiki must never ingest another wiki's exported bundle."""
+
+    def test_finds_a_nested_bundle_by_its_marker(self, tmp_path: Path):
+        _write(tmp_path, f"docs/parrot/{WIKI_BUNDLE_MARKER}", "{}")
+        _write(tmp_path, "docs/parrot/index.md", "# Wiki")
+        assert find_wiki_bundle_dirs(tmp_path) == ["docs/parrot"]
+
+    def test_reports_no_bundle_for_an_ordinary_tree(self, tmp_path: Path):
+        _write(tmp_path, "docs/guide.md", "# Guide")
+        assert find_wiki_bundle_dirs(tmp_path) == []
+
+    def test_discovery_skips_everything_inside_a_bundle(self, tmp_path: Path):
+        _write(tmp_path, "app.py", "x = 1")
+        _write(tmp_path, "docs/guide.md", "# A real doc")
+        _write(tmp_path, f"docs/parrot/{WIKI_BUNDLE_MARKER}", "{}")
+        _write(tmp_path, "docs/parrot/index.md", "# Wiki")
+        _write(
+            tmp_path,
+            "docs/parrot/overviews/doc:app-py.md",
+            "---\ntitle: app.py\n---\n\n# app.py\n",
+        )
+
+        found = discover_repo_files(tmp_path, use_git=False)
+
+        assert "app.py" in found
+        assert "docs/guide.md" in found
+        assert all(not f.startswith("docs/parrot/") for f in found)
+
+    def test_detects_a_path_inside_a_bundle_without_walking_the_repo(
+        self, tmp_path: Path
+    ):
+        # The incremental path must answer "is this one file inside a
+        # bundle?" by looking at its ancestors, not by scanning the tree:
+        # the git post-commit hook pays this cost on every commit.
+        _write(tmp_path, f"docs/parrot/{WIKI_BUNDLE_MARKER}", "{}")
+        _write(tmp_path, "docs/parrot/overviews/doc:app-py.md", "# app")
+        _write(tmp_path, "docs/guide.md", "# Guide")
+
+        assert is_inside_wiki_bundle(tmp_path, "docs/parrot/overviews/doc:app-py.md")
+        assert is_inside_wiki_bundle(tmp_path, "docs/parrot/index.md")
+        assert not is_inside_wiki_bundle(tmp_path, "docs/guide.md")
+        assert not is_inside_wiki_bundle(tmp_path, "app.py")
+
+    def test_inside_check_ignores_a_marker_at_the_repo_root(self, tmp_path: Path):
+        _write(tmp_path, WIKI_BUNDLE_MARKER, "{}")
+        _write(tmp_path, "app.py", "x = 1")
+        assert not is_inside_wiki_bundle(tmp_path, "app.py")
+
+    def test_walk_does_not_descend_into_path_prefix_excludes(self, tmp_path: Path):
+        _write(tmp_path, f"vendor/stuff/{WIKI_BUNDLE_MARKER}", "{}")
+        _write(tmp_path, f"docs/parrot/{WIKI_BUNDLE_MARKER}", "{}")
+
+        found = find_wiki_bundle_dirs(tmp_path, exclude_dirs=["vendor/stuff"])
+
+        assert found == ["docs/parrot"]
+
+    def test_a_bundle_at_the_repo_root_does_not_prune_the_repo(self, tmp_path: Path):
+        # The scanned repo may itself be a wiki bundle root; excluding "."
+        # would silently discover nothing at all.
+        _write(tmp_path, WIKI_BUNDLE_MARKER, "{}")
+        _write(tmp_path, "app.py", "x = 1")
+
+        found = discover_repo_files(tmp_path, use_git=False)
+
+        assert "app.py" in found
 
 
 class TestDiscovery:


### PR DESCRIPTION
## Problem

`build` excludes the export directory it is **currently** configured to write (`cli.py`, `export_rel`), but nothing excluded a bundle left behind by an *earlier* configuration.

When this repo moved its wiki from `docs/parrot` to `.parrot/wiki`, the old export stopped being `export_rel` and silently became indexable content. Measured on a checkout that still has it:

```
without guardrail: 17506 files discovered
with guardrail   :  8471 files discovered
pruned           :  9035  (52% of the corpus) — all under docs/parrot/
```

Half the index was the wiki's own mirror of itself, so query results competed against near-duplicates of their own sources — `sdd/specs/X.spec.md` (score 1.00) sitting next to `docs/parrot/overviews/doc:sdd-specs-X-spec-md.md` (score 0.88), same content, two result slots.

It also accounts for the store's junk-summary rate: 56% of pages had `---` as their summary, and the bundle *is* the set of frontmatter files.

## Change

Recognise a bundle by the `wiki_stats.json` build report at its root and prune it, whichever configuration produced it. Two entry points, because the two call paths have very different cost profiles:

| Function | Used by | Cost |
|---|---|---|
| `find_wiki_bundle_dirs()` | full discovery — one walk, honours bare-name *and* path-prefix exclusions, never descends into a bundle it finds | O(repo), once per build |
| `is_inside_wiki_bundle()` | incremental upsert — ancestor walk for a single path | **0.072 ms** |

The split is load-bearing. A repo-wide walk in `upsert` measured **282 ms** and would have defeated the docs-only fast path that `repo_scan.py:626` documents explicitly and the git post-commit hook depends on. Ancestor walk instead: **282 ms → 0.072 ms**.

A marker at the repository root is ignored — the scanned repo may legitimately be a bundle, and pruning `"."` would discover nothing at all.

## Scope note

`scan_repository(rel_paths=...)` still trusts its caller and applies no selection filter. That is pre-existing and equally true of `.parrot` and every other exclusion: the CLI is the filtering layer, as pinned by `test_upsert_ignores_excluded_dirs`. Changing that contract would affect every caller, so it is left alone.

## Verification

- `tests/knowledge/` — **445 passed**; 7 new tests, each written before the code it covers
- Real-world: detects `['docs/parrot']` on a checkout that still has the legacy bundle, `[]` on one where it was deleted — no over-pruning
- `ruff` — 86 vs 85 on `dev`: one new `UP045` from `Optional[Iterable[str]]`, matching the five identical ones already in that module rather than introducing a lone divergent signature

## Not included

The existing store is untouched — the ~10K stale pages persist until a `wikitoolkit build --force`. The summary-extraction cascade (frontmatter `summary:` → `title:` → first heading) is still open, but much less urgent: removing the bundle removes most of the `---` at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)