### PR TITLE
fix(wiki): summarise frontmatter documents by their metadata, not "---"

### DIFF
--- a/packages/ai-parrot/src/parrot/knowledge/wiki/repo_scan.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/repo_scan.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import ast
 import logging
+import re
 import subprocess
 from pathlib import Path, PurePosixPath
 from typing import Iterable, Optional
@@ -81,6 +82,46 @@ DEFAULT_MAX_FILE_BYTES = 512 * 1024
 DEFAULT_BODY_MAX_CHARS = 16_000
 
 _SUMMARY_MAX_CHARS = 240
+
+#: Opens and closes a YAML frontmatter block.
+_FRONTMATTER_DELIMITER = "---"
+
+#: Frontmatter keys consulted for a document summary, in priority order.
+_FRONTMATTER_SUMMARY_KEYS = ("summary", "title")
+
+#: A top-level YAML mapping key, used to tell a frontmatter block from a
+#: document that merely opens with a horizontal rule.
+_YAML_KEY_RE = re.compile(r"^[A-Za-z_][\w-]*:")
+
+#: Scalar values that carry no summary: YAML block-scalar indicators
+#: (the text lives on following lines) and the delimiter itself.
+_EMPTY_YAML_SCALARS = frozenset({"|", "|-", "|+", ">", ">-", ">+", "---"})
+
+
+def _frontmatter_lead(block: list[str]) -> str:
+    """Best summary carried by a YAML frontmatter block, if any.
+
+    Deliberately not a YAML parse: only top-level ``key: value`` scalars
+    are read, which is all a summary needs and keeps this dependency-free
+    on the hot ingest path.
+
+    Args:
+        block: Lines between the frontmatter delimiters.
+
+    Returns:
+        The first usable value among :data:`_FRONTMATTER_SUMMARY_KEYS`,
+        or ``""`` when the block carries none.
+    """
+    for key in _FRONTMATTER_SUMMARY_KEYS:
+        prefix = f"{key}:"
+        for line in block:
+            if not line.startswith(prefix):  # top-level keys only
+                continue
+            value = line[len(prefix):].strip().strip("\"'").strip()
+            if value and value not in _EMPTY_YAML_SCALARS:
+                return value
+            break  # key present but unusable — try the next one
+    return ""
 
 
 # --------------------------------------------------------------------------
@@ -426,10 +467,49 @@ def _python_outline(source: str) -> tuple[str, list[str], list[str]]:
 
 
 def _markdown_summary(content: str) -> str:
-    """Summary for a markdown/rst document: first heading or first line."""
-    for line in content.splitlines():
+    """Summary for a markdown/rst document.
+
+    Resolution order, first hit wins:
+
+    1. the ``summary`` field of a leading YAML frontmatter block,
+    2. its ``title`` field,
+    3. the first heading or non-empty line of the body after the block.
+
+    Frontmatter is metadata, not prose. Reading straight from the top
+    of such a file yields its ``---`` delimiter, which is useless in a
+    search result *and* gets indexed by FTS as though it were content —
+    the same meaningless token repeated across every document that has
+    a frontmatter block.
+
+    Args:
+        content: Raw document text.
+
+    Returns:
+        The summary line, truncated to :data:`_SUMMARY_MAX_CHARS`.
+    """
+    lines = content.splitlines()
+    body = lines
+    if lines and lines[0].strip() == _FRONTMATTER_DELIMITER:
+        for idx in range(1, len(lines)):
+            if lines[idx].strip() != _FRONTMATTER_DELIMITER:
+                continue
+            block = lines[1:idx]
+            # Position is not enough: a document may simply open with a
+            # horizontal rule. Without a single top-level `key:` this is
+            # not metadata, and consuming it would drop the real lead.
+            if not any(_YAML_KEY_RE.match(line) for line in block):
+                break
+            lead = _frontmatter_lead(block)
+            if lead:
+                return lead[:_SUMMARY_MAX_CHARS]
+            body = lines[idx + 1:]
+            break
+        # No closing delimiter: not a frontmatter block after all. Fall
+        # through and read the document, delimiter line skipped below.
+
+    for line in body:
         stripped = line.strip().lstrip("#").strip()
-        if stripped:
+        if stripped and stripped != _FRONTMATTER_DELIMITER:
             return stripped[:_SUMMARY_MAX_CHARS]
     return ""
 

--- a/tests/knowledge/wiki/test_repo_scan.py
+++ b/tests/knowledge/wiki/test_repo_scan.py
@@ -33,6 +33,81 @@ PY_A = '"""Mod A does things."""\nfrom pkg.b import x\n\n\nclass Alpha:\n    """
 PY_B = '"""Mod B."""\nx = 1\n'
 
 
+class TestFrontmatterSummary:
+    """A YAML frontmatter block is metadata, not the document's lead.
+
+    Taking the first non-empty line of such a file yields the ``---``
+    delimiter, which is both useless in search results and indexed by
+    FTS as if it were content.
+    """
+
+    def _summary(self, tmp_path: Path, body: str) -> str:
+        _write(tmp_path, "doc.md", body)
+        slice_ = build_file_slice(tmp_path, "doc.md")
+        assert slice_ is not None
+        return slice_.record.summary
+
+    def test_prefers_the_frontmatter_summary_field(self, tmp_path: Path):
+        got = self._summary(
+            tmp_path,
+            "---\ntitle: query()\nsummary: Scoped question against the KB.\n"
+            "---\n\n# query\n\nBody text.\n",
+        )
+        assert got == "Scoped question against the KB."
+
+    def test_falls_back_to_the_frontmatter_title(self, tmp_path: Path):
+        got = self._summary(
+            tmp_path, "---\ntype: Concept\ntitle: query()\n---\n\n# query\n"
+        )
+        assert got == "query()"
+
+    def test_falls_back_to_the_first_heading_after_the_block(self, tmp_path: Path):
+        got = self._summary(
+            tmp_path, "---\ntype: Concept\ntags:\n- a\n---\n\n# Real Heading\n\nText.\n"
+        )
+        assert got == "Real Heading"
+
+    def test_strips_quotes_from_frontmatter_values(self, tmp_path: Path):
+        got = self._summary(tmp_path, '---\nsummary: "Quoted lead."\n---\n\n# H\n')
+        assert got == "Quoted lead."
+
+    def test_ignores_an_empty_frontmatter_summary(self, tmp_path: Path):
+        got = self._summary(tmp_path, "---\nsummary:\ntitle: The Title\n---\n\n# H\n")
+        assert got == "The Title"
+
+    def test_ignores_a_block_scalar_summary(self, tmp_path: Path):
+        # `summary: |` introduces a folded block; the indicator itself
+        # is not a summary.
+        got = self._summary(tmp_path, "---\nsummary: |\ntitle: The Title\n---\n\n# H\n")
+        assert got == "The Title"
+
+    def test_never_returns_the_delimiter(self, tmp_path: Path):
+        got = self._summary(tmp_path, "---\ntype: Concept\n---\n\nPlain lead line.\n")
+        assert got == "Plain lead line."
+
+    def test_unterminated_frontmatter_does_not_swallow_the_document(
+        self, tmp_path: Path
+    ):
+        got = self._summary(tmp_path, "---\nnot really frontmatter\n\n# Heading\n")
+        assert got
+        assert got != "---"
+
+    def test_a_document_without_frontmatter_is_unchanged(self, tmp_path: Path):
+        got = self._summary(tmp_path, "# Project Title\n\nSome text.\n")
+        assert got == "Project Title"
+
+    def test_a_leading_horizontal_rule_is_not_frontmatter(self, tmp_path: Path):
+        # Position alone does not make a block frontmatter: without any
+        # `key:` line this is a rule, and swallowing it would silently
+        # discard the document's real lead.
+        got = self._summary(tmp_path, "---\nIntro line.\n---\n\nAfter the rule.\n")
+        assert got == "Intro line."
+
+    def test_a_horizontal_rule_mid_document_is_not_frontmatter(self, tmp_path: Path):
+        got = self._summary(tmp_path, "# Heading\n\n---\n\nAfter the rule.\n")
+        assert got == "Heading"
+
+
 class TestWikiBundleGuardrail:
     """A wiki must never ingest another wiki's exported bundle."""
 


### PR DESCRIPTION
## Problem

`_markdown_summary()` took the first non-empty line of a document. For any file opening with a YAML frontmatter block, that line is the `---` delimiter.

**760 pages** in this repo's store carried `---` as their summary — useless in a result list, and indexed by SQLite FTS (`title`/`summary`/`body`) as though it were content, so the same meaningless token sat in the index for every such document.

## Change

Resolve in order:

1. the block's `summary` field,
2. its `title` field,
3. the first heading or line of the body after the block.

A block only counts as frontmatter when it contains at least one top-level `key:`. Position alone is not enough — a document may open with a horizontal rule, and consuming that as metadata would silently discard its real lead.

## Measured against the live store

**760 of 760 affected pages fixed.** By branch:

| Branch | Pages | |
|---|---:|---|
| 1. `summary:` | **0** | not exercised in this repo |
| 2. `title:` | 77 | |
| 3. body | 683 | |

The `summary:` branch resolves nothing here — the documents that carried that field were the `docs/parrot` bundle, since deleted. It stays because it is the correct priority, not because it is doing the work.

The `title:` branch earns its place. In specs the body heading is usually just the identifier:

```
title : 'A2UI Protocol Integration — parrot.outputs Rewrite (Rendering…'
body  : 'Brainstorm Input: A2UI Integration into `parrot.outputs`'
```

## Considered and rejected: `description:`

Files under `.agent/` carry a `description:` field, which looked like an obvious fourth key. Measured first — in those files it is a *trigger condition*, not a summary:

```
description: 'when we are creating python (.py, .pyx) files'
body       : 'You are an expert in Python asynchronous programming…'
```

Adding it would have made those pages worse.

## Deliberately not handled

Block scalars (`summary: |`) and inline YAML comments (`title: "X" # note`). **Zero occurrences across the 789 frontmatter documents in this repo**, and both would need a real YAML parse on the ingest hot path. The current fall-through to the body degrades safely rather than failing.

The page body still stores raw content including the frontmatter, so `type`, `id` and tag fields stay searchable in FTS — that is deliberate, not an oversight.

## Verification

- `tests/knowledge/` — **462 passed**; 11 new tests, each written before the code
- `ruff` — **14 findings, identical to `dev`**; zero introduced
- Impact re-measured against the real store after every change

## Follow-up

The store keeps its stale `---` summaries until the next `wikitoolkit build --force`. That run takes ~18 minutes here; `--no-export --no-graph` skips the expensive tail when the goal is only to refresh the store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)