### PR TITLE
fix(wikitoolkit): a non-UTF-8 config file aborts the entire wiki scan (missed by #1090)

### DIFF
--- a/packages/ai-parrot/src/parrot/knowledge/wiki/languages/javascript.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/languages/javascript.py
@@ -334,16 +334,17 @@ def _aliases_from_tsconfig(data: Any, config_rel: str) -> list[tuple[str, str]]:
     for pattern, targets in paths.items():
         if not isinstance(pattern, str):
             continue
-        target = None
-        if isinstance(targets, list) and targets:
-            target = targets[0]
-        elif isinstance(targets, str):
-            target = targets
-        if not isinstance(target, str):
-            continue
-        pair = _as_prefix_pair(pattern, target, base_dir)
-        if pair is not None:
-            pairs.append(pair)
+        # A `paths` entry may list several fallback targets. Keep them all,
+        # in declared order — `resolve_import` tries each matching prefix
+        # until one lands on a real file, so a target that expands to
+        # nothing simply falls through to the next.
+        candidates = targets if isinstance(targets, list) else [targets]
+        for target in candidates:
+            if not isinstance(target, str):
+                continue
+            pair = _as_prefix_pair(pattern, target, base_dir)
+            if pair is not None:
+                pairs.append(pair)
     return pairs
 
 
@@ -388,12 +389,15 @@ def _discover_aliases(file_set: frozenset[str]) -> tuple[tuple[str, str], ...]:
     ``.svelte-kit/tsconfig.json``, and the committed ``tsconfig.json``
     merely extends it — so a fresh clone declares no alias anywhere.
 
-    *Known limitation*: ``$lib/`` is a single global prefix, so a
-    monorepo with several ``svelte.config.js`` files gets one convention
-    mapping, resolved against whichever config sorts first — not
-    necessarily the one at the repository root. Explicit declarations
-    (steps 1 and 2) always win over the convention, so a monorepo that
-    declares its aliases is unaffected.
+    *Known limitation — the alias map is flat and repository-global.*
+    Prefixes are deduplicated across the whole scan, so when two
+    sub-projects declare the **same** prefix (``"@/*"`` pointing at each
+    app's own ``src/``, a common monorepo shape) the config that sorts
+    first wins for both, and the other app's imports resolve to the wrong
+    files with no diagnostic. The same applies to the step-3 convention:
+    several ``svelte.config.js`` files still yield one ``$lib/`` mapping.
+    Declaring aliases explicitly does **not** avoid this — only
+    per-subtree scoping would, which this implementation does not do.
 
     Args:
         file_set: Every scanned repository path. ``build_reference_index``
@@ -415,7 +419,13 @@ def _discover_aliases(file_set: frozenset[str]) -> tuple[tuple[str, str], ...]:
         path = (scan_root / rel) if scan_root is not None else Path(rel)
         try:
             return path.read_text(encoding="utf-8")
-        except OSError as exc:
+        except (OSError, ValueError) as exc:
+            # ValueError covers UnicodeDecodeError: a config file saved as
+            # UTF-16/Latin-1, or with a stray invalid byte, must degrade
+            # this one alias source — never abort the scan. Alias discovery
+            # runs for every JS/TS repository, and repo_scan calls
+            # build_reference_index unguarded, so a leak here kills the
+            # whole build. Same breadth as the php.py precedent (php.py:362).
             logger.debug("Could not read %s: %s", rel, exc)
             return None
 
@@ -451,12 +461,18 @@ def _discover_aliases(file_set: frozenset[str]) -> tuple[tuple[str, str], ...]:
         target = f"{config_dir}/src/lib/" if config_dir else "src/lib/"
         pairs.append(("$lib/", target))
 
-    deduped: dict[str, str] = {}
-    for prefix, target in pairs:
-        deduped.setdefault(prefix, target)
-    return tuple(
-        sorted(deduped.items(), key=lambda pair: len(pair[0]), reverse=True)
-    )
+    # Deduplicate whole pairs, not prefixes: one prefix may legitimately
+    # have several targets (a `paths` entry with fallbacks, or an explicit
+    # declaration plus the step-3 convention), and `resolve_import` tries
+    # each in turn. `sorted` is stable, so equal-length prefixes keep
+    # discovery order — explicit declarations stay ahead of the convention.
+    seen: set[tuple[str, str]] = set()
+    ordered: list[tuple[str, str]] = []
+    for pair in pairs:
+        if pair not in seen:
+            seen.add(pair)
+            ordered.append(pair)
+    return tuple(sorted(ordered, key=lambda pair: len(pair[0]), reverse=True))
 
 
 def _normalize_posix(path: PurePosixPath) -> str:

--- a/tests/knowledge/wiki/languages/test_javascript_plugin.py
+++ b/tests/knowledge/wiki/languages/test_javascript_plugin.py
@@ -533,6 +533,64 @@ class TestAliasResolution:
             == "src/lib/util.ts"
         )
 
+    @pytest.mark.parametrize(
+        "config_name", ["tsconfig.json", "jsconfig.json", "svelte.config.js"]
+    )
+    def test_non_utf8_config_does_not_abort_the_scan(
+        self, tmp_path, restore_scan_root, config_name
+    ):
+        """A config file that is not valid UTF-8 must degrade, not crash.
+
+        `UnicodeDecodeError` is a `ValueError`, not an `OSError`, so a
+        read guarded only by `OSError` leaks it. `repo_scan` calls
+        `build_reference_index` unguarded, so the leak aborts the whole
+        scan — for any JS/TS repository, not just Svelte ones.
+        """
+        (tmp_path / config_name).write_bytes(b"\xff\xfe{\x00}\x00")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src/a.ts").write_text("import { b } from './b'\n")
+        (tmp_path / "src/b.ts").write_text("export const b = 2\n")
+        restore_scan_root(tmp_path)
+
+        scanner = JavaScriptScanner()
+        index = scanner.build_reference_index(
+            [config_name, "src/a.ts", "src/b.ts"]
+        )
+        # Relative resolution is unaffected by the unreadable config.
+        assert scanner.resolve_import("./b", "src/a.ts", index) == "src/b.ts"
+
+    def test_non_utf8_config_scan_completes_end_to_end(self, tmp_path):
+        """The same, through the real entry point that has no guard."""
+        (tmp_path / "tsconfig.json").write_bytes(b"\xff\xfe{\x00}\x00")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src/a.ts").write_text("import { b } from './b'\n")
+        (tmp_path / "src/b.ts").write_text("export const b = 2\n")
+
+        from parrot.knowledge.wiki.repo_scan import scan_repository
+
+        scan = scan_repository(tmp_path, use_git=False)
+        assert {fs.rel_path for fs in scan.files} >= {"src/a.ts", "src/b.ts"}
+
+    def test_tsconfig_paths_keeps_every_fallback_target(
+        self, tmp_path, restore_scan_root
+    ):
+        """A `paths` entry may list fallbacks; all of them stay usable."""
+        (tmp_path / "tsconfig.json").write_text(
+            '{"compilerOptions": {"baseUrl": ".", "paths": {'
+            '"$lib/*": ["missing/*", "src/lib/*"]}}}'
+        )
+        (tmp_path / "src/lib").mkdir(parents=True)
+        (tmp_path / "src/lib/util.ts").write_text("export function helper() {}\n")
+        restore_scan_root(tmp_path)
+
+        scanner = JavaScriptScanner()
+        index = scanner.build_reference_index(["tsconfig.json", "src/lib/util.ts"])
+        # The first target expands to nothing; the second must still be tried.
+        assert (
+            scanner.resolve_import("$lib/util", "src/routes/x.svelte", index)
+            == "src/lib/util.ts"
+        )
+
     def test_no_scan_root_does_not_raise(self, restore_scan_root):
         """A scanner used outside a scan still builds a usable index."""
         restore_scan_root(None)
@@ -565,7 +623,11 @@ class TestAliasResolution:
         """JsIndex keeps the frozenset's immutability guarantees."""
         restore_scan_root(None)
         index = JavaScriptScanner().build_reference_index(["a.ts"])
-        assert hash(index) is not None
+        # The point is that hashing does not raise, and that equal indexes
+        # hash equally — `hash(x) is not None` would hold for any value.
+        assert hash(index) == hash(
+            JavaScriptScanner().build_reference_index(["a.ts"])
+        )
         with pytest.raises(FrozenInstanceError):
             index.files = frozenset()
 


### PR DESCRIPTION
## Why this exists separately from #1090

#1090 merged at `2026-08-01T01:29:56Z`. This fix was pushed to the branch a few
minutes later, so it landed on the branch **after** the merge and is the one commit
from that work not present on `dev`. Everything else from #1090 is in.

`dev` currently carries the regression described below. This PR is only that one
commit, cherry-picked onto current `dev`.

## The bug

`_discover_aliases`'s `_read()` guards only `OSError`. `UnicodeDecodeError` is a
`ValueError`, not an `OSError`, so any `tsconfig.json` / `jsconfig.json` /
`svelte.config.js` that is not valid UTF-8 — a UTF-16 or Latin-1 save, a stray invalid
byte — leaks out of `build_reference_index`. `repo_scan.py:757` calls that method with
no `try/except`, so **the entire scan aborts**.

Reproduced on a plain TypeScript repo with no Svelte in it at all:

```
SCAN COMPLETO ABORTADO: UnicodeDecodeError
  -> 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte
```

This is not Svelte-specific. `_discover_aliases` runs for every scan containing any
`.js`/`.jsx`/`.mjs`/`.ts`/`.tsx`/`.svelte` file, which in practice means every JS/TS
repository, as soon as it also has a `tsconfig.json` anywhere — nearly universal.

It is strictly worse than the pre-FEAT-396 behaviour, where `build_reference_index`
read no files at all and so could not fail this way, and it violates FEAT-396's own
acceptance criterion that behaviour on `.js`/`.jsx`/`.mjs`/`.ts`/`.tsx` files is
unchanged except for the grammar fix.

**Root cause** is a deviation from spec §7, which required mirroring `php.py`.
`php.py:362` guards the combined read-and-parse with `(OSError, ValueError)`; FEAT-396
split the read from the `json.loads` and widened only the parse side, leaving the read
narrower than the precedent it was told to follow. Now matched.

The pre-existing `test_malformed_tsconfig_degrades_to_convention` covered only a JSON
*syntax* error, which correctly hits the guard around `json.loads` — so the suite's
blind spot sat exactly where the bug lived.

## Also in this commit

Two smaller items found in the same review pass:

- **tsconfig `paths` fallback targets were discarded.** Only `targets[0]` was kept. All
  are kept now, which required deduplicating whole `(prefix, target)` pairs instead of
  prefixes — the previous `setdefault`-by-prefix would have collapsed them straight
  back. `sorted` is stable, so equal-length prefixes keep discovery order and explicit
  declarations stay ahead of the convention fallback.
- **A docstring that was wrong.** The monorepo limitation note claimed explicit alias
  declarations make monorepos safe. They do not — the alias map is flat and
  repository-global, so two sub-projects declaring the same prefix both resolve against
  whichever config sorts first. Corrected to state the real limitation.

`test_index_is_hashable_and_frozen` also had a vacuous assertion (`hash(x) is not
None`, true of any hash value); it now checks that equal indexes hash equally.

## Verification

- New tests: `test_non_utf8_config_does_not_abort_the_scan` (parametrized over all
  three config filenames), `test_non_utf8_config_scan_completes_end_to_end` (through
  `scan_repository` itself, the unguarded entry point), and
  `test_tsconfig_paths_keeps_every_fallback_target`.
- `tests/knowledge/wiki/languages/` — **145 passed, 1 skipped** on this branch.
- The original crash reproduction now completes: `scan OK: 2 archivos, 1 aristas`.
- `ruff` clean.

CI is not usable for this: `dev` has been red since 2026-07-27 on an unrelated
`pillow-heif` conflict that fails `uv sync` before any test runs.

---
_Found by an independent code-review pass. The `codex` CLI that `CLAUDE.md` prescribes
for this is not installed (`exit 127`), so a `code-reviewer` subagent stood in._
