### PR TITLE
fix(wiki): serialise store writers behind an advisory lock

### DIFF
--- a/packages/ai-parrot/src/parrot/knowledge/wiki/cli.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/cli.py
@@ -42,6 +42,7 @@ from parrot.knowledge.wiki.project import (
     find_project_root,
     load_project_config,
     save_project_config,
+    wiki_write_lock,
 )
 from parrot.knowledge.wiki.repo_scan import (
     is_inside_wiki_bundle,
@@ -54,6 +55,11 @@ from parrot.knowledge.wiki.store import BaseWikiStore, create_wiki_store
 import logging
 
 _cli_logger = logging.getLogger("wikitoolkit.cli")
+
+#: How long `upsert` waits for a contended store lock before skipping.
+#: Long enough to outlast a peer upsert (sub-second), short enough that
+#: a commit hook never stalls behind a multi-minute build.
+UPSERT_LOCK_WAIT_SECONDS = 3.0
 
 
 # --------------------------------------------------------------------------
@@ -654,91 +660,99 @@ def build(
     map, a wiki_stats.json build report, and a README.md entry point.
     """
     root, config = _resolve_project(path_)
-    if name:
-        config.wiki_name = name
-    if backend:
-        config.backend = backend  # type: ignore[assignment]
-
-    if not quiet:
-        click.echo(f"Scanning {root} ...")
-    scan = scan_repository(
-        root,
-        suffixes=config.include_suffixes or None,
-        exclude_dirs=config.exclude_dirs,
-        body_max_chars=config.body_max_chars,
-        max_file_bytes=config.max_file_kb * 1024,
-        use_git=not no_git,
-    )
-
-    output_dir = config.storage_path(root)
-
-    async def _pipeline() -> dict[str, Any]:
-        store = _open_store(root, config)
-        sources = _open_sources(root, config)
-        counts = await _ingest_files(store, sources, root, scan, force=force)
-        await store.upsert_pages(scan.dir_records)
-        await store.add_edges(scan.dir_edges)
-        counts["removed"] = await _prune_removed(store, sources, root, scan)
-        counts["stats"] = await store.stats()
-
-        okf_report: Optional[dict[str, Any]] = None
-        if not no_export:
-            okf_report = await _export_okf(
-                store, output_dir, config.wiki_name,
+    with wiki_write_lock(config.storage_path(root)) as _acquired:
+        if not _acquired:
+            click.echo(
+                "Another wiki writer is in progress (build or upsert) — "
+                "refusing to run two writers against the same store. Wait "
+                "for it to finish, then retry."
             )
-            # Exclude the export output from future scans.
-            try:
-                export_rel = output_dir.resolve().relative_to(root).as_posix()
-            except ValueError:
-                export_rel = None
-            if export_rel and export_rel not in config.exclude_dirs:
-                config.exclude_dirs.append(export_rel)
-        counts["okf"] = okf_report
+            raise SystemExit(1)
+        if name:
+            config.wiki_name = name
+        if backend:
+            config.backend = backend  # type: ignore[assignment]
 
-        graph_stats: Optional[dict[str, Any]] = None
-        if not no_graph:
-            kinds = frozenset(
-                k.strip() for k in graph_kinds.split(",") if k.strip()
-            )
-            graph_stats = await _export_graph_html(
-                store, output_dir, config.wiki_name, kinds,
-            )
-        counts["graph"] = graph_stats
-
-        return counts
-
-    counts = _run(_pipeline())
-    save_project_config(root, config)
-
-    stats = counts["stats"]
-
-    # Write wiki_stats.json + README.md.
-    _write_build_stats(
-        output_dir, config.wiki_name, stats,
-        counts.get("okf"), counts.get("graph"),
-    )
-
-    click.echo(
-        f"Wiki '{config.wiki_name}' built at "
-        f"{output_dir} — "
-        f"{counts['written']} ingested, {counts['unchanged']} unchanged, "
-        f"{counts['removed']} removed; "
-        f"{stats.get('pages', 0)} pages, {stats.get('edges', 0)} edges."
-    )
-    okf = counts.get("okf")
-    if okf and not quiet:
-        click.echo(f"OKF bundle: {okf['files_written']} files exported.")
-    graph = counts.get("graph")
-    if graph and graph.get("exported") and not quiet:
-        click.echo(
-            f"Graph: {graph['nodes']} nodes, {graph['edges']} edges "
-            f"→ {graph['html']}"
+        if not quiet:
+            click.echo(f"Scanning {root} ...")
+        scan = scan_repository(
+            root,
+            suffixes=config.include_suffixes or None,
+            exclude_dirs=config.exclude_dirs,
+            body_max_chars=config.body_max_chars,
+            max_file_bytes=config.max_file_kb * 1024,
+            use_git=not no_git,
         )
-    if scan.skipped and not quiet:
-        click.echo(f"Skipped {len(scan.skipped)} binary/oversized files.")
-        if len(scan.skipped) <= 10:
-            for path in scan.skipped:
-                click.echo(f"  - {path}")
+
+        output_dir = config.storage_path(root)
+
+        async def _pipeline() -> dict[str, Any]:
+            store = _open_store(root, config)
+            sources = _open_sources(root, config)
+            counts = await _ingest_files(store, sources, root, scan, force=force)
+            await store.upsert_pages(scan.dir_records)
+            await store.add_edges(scan.dir_edges)
+            counts["removed"] = await _prune_removed(store, sources, root, scan)
+            counts["stats"] = await store.stats()
+
+            okf_report: Optional[dict[str, Any]] = None
+            if not no_export:
+                okf_report = await _export_okf(
+                    store, output_dir, config.wiki_name,
+                )
+                # Exclude the export output from future scans.
+                try:
+                    export_rel = output_dir.resolve().relative_to(root).as_posix()
+                except ValueError:
+                    export_rel = None
+                if export_rel and export_rel not in config.exclude_dirs:
+                    config.exclude_dirs.append(export_rel)
+            counts["okf"] = okf_report
+
+            graph_stats: Optional[dict[str, Any]] = None
+            if not no_graph:
+                kinds = frozenset(
+                    k.strip() for k in graph_kinds.split(",") if k.strip()
+                )
+                graph_stats = await _export_graph_html(
+                    store, output_dir, config.wiki_name, kinds,
+                )
+            counts["graph"] = graph_stats
+
+            return counts
+
+        counts = _run(_pipeline())
+        save_project_config(root, config)
+
+        stats = counts["stats"]
+
+        # Write wiki_stats.json + README.md.
+        _write_build_stats(
+            output_dir, config.wiki_name, stats,
+            counts.get("okf"), counts.get("graph"),
+        )
+
+        click.echo(
+            f"Wiki '{config.wiki_name}' built at "
+            f"{output_dir} — "
+            f"{counts['written']} ingested, {counts['unchanged']} unchanged, "
+            f"{counts['removed']} removed; "
+            f"{stats.get('pages', 0)} pages, {stats.get('edges', 0)} edges."
+        )
+        okf = counts.get("okf")
+        if okf and not quiet:
+            click.echo(f"OKF bundle: {okf['files_written']} files exported.")
+        graph = counts.get("graph")
+        if graph and graph.get("exported") and not quiet:
+            click.echo(
+                f"Graph: {graph['nodes']} nodes, {graph['edges']} edges "
+                f"→ {graph['html']}"
+            )
+        if scan.skipped and not quiet:
+            click.echo(f"Skipped {len(scan.skipped)} binary/oversized files.")
+            if len(scan.skipped) <= 10:
+                for path in scan.skipped:
+                    click.echo(f"  - {path}")
 
 
 def _changed_files_from_git(root: Path) -> list[str]:
@@ -800,77 +814,90 @@ def upsert(
     next full `wikitoolkit build`.
     """
     root, config = _resolve_project(path_)
-    if not config.is_built(root):
-        if not quiet:
-            click.echo("Wiki not built yet — run `wikitoolkit build` first.")
-        return
+    # Wait out a peer upsert (sub-second) rather than dropping the
+    # commit's files; give up quickly if a multi-minute build holds it.
+    with wiki_write_lock(
+        config.storage_path(root), timeout=UPSERT_LOCK_WAIT_SECONDS
+    ) as _acquired:
+        if not _acquired:
+            if not quiet:
+                click.echo(
+                    "Another wiki writer is in progress (likely a full "
+                    "build) — skipping this upsert; the build will cover "
+                    "these files."
+                )
+            return
+        if not config.is_built(root):
+            if not quiet:
+                click.echo("Wiki not built yet — run `wikitoolkit build` first.")
+            return
 
-    rel_paths = list(paths)
-    if changed:
-        rel_paths.extend(_changed_files_from_git(root))
-    if not rel_paths:
-        if not quiet:
-            click.echo("Nothing to upsert (no paths given).")
-        return
+        rel_paths = list(paths)
+        if changed:
+            rel_paths.extend(_changed_files_from_git(root))
+        if not rel_paths:
+            if not quiet:
+                click.echo("Nothing to upsert (no paths given).")
+            return
 
-    normalized: list[str] = []
-    for rel in rel_paths:
-        p = Path(rel)
-        if p.is_absolute():
-            try:
-                rel = p.resolve().relative_to(root).as_posix()
-            except ValueError:
-                continue
-        rel = PurePosixPath(rel).as_posix()
-        # Same selection filter as full discovery — the two paths must
-        # never disagree about what belongs in the wiki. The bundle
-        # guardrail is checked per path (ancestor walk) rather than by
-        # discovering every bundle in the repo, so a docs-only commit
-        # keeps its O(1) fast path.
-        if is_wiki_relevant(
-            rel,
+        normalized: list[str] = []
+        for rel in rel_paths:
+            p = Path(rel)
+            if p.is_absolute():
+                try:
+                    rel = p.resolve().relative_to(root).as_posix()
+                except ValueError:
+                    continue
+            rel = PurePosixPath(rel).as_posix()
+            # Same selection filter as full discovery — the two paths must
+            # never disagree about what belongs in the wiki. The bundle
+            # guardrail is checked per path (ancestor walk) rather than by
+            # discovering every bundle in the repo, so a docs-only commit
+            # keeps its O(1) fast path.
+            if is_wiki_relevant(
+                rel,
+                suffixes=config.include_suffixes or None,
+                exclude_dirs=config.exclude_dirs,
+            ) and not is_inside_wiki_bundle(root, rel):
+                normalized.append(rel)
+
+        existing = [rel for rel in normalized if (root / rel).is_file()]
+        deleted = [rel for rel in normalized if not (root / rel).is_file()]
+        if not existing and not deleted:
+            if not quiet:
+                click.echo("No wiki-relevant files in the given set.")
+            return
+
+        scan = scan_repository(
+            root,
             suffixes=config.include_suffixes or None,
             exclude_dirs=config.exclude_dirs,
-        ) and not is_inside_wiki_bundle(root, rel):
-            normalized.append(rel)
-
-    existing = [rel for rel in normalized if (root / rel).is_file()]
-    deleted = [rel for rel in normalized if not (root / rel).is_file()]
-    if not existing and not deleted:
-        if not quiet:
-            click.echo("No wiki-relevant files in the given set.")
-        return
-
-    scan = scan_repository(
-        root,
-        suffixes=config.include_suffixes or None,
-        exclude_dirs=config.exclude_dirs,
-        body_max_chars=config.body_max_chars,
-        max_file_bytes=config.max_file_kb * 1024,
-        rel_paths=existing,
-    )
-
-    async def _pipeline() -> dict[str, int]:
-        store = _open_store(root, config)
-        sources = _open_sources(root, config)
-        counts = await _ingest_files(store, sources, root, scan, force=True)
-        removed = 0
-        for rel in deleted:
-            uri = str((root / rel).resolve())
-            source_id = await asyncio.to_thread(sources.find_by_uri, uri)
-            if source_id:
-                await store.replace_source_slice(source_id, [], [])
-                await asyncio.to_thread(sources.remove_source, source_id)
-                removed += 1
-        counts["removed"] = removed
-        return counts
-
-    counts = _run(_pipeline())
-    if not quiet:
-        click.echo(
-            f"Upserted {counts['written']} page(s), "
-            f"removed {counts['removed']}."
+            body_max_chars=config.body_max_chars,
+            max_file_bytes=config.max_file_kb * 1024,
+            rel_paths=existing,
         )
+
+        async def _pipeline() -> dict[str, int]:
+            store = _open_store(root, config)
+            sources = _open_sources(root, config)
+            counts = await _ingest_files(store, sources, root, scan, force=True)
+            removed = 0
+            for rel in deleted:
+                uri = str((root / rel).resolve())
+                source_id = await asyncio.to_thread(sources.find_by_uri, uri)
+                if source_id:
+                    await store.replace_source_slice(source_id, [], [])
+                    await asyncio.to_thread(sources.remove_source, source_id)
+                    removed += 1
+            counts["removed"] = removed
+            return counts
+
+        counts = _run(_pipeline())
+        if not quiet:
+            click.echo(
+                f"Upserted {counts['written']} page(s), "
+                f"removed {counts['removed']}."
+            )
 
 
 @wiki.command()

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/project.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/project.py
@@ -13,16 +13,94 @@ PreToolUse hook can import them with minimal startup cost.
 from __future__ import annotations
 
 import json
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
+
+try:  # POSIX only — see wiki_write_lock().
+    import fcntl
+except ImportError:  # pragma: no cover - non-POSIX platform
+    fcntl = None  # type: ignore[assignment]
 
 #: Directory (relative to repo root) holding parrot project state.
 PARROT_DIR = ".parrot"
 
 #: Config filename inside :data:`PARROT_DIR`.
 CONFIG_FILENAME = "wiki.json"
+
+#: Lock filename inside the wiki storage directory, guarding writers.
+LOCK_FILENAME = "wiki.lock"
+
+#: Poll interval while waiting for a contended lock.
+_LOCK_POLL_SECONDS = 0.05
+
+
+@contextmanager
+def wiki_write_lock(store_dir: Path, timeout: float = 0.0) -> Iterator[bool]:
+    """Hold the exclusive writer lock for a wiki store.
+
+    A full ``build`` rewrites the entire store and can run for many
+    minutes, while the git post-commit hook fires ``upsert --changed``
+    on its own schedule. Without mutual exclusion the two write the
+    same SQLite file concurrently.
+
+    The lock lives **beside the store**, not at the repository root:
+    ``storage_dir`` may be absolute, so two repositories can share one
+    store and must contend on the same lock for it to mean anything.
+    Pass :meth:`WikiProjectConfig.storage_path`, never the repo root.
+
+    It is advisory: the context manager yields whether the lock was
+    acquired and lets the caller decide what that means. ``build``
+    refuses; ``upsert`` waits briefly (so back-to-back commits are not
+    silently dropped) and then skips, because a commit hook must never
+    stall behind a multi-minute build. The lock is held via ``flock``
+    on an open descriptor, so the kernel releases it if the holder
+    crashes — no stale lock file can wedge the wiki.
+
+    On platforms without :mod:`fcntl` it degrades to a no-op and always
+    yields ``True``: no protection, but no false blocking either.
+
+    Args:
+        store_dir: Directory holding the wiki store, created if absent.
+        timeout: Seconds to keep retrying before giving up. ``0.0``
+            (the default) tries exactly once.
+
+    Yields:
+        ``True`` when the lock is held by this caller, ``False`` when
+        another process holds it.
+    """
+    store_dir.mkdir(parents=True, exist_ok=True)
+    handle = open(store_dir / LOCK_FILENAME, "a+")  # noqa: SIM115 - closed below
+    try:
+        if fcntl is None:  # pragma: no cover - non-POSIX platform
+            yield True
+            return
+
+        deadline = time.monotonic() + max(timeout, 0.0)
+        acquired = False
+        while True:
+            try:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                acquired = True
+                break
+            except OSError:
+                if time.monotonic() >= deadline:
+                    break
+                time.sleep(_LOCK_POLL_SECONDS)
+
+        if not acquired:
+            yield False
+            return
+        try:
+            yield True
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    finally:
+        handle.close()
 
 
 class ClaudeIntegrationConfig(BaseModel):

--- a/tests/knowledge/wiki/test_cli.py
+++ b/tests/knowledge/wiki/test_cli.py
@@ -12,10 +12,12 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+from parrot.knowledge.wiki import cli as cli_module
 from parrot.knowledge.wiki.cli import _changed_files_from_git, wiki
 from parrot.knowledge.wiki.project import (
     config_path,
     load_project_config,
+    wiki_write_lock,
 )
 
 PY_STORE = '"""A tiny key-value store module."""\n\n\nclass Store:\n    """In-memory key-value store."""\n\n    def get(self, key):\n        """Fetch a value."""\n        return key\n'
@@ -45,6 +47,26 @@ def _build(runner: CliRunner, repo: Path, *extra: str):
     )
     assert result.exit_code == 0, result.output
     return result
+
+
+def _store_dir(repo: Path) -> Path:
+    """The directory the writer lock guards — beside the store, not the root."""
+    return load_project_config(repo).storage_path(repo)
+
+
+class TestBuildLock:
+    def test_build_refuses_while_another_writer_holds_the_lock(self, runner, repo):
+        with wiki_write_lock(_store_dir(repo)) as held:
+            assert held is True
+            result = runner.invoke(
+                wiki, ["build", "--path", str(repo), "--no-git"]
+            )
+        assert result.exit_code != 0
+        assert "in progress" in result.output.lower()
+
+    def test_build_releases_the_lock_for_the_next_run(self, runner, repo):
+        _build(runner, repo)
+        _build(runner, repo)
 
 
 class TestBuild:
@@ -303,6 +325,29 @@ class TestUpsert:
         )
         assert result.exit_code == 0
         assert "No wiki-relevant files" in result.output
+
+    def test_upsert_skips_while_another_writer_holds_the_lock(
+        self, runner, repo, monkeypatch
+    ):
+        # The git post-commit hook must never stall behind a build that
+        # can run for minutes, nor write the store underneath it.
+        monkeypatch.setattr(cli_module, "UPSERT_LOCK_WAIT_SECONDS", 0.1)
+        _build(runner, repo)
+        with wiki_write_lock(_store_dir(repo)) as held:
+            assert held is True
+            result = runner.invoke(
+                wiki, ["upsert", "pkg/util.py", "--path", str(repo)]
+            )
+        assert result.exit_code == 0
+        assert "in progress" in result.output.lower()
+
+    def test_upsert_proceeds_once_the_lock_is_free(self, runner, repo):
+        _build(runner, repo)
+        with wiki_write_lock(_store_dir(repo)) as held:
+            assert held is True
+        result = runner.invoke(wiki, ["upsert", "pkg/util.py", "--path", str(repo)])
+        assert result.exit_code == 0
+        assert "in progress" not in result.output.lower()
 
     def test_upsert_before_build_is_noop(self, runner, tmp_path):
         (tmp_path / "a.py").write_text("x = 1", encoding="utf-8")

--- a/tests/knowledge/wiki/test_project_lock.py
+++ b/tests/knowledge/wiki/test_project_lock.py
@@ -1,0 +1,92 @@
+"""Tests for the wiki writer lock (project.wiki_write_lock).
+
+A full `wikitoolkit build` rewrites the whole store and can run for
+many minutes; the git post-commit hook fires `upsert --changed`
+independently. Without mutual exclusion both processes write the same
+SQLite file concurrently.
+
+The lock is scoped to the *store directory*, not the repo root:
+`storage_dir` may be absolute, so two repositories can legitimately
+share one store and must contend on the same lock.
+"""
+
+import time
+from pathlib import Path
+
+from parrot.knowledge.wiki.project import (
+    LOCK_FILENAME,
+    WikiProjectConfig,
+    wiki_write_lock,
+)
+
+
+class TestWikiWriteLock:
+    def test_grants_the_lock_when_free(self, tmp_path: Path):
+        with wiki_write_lock(tmp_path) as acquired:
+            assert acquired is True
+
+    def test_refuses_a_second_holder(self, tmp_path: Path):
+        with wiki_write_lock(tmp_path) as first:
+            assert first is True
+            with wiki_write_lock(tmp_path) as second:
+                assert second is False
+
+    def test_releases_on_exit(self, tmp_path: Path):
+        with wiki_write_lock(tmp_path) as first:
+            assert first is True
+        with wiki_write_lock(tmp_path) as again:
+            assert again is True
+
+    def test_releases_when_the_body_raises(self, tmp_path: Path):
+        try:
+            with wiki_write_lock(tmp_path):
+                raise RuntimeError("build blew up")
+        except RuntimeError:
+            pass
+        with wiki_write_lock(tmp_path) as again:
+            assert again is True
+
+    def test_creates_the_store_directory_on_first_use(self, tmp_path: Path):
+        store = tmp_path / "nested" / "wiki"
+        assert not store.exists()
+        with wiki_write_lock(store) as acquired:
+            assert acquired is True
+        assert (store / LOCK_FILENAME).is_file()
+
+    def test_two_repos_sharing_one_store_contend_on_one_lock(self, tmp_path: Path):
+        # storage_dir may be absolute — the lock must follow the store,
+        # not the repo root, or the shared store gets two writers.
+        shared = tmp_path / "shared-store"
+        config = WikiProjectConfig(wiki_name="x", storage_dir=str(shared))
+        repo_a, repo_b = tmp_path / "repo-a", tmp_path / "repo-b"
+
+        with wiki_write_lock(config.storage_path(repo_a)) as first:
+            assert first is True
+            with wiki_write_lock(config.storage_path(repo_b)) as second:
+                assert second is False
+
+    def test_gives_up_after_the_timeout(self, tmp_path: Path):
+        with wiki_write_lock(tmp_path):
+            started = time.monotonic()
+            with wiki_write_lock(tmp_path, timeout=0.3) as second:
+                waited = time.monotonic() - started
+            assert second is False
+            assert waited >= 0.3
+
+    def test_acquires_within_the_timeout_once_released(self, tmp_path: Path):
+        import threading
+
+        holder_done = threading.Event()
+
+        def _hold():
+            with wiki_write_lock(tmp_path):
+                time.sleep(0.2)
+            holder_done.set()
+
+        t = threading.Thread(target=_hold)
+        t.start()
+        time.sleep(0.05)
+        with wiki_write_lock(tmp_path, timeout=5.0) as acquired:
+            assert acquired is True
+        t.join()
+        assert holder_done.is_set()


### PR DESCRIPTION
## Problem

A full `build` rewrites the whole SQLite store and takes ~18 minutes on this repo. The git post-commit hook fires `upsert --changed` on its own schedule. Both were observed running against the same database simultaneously — the store survived (`quick_check` clean), but nothing prevented it.

## Change

`wiki_write_lock()` takes an exclusive `flock` on a lock file **beside the store**. Because the lock lives on an open descriptor, the kernel releases it if the holder dies — a crashed build cannot wedge the wiki with a stale lock file.

The context manager yields whether it won the lock; each caller decides what that means:

| Command | On contention | Exit |
|---|---|---|
| `build` | refuses immediately | `1` |
| `upsert` | waits `UPSERT_LOCK_WAIT_SECONDS` (3s), then skips | `0` |

The wait is the interesting part. It outlasts a peer upsert (sub-second), so two back-to-back commits don't lose the second one's indexing; it is capped so a commit hook never stalls behind a multi-minute build; and exit 0 keeps the hook from failing the commit.

Without `fcntl` the lock degrades to a no-op rather than blocking.

## Why the lock is beside the store, not at the repo root

The first version locked `root/.parrot/wiki.lock`. That is wrong, because `storage_dir` may be absolute:

```
storage_dir = "/var/shared/wiki"
  repo/a  ->  /var/shared/wiki      # one store...
  repo/b  ->  /var/shared/wiki      # ...two different lock files
```

Two repositories sharing a store would have taken different locks and written it concurrently anyway. The lock now follows the store, pinned by `test_two_repos_sharing_one_store_contend_on_one_lock`.

## Deliberately out of scope

- **`remember` / `note` / `link`** write the store through their own path and remain unprotected. Each needs its own contention behaviour (these should *fail* rather than skip — silently losing a memory is worse than an error), which is a separate decision from the build/upsert hazard this PR closes.
- **Read commands.** `query`, `page` and `status` do write to SQLite during schema/meta setup on connect, so they are not purely readers. Putting them behind the writer lock would make querying fail for the entire duration of a build — worse than the race it would close.
- **The hook blocking a commit during a normal upsert** is pre-existing behaviour, not introduced here.

## Verification

- `tests/knowledge/` — **463 passed**, no measurable slowdown (the contention test tunes the wait via `monkeypatch`)
- `ruff` — **75 findings, identical to `dev`**; zero introduced
- Real two-process run:

```
lock at: wiki/wiki.lock
upsert  exit=0  waited=3.2s  :: skipping this upsert…
build   exit=1               :: refusing to run two writers…
after release exit=0         :: Upserted 1 page(s), removed 0.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)