### PR TITLE
Distinguish missing satellites from broken imports

### DIFF
--- a/packages/ai-parrot/src/parrot/_imports.py
+++ b/packages/ai-parrot/src/parrot/_imports.py
@@ -81,6 +81,32 @@ def _ensure_torchcodec_optional() -> None:
     sys.modules["torchcodec.decoders"] = decoders
 
 
+def _is_missing_module(exc: ImportError, module_path: str) -> bool:
+    """Check whether ``exc`` means ``module_path`` itself is not installed.
+
+    Distinguishes "the module is absent" from "the module is present but
+    something it imports is broken". Only a ``ModuleNotFoundError`` naming
+    ``module_path`` or one of its ancestor packages means the target is
+    genuinely missing; every other ``ImportError`` (a missing name, a
+    missing third-party dependency, a circular import) comes from code that
+    *did* get imported and must not be reported as a missing install.
+
+    Args:
+        exc: The exception raised by ``importlib.import_module``.
+        module_path: Dotted path of the module that was being imported.
+
+    Returns:
+        True if ``module_path`` (or an ancestor package) is the module that
+        could not be found.
+    """
+    if not isinstance(exc, ModuleNotFoundError):
+        return False
+    missing = exc.name
+    if not missing:
+        return False
+    return module_path == missing or module_path.startswith(f"{missing}.")
+
+
 def lazy_import(
     module_path: str,
     package_name: str | None = None,
@@ -130,6 +156,16 @@ def lazy_import(
     try:
         return importlib.import_module(module_path)
     except ImportError as exc:
+        if not _is_missing_module(exc, module_path):
+            # ``module_path`` was found and executed — the failure came from
+            # inside it (a broken dependency of its own, a circular import).
+            # Reporting that as "not installed" sends the reader after a
+            # package that is already there, so re-raise it verbatim.
+            exc.add_note(
+                f"Raised while lazily importing {module_path!r}. The module "
+                f"was found, so this is NOT a missing install."
+            )
+            raise
         pkg = package_name or module_path.split(".")[0]
         if extra:
             msg = (
@@ -142,6 +178,71 @@ def lazy_import(
                 f"Install it with: pip install {pkg}"
             )
         raise ImportError(msg) from exc
+
+
+def load_satellite_attr(
+    name: str,
+    module_path: str,
+    *,
+    install: str,
+    attr: str | None = None,
+) -> object:
+    """Resolve a public name from a satellite package, lazily.
+
+    Used by the core namespace stubs (``parrot.manager``, ``parrot.a2a``,
+    ``parrot.mcp``, ...) whose public API is implemented in a sibling
+    distribution that merges into the same ``parrot.*`` namespace via PEP 420.
+
+    Only a genuinely absent satellite module produces the "install the
+    package" hint. Any other ``ImportError`` is re-raised **unchanged** —
+    same type, same message, same traceback — with a diagnostic note
+    attached. Masking those was how a version skew between ``ai-parrot`` and
+    ``ai-parrot-server`` (a satellite module importing a core symbol that the
+    installed core does not have) surfaced as a misleading "install
+    ai-parrot-server", pointing at a package that was already installed.
+
+    Args:
+        name: Public name being resolved, as written by the caller. Used in
+            the error message.
+        module_path: Dotted path of the satellite module implementing it,
+            e.g. ``"parrot.manager.manager"``.
+        install: pip install target advertised when the satellite is absent,
+            e.g. ``"ai-parrot-server"`` or ``"ai-parrot-server[scheduler]"``.
+        attr: Attribute to read from the module. Defaults to ``name``.
+
+    Returns:
+        The resolved attribute.
+
+    Raises:
+        ImportError: If the satellite module is not installed (with the
+            install hint), or — re-raised untouched — whatever the satellite
+            module's own import failed with.
+        AttributeError: If the module imports cleanly but does not define
+            the requested attribute.
+    """
+    try:
+        module = importlib.import_module(module_path)
+    except ImportError as exc:
+        if _is_missing_module(exc, module_path):
+            raise ImportError(
+                f"{name!r} requires the {install} package. "
+                f"Install it with: pip install {install}"
+            ) from exc
+        # The satellite IS installed — this failure came from inside it.
+        # Re-raise verbatim so the real cause stays at the top of the report.
+        exc.add_note(
+            f"Raised while resolving {name!r} from {module_path!r} "
+            f"({install}). The module was found, so this is NOT a missing "
+            f"install — check for a version mismatch between ai-parrot and "
+            f"its satellite packages, or a missing optional dependency."
+        )
+        raise
+    try:
+        return getattr(module, attr or name)
+    except AttributeError as exc:
+        raise AttributeError(
+            f"module {module_path!r} has no attribute {attr or name!r}"
+        ) from exc
 
 
 def require_extra(extra: str, *modules: str) -> None:

--- a/packages/ai-parrot/src/parrot/a2a/__init__.py
+++ b/packages/ai-parrot/src/parrot/a2a/__init__.py
@@ -155,16 +155,12 @@ _SERVER_CLASSES = {
 
 def __getattr__(name: str):
     if name in _SERVER_CLASSES:
+        from parrot._imports import load_satellite_attr
+
         module_path, cls_name = _SERVER_CLASSES[name]
-        try:
-            import importlib
-            mod = importlib.import_module(module_path)
-            return getattr(mod, cls_name)
-        except ImportError as e:
-            raise ImportError(
-                f"{name!r} requires the ai-parrot-server package. "
-                f"Install it with: pip install ai-parrot-server"
-            ) from e
+        return load_satellite_attr(
+            name, module_path, install="ai-parrot-server", attr=cls_name
+        )
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/packages/ai-parrot/src/parrot/autonomous/__init__.py
+++ b/packages/ai-parrot/src/parrot/autonomous/__init__.py
@@ -50,21 +50,13 @@ _AUTONOMOUS_CLASSES: dict[str, str] = {
 def __getattr__(name: str):
     """Lazy-import autonomous classes from the satellite package."""
     if name in _AUTONOMOUS_CLASSES:
-        import importlib
-        module_path = _AUTONOMOUS_CLASSES[name]
-        try:
-            module = importlib.import_module(module_path)
-        except ImportError as exc:
-            raise ImportError(
-                f"{name!r} requires the ai-parrot-server package. "
-                "Install it with: pip install ai-parrot-server[autonomous]"
-            ) from exc
-        attr = getattr(module, name, None)
-        if attr is None:
-            raise AttributeError(
-                f"module {module_path!r} has no attribute {name!r}"
-            )
-        return attr
+        from parrot._imports import load_satellite_attr
+
+        return load_satellite_attr(
+            name,
+            _AUTONOMOUS_CLASSES[name],
+            install="ai-parrot-server[autonomous]",
+        )
     raise AttributeError(
         f"module 'parrot.autonomous' has no attribute {name!r}. "
         "Install the server package: pip install ai-parrot-server[autonomous]"

--- a/packages/ai-parrot/src/parrot/manager/__init__.py
+++ b/packages/ai-parrot/src/parrot/manager/__init__.py
@@ -15,16 +15,12 @@ _SERVER_CLASSES = {
 
 def __getattr__(name: str):
     if name in _SERVER_CLASSES:
+        from parrot._imports import load_satellite_attr
+
         module_path, cls_name = _SERVER_CLASSES[name]
-        try:
-            import importlib
-            mod = importlib.import_module(module_path)
-            return getattr(mod, cls_name)
-        except ImportError as e:
-            raise ImportError(
-                f"{name!r} requires the ai-parrot-server package. "
-                f"Install it with: pip install ai-parrot-server"
-            ) from e
+        return load_satellite_attr(
+            name, module_path, install="ai-parrot-server", attr=cls_name
+        )
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/packages/ai-parrot/src/parrot/mcp/__init__.py
+++ b/packages/ai-parrot/src/parrot/mcp/__init__.py
@@ -67,16 +67,12 @@ def __getattr__(name: str):
         mod = importlib.import_module(_CORE_CLASSES[name], package=__name__)
         return getattr(mod, name)
     if name in _SERVER_CLASSES:
+        from parrot._imports import load_satellite_attr
+
         module_path, cls_name = _SERVER_CLASSES[name]
-        try:
-            import importlib
-            mod = importlib.import_module(module_path)
-            return getattr(mod, cls_name)
-        except ImportError as e:
-            raise ImportError(
-                f"{name!r} requires the ai-parrot-server package. "
-                f"Install it with: pip install ai-parrot-server"
-            ) from e
+        return load_satellite_attr(
+            name, module_path, install="ai-parrot-server", attr=cls_name
+        )
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/packages/ai-parrot/src/parrot/scheduler/__init__.py
+++ b/packages/ai-parrot/src/parrot/scheduler/__init__.py
@@ -20,16 +20,12 @@ _SERVER_CLASSES = {
 
 def __getattr__(name: str):
     if name in _SERVER_CLASSES:
+        from parrot._imports import load_satellite_attr
+
         module_path, cls_name = _SERVER_CLASSES[name]
-        try:
-            import importlib
-            mod = importlib.import_module(module_path)
-            return getattr(mod, cls_name)
-        except ImportError as e:
-            raise ImportError(
-                f"{name!r} requires the ai-parrot-server package with the scheduler extra. "
-                f"Install it with: pip install ai-parrot-server[scheduler]"
-            ) from e
+        return load_satellite_attr(
+            name, module_path, install="ai-parrot-server[scheduler]", attr=cls_name
+        )
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/packages/ai-parrot/src/parrot/services/__init__.py
+++ b/packages/ai-parrot/src/parrot/services/__init__.py
@@ -22,16 +22,12 @@ _SERVER_CLASSES = {
 
 def __getattr__(name: str):
     if name in _SERVER_CLASSES:
+        from parrot._imports import load_satellite_attr
+
         module_path, cls_name = _SERVER_CLASSES[name]
-        try:
-            import importlib
-            mod = importlib.import_module(module_path)
-            return getattr(mod, cls_name)
-        except ImportError as e:
-            raise ImportError(
-                f"{name!r} requires the ai-parrot-server package. "
-                f"Install it with: pip install ai-parrot-server"
-            ) from e
+        return load_satellite_attr(
+            name, module_path, install="ai-parrot-server", attr=cls_name
+        )
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/packages/ai-parrot/tests/test_lazy_imports.py
+++ b/packages/ai-parrot/tests/test_lazy_imports.py
@@ -6,6 +6,8 @@ Tests cover:
 - Custom package_name parameter
 - Submodule imports
 - Error message formatting
+- load_satellite_attr() discriminating an absent satellite from an installed
+  one whose own import failed (version skew / missing optional dependency)
 """
 
 import builtins
@@ -19,6 +21,7 @@ import pytest
 from parrot._imports import (
     _ensure_torchcodec_optional,
     lazy_import,
+    load_satellite_attr,
     require_extra,
 )
 
@@ -294,7 +297,9 @@ class TestLazyImportIntegration:
         for module_name, package_name, extra in extras_and_packages:
             def blocking_import_module(name, *args, blocked=module_name, orig=original_import_module, **kwargs):
                 if name.split(".")[0] == blocked:
-                    raise ImportError(f"No module named '{name}'")
+                    # Mirror CPython: a missing module is a ModuleNotFoundError
+                    # carrying `.name` — lazy_import discriminates on both.
+                    raise ModuleNotFoundError(f"No module named '{blocked}'", name=blocked)
                 return orig(name, *args, **kwargs)
 
             with patch("parrot._imports.importlib.import_module", side_effect=blocking_import_module):
@@ -314,7 +319,8 @@ class TestLazyImportIntegration:
 
         def block_submod(name, *args, **kwargs):
             if name == "fake_top.submod":
-                raise ImportError(f"No module named '{name}'")
+                # CPython reports the missing *ancestor*, not the submodule.
+                raise ModuleNotFoundError("No module named 'fake_top'", name="fake_top")
             return original_import_module(name, *args, **kwargs)
 
         with patch("parrot._imports.importlib.import_module", side_effect=block_submod):
@@ -331,9 +337,10 @@ class TestLazyImportIntegration:
         call_order = []
 
         def tracking_import_module(name, *args, **kwargs):
-            call_order.append(name.split(".")[0])
-            if name.split(".")[0] in ("missing_a", "missing_b", "missing_c"):
-                raise ImportError(f"No module named '{name}'")
+            top = name.split(".")[0]
+            call_order.append(top)
+            if top in ("missing_a", "missing_b", "missing_c"):
+                raise ModuleNotFoundError(f"No module named '{top}'", name=top)
             return original_import_module(name, *args, **kwargs)
 
         with patch("parrot._imports.importlib.import_module", side_effect=tracking_import_module):
@@ -344,3 +351,141 @@ class TestLazyImportIntegration:
         # missing_b and missing_c should NOT have been tried
         assert "missing_b" not in call_order
         assert "missing_c" not in call_order
+
+
+class TestLoadSatelliteAttr:
+    """Tests for load_satellite_attr() — satellite resolution without masking.
+
+    The core namespace stubs (``parrot.manager``, ``parrot.a2a``, ...) resolve
+    their public API from a sibling distribution. Only a genuinely absent
+    satellite may be reported as "install the package"; every other
+    ``ImportError`` must survive verbatim, because masking it is what turned a
+    version skew between ``ai-parrot`` and ``ai-parrot-server`` into a
+    misleading "install ai-parrot-server" for an already-installed package.
+    """
+
+    @staticmethod
+    def _raising(exc):
+        """Build an import_module side effect that always raises ``exc``."""
+        def _side_effect(name, *args, **kwargs):
+            raise exc
+        return _side_effect
+
+    def test_absent_satellite_reports_install_hint(self):
+        """A missing satellite module produces the actionable install hint."""
+        exc = ModuleNotFoundError(
+            "No module named 'parrot.manager.manager'", name="parrot.manager.manager"
+        )
+        with patch("parrot._imports.importlib.import_module", side_effect=self._raising(exc)):
+            with pytest.raises(ImportError, match=r"pip install ai-parrot-server") as info:
+                load_satellite_attr(
+                    "BotManager", "parrot.manager.manager", install="ai-parrot-server"
+                )
+        assert "BotManager" in str(info.value)
+        assert info.value.__cause__ is exc
+
+    def test_absent_ancestor_package_reports_install_hint(self):
+        """A missing ancestor package also means the satellite is not installed."""
+        exc = ModuleNotFoundError("No module named 'parrot.manager'", name="parrot.manager")
+        with patch("parrot._imports.importlib.import_module", side_effect=self._raising(exc)):
+            with pytest.raises(ImportError, match=r"pip install ai-parrot-server"):
+                load_satellite_attr(
+                    "BotManager", "parrot.manager.manager", install="ai-parrot-server"
+                )
+
+    def test_version_skew_reraises_original_error(self):
+        """A missing symbol in a core module is re-raised untouched.
+
+        Regression test for the reported failure: ai-parrot-server shipped a
+        handler importing ``build_principal_context`` from a core module that
+        an older installed ``ai-parrot`` did not define.
+        """
+        exc = ImportError(
+            "cannot import name 'build_principal_context' from "
+            "'parrot.auth.permission' (/x/parrot/auth/permission.py)",
+            name="parrot.auth.permission",
+        )
+        with patch("parrot._imports.importlib.import_module", side_effect=self._raising(exc)):
+            with pytest.raises(ImportError) as info:
+                load_satellite_attr(
+                    "BotManager", "parrot.manager.manager", install="ai-parrot-server"
+                )
+        assert info.value is exc
+        assert "build_principal_context" in str(info.value)
+        assert "pip install" not in str(info.value)
+
+    def test_reraised_error_carries_diagnostic_note(self):
+        """The re-raised error is annotated instead of replaced."""
+        exc = ImportError("cannot import name 'X' from 'parrot.auth.permission'")
+        with patch("parrot._imports.importlib.import_module", side_effect=self._raising(exc)):
+            with pytest.raises(ImportError) as info:
+                load_satellite_attr(
+                    "BotManager", "parrot.manager.manager", install="ai-parrot-server"
+                )
+        notes = " ".join(getattr(info.value, "__notes__", []))
+        assert "NOT a missing install" in notes
+        assert "parrot.manager.manager" in notes
+
+    def test_missing_optional_dependency_reraises_original_error(self):
+        """A third-party dep missing inside an installed satellite is not masked."""
+        exc = ModuleNotFoundError("No module named 'apscheduler'", name="apscheduler")
+        with patch("parrot._imports.importlib.import_module", side_effect=self._raising(exc)):
+            with pytest.raises(ModuleNotFoundError) as info:
+                load_satellite_attr(
+                    "AgentSchedulerManager",
+                    "parrot.scheduler.manager",
+                    install="ai-parrot-server[scheduler]",
+                )
+        assert info.value is exc
+        assert "apscheduler" in str(info.value)
+
+    def test_resolves_attribute_from_installed_module(self):
+        """The happy path returns the attribute itself."""
+        import json
+
+        resolved = load_satellite_attr("dumps", "json", install="ai-parrot-server")
+        assert resolved is json.dumps
+
+    def test_attr_overrides_public_name(self):
+        """``attr`` resolves a differently-named attribute in the target module."""
+        import json
+
+        resolved = load_satellite_attr(
+            "PublicName", "json", install="ai-parrot-server", attr="loads"
+        )
+        assert resolved is json.loads
+
+    def test_absent_attribute_raises_attribute_error(self):
+        """A clean import with no such attribute is an AttributeError, not ImportError."""
+        with pytest.raises(AttributeError, match=r"has no attribute 'NopeNotHere'"):
+            load_satellite_attr("NopeNotHere", "json", install="ai-parrot-server")
+
+
+class TestLazyImportDoesNotMaskBrokenModules:
+    """lazy_import must not report an installed-but-broken module as missing."""
+
+    def test_broken_installed_module_reraises_original_error(self):
+        """An error raised from *inside* the module survives verbatim."""
+        exc = ImportError("libavdevice.so: cannot open shared object file")
+
+        def _side_effect(name, *args, **kwargs):
+            raise exc
+
+        with patch("parrot._imports.importlib.import_module", side_effect=_side_effect):
+            with pytest.raises(ImportError) as info:
+                lazy_import("pydub", extra="audio")
+        assert info.value is exc
+        assert "not installed" not in str(info.value)
+        notes = " ".join(getattr(info.value, "__notes__", []))
+        assert "NOT a missing install" in notes
+
+    def test_genuinely_missing_module_still_reports_install_hint(self):
+        """The real missing-install path is unchanged."""
+        exc = ModuleNotFoundError("No module named 'pydub'", name="pydub")
+
+        def _side_effect(name, *args, **kwargs):
+            raise exc
+
+        with patch("parrot._imports.importlib.import_module", side_effect=_side_effect):
+            with pytest.raises(ImportError, match=r"pip install ai-parrot\[audio\]"):
+                lazy_import("pydub", extra="audio")


### PR DESCRIPTION
## Summary

Refactor import error handling to correctly distinguish between genuinely missing satellite packages and installed packages that fail to import due to version skew, missing optional dependencies, or internal errors. This prevents misleading "install the package" hints when the package is already installed but broken.

## Key Changes

- **New `_is_missing_module()` helper**: Inspects `ModuleNotFoundError` to determine if a module is genuinely absent (by checking `.name` attribute) versus present but internally broken. Only `ModuleNotFoundError` with a matching module name indicates a missing install; all other `ImportError` types come from code that was found and executed.

- **Enhanced `lazy_import()` error handling**: Now re-raises non-missing `ImportError` exceptions verbatim with a diagnostic note, instead of masking them as missing installs. Preserves the original exception type, message, and traceback for debugging.

- **New `load_satellite_attr()` function**: Centralizes satellite package resolution logic used by namespace stubs (`parrot.manager`, `parrot.a2a`, `parrot.mcp`, `parrot.scheduler`, `parrot.services`, `parrot.autonomous`). Applies the same discrimination: only genuinely absent satellites produce the "install" hint; all other import failures are re-raised with diagnostic context.

- **Refactored namespace stubs**: All `__getattr__` implementations in core namespace modules now delegate to `load_satellite_attr()`, eliminating duplicated error-handling logic and ensuring consistent behavior across all satellite resolution points.

- **Comprehensive test coverage**: Added `TestLoadSatelliteAttr` and `TestLazyImportDoesNotMaskBrokenModules` test classes covering:
  - Absent satellites (install hint)
  - Absent ancestor packages (install hint)
  - Version skew / missing symbols (re-raised untouched)
  - Missing optional dependencies (re-raised untouched)
  - Diagnostic notes on re-raised errors
  - Happy path attribute resolution

- **Test infrastructure updates**: Updated existing test mocks to use `ModuleNotFoundError` with `.name` attribute (matching CPython behavior) instead of generic `ImportError`.

## Implementation Details

The core insight is that `ModuleNotFoundError` carries a `.name` attribute identifying which module could not be found. By comparing this against the requested module path and its ancestors, we can distinguish:
- **Missing**: `exc.name == module_path` or `module_path.startswith(f"{exc.name}.")`
- **Broken**: Any other `ImportError` type, or `ModuleNotFoundError` with a different `.name`

This fixes the reported regression where `ai-parrot-server` importing a symbol from a core module that an older `ai-parrot` didn't define was incorrectly reported as "install ai-parrot-server" instead of surfacing the actual version mismatch error.

https://claude.ai/code/session_01HLRSA4SXh3ijVx9nGciUux