### PR TITLE
sdd: FEAT-396 unified guardrails infrastructure — reposition PII (FEAT-324) and groundedness (FEAT-325) as plugins

### DIFF
--- a/sdd/proposals/guardrails-infrastructure.brainstorm.md
+++ b/sdd/proposals/guardrails-infrastructure.brainstorm.md
@@ -1,0 +1,467 @@
+---
+# SDD flow type and base branch (FEAT-145).
+type: feature
+base_branch: dev
+---
+
+# Brainstorm: Unified Guardrails Infrastructure (Pluggable Input/Output Controls)
+
+**Date**: 2026-07-24
+**Author**: Jesús Lara (with Claude Code research)
+**Status**: exploration
+**Recommended Option**: A
+
+> Candidate feature id: FEAT-396 (assigned at spec time; highest on dev is
+> FEAT-395). Supersedes the *integration layers* of FEAT-324
+> (`pii-detection-redaction`) and FEAT-325
+> (`deterministic-groundedness-scoring`) — their engines are unchanged;
+> their seam wiring becomes guardrail plugins of this infrastructure.
+
+---
+
+## Problem Statement
+
+AI-Parrot has grown **five uncoordinated input/output control mechanisms**,
+each with its own configuration style, seam, and semantics (all refs
+verified on `dev` @ `58829cf9`):
+
+1. **Prompt-injection check** — hardcoded into
+   `AbstractBot._sanitize_question()` (`bots/abstract.py:1836-1942`),
+   invoked from exactly 3 call sites in `BaseBot`
+   (`bots/base.py:625, 997, 1641`). The only mechanism that can **block**
+   (via `PromptInjectionException`). Configured through four explicit ctor
+   params (`strict_mode`, `block_on_threat`, `injection_detection`,
+   `injection_probability_threshold`, `bots/abstract.py:294-297`).
+2. **`PromptPipeline`** (`bots/middleware.py`, 49 lines) — input-only
+   string→string transforms, **cannot block**, **swallows exceptions**
+   (`middleware.py:42-45`), defaults to `None` so most bots have none;
+   only two registration sites in the whole tree (`bots/search.py:119`,
+   `skills/mixin.py:178`).
+3. **`OutputScrubber`** (secrets, FEAT-252) — policy-driven and genuinely
+   pluggable, but wired ad-hoc at four seams (tool egress
+   `tools/abstract.py:784-810`, channel egress `bots/base.py:1445` for
+   only 4 chat modes, Google client `clients/google/client.py:~2533`,
+   PythonREPL `tools/pythonrepl.py:599`), opt-in via a popped kwarg
+   (`enable_redaction`, `bots/abstract.py:379`).
+4. **Provider-native guardrails** — Bedrock `apply_guardrail_text()`
+   (`clients/bedrock.py:444-469`); Google safety settings hardcoded to
+   `BLOCK_NONE` (`clients/google/client.py:3085-3092`).
+5. **Hand-rolled redactors** outside any policy — `scrub_git_output()`
+   (`flows/dev_loop/nodes/base.py:39`), server-side `_redact()`
+   (`ai-parrot-server .../handlers/agents/users.py:37`).
+
+Meanwhile two spec'd features (FEAT-324 PII, FEAT-325 groundedness) are
+about to add *more* per-feature seam wiring, and there is **no content
+moderation at all**. Every new control repeats the same work: find the
+seams, invent a config toggle, decide error semantics, wire telemetry.
+
+**Goal**: one pluggable guardrails infrastructure in
+`parrot/bots/guardrails/` — attach controls to the **input** or the
+**output** (tool egress, final response, streaming) of any bot, with
+uniform policy, ordering, blocking semantics, error contracts and audit —
+so PII, groundedness, prompt-injection, moderation and future modes are
+plugins of one abstraction instead of five parallel inventions.
+
+## Constraints & Requirements
+
+- **One abstraction, four stages**: `input` (user → LLM), `tool_output`
+  (tool → LLM), `output` (LLM → caller), `output_stream` (chunked).
+- **Verdict semantics richer than transform-only**: a guardrail must be
+  able to PASS, TRANSFORM (rewrite content), FLAG (observe/annotate, never
+  mutate), or BLOCK (abort with a controlled response) — today only the
+  injection check can block, and the pipeline cannot.
+- **Explicit error contract per guardrail**: fail-open (log + continue,
+  today's scrubber behavior) or fail-closed (block on internal error) —
+  the current `PromptPipeline` silently swallowing exceptions is not an
+  acceptable base for security checks.
+- **Deterministic ordering** (priority), per-bot registry, uniform config
+  (Pydantic policy per guardrail + one bot-level `guardrails=[...]`),
+  following the `enable_redaction` stamping precedent
+  (`bots/abstract.py:379→390` → `tools/manager.py` → clients).
+- **Latency discipline inherited from FEAT-324/325**: hot-path guardrails
+  must be sub-10 ms; expensive checks (LLM/API moderation) must declare
+  themselves and default to observe/async where possible.
+- **Backwards compatible**: existing ctor flags (`strict_mode`,
+  `block_on_threat`, `injection_detection`, `enable_redaction`) keep
+  working, internally mapped to guardrail registrations; secrets scrubbing
+  semantics unchanged.
+- **Engines stay reusable**: analysis engines live in `parrot/security/`
+  (injection detector, scrubber, future pii/groundedness engines);
+  `parrot/bots/guardrails/` holds the abstraction and thin plugin wrappers
+  — engines remain importable outside bots (handlers, flows, offline).
+
+---
+
+## Options Explored
+
+### Option A: Native guardrails package — `Guardrail` ABC + per-stage pipelines in `parrot/bots/guardrails/`
+
+New subpackage (structural sibling of `bots/mixins/`):
+
+- `base.py`: `GuardrailStage` enum (INPUT, TOOL_OUTPUT, OUTPUT,
+  OUTPUT_STREAM); `GuardrailAction` (PASS, TRANSFORM, FLAG, BLOCK);
+  `GuardrailResult` (action, content, report, reason); abstract
+  `Guardrail` (name, stages, priority, `on_error: fail_open|fail_closed`,
+  `async check(content, ctx) -> GuardrailResult`).
+- `pipeline.py`: `GuardrailPipeline` — priority-ordered, short-circuits on
+  BLOCK, accumulates FLAG reports into `AIMessage.metadata["guardrails"]`,
+  honors per-guardrail error contract, emits telemetry (guardrail name +
+  action + duration, never content) via FEAT-176 observers.
+- `registry.py` + `config.py`: named factories; bot kwarg
+  `guardrails=[...]` (names, instances, or dicts) coerced per the existing
+  structured-kwargs pattern; legacy flags mapped for compatibility.
+- `streaming.py`: `StreamingGuardrail` adapter contract
+  (`feed(chunk) -> str` / `flush()`), generalizing FEAT-324's sliding
+  window so any transforming output guardrail can run on streams.
+- Built-in plugins (thin wrappers over `parrot/security/` engines):
+  `PromptInjectionGuardrail` (migrates `_sanitize_question` logic; INPUT;
+  can BLOCK), `SecretsGuardrail` (wraps `OutputScrubber`; TOOL_OUTPUT +
+  OUTPUT; TRANSFORM), `PIIGuardrail` + `PseudonymizeGuardrail` (FEAT-324
+  engines), `GroundednessGuardrail` (FEAT-325 scorer; OUTPUT; FLAG-only),
+  `ModerationGuardrail` (reference interface + stub backend — concrete
+  backends are a follow-up).
+- Seam integration replaces the ad-hoc wiring: the 3
+  `_sanitize_question`/pipeline call sites in `BaseBot` run the INPUT
+  pipeline; the FEAT-252 tool hook runs TOOL_OUTPUT; `get_response()` and
+  `ask_stream` run OUTPUT/OUTPUT_STREAM.
+
+✅ **Pros:**
+- Closes all four verified gaps at once (no output chain, no block
+  semantics in pipeline, no per-bot registry, split configuration).
+- FEAT-324/325 integration layers become ~thin plugins instead of
+  bespoke seam wiring — their specs shrink, their engines don't change.
+- Moderation and future modes (jailbreak, topic filters, compliance) are
+  additive: implement `Guardrail`, register, done.
+- Generalizes the two best existing patterns (`ScrubPolicy`-style policy
+  objects; `enable_redaction`-style per-bot propagation).
+- Uniform audit/telemetry surface (name + action + counts, never values).
+
+❌ **Cons:**
+- Touches the three hottest methods in `BaseBot` (invoke/ask/ask_stream)
+  — needs careful compat testing of the canned-response semantics
+  (`bots/base.py:632, 1004, 1648`).
+- Migration of `_sanitize_question` must preserve a subtle invariant: the
+  sanitized text feeds only `prompt_for_llm`; the canonical `question`
+  stays clean for memory/events/vector retrieval.
+- One more abstraction to learn; risk of over-engineering if kept too
+  generic (mitigated: four fixed stages, one result type).
+
+📊 **Effort:** Medium
+
+📦 **Libraries / Tools:**
+| Package | Purpose | Notes |
+|---|---|---|
+| stdlib + Pydantic | abstraction, config | zero new deps |
+
+🔗 **Existing Code to Reuse:**
+- `security/prompt_injection.py:27` `PromptInjectionDetector` (+ shared
+  singleton `bots/abstract.py:64-95`) — engine for the INPUT plugin.
+- `security/redaction.py:128,149` `ScrubPolicy`/`OutputScrubber` — engine
+  for `SecretsGuardrail`; its idempotency/audit patterns are the template.
+- `bots/middleware.py` `PromptPipeline` — priority/ordering model to
+  generalize (and then wrap as a legacy TRANSFORM guardrail).
+- `enable_redaction` stamping chain (`bots/abstract.py:379→390`,
+  `tools/manager.py:276,570,632,1425`) — config-propagation precedent.
+- FEAT-176 observers — telemetry emission.
+- FEAT-324/325 specs — plugin payloads (engines + policies already
+  designed).
+
+---
+
+### Option B: Adopt an external guardrails framework (openai-guardrails-python style config)
+
+Configure checks via a JSON/YAML "guardrails config" with named checks per
+stage, executed by a generic runner (possibly vendoring parts of
+`openai-guardrails-python`).
+
+✅ **Pros:**
+- Familiar config surface for users coming from OpenAI's ecosystem.
+- Some checks come pre-built.
+
+❌ **Cons:**
+- The comparative analysis (FEAT-324 comparison doc) already showed the
+  flagship checks are unusable in our hot paths: PII masks input-only,
+  hallucination check is an LLM judge at P50 ~7 s; we would keep only the
+  runner shape and rewrite every check anyway.
+- External model deps (spaCy models, OpenAI API) at the security boundary;
+  no streaming story; no per-agent policy model.
+- Doesn't integrate with our seams, `AIMessage`, FEAT-176 telemetry, or
+  the `enable_redaction` compat surface — the adapter *is* Option A.
+
+📊 **Effort:** Medium-High (adapter + rewrites)
+
+📦 **Libraries / Tools:**
+| Package | Purpose | Notes |
+|---|---|---|
+| `openai-guardrails-python` | check runner/config | brings model deps |
+
+🔗 **Existing Code to Reuse:** same seams as Option A.
+
+---
+
+### Option C: Incremental — extend `PromptPipeline` and add a symmetric `ResponsePipeline`
+
+Keep string→string middlewares; add blocking by convention (raise from a
+middleware); add an output twin; wire features one by one.
+
+✅ **Pros:**
+- Smallest diff; no new concepts.
+
+❌ **Cons:**
+- The middleware contract is the *problem*: exceptions swallowed
+  (`middleware.py:42-45`), no verdicts, no FLAG/observe mode (groundedness
+  needs non-mutating), no per-guardrail error contract, `None` by default.
+- Blocking-by-exception from a chain that swallows exceptions is a
+  security anti-pattern.
+- Config remains scattered (ctor params + popped kwargs + pipeline
+  registration in subclasses).
+
+📊 **Effort:** Low (but re-paid on every future control)
+
+📦 **Libraries / Tools:** none.
+
+🔗 **Existing Code to Reuse:** `bots/middleware.py` as-is.
+
+---
+
+## Recommendation
+
+**Option A** is recommended because:
+
+- The exploration shows the fragmentation is structural, not incidental:
+  five mechanisms, four config styles, one blocking path, zero output
+  chain. Only a first-class abstraction closes that; Option C rebuilds on
+  a contract (swallowed exceptions, transform-only) that disqualifies
+  itself for security checks, and Option B converges to Option A after
+  discarding checks we already proved unusable in the hot path.
+- It is the cheapest path for the *in-flight* work: FEAT-324 and FEAT-325
+  each planned bespoke seam wiring; as plugins they reuse one pipeline,
+  one config surface, one telemetry stream — and their engines (the hard
+  part, already prototyped and benchmarked) are untouched.
+- Extensibility is the user's stated goal ("agregar moderation u otros
+  modos"): `ModerationGuardrail` as a reference plugin proves the point
+  without expanding scope.
+
+Trade-off accepted: a migration of `_sanitize_question` and the tool-seam
+hook with strict behavioral-compat tests, and the discipline to keep the
+abstraction at exactly four stages and one result type.
+
+---
+
+## Feature Description
+
+### User-Facing Behavior
+
+- One bot-level configuration surface:
+  `guardrails=[...]` accepting names (`"pii"`, `"prompt_injection"`,
+  `"groundedness"`, `"secrets"`, `"moderation"`), configured dicts
+  (`{"name": "pii", "policy": {...}}`), or `Guardrail` instances.
+- Legacy flags keep working and map internally:
+  `injection_detection/strict_mode/block_on_threat/…` →
+  `PromptInjectionGuardrail`; `enable_redaction` → `SecretsGuardrail`.
+- Blocked turns return the same canned-`AIMessage` shape used today by
+  the injection path (metadata `error: guardrail_block`, guardrail name,
+  reason category — never the offending content).
+- FLAG-mode guardrails (groundedness; any check in `detect_only`) attach
+  reports under `AIMessage.metadata["guardrails"][<name>]`.
+- Custom guardrails: subclass `Guardrail`, implement `check()`, register
+  by name or pass the instance.
+
+### Internal Behavior
+
+- `parrot/bots/guardrails/` — `base.py`, `pipeline.py`, `registry.py`,
+  `config.py`, `streaming.py`, `builtin/` (one module per plugin).
+- Bot wiring: `AbstractBot.__init__` builds four `GuardrailPipeline`s from
+  config + legacy flags. `BaseBot.invoke/ask/ask_stream` replace the
+  direct `_sanitize_question` + `PromptPipeline` calls with the INPUT
+  pipeline (preserving the `prompt_for_llm` vs canonical-`question`
+  invariant and the existing canned-response catch sites). The FEAT-252
+  tool hook delegates to the TOOL_OUTPUT pipeline (secrets guardrail
+  first, unconditional when `enable_redaction`). `get_response()` runs
+  OUTPUT; `ask_stream` wraps chunks through registered
+  `StreamingGuardrail`s and runs non-streaming OUTPUT guardrails on the
+  final `AIMessage`.
+- Ordering: fixed priority bands — sanitizers (secrets) → transformers
+  (PII) → observers (groundedness) — overridable per guardrail.
+- Telemetry: pipeline emits (guardrail, stage, action, duration_ms,
+  counts) via FEAT-176 observers; content never leaves the process.
+- `ModerationGuardrail`: policy model (`categories`, `threshold`,
+  `action`), `ModerationBackend` protocol, one `StubBackend`
+  (allow-all, logs shape) — concrete backends (OpenAI moderation API,
+  local classifier, keyword lists) are explicit follow-ups.
+
+### Edge Cases & Error Handling
+
+- Guardrail exception → per-guardrail `on_error`: `fail_open` (warn,
+  continue; default for observers/transformers) or `fail_closed` (BLOCK;
+  default for injection/moderation in enforce mode).
+- BLOCK short-circuits the remaining pipeline; already-applied TRANSFORMs
+  are discarded in favor of the canned response.
+- Streaming: only `StreamingGuardrail`-capable plugins run per-chunk;
+  others run at stream close on the final text (FEAT-325 semantics).
+- Empty pipeline == today's behavior; zero overhead when nothing is
+  registered (guard on `has_guardrails`, mirroring `has_middlewares`).
+- Double-wrapping protection: pipeline stamps processed content
+  (idempotency, `_already_scrubbed` precedent).
+
+---
+
+## Capabilities
+
+### New Capabilities
+- `guardrails-core`: stages, verdicts, `Guardrail` ABC, pipelines,
+  registry, config coercion, telemetry.
+- `guardrails-input-migration`: `PromptInjectionGuardrail` +
+  `_sanitize_question`/`PromptPipeline` migration with behavioral compat.
+- `guardrails-output-plugins`: `SecretsGuardrail` (wraps FEAT-252 seams),
+  hooks in `get_response`/`ask_stream`, `StreamingGuardrail` contract.
+- `guardrails-moderation-reference`: `ModerationGuardrail` interface +
+  stub backend.
+
+### Modified Capabilities
+- `pii-detection-redaction` (FEAT-324): Modules 1/3/4 integration layer
+  re-targeted to guardrail plugins (`PIIGuardrail`,
+  `PseudonymizeGuardrail`, streaming via `StreamingGuardrail`); engines
+  (`parrot/security/pii/`, `pii-rs`) unchanged.
+- `deterministic-groundedness-scoring` (FEAT-325): Module 3 reporting
+  becomes `GroundednessGuardrail` (FLAG-only); engine unchanged.
+
+---
+
+## Impact & Integration
+
+| Affected Component | Impact Type | Notes |
+|---|---|---|
+| `parrot/bots/guardrails/` | new | the infrastructure |
+| `bots/base.py:625,997,1641` (+ catches `:632,1004,1648`) | modifies | INPUT pipeline replaces direct `_sanitize_question` + `PromptPipeline` calls; canned responses preserved |
+| `bots/abstract.py` (`__init__`, `_sanitize_question`, `:365,379,661-664,672-685`) | modifies | pipeline construction; legacy-flag mapping; `_sanitize_question` body moves into the plugin |
+| `tools/abstract.py:784-810` | modifies | hook delegates to TOOL_OUTPUT pipeline (secrets semantics unchanged) |
+| `bots/middleware.py` | deprecates | kept working; wrapped as legacy TRANSFORM guardrail; the two registration sites (`bots/search.py:119`, `skills/mixin.py:178`) migrate |
+| `bots/base.py:1445` channel egress scrub | modifies | folds into OUTPUT pipeline (all modes, not just 4 chat modes) |
+| `security/` package | unchanged | engines stay; export surface intact |
+| FEAT-324 / FEAT-325 specs | modified | v-bump: integration sections re-targeted (see Modified Capabilities) |
+| Provider guardrails (Bedrock/Google) | unchanged | out of scope; potential future `ProviderGuardrail` wrapper noted |
+
+No breaking changes: defaults preserve today's behavior exactly.
+
+---
+
+## Code Context
+
+### User-Provided Code
+
+(none — requirement provided as prose)
+
+### Verified Codebase References
+
+All verified on branch base `origin/dev` @ `58829cf9`; paths relative to
+`packages/ai-parrot/src/parrot/`.
+
+#### Classes & Signatures
+```python
+# security/prompt_injection.py
+class ThreatLevel: ...                    # :10
+class PromptInjectionException: ...       # :19
+class PromptInjectionDetector: ...        # :27  (regex engine; pytector optional)
+class SecurityEventLogger: ...            # :222
+
+# bots/abstract.py
+_SHARED_INJECTION_DETECTOR / _get_shared_injection_detector()  # :64-95 (:78)
+# ctor params: strict_mode=True (:294), block_on_threat=False (:295),
+#   injection_detection=True (:296), injection_probability_threshold=0.98 (:297)
+#   assigned :661-664; detector/logger wiring :672-685
+self._prompt_pipeline = None              # :365 (property/setter :715-720)
+self.enable_redaction = bool(kwargs.pop('enable_redaction', False))  # :379 → :390
+def _sanitize_question(...)               # :1836-1942; _wrap_flagged_input :1944
+
+# bots/base.py — the three input call sites + canned-response catches:
+#   invoke :625/:632, ask :997/:1004, ask_stream :1641/:1648
+# invariant: sanitized text → prompt_for_llm only; canonical question stays clean
+# PromptPipeline runs after sanitize: :641, :1017, :1657
+# channel egress scrub singleton :61, applied :1445 (4 chat modes only)
+
+# bots/middleware.py (49 lines)
+class PromptMiddleware: ...               # :8  (priority :11, apply :17)
+class PromptPipeline: ...                 # :23 (add :30, apply :37 — swallows exceptions :42-45)
+
+# tools/abstract.py
+# FEAT-252 hook :784-810, gated `if self.enable_redaction:` (:784);
+# _default_scrubber :63; tool attr enable_redaction :155
+
+# security/redaction.py
+class ScrubPolicy: ...                    # :128 (frozen dataclass)
+class OutputScrubber: ...                 # :149; _already_scrubbed :122
+```
+
+#### Verified Imports
+```python
+from parrot.security.prompt_injection import PromptInjectionDetector  # security/__init__.py exports :8-55
+from parrot.security.redaction import OutputScrubber, ScrubPolicy
+from parrot.bots.middleware import PromptPipeline, PromptMiddleware
+```
+
+#### Key Attributes & Constants
+- `bots/` structure: `mixins/` is the closest sibling for `guardrails/`;
+  `bots/__init__.py` exports only bot classes.
+- Config-propagation precedent: `enable_redaction` stamping
+  (`tools/manager.py:276,570-571,632-633,1425-1426`; client stamping
+  `bots/abstract.py:937,956`).
+- `flows/dev_loop/nodes/base.py:39` `scrub_git_output()` — hand-rolled
+  redactor worth folding into `SecretsGuardrail` later.
+
+### Does NOT Exist (Anti-Hallucination)
+- ~~Anything named `guardrail*` in the repo~~ — `find -iname` is empty
+  (Bedrock/Nova provider params aside: `clients/bedrock.py:79-80,444`).
+- ~~An output/response transform chain~~ — `PromptPipeline` is input-only.
+- ~~Blocking semantics in `PromptPipeline`~~ — transforms only; exceptions
+  swallowed (`middleware.py:42-45`).
+- ~~Content-moderation API/code~~ — all `moderate` hits are
+  `SecurityLevel.MODERATE` in command/python sanitizers; no toxicity or
+  content_filter anywhere.
+- ~~`parrot.security.pii` / `parrot.security.groundedness`~~ — FEAT-324/
+  325 are specs, not implemented; this feature defines the sockets their
+  plugins will fill.
+- ~~Server-side usage of the security stack~~ — handlers' `guardian` is
+  navigator-auth authn/authz, unrelated.
+
+---
+
+## Parallelism Assessment
+
+- **Internal parallelism**: medium — `guardrails-core` first (blocks
+  everything); then input-migration ∥ output-plugins in separate
+  worktrees (disjoint seams: `bots/base.py` input sites vs tool hook +
+  `get_response`); moderation-reference after core only.
+- **Cross-feature independence**: FEAT-324/325 implementations should
+  build *on top of* this feature (their specs get v-bumped to plugins);
+  implementing them first would create the bespoke wiring this feature
+  removes.
+- **Recommended isolation**: mixed (core sequential, then two parallel
+  worktrees).
+- **Rationale**: the abstraction is small but load-bearing; the two
+  migrations touch disjoint files once core is frozen.
+
+---
+
+## Open Questions
+
+- [x] Where do engines vs guardrails live? — *Resolved (session default,
+  confirm in review)*: engines in `parrot/security/` (reusable outside
+  bots), abstraction + plugins in `parrot/bots/guardrails/`.
+- [x] Fate of FEAT-324/325 specs — *Resolved (session default)*: v-bump
+  as plugins of this infrastructure; engines and acceptance criteria
+  unchanged.
+- [x] Moderation scope — *Resolved (session default)*: interface +
+  reference stub in this feature; concrete backends are follow-ups.
+- [ ] Should `SecretsGuardrail` become *unconditional* (like FEAT-252
+  intended) instead of `enable_redaction` opt-in, now that ordering is
+  explicit? — *Owner: Jesús*
+- [ ] Deprecation horizon for `PromptPipeline` and the four legacy
+  injection ctor params (keep mapped indefinitely vs warn in 0.27)? —
+  *Owner: Jesús*
+- [ ] Should the channel-egress scrub extension (all output modes, not 4)
+  ship here or as a follow-up? — *Owner: Jesús*
+- [ ] `ProviderGuardrail` wrapper for Bedrock/Google native guardrails —
+  in-scope later? — *Owner: Jesús*
+- [ ] Handler-level (server package) guardrail execution for non-bot
+  egress — follow-up feature? — *Owner: Jesús*

--- a/sdd/specs/deterministic-groundedness-scoring.spec.md
+++ b/sdd/specs/deterministic-groundedness-scoring.spec.md
@@ -16,6 +16,19 @@ base_branch: dev
 > (`sdd/specs/pii-detection-redaction.spec.md`) — shares seams and, later,
 > extraction machinery; neither depends on the other to ship.
 
+> **v0.2 — Guardrails repositioning.** This feature is now a **plugin of
+> the unified guardrails infrastructure** (FEAT-396,
+> `sdd/proposals/guardrails-infrastructure.brainstorm.md`). Unchanged:
+> Modules 1–2 (extractors, normalization, `EvidenceIndex`, scorer,
+> precision-aware tolerance, canonical test cases, benchmark gates).
+> Re-targeted: Module 3's seam wiring (bot kwargs, `get_response()`/
+> `ask_stream` hooks, metadata attachment, telemetry) is delivered as a
+> **`GroundednessGuardrail`** — a FLAG-only plugin on the OUTPUT pipeline
+> of `parrot/bots/guardrails/` (its report lands in
+> `AIMessage.metadata["guardrails"]["groundedness"]`). Implementation
+> depends on FEAT-396 `guardrails-core`. Where this spec's integration
+> sections conflict with the guardrails spec, the guardrails spec wins.
+
 ---
 
 ## 1. Motivation & Business Requirements
@@ -502,3 +515,4 @@ class AIMessage(BaseModel):
 | Version | Date | Author | Change |
 |---|---|---|---|
 | 0.1 | 2026-07-22 | Jesús Lara / Claude Code | Initial draft from `deterministic-groundedness-scoring.brainstorm.md` (Option A, prototype-validated) |
+| 0.2 | 2026-07-24 | Jesús Lara / Claude Code | Repositioned as plugin of the unified guardrails infrastructure (FEAT-396): Module 3 seam wiring → `GroundednessGuardrail` (FLAG-only, OUTPUT pipeline); engine unchanged |

--- a/sdd/specs/guardrails-infrastructure.spec.md
+++ b/sdd/specs/guardrails-infrastructure.spec.md
@@ -1,0 +1,517 @@
+---
+type: feature
+base_branch: dev
+---
+
+# Feature Specification: Unified Guardrails Infrastructure
+
+**Feature ID**: FEAT-396
+**Date**: 2026-07-24
+**Author**: Jesús Lara (spec drafted with Claude Code)
+**Status**: draft
+**Target version**: 0.27.0
+
+> Source brainstorm: `sdd/proposals/guardrails-infrastructure.brainstorm.md`
+> (Recommended Option A). Plugin features: FEAT-324
+> (`pii-detection-redaction`, v0.4) and FEAT-325
+> (`deterministic-groundedness-scoring`, v0.2) deliver their integration
+> layers as plugins of this infrastructure; their engines are unchanged.
+
+---
+
+## 1. Motivation & Business Requirements
+
+### Problem Statement
+
+AI-Parrot has five uncoordinated input/output control mechanisms (verified
+on `dev` @ `58829cf9`): the hardcoded prompt-injection check in
+`AbstractBot._sanitize_question()` (the only one that can block), the
+input-only `PromptPipeline` (cannot block, swallows exceptions), the
+`OutputScrubber` wired ad-hoc at four seams behind `enable_redaction`,
+provider-native guardrails (Bedrock; Google safety pinned to BLOCK_NONE),
+and hand-rolled redactors in flows and the server package. There is no
+output guardrail chain, no per-bot registry of pluggable checks, no
+uniform blocking/error semantics, and no content moderation at all — and
+two spec'd features (PII, groundedness) were about to add yet more
+bespoke seam wiring.
+
+This feature centralizes all of it: a pluggable guardrails infrastructure
+in `parrot/bots/guardrails/` where controls attach to the input or output
+of any bot and PII, groundedness, prompt-injection, secrets and future
+modes (moderation, jailbreak, topic filters) are plugins of one
+abstraction.
+
+### Goals
+
+- One `Guardrail` abstraction with four stages — INPUT, TOOL_OUTPUT,
+  OUTPUT, OUTPUT_STREAM — and four verdicts — PASS, TRANSFORM, FLAG,
+  BLOCK.
+- Per-stage, priority-ordered `GuardrailPipeline` with BLOCK
+  short-circuit, per-guardrail error contract (`fail_open`/`fail_closed`),
+  idempotency stamping, and uniform telemetry (name + action + duration +
+  counts, never content) via FEAT-176 observers.
+- One bot-level config surface (`guardrails=[...]`) with a named registry;
+  legacy flags (`injection_detection`, `strict_mode`, `block_on_threat`,
+  `injection_probability_threshold`, `enable_redaction`) keep working,
+  mapped internally.
+- Built-in plugins: `PromptInjectionGuardrail` (migrates
+  `_sanitize_question`), `SecretsGuardrail` (wraps `OutputScrubber`),
+  sockets for FEAT-324 (`PIIGuardrail`/`PseudonymizeGuardrail`) and
+  FEAT-325 (`GroundednessGuardrail`), `ModerationGuardrail` reference
+  interface + stub backend.
+- `StreamingGuardrail` adapter contract (`feed`/`flush`) so transforming
+  output guardrails can run on `ask_stream` chunks.
+- Zero behavior change with default configuration; zero new runtime deps.
+
+### Non-Goals (explicitly out of scope)
+
+- Concrete moderation backends (OpenAI moderation API, local classifiers,
+  keyword lists) — follow-ups behind the `ModerationBackend` protocol.
+- Implementing the FEAT-324/FEAT-325 engines — separate features; this
+  spec defines the sockets their plugins fill.
+- Wrapping provider-native guardrails (Bedrock `apply_guardrail_text`,
+  Google safety settings) — noted as a possible future `ProviderGuardrail`.
+- Server-package (handler-level) guardrail execution for non-bot egress.
+- Removing `PromptPipeline` — deprecated but kept working (wrapped as a
+  legacy TRANSFORM guardrail); removal horizon is an open question.
+
+---
+
+## 2. Architectural Design
+
+### Overview
+
+`parrot/bots/guardrails/` (structural sibling of `bots/mixins/`) defines:
+
+- **`GuardrailStage`**: INPUT (user text before LLM), TOOL_OUTPUT
+  (ToolResult egress), OUTPUT (final answer), OUTPUT_STREAM (chunks).
+- **`GuardrailResult`**: `action` ∈ {PASS, TRANSFORM, FLAG, BLOCK} +
+  `content` (TRANSFORM), `report` (FLAG, attached to
+  `AIMessage.metadata["guardrails"][<name>]`), `reason` (BLOCK — a
+  category label, never the offending content).
+- **`Guardrail` ABC**: `name`, `stages`, `priority` (fixed default bands:
+  sanitizers 0–99 → transformers 100–199 → observers 200+), `on_error`
+  (`fail_open` default for transformers/observers; `fail_closed` default
+  for enforce-mode injection/moderation), `async check(content, ctx) →
+  GuardrailResult`. `ctx` carries agent_name/user_id/session_id/stage/
+  method plus stage-specific extras (tool_name; the outgoing `AIMessage`
+  at OUTPUT).
+- **`GuardrailPipeline`**: ordered execution; BLOCK short-circuits and
+  discards prior TRANSFORMs in favor of the canned response; FLAG reports
+  accumulate; exceptions honor `on_error`; every run emits telemetry;
+  processed-content stamping prevents double transformation (the
+  `_already_scrubbed` precedent, `security/redaction.py:122`).
+- **Registry/config**: named factories (`"prompt_injection"`, `"secrets"`,
+  `"pii"`, `"pseudonymize"`, `"groundedness"`, `"moderation"`); bot kwarg
+  `guardrails=[...]` accepting names, `{"name": ..., "policy": {...}}`
+  dicts, or `Guardrail` instances — coerced like other structured bot
+  configs. Legacy flags map to registrations at `__init__` time.
+
+**Seam integration** replaces the ad-hoc wiring:
+
+- The three `_sanitize_question` call sites + catches in `BaseBot`
+  (`bots/base.py:625/632, 997/1004, 1641/1648`) and the pipeline runs at
+  `:641/:1017/:1657` collapse into one INPUT-pipeline invocation each,
+  preserving two invariants exactly: (1) sanitized/transformed text binds
+  only to `prompt_for_llm` — the canonical `question` stays clean for
+  memory/events/vector retrieval; (2) BLOCK produces the same canned
+  `AIMessage`/string shapes the injection path produces today.
+- The FEAT-252 tool hook (`tools/abstract.py:784-810`) delegates to the
+  TOOL_OUTPUT pipeline; `SecretsGuardrail` keeps identical semantics and
+  ordering (secrets always first).
+- `get_response()` (`bots/abstract.py`, non-streaming funnel) runs OUTPUT;
+  `ask_stream` wraps chunk yields through registered `StreamingGuardrail`s
+  and runs remaining OUTPUT guardrails on the final `AIMessage`. The
+  channel-egress scrub (`bots/base.py:1445`, 4 chat modes only) folds into
+  the OUTPUT pipeline for all modes.
+- Empty pipelines short-circuit (`has_guardrails`, mirroring
+  `has_middlewares`) — zero overhead when nothing is registered.
+
+### Component Diagram
+
+```
+                       ┌──────────── AbstractBot.__init__ ────────────┐
+ guardrails=[...] ────►│ registry + legacy-flag mapping               │
+ legacy flags ────────►│  → 4 × GuardrailPipeline (per stage)         │
+                       └───────┬───────────┬───────────┬──────────────┘
+        user input             │           │           │
+BaseBot.invoke/ask/ask_stream  ▼           │           │
+        ── INPUT ──► [PromptInjection, Moderation, legacy PromptPipeline]
+                               │           ▼           │
+AbstractTool.execute() ─ TOOL_OUTPUT ─► [Secrets, PII, Pseudonymize]
+                               │                       ▼
+get_response()/stream close ── OUTPUT ─► [Secrets, PII, Moderation,
+                               │                       Groundedness(FLAG)]
+ask_stream chunk loop ── OUTPUT_STREAM ─► [StreamingGuardrail adapters]
+                               │
+                    BLOCK → canned AIMessage        FLAG → metadata["guardrails"]
+                    telemetry → FEAT-176 observers (name+action+counts only)
+```
+
+### Integration Points
+
+| Existing Component | Integration Type | Notes |
+|---|---|---|
+| `bots/base.py:625/632, 997/1004, 1641/1648` (+ `:641/:1017/:1657`) | modifies | INPUT pipeline replaces `_sanitize_question` + `PromptPipeline` calls; canned responses and `prompt_for_llm` invariant preserved |
+| `bots/abstract.py` `__init__` (`:294-297, :365, :379, :661-664, :672-685`) | modifies | pipeline construction + legacy-flag mapping; detector singletons reused |
+| `bots/abstract.py` `_sanitize_question` (`:1836-1942`) | migrates | body moves into `PromptInjectionGuardrail`; method kept as thin delegate for compat |
+| `tools/abstract.py:784-810` | modifies | hook delegates to TOOL_OUTPUT pipeline; `enable_redaction` semantics unchanged |
+| `bots/base.py:1445` channel-egress scrub | folds in | OUTPUT pipeline, all output modes |
+| `bots/middleware.py` + registration sites (`bots/search.py:119`, `skills/mixin.py:178`) | deprecates | wrapped as legacy TRANSFORM guardrail; sites migrated |
+| `security/` engines (`prompt_injection.py:27`, `redaction.py:128,149`) | uses | unchanged; plugins are thin wrappers |
+| FEAT-176 observers | uses | uniform telemetry |
+| FEAT-324 / FEAT-325 | provides sockets | their plugins register here (spec v0.4 / v0.2) |
+
+No breaking changes: with no `guardrails` kwarg and default legacy flags,
+behavior is bit-identical to today.
+
+### Data Models
+
+```python
+# parrot/bots/guardrails/base.py — design signatures
+class GuardrailStage(str, Enum):
+    INPUT = "input"; TOOL_OUTPUT = "tool_output"
+    OUTPUT = "output"; OUTPUT_STREAM = "output_stream"
+
+class GuardrailAction(str, Enum):
+    PASS = "pass"; TRANSFORM = "transform"; FLAG = "flag"; BLOCK = "block"
+
+class GuardrailResult(BaseModel):
+    action: GuardrailAction
+    content: Optional[str] = None          # TRANSFORM
+    report: Optional[dict] = None          # FLAG
+    reason: Optional[str] = None           # BLOCK (category, never content)
+
+class GuardrailContext(BaseModel):
+    stage: GuardrailStage
+    agent_name: str
+    user_id: Optional[str] = None
+    session_id: Optional[str] = None
+    method: str = ""                       # invoke | ask | ask_stream
+    tool_name: Optional[str] = None        # TOOL_OUTPUT only
+    extras: dict = {}
+
+class Guardrail(ABC):
+    name: str
+    stages: set[GuardrailStage]
+    priority: int                          # bands: 0-99 sanitize, 100-199 transform, 200+ observe
+    on_error: Literal["fail_open", "fail_closed"]
+    @abstractmethod
+    async def check(self, content: str, ctx: GuardrailContext) -> GuardrailResult: ...
+
+# parrot/bots/guardrails/streaming.py
+class StreamingGuardrail(ABC):
+    def feed(self, chunk: str) -> str: ...   # "" while withholding
+    def flush(self) -> str: ...
+```
+
+### New Public Interfaces
+
+```python
+# parrot/bots/guardrails/pipeline.py
+class GuardrailPipeline:
+    def add(self, guardrail: Guardrail) -> None: ...
+    @property
+    def has_guardrails(self) -> bool: ...
+    async def run(self, content: str, ctx: GuardrailContext) -> "PipelineOutcome":
+        """PipelineOutcome: final content, blocked flag + reason, flag reports."""
+
+# parrot/bots/guardrails/registry.py
+def register_guardrail(name: str, factory: Callable[..., Guardrail]) -> None: ...
+def build_guardrails(spec: list[str | dict | Guardrail]) -> list[Guardrail]: ...
+
+# Built-ins (parrot/bots/guardrails/builtin/)
+class PromptInjectionGuardrail(Guardrail): ...   # INPUT; can BLOCK; wraps shared detector
+class SecretsGuardrail(Guardrail): ...           # TOOL_OUTPUT+OUTPUT; TRANSFORM; wraps OutputScrubber
+class ModerationGuardrail(Guardrail): ...        # INPUT+OUTPUT; policy: categories/threshold/action
+class ModerationBackend(Protocol):
+    async def classify(self, text: str) -> dict[str, float]: ...
+class StubModerationBackend: ...                 # allow-all reference backend
+```
+
+New bot kwarg: `guardrails: list[str | dict | Guardrail] | None = None`.
+
+---
+
+## 3. Module Breakdown
+
+### Module 1: guardrails-core
+- **Path**: `parrot/bots/guardrails/` (`base.py`, `pipeline.py`,
+  `registry.py`, `config.py`, `streaming.py`, `__init__.py`)
+- **Responsibility**: stages, verdicts, ABC, context, pipeline (ordering,
+  BLOCK short-circuit, error contract, idempotency stamping, telemetry),
+  registry + config coercion, `StreamingGuardrail` contract. No bot
+  wiring yet.
+- **Depends on**: nothing new.
+
+### Module 2: guardrails-input-migration
+- **Path**: `builtin/prompt_injection.py` + wiring in `bots/abstract.py`
+  and the three `BaseBot` input sites
+- **Responsibility**: `PromptInjectionGuardrail` encapsulating the
+  `_sanitize_question` flow (trusted-source bypass, framework-pattern
+  strip, pytector/native detection, `SecurityEventLogger`,
+  block-vs-`_wrap_flagged_input` mitigation); legacy ctor-flag mapping;
+  `PromptPipeline` wrapped as legacy TRANSFORM guardrail and its two
+  registration sites migrated; behavioral-compat test suite.
+- **Depends on**: Module 1.
+
+### Module 3: guardrails-output-plugins
+- **Path**: `builtin/secrets.py` + wiring in `tools/abstract.py` hook,
+  `get_response()`, `ask_stream`, channel egress
+- **Responsibility**: `SecretsGuardrail` (identical scrub semantics,
+  always-first ordering); TOOL_OUTPUT/OUTPUT/OUTPUT_STREAM pipeline
+  execution at the seams; sockets documented for FEAT-324/325 plugins.
+- **Depends on**: Module 1. Parallel with Module 2 (disjoint files).
+
+### Module 4: guardrails-moderation-reference
+- **Path**: `builtin/moderation.py`
+- **Responsibility**: `ModerationPolicy` (categories, threshold, action
+  flag|block), `ModerationBackend` protocol, `StubModerationBackend`,
+  docs marking concrete backends as follow-ups.
+- **Depends on**: Module 1.
+
+---
+
+## 4. Test Specification
+
+### Unit Tests
+
+| Test | Module | Description |
+|---|---|---|
+| `test_pipeline_ordering` | M1 | Priority bands honored; stable order within band |
+| `test_pipeline_block_shortcircuit` | M1 | BLOCK stops the chain and discards prior TRANSFORMs |
+| `test_pipeline_error_contract` | M1 | `fail_open` → warn+continue; `fail_closed` → BLOCK |
+| `test_pipeline_flag_accumulation` | M1 | Multiple FLAG reports land under distinct names |
+| `test_pipeline_idempotency` | M1 | Re-running on stamped content is a no-op |
+| `test_registry_config_coercion` | M1 | names / dicts / instances / invalid name → clear error |
+| `test_zero_overhead_empty` | M1 | `has_guardrails` False → no pipeline invocation |
+| `test_injection_guardrail_compat` | M2 | For each of invoke/ask/ask_stream: same canned response, same `threats_detected` metadata, same `prompt_for_llm`-only rewriting as the legacy path (golden tests against current behavior) |
+| `test_legacy_flag_mapping` | M2 | The four ctor flags + `enable_redaction` produce equivalent registrations; defaults → bit-identical behavior |
+| `test_prompt_pipeline_wrapped` | M2 | Existing middlewares (competitor, skill-trigger) still apply via the legacy wrapper |
+| `test_secrets_guardrail_compat` | M3 | Tool-seam scrub results identical to direct `OutputScrubber` for the FEAT-252 corpus; scrub failure non-fatal |
+| `test_output_stage_all_modes` | M3 | Channel-egress scrub now applies beyond the 4 chat modes |
+| `test_streaming_adapter` | M3 | `StreamingGuardrail.feed/flush` invariant: concatenated == non-streaming transform |
+| `test_moderation_stub` | M4 | Policy threshold/action logic against stub scores; flag vs block |
+
+### Integration Tests
+
+| Test | Description |
+|---|---|
+| `test_ask_end_to_end_guardrails` | Bot with injection+secrets+custom FLAG guardrail: blocked input → canned AIMessage; clean input → transforms applied, reports in `metadata["guardrails"]` |
+| `test_ask_stream_end_to_end` | Streaming: chunk transforms via adapter, OUTPUT observers at close |
+| `test_default_config_regression` | Full existing bot test-suite subset passes with zero guardrails config (bit-identical behavior) |
+
+### Performance
+
+| Benchmark | Gate |
+|---|---|
+| Pipeline overhead, 3 no-op guardrails, 1 KB content | p99 < 0.5 ms |
+| Empty-pipeline path | no measurable overhead vs baseline |
+
+### Test Data / Fixtures
+
+```python
+@pytest.fixture
+def golden_injection_cases():  # captured from current _sanitize_question behavior
+    ...
+@pytest.fixture
+def stub_guardrails():  # PASS/TRANSFORM/FLAG/BLOCK/raise stand-ins
+    ...
+```
+
+---
+
+## 5. Acceptance Criteria
+
+> This feature is complete when ALL of the following are true:
+
+- [ ] All unit + integration tests pass (`pytest tests/ -v`).
+- [ ] **Compat invariant**: with no `guardrails` kwarg and default legacy
+      flags, bot behavior is bit-identical (golden tests for the three
+      injection call sites, tool-seam scrubbing, canned responses).
+- [ ] The four legacy injection ctor params and `enable_redaction` work
+      unchanged, mapped to guardrail registrations.
+- [ ] A custom `Guardrail` subclass can be attached per bot via
+      `guardrails=[...]` at any stage, with all four verdicts honored.
+- [ ] BLOCK produces the existing canned-`AIMessage`/string shapes and
+      never leaks the offending content; FLAG reports appear under
+      `AIMessage.metadata["guardrails"]`.
+- [ ] Per-guardrail `on_error` enforced; a raising `fail_open` guardrail
+      cannot break a turn; a raising `fail_closed` one blocks it.
+- [ ] `PromptPipeline` middlewares keep working via the legacy wrapper;
+      both existing registration sites migrated.
+- [ ] Telemetry emits guardrail name/stage/action/duration/counts and
+      never content, via existing FEAT-176 observers.
+- [ ] `ModerationGuardrail` interface + stub backend ship with docs
+      marking backends as follow-ups.
+- [ ] FEAT-324/325 sockets documented (registry names reserved:
+      `pii`, `pseudonymize`, `groundedness`).
+- [ ] Pipeline-overhead benchmark gate met; empty pipeline adds no
+      measurable overhead.
+- [ ] Zero new runtime dependencies; no breaking changes to public API.
+
+---
+
+## 6. Codebase Contract
+
+> **CRITICAL — Anti-Hallucination Anchor**
+> Verified on branch base `origin/dev` @ `58829cf9` (2026-07-24).
+> Paths relative to `packages/ai-parrot/src/parrot/`.
+
+### Verified Imports
+
+```python
+from parrot.security.prompt_injection import (
+    PromptInjectionDetector,      # security/prompt_injection.py:27
+    PromptInjectionException,     # :19
+    SecurityEventLogger,          # :222
+)
+from parrot.security.redaction import OutputScrubber, ScrubPolicy  # :149 / :128
+from parrot.bots.middleware import PromptPipeline, PromptMiddleware  # bots/middleware.py:23 / :8
+```
+
+### Existing Class Signatures
+
+```python
+# bots/abstract.py
+_get_shared_injection_detector()          # :78 (singleton block :64-95)
+# ctor params strict_mode/block_on_threat/injection_detection/threshold  # :294-297 → :661-664
+self._framework_sanitizer / self._injection_detector / self._security_logger  # :672-685
+self._prompt_pipeline = None              # :365 (property :715-720)
+self.enable_redaction = bool(kwargs.pop('enable_redaction', False))  # :379 → :390
+def _sanitize_question(...)               # :1836-1942 ; _wrap_flagged_input :1944
+# trusted-source bypass :1862; gate :1864; strip :1879; pytector :1884;
+# native sanitize :1904; log :1911; raise-if-block :1927; soft-wrap :1937
+
+# bots/base.py — input sites and catches (invariant: prompt_for_llm only):
+#   invoke :625/:632 · ask :997/:1004 · ask_stream :1641/:1648
+# PromptPipeline runs at :641/:1017/:1657 (ask_stream passes method:'ask' — known
+#   inconsistency near :1663, fix in migration)
+# channel-egress scrub singleton :61, applied :1445 (TELEGRAM/MSTEAMS/SLACK/WHATSAPP only)
+
+# bots/middleware.py (49 lines)
+class PromptMiddleware  # :8 — priority :11 (lower first), apply :17
+class PromptPipeline    # :23 — add :30, apply :37, exceptions swallowed :42-45, has_middlewares :48
+
+# tools/abstract.py
+# FEAT-252 hook :784-810 gated `if self.enable_redaction:` (:784); error path :856-858
+# _default_scrubber :63; tool attr enable_redaction :155
+
+# security/redaction.py
+class ScrubPolicy  # :128 (frozen); OutputScrubber :149; _already_scrubbed :122
+
+# enable_redaction stamping chain (config-propagation precedent):
+#   bots/abstract.py:379 → :390 → tools/manager.py:276,570-571,632-633,1425-1426
+#   → client stamping bots/abstract.py:937,956
+```
+
+### Integration Points
+
+| New Component | Connects To | Via | Verified At |
+|---|---|---|---|
+| INPUT pipeline | 3 `BaseBot` call sites + catches | replaces `_sanitize_question` + `PromptPipeline` calls | `bots/base.py:625/632,997/1004,1641/1648` |
+| `PromptInjectionGuardrail` | shared detector + logger | reuses singletons | `bots/abstract.py:78,672-685` |
+| TOOL_OUTPUT pipeline | FEAT-252 hook | delegation | `tools/abstract.py:784-810` |
+| `SecretsGuardrail` | `OutputScrubber` | wrap | `security/redaction.py:149` |
+| OUTPUT pipeline | `get_response()` / stream close / channel egress | seam calls | `bots/abstract.py` funnel; `bots/base.py:1445,1846` |
+| telemetry | FEAT-176 observers | emit | `core/events/lifecycle/` |
+
+### Does NOT Exist (Anti-Hallucination)
+
+- ~~Anything named `guardrail*` in the repo~~ (provider params in
+  `clients/bedrock.py:79-80,444` aside).
+- ~~An output/response transform chain~~ — `PromptPipeline` is input-only.
+- ~~Blocking or error-propagation semantics in `PromptPipeline`~~ —
+  transforms only; exceptions swallowed (`middleware.py:42-45`).
+- ~~Content-moderation code~~ — all `moderate` hits are
+  `SecurityLevel.MODERATE` in command/python sanitizers.
+- ~~`parrot.security.pii` / `parrot.security.groundedness`~~ — FEAT-324/
+  325 are specs; this feature only reserves their registry names.
+- ~~Server-package usage of the security stack~~ — handlers' `guardian`
+  is navigator-auth authn/authz.
+- ~~`AIMessage.guardrails` field~~ — reports live inside the existing
+  `metadata` dict.
+
+---
+
+## 7. Implementation Notes & Constraints
+
+### Patterns to Follow
+
+- Pydantic for results/context/policies; Google docstrings; strict type
+  hints; `self.logger`.
+- Async-first: `check()` is async (moderation backends will await I/O);
+  hot built-ins (secrets) do CPU work synchronously inside.
+- Generalize, don't reinvent: `ScrubPolicy`-style policy objects; the
+  `enable_redaction` stamping chain for propagation; `_already_scrubbed`
+  for idempotency; FEAT-176 for telemetry.
+- Migration discipline: golden tests captured **before** touching
+  `_sanitize_question`; the `prompt_for_llm` vs canonical-`question`
+  invariant is the highest-risk compat point.
+- Fix the `ask_stream` context `method:'ask'` copy-paste (near
+  `bots/base.py:1663`) as part of the migration.
+
+### Known Risks / Gotchas
+
+- Touches the three hottest `BaseBot` methods — mitigate with the
+  default-config regression suite and empty-pipeline zero-overhead gate.
+- Two skills packages exist (`parrot/skills/` and `parrot/memory/skills/`)
+  with middleware in both; migrate the live registration site
+  (`skills/mixin.py:178`) and leave the duplicate for a cleanup feature.
+- Ordering matters for correctness: secrets must transform before PII
+  (never scan already-`***REDACTED***` text) and observers must run last
+  on final content — encoded in the default priority bands.
+- `fail_closed` on a misconfigured guardrail can block every turn —
+  registry validates configs eagerly at bot construction, not first use.
+
+### External Dependencies
+
+| Package | Version | Reason |
+|---|---|---|
+| — | — | none — stdlib + Pydantic already in core |
+
+---
+
+## Worktree Strategy
+
+- **Default isolation unit**: mixed — Module 1 first (sequential; the
+  abstraction is load-bearing); then Module 2 ∥ Module 3 in separate
+  worktrees (disjoint seams: input sites vs tool hook/output funnel);
+  Module 4 after Module 1 (small, independent).
+- **Cross-feature dependencies**: FEAT-324/325 implementations depend on
+  this feature's Modules 1+3 (their sockets); schedule them after.
+
+---
+
+## 8. Open Questions
+
+> Carried forward from the brainstorm; session-default resolutions are
+> reflected in the body and flagged for review.
+
+- [x] Engines vs guardrails placement — *Resolved (session default)*:
+  engines in `parrot/security/`, abstraction + plugins in
+  `parrot/bots/guardrails/` (§2, §6).
+- [x] FEAT-324/325 fate — *Resolved (session default)*: v-bumped as
+  plugins (v0.4 / v0.2); engines unchanged.
+- [x] Moderation scope — *Resolved (session default)*: interface + stub
+  here; backends are follow-ups (§1 Non-Goals, §3 Module 4).
+- [ ] Should `SecretsGuardrail` become unconditional instead of
+  `enable_redaction` opt-in, now that ordering is explicit? —
+  *Owner: Jesús*
+- [ ] Deprecation horizon for `PromptPipeline` and the four legacy
+  injection ctor params (mapped indefinitely vs DeprecationWarning in
+  0.27)? — *Owner: Jesús*
+- [ ] Channel-egress extension to all output modes: ship here (current
+  plan, §2) or split out if compat risk emerges? — *Owner: Jesús*
+- [ ] `ProviderGuardrail` wrapper for Bedrock/Google native guardrails —
+  later feature? — *Owner: Jesús*
+- [ ] Handler-level (server package) guardrail execution — later
+  feature? — *Owner: Jesús*
+
+---
+
+## Revision History
+
+| Version | Date | Author | Change |
+|---|---|---|---|
+| 0.1 | 2026-07-24 | Jesús Lara / Claude Code | Initial draft from `guardrails-infrastructure.brainstorm.md` (Option A) |

--- a/sdd/specs/pii-detection-redaction.spec.md
+++ b/sdd/specs/pii-detection-redaction.spec.md
@@ -16,6 +16,22 @@ base_branch: dev
 > both ranges were claimed by the eventbus workstream (FEAT-316–319) while
 > this spec was in flight; final id is **FEAT-324** (highest on main: 323).
 
+> **v0.4 — Guardrails repositioning.** This feature is now a **plugin of
+> the unified guardrails infrastructure** (FEAT-396,
+> `sdd/proposals/guardrails-infrastructure.brainstorm.md`). Unchanged:
+> the engines and their acceptance criteria — catalog, `python_engine`,
+> `pii-rs` crate, validators, pseudonym store, benchmark gates
+> (Modules 1–2 engine work, Module 3 stores). Re-targeted: all *seam
+> wiring* described in this spec (the FEAT-252 tool-hook extension,
+> `get_response()`/`ask_stream` integration, bot kwargs
+> `enable_pii_protection`/`pii_policy`, the sliding-window streaming
+> filter) is delivered as guardrail plugins — `PIIGuardrail`,
+> `PseudonymizeGuardrail`, and a `StreamingGuardrail` adapter — attached
+> to the TOOL_OUTPUT / OUTPUT / OUTPUT_STREAM pipelines of
+> `parrot/bots/guardrails/`. Implementation depends on FEAT-396
+> `guardrails-core`. Where this spec's integration sections conflict with
+> the guardrails spec, the guardrails spec wins.
+
 ---
 
 ## 1. Motivation & Business Requirements
@@ -652,3 +668,4 @@ def encrypt_credential(...)   # line 19 — AES-GCM via navigator_session.vault.
 | 0.1 | 2026-07-20 | Jesús Lara / Claude Code | Initial draft from `pii-detection-redaction.brainstorm.md`; FEAT id corrected 316→319 |
 | 0.2 | 2026-07-22 | Jesús Lara / Claude Code | Adopt Unicode normalization + `detect_encoded_pii` from the OpenAI-Guardrails comparison; add measured Presidio baseline (`pii-detection-redaction.comparison.md`) |
 | 0.3 | 2026-07-22 | Jesús Lara / Claude Code | Renumber FEAT-319 → FEAT-324 (id claimed by `eventbus-consolidation.spec.md` on main) |
+| 0.4 | 2026-07-24 | Jesús Lara / Claude Code | Repositioned as plugin of the unified guardrails infrastructure (FEAT-396): seam wiring → `PIIGuardrail`/`PseudonymizeGuardrail`/`StreamingGuardrail`; engines unchanged |


### PR DESCRIPTION
## Summary

Follow-up to #1048 (merged). This PR refocuses the input/output control work as a **unified, pluggable guardrails infrastructure** centralized in `parrot/bots/guardrails/`, per the architectural pivot: PII, groundedness, prompt-injection, secrets and future modes (moderation, jailbreak, topic filters) become plugins of one abstraction instead of five parallel inventions.

### New documents

- **`sdd/proposals/guardrails-infrastructure.brainstorm.md`** — grounded in a verified survey of the five uncoordinated mechanisms in the current tree: the hardcoded `_sanitize_question` injection check (the only one that can block), the input-only `PromptPipeline` (cannot block, swallows exceptions), `OutputScrubber` at four ad-hoc seams behind `enable_redaction`, provider-native guardrails, and hand-rolled redactors. Options explored: native abstraction (A, recommended) vs adopting openai-guardrails-python (B) vs incremental pipeline extension (C).
- **`sdd/specs/guardrails-infrastructure.spec.md`** — formal spec (**FEAT-396**, v0.1): `Guardrail` ABC with 4 stages (INPUT / TOOL_OUTPUT / OUTPUT / OUTPUT_STREAM) and 4 verdicts (PASS / TRANSFORM / FLAG / BLOCK); priority-ordered pipelines with BLOCK short-circuit and per-guardrail `fail_open`/`fail_closed` error contracts; per-bot `guardrails=[...]` registry with full legacy-flag compatibility (`injection_detection`, `strict_mode`, `block_on_threat`, `enable_redaction`); `StreamingGuardrail` adapter; `ModerationGuardrail` reference interface + stub backend. Engines stay in `parrot/security/`; plugins are thin wrappers. Compat invariant: default configuration is bit-identical to today (golden tests specified).

### Spec revisions (plugins of FEAT-396)

- **`pii-detection-redaction.spec.md` → v0.4**: seam wiring re-targeted to `PIIGuardrail` / `PseudonymizeGuardrail` / `StreamingGuardrail` adapter; engines (catalog, `pii-rs` crate, pseudonym stores, benchmark gates) unchanged.
- **`deterministic-groundedness-scoring.spec.md` → v0.2**: Module 3 reporting becomes `GroundednessGuardrail` (FLAG-only, OUTPUT pipeline); scorer engine and precision-aware tolerance rule unchanged.

### Implementation order

FEAT-396 Modules 1+3 (core + output plugins) unblock the FEAT-324/325 implementations; Module 2 (input migration) and Module 4 (moderation reference) can proceed in parallel after core.

## Next steps

1. Review the FEAT-396 spec (Acceptance Criteria + the four session-default resolutions flagged in §8) and mark `approved`.
2. `/sdd-task sdd/specs/guardrails-infrastructure.spec.md` to decompose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeqDJyFSV1CywVXnJEwgnq

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeqDJyFSV1CywVXnJEwgnq)_