### PR TITLE
fix(formdesigner): bind form_uid as UUID, matching the column 004 creates

### DIFF
--- a/packages/parrot-formdesigner/src/parrot_formdesigner/api/handlers.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/api/handlers.py
@@ -671,10 +671,12 @@ class FormAPIHandler:
                 fuid = row.get("form_uid")
                 if not fuid:
                     continue
-                # storage.list_forms() returns form_uid as a raw string (the
-                # DB column is still VARCHAR(36) until TASK-2008) — normalize
-                # to uuid.UUID so lookups against the in-memory descriptors
-                # (keyed by FormSchema.form_uid, now uuid.UUID) actually match.
+                # Descriptors are keyed by FormSchema.form_uid (uuid.UUID), so
+                # the row's form_uid must be one too. Since the column is now
+                # native UUID, asyncpg already hands back a uuid.UUID and this
+                # branch is inert — kept as belt-and-braces for a deployment
+                # that has not yet applied 004_form_uid_uuid_type.sql, where
+                # the column is still VARCHAR(36) and rows come back as str.
                 if isinstance(fuid, str):
                     try:
                         fuid = _uuid.UUID(fuid)

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/storage.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/storage.py
@@ -11,7 +11,7 @@ the same storage instance can serve many tenants
 
 Table columns:
 - id: UUID primary key
-- form_uid: VARCHAR(36) — immutable UUID identity (FEAT-389). Primary
+- form_uid: UUID — immutable UUID identity (FEAT-389/FEAT-393). Primary
   uniqueness key for this table, together with ``version``.
 - form_id: VARCHAR — mutable, human-readable slug. Kept for display/search
   and slug-based lookups via :meth:`PostgresFormStorage.load_by_slug`.
@@ -156,7 +156,7 @@ class PostgresFormStorage(FormStorage):
         return f"""
         CREATE TABLE IF NOT EXISTS {qt} (
             id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-            form_uid VARCHAR(36) NOT NULL,
+            form_uid UUID NOT NULL,
             form_id VARCHAR(255) NOT NULL,
             version VARCHAR(50) NOT NULL DEFAULT '1.0',
             schema_json JSONB NOT NULL,
@@ -338,8 +338,7 @@ class PostgresFormStorage(FormStorage):
         async with self._pool.acquire() as conn:
             await conn.execute(
                 self._upsert_sql(effective_tenant),
-                # TASK-2008: form_uid column is VARCHAR(36) until migrated.
-                str(form.form_uid),
+                form.form_uid,
                 form.form_id,
                 version,
                 schema_json,
@@ -378,8 +377,7 @@ class PostgresFormStorage(FormStorage):
             FormSchema if found, None otherwise.
         """
         self._require_pool()
-        # TASK-2008: form_uid column is VARCHAR(36) until migrated.
-        form_uid_param = str(form_uid)
+        form_uid_param = form_uid
         async with self._pool.acquire() as conn:
             if version is not None:
                 row = await conn.fetchrow(
@@ -496,8 +494,7 @@ class PostgresFormStorage(FormStorage):
         """
         self._require_pool()
         async with self._pool.acquire() as conn:
-            # TASK-2008: form_uid column is VARCHAR(36) until migrated.
-            result = await conn.execute(self._delete_sql(tenant), str(form_uid))
+            result = await conn.execute(self._delete_sql(tenant), form_uid)
 
         try:
             count = int(result.split()[-1])

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/submissions.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/submissions.py
@@ -184,7 +184,7 @@ class FormSubmissionStorage:
         CREATE TABLE IF NOT EXISTS {qt} (
             id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
             submission_id VARCHAR(255) NOT NULL UNIQUE,
-            form_uid VARCHAR(36),
+            form_uid UUID,
             form_id VARCHAR(255) NOT NULL,
             form_version VARCHAR(50) NOT NULL,
             data JSONB NOT NULL,
@@ -234,7 +234,7 @@ class FormSubmissionStorage:
         schema = self._resolve_schema(tenant)
         return f"""
         ALTER TABLE {qt}
-            ADD COLUMN IF NOT EXISTS form_uid VARCHAR(36),
+            ADD COLUMN IF NOT EXISTS form_uid UUID,
             ADD COLUMN IF NOT EXISTS user_id VARCHAR(255),
             ADD COLUMN IF NOT EXISTS username VARCHAR(255),
             ADD COLUMN IF NOT EXISTS org_id INTEGER,
@@ -318,8 +318,7 @@ class FormSubmissionStorage:
             await conn.execute(
                 self._insert_sql(effective_tenant),
                 submission.submission_id,
-                # TASK-2008: form_uid column is VARCHAR(36) until migrated.
-                str(submission.form_uid),
+                submission.form_uid,
                 submission.form_id,
                 submission.form_version,
                 json.dumps(submission.data),

--- a/packages/parrot-formdesigner/tests/unit/test_storage_form_uid.py
+++ b/packages/parrot-formdesigner/tests/unit/test_storage_form_uid.py
@@ -80,7 +80,7 @@ def test_create_table_sql_includes_form_uid_column_and_constraints() -> None:
     """DDL adds form_uid NOT NULL plus both UNIQUE constraints."""
     storage, _ = _make_storage()
     sql = storage._create_table_sql(None)
-    assert "form_uid VARCHAR(36) NOT NULL" in sql
+    assert "form_uid UUID NOT NULL" in sql
     assert "UNIQUE(form_uid, version)" in sql
     assert "UNIQUE(tenant, form_id, version)" in sql
 
@@ -121,9 +121,14 @@ async def test_save_passes_form_uid_as_first_param() -> None:
     await storage.save(form)
 
     _, args = conn.executed[0]
-    # TASK-2008: form_uid column is VARCHAR(36) until migrated — the storage
-    # boundary binds the canonical UUID string, not the uuid.UUID object.
-    assert args[0] == uid
+    # The column is native UUID (004_form_uid_uuid_type.sql), so the storage
+    # boundary binds a uuid.UUID — asyncpg rejects a str for a uuid parameter
+    # with "'str' object has no attribute 'bytes'". Asserting the TYPE, not
+    # just equality, is the point: `UUID(x) == str(x)` is False in Python, but
+    # a test comparing against `uuid.UUID(uid)` alone would still pass if the
+    # code went back to binding a string in some other shape.
+    assert args[0] == uuid.UUID(uid)
+    assert isinstance(args[0], uuid.UUID)
     assert args[1] == "my-form"
 
 
@@ -144,7 +149,9 @@ async def test_save_and_load_by_form_uid() -> None:
 
     sql, load_args = conn.fetchrow_calls[0]
     assert "form_uid" in sql
-    assert load_args[0] == uid
+    # Bound as a uuid.UUID, not its string form — the column is native UUID.
+    assert load_args[0] == uuid.UUID(uid)
+    assert isinstance(load_args[0], uuid.UUID)
 
 
 @pytest.mark.asyncio
@@ -160,7 +167,8 @@ async def test_load_with_version_queries_form_uid_and_version() -> None:
     assert loaded is not None
     sql, args = conn.fetchrow_calls[0]
     assert "form_uid" in sql and "version" in sql
-    assert args == (uid, "2.0")
+    assert args == (uuid.UUID(uid), "2.0")
+    assert isinstance(args[0], uuid.UUID)
 
 
 # ---------------------------------------------------------------------------
@@ -218,13 +226,19 @@ async def test_delete_by_form_uid() -> None:
     """delete() queries and deletes by form_uid, returning True on success."""
     conn = _Conn(execute_result="DELETE 1")
     storage, _ = _make_storage(conn)
+    uid = uuid.uuid4()
 
-    result = await storage.delete("test-uid-004")
+    result = await storage.delete(uid)
 
     assert result is True
     sql, args = conn.executed[0]
     assert "form_uid" in sql
-    assert args[0] == "test-uid-004"
+    # This used to pass the literal string "test-uid-004" — which is not even
+    # a UUID — and passed only because `delete()` called `str()` on it and the
+    # fake connection type-checks nothing. Against the real native-UUID column
+    # that binding raises. The signature says uuid.UUID; the test now honours it.
+    assert args[0] == uid
+    assert isinstance(args[0], uuid.UUID)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## The bug

`packages/parrot-formdesigner/migrations/004_form_uid_uuid_type.sql` retypes `form_schemas.form_uid` and `form_data.form_uid` to native `UUID`. The storage layer never followed: it still called `str()` on every form_uid before binding, each site marked `# TASK-2008: form_uid column is VARCHAR(36) until migrated`.

**The package ships a migration that breaks its own data access.** Apply 004 — the migration parrot itself publishes — and asyncpg rejects every bind:

```
invalid input for query argument $1: '001308f6-...' ('str' object has no attribute 'bytes')
```

The failure mode is the bad kind. `FormRegistry.load_from_storage()` catches per row and logs a warning (`registry.py:1070`), so **the app boots looking healthy with an empty registry**.

Observed on a real deployment (FieldSync staging, 2026-08-02): 64 forms loaded before applying 004, `Loaded 0 forms from storage` after.

## The fix

The column is UUID, so bind a UUID.

- **`services/storage.py`** — `_create_table_sql` declares `form_uid UUID NOT NULL`; save / load / delete bind `form.form_uid` directly. Module docstring updated.
- **`services/submissions.py`** — same for the `form_data` DDL, its `ADD COLUMN IF NOT EXISTS`, and the insert.
- **`api/handlers.py`** — the `str -> UUID` normalisation in the descriptor merge is **kept**. It is inert against a UUID column and still covers a deployment that has not applied 004. Only its now-false comment is corrected.

## Tests: updated, not deleted

Four tests failed. They were pinning the old contract and were right to fail — so they now pin the new one:

- The DDL assertion becomes `form_uid UUID NOT NULL`.
- save / load / load-with-version assert `isinstance(arg, uuid.UUID)` **as well as** equality. Equality alone would still pass if the code found another way to bind a string.
- `test_delete_by_form_uid` passed the literal `"test-uid-004"` — not even a UUID — to a method annotated `form_uid: uuid.UUID`. It only passed because `delete()` stringified it and the fake connection type-checks nothing. It now uses a real UUID.

## Verification

| | |
|---|---|
| Package suite, this branch | **18 failed / 1790 passed / 80 errors** |
| Same suite, clean `dev` | **18 failed / 1790 passed / 80 errors** |
| Delta | **empty** — the pre-existing failures are untouched |
| End to end vs a real 004-migrated Postgres | `list_forms()` -> 59, `load()` resolves **59 of 59**. Before: **0** |

## Note on compatibility

This is a clean cut: after this change the code requires 004 to have been applied. That matches the direction FEAT-393 already took in Python (`FormSchema.form_uid` is `uuid.UUID`), and 004 is already published. A deployment on an unmigrated column needs to run 004 — which was always the intent, since `initialize()` does not retype.

Worth flagging separately: `migrations/README.md` documents only steps 001-003. 004, 005 and 006 exist in the directory but appear in no execution order, so anyone following the README lands exactly in the state this PR fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)