### PR TITLE
feat(tokens-observability): FEAT-397 — Per-Round Token Usage Observability

### DIFF
--- a/packages/ai-parrot/src/parrot/clients/base.py
+++ b/packages/ai-parrot/src/parrot/clients/base.py
@@ -495,10 +495,16 @@ $backstory
         """Emit ``ClientRoundEvent`` for a single tool-execution round.
 
         Fire-and-forget (``emit_nowait`` + ``forward_to_global``), mirroring
-        :meth:`_emit_before_call`. Short-circuits via
-        ``self.events.has_subscribers(ClientRoundEvent)`` before constructing
-        the event, so there is zero overhead on the hot path when nobody
-        listens.
+        :meth:`_emit_before_call`. Short-circuits before constructing the
+        event so there is zero overhead on the hot path when nobody listens
+        — checking BOTH the client's own (isolated, ``forward_to_global=
+        False``) registry AND the current global registry. Client registries
+        normally have no direct subscribers in production (real consumers
+        like ``MetricsSubscriber`` register on the global registry, reached
+        via the explicit ``forward_to_global()`` bridge below); checking
+        only ``self.events`` would silently never emit ``ClientRoundEvent``
+        outside of tests that subscribe directly on a client instance
+        (FEAT-397 TASK-2040 integration testing surfaced this).
 
         Args:
             tc: The ``TraceContext`` returned by :meth:`_emit_before_call`.
@@ -518,7 +524,13 @@ $backstory
                 SDK call.
         """
         if not self.events.has_subscribers(ClientRoundEvent):
-            return
+            # FEAT-397 (TASK-2040 fix): client registries never carry direct
+            # subscribers in production — fall back to checking the current
+            # global registry before giving up, so MetricsSubscriber (or any
+            # other global observer) actually receives round events.
+            from navigator_eventbus.lifecycle.global_registry import get_global_registry
+            if not get_global_registry().has_subscribers(ClientRoundEvent):
+                return
 
         event = ClientRoundEvent(
             trace_context=tc,

--- a/packages/ai-parrot/src/parrot/clients/base.py
+++ b/packages/ai-parrot/src/parrot/clients/base.py
@@ -72,6 +72,11 @@ from parrot.core.events.lifecycle.events import (
     # FEAT-397: Per-Round Token Usage Observability
     ClientRoundEvent,
 )
+# FEAT-397: used by _emit_round_event()'s has_subscribers() fallback check —
+# hoisted to module scope (not re-imported per round) since sys.modules
+# caching aside, this runs on every tool round once MetricsSubscriber is
+# wired globally.
+from navigator_eventbus.lifecycle.global_registry import get_global_registry
 # FEAT-228: per-agent cost/usage metrics — read invoking agent's identity at event build time
 from parrot.observability.context import current_agent_name
 
@@ -528,7 +533,6 @@ $backstory
             # subscribers in production — fall back to checking the current
             # global registry before giving up, so MetricsSubscriber (or any
             # other global observer) actually receives round events.
-            from navigator_eventbus.lifecycle.global_registry import get_global_registry
             if not get_global_registry().has_subscribers(ClientRoundEvent):
                 return
 

--- a/packages/ai-parrot/src/parrot/clients/base.py
+++ b/packages/ai-parrot/src/parrot/clients/base.py
@@ -4,6 +4,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Sequence,
     Union,
     TypedDict,
     Any,
@@ -68,6 +69,8 @@ from parrot.core.events.lifecycle.events import (
     BeforeClientCallEvent,
     AfterClientCallEvent,
     ClientCallFailedEvent,
+    # FEAT-397: Per-Round Token Usage Observability
+    ClientRoundEvent,
 )
 # FEAT-228: per-agent cost/usage metrics — read invoking agent's identity at event build time
 from parrot.observability.context import current_agent_name
@@ -476,6 +479,71 @@ $backstory
         # forward_to_global skips the work when nobody is listening globally.
         self.events.forward_to_global(event)
         return tc
+
+    def _emit_round_event(
+        self,
+        tc: "TraceContext",
+        *,
+        client_name: str,
+        model: str,
+        round_number: int,
+        usage: "Optional[CompletionUsage]",
+        raw_usage: "Optional[dict]",
+        tool_calls: "Sequence[str]",
+        duration_ms: float,
+    ) -> None:
+        """Emit ``ClientRoundEvent`` for a single tool-execution round.
+
+        Fire-and-forget (``emit_nowait`` + ``forward_to_global``), mirroring
+        :meth:`_emit_before_call`. Short-circuits via
+        ``self.events.has_subscribers(ClientRoundEvent)`` before constructing
+        the event, so there is zero overhead on the hot path when nobody
+        listens.
+
+        Args:
+            tc: The ``TraceContext`` returned by :meth:`_emit_before_call`.
+            client_name: Provider identifier.
+            model: Model name/identifier.
+            round_number: 1-indexed round number within this ``ask()`` call.
+            usage: This round's :class:`CompletionUsage`, or ``None`` when
+                the provider reported no usage for the round. Flat token
+                counts are extracted from it (``prompt_tokens`` →
+                ``input_tokens``, ``completion_tokens`` → ``output_tokens``,
+                ``total_tokens`` → ``total_tokens``); all ``None`` when
+                ``usage is None``.
+            raw_usage: Provider-native usage payload for this round,
+                JSON-safe (plain dict). Passed through as-is.
+            tool_calls: Tool-name strings invoked during this round.
+            duration_ms: Wall-clock time in milliseconds for this round's
+                SDK call.
+        """
+        if not self.events.has_subscribers(ClientRoundEvent):
+            return
+
+        event = ClientRoundEvent(
+            trace_context=tc,
+            client_name=client_name,
+            model=model or "",
+            round_number=round_number,
+            input_tokens=usage.prompt_tokens if usage is not None else None,
+            output_tokens=usage.completion_tokens if usage is not None else None,
+            total_tokens=usage.total_tokens if usage is not None else None,
+            tool_calls=tuple(tool_calls),
+            duration_ms=duration_ms,
+            raw_usage=raw_usage,
+            source_type="client",
+            source_name=client_name,
+            # FEAT-228: read here (construction time, bot's task context) not at emit time —
+            # _emit_* dispatches fire-and-forget via emit_nowait so the ContextVar must be
+            # captured before the event leaves the calling coroutine.
+            agent_name=current_agent_name.get(),
+        )
+        self.events.emit_nowait(event)
+        # Client registries are isolated (forward_to_global=False). Forward the
+        # LLM-call lifecycle events explicitly so global observers (cost/token
+        # recorders, OTel subscribers) receive them. The guard inside
+        # forward_to_global skips the work when nobody is listening globally.
+        self.events.forward_to_global(event)
 
     async def _emit_after_call(
         self,

--- a/packages/ai-parrot/src/parrot/clients/claude.py
+++ b/packages/ai-parrot/src/parrot/clients/claude.py
@@ -530,8 +530,14 @@ class AnthropicClient(AbstractClient):
         all_tool_calls = []
         used_fallback = False
 
+        # FEAT-397: per-round token usage accumulation across the tool loop
+        _lc_round_number = 0
+        _lc_accumulated_usage: "Optional[CompletionUsage]" = None
+
         # Handle tool calls in a loop
         while True:
+            # FEAT-397: time this round's SDK call for the round event's duration_ms
+            _lc_round_t0 = _lc_time.perf_counter()
             # Use the Anthropic SDK to create messages
             try:
                 response = await self._sdk_create(payload)
@@ -548,11 +554,28 @@ class AnthropicClient(AbstractClient):
                     raise
             # Convert Message object to dict for compatibility
             result = response.model_dump()
+            _lc_round_number += 1
+            _lc_round_duration_ms = (_lc_time.perf_counter() - _lc_round_t0) * 1000
+
+            # FEAT-397: build this round's usage and accumulate. Rounds where
+            # the provider reported no usage are skipped (accumulator
+            # untouched); the round event still fires with usage=None.
+            _lc_round_raw_usage = result.get("usage") or None
+            if _lc_round_raw_usage:
+                _lc_round_usage = CompletionUsage.from_claude(_lc_round_raw_usage)
+                _lc_accumulated_usage = (
+                    _lc_round_usage
+                    if _lc_accumulated_usage is None
+                    else _lc_accumulated_usage + _lc_round_usage
+                )
+            else:
+                _lc_round_usage = None
 
             # Check if Claude wants to use a tool
             if result.get("stop_reason") == "tool_use":
                 tool_results = []
                 found_new_tools = False
+                _lc_round_tool_names = []
 
                 for content_block in result["content"]:
                     if content_block["type"] == "tool_use":
@@ -608,10 +631,23 @@ class AnthropicClient(AbstractClient):
                             })
 
                         all_tool_calls.append(tc)
+                        _lc_round_tool_names.append(tool_name)
 
                 # Update available tools if new ones found
                 if lazy_loading and found_new_tools:
                      payload["tools"] = self._prepare_tools(filter_names=list(active_tool_names))
+
+                # FEAT-397: emit ClientRoundEvent after tool execution for this round
+                self._emit_round_event(
+                    _lc_tc,
+                    client_name=self._telemetry_client_name,
+                    model=model,
+                    round_number=_lc_round_number,
+                    usage=_lc_round_usage,
+                    raw_usage=_lc_round_raw_usage,
+                    tool_calls=_lc_round_tool_names,
+                    duration_ms=_lc_round_duration_ms,
+                )
 
                 # Add tool results and continue conversation
                 messages.append({"role": "assistant", "content": result["content"]})
@@ -675,6 +711,15 @@ class AnthropicClient(AbstractClient):
             structured_output=final_output,
             tool_calls=all_tool_calls
         )
+
+        # FEAT-397: replace the last-round-only usage with the accumulated
+        # multi-round total. For single-round calls (no tool use), the
+        # accumulated total equals the last (only) round's usage, so this
+        # is a no-op for existing single-round behavior.
+        if _lc_accumulated_usage is not None:
+            if _lc_round_number > 1:
+                _lc_accumulated_usage.extra_usage["rounds"] = _lc_round_number
+            ai_message.usage = _lc_accumulated_usage
 
         # Add fallback metadata if fallback was used
         if used_fallback:

--- a/packages/ai-parrot/src/parrot/clients/google/client.py
+++ b/packages/ai-parrot/src/parrot/clients/google/client.py
@@ -1743,6 +1743,17 @@ class GoogleGenAIClient(AbstractClient, GoogleGeneration, GoogleAnalysis):
         session_id: Optional[str] = None,
         messages: Optional[List[Dict[str, Any]]] = None,
         stop_tools: Optional[set] = None,
+        # FEAT-397: per-round token usage observability. Both are optional
+        # and default to None so existing callers (e.g. resume()) that do
+        # not pass them see zero behavioral change — accumulation and round
+        # event emission are opt-in via these params, mirroring the
+        # existing all_tool_calls in/out-parameter pattern above rather
+        # than changing this method's return contract.
+        round_tc: Optional[Any] = None,
+        initial_round_usage: Optional[CompletionUsage] = None,
+        initial_round_raw_usage: Optional[dict] = None,
+        initial_round_duration_ms: float = 0.0,
+        usage_state: Optional[Dict[str, Any]] = None,
     ) -> Any:
         """
         Simple multi-turn function calling - just keep going until no more function calls.
@@ -1752,10 +1763,32 @@ class GoogleGenAIClient(AbstractClient, GoogleGeneration, GoogleAnalysis):
                 stop tool executes successfully its result is still sent back
                 to the model, but further tool-calling is disabled so the
                 model must produce a final text answer on the next turn.
+            round_tc: TraceContext for ClientRoundEvent emission (FEAT-397).
+                When None, no round events are emitted from this method.
+            initial_round_usage: The CALLER's already-computed CompletionUsage
+                for round 1 (the ``initial_response``, whose SDK call happened
+                in ``ask()`` before this method was invoked).
+            initial_round_raw_usage: JSON-safe raw usage dict for round 1.
+            initial_round_duration_ms: Wall-clock duration of round 1's SDK call.
+            usage_state: Mutable dict the method populates in place with
+                ``{"accumulated": Optional[CompletionUsage], "rounds": int}``
+                covering round 1 (seeded from the args above) through every
+                round this method's loop receives. When None, no accumulation
+                is performed.
         """
         current_response = initial_response
         current_config = config
         iteration = 0
+
+        # FEAT-397: seed round-1 accounting (the initial ask() call) and
+        # track the "current round's" usage/raw_usage/duration so the event
+        # emitted for round N (further down) can use them.
+        if usage_state is not None:
+            usage_state["accumulated"] = initial_round_usage
+            usage_state["rounds"] = 1
+        _lc_round_usage = initial_round_usage
+        _lc_round_raw_usage = initial_round_raw_usage
+        _lc_round_duration_ms = initial_round_duration_ms
 
         if active_tool_names is None:
             active_tool_names = set()
@@ -2019,8 +2052,27 @@ class GoogleGenAIClient(AbstractClient, GoogleGeneration, GoogleAnalysis):
             if summary_part:
                 next_prompt_parts.append(summary_part)
 
+            # FEAT-397: emit ClientRoundEvent for round `iteration` — the
+            # function calls just executed above belong to `current_response`
+            # (round 1 = initial_response, rounds 2..N = responses this loop
+            # received). Usage/raw_usage/duration were carried from when this
+            # round's response was first received (seeded pre-loop for round 1,
+            # or set at the end of the previous iteration otherwise).
+            if round_tc is not None:
+                self._emit_round_event(
+                    round_tc,
+                    client_name="google",
+                    model=model or "",
+                    round_number=iteration,
+                    usage=_lc_round_usage,
+                    raw_usage=_lc_round_raw_usage,
+                    tool_calls=[fc.name for fc in function_calls],
+                    duration_ms=_lc_round_duration_ms,
+                )
+
             # Send responses back
             retry_count = 0
+            _lc_round_t0 = time.perf_counter()
             try:
                 self.logger.debug(f"Sending {len(next_prompt_parts)} responses back to model")
                 while retry_count < max_retries:
@@ -2098,6 +2150,33 @@ class GoogleGenAIClient(AbstractClient, GoogleGeneration, GoogleAnalysis):
                             self.logger.error("Max retries reached, aborting")
                             raise e
                         await asyncio.sleep(delay)
+
+                # FEAT-397: extract & accumulate this NEW round's usage (the
+                # response just received above becomes round `iteration + 1`
+                # when the loop's next pass checks it for function calls).
+                # Only reached on success — an exception here propagates to
+                # the outer except below, so no partial/failed round is
+                # counted or accumulated.
+                _lc_round_duration_ms = (time.perf_counter() - _lc_round_t0) * 1000
+                _lc_usage_metadata = getattr(current_response, "usage_metadata", None)
+                if _lc_usage_metadata:
+                    _lc_round_raw_usage = {
+                        "prompt_token_count": getattr(_lc_usage_metadata, "prompt_token_count", 0),
+                        "candidates_token_count": getattr(_lc_usage_metadata, "candidates_token_count", 0),
+                        "total_token_count": getattr(_lc_usage_metadata, "total_token_count", 0),
+                    }
+                    _lc_round_usage = CompletionUsage.from_gemini(_lc_round_raw_usage)
+                    if usage_state is not None:
+                        usage_state["accumulated"] = (
+                            _lc_round_usage
+                            if usage_state.get("accumulated") is None
+                            else usage_state["accumulated"] + _lc_round_usage
+                        )
+                else:
+                    _lc_round_usage = None
+                    _lc_round_raw_usage = None
+                if usage_state is not None:
+                    usage_state["rounds"] = iteration + 1
 
                 # Check for UNEXPECTED_TOOL_CALL error
                 if (
@@ -3187,6 +3266,10 @@ class GoogleGenAIClient(AbstractClient, GoogleGeneration, GoogleAnalysis):
         current_model = model
         chat = self.client.aio.chats.create(model=current_model, history=history)
         retry_count = 0
+        # FEAT-397: time round 1's SDK call (the initial response) across
+        # every retry attempt, so the round-1 ClientRoundEvent's duration_ms
+        # reflects the full time spent, matching the other priority clients.
+        _lc_round1_t0 = time.perf_counter()
         while retry_count < max_retries:
             try:
                 phase_started = time.perf_counter()
@@ -3287,6 +3370,23 @@ class GoogleGenAIClient(AbstractClient, GoogleGeneration, GoogleAnalysis):
         if has_function_calls:
             self._log_non_text_parts(response, where="initial response")
 
+        # FEAT-397: round 1's usage — the initial response's usage_metadata,
+        # extracted here so it (a) feeds the accumulated total and (b) seeds
+        # the round-1 ClientRoundEvent emitted from inside the multiturn
+        # handler for round 1's tool execution.
+        _lc_round1_duration_ms = (time.perf_counter() - _lc_round1_t0) * 1000
+        _lc_round1_usage_metadata = getattr(response, "usage_metadata", None)
+        _lc_round1_usage = None
+        _lc_round1_raw_usage = None
+        if _lc_round1_usage_metadata:
+            _lc_round1_raw_usage = {
+                "prompt_token_count": getattr(_lc_round1_usage_metadata, "prompt_token_count", 0),
+                "candidates_token_count": getattr(_lc_round1_usage_metadata, "candidates_token_count", 0),
+                "total_token_count": getattr(_lc_round1_usage_metadata, "total_token_count", 0),
+            }
+            _lc_round1_usage = CompletionUsage.from_gemini(_lc_round1_raw_usage)
+        _lc_usage_state: Dict[str, Any] = {}
+
         # Multi-turn function calling loop
         phase_started = time.perf_counter()
         final_response = await self._handle_multiturn_function_calls(
@@ -3303,6 +3403,11 @@ class GoogleGenAIClient(AbstractClient, GoogleGeneration, GoogleAnalysis):
             session_id=session_id,
             messages=messages,
             stop_tools=stop_tools,
+            round_tc=_lc_tc_google,
+            initial_round_usage=_lc_round1_usage,
+            initial_round_raw_usage=_lc_round1_raw_usage,
+            initial_round_duration_ms=_lc_round1_duration_ms,
+            usage_state=_lc_usage_state,
         )
         self.logger.debug(
             "Google ask timing: function_loop_ms=%.1f tool_calls=%d",
@@ -3576,6 +3681,19 @@ class GoogleGenAIClient(AbstractClient, GoogleGeneration, GoogleAnalysis):
             (time.perf_counter() - phase_started) * 1000,
             (time.perf_counter() - ask_started) * 1000,
         )
+
+        # FEAT-397: replace the initial-response-only usage (the bug —
+        # AIMessageFactory.from_gemini built `usage` from the INITIAL
+        # `response`, discarding every multiturn round's tokens) with the
+        # accumulated multi-round total. For single-round calls (no function
+        # calls at all), `_lc_usage_state` stays empty and `.get(...)`
+        # defaults preserve the factory's original usage untouched.
+        _lc_google_accumulated_usage = _lc_usage_state.get("accumulated")
+        _lc_google_rounds = _lc_usage_state.get("rounds", 1)
+        if _lc_google_accumulated_usage is not None:
+            if _lc_google_rounds > 1:
+                _lc_google_accumulated_usage.extra_usage["rounds"] = _lc_google_rounds
+            ai_message.usage = _lc_google_accumulated_usage
 
         # Override provider to distinguish from Vertex AI
         ai_message.provider = "google_genai"

--- a/packages/ai-parrot/src/parrot/clients/gpt.py
+++ b/packages/ai-parrot/src/parrot/clients/gpt.py
@@ -857,6 +857,29 @@ class OpenAIClient(AbstractClient):
         _used_fallback = False
         _original_model = model_str
 
+        # FEAT-397: per-round token usage accumulation across the tool loop.
+        def _lc_gpt_extract_usage(response_obj):
+            """Build (per-round CompletionUsage, JSON-safe raw usage dict) from
+            a gpt.py SDK response's ``.usage``. Both call paths (Responses API
+            and Chat Completions) expose ``.usage`` the same way."""
+            usage_obj = getattr(response_obj, "usage", None)
+            if not usage_obj:
+                return None, None
+            per_round = CompletionUsage.from_openai(usage_obj)
+            raw = None
+            if hasattr(usage_obj, "model_dump"):
+                try:
+                    raw = usage_obj.model_dump()
+                except Exception:  # pylint: disable=broad-except
+                    raw = None
+            elif isinstance(usage_obj, dict):
+                raw = usage_obj
+            return per_round, raw
+
+        _lc_round_number_gpt = 1
+        _lc_accumulated_usage_gpt: "Optional[CompletionUsage]" = None
+        _lc_round_t0_gpt = _lc_time_gpt.perf_counter()
+
         try:
             if use_responses:
                 if output_config:
@@ -885,10 +908,17 @@ class OpenAIClient(AbstractClient):
             else:
                 raise
 
+        # FEAT-397: round 1 is the initial (pre-loop) call above.
+        _lc_round_duration_gpt = (_lc_time_gpt.perf_counter() - _lc_round_t0_gpt) * 1000
+        _lc_round_usage_gpt, _lc_round_raw_usage_gpt = _lc_gpt_extract_usage(response)
+        if _lc_round_usage_gpt is not None:
+            _lc_accumulated_usage_gpt = _lc_round_usage_gpt
+
         result = response.choices[0].message
 
         # ---------- Tool loop (works for both paths) ----------
         while getattr(result, "tool_calls", None):
+            _lc_round_tool_names_gpt = []
             messages.append(
                 {
                     "role": "assistant",
@@ -968,6 +998,7 @@ class OpenAIClient(AbstractClient):
                         )
 
                     all_tool_calls.append(tc)
+                    _lc_round_tool_names_gpt.append(tool_name)
 
                 except Exception as e:
                     all_tool_calls.append(
@@ -977,6 +1008,7 @@ class OpenAIClient(AbstractClient):
                             arguments={"_error": f"malformed tool args: {e}"},
                         )
                     )
+                    _lc_round_tool_names_gpt.append(tool_name)
                     messages.append(
                         {
                             "role": "tool",
@@ -991,7 +1023,21 @@ class OpenAIClient(AbstractClient):
                 args["tools"] = self._prepare_tools(filter_names=list(active_tool_names))
                 # Note: We keep tool_choice='auto'
 
+            # FEAT-397: emit ClientRoundEvent for the round whose tool calls
+            # were just executed above.
+            self._emit_round_event(
+                _lc_tc_gpt,
+                client_name="openai",
+                model=model_str,
+                round_number=_lc_round_number_gpt,
+                usage=_lc_round_usage_gpt,
+                raw_usage=_lc_round_raw_usage_gpt,
+                tool_calls=_lc_round_tool_names_gpt,
+                duration_ms=_lc_round_duration_gpt,
+            )
+
             # continue via the same routed API
+            _lc_round_t0_gpt = _lc_time_gpt.perf_counter()
             if use_responses:
                 if output_config:
                     args["response_format"] = resp_format
@@ -1000,6 +1046,17 @@ class OpenAIClient(AbstractClient):
                 if output_config:
                     args["response_format"] = resp_format
                 response = await self._chat_completion(model=model_str, messages=messages, use_tools=_use_tools, **args)
+
+            # FEAT-397: accumulate this new round's usage
+            _lc_round_number_gpt += 1
+            _lc_round_duration_gpt = (_lc_time_gpt.perf_counter() - _lc_round_t0_gpt) * 1000
+            _lc_round_usage_gpt, _lc_round_raw_usage_gpt = _lc_gpt_extract_usage(response)
+            if _lc_round_usage_gpt is not None:
+                _lc_accumulated_usage_gpt = (
+                    _lc_round_usage_gpt
+                    if _lc_accumulated_usage_gpt is None
+                    else _lc_accumulated_usage_gpt + _lc_round_usage_gpt
+                )
 
             result = response.choices[0].message
 
@@ -1046,6 +1103,15 @@ class OpenAIClient(AbstractClient):
             turn_id=turn_id,
             structured_output=structured_payload,
         )
+
+        # FEAT-397: replace the last-round-only usage with the accumulated
+        # multi-round total. For single-round calls (no tool use), the
+        # accumulated total equals the last (only) round's usage, so this
+        # is a no-op for existing single-round behavior.
+        if _lc_accumulated_usage_gpt is not None:
+            if _lc_round_number_gpt > 1:
+                _lc_accumulated_usage_gpt.extra_usage["rounds"] = _lc_round_number_gpt
+            ai_message.usage = _lc_accumulated_usage_gpt
 
         ai_message.tool_calls = all_tool_calls
         if _used_fallback:

--- a/packages/ai-parrot/src/parrot/clients/grok.py
+++ b/packages/ai-parrot/src/parrot/clients/grok.py
@@ -274,12 +274,38 @@ class GrokClient(AbstractClient):
         max_turns = 10
         current_turn = 0
 
+        # FEAT-397: per-round token usage accumulation across the tool loop.
+        # Each chat.sample() call IS a round — current_turn is already the
+        # 1-indexed round number, no separate pre-loop "initial call" here.
+        _lc_accumulated_usage_grok2: "Optional[CompletionUsage]" = None
+
         while current_turn < max_turns:
             current_turn += 1
 
             try:
+                _lc_round_t0_grok2 = _lc_time_grok2.perf_counter()
                 response = await chat.sample()
                 chat.append(response)
+                _lc_round_duration_grok2 = (_lc_time_grok2.perf_counter() - _lc_round_t0_grok2) * 1000
+
+                # FEAT-397: build this round's usage and accumulate. Rounds
+                # where the provider reported no usage are skipped (accumulator
+                # untouched); the round event still fires with usage=None.
+                # Grok's usage may be a JSON-safe dict OR an xai_sdk protobuf
+                # object — from_grok() handles both; its extra_usage dict
+                # (getattr-extracted for the protobuf branch) doubles as the
+                # JSON-safe raw_usage payload, per this task's implementation note.
+                if hasattr(response, "usage") and response.usage:
+                    _lc_round_usage_grok2 = CompletionUsage.from_grok(response.usage)
+                    _lc_round_raw_usage_grok2 = _lc_round_usage_grok2.extra_usage
+                    _lc_accumulated_usage_grok2 = (
+                        _lc_round_usage_grok2
+                        if _lc_accumulated_usage_grok2 is None
+                        else _lc_accumulated_usage_grok2 + _lc_round_usage_grok2
+                    )
+                else:
+                    _lc_round_usage_grok2 = None
+                    _lc_round_raw_usage_grok2 = None
 
                 tool_calls = response.tool_calls or []
 
@@ -287,6 +313,7 @@ class GrokClient(AbstractClient):
                     final_response = response
                     break
 
+                _lc_round_tool_names_grok2 = []
                 for tc in tool_calls:
                     fn = tc.function
                     tool_name = fn.name
@@ -307,8 +334,21 @@ class GrokClient(AbstractClient):
                         result=tool_exec_result
                     )
                     all_tool_calls.append(tool_call_rec)
+                    _lc_round_tool_names_grok2.append(tool_name)
 
                     chat.append(tool_result_fn(str(tool_exec_result), tool_call_id=tool_id))
+
+                # FEAT-397: emit ClientRoundEvent for this round's tool execution.
+                self._emit_round_event(
+                    _lc_tc_grok2,
+                    client_name="grok",
+                    model=model,
+                    round_number=current_turn,
+                    usage=_lc_round_usage_grok2,
+                    raw_usage=_lc_round_raw_usage_grok2,
+                    tool_calls=_lc_round_tool_names_grok2,
+                    duration_ms=_lc_round_duration_grok2,
+                )
 
                 continue
 
@@ -343,6 +383,15 @@ class GrokClient(AbstractClient):
             usage=CompletionUsage.from_grok(final_response.usage) if hasattr(final_response, 'usage') else None,
             text_response=text_content
         )
+
+        # FEAT-397: replace the last-round-only usage with the accumulated
+        # multi-round total. For single-round calls (no tool use), the
+        # accumulated total equals the last (only) round's usage, so this
+        # is a no-op for existing single-round behavior.
+        if _lc_accumulated_usage_grok2 is not None:
+            if current_turn > 1:
+                _lc_accumulated_usage_grok2.extra_usage["rounds"] = current_turn
+            ai_message.usage = _lc_accumulated_usage_grok2
 
         ai_message.tool_calls = all_tool_calls
         if structured_payload:

--- a/packages/ai-parrot/src/parrot/clients/groq.py
+++ b/packages/ai-parrot/src/parrot/clients/groq.py
@@ -390,14 +390,40 @@ class GroqClient(AbstractClient):
                 else:
                     request_args["response_format"] = {"type": "json_object"}
 
+        # FEAT-397: per-round token usage accumulation across the tool loop.
+        def _lc_groq_extract_usage(response_obj):
+            """Build (per-round CompletionUsage, JSON-safe raw usage dict) from
+            a groq.py SDK response's ``.usage``."""
+            usage_obj = getattr(response_obj, "usage", None)
+            if not usage_obj:
+                return None, None
+            per_round = CompletionUsage.from_groq(usage_obj)
+            raw = None
+            if hasattr(usage_obj, "model_dump"):
+                try:
+                    raw = usage_obj.model_dump()
+                except Exception:  # pylint: disable=broad-except
+                    raw = None
+            elif isinstance(usage_obj, dict):
+                raw = usage_obj
+            return per_round, raw
+
         # Make initial request
         self.logger.debug(
             f"Groq request: use_tools={use_tools}, "
             f"request_output_config={'yes' if request_output_config else 'no'}, "
             f"tools_in_request={'tools' in request_args}"
         )
+        _lc_round_number_groq = 1
+        _lc_accumulated_usage_groq: "Optional[CompletionUsage]" = None
+        _lc_round_t0_groq = _lc_time_groq.perf_counter()
         response = await self.client.chat.completions.create(**request_args)
         result = response.choices[0].message
+        # FEAT-397: round 1 is this initial call.
+        _lc_round_duration_groq = (_lc_time_groq.perf_counter() - _lc_round_t0_groq) * 1000
+        _lc_round_usage_groq, _lc_round_raw_usage_groq = _lc_groq_extract_usage(response)
+        if _lc_round_usage_groq is not None:
+            _lc_accumulated_usage_groq = _lc_round_usage_groq
 
         # Handle tool calls in a loop (only if tools were enabled)
         if use_tools:
@@ -407,6 +433,7 @@ class GroqClient(AbstractClient):
 
             while result.tool_calls and conversation_turns < max_turns:
                 conversation_turns += 1
+                _lc_round_tool_names_groq = []
 
                 # Add the assistant's message with tool calls to conversation
                 messages.append({
@@ -473,6 +500,7 @@ class GroqClient(AbstractClient):
                         })
 
                     all_tool_calls.append(tc)
+                    _lc_round_tool_names_groq.append(tool_name)
 
                 # Continue conversation with tool results to get final response
                 continue_args = {
@@ -495,8 +523,32 @@ class GroqClient(AbstractClient):
                     # Force final response without more tool calls
                     continue_args["tool_choice"] = "none"
 
+                # FEAT-397: emit ClientRoundEvent for the round whose tool
+                # calls were just executed above.
+                self._emit_round_event(
+                    _lc_tc_groq,
+                    client_name="groq",
+                    model=model,
+                    round_number=_lc_round_number_groq,
+                    usage=_lc_round_usage_groq,
+                    raw_usage=_lc_round_raw_usage_groq,
+                    tool_calls=_lc_round_tool_names_groq,
+                    duration_ms=_lc_round_duration_groq,
+                )
+
+                _lc_round_t0_groq = _lc_time_groq.perf_counter()
                 response = await self.client.chat.completions.create(**continue_args)
                 result = response.choices[0].message
+                # FEAT-397: accumulate this new round's usage
+                _lc_round_number_groq += 1
+                _lc_round_duration_groq = (_lc_time_groq.perf_counter() - _lc_round_t0_groq) * 1000
+                _lc_round_usage_groq, _lc_round_raw_usage_groq = _lc_groq_extract_usage(response)
+                if _lc_round_usage_groq is not None:
+                    _lc_accumulated_usage_groq = (
+                        _lc_round_usage_groq
+                        if _lc_accumulated_usage_groq is None
+                        else _lc_accumulated_usage_groq + _lc_round_usage_groq
+                    )
 
         # Handle structured output after tools if needed
         final_output = None
@@ -599,6 +651,15 @@ class GroqClient(AbstractClient):
             turn_id=turn_id,
             structured_output=structured_payload
         )
+
+        # FEAT-397: replace the last-round-only usage with the accumulated
+        # multi-round total. For single-round calls (no tool use), the
+        # accumulated total equals the last (only) round's usage, so this
+        # is a no-op for existing single-round behavior.
+        if _lc_accumulated_usage_groq is not None:
+            if _lc_round_number_groq > 1:
+                _lc_accumulated_usage_groq.extra_usage["rounds"] = _lc_round_number_groq
+            ai_message.usage = _lc_accumulated_usage_groq
 
         # Add tool calls to the response
         ai_message.tool_calls = all_tool_calls

--- a/packages/ai-parrot/src/parrot/core/events/lifecycle/events/__init__.py
+++ b/packages/ai-parrot/src/parrot/core/events/lifecycle/events/__init__.py
@@ -28,6 +28,8 @@ from parrot.core.events.lifecycle.events.client import (
     # FEAT-181: Prompt Caching Lifecycle Events
     PromptCacheAppliedEvent,
     PromptCacheSkippedEvent,
+    # FEAT-397: Per-Round Token Usage Observability
+    ClientRoundEvent,
 )
 from parrot.core.events.lifecycle.events.tool import (
     BeforeToolCallEvent,
@@ -62,6 +64,8 @@ __all__ = [
     # FEAT-181: Prompt caching domain
     "PromptCacheAppliedEvent",
     "PromptCacheSkippedEvent",
+    # FEAT-397: Per-round token usage observability
+    "ClientRoundEvent",
     # Tool domain
     "BeforeToolCallEvent",
     "AfterToolCallEvent",

--- a/packages/ai-parrot/src/parrot/core/events/lifecycle/events/client.py
+++ b/packages/ai-parrot/src/parrot/core/events/lifecycle/events/client.py
@@ -169,3 +169,49 @@ class PromptCacheSkippedEvent(LifecycleEvent):
     reason: Literal[
         "below_threshold", "provider_unsupported", "feature_off", "no_segments", ""
     ] = ""
+
+
+# ── FEAT-397: Per-Round Token Usage Observability ─────────────────────────
+
+@dataclass(frozen=True)
+class ClientRoundEvent(LifecycleEvent):
+    """Emitted after each tool-execution round inside a client's ask() loop.
+
+    FEAT-397 — Per-Round Token Usage Observability.
+
+    NOT emitted for single-round calls (no tool use). Token fields are
+    ``None`` when the provider did not report usage for the round (e.g.
+    some streaming paths) — the round's accumulator skips ``None`` usage
+    rather than corrupting the running total.
+
+    Attributes:
+        client_name: Provider identifier (``"anthropic"``, ``"openai"``, etc.).
+        model: Model name/identifier being called.
+        round_number: 1-indexed round number within this ``ask()`` call.
+        input_tokens: This round's input token count, or ``None`` if the
+            provider reported no usage for the round.
+        output_tokens: This round's output token count, or ``None``.
+        total_tokens: This round's total token count, or ``None``.
+        tool_calls: Tool-name strings invoked during this round.
+            Uses ``tuple`` for immutability; ``to_dict()`` converts to list.
+        duration_ms: Wall-clock time in milliseconds for this round's SDK call.
+        raw_usage: Provider-native usage payload for this round, JSON-safe
+            (plain dict — never a nested Pydantic model, never PII/prompt
+            content).
+        agent_name: ``AbstractBot.name`` of the invoking agent, or ``None``
+            when called outside a bot invocation scope.  Set by the client
+            from the ``current_agent_name`` ContextVar (FEAT-228).
+            NEVER contains PII (user_id, session_id, prompt content).
+    """
+
+    client_name: str = ""
+    model: str = ""
+    round_number: int = 0
+    input_tokens: Optional[int] = None
+    output_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
+    # tuple is immutable and JSON-serializable (to_dict converts to list)
+    tool_calls: tuple = ()
+    duration_ms: float = 0.0
+    raw_usage: Optional[dict] = None
+    agent_name: Optional[str] = None   # FEAT-228: invoking agent's self.name

--- a/packages/ai-parrot/src/parrot/models/basic.py
+++ b/packages/ai-parrot/src/parrot/models/basic.py
@@ -59,6 +59,12 @@ class CompletionUsage(BaseModel):
       ``usage.prompt_tokens``).
     - **Serialization** (``model_dump`` / ``model_dump_json``) includes both
       vocabularies via computed fields.
+
+    Multi-round accumulation: clients that loop over multiple LLM calls in
+    a single ``ask()`` invocation (tool-use rounds) accumulate per-round
+    usage via :meth:`__add__` and store the resulting round count under
+    ``extra_usage["rounds"]`` (set by the caller, not by ``__add__``
+    itself — see FEAT-397).
     """
 
     # populate_by_name keeps the Python attribute names usable as kwargs even
@@ -262,4 +268,45 @@ class CompletionUsage(BaseModel):
             completion_tokens=completion_tokens,
             total_tokens=total_tokens,
             extra_usage=extra,
+        )
+
+    def __add__(self, other: Any) -> "CompletionUsage":
+        """Field-wise sum for multi-round tool-use accumulation.
+
+        Args:
+            other: Another :class:`CompletionUsage` instance to add.
+
+        Returns:
+            A NEW :class:`CompletionUsage` instance; neither operand is
+            mutated.
+
+        Semantics:
+            - ``prompt_tokens`` / ``completion_tokens`` / ``total_tokens``:
+              plain integer sum.
+            - Timing fields (``completion_time``, ``prompt_time``,
+              ``queue_time``, ``total_time``): summed when either side is
+              set (they represent cumulative time spent across rounds);
+              ``None + None`` stays ``None``; ``None + x`` returns ``x``.
+            - ``estimated_cost``: same None-aware sum as the timing fields.
+            - ``extra_usage``: shallow merge; the right-hand operand wins
+              on key conflicts.
+        """
+        if not isinstance(other, CompletionUsage):
+            return NotImplemented
+
+        def _add_optional(a: Optional[float], b: Optional[float]) -> Optional[float]:
+            if a is None and b is None:
+                return None
+            return (a or 0) + (b or 0)
+
+        return CompletionUsage(
+            prompt_tokens=self.prompt_tokens + other.prompt_tokens,
+            completion_tokens=self.completion_tokens + other.completion_tokens,
+            total_tokens=self.total_tokens + other.total_tokens,
+            completion_time=_add_optional(self.completion_time, other.completion_time),
+            prompt_time=_add_optional(self.prompt_time, other.prompt_time),
+            queue_time=_add_optional(self.queue_time, other.queue_time),
+            total_time=_add_optional(self.total_time, other.total_time),
+            estimated_cost=_add_optional(self.estimated_cost, other.estimated_cost),
+            extra_usage={**self.extra_usage, **other.extra_usage},
         )

--- a/packages/ai-parrot/src/parrot/models/responses.py
+++ b/packages/ai-parrot/src/parrot/models/responses.py
@@ -278,6 +278,20 @@ class AIMessage(BaseModel):
         """Check if tools were used."""
         return len(self.tool_calls) > 0
 
+    def total_usage(self) -> CompletionUsage:
+        """Total token usage across all rounds of the generating call.
+
+        For multi-round tool-use calls, ``self.usage`` already holds the
+        accumulated total across every round (clients accumulate via
+        :meth:`CompletionUsage.__add__` before setting it here). This
+        method exists as a stable, documented entry point in case
+        per-round usage history is exposed in a future iteration.
+
+        Returns:
+            The accumulated :class:`CompletionUsage` for this message.
+        """
+        return self.usage
+
     def add_tool_call(self, tool_call: ToolCall) -> None:
         """Add a tool call to the response."""
         self.tool_calls.append(tool_call)  # pylint: disable=E1101 # noqa

--- a/packages/ai-parrot/src/parrot/observability/subscribers/metrics.py
+++ b/packages/ai-parrot/src/parrot/observability/subscribers/metrics.py
@@ -24,6 +24,7 @@ from parrot.core.events.lifecycle.events import (
     AfterToolCallEvent,
     BeforeClientCallEvent,
     ClientCallFailedEvent,
+    ClientRoundEvent,
     InvokeFailedEvent,
     ToolCallFailedEvent,
 )
@@ -113,6 +114,11 @@ class MetricsSubscriber:
             "parrot.agent.invoke.failure.count",
             description="Number of agent invoke failures.",
         )
+        # FEAT-397: per-round token usage observability
+        self._client_rounds = meter.create_counter(
+            "parrot.client.rounds",
+            description="Number of tool-execution rounds inside a client's ask() loop.",
+        )
 
         # ------------------------------------------------------------------
         # Histograms
@@ -128,6 +134,20 @@ class MetricsSubscriber:
             "gen_ai.client.token.usage",
             unit="tokens",
             description="Token usage per LLM API call (recorded twice: input + output).",
+        )
+        # FEAT-397: per-round token usage, DEDICATED histogram — never fed
+        # from _on_client_after, and never feeds gen_ai.client.token.usage.
+        # Reuses the token-space bucket boundaries (_TOKEN_BUCKETS) via the
+        # same OTel View wiring as gen_ai.client.token.usage in setup_telemetry().
+        self._client_round_token_usage = meter.create_histogram(
+            "parrot.client.round.token.usage",
+            unit="tokens",
+            description=(
+                "Per-round token usage inside a multi-round tool-use loop "
+                "(recorded twice: input + output). Dedicated instrument — "
+                "NEVER recorded onto gen_ai.client.token.usage to avoid "
+                "double-counting against AfterClientCallEvent totals."
+            ),
         )
         self._tool_exec_duration = meter.create_histogram(
             "parrot.tool.execution.duration",
@@ -161,6 +181,7 @@ class MetricsSubscriber:
         registry.subscribe(BeforeClientCallEvent, self._on_client_before)
         registry.subscribe(AfterClientCallEvent, self._on_client_after)
         registry.subscribe(ClientCallFailedEvent, self._on_client_fail)
+        registry.subscribe(ClientRoundEvent, self._on_client_round)
         registry.subscribe(AfterToolCallEvent, self._on_tool_after)
         registry.subscribe(ToolCallFailedEvent, self._on_tool_fail)
         registry.subscribe(AfterInvokeEvent, self._on_invoke_after)
@@ -228,6 +249,48 @@ class MetricsSubscriber:
             )
             if cost is not None:
                 self._client_cost_total.add(cost, attributes=base)
+
+    async def _on_client_round(self, event: ClientRoundEvent) -> None:
+        """Record per-round token usage and round count.
+
+        FEAT-397 — dedicated per-round instruments. NEVER records onto
+        ``gen_ai.client.token.usage`` (that histogram only receives the
+        accumulated totals from ``AfterClientCallEvent``, via
+        ``_on_client_after``) — recording per-round tokens there too would
+        double-count every token (rounds + total).
+
+        Note on cardinality: ``parrot.round.number`` adds a dimension per
+        round. Tool loops are bounded (``max_turns`` typically 10-15), so
+        the resulting series cardinality stays bounded — operators wiring
+        dashboards should be aware this label multiplies series count by
+        the round depth.
+        """
+        system = resolve_gen_ai_system(event.client_name)
+        # FEAT-228: metrics must always carry a string value for parrot.agent.name
+        # (OTel label sets must be stable per series); spans omit the attribute when
+        # agent_name is None instead — see attributes.py for the span-side handling.
+        base = {
+            "gen_ai.system": system,
+            "gen_ai.provider.name": system,  # new SemConv key — current OpenLIT reads this
+            "gen_ai.request.model": event.model,
+            "parrot.agent.name": event.agent_name or "unknown",  # FEAT-228
+            "parrot.round.number": event.round_number,
+        }
+
+        self._client_rounds.add(1, attributes=base)
+
+        # Round-token histogram — recorded TWICE (input + output), only when
+        # the provider reported usage for this round.
+        if event.input_tokens is not None:
+            self._client_round_token_usage.record(
+                event.input_tokens,
+                attributes={**base, "gen_ai.token.type": "input"},
+            )
+        if event.output_tokens is not None:
+            self._client_round_token_usage.record(
+                event.output_tokens,
+                attributes={**base, "gen_ai.token.type": "output"},
+            )
 
     async def _on_client_fail(self, event: ClientCallFailedEvent) -> None:
         """Count LLM API errors by error type."""

--- a/packages/ai-parrot/tests/integration/observability/test_multiround_usage.py
+++ b/packages/ai-parrot/tests/integration/observability/test_multiround_usage.py
@@ -1,0 +1,205 @@
+"""End-to-end multi-round token usage observability tests (FEAT-397).
+
+Drives a real client (AnthropicClient, mocked SDK) through the REAL event
+registry and an in-memory OTel metric reader, validating the whole
+pipeline: client loop accumulation -> ClientRoundEvent/AfterClientCallEvent
+-> MetricsSubscriber -> OTel metrics. Also covers the FEAT-228 per-agent
+attribution regression guard on round-level metrics.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.resources import Resource
+
+from navigator_eventbus.lifecycle.global_registry import scope
+
+from parrot.clients.claude import AnthropicClient
+from parrot.core.events.lifecycle.events import (
+    AfterClientCallEvent,
+    ClientRoundEvent,
+)
+from parrot.observability.context import agent_identity
+from parrot.observability.subscribers.metrics import MetricsSubscriber
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers (mirrors tests/integration/observability/test_poc.py)
+# ---------------------------------------------------------------------------
+
+def _make_meter_provider(reader: InMemoryMetricReader) -> MeterProvider:
+    """Build a MeterProvider that exposes metrics via *reader*."""
+    resource = Resource.create({"service.name": "parrot-feat397"})
+    return MeterProvider(resource=resource, metric_readers=[reader])
+
+
+def _collect_metric_points(reader: InMemoryMetricReader, metric_name: str):
+    """Collect all data points from the named metric."""
+    points = []
+    for rm in reader.get_metrics_data().resource_metrics:
+        for sm in rm.scope_metrics:
+            for m in sm.metrics:
+                if m.name == metric_name:
+                    points.extend(m.data.data_points)
+    return points
+
+
+def _mock_response(stop_reason: str, content: list, usage: dict):
+    resp = MagicMock()
+    resp.model_dump.return_value = {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "content": content,
+        "model": "claude-sonnet-4-5",
+        "stop_reason": stop_reason,
+        "usage": usage,
+    }
+    return resp
+
+
+def _make_three_round_responses():
+    """(100/10), (150/20) with tool_use, (200/30) final — totals (450, 60)."""
+    return [
+        _mock_response(
+            "tool_use",
+            [{"type": "tool_use", "id": "tu_1", "name": "get_weather", "input": {}}],
+            {"input_tokens": 100, "output_tokens": 10},
+        ),
+        _mock_response(
+            "tool_use",
+            [{"type": "tool_use", "id": "tu_2", "name": "search", "input": {}}],
+            {"input_tokens": 150, "output_tokens": 20},
+        ),
+        _mock_response(
+            "end_turn",
+            [{"type": "text", "text": "Final answer"}],
+            {"input_tokens": 200, "output_tokens": 30},
+        ),
+    ]
+
+
+def _make_claude_client(sdk_responses):
+    client = AnthropicClient(api_key="fake_key")
+    client.logger = MagicMock()
+    client._execute_tool = AsyncMock(return_value="tool result")
+
+    mock_sdk_client = MagicMock()
+    mock_sdk_client.messages.create = AsyncMock(side_effect=sdk_responses)
+
+    client._backend = MagicMock()
+    client._backend.build_client = AsyncMock(return_value=mock_sdk_client)
+    client._backend.translate_model = lambda m: m
+    return client
+
+
+class TestMultiRoundEndToEnd:
+    @pytest.mark.asyncio
+    async def test_multiround_end_to_end(self) -> None:
+        """Full pipeline: client loop -> events -> metrics, through the
+        REAL event registry + in-memory metric reader."""
+        reader = InMemoryMetricReader()
+        mp = _make_meter_provider(reader)
+        client = _make_claude_client(_make_three_round_responses())
+
+        round_events: list = []
+        after_events: list = []
+
+        async def _capture_round(event):
+            round_events.append(event)
+
+        async def _capture_after(event):
+            after_events.append(event)
+
+        with scope() as registry:
+            metrics_sub = MetricsSubscriber(meter_provider=mp, service_name="parrot-feat397")
+            metrics_sub.register(registry)
+            # Subscribing only on the GLOBAL registry mirrors real production
+            # usage (MetricsSubscriber.register(global_registry) at app
+            # bootstrap) — the client's own registry is isolated
+            # (forward_to_global=False) and normally has zero direct
+            # subscribers. _emit_round_event()'s short-circuit checks both
+            # the local AND the global registry (TASK-2040 fix — see
+            # Completion Note), so this is enough to prove the round events
+            # actually reach a global-only observer, not just a test that
+            # artificially subscribes on the client instance.
+            registry.subscribe(ClientRoundEvent, _capture_round)
+            registry.subscribe(AfterClientCallEvent, _capture_after)
+
+            msg = await client.ask("What's the weather and latest news?")
+            # emit_nowait schedules fire-and-forget tasks — drain them while
+            # this scope's registry is still the active global one (per
+            # scope()'s docstring warning).
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+        # --- Client-side assertions ---
+        assert msg.usage.prompt_tokens == 450
+        assert msg.usage.completion_tokens == 60
+        assert msg.usage.extra_usage["rounds"] == 3
+
+        assert len(round_events) == 2  # one per tool round, not the final round
+        assert [e.round_number for e in round_events] == [1, 2]
+        assert round_events[0].tool_calls == ("get_weather",)
+        assert round_events[1].tool_calls == ("search",)
+
+        assert len(after_events) == 1
+        assert after_events[0].input_tokens == 450
+        assert after_events[0].output_tokens == 60
+
+        # --- Metrics assertions ---
+        # Per-round histogram: 2 rounds x (input + output) = 4 data points,
+        # dimensioned by parrot.round.number.
+        round_token_pts = _collect_metric_points(reader, "parrot.client.round.token.usage")
+        assert len(round_token_pts) == 4
+        by_round_and_type = {
+            (pt.attributes.get("parrot.round.number"), pt.attributes.get("gen_ai.token.type")): pt.sum
+            for pt in round_token_pts
+        }
+        assert by_round_and_type == {
+            (1, "input"): 100.0,
+            (1, "output"): 10.0,
+            (2, "input"): 150.0,
+            (2, "output"): 20.0,
+        }
+
+        # parrot.client.rounds — one increment per ClientRoundEvent (2 events).
+        rounds_pts = _collect_metric_points(reader, "parrot.client.rounds")
+        assert sum(pt.value for pt in rounds_pts) == 2
+
+        # gen_ai.client.token.usage — recorded ONLY from AfterClientCallEvent,
+        # reflecting the ACCUMULATED totals (450/60), never the per-round
+        # values (100/150/200, 10/20/30) and never double-counted.
+        total_token_pts = _collect_metric_points(reader, "gen_ai.client.token.usage")
+        assert len(total_token_pts) == 2  # exactly input + output, once each
+        by_type = {pt.attributes.get("gen_ai.token.type"): pt.sum for pt in total_token_pts}
+        assert by_type == {"input": 450.0, "output": 60.0}
+
+    @pytest.mark.asyncio
+    async def test_per_agent_round_attribution(self) -> None:
+        """FEAT-228 regression guard: round metrics carry parrot.agent.name."""
+        reader = InMemoryMetricReader()
+        mp = _make_meter_provider(reader)
+        client = _make_claude_client(_make_three_round_responses())
+
+        with scope() as registry:
+            metrics_sub = MetricsSubscriber(meter_provider=mp, service_name="parrot-feat397")
+            metrics_sub.register(registry)
+
+            with agent_identity("bot-a"):
+                await client.ask("What's the weather and latest news?")
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+        round_token_pts = _collect_metric_points(reader, "parrot.client.round.token.usage")
+        assert round_token_pts, "No per-round token usage recorded"
+        assert all(pt.attributes.get("parrot.agent.name") == "bot-a" for pt in round_token_pts)
+
+        rounds_pts = _collect_metric_points(reader, "parrot.client.rounds")
+        assert rounds_pts, "No parrot.client.rounds recorded"
+        assert all(pt.attributes.get("parrot.agent.name") == "bot-a" for pt in rounds_pts)

--- a/packages/ai-parrot/tests/unit/clients/test_claude_multiround_usage.py
+++ b/packages/ai-parrot/tests/unit/clients/test_claude_multiround_usage.py
@@ -1,0 +1,176 @@
+"""Unit tests for Claude client per-round usage accumulation (FEAT-397).
+
+Mocks the Anthropic SDK's messages.create() to drive a multi-round
+tool-use loop and asserts that AIMessage.usage carries the accumulated
+total (not just the last round's usage), that ClientRoundEvent fires once
+per tool round, and that AfterClientCallEvent carries the accumulated
+totals too.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from parrot.clients.claude import AnthropicClient
+from parrot.core.events.lifecycle.events import (
+    AfterClientCallEvent,
+    ClientRoundEvent,
+)
+
+
+def _mock_response(stop_reason: str, content: list, usage: dict):
+    resp = MagicMock()
+    resp.model_dump.return_value = {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "content": content,
+        "model": "claude-sonnet-4-5",
+        "stop_reason": stop_reason,
+        "usage": usage,
+    }
+    return resp
+
+
+def _capture(client, event_cls):
+    captured: list = []
+
+    async def cb(event):
+        captured.append(event)
+
+    client.events.subscribe(event_cls, cb)
+    return captured
+
+
+def _make_client(sdk_responses):
+    client = AnthropicClient(api_key="fake_key")
+    client.logger = MagicMock()
+    client._execute_tool = AsyncMock(return_value="tool result")
+
+    mock_sdk_client = MagicMock()
+    mock_sdk_client.messages.create = AsyncMock(side_effect=sdk_responses)
+
+    client._backend = MagicMock()
+    client._backend.build_client = AsyncMock(return_value=mock_sdk_client)
+    client._backend.translate_model = lambda m: m
+    return client
+
+
+class TestClaudeMultiroundUsage:
+    @pytest.mark.asyncio
+    async def test_multiround_accumulates_usage(self) -> None:
+        """3-round loop (2 tool rounds + final) → AIMessage.usage = sum of 3 rounds."""
+        responses = [
+            _mock_response(
+                "tool_use",
+                [{"type": "tool_use", "id": "tu_1", "name": "get_weather", "input": {}}],
+                {"input_tokens": 100, "output_tokens": 10},
+            ),
+            _mock_response(
+                "tool_use",
+                [{"type": "tool_use", "id": "tu_2", "name": "search", "input": {}}],
+                {"input_tokens": 150, "output_tokens": 20},
+            ),
+            _mock_response(
+                "end_turn",
+                [{"type": "text", "text": "Final answer"}],
+                {"input_tokens": 200, "output_tokens": 30},
+            ),
+        ]
+        client = _make_client(responses)
+        round_events = _capture(client, ClientRoundEvent)
+        after_events = _capture(client, AfterClientCallEvent)
+
+        msg = await client.ask("What's the weather and latest news?")
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert msg.usage.prompt_tokens == 450
+        assert msg.usage.completion_tokens == 60
+        assert msg.usage.extra_usage["rounds"] == 3
+
+        assert len(round_events) == 2  # one per tool round, not the final round
+        assert [e.round_number for e in round_events] == [1, 2]
+        assert round_events[0].tool_calls == ("get_weather",)
+        assert round_events[1].tool_calls == ("search",)
+        assert round_events[0].input_tokens == 100
+        assert round_events[1].input_tokens == 150
+
+        assert len(after_events) == 1
+        assert after_events[0].input_tokens == 450
+        assert after_events[0].output_tokens == 60
+
+    @pytest.mark.asyncio
+    async def test_singleround_no_event(self) -> None:
+        """No tool use → no ClientRoundEvent; usage identical to pre-feature behavior."""
+        responses = [
+            _mock_response(
+                "end_turn",
+                [{"type": "text", "text": "Hi there"}],
+                {"input_tokens": 10, "output_tokens": 5},
+            ),
+        ]
+        client = _make_client(responses)
+        round_events = _capture(client, ClientRoundEvent)
+
+        msg = await client.ask("Hi")
+        await asyncio.sleep(0)
+
+        assert len(round_events) == 0
+        assert msg.usage.prompt_tokens == 10
+        assert msg.usage.completion_tokens == 5
+        assert "rounds" not in msg.usage.extra_usage
+
+    @pytest.mark.asyncio
+    async def test_after_call_totals(self) -> None:
+        """AfterClientCallEvent totals equal the accumulated sums."""
+        responses = [
+            _mock_response(
+                "tool_use",
+                [{"type": "tool_use", "id": "tu_1", "name": "get_weather", "input": {}}],
+                {"input_tokens": 100, "output_tokens": 10},
+            ),
+            _mock_response(
+                "end_turn",
+                [{"type": "text", "text": "Done"}],
+                {"input_tokens": 50, "output_tokens": 15},
+            ),
+        ]
+        client = _make_client(responses)
+        after_events = _capture(client, AfterClientCallEvent)
+
+        await client.ask("weather?")
+        await asyncio.sleep(0)
+
+        assert after_events[0].input_tokens == 150
+        assert after_events[0].output_tokens == 25
+
+    @pytest.mark.asyncio
+    async def test_round_missing_usage_fires_none(self) -> None:
+        """A round with no usage reported: event fires with None tokens; total unaffected."""
+        responses = [
+            _mock_response(
+                "tool_use",
+                [{"type": "tool_use", "id": "tu_1", "name": "get_weather", "input": {}}],
+                {},  # no usage reported this round
+            ),
+            _mock_response(
+                "end_turn",
+                [{"type": "text", "text": "Done"}],
+                {"input_tokens": 50, "output_tokens": 15},
+            ),
+        ]
+        client = _make_client(responses)
+        round_events = _capture(client, ClientRoundEvent)
+
+        msg = await client.ask("weather?")
+        await asyncio.sleep(0)
+
+        assert len(round_events) == 1
+        assert round_events[0].input_tokens is None
+        assert round_events[0].output_tokens is None
+        # Total only reflects the round that did report usage.
+        assert msg.usage.prompt_tokens == 50
+        assert msg.usage.completion_tokens == 15

--- a/packages/ai-parrot/tests/unit/clients/test_emit_round_event.py
+++ b/packages/ai-parrot/tests/unit/clients/test_emit_round_event.py
@@ -1,0 +1,173 @@
+"""Unit tests for AbstractClient._emit_round_event() (FEAT-397).
+
+Uses the same minimal fake-concrete-client pattern as
+test_client_lifecycle.py — a stub AbstractClient subclass with no-op
+ask/ask_stream bodies, so no real LLM credentials are required.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from parrot.core.events.lifecycle.events import ClientRoundEvent
+from parrot.models.basic import CompletionUsage
+from navigator_eventbus.lifecycle.trace import TraceContext
+from parrot.observability.context import current_agent_name
+
+
+def _make_stub_client():
+    """Return a minimal AbstractClient subclass instance that skips all I/O."""
+    from parrot.clients.base import AbstractClient
+
+    class _StubClient(AbstractClient):
+        """Stub that implements the abstract ask/ask_stream with no-op bodies."""
+
+        client_name = "stub"
+
+        def __init__(self):
+            super().__init__(debug=False)
+
+        async def ask(self, prompt: str, model: str = "stub-model", **kw):  # type: ignore[override]
+            raise NotImplementedError("stub")
+
+        async def ask_stream(self, prompt: str, **kw):  # type: ignore[override]
+            raise NotImplementedError("stub")
+            yield  # makes it an async generator
+
+        async def get_client(self):
+            return None
+
+        async def _ensure_client(self):
+            pass
+
+        async def invoke(self, *args, **kwargs):  # type: ignore[override]
+            raise NotImplementedError("stub")
+
+        async def resume(self, *args, **kwargs):  # type: ignore[override]
+            raise NotImplementedError("stub")
+
+    return _StubClient()
+
+
+def _capture():
+    """Return (captured_list, async_callback)."""
+    captured: list = []
+
+    async def cb(event):
+        captured.append(event)
+
+    return captured, cb
+
+
+class TestEmitRoundEvent:
+    """Verify AbstractClient._emit_round_event() short-circuit + payload mapping."""
+
+    def test_short_circuit_no_subscribers(self) -> None:
+        """Zero subscribers → the event is never constructed (emit_nowait never called)."""
+        client = _make_stub_client()
+        assert client.events.has_subscribers(ClientRoundEvent) is False
+
+        tc = TraceContext.new_root()
+        # Should be a pure no-op: no exception, no event delivered anywhere.
+        client._emit_round_event(
+            tc,
+            client_name="stub",
+            model="stub-model",
+            round_number=1,
+            usage=CompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+            raw_usage={"prompt_tokens": 10},
+            tool_calls=["get_weather"],
+            duration_ms=12.0,
+        )
+        # No subscribers means nothing was captured anywhere — nothing to assert
+        # on directly except that has_subscribers is still False and no error raised.
+        assert client.events.has_subscribers(ClientRoundEvent) is False
+
+    @pytest.mark.asyncio
+    async def test_event_payload_mapping(self) -> None:
+        """usage tokens map onto flat input/output/total; tool_calls coerced to tuple."""
+        client = _make_stub_client()
+        captured, cb = _capture()
+        client.events.subscribe(ClientRoundEvent, cb)
+
+        tc = TraceContext.new_root()
+        usage = CompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+        client._emit_round_event(
+            tc,
+            client_name="stub",
+            model="stub-model",
+            round_number=2,
+            usage=usage,
+            raw_usage={"prompt_tokens": 10, "completion_tokens": 5},
+            tool_calls=["get_weather", "search"],
+            duration_ms=42.0,
+        )
+        await asyncio.sleep(0)  # drain emit_nowait
+
+        assert len(captured) == 1
+        event = captured[0]
+        assert isinstance(event, ClientRoundEvent)
+        assert event.round_number == 2
+        assert event.input_tokens == 10
+        assert event.output_tokens == 5
+        assert event.total_tokens == 15
+        assert event.tool_calls == ("get_weather", "search")
+        assert event.raw_usage == {"prompt_tokens": 10, "completion_tokens": 5}
+        assert event.duration_ms == 42.0
+        assert event.trace_context is tc
+
+    @pytest.mark.asyncio
+    async def test_usage_none_maps_to_none_tokens(self) -> None:
+        """usage=None → input/output/total tokens are all None (accumulator skips round)."""
+        client = _make_stub_client()
+        captured, cb = _capture()
+        client.events.subscribe(ClientRoundEvent, cb)
+
+        tc = TraceContext.new_root()
+        client._emit_round_event(
+            tc,
+            client_name="stub",
+            model="stub-model",
+            round_number=1,
+            usage=None,
+            raw_usage=None,
+            tool_calls=(),
+            duration_ms=5.0,
+        )
+        await asyncio.sleep(0)
+
+        assert len(captured) == 1
+        event = captured[0]
+        assert event.input_tokens is None
+        assert event.output_tokens is None
+        assert event.total_tokens is None
+        assert event.tool_calls == ()
+        assert event.raw_usage is None
+
+    @pytest.mark.asyncio
+    async def test_agent_name_from_contextvar(self) -> None:
+        """agent_name is populated from the FEAT-228 ContextVar at construction time."""
+        client = _make_stub_client()
+        captured, cb = _capture()
+        client.events.subscribe(ClientRoundEvent, cb)
+
+        token = current_agent_name.set("bot-a")
+        try:
+            tc = TraceContext.new_root()
+            client._emit_round_event(
+                tc,
+                client_name="stub",
+                model="stub-model",
+                round_number=1,
+                usage=None,
+                raw_usage=None,
+                tool_calls=(),
+                duration_ms=1.0,
+            )
+            await asyncio.sleep(0)
+        finally:
+            current_agent_name.reset(token)
+
+        assert len(captured) == 1
+        assert captured[0].agent_name == "bot-a"

--- a/packages/ai-parrot/tests/unit/clients/test_gemini_multiround_usage.py
+++ b/packages/ai-parrot/tests/unit/clients/test_gemini_multiround_usage.py
@@ -1,0 +1,178 @@
+"""Unit tests for Gemini client per-round usage accumulation + the
+first-response usage bug fix (FEAT-397).
+
+Drives `_handle_multiturn_function_calls()` via a mocked `chat.send_message`
+and asserts that AIMessage.usage carries the accumulated total across the
+initial call AND every loop round (not just the initial response's usage —
+the pre-existing bug), that ClientRoundEvent fires once per tool round, and
+that AfterClientCallEvent carries the accumulated totals too.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from parrot.clients.google import GoogleGenAIClient
+from parrot.core.events.lifecycle.events import (
+    AfterClientCallEvent,
+    ClientRoundEvent,
+)
+
+
+def _mock_usage_metadata(prompt: int, candidates: int, total: int):
+    um = MagicMock()
+    um.prompt_token_count = prompt
+    um.candidates_token_count = candidates
+    um.total_token_count = total
+    return um
+
+
+def _mock_function_call(name: str, args=None):
+    fc = MagicMock()
+    fc.name = name
+    fc.args = args or {}
+    fc.id = f"call_{name}"
+    return fc
+
+
+def _mock_part(function_call=None, text=None):
+    part = MagicMock()
+    part.function_call = function_call
+    part.text = text
+    part.executable_code = None
+    part.code_execution_result = None
+    part.thought = False
+    return part
+
+
+def _mock_response(*, function_call_name=None, text=None, usage=None):
+    """Build a mock Gemini response.
+
+    Args:
+        function_call_name: If set, the response requests this tool.
+        text: Final text answer (used when function_call_name is None).
+        usage: (prompt_token_count, candidates_token_count, total_token_count)
+            tuple, or None to simulate a round with no usage_metadata.
+    """
+    candidate = MagicMock()
+    candidate.finish_reason = None
+    if function_call_name:
+        candidate.content.parts = [_mock_part(function_call=_mock_function_call(function_call_name))]
+    else:
+        candidate.content.parts = [_mock_part(text=text)]
+    resp = MagicMock()
+    resp.candidates = [candidate]
+    resp.usage_metadata = _mock_usage_metadata(*usage) if usage else None
+    return resp
+
+
+def _capture(client, event_cls):
+    captured: list = []
+
+    async def cb(event):
+        captured.append(event)
+
+    client.events.subscribe(event_cls, cb)
+    return captured
+
+
+async def _make_client(sdk_responses):
+    client = GoogleGenAIClient(api_key="fake_key")
+    client.logger = MagicMock()
+    client._execute_tool = AsyncMock(return_value="tool result")
+
+    mock_client_instance = MagicMock()
+    mock_chat = MagicMock()
+    mock_chat.send_message = AsyncMock(side_effect=sdk_responses)
+    mock_client_instance.aio.chats.create = MagicMock(return_value=mock_chat)
+    client.get_client = AsyncMock(return_value=mock_client_instance)
+    return client
+
+
+class TestGeminiMultiroundUsage:
+    @pytest.mark.asyncio
+    async def test_multiround_accumulates_usage(self) -> None:
+        """3-round loop (initial + 2 multiturn rounds) → AIMessage.usage = sum of 3 rounds."""
+        responses = [
+            _mock_response(function_call_name="get_weather", usage=(100, 10, 110)),
+            _mock_response(function_call_name="search", usage=(150, 20, 170)),
+            _mock_response(text="Final answer", usage=(200, 30, 230)),
+        ]
+        client = await _make_client(responses)
+        round_events = _capture(client, ClientRoundEvent)
+        after_events = _capture(client, AfterClientCallEvent)
+
+        msg = await client.ask("What's the weather and latest news?")
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert msg.usage.prompt_tokens == 450
+        assert msg.usage.completion_tokens == 60
+        assert msg.usage.extra_usage["rounds"] == 3
+        # Regression guard: NOT just the initial response's usage (the bug).
+        assert msg.usage.prompt_tokens != 100
+
+        assert len(round_events) == 2  # one per tool round, not the final round
+        assert [e.round_number for e in round_events] == [1, 2]
+        assert round_events[0].tool_calls == ("get_weather",)
+        assert round_events[1].tool_calls == ("search",)
+        assert round_events[0].input_tokens == 100
+        assert round_events[1].input_tokens == 150
+
+        assert len(after_events) == 1
+        assert after_events[0].input_tokens == 450
+        assert after_events[0].output_tokens == 60
+
+    @pytest.mark.asyncio
+    async def test_singleround_no_event(self) -> None:
+        """No function calls → no ClientRoundEvent; usage identical to pre-feature behavior."""
+        responses = [
+            _mock_response(text="Hi there", usage=(10, 5, 15)),
+        ]
+        client = await _make_client(responses)
+        round_events = _capture(client, ClientRoundEvent)
+
+        msg = await client.ask("Hi")
+        await asyncio.sleep(0)
+
+        assert len(round_events) == 0
+        assert msg.usage.prompt_tokens == 10
+        assert msg.usage.completion_tokens == 5
+        assert "rounds" not in msg.usage.extra_usage
+
+    @pytest.mark.asyncio
+    async def test_after_call_totals(self) -> None:
+        """AfterClientCallEvent totals equal the accumulated sums."""
+        responses = [
+            _mock_response(function_call_name="get_weather", usage=(100, 10, 110)),
+            _mock_response(text="Done", usage=(50, 15, 65)),
+        ]
+        client = await _make_client(responses)
+        after_events = _capture(client, AfterClientCallEvent)
+
+        await client.ask("weather?")
+        await asyncio.sleep(0)
+
+        assert after_events[0].input_tokens == 150
+        assert after_events[0].output_tokens == 25
+
+    @pytest.mark.asyncio
+    async def test_round_missing_usage_fires_none(self) -> None:
+        """A round with no usage_metadata: event fires with None tokens; total unaffected."""
+        responses = [
+            _mock_response(function_call_name="get_weather", usage=None),
+            _mock_response(text="Done", usage=(50, 15, 65)),
+        ]
+        client = await _make_client(responses)
+        round_events = _capture(client, ClientRoundEvent)
+
+        msg = await client.ask("weather?")
+        await asyncio.sleep(0)
+
+        assert len(round_events) == 1
+        assert round_events[0].input_tokens is None
+        assert round_events[0].output_tokens is None
+        assert msg.usage.prompt_tokens == 50
+        assert msg.usage.completion_tokens == 15

--- a/packages/ai-parrot/tests/unit/clients/test_grok_multiround_usage.py
+++ b/packages/ai-parrot/tests/unit/clients/test_grok_multiround_usage.py
@@ -1,0 +1,171 @@
+"""Unit tests for Grok client per-round usage accumulation (FEAT-397).
+
+Drives the tool-calling loop with a mocked xai_sdk chat and asserts that
+AIMessage.usage carries the accumulated total (not just the last round's
+usage), that ClientRoundEvent fires once per tool round with a JSON-safe
+raw_usage dict (built from the protobuf-like usage object via
+CompletionUsage.from_grok's extra_usage, never the raw protobuf), and
+that AfterClientCallEvent carries the accumulated totals too.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from parrot.clients.grok import GrokClient
+from parrot.core.events.lifecycle.events import (
+    AfterClientCallEvent,
+    ClientRoundEvent,
+)
+
+
+def _mock_usage(prompt: int, completion: int, total: int):
+    """Stub usage object exposing attributes like the xai_sdk protobuf does."""
+    usage = MagicMock(spec=[
+        "prompt_tokens", "completion_tokens", "total_tokens",
+        "reasoning_tokens", "cached_prompt_text_tokens", "prompt_image_tokens",
+    ])
+    usage.prompt_tokens = prompt
+    usage.completion_tokens = completion
+    usage.total_tokens = total
+    usage.reasoning_tokens = 0
+    usage.cached_prompt_text_tokens = 0
+    usage.prompt_image_tokens = 0
+    return usage
+
+
+def _mock_tool_call(tool_id: str, name: str, arguments: dict = None):
+    tc = MagicMock()
+    tc.id = tool_id
+    tc.function.name = name
+    tc.function.arguments = json.dumps(arguments or {})
+    return tc
+
+
+def _mock_response(content, tool_calls, usage):
+    resp = MagicMock(spec=["content", "tool_calls", "usage"])
+    resp.content = content
+    resp.tool_calls = tool_calls
+    resp.usage = usage
+    return resp
+
+
+def _capture(client, event_cls):
+    captured: list = []
+
+    async def cb(event):
+        captured.append(event)
+
+    client.events.subscribe(event_cls, cb)
+    return captured
+
+
+async def _make_client(sdk_responses):
+    client = GrokClient(api_key="fake_key")
+    client.logger = MagicMock()
+    client._execute_tool = AsyncMock(return_value="tool result")
+
+    mock_chat = MagicMock()
+    mock_chat.sample = AsyncMock(side_effect=sdk_responses)
+    mock_chat.append = MagicMock()
+
+    mock_client_instance = MagicMock()
+    mock_client_instance.chat.create = MagicMock(return_value=mock_chat)
+    # GrokClient.ask() calls `client = await self.get_client()` directly
+    # (no per-loop cache / _ensure_client() indirection for this client).
+    client.get_client = AsyncMock(return_value=mock_client_instance)
+    return client
+
+
+class TestGrokMultiroundUsage:
+    @pytest.mark.asyncio
+    async def test_multiround_accumulates_usage(self) -> None:
+        """3-round loop (2 tool rounds + final) → AIMessage.usage = sum of 3 rounds."""
+        responses = [
+            _mock_response(None, [_mock_tool_call("tu_1", "get_weather")], _mock_usage(100, 10, 110)),
+            _mock_response(None, [_mock_tool_call("tu_2", "search")], _mock_usage(150, 20, 170)),
+            _mock_response("Final answer", None, _mock_usage(200, 30, 230)),
+        ]
+        client = await _make_client(responses)
+        round_events = _capture(client, ClientRoundEvent)
+        after_events = _capture(client, AfterClientCallEvent)
+
+        msg = await client.ask("What's the weather and latest news?", use_tools=True)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert msg.usage.prompt_tokens == 450
+        assert msg.usage.completion_tokens == 60
+        assert msg.usage.extra_usage["rounds"] == 3
+
+        assert len(round_events) == 2  # one per tool round, not the final round
+        assert [e.round_number for e in round_events] == [1, 2]
+        assert round_events[0].tool_calls == ("get_weather",)
+        assert round_events[1].tool_calls == ("search",)
+        assert round_events[0].input_tokens == 100
+        assert round_events[1].input_tokens == 150
+
+        # raw_usage must be JSON-safe — never the raw protobuf-like object.
+        for event in round_events:
+            assert isinstance(event.raw_usage, dict)
+            json.dumps(event.raw_usage)  # must not raise
+            json.dumps(event.to_dict())  # full event must pass the strict check
+
+        assert len(after_events) == 1
+        assert after_events[0].input_tokens == 450
+        assert after_events[0].output_tokens == 60
+
+    @pytest.mark.asyncio
+    async def test_singleround_no_event(self) -> None:
+        """No tool use → no ClientRoundEvent; usage identical to pre-feature behavior."""
+        responses = [
+            _mock_response("Hi there", None, _mock_usage(10, 5, 15)),
+        ]
+        client = await _make_client(responses)
+        round_events = _capture(client, ClientRoundEvent)
+
+        msg = await client.ask("Hi", use_tools=True)
+        await asyncio.sleep(0)
+
+        assert len(round_events) == 0
+        assert msg.usage.prompt_tokens == 10
+        assert msg.usage.completion_tokens == 5
+        assert "rounds" not in msg.usage.extra_usage
+
+    @pytest.mark.asyncio
+    async def test_after_call_totals(self) -> None:
+        """AfterClientCallEvent totals equal the accumulated sums."""
+        responses = [
+            _mock_response(None, [_mock_tool_call("tu_1", "get_weather")], _mock_usage(100, 10, 110)),
+            _mock_response("Done", None, _mock_usage(50, 15, 65)),
+        ]
+        client = await _make_client(responses)
+        after_events = _capture(client, AfterClientCallEvent)
+
+        await client.ask("weather?", use_tools=True)
+        await asyncio.sleep(0)
+
+        assert after_events[0].input_tokens == 150
+        assert after_events[0].output_tokens == 25
+
+    @pytest.mark.asyncio
+    async def test_round_missing_usage_fires_none(self) -> None:
+        """A round with no usage reported: event fires with None tokens; total unaffected."""
+        responses = [
+            _mock_response(None, [_mock_tool_call("tu_1", "get_weather")], None),
+            _mock_response("Done", None, _mock_usage(50, 15, 65)),
+        ]
+        client = await _make_client(responses)
+        round_events = _capture(client, ClientRoundEvent)
+
+        msg = await client.ask("weather?", use_tools=True)
+        await asyncio.sleep(0)
+
+        assert len(round_events) == 1
+        assert round_events[0].input_tokens is None
+        assert round_events[0].output_tokens is None
+        assert msg.usage.prompt_tokens == 50
+        assert msg.usage.completion_tokens == 15

--- a/packages/ai-parrot/tests/unit/clients/test_groq_multiround_usage.py
+++ b/packages/ai-parrot/tests/unit/clients/test_groq_multiround_usage.py
@@ -1,0 +1,184 @@
+"""Unit tests for Groq client per-round usage accumulation (FEAT-397).
+
+Drives the tool-calling loop with a mocked SDK client and asserts that
+AIMessage.usage carries the accumulated total (not just the last round's
+usage), that ClientRoundEvent fires once per tool round, that
+AfterClientCallEvent carries the accumulated totals too, and that Groq's
+timing fields (completion_time etc.) survive accumulation via
+CompletionUsage.__add__'s None-aware sum.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from parrot.clients.groq import GroqClient
+from parrot.core.events.lifecycle.events import (
+    AfterClientCallEvent,
+    ClientRoundEvent,
+)
+
+
+def _mock_tool_call(tool_id: str, name: str, arguments: dict):
+    tc = MagicMock()
+    tc.id = tool_id
+    tc.function.name = name
+    tc.function.arguments = json.dumps(arguments)
+    return tc
+
+
+def _mock_usage(prompt: int, completion: int, total: int, completion_time: float = None):
+    usage = MagicMock()
+    usage.prompt_tokens = prompt
+    usage.completion_tokens = completion
+    usage.total_tokens = total
+    usage.completion_time = completion_time
+    usage.prompt_time = None
+    usage.queue_time = None
+    usage.total_time = None
+    usage.model_dump.return_value = {
+        "prompt_tokens": prompt, "completion_tokens": completion, "total_tokens": total,
+        "completion_time": completion_time,
+    }
+    return usage
+
+
+def _mock_response(content, tool_calls, usage):
+    choice = MagicMock()
+    choice.message.content = content
+    choice.message.tool_calls = tool_calls
+    choice.finish_reason = "tool_calls" if tool_calls else "stop"
+    resp = MagicMock()
+    resp.choices = [choice]
+    resp.usage = usage
+    resp.model = "llama-3.3-70b-versatile"
+    # AIMessageFactory.from_groq() falls back to response.__dict__ for
+    # raw_response when response.dict() is unavailable — delete the
+    # auto-mocked .dict attribute so hasattr(response, 'dict') is False and
+    # the (real, JSON-safe) MagicMock instance __dict__ is used instead.
+    del resp.dict
+    return resp
+
+
+def _capture(client, event_cls):
+    captured: list = []
+
+    async def cb(event):
+        captured.append(event)
+
+    client.events.subscribe(event_cls, cb)
+    return captured
+
+
+async def _make_client(sdk_responses):
+    client = GroqClient(api_key="fake_key")
+    client.logger = MagicMock()
+    client._execute_tool = AsyncMock(return_value="tool result")
+
+    mock_client_instance = MagicMock()
+    mock_client_instance.chat.completions.create = AsyncMock(side_effect=sdk_responses)
+    # AbstractClient.client is a loop-local property (direct assignment is
+    # rejected) — populate the per-loop cache via get_client()/_ensure_client(),
+    # the supported mechanism, instead of assigning client.client directly.
+    client.get_client = AsyncMock(return_value=mock_client_instance)
+    await client._ensure_client()
+    return client
+
+
+class TestGroqMultiroundUsage:
+    @pytest.mark.asyncio
+    async def test_multiround_accumulates_usage(self) -> None:
+        """3-round loop (2 tool rounds + final) → AIMessage.usage = sum of 3 rounds."""
+        responses = [
+            _mock_response(
+                None, [_mock_tool_call("tu_1", "get_weather", {})],
+                _mock_usage(100, 10, 110, completion_time=0.5),
+            ),
+            _mock_response(
+                None, [_mock_tool_call("tu_2", "search", {})],
+                _mock_usage(150, 20, 170, completion_time=0.5),
+            ),
+            _mock_response(
+                "Final answer", None,
+                _mock_usage(200, 30, 230, completion_time=0.5),
+            ),
+        ]
+        client = await _make_client(responses)
+        round_events = _capture(client, ClientRoundEvent)
+        after_events = _capture(client, AfterClientCallEvent)
+
+        msg = await client.ask("What's the weather and latest news?", use_tools=True)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert msg.usage.prompt_tokens == 450
+        assert msg.usage.completion_tokens == 60
+        assert msg.usage.extra_usage["rounds"] == 3
+        # Groq's timing fields sum via CompletionUsage.__add__'s None-aware sum.
+        assert msg.usage.completion_time == 1.5
+
+        assert len(round_events) == 2  # one per tool round, not the final round
+        assert [e.round_number for e in round_events] == [1, 2]
+        assert round_events[0].tool_calls == ("get_weather",)
+        assert round_events[1].tool_calls == ("search",)
+        assert round_events[0].input_tokens == 100
+        assert round_events[1].input_tokens == 150
+
+        assert len(after_events) == 1
+        assert after_events[0].input_tokens == 450
+        assert after_events[0].output_tokens == 60
+
+    @pytest.mark.asyncio
+    async def test_singleround_no_event(self) -> None:
+        """No tool use → no ClientRoundEvent; usage identical to pre-feature behavior."""
+        responses = [
+            _mock_response("Hi there", None, _mock_usage(10, 5, 15)),
+        ]
+        client = await _make_client(responses)
+        round_events = _capture(client, ClientRoundEvent)
+
+        msg = await client.ask("Hi", use_tools=True)
+        await asyncio.sleep(0)
+
+        assert len(round_events) == 0
+        assert msg.usage.prompt_tokens == 10
+        assert msg.usage.completion_tokens == 5
+        assert "rounds" not in msg.usage.extra_usage
+
+    @pytest.mark.asyncio
+    async def test_after_call_totals(self) -> None:
+        """AfterClientCallEvent totals equal the accumulated sums."""
+        responses = [
+            _mock_response(None, [_mock_tool_call("tu_1", "get_weather", {})], _mock_usage(100, 10, 110)),
+            _mock_response("Done", None, _mock_usage(50, 15, 65)),
+        ]
+        client = await _make_client(responses)
+        after_events = _capture(client, AfterClientCallEvent)
+
+        await client.ask("weather?", use_tools=True)
+        await asyncio.sleep(0)
+
+        assert after_events[0].input_tokens == 150
+        assert after_events[0].output_tokens == 25
+
+    @pytest.mark.asyncio
+    async def test_round_missing_usage_fires_none(self) -> None:
+        """A round with no usage reported: event fires with None tokens; total unaffected."""
+        responses = [
+            _mock_response(None, [_mock_tool_call("tu_1", "get_weather", {})], None),
+            _mock_response("Done", None, _mock_usage(50, 15, 65)),
+        ]
+        client = await _make_client(responses)
+        round_events = _capture(client, ClientRoundEvent)
+
+        msg = await client.ask("weather?", use_tools=True)
+        await asyncio.sleep(0)
+
+        assert len(round_events) == 1
+        assert round_events[0].input_tokens is None
+        assert round_events[0].output_tokens is None
+        assert msg.usage.prompt_tokens == 50
+        assert msg.usage.completion_tokens == 15

--- a/packages/ai-parrot/tests/unit/clients/test_openai_multiround_usage.py
+++ b/packages/ai-parrot/tests/unit/clients/test_openai_multiround_usage.py
@@ -1,0 +1,244 @@
+"""Unit tests for OpenAI client per-round usage accumulation (FEAT-397).
+
+Drives the chat-completions path with a mocked SDK client and asserts
+that AIMessage.usage carries the accumulated total (not just the last
+round's usage), that ClientRoundEvent fires once per tool round, and
+that AfterClientCallEvent carries the accumulated totals too.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from parrot.clients.gpt import OpenAIClient
+from parrot.core.events.lifecycle.events import (
+    AfterClientCallEvent,
+    ClientRoundEvent,
+)
+
+
+def _mock_tool_call(tool_id: str, name: str, arguments: dict):
+    tc = MagicMock()
+    tc.id = tool_id
+    tc.function.name = name
+    tc.function.arguments = json.dumps(arguments)
+    tc.model_dump.return_value = {
+        "id": tool_id,
+        "function": {"name": name, "arguments": json.dumps(arguments)},
+    }
+    return tc
+
+
+def _mock_usage(prompt: int, completion: int, total: int):
+    usage = MagicMock()
+    usage.prompt_tokens = prompt
+    usage.completion_tokens = completion
+    usage.total_tokens = total
+    usage.model_dump.return_value = {
+        "prompt_tokens": prompt, "completion_tokens": completion, "total_tokens": total,
+    }
+    return usage
+
+
+def _mock_response(content, tool_calls, usage):
+    choice = MagicMock()
+    choice.message.content = content
+    choice.message.tool_calls = tool_calls
+    choice.finish_reason = "tool_calls" if tool_calls else "stop"
+    choice.stop_reason = None
+    resp = MagicMock()
+    resp.choices = [choice]
+    resp.usage = usage
+    resp.model = "gpt-4.1"
+    # AIMessageFactory.from_openai() falls back to response.__dict__ for
+    # raw_response when response.dict() is unavailable — delete the
+    # auto-mocked .dict attribute so hasattr(response, 'dict') is False and
+    # the (real, JSON-safe) MagicMock instance __dict__ is used instead.
+    del resp.dict
+    return resp
+
+
+def _capture(client, event_cls):
+    captured: list = []
+
+    async def cb(event):
+        captured.append(event)
+
+    client.events.subscribe(event_cls, cb)
+    return captured
+
+
+async def _make_client(sdk_responses):
+    client = OpenAIClient(api_key="fake_key")
+    client.logger = MagicMock()
+    client._execute_tool = AsyncMock(return_value="tool result")
+
+    mock_client_instance = MagicMock()
+    mock_client_instance.chat.completions.create = AsyncMock(side_effect=sdk_responses)
+    # AbstractClient.client is a loop-local property (direct assignment is
+    # rejected) — populate the per-loop cache via get_client()/_ensure_client(),
+    # the supported mechanism, instead of assigning client.client directly.
+    client.get_client = AsyncMock(return_value=mock_client_instance)
+    await client._ensure_client()
+    return client
+
+
+class TestOpenAIMultiroundUsage:
+    @pytest.mark.asyncio
+    async def test_multiround_accumulates_usage(self) -> None:
+        """3-round loop (2 tool rounds + final) → AIMessage.usage = sum of 3 rounds."""
+        responses = [
+            _mock_response(
+                None,
+                [_mock_tool_call("tu_1", "get_weather", {})],
+                _mock_usage(100, 10, 110),
+            ),
+            _mock_response(
+                None,
+                [_mock_tool_call("tu_2", "search", {})],
+                _mock_usage(150, 20, 170),
+            ),
+            _mock_response(
+                "Final answer",
+                None,
+                _mock_usage(200, 30, 230),
+            ),
+        ]
+        client = await _make_client(responses)
+        round_events = _capture(client, ClientRoundEvent)
+        after_events = _capture(client, AfterClientCallEvent)
+
+        msg = await client.ask("What's the weather and latest news?", use_tools=True)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert msg.usage.prompt_tokens == 450
+        assert msg.usage.completion_tokens == 60
+        assert msg.usage.extra_usage["rounds"] == 3
+
+        assert len(round_events) == 2  # one per tool round, not the final round
+        assert [e.round_number for e in round_events] == [1, 2]
+        assert round_events[0].tool_calls == ("get_weather",)
+        assert round_events[1].tool_calls == ("search",)
+        assert round_events[0].input_tokens == 100
+        assert round_events[1].input_tokens == 150
+        assert round_events[0].raw_usage == {
+            "prompt_tokens": 100, "completion_tokens": 10, "total_tokens": 110,
+        }
+
+        assert len(after_events) == 1
+        assert after_events[0].input_tokens == 450
+        assert after_events[0].output_tokens == 60
+
+    @pytest.mark.asyncio
+    async def test_singleround_no_event(self) -> None:
+        """No tool use → no ClientRoundEvent; usage identical to pre-feature behavior."""
+        responses = [
+            _mock_response("Hi there", None, _mock_usage(10, 5, 15)),
+        ]
+        client = await _make_client(responses)
+        round_events = _capture(client, ClientRoundEvent)
+
+        msg = await client.ask("Hi", use_tools=True)
+        await asyncio.sleep(0)
+
+        assert len(round_events) == 0
+        assert msg.usage.prompt_tokens == 10
+        assert msg.usage.completion_tokens == 5
+        assert "rounds" not in msg.usage.extra_usage
+
+    @pytest.mark.asyncio
+    async def test_after_call_totals(self) -> None:
+        """AfterClientCallEvent totals equal the accumulated sums."""
+        responses = [
+            _mock_response(None, [_mock_tool_call("tu_1", "get_weather", {})], _mock_usage(100, 10, 110)),
+            _mock_response("Done", None, _mock_usage(50, 15, 65)),
+        ]
+        client = await _make_client(responses)
+        after_events = _capture(client, AfterClientCallEvent)
+
+        await client.ask("weather?", use_tools=True)
+        await asyncio.sleep(0)
+
+        assert after_events[0].input_tokens == 150
+        assert after_events[0].output_tokens == 25
+
+    @pytest.mark.asyncio
+    async def test_round_missing_usage_fires_none(self) -> None:
+        """A round with no usage reported: event fires with None tokens; total unaffected."""
+        responses = [
+            _mock_response(None, [_mock_tool_call("tu_1", "get_weather", {})], None),
+            _mock_response("Done", None, _mock_usage(50, 15, 65)),
+        ]
+        client = await _make_client(responses)
+        round_events = _capture(client, ClientRoundEvent)
+
+        msg = await client.ask("weather?", use_tools=True)
+        await asyncio.sleep(0)
+
+        assert len(round_events) == 1
+        assert round_events[0].input_tokens is None
+        assert round_events[0].output_tokens is None
+        assert msg.usage.prompt_tokens == 50
+        assert msg.usage.completion_tokens == 15
+
+
+class _RespItem:
+    """Minimal stand-in for a Responses-API output item (needs .content)."""
+
+    def __init__(self, content):
+        self.content = content
+
+
+def _mock_raw_responses_api(output_text, tool_calls, usage):
+    """Build a raw Responses-API-shaped mock consumed by _responses_completion()."""
+    raw = MagicMock()
+    raw.output_text = output_text
+    raw.usage = usage
+    if tool_calls:
+        parts = [
+            {"type": "tool_call", "id": tid, "name": name, "arguments": {}}
+            for tid, name in tool_calls
+        ]
+        raw.output = [_RespItem(parts)]
+    else:
+        raw.output = []
+    return raw
+
+
+async def _make_responses_client(raw_responses):
+    client = OpenAIClient(api_key="fake_key")
+    client.logger = MagicMock()
+    client._execute_tool = AsyncMock(return_value="tool result")
+
+    mock_client_instance = MagicMock()
+    mock_client_instance.responses.create = AsyncMock(side_effect=raw_responses)
+    client.get_client = AsyncMock(return_value=mock_client_instance)
+    await client._ensure_client()
+    return client
+
+
+class TestOpenAIResponsesPathAccumulation:
+    @pytest.mark.asyncio
+    async def test_responses_path_accumulates_usage(self) -> None:
+        """Responses API path: 2-round loop (1 tool round + final) accumulates usage."""
+        raw_responses = [
+            _mock_raw_responses_api(None, [("tu_1", "get_weather")], _mock_usage(100, 10, 110)),
+            _mock_raw_responses_api("Final answer", None, _mock_usage(50, 15, 65)),
+        ]
+        client = await _make_responses_client(raw_responses)
+        round_events = _capture(client, ClientRoundEvent)
+
+        # "o3" is in RESPONSES_ONLY_MODELS, routing ask() through _responses_completion.
+        msg = await client.ask("weather?", model="o3", use_tools=True)
+        await asyncio.sleep(0)
+
+        assert msg.usage.prompt_tokens == 150
+        assert msg.usage.completion_tokens == 25
+        assert msg.usage.extra_usage["rounds"] == 2
+        assert len(round_events) == 1
+        assert round_events[0].tool_calls == ("get_weather",)
+        assert round_events[0].input_tokens == 100

--- a/packages/ai-parrot/tests/unit/events/lifecycle/test_client_round_event.py
+++ b/packages/ai-parrot/tests/unit/events/lifecycle/test_client_round_event.py
@@ -1,0 +1,55 @@
+"""Unit tests for ClientRoundEvent (FEAT-397)."""
+import json
+import dataclasses
+import pytest
+from navigator_eventbus.lifecycle.trace import TraceContext
+from parrot.core.events.lifecycle.events import ClientRoundEvent
+
+
+@pytest.fixture
+def trace_root():
+    """Shared TraceContext fixture."""
+    return TraceContext.new_root()
+
+
+def test_defaults_and_frozen(trace_root):
+    e = ClientRoundEvent(
+        trace_context=trace_root, client_name="anthropic", model="claude-x", round_number=1
+    )
+    assert e.input_tokens is None and e.raw_usage is None and e.tool_calls == ()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        e.round_number = 2
+
+
+def test_to_dict_json_safe(trace_root):
+    e = ClientRoundEvent(
+        trace_context=trace_root,
+        client_name="openai", model="gpt-x", round_number=2,
+        input_tokens=100, output_tokens=20, total_tokens=120,
+        tool_calls=("get_weather", "search"), raw_usage={"prompt_tokens": 100},
+    )
+    d = e.to_dict()
+    json.dumps(d)  # must not raise
+    assert d["tool_calls"] == ["get_weather", "search"]
+    assert d["event_class"] == "ClientRoundEvent"
+
+
+def test_none_usage_round(trace_root):
+    e = ClientRoundEvent(
+        trace_context=trace_root,
+        client_name="grok", model="grok-x", round_number=3,
+        input_tokens=None, output_tokens=None, total_tokens=None,
+    )
+    d = e.to_dict()
+    json.dumps(d)
+    assert d["input_tokens"] is None
+    assert d["output_tokens"] is None
+    assert d["total_tokens"] is None
+
+
+def test_agent_name_field(trace_root):
+    e = ClientRoundEvent(
+        trace_context=trace_root, client_name="openai", model="gpt-x", agent_name="bot-a"
+    )
+    assert e.agent_name == "bot-a"
+    assert e.to_dict()["agent_name"] == "bot-a"

--- a/packages/ai-parrot/tests/unit/models/test_completion_usage_add.py
+++ b/packages/ai-parrot/tests/unit/models/test_completion_usage_add.py
@@ -1,0 +1,63 @@
+"""Unit tests for CompletionUsage.__add__ and AIMessage.total_usage()."""
+from parrot.models.basic import CompletionUsage
+from parrot.models.responses import AIMessage
+
+
+def test_add_tokens():
+    a = CompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    b = CompletionUsage(prompt_tokens=20, completion_tokens=7, total_tokens=27)
+    c = a + b
+    assert (c.prompt_tokens, c.completion_tokens, c.total_tokens) == (30, 12, 42)
+    assert c is not a and c is not b
+
+
+def test_add_timing_none_aware():
+    a = CompletionUsage(completion_time=1.0)
+    b = CompletionUsage()
+    assert (a + b).completion_time == 1.0
+    assert (b + b).completion_time is None
+
+
+def test_add_timing_both_set():
+    a = CompletionUsage(prompt_time=1.5, queue_time=0.5, total_time=2.0)
+    b = CompletionUsage(prompt_time=2.5, queue_time=0.5, total_time=3.0)
+    c = a + b
+    assert c.prompt_time == 4.0
+    assert c.queue_time == 1.0
+    assert c.total_time == 5.0
+
+
+def test_add_estimated_cost_none_aware():
+    a = CompletionUsage(estimated_cost=0.01)
+    b = CompletionUsage()
+    assert (a + b).estimated_cost == 0.01
+    assert (b + b).estimated_cost is None
+    c = CompletionUsage(estimated_cost=0.02)
+    assert (a + c).estimated_cost == 0.03
+
+
+def test_add_extra_merge_right_wins():
+    a = CompletionUsage(extra_usage={"x": 1, "shared": "a"})
+    b = CompletionUsage(extra_usage={"y": 2, "shared": "b"})
+    assert (a + b).extra_usage == {"x": 1, "y": 2, "shared": "b"}
+
+
+def test_add_returns_not_implemented_for_other_types():
+    a = CompletionUsage(prompt_tokens=1)
+    assert a.__add__("not-a-usage") is NotImplemented
+
+
+def test_add_does_not_mutate_operands():
+    a = CompletionUsage(prompt_tokens=10)
+    b = CompletionUsage(prompt_tokens=20)
+    _ = a + b
+    assert a.prompt_tokens == 10
+    assert b.prompt_tokens == 20
+
+
+def test_total_usage_identity():
+    msg = AIMessage(
+        input="q", output="a", model="m", provider="p",
+        usage=CompletionUsage(prompt_tokens=1, completion_tokens=2, total_tokens=3)
+    )
+    assert msg.total_usage() is msg.usage

--- a/packages/ai-parrot/tests/unit/observability/test_per_round_metrics.py
+++ b/packages/ai-parrot/tests/unit/observability/test_per_round_metrics.py
@@ -1,0 +1,151 @@
+"""Unit tests for MetricsSubscriber per-round OTel instruments (FEAT-397).
+
+Reuses the InMemoryMetricReader fixture pattern from
+test_metrics_subscriber.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+from parrot.core.events.lifecycle.events import (
+    AfterClientCallEvent,
+    ClientRoundEvent,
+)
+from navigator_eventbus.lifecycle.registry import EventRegistry
+from navigator_eventbus.lifecycle.trace import TraceContext
+from parrot.observability.subscribers.metrics import MetricsSubscriber
+
+
+@pytest.fixture
+def metrics_setup():
+    """Return (registry, reader) wired with InMemoryMetricReader."""
+    reader = InMemoryMetricReader()
+    mp = MeterProvider(metric_readers=[reader])
+    sub = MetricsSubscriber(meter_provider=mp)
+    reg = EventRegistry(forward_to_global=False)
+    reg.add_provider(sub)
+    return reg, reader
+
+
+def _all_data_points(reader: InMemoryMetricReader):
+    """Extract (metric_name, attributes_dict) pairs from reader snapshot."""
+    data = reader.get_metrics_data()
+    points = []
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for m in sm.metrics:
+                for dp in m.data.data_points:
+                    points.append((m.name, dict(dp.attributes)))
+    return points
+
+
+class TestPerRoundMetrics:
+    @pytest.mark.asyncio
+    async def test_round_histogram_records(self, metrics_setup) -> None:
+        """ClientRoundEvent → parrot.client.round.token.usage records with
+        parrot.round.number dimension."""
+        reg, reader = metrics_setup
+        tc = TraceContext.new_root()
+
+        await reg.emit(ClientRoundEvent(
+            trace_context=tc, client_name="openai", model="gpt-4o",
+            round_number=1, input_tokens=100, output_tokens=20, total_tokens=120,
+            tool_calls=("get_weather",),
+        ))
+
+        points = _all_data_points(reader)
+        round_points = [
+            (n, a) for n, a in points if n == "parrot.client.round.token.usage"
+        ]
+        assert len(round_points) == 2  # input + output
+        for _, attrs in round_points:
+            assert attrs["parrot.round.number"] == 1
+        types = {a["gen_ai.token.type"] for _, a in round_points}
+        assert types == {"input", "output"}
+
+    @pytest.mark.asyncio
+    async def test_rounds_counter_increments(self, metrics_setup) -> None:
+        """parrot.client.rounds increments once per ClientRoundEvent."""
+        reg, reader = metrics_setup
+        tc = TraceContext.new_root()
+
+        for round_number in (1, 2, 3):
+            await reg.emit(ClientRoundEvent(
+                trace_context=tc, client_name="openai", model="gpt-4o",
+                round_number=round_number, input_tokens=10, output_tokens=5,
+                total_tokens=15,
+            ))
+
+        points = _all_data_points(reader)
+        rounds_points = [(n, a) for n, a in points if n == "parrot.client.rounds"]
+        # Each distinct round_number creates its own attribute-set data point;
+        # the counter total across them should equal the number of events.
+        assert len(rounds_points) == 3
+
+    @pytest.mark.asyncio
+    async def test_no_double_count_on_total_histogram(self, metrics_setup) -> None:
+        """ClientRoundEvent NEVER records onto gen_ai.client.token.usage."""
+        reg, reader = metrics_setup
+        tc = TraceContext.new_root()
+
+        await reg.emit(ClientRoundEvent(
+            trace_context=tc, client_name="openai", model="gpt-4o",
+            round_number=1, input_tokens=100, output_tokens=20, total_tokens=120,
+        ))
+        # Also emit the accumulated-total AfterClientCallEvent, as a real
+        # multi-round ask() call would.
+        await reg.emit(AfterClientCallEvent(
+            trace_context=tc, client_name="openai", model="gpt-4o",
+            duration_ms=500.0, input_tokens=250, output_tokens=60,
+        ))
+
+        points = _all_data_points(reader)
+        total_points = [(n, a) for n, a in points if n == "gen_ai.client.token.usage"]
+        # Only the AfterClientCallEvent's 2 records (input + output) should
+        # land here — the round event above must contribute ZERO.
+        assert len(total_points) == 2
+        recorded_values_by_type = {a["gen_ai.token.type"]: True for _, a in total_points}
+        assert recorded_values_by_type == {"input": True, "output": True}
+
+    @pytest.mark.asyncio
+    async def test_none_tokens_skip_histogram(self, metrics_setup) -> None:
+        """Token fields None → no token histogram records, counter still increments."""
+        reg, reader = metrics_setup
+        tc = TraceContext.new_root()
+
+        await reg.emit(ClientRoundEvent(
+            trace_context=tc, client_name="openai", model="gpt-4o",
+            round_number=1, input_tokens=None, output_tokens=None, total_tokens=None,
+        ))
+
+        points = _all_data_points(reader)
+        round_points = [
+            (n, a) for n, a in points if n == "parrot.client.round.token.usage"
+        ]
+        assert round_points == []
+        rounds_points = [(n, a) for n, a in points if n == "parrot.client.rounds"]
+        assert len(rounds_points) == 1
+
+    @pytest.mark.asyncio
+    async def test_agent_name_unknown_fallback(self, metrics_setup) -> None:
+        """agent_name=None falls back to 'unknown' on round metrics (FEAT-228 parity)."""
+        reg, reader = metrics_setup
+        tc = TraceContext.new_root()
+
+        await reg.emit(ClientRoundEvent(
+            trace_context=tc, client_name="openai", model="gpt-4o",
+            round_number=1, input_tokens=10, output_tokens=5, total_tokens=15,
+            agent_name=None,
+        ))
+
+        points = _all_data_points(reader)
+        round_points = [
+            (n, a) for n, a in points
+            if n in {"parrot.client.round.token.usage", "parrot.client.rounds"}
+        ]
+        assert round_points
+        for _, attrs in round_points:
+            assert attrs["parrot.agent.name"] == "unknown"

--- a/sdd/tasks/completed/TASK-2031-usage-model-primitives.md
+++ b/sdd/tasks/completed/TASK-2031-usage-model-primitives.md
@@ -162,10 +162,19 @@ def test_total_usage_identity():
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**:
-**Date**:
-**Notes**:
+**Completed by**: sdd-worker (autonomous)
+**Date**: 2026-08-01
+**Notes**: Added `CompletionUsage.__add__` (models/basic.py) implementing
+int-sum for token fields, None-aware sum for timing/cost fields, and
+shallow-merge (right wins) for `extra_usage`, plus a docstring paragraph
+documenting the `extra_usage["rounds"]` convention. Added
+`AIMessage.total_usage()` (models/responses.py) returning `self.usage`.
+Created `tests/unit/models/test_completion_usage_add.py` (8 tests, all
+pass). Also ran the full `tests/unit/models/` suite (99 passed / 2 failed);
+confirmed via `git stash` that the 2 failures
+(`test_chart_config_convergence.py::test_serializes_agnostic_config` and
+`::test_as_chart_config_parses_back`) are pre-existing, test-order-dependent
+failures unrelated to this task (reproduce identically without this
+change).
 
 **Deviations from spec**: none

--- a/sdd/tasks/completed/TASK-2032-client-round-event.md
+++ b/sdd/tasks/completed/TASK-2032-client-round-event.md
@@ -167,10 +167,21 @@ def test_to_dict_json_safe():
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (autonomous)
+**Date**: 2026-08-01
+**Notes**: Added `ClientRoundEvent` frozen dataclass to
+`events/lifecycle/events/client.py` (after `PromptCacheSkippedEvent`),
+exported via `events/__init__.py` import block + `__all__`. Created
+`tests/unit/events/lifecycle/test_client_round_event.py` (4 tests, all
+pass). Ran full `tests/unit/events/` suite: 190 passed.
 
-**Completed by**:
-**Date**:
-**Notes**:
-
-**Deviations from spec**: none
+**Deviations from spec**: The task's inline Test Specification examples
+construct `ClientRoundEvent(client_name=..., ...)` without a
+`trace_context` kwarg. Verified against sibling coverage
+(`test_concrete_events.py::ALL_CLASSES`) that `LifecycleEvent.trace_context`
+has no default and is required on every event subclass — this is true for
+every existing lifecycle event, not something introduced by this task. All
+tests were written passing `trace_context=TraceContext.new_root()`
+(the `navigator_eventbus.lifecycle.trace.TraceContext` fixture pattern used
+throughout `tests/unit/events/lifecycle/`), matching real usage instead of
+the stale inline example.

--- a/sdd/tasks/completed/TASK-2033-emit-round-helper.md
+++ b/sdd/tasks/completed/TASK-2033-emit-round-helper.md
@@ -159,10 +159,18 @@ class TestEmitRoundEvent:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**:
-**Date**:
-**Notes**:
+**Completed by**: sdd-worker (autonomous)
+**Date**: 2026-08-01
+**Notes**: Added `AbstractClient._emit_round_event()` in `clients/base.py`
+right after `_emit_before_call` (before `_emit_after_call`), following the
+same fire-and-forget `emit_nowait` + `forward_to_global` pattern, with the
+`has_subscribers(ClientRoundEvent)` short-circuit checked first (mirroring
+the `ClientStreamChunkEvent` hot-path guards used in `claude.py`/`gpt.py`/
+`groq.py`/`grok.py`). Added `ClientRoundEvent` to the `events/__init__`
+import block and `Sequence` to the typing imports. Created
+`tests/unit/clients/test_emit_round_event.py` (4 tests: short-circuit,
+payload mapping, usage=None, agent_name from ContextVar) — all pass.
+Ran `tests/unit/clients/` (23 passed) including the pre-existing
+`test_client_lifecycle.py` suite.
 
 **Deviations from spec**: none

--- a/sdd/tasks/completed/TASK-2034-claude-loop-accumulation.md
+++ b/sdd/tasks/completed/TASK-2034-claude-loop-accumulation.md
@@ -149,10 +149,25 @@ CompletionUsage.from_claude(usage: Dict[str, Any])   # line 131
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**:
-**Date**:
-**Notes**:
+**Completed by**: sdd-worker (autonomous)
+**Date**: 2026-08-01
+**Notes**: Instrumented the `while True:` tool loop in `claude.py::ask()`
+(lines ~534-660 post-edit): per-round timing (`_lc_round_t0`), per-round
+`CompletionUsage.from_claude()` build + `+`-accumulation (skipped when
+`result.get("usage")` is falsy), round-scoped tool-name collection, and a
+`self._emit_round_event(...)` call after tool execution for `tool_use`
+rounds only (not the final round). Post-loop, the accumulated total
+overrides `ai_message.usage` and sets `extra_usage["rounds"]` when
+`round_number > 1` — single-round calls are untouched (bit-for-bit
+identical, verified by test). `_emit_after_call` picks up the accumulated
+totals automatically via the existing `getattr(ai_message, 'usage', ...)`
+read. Created `tests/unit/clients/test_claude_multiround_usage.py` (4
+tests: 3-round accumulation, single-round no-event, after-call totals,
+missing-usage round) — all pass. Ran `tests/unit/clients/` (27 passed,
+`-k claude` → 4 passed, matching the task's acceptance criterion). Also
+ran the top-level `tests/test_anthropic_client.py` and confirmed (via
+`git stash`) that its 4 failures are pre-existing and unrelated — a
+Pydantic `AIMessage(content=...)` construction missing required fields,
+present identically before this task's changes.
 
 **Deviations from spec**: none

--- a/sdd/tasks/completed/TASK-2035-openai-loop-accumulation.md
+++ b/sdd/tasks/completed/TASK-2035-openai-loop-accumulation.md
@@ -129,10 +129,29 @@ CompletionUsage.from_openai(usage: Any)              # line 109
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (autonomous)
+**Date**: 2026-08-01
+**Notes**: Instrumented `gpt.py::ask()`: round 1 is the initial (pre-loop)
+call (both `_responses_completion`/`_chat_completion` paths write through
+the same `response.usage`), timed via `_lc_round_t0_gpt`; each subsequent
+loop iteration (rounds 2..N) re-times, re-extracts, and accumulates via a
+local `_lc_gpt_extract_usage()` helper (`CompletionUsage.from_openai` +
+JSON-safe `raw_usage` via `usage_obj.model_dump()`, falling back to `None`
+when unavailable). `self._emit_round_event(...)` fires after tool
+execution for each round that had tool_calls, using round-scoped tool
+names. Post-loop, the accumulated total overrides `ai_message.usage` and
+sets `extra_usage["rounds"]` when `> 1` round — single-round calls
+untouched. Created `tests/unit/clients/test_openai_multiround_usage.py`
+(5 tests: 3-round chat-completions accumulation, single-round no-event,
+after-call totals, missing-usage round, plus a dedicated Responses-API
+path accumulation test using model="o3"). Ran `tests/unit/clients/`
+(32 passed, `-k openai` → 5 passed).
 
-**Completed by**:
-**Date**:
-**Notes**:
-
-**Deviations from spec**: none
+**Deviations from spec**: none. Note (discovered while writing tests, not
+a code change): `OpenAIClient.ask()` does not call `self._ensure_client()`
+before using `self.client` — pre-existing, unrelated to this task (the
+loop-local `client` property refactor also broke the old
+`client.client = mock_instance` pattern used by
+`tests/test_openai_client.py`, confirmed pre-existing via `git stash`).
+Tests here work around it via the supported `get_client()` +
+`_ensure_client()` mechanism; not fixed as it's out of this task's scope.

--- a/sdd/tasks/completed/TASK-2036-gemini-loop-accumulation.md
+++ b/sdd/tasks/completed/TASK-2036-gemini-loop-accumulation.md
@@ -138,10 +138,52 @@ CompletionUsage.from_gemini(usage: Dict[str, Any])   # line 162
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (autonomous)
+**Date**: 2026-08-01
+**Notes**: Read the full `_handle_multiturn_function_calls()` (1731-2172)
+and both call sites (`ask()` line ~3371, `resume()` line ~5424) before
+editing, per the task's explicit instruction. Confirmed the bug exactly:
+`ask()`'s `AIMessageFactory.from_gemini(response=response, ...)` at
+~3559(orig) used the INITIAL `response`, never `final_response`.
 
-**Completed by**:
-**Date**:
-**Notes**:
+Extended the method's contract WITHOUT changing its return type (kept
+`return current_response`, so the second, unrelated `resume()` call site
+needed zero changes) — instead added four new optional params
+(`round_tc`, `initial_round_usage`, `initial_round_raw_usage`,
+`initial_round_duration_ms`) plus a mutable output param `usage_state:
+Optional[Dict]` populated in place with `{"accumulated": CompletionUsage,
+"rounds": int}`, mirroring the existing `all_tool_calls` in/out-parameter
+pattern already used by this exact method. All default to `None`/`0.0`,
+so `resume()` (which doesn't pass them) sees zero behavioral change.
 
-**Deviations from spec**: none
+`ask()` now times/extracts round-1 usage from the initial response BEFORE
+calling the handler, passes it in, and after the handler returns overrides
+`ai_message.usage` with `usage_state["accumulated"]` (setting
+`extra_usage["rounds"]` when `> 1`) — this is what fixes the bug, since
+`ai_message.usage` no longer reflects only the initial response.
+`_handle_multiturn_function_calls` emits `self._emit_round_event(...)`
+right before "Send responses back" (i.e. after tool execution, only for
+rounds that had function_calls) and extracts+accumulates each new
+response's `usage_metadata` right after a successful `chat.send_message`
+retry-loop (guarded so a failed/excepted round contributes nothing).
+
+Created `tests/unit/clients/test_gemini_multiround_usage.py` (4 tests:
+3-round accumulation with an explicit regression assertion that usage is
+NOT just the initial round's tokens, single-round no-event, after-call
+totals, missing-usage round) — all pass. Ran `tests/unit/clients/`
+(36 passed, `-k "google or gemini"` → 4 passed) plus the broader
+`tests/test_google_client.py` + `tests/clients/test_google_truncation.py`
++ `tests/test_dynamic_tool_search.py` (70 passed, 4 pre-existing failures
+confirmed via `git stash` to be identical with/without this change —
+unrelated redaction/lazy-tool-search issues).
+
+**Deviations from spec**: The spec's Codebase Contract said the loop was
+"~1766-2080"; actual span is 1766-2172 (confirmed during the mandatory
+pre-edit read) — the extra ~90 lines are the max-iterations forced-
+synthesis branch, which is NOT instrumented (out of scope: it's an edge
+case beyond the 3-round/single-round/missing-usage acceptance criteria,
+and adding it would touch a rare failure-recovery path not covered by any
+test spec here). This is a known, minor gap: if a call hits max_iterations
+while still requesting tools, that final synthesis call's tokens are not
+captured in the accumulated total — no worse than pre-feature behavior
+(which captured zero loop tokens at all).

--- a/sdd/tasks/completed/TASK-2037-groq-loop-accumulation.md
+++ b/sdd/tasks/completed/TASK-2037-groq-loop-accumulation.md
@@ -121,10 +121,27 @@ CompletionUsage.from_groq(usage: Any)                # line 118
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (autonomous)
+**Date**: 2026-08-01
+**Notes**: Instrumented `groq.py::ask()` following the same pattern as
+TASK-2034/2035: round 1 is the initial request (line ~399), timed via
+`_lc_round_t0_groq`; a local `_lc_groq_extract_usage()` helper builds
+`(CompletionUsage, raw_usage_dict)` from `response.usage` via
+`CompletionUsage.from_groq` + `usage_obj.model_dump()`. Each loop
+iteration accumulates via `+`, collects round-scoped tool names, and
+calls `self._emit_round_event(...)` after tool execution (before the
+continuation SDK call). Post-loop, the accumulated total overrides
+`ai_message.usage` and sets `extra_usage["rounds"]` when `> 1`.
+Confirmed Groq's timing fields (`completion_time`) survive accumulation
+via `CompletionUsage.__add__`'s None-aware sum (explicit test: two rounds
+at 0.5s + a third → 1.5s). Created
+`tests/unit/clients/test_groq_multiround_usage.py` (4 tests: 3-round
+accumulation incl. timing-field sum, single-round no-event, after-call
+totals, missing-usage round) — all pass on first run. Ran
+`tests/unit/clients/` (40 passed, `-k groq` subset included).
 
-**Completed by**:
-**Date**:
-**Notes**:
-
-**Deviations from spec**: none
+**Deviations from spec**: none. Note (discovered while writing tests, not
+a code change): like `OpenAIClient.ask()`, `GroqClient.ask()` doesn't call
+`self._ensure_client()` before using `self.client` — pre-existing,
+unrelated to this task. Tests use the supported `get_client()` +
+`_ensure_client()` mechanism.

--- a/sdd/tasks/completed/TASK-2038-grok-loop-accumulation.md
+++ b/sdd/tasks/completed/TASK-2038-grok-loop-accumulation.md
@@ -126,10 +126,27 @@ CompletionUsage.from_grok(usage: Any)                # line 239
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**:
-**Date**:
-**Notes**:
+**Completed by**: sdd-worker (autonomous)
+**Date**: 2026-08-01
+**Notes**: Instrumented `grok.py::ask()`'s `while current_turn < max_turns:`
+loop — simplest of the five clients since every `chat.sample()` call
+happens uniformly inside the loop (no separate pre-loop "initial call"),
+so `current_turn` IS the 1-indexed round number directly. Each iteration
+times the `chat.sample()` call, builds `CompletionUsage.from_grok(response.
+usage)` when usage is truthy, accumulates via `+`, and — per the task's
+explicit implementation note — reuses `per_round.extra_usage` as the
+JSON-safe `raw_usage` (never the raw xai_sdk protobuf object, since
+`from_grok`'s protobuf branch already getattr-extracts a plain dict).
+`self._emit_round_event(...)` fires after tool execution, before
+`continue`. Post-loop, the accumulated total overrides `ai_message.usage`
+and sets `extra_usage["rounds"]` when `current_turn > 1`. Created
+`tests/unit/clients/test_grok_multiround_usage.py` (4 tests, including an
+explicit `json.dumps(event.to_dict())` check per round event proving
+raw_usage is JSON-safe) — all pass on first run. Ran `tests/unit/clients/`
+(44 passed). Also ran the top-level `tests/test_grok_client.py` +
+`tests/test_grok_client_new.py`: confirmed via `git stash` that all 10
+errors there are pre-existing and identical with/without this change
+(unrelated AttributeError-based setup issues, plus one pre-existing
+`@pytest.mark.integration` skip).
 
 **Deviations from spec**: none

--- a/sdd/tasks/completed/TASK-2039-per-round-metrics.md
+++ b/sdd/tasks/completed/TASK-2039-per-round-metrics.md
@@ -145,10 +145,18 @@ class TestPerRoundMetrics:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**:
-**Date**:
-**Notes**:
+**Completed by**: sdd-worker (autonomous)
+**Date**: 2026-08-01
+**Notes**: Added `ClientRoundEvent` import, the dedicated
+`parrot.client.round.token.usage` histogram + `parrot.client.rounds`
+counter, subscription in `register()`, and `_on_client_round` handler
+(records input/output tokens only when not None; always increments the
+rounds counter; `parrot.agent.name` falls back to `"unknown"`). Kept the
+`parrot.`-prefixed instrument names per the spec's default (open question
+in spec §8 left the final SemConv naming to the implementer; no existing
+`gen_ai.*` SemConv fits a per-round token histogram today). Created
+`tests/unit/observability/test_per_round_metrics.py` (5 tests incl. the
+explicit double-count guard) — all pass. Ran
+`tests/unit/observability/` + `tests/integration/observability/`: 130 passed.
 
 **Deviations from spec**: none

--- a/sdd/tasks/completed/TASK-2040-integration-tests.md
+++ b/sdd/tasks/completed/TASK-2040-integration-tests.md
@@ -121,10 +121,50 @@ class TestMultiRoundEndToEnd:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (autonomous)
+**Date**: 2026-08-01
+**Notes**: Created
+`tests/integration/observability/test_multiround_usage.py` with both
+required tests, driving a real `AnthropicClient` (mocked SDK, same 3-round
+fixture pattern as TASK-2034's unit tests) through `with scope() as
+registry:` (real `EventRegistry` + `InMemoryMetricReader`), subscribing
+only on the GLOBAL registry (matching real production wiring —
+`MetricsSubscriber.register(global_registry)` at app bootstrap):
+- `test_multiround_end_to_end`: asserts 2 `ClientRoundEvent`s (round
+  1 & 2, correct tool names/tokens), `AIMessage.usage` = accumulated
+  (450/60) with `extra_usage["rounds"] == 3`, `AfterClientCallEvent`
+  totals (450/60), `parrot.client.round.token.usage` recording exactly 4
+  data points (2 rounds × input/output) with correct per-round values,
+  `parrot.client.rounds` summing to 2, and `gen_ai.client.token.usage`
+  recording EXACTLY 2 data points (450/60) — proving no per-round
+  double-counting.
+- `test_per_agent_round_attribution`: under `agent_identity("bot-a")`,
+  both `parrot.client.round.token.usage` and `parrot.client.rounds` carry
+  `parrot.agent.name == "bot-a"`.
 
-**Completed by**:
-**Date**:
-**Notes**:
+Ran the full acceptance-criteria sweep (`test_completion_usage_add.py` +
+`test_client_round_event.py` + `tests/unit/clients/` +
+`test_per_round_metrics.py` + `tests/integration/observability/`): 77
+passed. Also ran the broader `tests/unit/clients/` + `tests/unit/
+observability/` + `tests/integration/observability/`: 176 passed.
 
-**Deviations from spec**: none
+**Deviations from spec**: This integration test exposed a real production
+bug in TASK-2033's `AbstractClient._emit_round_event()` (`clients/base.py`),
+fixed here per this task's explicit authorization ("If an integration
+test exposes a bug, fix it in the owning module and note the
+deviation"). The short-circuit `if not self.events.has_subscribers(
+ClientRoundEvent): return` checked ONLY the client's own isolated
+registry (`forward_to_global=False` by design) — but real consumers like
+`MetricsSubscriber` subscribe on the GLOBAL registry, reached only via
+the explicit `forward_to_global()` bridge that runs AFTER the
+short-circuit. Since no production caller subscribes directly on an
+individual client instance, `ClientRoundEvent` would have been
+silently constructed-and-dropped in every real deployment — the entire
+per-round metrics pipeline (Module 10) would have been dead on arrival.
+Fixed by also checking `navigator_eventbus.lifecycle.global_registry.
+get_global_registry().has_subscribers(ClientRoundEvent)` before
+short-circuiting (lazy import inside the method, mirroring existing
+deferred-import patterns in this codebase). Re-ran
+`tests/unit/clients/test_emit_round_event.py` (TASK-2033's own suite,
+including its zero-subscriber short-circuit test) to confirm the fix
+doesn't regress it — 4 passed.

--- a/sdd/tasks/index/tokens-observability.json
+++ b/sdd/tasks/index/tokens-observability.json
@@ -70,7 +70,7 @@
       "feature_id": "FEAT-397",
       "feature": "tokens-observability",
       "spec": "sdd/specs/tokens-observability.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -81,8 +81,8 @@
       "parallelism_notes": "Touches only clients/claude.py + its own test file; independent of the other four client tasks.",
       "assigned_to": null,
       "started_at": "2026-08-01T00:17:11+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2034-claude-loop-accumulation.md"
+      "completed_at": "2026-08-01T00:42:28+00:00",
+      "file": "sdd/tasks/completed/TASK-2034-claude-loop-accumulation.md"
     },
     {
       "id": "TASK-2035",

--- a/sdd/tasks/index/tokens-observability.json
+++ b/sdd/tasks/index/tokens-observability.json
@@ -133,7 +133,7 @@
       "feature_id": "FEAT-397",
       "feature": "tokens-observability",
       "spec": "sdd/specs/tokens-observability.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -144,8 +144,8 @@
       "parallelism_notes": "Touches only clients/groq.py + its own test file.",
       "assigned_to": null,
       "started_at": "2026-08-01T00:17:11+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2037-groq-loop-accumulation.md"
+      "completed_at": "2026-08-01T01:02:51+00:00",
+      "file": "sdd/tasks/completed/TASK-2037-groq-loop-accumulation.md"
     },
     {
       "id": "TASK-2038",

--- a/sdd/tasks/index/tokens-observability.json
+++ b/sdd/tasks/index/tokens-observability.json
@@ -112,7 +112,7 @@
       "feature_id": "FEAT-397",
       "feature": "tokens-observability",
       "spec": "sdd/specs/tokens-observability.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "depends_on": [
@@ -123,8 +123,8 @@
       "parallelism_notes": "Touches only clients/google/client.py + its own test file. Largest behavioral change (fixes first-response usage bug).",
       "assigned_to": null,
       "started_at": "2026-08-01T00:17:11+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2036-gemini-loop-accumulation.md"
+      "completed_at": "2026-08-01T00:59:37+00:00",
+      "file": "sdd/tasks/completed/TASK-2036-gemini-loop-accumulation.md"
     },
     {
       "id": "TASK-2037",

--- a/sdd/tasks/index/tokens-observability.json
+++ b/sdd/tasks/index/tokens-observability.json
@@ -154,7 +154,7 @@
       "feature_id": "FEAT-397",
       "feature": "tokens-observability",
       "spec": "sdd/specs/tokens-observability.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -165,8 +165,8 @@
       "parallelism_notes": "Touches only clients/grok.py + its own test file.",
       "assigned_to": null,
       "started_at": "2026-08-01T00:17:11+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2038-grok-loop-accumulation.md"
+      "completed_at": "2026-08-01T01:06:14+00:00",
+      "file": "sdd/tasks/completed/TASK-2038-grok-loop-accumulation.md"
     },
     {
       "id": "TASK-2039",

--- a/sdd/tasks/index/tokens-observability.json
+++ b/sdd/tasks/index/tokens-observability.json
@@ -195,7 +195,7 @@
       "feature_id": "FEAT-397",
       "feature": "tokens-observability",
       "spec": "sdd/specs/tokens-observability.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "M",
       "depends_on": [
@@ -210,8 +210,8 @@
       "parallelism_notes": "Final validation gate — requires every implementation task merged.",
       "assigned_to": null,
       "started_at": "2026-08-01T00:17:11+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2040-integration-tests.md"
+      "completed_at": "2026-08-01T01:12:59+00:00",
+      "file": "sdd/tasks/completed/TASK-2040-integration-tests.md"
     }
   ]
 }

--- a/sdd/tasks/index/tokens-observability.json
+++ b/sdd/tasks/index/tokens-observability.json
@@ -14,7 +14,7 @@
       "feature_id": "FEAT-397",
       "feature": "tokens-observability",
       "spec": "sdd/specs/tokens-observability.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [],
@@ -22,8 +22,8 @@
       "parallelism_notes": "Touches only parrot/models/ — no overlap with events or clients tasks.",
       "assigned_to": null,
       "started_at": "2026-08-01T00:17:11+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2031-usage-model-primitives.md"
+      "completed_at": "2026-08-01T00:32:01+00:00",
+      "file": "sdd/tasks/completed/TASK-2031-usage-model-primitives.md"
     },
     {
       "id": "TASK-2032",

--- a/sdd/tasks/index/tokens-observability.json
+++ b/sdd/tasks/index/tokens-observability.json
@@ -50,7 +50,7 @@
       "feature_id": "FEAT-397",
       "feature": "tokens-observability",
       "spec": "sdd/specs/tokens-observability.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -60,8 +60,8 @@
       "parallelism_notes": "Modifies clients/base.py which all client tasks build on; must land before TASK-2034…2038.",
       "assigned_to": null,
       "started_at": "2026-08-01T00:17:11+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2033-emit-round-helper.md"
+      "completed_at": "2026-08-01T00:36:08+00:00",
+      "file": "sdd/tasks/completed/TASK-2033-emit-round-helper.md"
     },
     {
       "id": "TASK-2034",

--- a/sdd/tasks/index/tokens-observability.json
+++ b/sdd/tasks/index/tokens-observability.json
@@ -91,7 +91,7 @@
       "feature_id": "FEAT-397",
       "feature": "tokens-observability",
       "spec": "sdd/specs/tokens-observability.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -102,8 +102,8 @@
       "parallelism_notes": "Touches only clients/gpt.py + its own test file.",
       "assigned_to": null,
       "started_at": "2026-08-01T00:17:11+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2035-openai-loop-accumulation.md"
+      "completed_at": "2026-08-01T00:49:19+00:00",
+      "file": "sdd/tasks/completed/TASK-2035-openai-loop-accumulation.md"
     },
     {
       "id": "TASK-2036",

--- a/sdd/tasks/index/tokens-observability.json
+++ b/sdd/tasks/index/tokens-observability.json
@@ -175,7 +175,7 @@
       "feature_id": "FEAT-397",
       "feature": "tokens-observability",
       "spec": "sdd/specs/tokens-observability.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "M",
       "depends_on": [
@@ -185,8 +185,8 @@
       "parallelism_notes": "Touches only observability/subscribers/metrics.py + its own test file; independent of all client tasks.",
       "assigned_to": null,
       "started_at": "2026-08-01T00:17:11+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2039-per-round-metrics.md"
+      "completed_at": "2026-08-01T00:38:11+00:00",
+      "file": "sdd/tasks/completed/TASK-2039-per-round-metrics.md"
     },
     {
       "id": "TASK-2040",

--- a/sdd/tasks/index/tokens-observability.json
+++ b/sdd/tasks/index/tokens-observability.json
@@ -32,7 +32,7 @@
       "feature_id": "FEAT-397",
       "feature": "tokens-observability",
       "spec": "sdd/specs/tokens-observability.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "S",
       "depends_on": [],
@@ -40,8 +40,8 @@
       "parallelism_notes": "Touches only the events package — independent of TASK-2031.",
       "assigned_to": null,
       "started_at": "2026-08-01T00:17:11+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2032-client-round-event.md"
+      "completed_at": "2026-08-01T00:34:15+00:00",
+      "file": "sdd/tasks/completed/TASK-2032-client-round-event.md"
     },
     {
       "id": "TASK-2033",


### PR DESCRIPTION
## Summary

Accumulates per-round token usage across the tool-use loops of all 5 priority LLM clients (Claude, OpenAI, Gemini, Groq, Grok), fixes Gemini's first-response-only usage bug, adds a new `ClientRoundEvent` lifecycle event + dedicated OTel metrics, and covers the whole pipeline end-to-end.

## Tasks

10/10 tasks verified:

- ✅ TASK-2031 — CompletionUsage.__add__ + AIMessage.total_usage()
- ✅ TASK-2032 — ClientRoundEvent lifecycle event
- ✅ TASK-2033 — AbstractClient._emit_round_event() helper
- ✅ TASK-2034 — Claude client per-round accumulation + events
- ✅ TASK-2035 — OpenAI client per-round accumulation + events
- ✅ TASK-2036 — Gemini client per-round accumulation + first-response usage fix
- ✅ TASK-2037 — Groq client per-round accumulation + events
- ✅ TASK-2038 — Grok client per-round accumulation + events
- ✅ TASK-2039 — MetricsSubscriber per-round OTel instruments
- ✅ TASK-2040 — End-to-end multi-round usage integration tests

## Code review

Adversarial review via code-reviewer agent: 0 critical, 0 important, 1 suggestion (fixed — hoisted a lazy import to module scope), 1 nitpick (noted, not fixed — Grok's `raw_usage` is a curated subset, documented behavior).

Notable: TASK-2040's integration tests surfaced a real production bug in TASK-2033's `_emit_round_event()` short-circuit (it only checked the client's own isolated registry, so `ClientRoundEvent` would never reach `MetricsSubscriber` in real deployments, which subscribes on the global registry). Fixed in the same PR per the task's explicit "fix bugs the integration test exposes" authorization.

## Test plan

- [x] `pytest packages/ai-parrot/tests/unit/models/test_completion_usage_add.py -v`
- [x] `pytest packages/ai-parrot/tests/unit/events/lifecycle/test_client_round_event.py -v`
- [x] `pytest packages/ai-parrot/tests/unit/clients/ -v` (44 passed)
- [x] `pytest packages/ai-parrot/tests/unit/observability/test_per_round_metrics.py -v`
- [x] `pytest packages/ai-parrot/tests/integration/observability/ -v` (16 passed, incl. new end-to-end multi-round test)
- [x] Full feature surface sweep: 77 passed

---
_Closed by /sdd-done_