### PR TITLE
feat(webagent-cicd-qa-runner): FEAT-410 — WebAgent CI/CD QA Runner Enhancements

### DIFF
--- a/examples/chrome_ci_test.py
+++ b/examples/chrome_ci_test.py
@@ -1,0 +1,149 @@
+"""WebAgent CI/CD QA testing example.
+
+Designed for CI pipelines — runs headless, filters by tags, retries
+flaky tests, applies a per-test timeout, saves failure screenshots as
+CI artifacts, writes JUnit XML for the test dashboard, and exits with
+0 (all pass) or 1 (any failure/error) for deploy-or-block gate
+decisions.
+
+Usage:
+    # In CircleCI / GitHub Actions / GitLab CI:
+    CHROME_HEADLESS=1 TARGET_URL=http://localhost:3000 \\
+        python examples/chrome_ci_test.py
+
+    # With tag filtering (only run smoke tests on a PR):
+    QA_TAGS=smoke CHROME_HEADLESS=1 python examples/chrome_ci_test.py
+
+    # Or use the CLI runner directly with the sample test file:
+    python -m parrot.bots.chrome_runner \\
+        --test-file examples/qa-tests-sample.json \\
+        --headless --tags smoke \\
+        --junit-output qa-results/results.xml \\
+        --screenshot-dir qa-screenshots/
+
+Example .circleci/config.yml snippet:
+    jobs:
+      ui-qa:
+        docker:
+          - image: cimg/python:3.12-browsers
+        steps:
+          - checkout
+          - run: uv pip install -e ".[all]"
+          - run:
+              command: python -m myapp serve --port 3000
+              background: true
+          - run: |
+              CHROME_HEADLESS=1 TARGET_URL=http://localhost:3000 \\
+              python examples/chrome_ci_test.py
+          - store_test_results:
+              path: qa-results/
+          - store_artifacts:
+              path: qa-screenshots/
+"""
+
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from parrot.bots.chrome import (
+    ChromeConfig,
+    QAAssertion,
+    QATestCase,
+    WebAgent,
+)
+
+logging.basicConfig(level=logging.INFO)
+
+QA_RESULTS_DIR = "qa-results"
+QA_SCREENSHOTS_DIR = "qa-screenshots"
+
+
+async def main() -> int:
+    target = os.getenv("TARGET_URL", "http://localhost:3000")
+    headless = os.getenv("CHROME_HEADLESS", "1") == "1"
+    tags_env = os.getenv("QA_TAGS")
+    tags = tags_env.split(",") if tags_env else ["smoke"]
+
+    os.makedirs(QA_RESULTS_DIR, exist_ok=True)
+    os.makedirs(QA_SCREENSHOTS_DIR, exist_ok=True)
+
+    agent = WebAgent(
+        name="CI-QA-Agent",
+        chrome_config=ChromeConfig(
+            headless=headless,
+            viewport="1920x1080",
+            no_usage_statistics=True,
+        ),
+        default_timeout_ms=60_000,
+        screenshot_dir=QA_SCREENSHOTS_DIR,
+    )
+
+    test_cases = [
+        QATestCase(
+            name="homepage-smoke",
+            url=target,
+            steps=["Wait for the page to fully load"],
+            expected="Page loads without errors",
+            assertions=[
+                QAAssertion(check="no_console_errors"),
+                QAAssertion(check="no_network_failures"),
+                QAAssertion(check="response_status", target="200"),
+            ],
+            tags=["smoke"],
+            max_retries=1,
+            timeout_ms=30_000,
+        ),
+        QATestCase(
+            name="login-validation",
+            url=f"{target}/login",
+            steps=[
+                "Leave the email field empty",
+                "Click the submit/login button",
+            ],
+            expected="Validation errors appear for required fields",
+            assertions=[
+                QAAssertion(check="url_matches", target="/login"),
+                QAAssertion(
+                    check="element_visible",
+                    target=".error-message",
+                    wait_timeout_ms=3000,
+                ),
+            ],
+            tags=["regression"],
+        ),
+    ]
+
+    await agent.configure()
+    async with agent:
+        result = await agent.run_tests(test_cases, url=target, tags=tags)
+
+    report = result.output
+
+    print(f"\n{'=' * 60}")
+    print(f"QA Report: {report.url}")
+    print(f"{'=' * 60}")
+    print(f"Summary: {report.summary}")
+    print(
+        f"Total: {report.total} | Passed: {report.passed} | "
+        f"Failed: {report.failed} | Errors: {report.errors} | "
+        f"Skipped: {report.skipped}"
+    )
+    for finding in report.findings:
+        print(f"  [{finding.status.upper()}] {finding.test_name}: {finding.detail}")
+        if finding.console_errors:
+            for err in finding.console_errors:
+                print(f"        Console: {err}")
+
+    junit_path = os.path.join(QA_RESULTS_DIR, "results.xml")
+    Path(junit_path).write_text(report.to_junit_xml(), encoding="utf-8")
+    print(f"\nJUnit XML written to: {junit_path}")
+
+    return report.exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/examples/chrome_qa_test.py
+++ b/examples/chrome_qa_test.py
@@ -1,5 +1,11 @@
 """WebAgent QA testing example.
 
+Demonstrates `max_retries` (flakiness absorption), `timeout_ms` (per-test
+timeout), `wait_timeout_ms` (element-wait semantics), and the
+`response_status` assertion. For a full CI/CD pipeline example (headless,
+tag filtering, JUnit XML, screenshots, exit code), see
+`examples/chrome_ci_test.py`.
+
 Usage:
     # Visible Chrome (default):
     python examples/chrome_qa_test.py
@@ -50,8 +56,11 @@ async def main():
             assertions=[
                 QAAssertion(check="no_console_errors"),
                 QAAssertion(check="no_network_failures"),
+                QAAssertion(check="response_status", target="200"),
             ],
             tags=["smoke"],
+            max_retries=1,       # Retry once on failure (absorbs flakiness)
+            timeout_ms=30_000,   # Abort after 30s so CI doesn't hang
         ),
         QATestCase(
             name="login-validation",
@@ -64,7 +73,11 @@ async def main():
             expected="Validation errors appear for required fields",
             assertions=[
                 QAAssertion(check="url_matches", target="/login"),
-                QAAssertion(check="element_visible", target=".error-message"),
+                QAAssertion(
+                    check="element_visible",
+                    target=".error-message",
+                    wait_timeout_ms=3000,  # Wait up to 3s for the error to render
+                ),
             ],
             tags=["regression"],
         ),

--- a/examples/qa-tests-sample.json
+++ b/examples/qa-tests-sample.json
@@ -1,0 +1,45 @@
+[
+  {
+    "name": "homepage-smoke",
+    "url": "http://localhost:3000",
+    "steps": ["Wait for the page to fully load"],
+    "expected": "Page loads without errors",
+    "assertions": [
+      {"check": "no_console_errors"},
+      {"check": "no_network_failures"},
+      {"check": "response_status", "target": "200"}
+    ],
+    "tags": ["smoke"],
+    "max_retries": 1,
+    "timeout_ms": 30000
+  },
+  {
+    "name": "login-validation",
+    "url": "http://localhost:3000/login",
+    "steps": [
+      "Leave the email field empty",
+      "Type '123' in the password field",
+      "Click the submit/login button"
+    ],
+    "expected": "Validation errors appear for required fields",
+    "assertions": [
+      {"check": "url_matches", "target": "/login"},
+      {
+        "check": "element_visible",
+        "target": ".error-message",
+        "wait_timeout_ms": 3000
+      }
+    ],
+    "tags": ["regression"]
+  },
+  {
+    "name": "accessibility-check",
+    "url": "http://localhost:3000",
+    "steps": ["Wait for the page to fully load"],
+    "expected": "Page meets basic accessibility standards",
+    "assertions": [
+      {"check": "accessibility_check"}
+    ],
+    "tags": ["smoke", "accessibility"]
+  }
+]

--- a/packages/ai-parrot/src/parrot/bots/chrome.py
+++ b/packages/ai-parrot/src/parrot/bots/chrome.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import time
 import xml.etree.ElementTree as ET
 from typing import Literal
 
@@ -355,7 +356,7 @@ class WebAgent(BasicAgent):
             AIMessage with the aggregate QAReport in `.output` and the
             summary in `.response`.
         """
-        base_url = url or test_cases[0].url
+        base_url = url or (test_cases[0].url if test_cases else "")
         findings: list[QAFinding] = []
 
         for case in test_cases:
@@ -383,6 +384,19 @@ class WebAgent(BasicAgent):
                         test_name=case.name,
                         status="error",
                         detail=f"Test timed out after {timeout_ms}ms",
+                    )
+                except Exception as exc:
+                    # CI reliability: a single failing test case (LLM/MCP/
+                    # network error) must not abort the whole suite (see
+                    # spec Motivation: "a single network glitch... causing
+                    # false negatives").
+                    self.logger.exception(
+                        "QA test case %r raised an unexpected error", case.name
+                    )
+                    finding = QAFinding(
+                        test_name=case.name,
+                        status="error",
+                        detail=f"Unexpected error: {exc}",
                     )
                 finding.retries = attempt
                 if finding.status == "pass":
@@ -436,7 +450,14 @@ class WebAgent(BasicAgent):
             f"Take a screenshot on failure if screenshot_on_fail is true.\n"
         )
         if self.screenshot_dir:
-            prompt += f"Save failure screenshots to: {self.screenshot_dir}\n"
+            timestamp = int(time.time())
+            screenshot_path = f"{self.screenshot_dir}/{case.name}_{timestamp}.png"
+            prompt += (
+                f"On failure, save the screenshot to exactly this path: "
+                f"{screenshot_path}\n"
+                f"Report this exact path in the finding's screenshot_path "
+                f"field.\n"
+            )
         for assertion in case.assertions:
             if assertion.wait_timeout_ms and assertion.check in (
                 "element_visible",

--- a/packages/ai-parrot/src/parrot/bots/chrome.py
+++ b/packages/ai-parrot/src/parrot/bots/chrome.py
@@ -1,12 +1,13 @@
 """WebAgent — browser interaction via Chrome DevTools MCP."""
 
+import asyncio
 import logging
 import xml.etree.ElementTree as ET
 from typing import Literal
 
 from pydantic import BaseModel, Field
 
-from ..models import AIMessage
+from ..models import AIMessage, CompletionUsage
 from .agent import BasicAgent
 
 
@@ -258,6 +259,25 @@ When given QA test cases, execute each one methodically:
 4. Take a screenshot on failure if requested
 5. Report findings with pass/fail status and details
 
+Assertion types you support:
+- element_visible: Check if a CSS selector is visible on the page. Respect \
+  the wait_timeout_ms — wait up to that many milliseconds before declaring \
+  the element not found.
+- element_not_visible: Inverse of element_visible.
+- text_contains: Check if the page contains the specified text.
+- url_matches: Check the current URL matches the target pattern.
+- no_console_errors: Verify no JavaScript errors in the console.
+- no_network_failures: Verify no failed network requests (4xx/5xx).
+- response_status: Verify the HTTP response status code matches the target \
+  value.
+- accessibility_check: Perform basic accessibility validation — check for \
+  ARIA roles, alt text on images, and proper heading hierarchy.
+- screenshot_diff: (placeholder — not yet implemented)
+- performance: Check performance metrics against thresholds.
+
+When an assertion has a wait_timeout_ms value, wait up to that many \
+milliseconds for the condition to become true before reporting failure.
+
 When used for general web interaction, follow the user's instructions and \
 report what you observe.
 
@@ -275,6 +295,8 @@ class WebAgent(BasicAgent):
         self,
         name: str = "WebAgent",
         chrome_config: ChromeConfig | None = None,
+        default_timeout_ms: int = 60_000,
+        screenshot_dir: str | None = None,
         **kwargs,
     ):
         super().__init__(name=name, **kwargs)
@@ -284,6 +306,8 @@ class WebAgent(BasicAgent):
         # silently discard WEB_AGENT_SYSTEM_PROMPT. Force the legacy path.
         self._prompt_builder = None
         self.chrome_config = chrome_config or ChromeConfig()
+        self.default_timeout_ms = default_timeout_ms
+        self.screenshot_dir = screenshot_dir
         self.logger = logging.getLogger(f"{self.name}.WebAgent")
 
     async def configure(self, app=None) -> None:
@@ -312,25 +336,118 @@ class WebAgent(BasicAgent):
         self,
         test_cases: list[QATestCase],
         url: str | None = None,
+        tags: list[str] | None = None,
     ) -> AIMessage:
         """Execute QA test cases and return a structured QAReport.
+
+        Each test case is executed individually (one `ask()` call per
+        case) so that per-test retry and timeout can be applied. Cases
+        that don't match `tags` (when provided) are reported as
+        `status="skip"` without calling the LLM.
 
         Args:
             test_cases: List of test cases to execute.
             url: Base URL override (defaults to first test case's URL).
+            tags: Optional tag filter — only test cases whose `tags`
+                intersect this list are executed. `None` runs all cases.
 
         Returns:
-            AIMessage with QAReport in .output and summary in .response.
+            AIMessage with the aggregate QAReport in `.output` and the
+            summary in `.response`.
         """
-        cases_text = "\n\n".join(
-            case.model_dump_json(indent=2) for case in test_cases
-        )
         base_url = url or test_cases[0].url
-        prompt = (
-            f"Execute the following QA test cases against {base_url}.\n"
-            f"For each test: navigate to the URL, execute the steps, "
-            f"evaluate the expected result and any assertions.\n"
-            f"Take a screenshot on failure if screenshot_on_fail is true.\n\n"
-            f"Test cases:\n{cases_text}"
+        findings: list[QAFinding] = []
+
+        for case in test_cases:
+            if tags and not set(tags).intersection(case.tags):
+                findings.append(
+                    QAFinding(
+                        test_name=case.name,
+                        status="skip",
+                        detail="Filtered by tags",
+                    )
+                )
+                continue
+
+            finding: QAFinding | None = None
+            for attempt in range(1 + case.max_retries):
+                timeout_ms = case.timeout_ms or self.default_timeout_ms
+                timeout_s = timeout_ms / 1000
+                try:
+                    finding = await asyncio.wait_for(
+                        self._execute_single_test(case, base_url),
+                        timeout=timeout_s,
+                    )
+                except TimeoutError:
+                    finding = QAFinding(
+                        test_name=case.name,
+                        status="error",
+                        detail=f"Test timed out after {timeout_ms}ms",
+                    )
+                finding.retries = attempt
+                if finding.status == "pass":
+                    break
+            findings.append(finding)
+
+        report = QAReport(
+            summary=(
+                f"{sum(1 for f in findings if f.status == 'pass')}/"
+                f"{len(findings)} passed"
+            ),
+            url=base_url,
+            findings=findings,
+            total=len(findings),
+            passed=sum(1 for f in findings if f.status == "pass"),
+            failed=sum(1 for f in findings if f.status == "fail"),
+            errors=sum(1 for f in findings if f.status == "error"),
+            skipped=sum(1 for f in findings if f.status == "skip"),
         )
-        return await self.ask(prompt, structured_output=QAReport)
+        return AIMessage(
+            input=f"Execute {len(test_cases)} QA test case(s) against {base_url}",
+            output=report,
+            response=report.summary,
+            model="",
+            provider="",
+            usage=CompletionUsage(
+                prompt_tokens=0, completion_tokens=0, total_tokens=0
+            ),
+        )
+
+    async def _execute_single_test(
+        self,
+        case: QATestCase,
+        base_url: str,
+    ) -> QAFinding:
+        """Execute a single QA test case and return its finding.
+
+        Args:
+            case: The test case to execute.
+            base_url: Base URL to report in the prompt (test cases may
+                have their own `url`, but `base_url` reflects the
+                `run_tests()`-level override).
+
+        Returns:
+            QAFinding: The structured result of executing this test case.
+        """
+        prompt = (
+            f"Execute the following QA test case against {base_url}.\n"
+            f"Navigate to the URL, execute the steps, evaluate the "
+            f"expected result and any assertions.\n"
+            f"Take a screenshot on failure if screenshot_on_fail is true.\n"
+        )
+        if self.screenshot_dir:
+            prompt += f"Save failure screenshots to: {self.screenshot_dir}\n"
+        for assertion in case.assertions:
+            if assertion.wait_timeout_ms and assertion.check in (
+                "element_visible",
+                "element_not_visible",
+                "text_contains",
+            ):
+                prompt += (
+                    f"For '{assertion.check}' on '{assertion.target}': "
+                    f"wait up to {assertion.wait_timeout_ms}ms.\n"
+                )
+        prompt += f"\nTest case:\n{case.model_dump_json(indent=2)}"
+
+        result = await self.ask(prompt, structured_output=QAFinding)
+        return result.output

--- a/packages/ai-parrot/src/parrot/bots/chrome.py
+++ b/packages/ai-parrot/src/parrot/bots/chrome.py
@@ -1,6 +1,7 @@
 """WebAgent — browser interaction via Chrome DevTools MCP."""
 
 import logging
+import xml.etree.ElementTree as ET
 from typing import Literal
 
 from pydantic import BaseModel, Field
@@ -153,6 +154,95 @@ class QAReport(BaseModel):
     errors: int = 0
     skipped: int = 0
     duration_ms: int | None = None
+
+    @property
+    def exit_code(self) -> int:
+        """Return 0 if all tests passed, 1 if any failure or error occurred.
+
+        Returns:
+            int: `0` when `failed + errors == 0`, otherwise `1`. Intended
+            to be used directly as a CI process exit code.
+        """
+        return 1 if (self.failed + self.errors) > 0 else 0
+
+    def to_junit_xml(self, suite_name: str = "WebAgent QA") -> str:
+        """Serialize this report to a JUnit XML document.
+
+        Uses only `xml.etree.ElementTree` (stdlib) to build a
+        `<testsuites><testsuite>...</testsuite></testsuites>` document
+        compatible with CircleCI, GitHub Actions, GitLab CI, and Jenkins
+        JUnit parsers.
+
+        Args:
+            suite_name: Name reported for the `<testsuite>` element and
+                used as the `classname` attribute on each `<testcase>`.
+
+        Returns:
+            str: The complete XML document (including the XML
+            declaration) as a string.
+        """
+        testsuites = ET.Element("testsuites")
+        total_time = (self.duration_ms or 0) / 1000
+        testsuite = ET.SubElement(
+            testsuites,
+            "testsuite",
+            {
+                "name": suite_name,
+                "tests": str(self.total),
+                "failures": str(self.failed),
+                "errors": str(self.errors),
+                "skipped": str(self.skipped),
+                "time": str(total_time),
+            },
+        )
+        for finding in self.findings:
+            time_s = (finding.duration_ms or 0) / 1000
+            testcase = ET.SubElement(
+                testsuite,
+                "testcase",
+                {
+                    "name": finding.test_name,
+                    "classname": suite_name,
+                    "time": str(time_s),
+                },
+            )
+            if finding.status == "fail":
+                failure = ET.SubElement(
+                    testcase, "failure", {"message": finding.detail}
+                )
+                failure.text = self._junit_detail_body(finding)
+            elif finding.status == "error":
+                error = ET.SubElement(
+                    testcase, "error", {"message": finding.detail}
+                )
+                error.text = self._junit_detail_body(finding)
+            elif finding.status == "skip":
+                ET.SubElement(testcase, "skipped", {"message": finding.detail})
+            # "pass" -> no child element
+
+        return ET.tostring(
+            testsuites, encoding="unicode", xml_declaration=True
+        )
+
+    @staticmethod
+    def _junit_detail_body(finding: "QAFinding") -> str:
+        """Build the failure/error text body for a `QAFinding`.
+
+        Args:
+            finding: The finding to render (status must be "fail" or
+                "error").
+
+        Returns:
+            str: Multi-line body with detail, console errors (if any),
+            and retry count (if > 0).
+        """
+        lines = [f"Detail: {finding.detail}"]
+        if finding.console_errors:
+            lines.append("Console errors:")
+            lines.extend(f"- {err}" for err in finding.console_errors)
+        if finding.retries > 0:
+            lines.append(f"Retries: {finding.retries}")
+        return "\n" + "\n".join(lines) + "\n"
 
 
 WEB_AGENT_SYSTEM_PROMPT = """\

--- a/packages/ai-parrot/src/parrot/bots/chrome.py
+++ b/packages/ai-parrot/src/parrot/bots/chrome.py
@@ -94,9 +94,16 @@ class QAAssertion(BaseModel):
         "no_network_failures",
         "screenshot_diff",
         "performance",
+        "response_status",
+        "accessibility_check",
     ]
     target: str | None = None
     value: str | None = None
+    wait_timeout_ms: int = Field(
+        default=5000,
+        ge=0,
+        description="Max wait for element-based checks before asserting",
+    )
 
 
 class QATestCase(BaseModel):
@@ -110,6 +117,16 @@ class QATestCase(BaseModel):
     screenshot_on_fail: bool = True
     viewport: str | None = None
     tags: list[str] = []
+    max_retries: int = Field(
+        default=0,
+        ge=0,
+        description="Retry failed test up to N times before final failure",
+    )
+    timeout_ms: int | None = Field(
+        default=None,
+        ge=1000,
+        description="Per-test timeout in ms; None -> use agent default",
+    )
 
 
 class QAFinding(BaseModel):
@@ -121,6 +138,7 @@ class QAFinding(BaseModel):
     screenshot_path: str | None = None
     console_errors: list[str] = []
     duration_ms: int | None = None
+    retries: int = 0
 
 
 class QAReport(BaseModel):

--- a/packages/ai-parrot/src/parrot/bots/chrome_runner.py
+++ b/packages/ai-parrot/src/parrot/bots/chrome_runner.py
@@ -19,6 +19,8 @@ import os
 import sys
 from pathlib import Path
 
+from pydantic import ValidationError
+
 from .chrome import ChromeConfig, QATestCase, WebAgent
 
 logger = logging.getLogger(__name__)
@@ -37,7 +39,8 @@ def load_test_cases(test_file: str) -> list[QATestCase]:
 
     Raises:
         SystemExit: With code 2 if the file cannot be read, is not valid
-            JSON/YAML, or (for YAML) PyYAML is not installed.
+            JSON/YAML, does not validate as `QATestCase`(s), or (for
+            YAML) PyYAML is not installed.
     """
     path = Path(test_file)
     if not path.is_file():
@@ -66,7 +69,14 @@ def load_test_cases(test_file: str) -> list[QATestCase]:
 
     if not isinstance(raw, list):
         raw = [raw]
-    return [QATestCase.model_validate(item) for item in raw]
+    try:
+        return [QATestCase.model_validate(item) for item in raw]
+    except ValidationError as exc:
+        print(
+            f"ERROR: invalid test case definition in {test_file}:\n{exc}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/packages/ai-parrot/src/parrot/bots/chrome_runner.py
+++ b/packages/ai-parrot/src/parrot/bots/chrome_runner.py
@@ -1,0 +1,216 @@
+"""CLI runner for WebAgent QA tests.
+
+Provides a zero-code entry point for running `WebAgent` QA test suites
+from CI/CD pipelines (CircleCI, GitHub Actions, GitLab CI).
+
+Usage:
+    python -m parrot.bots.chrome_runner --test-file tests.json --headless
+
+    CHROME_HEADLESS=1 TARGET_URL=http://app:3000 QA_TAGS=smoke \\
+        python -m parrot.bots.chrome_runner --test-file tests.json \\
+        --junit-output results.xml --screenshot-dir qa-screenshots/
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+from .chrome import ChromeConfig, QATestCase, WebAgent
+
+logger = logging.getLogger(__name__)
+
+
+def load_test_cases(test_file: str) -> list[QATestCase]:
+    """Load `QATestCase` definitions from a JSON or YAML file.
+
+    Args:
+        test_file: Path to a `.json`, `.yaml`, or `.yml` file containing
+            either a single test case object or a list of test case
+            objects.
+
+    Returns:
+        list[QATestCase]: The parsed and validated test cases.
+
+    Raises:
+        SystemExit: With code 2 if the file cannot be read, is not valid
+            JSON/YAML, or (for YAML) PyYAML is not installed.
+    """
+    path = Path(test_file)
+    if not path.is_file():
+        print(f"ERROR: test file not found: {test_file}", file=sys.stderr)
+        sys.exit(2)
+
+    text = path.read_text(encoding="utf-8")
+
+    if path.suffix in (".yaml", ".yml"):
+        try:
+            import yaml
+        except ImportError:
+            print(
+                "ERROR: PyYAML is required for YAML test files. "
+                "Install with: uv pip install pyyaml",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        raw = yaml.safe_load(text)
+    else:
+        try:
+            raw = json.loads(text)
+        except json.JSONDecodeError as exc:
+            print(f"ERROR: invalid JSON in {test_file}: {exc}", file=sys.stderr)
+            sys.exit(2)
+
+    if not isinstance(raw, list):
+        raw = [raw]
+    return [QATestCase.model_validate(item) for item in raw]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the `argparse.ArgumentParser` for the CLI runner.
+
+    Returns:
+        argparse.ArgumentParser: Configured parser with all CLI flags.
+    """
+    parser = argparse.ArgumentParser(
+        prog="parrot.bots.chrome_runner",
+        description="Run WebAgent QA tests from a definition file.",
+    )
+    parser.add_argument(
+        "--test-file", required=True, help="Path to JSON/YAML test definitions"
+    )
+    parser.add_argument("--url", default=None, help="Base URL override")
+    parser.add_argument(
+        "--headless", action="store_true", default=False, help="Run Chrome headless"
+    )
+    parser.add_argument("--tags", default=None, help="Comma-separated tag filter")
+    parser.add_argument(
+        "--junit-output", default=None, help="Path to write JUnit XML"
+    )
+    parser.add_argument(
+        "--screenshot-dir", default=None, help="Directory for failure screenshots"
+    )
+    parser.add_argument(
+        "--default-timeout",
+        type=int,
+        default=60_000,
+        help="Default per-test timeout in ms",
+    )
+    parser.add_argument(
+        "--port", type=int, default=9222, help="Chrome debugging port"
+    )
+    parser.add_argument(
+        "--viewport", default=None, help="Viewport size (e.g. 1920x1080)"
+    )
+    parser.add_argument(
+        "--verbose", action="store_true", default=False, help="Enable DEBUG logging"
+    )
+    return parser
+
+
+async def run_qa(
+    test_file: str,
+    url: str | None = None,
+    headless: bool = True,
+    tags: list[str] | None = None,
+    junit_output: str | None = None,
+    screenshot_dir: str | None = None,
+    default_timeout_ms: int = 60_000,
+    port: int = 9222,
+    viewport: str | None = None,
+) -> int:
+    """Execute QA tests from a file and return an exit code.
+
+    Args:
+        test_file: Path to the JSON/YAML file with `QATestCase` definitions.
+        url: Base URL override (defaults to the first test case's URL).
+        headless: Whether to launch Chrome headless.
+        tags: Optional tag filter — only cases whose `tags` intersect
+            this list are executed.
+        junit_output: If set, path to write the JUnit XML report to.
+        screenshot_dir: If set, directory for failure screenshots
+            (created if missing).
+        default_timeout_ms: Default per-test timeout in milliseconds.
+        port: Chrome debugging port.
+        viewport: Initial viewport size (e.g. `"1920x1080"`).
+
+    Returns:
+        int: `0` if all tests passed, `1` if any failed/errored.
+    """
+    if screenshot_dir:
+        Path(screenshot_dir).mkdir(parents=True, exist_ok=True)
+
+    test_cases = load_test_cases(test_file)
+
+    agent = WebAgent(
+        name="CI-QA-Agent",
+        chrome_config=ChromeConfig(
+            headless=headless,
+            port=port,
+            viewport=viewport,
+        ),
+        default_timeout_ms=default_timeout_ms,
+        screenshot_dir=screenshot_dir,
+    )
+
+    await agent.configure()
+    async with agent:
+        result = await agent.run_tests(test_cases, url=url, tags=tags)
+
+    report = result.output
+
+    print(f"\n{'=' * 60}")
+    print(f"QA Report: {report.url}")
+    print(f"{'=' * 60}")
+    print(f"Summary: {report.summary}")
+    print(
+        f"Total: {report.total} | Passed: {report.passed} | "
+        f"Failed: {report.failed} | Errors: {report.errors} | "
+        f"Skipped: {report.skipped}"
+    )
+    for finding in report.findings:
+        print(f"  [{finding.status.upper()}] {finding.test_name}: {finding.detail}")
+
+    if junit_output:
+        Path(junit_output).write_text(report.to_junit_xml(), encoding="utf-8")
+        print(f"\nJUnit XML written to: {junit_output}")
+
+    return report.exit_code
+
+
+def main() -> None:
+    """CLI entry point: `python -m parrot.bots.chrome_runner`."""
+    parser = build_parser()
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+    )
+
+    # Environment variable overrides — CLI flags take precedence.
+    headless = args.headless or os.getenv("CHROME_HEADLESS", "0") == "1"
+    url = args.url or os.getenv("TARGET_URL")
+    tags_str = args.tags or os.getenv("QA_TAGS")
+    tags = tags_str.split(",") if tags_str else None
+
+    exit_code = asyncio.run(
+        run_qa(
+            test_file=args.test_file,
+            url=url,
+            headless=headless,
+            tags=tags,
+            junit_output=args.junit_output,
+            screenshot_dir=args.screenshot_dir,
+            default_timeout_ms=args.default_timeout,
+            port=args.port,
+            viewport=args.viewport,
+        )
+    )
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/ai-parrot/tests/bots/test_chrome.py
+++ b/packages/ai-parrot/tests/bots/test_chrome.py
@@ -1,6 +1,8 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
+
 from parrot.bots.agent import BasicAgent
 from parrot.bots.chrome import (
     ChromeConfig,
@@ -297,3 +299,86 @@ async def test_run_tests_uses_explicit_url_param():
 
         prompt = agent.ask.call_args[0][0]
         assert "http://override.com" in prompt
+
+
+# --- TASK-2115: QA Model Enhancements ---
+
+
+def test_qa_assertion_wait_timeout_default():
+    a = QAAssertion(check="element_visible")
+    assert a.wait_timeout_ms == 5000
+
+
+def test_qa_assertion_wait_timeout_custom():
+    a = QAAssertion(check="element_visible", wait_timeout_ms=3000)
+    assert a.wait_timeout_ms == 3000
+
+
+def test_qa_assertion_wait_timeout_zero():
+    a = QAAssertion(check="element_visible", wait_timeout_ms=0)
+    assert a.wait_timeout_ms == 0
+
+
+def test_qa_assertion_response_status():
+    a = QAAssertion(check="response_status", target="200")
+    assert a.check == "response_status"
+
+
+def test_qa_assertion_accessibility_check():
+    a = QAAssertion(check="accessibility_check")
+    assert a.check == "accessibility_check"
+
+
+def test_qa_assertion_check_is_required():
+    with pytest.raises(ValidationError):
+        QAAssertion()
+
+
+def test_qa_test_case_max_retries_default():
+    tc = QATestCase(name="t", url="/", steps=["s"], expected="e")
+    assert tc.max_retries == 0
+
+
+def test_qa_test_case_max_retries_custom():
+    tc = QATestCase(name="t", url="/", steps=["s"], expected="e", max_retries=3)
+    assert tc.max_retries == 3
+
+
+def test_qa_test_case_timeout_ms_default():
+    tc = QATestCase(name="t", url="/", steps=["s"], expected="e")
+    assert tc.timeout_ms is None
+
+
+def test_qa_test_case_timeout_ms_custom():
+    tc = QATestCase(name="t", url="/", steps=["s"], expected="e", timeout_ms=30000)
+    assert tc.timeout_ms == 30000
+
+
+def test_qa_test_case_timeout_ms_minimum():
+    with pytest.raises(ValidationError):
+        QATestCase(name="t", url="/", steps=["s"], expected="e", timeout_ms=500)
+
+
+def test_qa_finding_retries_default():
+    f = QAFinding(test_name="t", status="pass", detail="ok")
+    assert f.retries == 0
+
+
+def test_qa_finding_retries_custom():
+    f = QAFinding(test_name="t", status="fail", detail="nok", retries=2)
+    assert f.retries == 2
+
+
+def test_new_fields_serialization_roundtrip():
+    tc = QATestCase(
+        name="t", url="/", steps=["s"], expected="e",
+        max_retries=2, timeout_ms=15000,
+        assertions=[
+            QAAssertion(check="response_status", target="200", wait_timeout_ms=3000)
+        ],
+    )
+    restored = QATestCase.model_validate_json(tc.model_dump_json())
+    assert restored.max_retries == 2
+    assert restored.timeout_ms == 15000
+    assert restored.assertions[0].wait_timeout_ms == 3000
+    assert restored.assertions[0].check == "response_status"

--- a/packages/ai-parrot/tests/bots/test_chrome.py
+++ b/packages/ai-parrot/tests/bots/test_chrome.py
@@ -749,3 +749,70 @@ def test_web_agent_system_prompt_documents_new_assertions():
     assert "response_status" in WEB_AGENT_SYSTEM_PROMPT
     assert "accessibility_check" in WEB_AGENT_SYSTEM_PROMPT
     assert "wait_timeout_ms" in WEB_AGENT_SYSTEM_PROMPT
+
+
+# --- Post-review fixes (code-reviewer findings on FEAT-410) ---
+
+
+@pytest.mark.asyncio
+async def test_run_tests_empty_list_does_not_crash():
+    """run_tests([]) must not raise IndexError (empty base_url resolution)."""
+    with patch.object(BasicAgent, "__init__", return_value=None):
+        agent = WebAgent.__new__(WebAgent)
+        agent.name = "test"
+        agent.chrome_config = ChromeConfig()
+        agent.default_timeout_ms = 60_000
+        agent.screenshot_dir = None
+        agent.logger = MagicMock()
+        agent.ask = AsyncMock()
+
+        result = await agent.run_tests([])
+
+        assert result.output.total == 0
+        assert result.output.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_run_tests_unexpected_exception_marks_error_not_crash():
+    """A non-timeout exception from ask() must produce a per-case error
+    finding, not abort the whole run_tests() call (CI reliability)."""
+    with patch.object(BasicAgent, "__init__", return_value=None):
+        agent = WebAgent.__new__(WebAgent)
+        agent.name = "test"
+        agent.chrome_config = ChromeConfig()
+        agent.default_timeout_ms = 60_000
+        agent.screenshot_dir = None
+        agent.logger = MagicMock()
+        agent.ask = AsyncMock(side_effect=RuntimeError("LLM API error"))
+
+        cases = [QATestCase(name="t1", url="/", steps=["s"], expected="e")]
+        result = await agent.run_tests(cases)
+
+        finding = result.output.findings[0]
+        assert finding.status == "error"
+        assert "LLM API error" in finding.detail
+        assert result.output.exit_code == 1
+
+
+@pytest.mark.asyncio
+async def test_run_tests_screenshot_path_includes_predictable_name():
+    """screenshot_dir prompt instruction includes a {test_name}_{timestamp}.png
+    style path, not just the bare directory."""
+    with patch.object(BasicAgent, "__init__", return_value=None):
+        agent = WebAgent.__new__(WebAgent)
+        agent.name = "test"
+        agent.chrome_config = ChromeConfig()
+        agent.default_timeout_ms = 60_000
+        agent.screenshot_dir = "/tmp/qa-screenshots"
+        agent.logger = MagicMock()
+
+        mock_msg = MagicMock()
+        mock_msg.output = QAFinding(test_name="t1", status="pass", detail="ok")
+        agent.ask = AsyncMock(return_value=mock_msg)
+
+        cases = [QATestCase(name="t1", url="/", steps=["s"], expected="e")]
+        await agent.run_tests(cases)
+
+        prompt = agent.ask.call_args[0][0]
+        assert "/tmp/qa-screenshots/t1_" in prompt
+        assert ".png" in prompt

--- a/packages/ai-parrot/tests/bots/test_chrome.py
+++ b/packages/ai-parrot/tests/bots/test_chrome.py
@@ -1,3 +1,4 @@
+import xml.etree.ElementTree as ET
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -382,3 +383,108 @@ def test_new_fields_serialization_roundtrip():
     assert restored.timeout_ms == 15000
     assert restored.assertions[0].wait_timeout_ms == 3000
     assert restored.assertions[0].check == "response_status"
+
+
+# --- TASK-2116: JUnit XML Serialization & Exit Code ---
+
+
+def test_qa_report_exit_code_all_pass():
+    r = QAReport(summary="ok", url="/", total=3, passed=3)
+    assert r.exit_code == 0
+
+
+def test_qa_report_exit_code_with_failure():
+    r = QAReport(summary="nok", url="/", total=3, passed=2, failed=1)
+    assert r.exit_code == 1
+
+
+def test_qa_report_exit_code_with_error():
+    r = QAReport(summary="err", url="/", total=3, passed=2, errors=1)
+    assert r.exit_code == 1
+
+
+def test_qa_report_exit_code_empty():
+    r = QAReport(summary="empty", url="/")
+    assert r.exit_code == 0
+
+
+def test_to_junit_xml_well_formed():
+    r = QAReport(
+        summary="1/1 passed", url="http://localhost",
+        findings=[QAFinding(test_name="t1", status="pass", detail="ok")],
+        total=1, passed=1,
+    )
+    xml_str = r.to_junit_xml()
+    assert xml_str.startswith("<?xml")
+    root = ET.fromstring(xml_str)
+    assert root.tag == "testsuites"
+
+
+def test_to_junit_xml_pass_no_children():
+    r = QAReport(
+        summary="ok", url="/",
+        findings=[QAFinding(test_name="t1", status="pass", detail="ok", duration_ms=2100)],
+        total=1, passed=1,
+    )
+    root = ET.fromstring(r.to_junit_xml())
+    tc = root.find(".//testcase[@name='t1']")
+    assert tc is not None
+    assert len(tc) == 0  # no child elements
+    assert float(tc.get("time", "0")) == pytest.approx(2.1, abs=0.01)
+
+
+def test_to_junit_xml_failure_with_console_errors():
+    r = QAReport(
+        summary="nok", url="/",
+        findings=[QAFinding(
+            test_name="t1", status="fail", detail="broken",
+            console_errors=["TypeError: x is undefined"],
+            retries=2,
+        )],
+        total=1, failed=1,
+    )
+    root = ET.fromstring(r.to_junit_xml())
+    failure = root.find(".//testcase/failure")
+    assert failure is not None
+    assert "broken" in (failure.text or "")
+    assert "TypeError" in (failure.text or "")
+    assert "Retries: 2" in (failure.text or "")
+
+
+def test_to_junit_xml_error_status():
+    r = QAReport(
+        summary="err", url="/",
+        findings=[QAFinding(test_name="t1", status="error", detail="timed out")],
+        total=1, errors=1,
+    )
+    root = ET.fromstring(r.to_junit_xml())
+    error = root.find(".//testcase/error")
+    assert error is not None
+
+
+def test_to_junit_xml_skipped_status():
+    r = QAReport(
+        summary="skip", url="/",
+        findings=[QAFinding(test_name="t1", status="skip", detail="filtered")],
+        total=1, skipped=1,
+    )
+    root = ET.fromstring(r.to_junit_xml())
+    skipped = root.find(".//testcase/skipped")
+    assert skipped is not None
+
+
+def test_to_junit_xml_suite_attributes():
+    r = QAReport(
+        summary="2/3", url="/",
+        findings=[
+            QAFinding(test_name="t1", status="pass", detail="ok"),
+            QAFinding(test_name="t2", status="fail", detail="nok"),
+            QAFinding(test_name="t3", status="skip", detail="filtered"),
+        ],
+        total=3, passed=1, failed=1, skipped=1, duration_ms=5000,
+    )
+    root = ET.fromstring(r.to_junit_xml())
+    suite = root.find("testsuite")
+    assert suite.get("tests") == "3"
+    assert suite.get("failures") == "1"
+    assert suite.get("skipped") == "1"

--- a/packages/ai-parrot/tests/bots/test_chrome.py
+++ b/packages/ai-parrot/tests/bots/test_chrome.py
@@ -1,9 +1,8 @@
+import asyncio
 import xml.etree.ElementTree as ET
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from pydantic import ValidationError
-
 from parrot.bots.agent import BasicAgent
 from parrot.bots.chrome import (
     ChromeConfig,
@@ -14,6 +13,7 @@ from parrot.bots.chrome import (
     WebAgent,
 )
 from parrot.mcp.integration import create_chrome_devtools_mcp_server
+from pydantic import ValidationError
 
 
 def test_chrome_config_defaults():
@@ -230,20 +230,21 @@ async def test_web_agent_configure_adds_mcp_server():
 
 @pytest.mark.asyncio
 async def test_run_tests_calls_ask_with_structured_output():
+    """TASK-2117: run_tests() now processes one case at a time, so each
+    ask() call uses structured_output=QAFinding (not QAReport); the
+    aggregate QAReport is built in Python and returned in a fresh
+    AIMessage, not passed through directly."""
     with patch.object(BasicAgent, "__init__", return_value=None):
         agent = WebAgent.__new__(WebAgent)
         agent.name = "WebAgent"
         agent.chrome_config = ChromeConfig()
+        agent.default_timeout_ms = 60_000
+        agent.screenshot_dir = None
         agent.logger = MagicMock()
 
-        mock_report = QAReport(
-            summary="1/1 passed",
-            url="http://localhost:8080",
-            total=1,
-            passed=1,
-        )
+        mock_finding = QAFinding(test_name="t1", status="pass", detail="ok")
         mock_msg = MagicMock()
-        mock_msg.output = mock_report
+        mock_msg.output = mock_finding
         agent.ask = AsyncMock(return_value=mock_msg)
 
         cases = [
@@ -258,18 +259,27 @@ async def test_run_tests_calls_ask_with_structured_output():
 
         agent.ask.assert_called_once()
         call_kwargs = agent.ask.call_args
-        assert call_kwargs.kwargs.get("structured_output") is QAReport
-        assert result is mock_msg
+        assert call_kwargs.kwargs.get("structured_output") is QAFinding
+        assert isinstance(result.output, QAReport)
+        assert result.output.total == 1
+        assert result.output.passed == 1
 
 
 @pytest.mark.asyncio
-async def test_run_tests_serializes_all_cases_in_prompt():
+async def test_run_tests_serializes_case_in_its_own_prompt():
+    """TASK-2117: each case gets its own ask() call/prompt (no longer a
+    single combined prompt for all cases)."""
     with patch.object(BasicAgent, "__init__", return_value=None):
         agent = WebAgent.__new__(WebAgent)
         agent.name = "WebAgent"
         agent.chrome_config = ChromeConfig()
+        agent.default_timeout_ms = 60_000
+        agent.screenshot_dir = None
         agent.logger = MagicMock()
-        agent.ask = AsyncMock(return_value=MagicMock())
+
+        mock_msg = MagicMock()
+        mock_msg.output = QAFinding(test_name="x", status="pass", detail="ok")
+        agent.ask = AsyncMock(return_value=mock_msg)
 
         cases = [
             QATestCase(name="t1", url="http://a.com", steps=["step1"], expected="ok"),
@@ -277,11 +287,12 @@ async def test_run_tests_serializes_all_cases_in_prompt():
         ]
         await agent.run_tests(cases)
 
-        prompt = agent.ask.call_args[0][0]  # first positional arg
-        assert "t1" in prompt
-        assert "t2" in prompt
-        assert "step1" in prompt
-        assert "step2" in prompt
+        assert agent.ask.call_count == 2
+        prompt1 = agent.ask.call_args_list[0][0][0]
+        prompt2 = agent.ask.call_args_list[1][0][0]
+        assert "t1" in prompt1 and "step1" in prompt1
+        assert "t1" not in prompt2 or "step2" not in prompt1
+        assert "t2" in prompt2 and "step2" in prompt2
 
 
 @pytest.mark.asyncio
@@ -290,8 +301,12 @@ async def test_run_tests_uses_explicit_url_param():
         agent = WebAgent.__new__(WebAgent)
         agent.name = "WebAgent"
         agent.chrome_config = ChromeConfig()
+        agent.default_timeout_ms = 60_000
+        agent.screenshot_dir = None
         agent.logger = MagicMock()
-        agent.ask = AsyncMock(return_value=MagicMock())
+        mock_msg = MagicMock()
+        mock_msg.output = QAFinding(test_name="t1", status="pass", detail="ok")
+        agent.ask = AsyncMock(return_value=mock_msg)
 
         cases = [
             QATestCase(name="t1", url="http://a.com", steps=["s"], expected="ok"),
@@ -488,3 +503,249 @@ def test_to_junit_xml_suite_attributes():
     assert suite.get("tests") == "3"
     assert suite.get("failures") == "1"
     assert suite.get("skipped") == "1"
+
+
+# --- TASK-2117: WebAgent run_tests Enhancements ---
+
+
+def test_web_agent_default_timeout_ms():
+    agent = WebAgent(name="test")
+    assert agent.default_timeout_ms == 60_000
+
+
+def test_web_agent_custom_timeout_ms():
+    agent = WebAgent(name="test", default_timeout_ms=30_000)
+    assert agent.default_timeout_ms == 30_000
+
+
+def test_web_agent_screenshot_dir_default():
+    agent = WebAgent(name="test")
+    assert agent.screenshot_dir is None
+
+
+def test_web_agent_screenshot_dir_custom():
+    agent = WebAgent(name="test", screenshot_dir="/tmp/screenshots")
+    assert agent.screenshot_dir == "/tmp/screenshots"
+
+
+@pytest.mark.asyncio
+async def test_run_tests_tag_filtering():
+    with patch.object(BasicAgent, "__init__", return_value=None):
+        agent = WebAgent.__new__(WebAgent)
+        agent.name = "test"
+        agent.chrome_config = ChromeConfig()
+        agent.default_timeout_ms = 60_000
+        agent.screenshot_dir = None
+        agent.logger = MagicMock()
+
+        pass_finding = QAFinding(test_name="t1", status="pass", detail="ok")
+        mock_msg = MagicMock()
+        mock_msg.output = pass_finding
+        agent.ask = AsyncMock(return_value=mock_msg)
+
+        cases = [
+            QATestCase(name="t1", url="/", steps=["s"], expected="e", tags=["smoke"]),
+            QATestCase(name="t2", url="/", steps=["s"], expected="e", tags=["regression"]),
+        ]
+        result = await agent.run_tests(cases, tags=["smoke"])
+        report = result.output
+
+        assert report.total == 2
+        assert report.skipped == 1
+        # Only one ask() call (the smoke test), not two
+        assert agent.ask.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_run_tests_empty_after_tag_filtering():
+    with patch.object(BasicAgent, "__init__", return_value=None):
+        agent = WebAgent.__new__(WebAgent)
+        agent.name = "test"
+        agent.chrome_config = ChromeConfig()
+        agent.default_timeout_ms = 60_000
+        agent.screenshot_dir = None
+        agent.logger = MagicMock()
+        agent.ask = AsyncMock()
+
+        cases = [
+            QATestCase(name="t1", url="/", steps=["s"], expected="e", tags=["regression"]),
+        ]
+        result = await agent.run_tests(cases, tags=["smoke"])
+        report = result.output
+
+        assert report.total == 1
+        assert report.skipped == 1
+        assert report.passed == 0
+        agent.ask.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_tests_no_tags_runs_all():
+    """Backward compatibility: no tags filter runs everything."""
+    with patch.object(BasicAgent, "__init__", return_value=None):
+        agent = WebAgent.__new__(WebAgent)
+        agent.name = "test"
+        agent.chrome_config = ChromeConfig()
+        agent.default_timeout_ms = 60_000
+        agent.screenshot_dir = None
+        agent.logger = MagicMock()
+
+        pass_finding = QAFinding(test_name="t1", status="pass", detail="ok")
+        mock_msg = MagicMock()
+        mock_msg.output = pass_finding
+        agent.ask = AsyncMock(return_value=mock_msg)
+
+        cases = [
+            QATestCase(name="t1", url="/", steps=["s"], expected="e", tags=["smoke"]),
+            QATestCase(name="t2", url="/", steps=["s"], expected="e", tags=["regression"]),
+        ]
+        await agent.run_tests(cases)
+
+        assert agent.ask.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_run_tests_screenshot_dir_in_prompt():
+    with patch.object(BasicAgent, "__init__", return_value=None):
+        agent = WebAgent.__new__(WebAgent)
+        agent.name = "test"
+        agent.chrome_config = ChromeConfig()
+        agent.default_timeout_ms = 60_000
+        agent.screenshot_dir = "/tmp/qa-screenshots"
+        agent.logger = MagicMock()
+
+        pass_finding = QAFinding(test_name="t1", status="pass", detail="ok")
+        mock_msg = MagicMock()
+        mock_msg.output = pass_finding
+        agent.ask = AsyncMock(return_value=mock_msg)
+
+        cases = [QATestCase(name="t1", url="/", steps=["s"], expected="e")]
+        await agent.run_tests(cases)
+
+        prompt = agent.ask.call_args[0][0]
+        assert "/tmp/qa-screenshots" in prompt
+
+
+@pytest.mark.asyncio
+async def test_run_tests_retry_on_failure():
+    """max_retries=2 -> ask() called up to 1 + 2 = 3 times for a failing case."""
+    with patch.object(BasicAgent, "__init__", return_value=None):
+        agent = WebAgent.__new__(WebAgent)
+        agent.name = "test"
+        agent.chrome_config = ChromeConfig()
+        agent.default_timeout_ms = 60_000
+        agent.screenshot_dir = None
+        agent.logger = MagicMock()
+
+        fail_finding = QAFinding(test_name="t1", status="fail", detail="nok")
+        mock_msg = MagicMock()
+        mock_msg.output = fail_finding
+        agent.ask = AsyncMock(return_value=mock_msg)
+
+        cases = [
+            QATestCase(name="t1", url="/", steps=["s"], expected="e", max_retries=2),
+        ]
+        result = await agent.run_tests(cases)
+
+        assert agent.ask.call_count == 3
+        finding = result.output.findings[0]
+        assert finding.status == "fail"
+        assert finding.retries == 2
+
+
+@pytest.mark.asyncio
+async def test_run_tests_retry_stops_on_first_pass():
+    """A test that passes on the first attempt should not be retried."""
+    with patch.object(BasicAgent, "__init__", return_value=None):
+        agent = WebAgent.__new__(WebAgent)
+        agent.name = "test"
+        agent.chrome_config = ChromeConfig()
+        agent.default_timeout_ms = 60_000
+        agent.screenshot_dir = None
+        agent.logger = MagicMock()
+
+        pass_finding = QAFinding(test_name="t1", status="pass", detail="ok")
+        mock_msg = MagicMock()
+        mock_msg.output = pass_finding
+        agent.ask = AsyncMock(return_value=mock_msg)
+
+        cases = [
+            QATestCase(name="t1", url="/", steps=["s"], expected="e", max_retries=2),
+        ]
+        result = await agent.run_tests(cases)
+
+        assert agent.ask.call_count == 1
+        assert result.output.findings[0].retries == 0
+
+
+@pytest.mark.asyncio
+async def test_run_tests_timeout_marks_error():
+    with patch.object(BasicAgent, "__init__", return_value=None):
+        agent = WebAgent.__new__(WebAgent)
+        agent.name = "test"
+        agent.chrome_config = ChromeConfig()
+        agent.default_timeout_ms = 60_000
+        agent.screenshot_dir = None
+        agent.logger = MagicMock()
+
+        async def slow_ask(*args, **kwargs):
+            await asyncio.sleep(0.2)
+            mock_msg = MagicMock()
+            mock_msg.output = QAFinding(test_name="t1", status="pass", detail="ok")
+            return mock_msg
+
+        agent.ask = slow_ask
+
+        cases = [
+            QATestCase(
+                name="t1", url="/", steps=["s"], expected="e", timeout_ms=1000,
+            ),
+        ]
+        # Bypass the ge=1000 minimum (Pydantic doesn't re-validate plain
+        # attribute assignment) so the real asyncio.wait_for actually
+        # fires within the test's timeframe — avoids mocking wait_for
+        # itself, which would leave the wrapped coroutine unawaited.
+        cases[0].timeout_ms = 50
+        result = await agent.run_tests(cases)
+
+        finding = result.output.findings[0]
+        assert finding.status == "error"
+        assert "timed out" in finding.detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_run_tests_wait_timeout_ms_in_prompt():
+    with patch.object(BasicAgent, "__init__", return_value=None):
+        agent = WebAgent.__new__(WebAgent)
+        agent.name = "test"
+        agent.chrome_config = ChromeConfig()
+        agent.default_timeout_ms = 60_000
+        agent.screenshot_dir = None
+        agent.logger = MagicMock()
+
+        mock_msg = MagicMock()
+        mock_msg.output = QAFinding(test_name="t1", status="pass", detail="ok")
+        agent.ask = AsyncMock(return_value=mock_msg)
+
+        cases = [
+            QATestCase(
+                name="t1", url="/", steps=["s"], expected="e",
+                assertions=[
+                    QAAssertion(
+                        check="element_visible", target=".error", wait_timeout_ms=3000,
+                    ),
+                ],
+            ),
+        ]
+        await agent.run_tests(cases)
+
+        prompt = agent.ask.call_args[0][0]
+        assert "3000" in prompt
+        assert ".error" in prompt
+
+
+def test_web_agent_system_prompt_documents_new_assertions():
+    from parrot.bots.chrome import WEB_AGENT_SYSTEM_PROMPT
+    assert "response_status" in WEB_AGENT_SYSTEM_PROMPT
+    assert "accessibility_check" in WEB_AGENT_SYSTEM_PROMPT
+    assert "wait_timeout_ms" in WEB_AGENT_SYSTEM_PROMPT

--- a/packages/ai-parrot/tests/bots/test_chrome_runner.py
+++ b/packages/ai-parrot/tests/bots/test_chrome_runner.py
@@ -92,6 +92,16 @@ def test_load_test_cases_invalid_json_exits_2(tmp_path):
     assert exc_info.value.code == 2
 
 
+def test_load_test_cases_schema_validation_error_exits_2(tmp_path):
+    """A well-formed JSON document that doesn't satisfy QATestCase's schema
+    (missing required fields) must exit(2), not raise ValidationError."""
+    f = tmp_path / "tests.json"
+    f.write_text(json.dumps([{"name": "t1"}]))  # missing url/steps/expected
+    with pytest.raises(SystemExit) as exc_info:
+        load_test_cases(str(f))
+    assert exc_info.value.code == 2
+
+
 def test_load_test_cases_yaml_missing_pyyaml_exits_2(tmp_path):
     f = tmp_path / "tests.yaml"
     f.write_text("- name: t1\n  url: /\n  steps: [s]\n  expected: e\n")

--- a/packages/ai-parrot/tests/bots/test_chrome_runner.py
+++ b/packages/ai-parrot/tests/bots/test_chrome_runner.py
@@ -1,0 +1,306 @@
+import json
+import xml.etree.ElementTree as ET
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from parrot.bots.chrome import QAFinding, QAReport, QATestCase
+from parrot.bots.chrome_runner import build_parser, load_test_cases, main, run_qa
+
+
+def test_build_parser_requires_test_file():
+    parser = build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args([])
+
+
+def test_build_parser_minimal():
+    parser = build_parser()
+    args = parser.parse_args(["--test-file", "tests.json"])
+    assert args.test_file == "tests.json"
+    assert args.headless is False
+    assert args.url is None
+    assert args.tags is None
+    assert args.junit_output is None
+
+
+def test_build_parser_full():
+    parser = build_parser()
+    args = parser.parse_args([
+        "--test-file", "tests.json",
+        "--url", "http://localhost:3000",
+        "--headless",
+        "--tags", "smoke,critical",
+        "--junit-output", "results.xml",
+        "--screenshot-dir", "./screenshots",
+        "--default-timeout", "30000",
+        "--port", "9333",
+        "--viewport", "1920x1080",
+    ])
+    assert args.headless is True
+    assert args.tags == "smoke,critical"
+    assert args.default_timeout == 30000
+    assert args.port == 9333
+    assert args.junit_output == "results.xml"
+    assert args.screenshot_dir == "./screenshots"
+    assert args.viewport == "1920x1080"
+
+
+def test_load_test_cases_json(tmp_path):
+    f = tmp_path / "tests.json"
+    f.write_text(json.dumps([{
+        "name": "t1", "url": "/", "steps": ["s"], "expected": "e",
+    }]))
+    cases = load_test_cases(str(f))
+    assert len(cases) == 1
+    assert cases[0].name == "t1"
+    assert isinstance(cases[0], QATestCase)
+
+
+def test_load_test_cases_single_object(tmp_path):
+    """A single object (not wrapped in array) should also work."""
+    f = tmp_path / "tests.json"
+    f.write_text(json.dumps({
+        "name": "t1", "url": "/", "steps": ["s"], "expected": "e",
+    }))
+    cases = load_test_cases(str(f))
+    assert len(cases) == 1
+
+
+def test_load_test_cases_with_new_fields(tmp_path):
+    f = tmp_path / "tests.json"
+    f.write_text(json.dumps([{
+        "name": "t1", "url": "/", "steps": ["s"], "expected": "e",
+        "max_retries": 2, "timeout_ms": 15000, "tags": ["smoke"],
+    }]))
+    cases = load_test_cases(str(f))
+    assert cases[0].max_retries == 2
+    assert cases[0].timeout_ms == 15000
+    assert cases[0].tags == ["smoke"]
+
+
+def test_load_test_cases_missing_file_exits_2():
+    with pytest.raises(SystemExit) as exc_info:
+        load_test_cases("/nonexistent/path/tests.json")
+    assert exc_info.value.code == 2
+
+
+def test_load_test_cases_invalid_json_exits_2(tmp_path):
+    f = tmp_path / "tests.json"
+    f.write_text("{not valid json")
+    with pytest.raises(SystemExit) as exc_info:
+        load_test_cases(str(f))
+    assert exc_info.value.code == 2
+
+
+def test_load_test_cases_yaml_missing_pyyaml_exits_2(tmp_path):
+    f = tmp_path / "tests.yaml"
+    f.write_text("- name: t1\n  url: /\n  steps: [s]\n  expected: e\n")
+    with patch.dict("sys.modules", {"yaml": None}), pytest.raises(SystemExit) as exc_info:
+        load_test_cases(str(f))
+    assert exc_info.value.code == 2
+
+
+def _mock_agent_ctx(report: QAReport):
+    """Patch WebAgent so run_qa() drives a scripted QAReport without Chrome."""
+    mock_agent = MagicMock()
+    mock_agent.configure = AsyncMock()
+    mock_agent.__aenter__ = AsyncMock(return_value=mock_agent)
+    mock_agent.__aexit__ = AsyncMock(return_value=False)
+    mock_msg = MagicMock()
+    mock_msg.output = report
+    mock_agent.run_tests = AsyncMock(return_value=mock_msg)
+    return mock_agent
+
+
+@pytest.mark.asyncio
+async def test_run_qa_all_pass_exit_code_0(tmp_path):
+    test_file = tmp_path / "tests.json"
+    test_file.write_text(json.dumps([
+        {"name": "t1", "url": "http://localhost", "steps": ["s"], "expected": "e"},
+    ]))
+
+    report = QAReport(
+        summary="1/1 passed", url="http://localhost",
+        findings=[QAFinding(test_name="t1", status="pass", detail="ok")],
+        total=1, passed=1,
+    )
+    mock_agent = _mock_agent_ctx(report)
+
+    with patch("parrot.bots.chrome_runner.WebAgent", return_value=mock_agent):
+        exit_code = await run_qa(test_file=str(test_file), headless=True)
+
+    assert exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_run_qa_with_failure_exit_code_1(tmp_path):
+    test_file = tmp_path / "tests.json"
+    test_file.write_text(json.dumps([
+        {"name": "t1", "url": "http://localhost", "steps": ["s"], "expected": "e"},
+    ]))
+
+    report = QAReport(
+        summary="0/1 passed", url="http://localhost",
+        findings=[QAFinding(test_name="t1", status="fail", detail="nok")],
+        total=1, failed=1,
+    )
+    mock_agent = _mock_agent_ctx(report)
+
+    with patch("parrot.bots.chrome_runner.WebAgent", return_value=mock_agent):
+        exit_code = await run_qa(test_file=str(test_file), headless=True)
+
+    assert exit_code == 1
+
+
+@pytest.mark.asyncio
+async def test_run_qa_tags_forwarded_to_run_tests(tmp_path):
+    test_file = tmp_path / "tests.json"
+    test_file.write_text(json.dumps([
+        {"name": "t1", "url": "http://localhost", "steps": ["s"], "expected": "e", "tags": ["smoke"]},
+    ]))
+
+    report = QAReport(
+        summary="1/1 passed", url="http://localhost",
+        findings=[QAFinding(test_name="t1", status="pass", detail="ok")],
+        total=1, passed=1,
+    )
+    mock_agent = _mock_agent_ctx(report)
+
+    with patch("parrot.bots.chrome_runner.WebAgent", return_value=mock_agent):
+        await run_qa(test_file=str(test_file), headless=True, tags=["smoke"])
+
+    call_kwargs = mock_agent.run_tests.call_args.kwargs
+    assert call_kwargs.get("tags") == ["smoke"]
+
+
+@pytest.mark.asyncio
+async def test_run_qa_writes_junit_output(tmp_path):
+    test_file = tmp_path / "tests.json"
+    test_file.write_text(json.dumps([
+        {"name": "t1", "url": "http://localhost", "steps": ["s"], "expected": "e"},
+    ]))
+    junit_path = tmp_path / "results.xml"
+
+    report = QAReport(
+        summary="1/1 passed", url="http://localhost",
+        findings=[QAFinding(test_name="t1", status="pass", detail="ok")],
+        total=1, passed=1,
+    )
+    mock_agent = _mock_agent_ctx(report)
+
+    with patch("parrot.bots.chrome_runner.WebAgent", return_value=mock_agent):
+        await run_qa(
+            test_file=str(test_file), headless=True, junit_output=str(junit_path),
+        )
+
+    assert junit_path.is_file()
+    root = ET.fromstring(junit_path.read_text(encoding="utf-8"))
+    assert root.tag == "testsuites"
+
+
+@pytest.mark.asyncio
+async def test_run_qa_creates_screenshot_dir(tmp_path):
+    test_file = tmp_path / "tests.json"
+    test_file.write_text(json.dumps([
+        {"name": "t1", "url": "http://localhost", "steps": ["s"], "expected": "e"},
+    ]))
+    screenshot_dir = tmp_path / "shots"
+
+    report = QAReport(
+        summary="1/1 passed", url="http://localhost",
+        findings=[QAFinding(test_name="t1", status="pass", detail="ok")],
+        total=1, passed=1,
+    )
+    mock_agent = _mock_agent_ctx(report)
+
+    with patch("parrot.bots.chrome_runner.WebAgent", return_value=mock_agent):
+        await run_qa(
+            test_file=str(test_file), headless=True,
+            screenshot_dir=str(screenshot_dir),
+        )
+
+    assert screenshot_dir.is_dir()
+
+
+def test_main_chrome_headless_env_var(tmp_path, monkeypatch):
+    test_file = tmp_path / "tests.json"
+    test_file.write_text(json.dumps([
+        {"name": "t1", "url": "http://localhost", "steps": ["s"], "expected": "e"},
+    ]))
+    monkeypatch.setenv("CHROME_HEADLESS", "1")
+    monkeypatch.setattr("sys.argv", ["chrome_runner", "--test-file", str(test_file)])
+
+    with patch("parrot.bots.chrome_runner.run_qa", new_callable=AsyncMock) as mock_run_qa:
+        mock_run_qa.return_value = 0
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+    assert exc_info.value.code == 0
+    assert mock_run_qa.call_args.kwargs["headless"] is True
+
+
+def test_main_target_url_env_var(tmp_path, monkeypatch):
+    test_file = tmp_path / "tests.json"
+    test_file.write_text(json.dumps([
+        {"name": "t1", "url": "http://localhost", "steps": ["s"], "expected": "e"},
+    ]))
+    monkeypatch.setenv("TARGET_URL", "http://app:3000")
+    monkeypatch.setattr("sys.argv", ["chrome_runner", "--test-file", str(test_file)])
+
+    with patch("parrot.bots.chrome_runner.run_qa", new_callable=AsyncMock) as mock_run_qa:
+        mock_run_qa.return_value = 0
+        with pytest.raises(SystemExit):
+            main()
+
+    assert mock_run_qa.call_args.kwargs["url"] == "http://app:3000"
+
+
+def test_main_qa_tags_env_var(tmp_path, monkeypatch):
+    test_file = tmp_path / "tests.json"
+    test_file.write_text(json.dumps([
+        {"name": "t1", "url": "http://localhost", "steps": ["s"], "expected": "e"},
+    ]))
+    monkeypatch.setenv("QA_TAGS", "smoke,critical")
+    monkeypatch.setattr("sys.argv", ["chrome_runner", "--test-file", str(test_file)])
+
+    with patch("parrot.bots.chrome_runner.run_qa", new_callable=AsyncMock) as mock_run_qa:
+        mock_run_qa.return_value = 0
+        with pytest.raises(SystemExit):
+            main()
+
+    assert mock_run_qa.call_args.kwargs["tags"] == ["smoke", "critical"]
+
+
+def test_main_cli_flags_override_env_vars(tmp_path, monkeypatch):
+    """CLI flags take precedence over env vars."""
+    test_file = tmp_path / "tests.json"
+    test_file.write_text(json.dumps([
+        {"name": "t1", "url": "http://localhost", "steps": ["s"], "expected": "e"},
+    ]))
+    monkeypatch.setenv("TARGET_URL", "http://env-url:3000")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["chrome_runner", "--test-file", str(test_file), "--url", "http://cli-url:3000"],
+    )
+
+    with patch("parrot.bots.chrome_runner.run_qa", new_callable=AsyncMock) as mock_run_qa:
+        mock_run_qa.return_value = 0
+        with pytest.raises(SystemExit):
+            main()
+
+    assert mock_run_qa.call_args.kwargs["url"] == "http://cli-url:3000"
+
+
+def test_main_exit_code_propagates(tmp_path, monkeypatch):
+    test_file = tmp_path / "tests.json"
+    test_file.write_text(json.dumps([
+        {"name": "t1", "url": "http://localhost", "steps": ["s"], "expected": "e"},
+    ]))
+    monkeypatch.setattr("sys.argv", ["chrome_runner", "--test-file", str(test_file)])
+
+    with patch("parrot.bots.chrome_runner.run_qa", new_callable=AsyncMock) as mock_run_qa:
+        mock_run_qa.return_value = 1
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+    assert exc_info.value.code == 1

--- a/sdd/tasks/completed/TASK-2115-qa-model-enhancements.md
+++ b/sdd/tasks/completed/TASK-2115-qa-model-enhancements.md
@@ -244,10 +244,14 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (Claude Sonnet 4.5)
+**Date**: 2026-08-04
+**Notes**: Added `wait_timeout_ms` (default 5000, ge=0) and two new `check`
+Literal values (`response_status`, `accessibility_check`) to `QAAssertion`;
+added `max_retries` (default 0, ge=0) and `timeout_ms` (default None, ge=1000)
+to `QATestCase`; added `retries: int = 0` to `QAFinding`. Appended 16 new unit
+tests to `test_chrome.py` covering defaults, custom values, validation
+errors, and JSON round-trip serialization. All 35 tests in the file pass
+(19 pre-existing + 16 new).
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
-**Notes**: What was implemented, any deviations from scope, issues encountered.
-
-**Deviations from spec**: none | describe if any
+**Deviations from spec**: none

--- a/sdd/tasks/completed/TASK-2116-junit-xml-and-exit-code.md
+++ b/sdd/tasks/completed/TASK-2116-junit-xml-and-exit-code.md
@@ -303,4 +303,14 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (Claude Sonnet 4.5)
+**Date**: 2026-08-04
+**Notes**: Added `exit_code` computed property (`1 if failed+errors>0 else 0`)
+and `to_junit_xml(suite_name="WebAgent QA")` to `QAReport`, built with stdlib
+`xml.etree.ElementTree` only. Maps pass/fail/error/skip to the JUnit
+conventions in the spec, includes console errors + retry count in
+failure/error bodies via a `_junit_detail_body` static helper, and reports
+`time` attributes in seconds. Appended 10 new unit tests. All 45 tests in
+`test_chrome.py` pass (35 pre-existing + 10 new).
+
+**Deviations from spec**: none

--- a/sdd/tasks/completed/TASK-2117-run-tests-enhancements.md
+++ b/sdd/tasks/completed/TASK-2117-run-tests-enhancements.md
@@ -150,6 +150,35 @@ class QAFinding(BaseModel):
 - ~~`WebAgent.run_single_test()`~~ — no per-test public method exists
 - ~~`BasicAgent.ask_with_timeout()`~~ — no such method; use `asyncio.wait_for()`
 
+### Codebase Contract Correction (found during implementation)
+
+`AIMessage(response=report.summary, output=report)` (as shown in the
+Implementation Notes below) is **stale and will raise
+`pydantic.ValidationError`** — verified at
+`packages/ai-parrot/src/parrot/models/responses.py:72-120`:
+`AIMessage.input`, `.model`, `.provider`, `.usage` are all required fields
+with no defaults (only `response` has `default=None`). This exact pitfall
+is already documented and fixed elsewhere in the codebase — see
+`packages/ai-parrot/src/parrot/bots/base.py:634-649`
+(FEAT-396 TASK-2028 comment) which establishes the "minimal AIMessage"
+pattern:
+
+```python
+from ..models import AIMessage, CompletionUsage   # CompletionUsage verified: models/__init__.py:7
+
+return AIMessage(
+    input=<original prompt/description text>,
+    output=report,
+    response=report.summary,
+    model="",
+    provider="",
+    usage=CompletionUsage(prompt_tokens=0, completion_tokens=0, total_tokens=0),
+)
+```
+
+This task's aggregate-`QAReport`-building code MUST use this pattern
+instead of the two-kwarg form shown further below.
+
 ---
 
 ## Implementation Notes
@@ -453,4 +482,35 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (Claude Sonnet 4.5)
+**Date**: 2026-08-04
+**Notes**: Added `default_timeout_ms` (60_000) and `screenshot_dir` (None)
+params to `WebAgent.__init__()`. Refactored `run_tests()` to process one
+`QATestCase` at a time (required for per-test retry/timeout): tag filtering
+produces `status="skip"` findings without an LLM call; each remaining case
+is retried up to `1 + max_retries` times via a new `_execute_single_test()`
+helper (`structured_output=QAFinding`), wrapped in `asyncio.wait_for()`
+using `case.timeout_ms or self.default_timeout_ms`, producing
+`status="error"` on `TimeoutError`. The aggregate `QAReport` is built in
+Python and wrapped in a manually-constructed `AIMessage` (see Codebase
+Contract Correction below). Updated `WEB_AGENT_SYSTEM_PROMPT` to document
+all assertion types including the two new ones and `wait_timeout_ms`
+wait semantics. Added 12 new unit tests and rewrote 3 pre-existing tests
+(`test_run_tests_calls_ask_with_structured_output`,
+`test_run_tests_serializes_all_cases_in_prompt` →
+`test_run_tests_serializes_case_in_its_own_prompt`,
+`test_run_tests_uses_explicit_url_param`) that asserted the old
+single-combined-prompt/`structured_output=QAReport` behavior explicitly
+superseded by this task's mandated refactor. All 58 tests in
+`test_chrome.py` pass; `ruff check` clean.
+
+**Deviations from spec**: none in behavior. One Codebase Contract
+correction was required and is documented in the "Codebase Contract
+Correction" section added to this task file: the spec's/task's example
+`AIMessage(response=report.summary, output=report)` does not compile —
+`AIMessage.input`/`.model`/`.provider`/`.usage` are required fields with
+no defaults (verified at `models/responses.py:72-120`). Used the
+established "minimal AIMessage" pattern from `bots/base.py:634-649`
+(`AIMessage(input=..., output=..., response=..., model="", provider="",
+usage=CompletionUsage(prompt_tokens=0, completion_tokens=0,
+total_tokens=0))`) instead.

--- a/sdd/tasks/completed/TASK-2118-cli-runner.md
+++ b/sdd/tasks/completed/TASK-2118-cli-runner.md
@@ -393,4 +393,25 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (Claude Sonnet 4.5)
+**Date**: 2026-08-04
+**Notes**: Created `parrot/bots/chrome_runner.py` with `load_test_cases()`
+(JSON always supported, YAML optional via `import yaml` with a graceful
+`sys.exit(2)` + install hint on `ImportError`; missing file / invalid JSON
+also exit 2), `build_parser()` (all 9 flags from the spec plus `--verbose`),
+`run_qa()` (creates `screenshot_dir` if missing, builds `WebAgent` with
+`default_timeout_ms`/`screenshot_dir`, calls `agent.configure()` then
+`async with agent: run_tests(...)` — same pattern as
+`examples/chrome_qa_test.py` — prints a human-readable summary, writes
+JUnit XML when requested, returns `report.exit_code`), and `main()`
+(env var overrides `CHROME_HEADLESS`/`TARGET_URL`/`QA_TAGS` applied only
+when the corresponding CLI flag is at its default, so flags win;
+`asyncio.run()` + `sys.exit()`). Verified `python -m
+parrot.bots.chrome_runner --help` works end-to-end. Created
+`tests/bots/test_chrome_runner.py` with 19 tests covering parser,
+file loading (JSON/YAML/missing/invalid), `run_qa()` exit codes/tags/
+JUnit output/screenshot dir (WebAgent mocked, no real Chrome), and
+`main()` env var precedence + exit code propagation. All 19 pass;
+`ruff check` clean.
+
+**Deviations from spec**: none.

--- a/sdd/tasks/completed/TASK-2119-examples-and-ci-docs.md
+++ b/sdd/tasks/completed/TASK-2119-examples-and-ci-docs.md
@@ -246,4 +246,33 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (Claude Sonnet 4.5)
+**Date**: 2026-08-04
+**Notes**: Updated `examples/chrome_qa_test.py` in place — added
+`max_retries=1`/`timeout_ms=30_000` to the homepage-loads case, a
+`response_status` assertion, and `wait_timeout_ms=3000` on the
+login-validation case's `element_visible` assertion; existing structure
+and backward-compatible usage pattern preserved. Created
+`examples/chrome_ci_test.py` demonstrating the full CI pattern: env-var
+driven headless/URL/tags, `max_retries`/`timeout_ms`, `screenshot_dir`
+CI-artifact directory, `to_junit_xml()` written to `qa-results/results.xml`,
+and `sys.exit(report.exit_code)` for a deploy-or-block gate, plus a
+`.circleci/config.yml` snippet in the docstring. Created
+`examples/qa-tests-sample.json` (3 cases: smoke/regression/accessibility)
+usable directly with `chrome_runner`.
+
+Verification: `ruff check` clean on both example files (fixed one
+`ASYNC230` blocking-`open()`-in-async finding by switching to
+`Path.write_text()`, matching the pattern already used in
+`chrome_runner.py`). Both example files import cleanly (verified via
+isolated `importlib.util` loads — a same-process double-import hit a
+pre-existing, unrelated framework quirk where importing `parrot.bots.chrome`
+chdir's the process to the app's resolved settings root; not something
+this task introduces or fixes). `qa-tests-sample.json` validates as
+`list[QATestCase]` and loads via `chrome_runner.load_test_cases()`
+(3 cases). `examples/chrome_ci_test.py` was gitignored by the repo-wide
+`examples/**/*.py` data-scratch rule (same rule `chrome_qa_test.py` was
+already force-added under) — force-added with `git add -f`, consistent
+with existing project convention.
+
+**Deviations from spec**: none.

--- a/sdd/tasks/index/webagent-cicd-qa-runner.json
+++ b/sdd/tasks/index/webagent-cicd-qa-runner.json
@@ -32,7 +32,7 @@
       "feature_id": "FEAT-410",
       "feature": "webagent-cicd-qa-runner",
       "spec": "sdd/specs/webagent-cicd-qa-runner.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -42,8 +42,8 @@
       "parallelism_notes": "Can run in parallel with TASK-2117 — both depend on TASK-2115 but touch different parts of chrome.py (QAReport methods vs WebAgent class)",
       "assigned_to": null,
       "started_at": "2026-08-04T17:46:40+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2116-junit-xml-and-exit-code.md"
+      "completed_at": "2026-08-04T17:52:25+00:00",
+      "file": "sdd/tasks/completed/TASK-2116-junit-xml-and-exit-code.md"
     },
     {
       "id": "TASK-2117",

--- a/sdd/tasks/index/webagent-cicd-qa-runner.json
+++ b/sdd/tasks/index/webagent-cicd-qa-runner.json
@@ -52,7 +52,7 @@
       "feature_id": "FEAT-410",
       "feature": "webagent-cicd-qa-runner",
       "spec": "sdd/specs/webagent-cicd-qa-runner.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "depends_on": [
@@ -62,8 +62,8 @@
       "parallelism_notes": "Can run in parallel with TASK-2116 — both depend on TASK-2115 but touch different parts of chrome.py (WebAgent class vs QAReport methods)",
       "assigned_to": null,
       "started_at": "2026-08-04T17:46:40+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2117-run-tests-enhancements.md"
+      "completed_at": "2026-08-04T18:01:38+00:00",
+      "file": "sdd/tasks/completed/TASK-2117-run-tests-enhancements.md"
     },
     {
       "id": "TASK-2118",

--- a/sdd/tasks/index/webagent-cicd-qa-runner.json
+++ b/sdd/tasks/index/webagent-cicd-qa-runner.json
@@ -5,7 +5,7 @@
   "type": "feature",
   "base_branch": "dev",
   "created_at": "2026-08-04T00:00:00Z",
-  "completed_at": null,
+  "completed_at": "2026-08-04T18:15:00+00:00",
   "tasks": [
     {
       "id": "TASK-2115",
@@ -94,7 +94,7 @@
       "feature_id": "FEAT-410",
       "feature": "webagent-cicd-qa-runner",
       "spec": "sdd/specs/webagent-cicd-qa-runner.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "S",
       "depends_on": [
@@ -105,8 +105,8 @@
       "parallelism_notes": "Final task — needs all features implemented to write accurate examples",
       "assigned_to": null,
       "started_at": "2026-08-04T17:46:40+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2119-examples-and-ci-docs.md"
+      "completed_at": "2026-08-04T18:15:00+00:00",
+      "file": "sdd/tasks/completed/TASK-2119-examples-and-ci-docs.md"
     }
   ]
 }

--- a/sdd/tasks/index/webagent-cicd-qa-runner.json
+++ b/sdd/tasks/index/webagent-cicd-qa-runner.json
@@ -14,7 +14,7 @@
       "feature_id": "FEAT-410",
       "feature": "webagent-cicd-qa-runner",
       "spec": "sdd/specs/webagent-cicd-qa-runner.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "S",
       "depends_on": [],
@@ -22,8 +22,8 @@
       "parallelism_notes": "Foundation task — all other tasks depend on the model changes here",
       "assigned_to": null,
       "started_at": "2026-08-04T17:46:40+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2115-qa-model-enhancements.md"
+      "completed_at": "2026-08-04T17:49:48+00:00",
+      "file": "sdd/tasks/completed/TASK-2115-qa-model-enhancements.md"
     },
     {
       "id": "TASK-2116",

--- a/sdd/tasks/index/webagent-cicd-qa-runner.json
+++ b/sdd/tasks/index/webagent-cicd-qa-runner.json
@@ -72,7 +72,7 @@
       "feature_id": "FEAT-410",
       "feature": "webagent-cicd-qa-runner",
       "spec": "sdd/specs/webagent-cicd-qa-runner.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "M",
       "depends_on": [
@@ -84,8 +84,8 @@
       "parallelism_notes": "Depends on all three prior tasks — uses models, JUnit XML, and run_tests()",
       "assigned_to": null,
       "started_at": "2026-08-04T17:46:40+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2118-cli-runner.md"
+      "completed_at": "2026-08-04T18:06:24+00:00",
+      "file": "sdd/tasks/completed/TASK-2118-cli-runner.md"
     },
     {
       "id": "TASK-2119",


### PR DESCRIPTION
## Summary

Extends `WebAgent` and its QA Pydantic models (`packages/ai-parrot/src/parrot/bots/chrome.py`) to be production-grade for CI/CD pipelines (CircleCI, GitHub Actions, GitLab CI), plus a new CLI entry point.

- **TASK-2115** — QA Model Enhancements: `QAAssertion.wait_timeout_ms`, `response_status`/`accessibility_check` checks, `QATestCase.max_retries`/`timeout_ms`, `QAFinding.retries`. All backward compatible (sensible defaults).
- **TASK-2116** — JUnit XML Serialization & Exit Code: `QAReport.exit_code` and `QAReport.to_junit_xml()` (stdlib `xml.etree.ElementTree` only).
- **TASK-2117** — WebAgent `run_tests()` Enhancements: tag-based filtering, per-test retry (`max_retries`) and timeout (`asyncio.wait_for`), refactored to process one test case at a time via a new `_execute_single_test()` helper, updated system prompt documenting new assertion semantics.
- **TASK-2118** — CLI QA Runner Entry Point: new `parrot/bots/chrome_runner.py` module (`python -m parrot.bots.chrome_runner`), JSON/YAML test file loading, env var overrides (`CHROME_HEADLESS`, `TARGET_URL`, `QA_TAGS`), JUnit XML output, screenshot dir creation, exit code propagation.
- **TASK-2119** — CI/CD Examples & Documentation: updated `examples/chrome_qa_test.py`, new `examples/chrome_ci_test.py` (full CI pattern incl. CircleCI snippet) and `examples/qa-tests-sample.json`.
- **Post-review fixes**: broadened per-test exception handling in `run_tests()` so one failing case can't abort the whole suite (was previously only catching `TimeoutError`), guarded against `IndexError` on an empty `test_cases` list, made the screenshot-path instruction in the LLM prompt concrete/predictable (`{test_name}_{timestamp}.png`), and hardened `chrome_runner.load_test_cases()` to exit(2) gracefully on schema validation errors instead of raising.

## Tasks

5/5 tasks verified — all have commits + files present, verified against acceptance criteria and re-tested after an adversarial code review pass (code-reviewer agent + Codex cross-check).

Test suite: 81 passed (`pytest packages/ai-parrot/tests/bots/test_chrome.py packages/ai-parrot/tests/bots/test_chrome_runner.py -v`). `ruff check` clean on all touched files.

Noted for reviewer (pre-existing design tradeoffs, not regressions):
- `QAReport.exit_code`/`to_junit_xml()` trust `failed`/`errors`/`total`/`skipped` fields as given rather than deriving from `findings` — real production path (`run_tests()`) keeps them in sync; only a hazard for manually-constructed `QAReport` objects.
- An all-`skip` report (tag filter matches nothing) reports `exit_code == 0` per the spec's literal `skip` semantics — worth a product decision on whether a typo'd tag filter should fail loudly.

---
_Closed by /sdd-done_