### PR TITLE
feat(sdd-dev-flow): FEAT-412 — Dev-Flow: SDD-Oriented AgentsFlow for Feature Development

### DIFF
--- a/.claude/agents/sdd-ideation.md
+++ b/.claude/agents/sdd-ideation.md
@@ -1,0 +1,320 @@
+---
+name: sdd-ideation
+description: |
+  Ideation-phase subagent for the dev-flow (FEAT-412). Turns a
+  natural-language development request into a committed SDD document,
+  resolving Open Questions with the human across bounded rounds.
+
+  DUAL-MODE — the dispatch payload carries a `mode` field:
+    * mode="brainstorm" (intent new_feature) → writes a full
+      sdd/proposals/<slug>.brainstorm.md with options analysis and a
+      recommendation.
+    * mode="proposal" (intent enhancement) → writes a LIGHT
+      sdd/proposals/<slug>.proposal.md (scope, rationale, impact, open
+      questions — no options analysis, NOT the deep /sdd-proposal
+      research artifact).
+
+  When the target document already exists the agent RESUMES/EXTENDS it in
+  place — never overwrites it, never creates a `-2`-suffixed copy.
+
+  The agent emits ONE final JSON object matching the IdeationOutput
+  Pydantic contract — no prose, no markdown fences, just JSON.
+
+  Examples:
+
+  Context: IdeationNode hands the agent a natural-language new_feature
+  request on round 1.
+  user: "DevRequestBrief: kind=new_feature, title='compression budget
+  telemetry', description='Add per-tool telemetry to the compression
+  budget so operators can see which tool blew the budget.'"
+  assistant: "I'll write sdd/proposals/compression-budget-telemetry.brainstorm.md
+  with options A/B/C plus a recommendation, commit it to dev, and emit the
+  IdeationOutput JSON listing my open questions."
+
+  Context: Round 2 — the human answered the previous round's questions.
+  user: "Resume sdd/proposals/compression-budget-telemetry.brainstorm.md.
+  answers={'Which store?': 'pgvector', 'Sync or async flush?': 'async'}"
+  assistant: "I'll flip those two questions to [x] with their answers,
+  fold the decisions into the document body, commit, and emit the
+  IdeationOutput JSON with the remaining open questions."
+
+model: sonnet
+color: cyan
+permissionMode: default
+tools: Read, Grep, Glob, Bash, Write, Edit
+---
+
+# SDD Ideation — Natural Language → Committed SDD Document
+
+You are the **ideation phase** of the `dev-flow`. Unlike `sdd-planner`
+(which consumes an SDD document that already exists), you are handed a
+developer's request in **plain natural language** and your job is to
+produce the document `sdd-planner` will later consume.
+
+You run in **bounded rounds**. On each dispatch you either create the
+document (round 1) or resume it with the human's answers (round 2+), then
+report your remaining Open Questions so the flow can ask the human.
+
+## Input
+
+The dispatch payload carries:
+
+| Field | Meaning |
+|---|---|
+| `mode` | `"brainstorm"` (new_feature) or `"proposal"` (enhancement) — **decides which document you write**. Never infer it from the text. |
+| `title` | Short name. The **slug source**. |
+| `description` | The natural-language request itself. |
+| `context` | Optional extra context/links/constraints. May be empty. |
+| `graph_context` | Optional pre-fetched knowledge-graph context (related modules, prior features). Read it before searching the codebase yourself. |
+| `answers` | Prior-round `question -> answer` mapping. Empty on round 1. |
+| `document_path` | Set on resume rounds: the document you must extend. |
+| `round` | 1-based round counter. |
+
+## Step 1 — Resolve the slug and target path
+
+Slugify `title`: lowercase, non-alphanumerics → single hyphens, no leading
+or trailing hyphen (e.g. `"Compression Budget Telemetry!"` →
+`compression-budget-telemetry`).
+
+The target path is decided **by `mode`**, not by your judgement:
+
+| `mode` | Target document |
+|---|---|
+| `brainstorm` | `sdd/proposals/<slug>.brainstorm.md` |
+| `proposal` | `sdd/proposals/<slug>.proposal.md` |
+
+## Step 2 — Existing-document policy (RESUME / EXTEND, never clobber)
+
+Check whether the target path already exists (`Read` it if so).
+
+- **Does not exist** → create it (Step 3). `resumed_existing: false`.
+- **Exists and is about the same request** → **RESUME/EXTEND IT IN PLACE**
+  using `Edit`. Add new sections/detail, fold in this round's `answers`,
+  keep the existing decision trail intact. Set
+  `resumed_existing: true`.
+- **Exists but its Problem Statement is clearly about something else**
+  (two different ideas slugified to the same name) → **DO NOT extend it
+  and DO NOT overwrite it.** Leave the file untouched, and return an
+  `IdeationOutput` whose `open_questions` contains ONE question naming the
+  collision explicitly, e.g.
+  `"sdd/proposals/<slug>.brainstorm.md already exists and describes <other
+  topic>, not <this request>. Use a different slug, or extend that
+  document anyway?"`
+  Set `committed: false` in that case — you wrote nothing.
+
+**Absolutely forbidden**: overwriting an existing document wholesale, or
+creating `<slug>-2.brainstorm.md` / `<slug>.brainstorm-2.md` style copies.
+The human resolves slug collisions, not you.
+
+## Step 3 — Write the document
+
+Every document you write starts with the FEAT-145 frontmatter, verbatim:
+
+```
+---
+# SDD flow type and base branch (FEAT-145).
+# - type: feature  (default)  → base_branch: dev (or any non-main branch)
+# - type: hotfix              → base_branch MUST be: main
+type: feature
+base_branch: dev
+---
+```
+
+### mode = "brainstorm"  (intent: new_feature)
+
+A full brainstorm — the reader must be able to see the alternatives you
+considered and why you picked one:
+
+```
+# Brainstorm: <Title>
+
+**Date**: <YYYY-MM-DD>
+**Author**: <requester> (with sdd-ideation)
+**Status**: draft
+
+## Problem Statement
+<what hurts today, in the requester's terms; quote the request>
+
+## Constraints & Requirements
+<hard constraints, existing conventions this must respect>
+
+## Options Explored
+
+### Option A: <Name>
+**Approach**: ...
+**Pros**: ...
+**Cons**: ...
+
+### Option B: <Name>
+...
+
+### Option C: <Name>            <!-- include when a third is genuinely distinct -->
+...
+
+## Recommendation
+<the chosen option and WHY, in terms of the constraints above>
+
+## Feature Description
+### User-Facing Behavior
+### Internal Behavior
+### Edge Cases & Error Handling
+
+## Impact & Integration
+<modules touched, integration points, migration/compat concerns>
+
+## Code Context
+<verified references only — see Cardinal rules>
+
+## Open Questions
+<see the Open-Questions convention below>
+```
+
+### mode = "proposal"  (intent: enhancement)
+
+A **light** proposal. An enhancement extends something that already
+exists, so options analysis is noise — scope, rationale and impact are the
+whole point. Do **NOT** produce the deep `/sdd-proposal` research artifact
+(no confidence maps, no hypothesis blocks, no research audit):
+
+```
+# Proposal: <Title>
+
+**Date**: <YYYY-MM-DD>
+**Author**: <requester> (with sdd-ideation)
+**Status**: draft
+
+## Origin
+<the request, quoted; what triggered it>
+
+## Scope
+### What Changes
+### What's New
+### What's Untouched (Non-Goals)
+
+## Rationale
+<why this is worth doing, and why THIS shape of change>
+
+## Impact
+<modules/files touched, integration points, backward-compatibility notes,
+ risks>
+
+## Code Context
+<verified references only — see Cardinal rules>
+
+## Open Questions
+<see the Open-Questions convention below>
+```
+
+Both formats deliberately share the frontmatter, the `## Open Questions`
+section and the `## Code Context` discipline, so `/sdd-spec` and
+`PlannerNode` treat them uniformly.
+
+## The Open-Questions convention (consumed by `/sdd-spec` §2b)
+
+Write questions as a flat list under `## Open Questions`:
+
+```
+- [ ] <Unresolved question> — *Owner: user*
+- [x] <Answered question> — *Resolved*: <answer text>
+```
+
+Rules:
+
+- `[ ]` = still open. `[x]` = answered by the human.
+- The answer is the text after the **final `:`** on the line — that is what
+  `/sdd-spec` parses, so never put a bare `:` after the answer.
+- When a prior-round `answers` entry matches a question, flip that
+  question to `[x]` and append `— *Resolved*: <answer>` **verbatim**.
+- **A resolved answer is not just bookkeeping**: fold the decision into the
+  document body where it actually applies (scope, recommendation, impact),
+  the same way `/sdd-spec` folds resolutions into the spec body. A `[x]`
+  question whose answer contradicts a paragraph you already wrote means
+  you must **update that paragraph**.
+- Questions the human did not answer stay `[ ]` — do not delete them and do
+  not silently rephrase them. Unanswered questions are carried into the
+  spec's §8 by the planner, which is the intended escape valve when the
+  round budget runs out.
+- Ask only questions that genuinely change the design. Anything decidable
+  during implementation belongs in the body as an implementation note, not
+  as an Open Question.
+
+## Step 4 — Commit the document
+
+The document **must be committed** before you return: `sdd-planner` runs
+later and creates its worktree from the base branch's HEAD, so an
+uncommitted document is invisible there and the run will fail.
+
+Stage **only** the document path — never `git add -A`, never `git add .`
+(other SDD sessions may have unrelated work in progress on this branch):
+
+```bash
+git add sdd/proposals/<slug>.<brainstorm|proposal>.md
+git commit -m "sdd: <create|extend> <brainstorm|proposal> for <slug>"
+```
+
+Report the outcome truthfully in `committed`. If the commit fails (hook
+rejection, nothing staged, detached HEAD), set `committed: false` and
+explain in `summary` — do **not** claim success.
+
+## Cardinal rules
+
+- **You write documents, not code.** Your only writes are the single
+  document under `sdd/proposals/` and its git commit. Never touch
+  production code, tests, `sdd/specs/`, or `sdd/tasks/`.
+- **Never invent codebase references.** Anything you put under
+  `## Code Context` must be verified with `Read`/`Grep`/`Glob` first.
+  Prefer "not verified" over a plausible-looking path. An
+  anti-hallucination note ("`X` does NOT exist today") is more valuable
+  than a guess.
+- **Never overwrite or suffix an existing document** (Step 2).
+- **Never fabricate an answer** on the human's behalf. If a question is
+  unanswered, it stays `[ ]`.
+- **`mode` decides the format.** Do not write a brainstorm in proposal
+  mode or vice versa, even if the request feels like the other kind.
+- Do not create, transition, or comment on a Jira ticket. If a
+  `jira_issue_key` is supplied it is link-only context.
+
+## Output Contract
+
+Your **final** assistant turn must be exactly ONE JSON object — no prose
+before or after it, no markdown fences:
+
+```json
+{
+  "document_path": "sdd/proposals/compression-budget-telemetry.brainstorm.md",
+  "document_kind": "brainstorm",
+  "slug": "compression-budget-telemetry",
+  "resumed_existing": false,
+  "open_questions": [
+    "Which store backs the telemetry?",
+    "Sync or async flush?"
+  ],
+  "summary": "Full brainstorm with three options; recommends B (in-process ring buffer).",
+  "committed": true
+}
+```
+
+Field rules:
+
+- `document_path` — the path you actually wrote (or the colliding path in
+  the Step 2 mismatch case).
+- `document_kind` — `"brainstorm"` when `mode="brainstorm"`, `"proposal"`
+  when `mode="proposal"`. It must agree with the path's suffix.
+- `slug` — the slug from Step 1.
+- `resumed_existing` — `true` only when you extended a pre-existing
+  document in place.
+- `open_questions` — the questions still `[ ]` in the document after this
+  round, as plain strings **matching the question text in the document
+  exactly** (the flow uses them as dictionary keys when it collects the
+  human's answers). Empty list when nothing is open.
+- `summary` — one or two sentences a human can read in a UI card.
+- `committed` — `true` only if the commit actually succeeded.
+
+## Failure handling
+
+If you cannot satisfy the contract (cannot write the file, cannot commit,
+slug collision per Step 2), still emit a **valid** `IdeationOutput` with
+`committed: false` and an explanatory `summary`. `IdeationNode` fails the
+run fast on `committed: false` and routes it to the failure handler — that
+is the intended, auditable outcome. Never emit prose instead of the JSON,
+and never claim a success you did not achieve.

--- a/examples/dev_loop/GUIA.md
+++ b/examples/dev_loop/GUIA.md
@@ -15,9 +15,11 @@ examples/dev_loop/
 ├── GUIA.md            ← este documento
 ├── e2e_demo.py        ← demo end-to-end SIN servicios externos (cero setup)
 ├── quickstart.py      ← flujo real, un run programático y sale (sin UI)
-├── server.py          ← servidor aiohttp: flujo real + WebSocket multiplexado
+├── server.py          ← consola de OPERACIÓN: bugs, triage de logs, Jira
+├── server_dev.py      ← consola de DESARROLLO: el dev-flow (FEAT-412), puerto 8081
 └── static/
-    └── index.html     ← cliente UI (JS vanilla, sin build step)
+    ├── index.html     ← UI de operación (la sirve server.py)
+    └── dev.html       ← UI de desarrollo con panel HITL (la sirve server_dev.py)
 ```
 
 El flujo es un `AgentsFlow` de 8 nodos:
@@ -34,7 +36,13 @@ La única diferencia es cómo se dispara y qué se simula:
 |---|---|---|---|
 | `e2e_demo.py` | **todos simulados** en proceso | ninguna (stdout) | Ver la mecánica sin montar nada |
 | `quickstart.py` | **reales** | ninguna (stdout) | Embeber el flujo en tu propio servicio |
-| `server.py` + UI | **reales** | HTTP + WebSocket + UI | Ver el stream de eventos en vivo |
+| `server.py` + UI | **reales** | HTTP + WebSocket + UI | Ver el stream de eventos en vivo (operación) |
+| `server_dev.py` + UI | **reales** (sin CloudWatch, Jira opcional) | HTTP + WebSocket + UI | Convertir una idea en un PR draft, contestando preguntas en el navegador |
+
+> **Dos consolas, dos públicos** (FEAT-412). `server.py` es la consola de
+> **operación** (bugs, logs de CloudWatch, tickets). `server_dev.py` es la de
+> **desarrollo**: entra lenguaje natural, sale un PR draft. Usan el mismo Redis
+> y puertos distintos (8080 y 8081), así que pueden correr a la vez. Ver §9.
 
 ---
 
@@ -296,6 +304,136 @@ consume tal cual:
 
 ---
 
+## 9. Consola de desarrollo (`server_dev.py` + `static/dev.html`)
+
+Esta es la consola para **desarrollar**: describes lo que quieres en lenguaje
+natural, el flujo escribe el documento SDD, **te pregunta lo que no sabe**, y
+termina en un PR draft contra `dev`.
+
+### 9.1. Arrancar
+
+```bash
+source .venv/bin/activate
+python examples/dev_loop/server_dev.py
+# abre http://localhost:8081
+```
+
+Lo único imprescindible es **Redis**. A diferencia de `server.py`:
+
+* **no necesita nada de CloudWatch** — este flujo no cablea toolkits de logs;
+* **no necesita Jira** — si no hay `JIRA_INSTANCE`/`JIRA_USERNAME` arranca
+  igual, con `jira_toolkit=None` (Jira aquí es sólo un enlace opcional).
+
+Sí necesita, como el modo real, el CLI `claude` autenticado y `gh` para el PR.
+
+Como el puerto es 8081, puedes tener las dos consolas levantadas al mismo
+tiempo:
+
+```bash
+python examples/dev_loop/server.py      # operación  → :8080
+python examples/dev_loop/server_dev.py  # desarrollo → :8081
+```
+
+### 9.2. Elegir el intent (lo eliges tú, no un LLM)
+
+| Intent | Qué escribes | Qué documento genera |
+|---|---|---|
+| **Enhancement** | título + descripción | `sdd/proposals/<slug>.proposal.md` — propuesta **ligera**: alcance, motivo, impacto (sin análisis de opciones) |
+| **New Feature** | título + descripción | `sdd/proposals/<slug>.brainstorm.md` — brainstorm **completo**: opciones A/B/C + recomendación |
+| **Feature (SDD)** | ruta de un documento que ya existe | ninguno — la ideación **se salta** y el run arranca en el planner |
+
+El **título** genera el slug. Si el documento ya existe **se retoma y se
+amplía** — nunca se sobreescribe ni se crea un `-2`. La ruta resuelta sale en
+el título del gate justamente para que puedas detectar (y rechazar) que haya
+cogido un documento que no era.
+
+### 9.3. Contestar las Open Questions (el paso nuevo)
+
+Cuando la ideación necesita decisiones tuyas:
+
+1. Aparece arriba el panel **“Waiting on you”** con **todas** las preguntas de
+   esa ronda (un gate por ronda, no uno por pregunta).
+2. Rellenas las que sepas — **las respuestas parciales valen**: lo que dejes en
+   blanco se queda como `[ ]` en el documento.
+3. **Submit answers** → tus respuestas viajan en el siguiente dispatch y el
+   subagente marca cada pregunta contestada como
+   `- [x] <pregunta> — *Resolved*: <respuesta>` en el documento, y mete la
+   decisión en el cuerpo.
+4. Puede haber otra ronda. El máximo es `DEV_FLOW_IDEATION_MAX_ROUNDS`
+   (por defecto **2**). Al agotarse, lo que siga sin contestar **no bloquea el
+   run**: se queda en el documento y el planner lo arrastra al §8 del spec.
+
+Mientras el gate está abierto el run se **aparca** y libera su slot de
+concurrencia, así que puedes tardar horas. Dos avisos:
+
+* **Reject & abort run** cancela la ideación y manda el run al
+  `failure_handler`.
+* Si nadie contesta, el gate **expira y el run falla** (fail-closed, TTL
+  `DEV_FLOW_GATE_TTL_QUESTIONS`, 24 h por defecto): en decisiones de diseño,
+  el silencio no es un “sí”.
+* Si recargas la página con un gate abierto, el panel **vuelve a aparecer**
+  (se pinta del estado, no del evento suelto).
+
+### 9.4. Contestar un gate por curl (sin UI)
+
+```bash
+# aprobar contestando
+curl -X POST http://localhost:8081/api/flow/run-1a2b3c4d/gates/9f8e7d6c/resolve \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "resolution": "approved",
+    "resolved_by": "jesus",
+    "answers": {"¿Qué store usamos?": "pgvector"}
+  }'
+
+# abortar
+curl -X POST http://localhost:8081/api/flow/run-1a2b3c4d/gates/9f8e7d6c/resolve \
+  -H 'Content-Type: application/json' \
+  -d '{"resolution": "rejected", "resolved_by": "jesus", "comment": "documento equivocado"}'
+```
+
+Aprobar un gate `open_questions` **sin** `answers` devuelve `400
+answers_required` (para abortar se usa `rejected`). Un segundo intento sobre el
+mismo gate devuelve `409` y dice quién lo resolvió primero.
+
+### 9.5. Lanzar un run por curl
+
+```bash
+curl -X POST http://localhost:8081/api/flow/run \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "kind": "new_feature",
+    "title": "telemetría del compression budget",
+    "description": "Añadir telemetría por herramienta al compression budget para ver cuál se come el presupuesto.",
+    "require_plan_approval": true
+  }'
+```
+
+`title` y `description` son obligatorios. Aquí **no hay**
+`affected_component`, `log_sources` ni `acceptance_criteria` — eso es del
+intake de bugs.
+
+### 9.6. Gate de aprobación del plan (opcional)
+
+En la pestaña **Ideation & gates** hay un check **Require plan approval**. Si
+lo marcas, después del planner y **antes** de que salga la flota de agentes se
+abre un gate `plan_approval` que se contesta en el mismo panel (aprobar/
+rechazar + comentario). Es **por run**: manda sobre el valor con el que se
+construyó el servidor, sin reconstruir el flujo.
+
+### 9.7. Variables nuevas
+
+| Variable | Default | Para qué |
+|---|---|---|
+| `DEV_FLOW_IDEATION_MAX_ROUNDS` | `2` | Rondas máximas de Open Questions por run |
+| `DEV_FLOW_GATE_TTL_QUESTIONS` | `86400` (24 h) | TTL del gate `open_questions`; al expirar el run **falla** |
+
+El resto se reutiliza tal cual de las `DEV_LOOP_*` que ya conoces
+(`DEV_LOOP_QA_MAX_RETRIES`, `DEV_LOOP_GATE_PARK`, `DEV_LOOP_JUDGE_PANEL`,
+`DEV_LOOP_DEV_AGENTS`, `FLOW_MAX_CONCURRENT_RUNS`…).
+
+---
+
 ## 8. Resumen — qué ejecutar según lo que quieras
 
 | Quiero… | Comando | Setup |
@@ -303,3 +441,4 @@ consume tal cual:
 | Ver el flujo sin montar nada | `python examples/dev_loop/e2e_demo.py` | solo `uv sync` |
 | Embeberlo en mi servicio | `python examples/dev_loop/quickstart.py` | modo real (§4.1) |
 | Verlo en vivo con UI | `python examples/dev_loop/server.py` → `http://localhost:8080` | modo real (§4.1) |
+| Desarrollar una feature de cero (idea → PR draft) | `python examples/dev_loop/server_dev.py` → `http://localhost:8081` | Redis + `claude` + `gh` (sin CloudWatch, Jira opcional) — §9 |

--- a/examples/dev_loop/README.md
+++ b/examples/dev_loop/README.md
@@ -28,10 +28,26 @@ examples/dev_loop/
 ├── README.md          ← this file
 ├── e2e_demo.py        ← self-contained end-to-end demo (no external services)
 ├── quickstart.py      ← real-mode programmatic example (no UI)
-├── server.py          ← aiohttp server: real flow + WS multiplexer
+├── server.py          ← OPERATIONS console: bug/enhancement/new_feature + feature
+├── server_dev.py      ← DEVELOPMENT console: the dev-flow (FEAT-412), port 8081
 └── static/
-    └── index.html     ← vanilla-JS UI client (no build step)
+    ├── index.html     ← operations UI (served by server.py)
+    └── dev.html       ← development UI with the HITL panel (served by server_dev.py)
 ```
+
+**Two consoles, two audiences** (FEAT-412). They share Redis, the streaming
+layer and the artifact conventions, and they can run side by side:
+
+| | `server.py` + `index.html` | `server_dev.py` + `dev.html` |
+|---|---|---|
+| For | operating: bugs, log triage, ticketed work | developing: turning an idea into a PR |
+| Port | 8080 | **8081** |
+| Intake | summary + affected component + log sources | natural language, or an SDD document |
+| CloudWatch | yes | **never wired** |
+| Jira | required for bug runs | optional, link-only |
+| HITL | read-only gate audit trail | **interactive** — answers gates from the browser |
+
+See **Development console** below.
 
 Both real-mode entry points wire the **real** flow — no fakes, no stubs.
 They differ only in how the run is triggered: `quickstart.py` runs the brief
@@ -359,6 +375,195 @@ Common gotchas:
   allowlisted head (e.g. `pytest scripts/check_pipeline.py`).
 * If you need a `FlowtaskCriterion` with a specific `task_path` /
   structured `args` array, post the full criterion dict via curl.
+
+## Development console — `server_dev.py` + `static/dev.html` (FEAT-412)
+
+```bash
+source .venv/bin/activate
+python examples/dev_loop/server_dev.py
+# open http://localhost:8081        (PORT / HOST / REDIS_URL env still win)
+```
+
+Redis is the only hard requirement. **No `CLOUDWATCH_*` and no `JIRA_*` env is
+needed** — the dev-flow wires no log toolkits at all, and Jira is link-only:
+when `JIRA_INSTANCE`/`JIRA_USERNAME` are unset the server logs one line and
+runs with `jira_toolkit=None`.
+
+Because the port differs, this console runs **alongside** the operations one
+(8080) against the same Redis.
+
+### The topology
+
+```
+dev_intake ─(enhancement | new_feature)→ ideation ─┐
+     └──────(feature)──────────────────────────────┤
+                                                   ▼
+planner → development → synthesis → qa ─(passed)→ feature_handoff → close
+                ↑                    │                  ▲   (draft PR)
+                └─(retry, bounded)───┤                  │
+                                     ▼                  │
+                              feedback_router ──(accept_with_notes)
+                                     ├─(escalate)→ failure_handler
+                          (+ on_error fan-in from every middle node)
+```
+
+Everything from `planner` onward behaves exactly like the feature-mode chain —
+same node types, same predicates, same bounded repair loop. Only the intake is
+new. The run always ends at a **draft PR against `dev`**; the flow never
+merges.
+
+### The three intents
+
+The intent is a **user choice in the UI** — there is no LLM classification
+anywhere in this flow.
+
+| Intent | Intake | Ideation writes | Then |
+|---|---|---|---|
+| `enhancement` | natural language (`title` + `description`) | `sdd/proposals/<slug>.proposal.md` — a **light** proposal: scope, rationale, impact, open questions (no options analysis) | planner → … |
+| `new_feature` | natural language (`title` + `description`) | `sdd/proposals/<slug>.brainstorm.md` — a **full** brainstorm: options A/B/C + a recommendation | planner → … |
+| `feature` | an existing SDD document (`document_path` + `document_kind`) | *nothing — ideation is skipped by routing* | planner → … |
+
+`title` is the slug source. **If the target document already exists it is
+resumed and extended in place** — never overwritten, never `-2`-suffixed. The
+resolved path is shown in the gate title so you can spot (and reject) an
+unintended reuse; if the existing document is clearly about something else the
+subagent refuses to touch it and returns the collision as an open question.
+
+### Endpoints
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/` | GET | Serves `static/dev.html` |
+| `/api/config` | GET | Backends/models catalog, the three intents, `document_kinds`, `nl_kinds`, `gate_resolve_url_template`, and the dev defaults (`ideation_max_rounds`, `gate_ttl_questions`, `require_plan_approval`, `qa_max_retries`, `development_pool_max`, `max_concurrent_runs`, …). Carries **no** `log_group`, `time_window_minutes` or `jira_project`. |
+| `/api/flow/run` | POST | Start a run. Body per the intent (below). Returns `run_id`, `mode`, `kind`, `ws_url`, `state_ws_url`, `bundle_url`, `gate_resolve_url`. |
+| `/api/flow/{run_id}/gates/{gate_id}/resolve` | POST | **The HITL write path** — resolve a gate. `server.py` never mounts this. |
+| `/api/flow/{run_id}/cancel` | POST | Cancel a run |
+| `/api/flow/{run_id}/ws` | GET | `flow_stream_ws` — `?view=flow\|dispatch\|both\|state` |
+| `/api/flow/{run_id}/bundle` | GET | Finished run's bundle (`?format=md` for the report) |
+| `/api/flow/{run_id}/replay` | GET | JSON dump of stored events |
+
+### Run payloads
+
+Natural language (`enhancement` / `new_feature`):
+
+```bash
+curl -X POST http://localhost:8081/api/flow/run \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "kind": "new_feature",
+    "title": "compression budget telemetry",
+    "description": "Add per-tool telemetry to the compression budget so operators can see which tool blew the budget.",
+    "context": "See PR #1204 for the original budget work.",
+    "require_plan_approval": true
+  }'
+```
+
+`title` and `description` are required; everything else is optional. There is
+**no** `affected_component`, `log_sources`, `acceptance_criteria`, `reporter`
+or `escalation_assignee` — those are bug-intake concepts.
+
+Existing document (`feature`) — identical to the ops console's feature payload:
+
+```bash
+curl -X POST http://localhost:8081/api/flow/run \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "kind": "feature",
+    "document_path": "sdd/proposals/my-feature.brainstorm.md",
+    "document_kind": "brainstorm"
+  }'
+```
+
+Optional in both shapes: `jira_issue_key` (link-only), `dev_agents`,
+`judge_panel`, `skip_qa`, `skip_jira`, `require_plan_approval`.
+
+### The `open_questions` gate protocol
+
+Ideation is **interactive and bounded**. Per round:
+
+1. `IdeationNode` dispatches `sdd-ideation`, which writes/extends the document
+   and reports the questions it still needs answered.
+2. If there are any, the node opens **ONE gate carrying ALL of that round's
+   questions** (`kind="open_questions"`, `questions=[...]`) and awaits it. The
+   run **parks** while waiting (`DEV_LOOP_GATE_PARK`), so it releases its
+   concurrency slot and a human can take hours.
+3. `dev.html` receives `gate/opened` on the state WebSocket and renders one
+   input per question. It renders from the folded **state**, not from the live
+   action alone — so reloading the page mid-gate re-renders the pending gate.
+4. You submit; the answers ride the next dispatch, and the subagent marks each
+   answered question `- [x] <question> — *Resolved*: <answer>` in the document
+   (the convention `/sdd-spec` §2b consumes) and folds the decision into the
+   body.
+5. A re-dispatch may surface new questions → a new gate, bounded by
+   `DEV_FLOW_IDEATION_MAX_ROUNDS`. When the budget is spent, anything still
+   `[ ]` **stays in the document and is carried into the spec's §8 by the
+   planner** — it does not block the run.
+
+**Partial answers are fine** — blanks stay open. **Rejecting aborts** the
+ideation and routes the run to `failure_handler`. **Expiry is fail-closed**:
+an unanswered gate expires the run into the failure path, because silence is
+not consent for spec decisions.
+
+Resolving a gate from the CLI (the same call the browser makes):
+
+```bash
+curl -X POST http://localhost:8081/api/flow/run-1a2b3c4d/gates/9f8e7d6c/resolve \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "resolution": "approved",
+    "resolved_by": "jesus",
+    "comment": "answered round 1",
+    "answers": {
+      "Which store backs the telemetry?": "pgvector",
+      "Sync or async flush?": "async"
+    }
+  }'
+```
+
+Responses: `200` with the sequenced envelope · `400 invalid_body` ·
+`400 answers_required` (approving an `open_questions` gate with no answers —
+use `"resolution": "rejected"` to abort instead) · `404 unknown_run` /
+`unknown_gate` · `409 already_resolved` (first writer wins, and the body names
+who won). To abort:
+
+```bash
+curl -X POST http://localhost:8081/api/flow/run-1a2b3c4d/gates/9f8e7d6c/resolve \
+  -H 'Content-Type: application/json' \
+  -d '{"resolution": "rejected", "resolved_by": "jesus", "comment": "wrong document"}'
+```
+
+The same panel handles a `plan_approval` gate (approve/reject + comment, no
+answer inputs) when you tick **Require plan approval** — see below.
+
+### Per-run plan-approval gate
+
+`dev.html`'s *Ideation & gates* tab has a **Require plan approval** toggle.
+Ticking it sends `require_plan_approval: true`, which the server forwards as
+`extra_shared["require_plan_approval"]`; `DevelopmentNode` honours that per-run
+value **over** its build-time flag, so no flow rebuild is needed. An explicit
+`false` suppresses a gate the server was built with; omitting the field leaves
+the build-time default alone. The resulting gate opens after the planner and
+before the dev-agent fleet dispatches.
+
+### New configuration keys
+
+| Key | Default | Meaning |
+|---|---|---|
+| `DEV_FLOW_IDEATION_MAX_ROUNDS` | `2` | Max Open-Questions HITL rounds (gates) per run. Leftover questions are carried into the spec, never re-asked forever. |
+| `DEV_FLOW_GATE_TTL_QUESTIONS` | `86400` (24 h) | TTL for an `open_questions` gate. **Fail-closed** — expiry routes the run to `failure_handler`. |
+
+Everything else is reused unchanged from the existing `DEV_LOOP_*` keys
+(`DEV_LOOP_QA_MAX_RETRIES`, `DEV_LOOP_GATE_PARK`, `DEV_LOOP_JUDGE_PANEL`,
+`DEV_LOOP_DEV_AGENTS`, `DEV_LOOP_DEV_POOL_MAX`, `DEV_LOOP_REPOS`,
+`DEV_LOOP_DOCS_ARTIFACT_DIR`, `FLOW_MAX_CONCURRENT_RUNS`, …) — the dev-flow
+deliberately does not fork the shared knobs.
+`DEV_LOOP_REQUIRE_PLAN_APPROVAL` still sets the server-wide default that the
+per-run toggle overrides.
+
+### Not exposed
+
+Revision mode (`DevLoopRunner.run_revision`) is a library/`e2e_demo` feature
+and is not served by either console.
 
 ## Stream layout (for reference)
 

--- a/examples/dev_loop/server_dev.py
+++ b/examples/dev_loop/server_dev.py
@@ -1,0 +1,580 @@
+"""Development console for the ``dev-flow`` topology (FEAT-412).
+
+The **development** sibling of ``server.py``: same streaming/telemetry
+plumbing, a different intake and a HITL write path.
+
+Deltas versus the operations console (spec §2 table):
+
+======================  ==============================  ===========================
+Concern                 ``server.py`` (ops)             ``server_dev.py`` (dev-flow)
+======================  ==============================  ===========================
+``GET /``               ``static/index.html``           ``static/dev.html``
+Flow                    bug graph + injected feature    ``build_dev_flow`` only
+Runner                  ``DevLoopRunner``               ``DevFlowRunner``
+Log toolkits            CloudWatch via                  **absent** — dev-flow has
+                        ``_build_log_toolkits()``       no ``ResearchNode``
+Jira                    required for bug runs           optional, link-only
+Brief building          summary + ``affected_component``  ``DevRequestBrief`` (title
+                        + ``log_sources``               + description) or
+                                                        ``FeatureBrief``
+Gate resolution         **not mounted**                 mounted (the HITL write path)
+Plan gate               fixed at flow build              per-run UI toggle
+Default port            8080                            **8081**
+======================  ==============================  ===========================
+
+Both servers can therefore run side by side against the same Redis.
+
+Reuse policy: every ops-free helper (dispatcher/reviewer builders, the
+document-brief form parser, the bundle/replay/cancel handlers) is **imported
+from** ``server.py`` rather than copied, so the two consoles cannot drift.
+``server.py`` itself is not modified in any way — this module only reads it.
+Deliberately NOT imported: ``_build_log_toolkits`` (CloudWatch) and
+``_build_brief_from_form`` (bug intake).
+
+Run it with::
+
+    PORT=8081 python examples/dev_loop/server_dev.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+import redis.asyncio as aioredis
+from aiohttp import web
+from parrot import conf
+from parrot.flows.dev_flow.flow import build_dev_flow
+from parrot.flows.dev_flow.models import DevRequestBrief
+from parrot.flows.dev_flow.runner import DevFlowRunner
+from parrot.flows.dev_loop import (
+    ClaudeCodeDispatcher,
+    flow_stream_ws,
+    parse_repo_specs,
+)
+from parrot.flows.dev_loop.agent_builder import (
+    build_dispatcher,
+    parse_pool_env,
+    resolve_pool_max,
+)
+from parrot.flows.dev_loop.commands import resolve_gate_handler
+from parrot.flows.dev_loop.graph_memory import DevLoopGraphMemory
+from parrot.flows.dev_loop.models import DevAgentSpec, JudgePanelConfig
+from parrot.flows.dev_loop.wiki_search import DevLoopWikiSearch
+
+# Sibling-module imports, resolvable whether this file is launched as a
+# script or imported from elsewhere — the same trick ``server.py`` uses for
+# ``llm_catalog``.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import llm_catalog
+import server as ops_server
+
+logger = logging.getLogger("dev_flow.server")
+STATIC_DIR = Path(__file__).parent / "static"
+# Same artifact convention as the ops console: DevLoopRunner._close_host
+# writes {run_id}.bundle.json / {run_id}.report.md there, and the reused
+# bundle/replay handlers read it from that module-level constant.
+RUN_ARTIFACT_DIR = ops_server.RUN_ARTIFACT_DIR
+
+# The three user-selected dev-flow intents (spec §8: no LLM classification).
+_DEV_KINDS = ("enhancement", "new_feature", "feature")
+
+
+# ---------------------------------------------------------------------------
+# Brief building
+# ---------------------------------------------------------------------------
+
+
+def _normalise_kind(raw: Any) -> str:
+    """Normalise a console ``kind`` label to its canonical value.
+
+    Args:
+        raw: The raw form value (e.g. ``"New Feature"``).
+
+    Returns:
+        The canonical kind (``"enhancement"``, ``"new_feature"`` or
+        ``"feature"``), or the normalised input when unrecognised — the
+        caller reports the error.
+    """
+    return (str(raw or "")).strip().lower().replace(" ", "_").replace("-", "_")
+
+
+def _build_dev_brief_from_form(
+    form: dict[str, Any]
+) -> DevRequestBrief | Any:
+    """Translate the dev console's form into a dev-flow brief.
+
+    Two shapes, selected by ``kind``:
+
+    * ``enhancement`` / ``new_feature`` → a :class:`DevRequestBrief`. The
+      request is **natural language**: ``title`` (the slug source) and
+      ``description`` are required; ``context`` is optional. No document
+      exists yet — ``IdeationNode`` writes it.
+    * ``feature`` → a ``FeatureBrief``, built by the ops console's own
+      ``_build_feature_brief_from_form`` (imported, not duplicated) so the
+      document intake behaves identically in both consoles.
+
+    Optional in both shapes: ``jira_issue_key`` (link-only — dev-flow never
+    creates a ticket), ``dev_agents``, ``judge_panel``.
+
+    Deliberately absent: ``affected_component``, ``log_sources``,
+    ``reporter``, ``escalation_assignee`` and ``acceptance_criteria`` — those
+    are bug-intake concepts with no meaning here.
+
+    Args:
+        form: The decoded JSON body posted by the console.
+
+    Returns:
+        A validated ``DevRequestBrief`` or ``FeatureBrief``.
+
+    Raises:
+        ValueError: Unknown ``kind``, or a missing ``title``/``description``
+            for a natural-language request (plus anything the models'
+            own validators reject).
+    """
+    kind = _normalise_kind(form.get("kind"))
+    if kind == "feature":
+        return ops_server._build_feature_brief_from_form(form)
+    if kind not in ("enhancement", "new_feature"):
+        raise ValueError(
+            "kind must be 'enhancement', 'new_feature' or 'feature', got "
+            f"{kind!r}"
+        )
+
+    title = (form.get("title") or "").strip()
+    if not title:
+        raise ValueError(
+            "title is required — it names the request and is the slug source "
+            "for sdd/proposals/<slug>.*.md"
+        )
+    description = (form.get("description") or "").strip()
+    if not description:
+        raise ValueError(
+            "description is required — it is the natural-language request the "
+            "sdd-ideation subagent turns into an SDD document"
+        )
+
+    payload: dict[str, Any] = {
+        "kind": kind,
+        "title": title,
+        "description": description,
+    }
+    context = (form.get("context") or "").strip()
+    if context:
+        payload["context"] = context
+    issue_key = (form.get("jira_issue_key") or "").strip()
+    if issue_key:
+        payload["jira_issue_key"] = issue_key
+    dev_agents = ops_server._parse_dev_agents(form.get("dev_agents"))
+    if dev_agents:
+        payload["dev_agents"] = dev_agents
+    judges = ops_server._parse_judge_panel(form.get("judge_panel"))
+    if judges:
+        payload["judge_panel"] = JudgePanelConfig(judges=judges)
+    return DevRequestBrief.model_validate(payload)
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+async def handle_index(request: web.Request) -> web.FileResponse:
+    """Serve the development console (never ``index.html``)."""
+    return web.FileResponse(STATIC_DIR / "dev.html")
+
+
+async def handle_config(request: web.Request) -> web.Response:
+    """Serve the dev console's configuration catalog.
+
+    Same LLM-catalog payload as the ops console, but the operator-visible
+    defaults carry the dev-flow knobs and **no** observability/Jira-project
+    settings: there is no CloudWatch log group, no time window and no
+    mandatory project, because nothing in this topology reads them.
+    """
+    app = request.app
+    runner = app.get("runner")
+    return web.json_response(
+        {
+            **llm_catalog.catalog_payload(),
+            "kinds": [
+                {"value": "enhancement", "label": "Enhancement"},
+                {"value": "new_feature", "label": "New Feature"},
+                {"value": "feature", "label": "Feature (existing SDD doc)"},
+            ],
+            "document_kinds": ["brainstorm", "proposal", "spec"],
+            # The intents whose runs go through ideation (the UI shows the
+            # natural-language intake for these, a document picker otherwise).
+            "nl_kinds": ["enhancement", "new_feature"],
+            "gate_resolve_url_template": (
+                "/api/flow/{run_id}/gates/{gate_id}/resolve"
+            ),
+            "defaults": {
+                "development_agent": conf.config.get(
+                    "DEV_LOOP_DEVELOPMENT_AGENT", fallback="claude-code"
+                ),
+                "codereview_agent": app.get("codereview_agent_key", "parallel"),
+                "codereview_agent_configured": conf.config.get(
+                    "DEV_LOOP_CODEREVIEW_AGENT", fallback="parallel"
+                ),
+                "qa_max_retries": conf.DEV_LOOP_QA_MAX_RETRIES,
+                "development_pool_max": app.get("development_pool_max", 4),
+                "max_concurrent_runs": getattr(
+                    runner, "max_concurrent_runs", None
+                ),
+                "ideation_max_rounds": getattr(
+                    conf, "DEV_FLOW_IDEATION_MAX_ROUNDS", 2
+                ),
+                "gate_ttl_questions": getattr(
+                    conf, "DEV_FLOW_GATE_TTL_QUESTIONS", 86400
+                ),
+                "require_plan_approval": bool(
+                    app.get("require_plan_approval", False)
+                ),
+                "skip_qa": bool(getattr(conf, "DEV_LOOP_SKIP_QA", False)),
+                "docs_artifact_dir": conf.DEV_LOOP_DOCS_ARTIFACT_DIR,
+                "wiki_page_ingest": conf.DEV_LOOP_WIKI_PAGE_INGEST,
+                "wiki_search": app.get("wiki_search") is not None,
+                "jira_configured": app.get("jira_toolkit") is not None,
+            },
+            "adversarial_review": {
+                "mandatory": True,
+                "scope": conf.DEV_LOOP_ADVERSARIAL_SCOPE,
+                "base_ref": conf.DEV_LOOP_ADVERSARIAL_BASE_REF,
+                "note": (
+                    "Every dev-flow run carries the read-only Codex "
+                    "sdd-secondopinion seat as a judge in the QA panel. It "
+                    "cannot be switched off."
+                ),
+            },
+        }
+    )
+
+
+async def handle_run(request: web.Request) -> web.Response:
+    """Start one ``DevFlowRunner.run(...)`` invocation.
+
+    The JSON body is the dev console's form payload. ``kind`` decides the
+    brief shape only — every run executes the SAME dev-flow graph, whose
+    ``dev_intake`` node routes a natural-language brief through ideation and
+    a document brief straight to the planner.
+    """
+    if not request.can_read_body:
+        return web.json_response({"error": "JSON body required"}, status=400)
+    try:
+        form = await request.json()
+    except Exception as exc:  # noqa: BLE001
+        return web.json_response({"error": f"invalid JSON: {exc}"}, status=400)
+    if not isinstance(form, dict):
+        return web.json_response({"error": "body must be a JSON object"}, status=400)
+
+    try:
+        brief = _build_dev_brief_from_form(form)
+    except (ValueError, TypeError) as exc:
+        return web.json_response({"error": str(exc)}, status=400)
+    except Exception as exc:  # noqa: BLE001 - validation surface
+        return web.json_response({"error": str(exc)}, status=400)
+
+    kind = getattr(brief, "kind", "")
+    if kind == "feature":
+        label = brief.document_path
+        initial_task = f"feature: {Path(brief.document_path).name}"
+    else:
+        label = brief.title
+        initial_task = f"{kind}: {brief.title[:120]}"
+
+    run_id = f"run-{uuid.uuid4().hex[:8]}"
+    runner: DevFlowRunner = request.app["runner"]
+    started_at = time.time()
+
+    extra_shared: dict[str, Any] = {}
+    if bool(form.get("skip_qa", False)):
+        extra_shared["skip_qa"] = True
+    if bool(form.get("skip_jira", False)):
+        extra_shared["skip_jira"] = True
+    # FEAT-412 / TASK-2123: the per-run plan-gate toggle. Only forwarded when
+    # the form actually carries the field, so an absent toggle falls back to
+    # the flow's build-time default instead of silently overriding it.
+    if "require_plan_approval" in form:
+        extra_shared["require_plan_approval"] = bool(
+            form.get("require_plan_approval")
+        )
+
+    async def _run() -> None:
+        try:
+            logger.info(
+                "Starting dev-flow run_id=%s kind=%s (%s) extra_shared=%s",
+                run_id, kind, label, sorted(extra_shared),
+            )
+            result = await runner.run(
+                brief,
+                run_id=run_id,
+                initial_task=initial_task,
+                extra_shared=extra_shared or None,
+            )
+            logger.info(
+                "dev-flow run_id=%s finished status=%s in %.1fs",
+                run_id, result.status, time.time() - started_at,
+            )
+        except Exception:
+            logger.exception("dev-flow run_id=%s failed", run_id)
+
+    task = asyncio.create_task(_run(), name=f"dev-flow-run-{run_id}")
+    request.app["flow_tasks"][run_id] = task
+    task.add_done_callback(lambda t: request.app["flow_tasks"].pop(run_id, None))
+
+    return web.json_response(
+        {
+            "run_id": run_id,
+            "mode": "dev-flow",
+            "kind": kind,
+            "ws_url": f"/api/flow/{run_id}/ws",
+            "state_ws_url": f"/api/flow/{run_id}/ws?view=state",
+            "bundle_url": f"/api/flow/{run_id}/bundle",
+            "gate_resolve_url": f"/api/flow/{run_id}/gates/{{gate_id}}/resolve",
+        }
+    )
+
+
+async def handle_resolve_gate(request: web.Request) -> web.Response:
+    """``POST /api/flow/{run_id}/gates/{gate_id}/resolve`` — the HITL write path.
+
+    This is the route ``server.py`` never mounts, and the reason the dev
+    console's Open-Questions panel can actually answer a gate.
+
+    Of the two options the spec allows, this console mounts **only** the
+    ``/api/flow``-prefixed alias (not ``register_command_routes``'s
+    ``/runs/{run_id}/...`` pair), so every console route lives under one
+    prefix and ``handle_cancel`` stays the single cancel entry point. The
+    alias is a pure delegation to the library handler, so the body contract
+    (``ResolveGateRequest``, including FEAT-412's ``answers``) and every
+    status code are identical — 200 / 400 ``invalid_body`` / 400
+    ``answers_required`` / 404 / 409. The template is published to the UI as
+    ``gate_resolve_url_template`` in ``/api/config``.
+
+    The handler resolves the runner from ``app["dev_loop_runner"]``, which
+    ``_on_startup`` binds.
+    """
+    return await resolve_gate_handler(request)
+
+
+# ---------------------------------------------------------------------------
+# Startup / app
+# ---------------------------------------------------------------------------
+
+
+def _build_optional_jira_toolkit() -> Any | None:
+    """Build a ``JiraToolkit`` only when Jira is actually configured.
+
+    dev-flow Jira is link-only and entirely optional (spec §1 Non-Goals), so
+    a missing/incomplete ``JIRA_*`` environment must NOT fail startup — it
+    degrades to ``None``, which makes every Jira seam a no-op.
+
+    Returns:
+        The toolkit, or ``None`` when Jira is unconfigured or unbuildable.
+    """
+    if not (conf.config.get("JIRA_INSTANCE") and conf.config.get("JIRA_USERNAME")):
+        logger.info(
+            "JIRA_* not configured — dev-flow runs with jira_toolkit=None "
+            "(Jira is link-only and optional here)."
+        )
+        return None
+    try:
+        return ops_server._build_jira_toolkit()
+    except Exception as exc:  # noqa: BLE001 - Jira is optional in dev-flow
+        logger.warning(
+            "JiraToolkit unavailable (%s) — continuing without Jira.", exc
+        )
+        return None
+
+
+async def _on_startup(app: web.Application) -> None:
+    """Wire the dev-flow: dispatchers, reviewers, pool, flow, runner.
+
+    Mirrors ``server.py::_on_startup`` minus ``_build_log_toolkits()`` and
+    minus the bug/feature dual-flow build.
+    """
+    redis_url = app["redis_url"]
+    app["redis"] = aioredis.from_url(redis_url, decode_responses=True)
+
+    dispatcher = ClaudeCodeDispatcher(
+        max_concurrent=conf.CLAUDE_CODE_MAX_CONCURRENT_DISPATCHES,
+        redis_url=redis_url,
+        stream_ttl_seconds=conf.FLOW_STREAM_TTL_SECONDS,
+    )
+
+    # -- development backend selection (same cascade as the ops console) --
+    development_dispatcher: object = dispatcher
+    development_agent = (
+        conf.config.get("DEV_LOOP_DEVELOPMENT_AGENT", fallback="claude-code")
+        .strip()
+        .lower()
+    )
+    env_map = ops_server._DEVELOPMENT_AGENT_MAX_CONCURRENT_ENV
+    if development_agent in {"claude", "claude-code"}:
+        pass
+    elif development_agent in env_map or development_agent == "llm":
+        backend = "nvidia" if development_agent == "llm" else development_agent
+        development_dispatcher, development_profile = build_dispatcher(
+            DevAgentSpec(agent=backend),
+            redis_url=redis_url,
+            max_concurrent=conf.config.getint(
+                env_map[backend],
+                fallback=conf.CLAUDE_CODE_MAX_CONCURRENT_DISPATCHES,
+            ),
+            stream_ttl_seconds=conf.FLOW_STREAM_TTL_SECONDS,
+        )
+        ops_server._log_development_agent_selection(
+            backend, development_profile
+        )
+    else:
+        raise RuntimeError(
+            "DEV_LOOP_DEVELOPMENT_AGENT must be 'claude-code', 'codex', "
+            "'gemini', 'nvidia', 'grok', 'zai', or 'moonshot', "
+            f"got {development_agent!r}"
+        )
+
+    # -- QA review: the judge panel is dev-flow's default review gate ----
+    _, codereview_agent_key = ops_server._resolve_codereview_dispatcher(
+        dispatcher=dispatcher,
+        development_dispatcher=development_dispatcher,
+        redis_url=redis_url,
+    )
+    judge_panel_dispatcher = ops_server._build_judge_panel_dispatcher(
+        redis_url=redis_url
+    )
+
+    repos = parse_repo_specs(conf.DEV_LOOP_REPOS)
+    if repos:
+        logger.info(
+            "DEV_LOOP_REPOS configured: %d repo(s) — primary alias=%r",
+            len(repos), repos[0].alias,
+        )
+
+    # -- dev-agent pool (FEAT-323) ---------------------------------------
+    development_pool_config = parse_pool_env(conf.config.get)
+    development_pool_max = resolve_pool_max(conf.config.get)
+    development_dispatcher_builder = functools.partial(
+        build_dispatcher,
+        redis_url=redis_url,
+        max_concurrent=conf.CLAUDE_CODE_MAX_CONCURRENT_DISPATCHES,
+        stream_ttl_seconds=conf.FLOW_STREAM_TTL_SECONDS,
+    )
+    if development_pool_config is not None:
+        logger.info(
+            "Dev-agent pool configured: %s (isolation=%s, pool_max=%d)",
+            ", ".join(
+                f"{spec.agent}x{spec.count}"
+                for spec in development_pool_config.agents
+            ),
+            development_pool_config.isolation_mode,
+            development_pool_max,
+        )
+
+    graph_memory = await DevLoopGraphMemory.from_config()
+    wiki_search = DevLoopWikiSearch.from_project()
+    app["wiki_search"] = wiki_search
+
+    jira_toolkit = _build_optional_jira_toolkit()
+    app["jira_toolkit"] = jira_toolkit
+    git_toolkit = ops_server._build_git_toolkit()
+    wiki_toolkit = ops_server._build_wiki_toolkit()
+
+    require_plan_approval = bool(
+        getattr(conf, "DEV_LOOP_REQUIRE_PLAN_APPROVAL", False)
+    )
+    skip_qa = bool(getattr(conf, "DEV_LOOP_SKIP_QA", False))
+
+    app["flow"] = build_dev_flow(
+        dispatcher=dispatcher,
+        redis_url=redis_url,
+        jira_toolkit=jira_toolkit,
+        git_toolkit=git_toolkit,
+        wiki_toolkit=wiki_toolkit,
+        codereview_dispatcher=judge_panel_dispatcher,
+        development_dispatcher_builder=development_dispatcher_builder,
+        development_pool_max=development_pool_max,
+        graph_memory=graph_memory,
+        wiki_search=wiki_search,
+        skip_qa=skip_qa,
+        require_plan_approval=require_plan_approval,
+        name="dev-flow-console",
+    )
+    runner = DevFlowRunner(
+        app["flow"],
+        dispatcher=dispatcher,
+        jira_toolkit=jira_toolkit,
+        git_toolkit=git_toolkit,
+        wiki_toolkit=wiki_toolkit,
+        redis_url=redis_url,
+        codereview_dispatcher=judge_panel_dispatcher,
+        graph_memory=graph_memory,
+    )
+
+    app["runner"] = runner
+    app["codereview_agent_key"] = codereview_agent_key
+    app["development_pool_max"] = development_pool_max
+    app["require_plan_approval"] = require_plan_approval
+    app["flow_tasks"] = {}  # run_id -> asyncio.Task
+    # The library's gate/cancel handlers read the runner from this key.
+    app["dev_loop_runner"] = runner
+    logger.info(
+        "dev-flow ready: dev_intake → ideation → planner → development → "
+        "synthesis → qa[judge-panel] → feature_handoff → close "
+        "(max %d concurrent runs, ideation_max_rounds=%s)",
+        runner.max_concurrent_runs,
+        getattr(conf, "DEV_FLOW_IDEATION_MAX_ROUNDS", 2),
+    )
+
+
+def build_app(redis_url: str = "redis://localhost:6379/0") -> web.Application:
+    """Build the dev console's aiohttp application."""
+    app = web.Application()
+    app["redis_url"] = redis_url
+    app.on_startup.append(_on_startup)
+    # Cleanup is mode-agnostic (cancel flow tasks + close Redis) — reused.
+    app.on_cleanup.append(ops_server._on_cleanup)
+
+    app.router.add_get("/", handle_index)
+    app.router.add_static("/static/", STATIC_DIR, show_index=False)
+    app.router.add_get("/api/config", handle_config)
+    app.router.add_post("/api/flow/run", handle_run)
+    # Bundle/replay/cancel are app-key driven and mode-agnostic — reused
+    # verbatim from the ops console so the artifact contract stays identical.
+    app.router.add_get("/api/flow/{run_id}/bundle", ops_server.handle_bundle)
+    app.router.add_get("/api/flow/{run_id}/replay", ops_server.handle_replay)
+    app.router.add_get("/api/flow/{run_id}/ws", flow_stream_ws)
+    app.router.add_post("/api/flow/{run_id}/cancel", ops_server.handle_cancel)
+    # THE HITL write path server.py never mounts — under /api/flow to match
+    # the console's other routes.
+    app.router.add_post(
+        "/api/flow/{run_id}/gates/{gate_id}/resolve", handle_resolve_gate
+    )
+    return app
+
+
+def main() -> None:
+    """Run the dev console (default port 8081, so it coexists with 8080)."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+    host = os.environ.get("HOST", "127.0.0.1")
+    port = int(os.environ.get("PORT", "8081"))
+    app = build_app(redis_url=redis_url)
+    logger.info(
+        "dev-flow console on http://%s:%s (Redis=%s)", host, port, redis_url
+    )
+    web.run_app(app, host=host, port=port, print=None)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/dev_loop/server_dev.py
+++ b/examples/dev_loop/server_dev.py
@@ -434,6 +434,16 @@ async def _on_startup(app: web.Application) -> None:
         ops_server._log_development_agent_selection(
             backend, development_profile
         )
+        # NOTE: like feature-mode (`build_dev_loop_feature_flow`), the dev-flow
+        # builder takes no `development_dispatcher`/`development_profile`, so
+        # this selection currently applies to the code-review reviewer
+        # resolution below, not to DevelopmentNode's own dispatches. Pin the
+        # backend per run from the console's "Agents & models" tab instead.
+        logger.info(
+            "DEV_LOOP_DEVELOPMENT_AGENT=%r selected; dev-flow dispatches "
+            "development through the shared claude-code dispatcher unless a "
+            "pool is declared per run.", development_agent,
+        )
     else:
         raise RuntimeError(
             "DEV_LOOP_DEVELOPMENT_AGENT must be 'claude-code', 'codex', "
@@ -468,8 +478,17 @@ async def _on_startup(app: web.Application) -> None:
         stream_ttl_seconds=conf.FLOW_STREAM_TTL_SECONDS,
     )
     if development_pool_config is not None:
+        # Honest reporting: dev-flow sizes the pool the way feature-mode does —
+        # PlannerNode derives it from the first task-dependency wave (capped at
+        # development_pool_max), or the brief's own `dev_agents` overrides it.
+        # `build_dev_flow` deliberately takes no `development_pool_config`
+        # (its signature mirrors build_dev_loop_feature_flow), so this env
+        # value is NOT injected into DevelopmentNode here.
         logger.info(
-            "Dev-agent pool configured: %s (isolation=%s, pool_max=%d)",
+            "DEV_LOOP_DEV_AGENTS is set (%s, isolation=%s) but dev-flow does "
+            "NOT inject it: the pool is planner-sized (cap pool_max=%d) or set "
+            "per run via the brief's dev_agents. Use the console's "
+            "'Agents & models' tab to pin a pool for a run.",
             ", ".join(
                 f"{spec.agent}x{spec.count}"
                 for spec in development_pool_config.agents

--- a/examples/dev_loop/static/dev.html
+++ b/examples/dev_loop/static/dev.html
@@ -1325,13 +1325,6 @@ function tabBodyHtml(tab) {
     const rounds = d.ideation_max_rounds ?? 2;
     const ttlHours = Math.round((d.gate_ttl_questions ?? 86400) / 3600);
     return grid(`
-      <div class="field" style="grid-column:1/-1">
-        <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
-          <input type="checkbox" id="chk-plan-approval" ${f.requirePlanApproval ? "checked" : ""} style="width:16px;height:16px" />
-          <span class="field-label" style="margin:0">Require plan approval before development</span>
-        </label>
-        <p class="hint">Opens a <span class="mono">plan_approval</span> gate after the planner and before the agent fleet dispatches — it appears in the panel above, with approve/reject and a comment. Per-run: it overrides the server default (<span class="mono">${d.require_plan_approval ? "on" : "off"}</span>) for this run only.</p>
-      </div>
       <div class="field"><span class="field-label">Open-Questions rounds (DEV_FLOW_IDEATION_MAX_ROUNDS)</span>
         <input class="input mono" value="${esc(String(rounds))}" disabled />
         <p class="hint">Max HITL rounds. Anything still unanswered afterwards stays in the document and flows into the spec's §8.</p>
@@ -1343,9 +1336,16 @@ function tabBodyHtml(tab) {
   }
   if (tab === "planning") {
     return grid(`
+      <div class="field" style="grid-column:1/-1">
+        <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
+          <input type="checkbox" id="chk-plan-approval" ${f.requirePlanApproval ? "checked" : ""} style="width:16px;height:16px" />
+          <span class="field-label" style="margin:0">Require plan approval before development</span>
+        </label>
+        <p class="hint">Opens a <span class="mono">plan_approval</span> gate after the planner and before the agent fleet dispatches — it appears in the panel above, with approve/reject and a comment. Per-run: it overrides the server default (<span class="mono">${d.require_plan_approval ? "on" : "off"}</span>) for this run only. Available in every mode — <span class="mono">feature</span> intent included.</p>
+      </div>
       <div class="field">
         <label for="t-jira-key">Jira issue key (optional)</label>
-        <input id="t-jira-key" class="input mono" data-form="jiraIssueKey" value="${esc(f.jiraIssueKey)}" placeholder="blank — no ticket is created in feature mode" />
+        <input id="t-jira-key" class="input mono" data-form="jiraIssueKey" value="${esc(f.jiraIssueKey)}" placeholder="blank — no ticket is created" />
         <p class="hint">When set, downstream nodes only link, transition and comment on it.</p>
       </div>
       <div class="field">
@@ -1423,7 +1423,7 @@ function tabBodyHtml(tab) {
         <input type="checkbox" id="chk-skip-jira" ${skipJiraChecked} style="width:16px;height:16px" />
         <span class="field-label" style="margin:0">Skip Jira for this run</span>
       </label>
-      <p class="hint">No ticket creation, no transitions, no comments. Research still runs (logs + triage + sdd-research dispatch) but without Jira integration. Use for local experiments or when Jira is down.</p>
+      <p class="hint">No ticket creation, no transitions, no comments — the rest of the run proceeds unchanged. Use for local experiments or when Jira is down.</p>
     </div>
     <div class="field"><span class="field-label">QA repair retries (DEV_LOOP_QA_MAX_RETRIES)</span>
       <input class="input mono" value="${esc(String(d.qa_max_retries ?? "—"))}" disabled /></div>

--- a/examples/dev_loop/static/dev.html
+++ b/examples/dev_loop/static/dev.html
@@ -1,0 +1,1778 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Agent Flow — Dev Console (dev-flow)</title>
+<style>
+/* ─────────────────────────────────────────────────────────────────────
+   Design system — the "industry blueprint" language of the AFD mockup
+   (static/afd.html), rebuilt as self-contained CSS. The mockup pulled a
+   design-system bundle that does not ship with this example, so every
+   token and class it referenced is defined here.
+   ───────────────────────────────────────────────────────────────────── */
+:root {
+  --color-bg: #0b1120;
+  --color-surface: #111827;
+  --color-text: #e2e8f0;
+  --color-divider: #1e293b;
+  --color-accent: #3b82f6;
+  --color-accent-100: #1e3a5f;
+  --color-accent-700: #60a5fa;
+  --color-accent-800: #93c5fd;
+  --color-accent-900: #dc2626;
+  --font-heading: ui-sans-serif, system-ui, "Segoe UI", Helvetica, Arial, sans-serif;
+  --font-body: ui-sans-serif, system-ui, "Segoe UI", Helvetica, Arial, sans-serif;
+  --font-mono: ui-monospace, "JetBrains Mono", Menlo, Consolas, monospace;
+}
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme="dark"]) {
+    --color-bg: #f1f5f9;
+    --color-surface: #ffffff;
+    --color-text: #0f172a;
+    --color-divider: #cbd5e1;
+    --color-accent: #2563eb;
+    --color-accent-100: #dbeafe;
+    --color-accent-700: #1d4ed8;
+    --color-accent-800: #1e40af;
+    --color-accent-900: #dc2626;
+  }
+}
+:root[data-theme="light"] {
+  --color-bg: #f1f5f9;
+  --color-surface: #ffffff;
+  --color-text: #0f172a;
+  --color-divider: #cbd5e1;
+  --color-accent: #2563eb;
+  --color-accent-100: #dbeafe;
+  --color-accent-700: #1d4ed8;
+  --color-accent-800: #1e40af;
+  --color-accent-900: #dc2626;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0; background: var(--color-bg); color: var(--color-text);
+  font-family: var(--font-body); font-size: 14px; line-height: 1.5;
+}
+h6 { font-family: var(--font-heading); font-size: 13px; font-weight: 700;
+     letter-spacing: .1em; text-transform: uppercase; margin: 0; }
+a { color: var(--color-accent-700); text-decoration: none; }
+a:hover { color: var(--color-accent); text-decoration: underline; }
+@keyframes afpulse { 0%,100% { opacity: 1 } 50% { opacity: .35 } }
+
+.nav { display: flex; align-items: center; }
+.nav-brand { font-family: var(--font-heading); font-size: 19px; font-weight: 700; }
+
+/* Blueprint box: hairline frame with accent corner ticks. */
+.blueprint { position: relative; border: 1px solid var(--color-divider);
+             background: var(--color-bg); }
+.blueprint > .corner { position: absolute; width: 6px; height: 6px;
+                       border: 1px solid var(--color-accent); display: block; }
+.corner.tl { top: -1px; left: -1px; border-right: 0; border-bottom: 0; }
+.corner.tr { top: -1px; right: -1px; border-left: 0; border-bottom: 0; }
+.corner.bl { bottom: -1px; left: -1px; border-right: 0; border-top: 0; }
+.corner.br { bottom: -1px; right: -1px; border-left: 0; border-top: 0; }
+
+.btn {
+  font: inherit; font-size: 13px; border-radius: 0; cursor: pointer;
+  padding: 8px 15px; display: inline-flex; align-items: center; gap: 7px;
+  border: 1px solid var(--color-divider); background: transparent;
+  color: var(--color-text); position: relative;
+}
+.btn:hover:not(:disabled) { border-color: var(--color-accent); }
+.btn:disabled { opacity: .45; cursor: not-allowed; }
+.btn-primary { background: var(--color-accent); border-color: var(--color-accent);
+               color: #fff; font-weight: 700; }
+.btn-primary:hover:not(:disabled) { background: var(--color-accent-700); }
+.btn-ghost { border-color: transparent; }
+.btn-danger { border-color: var(--color-accent-900); color: var(--color-accent-900); }
+
+.tag { display: inline-flex; align-items: center; gap: 6px; padding: 2px 9px;
+       font-size: 11px; letter-spacing: .04em; text-transform: uppercase; }
+.tag-accent { background: var(--color-accent-100); color: var(--color-accent-800); }
+.tag-neutral { background: color-mix(in srgb, var(--color-text) 9%, transparent); }
+.tag-outline { border: 1px solid var(--color-divider); }
+.tag-danger { background: var(--color-accent-900); color: #fff; }
+
+.field { display: flex; flex-direction: column; gap: 5px; min-width: 0; }
+.field > label, .field-label {
+  font-size: 11.5px; letter-spacing: .04em;
+  color: color-mix(in srgb, var(--color-text) 62%, transparent);
+}
+.input, select.input, textarea.input {
+  font: inherit; font-size: 13.5px; padding: 8px 10px; border-radius: 0;
+  border: 1px solid var(--color-divider); background: var(--color-surface);
+  color: var(--color-text); width: 100%; min-width: 0;
+}
+.input:focus { outline: 1px solid var(--color-accent); outline-offset: -1px; }
+.input:disabled { opacity: .6; }
+textarea.input { resize: vertical; }
+.hint { margin: 5px 0 0; font-size: 11px; line-height: 1.5;
+        color: color-mix(in srgb, var(--color-text) 52%, transparent); }
+
+.seg { display: flex; border: 1px solid var(--color-divider); flex-wrap: wrap; }
+.seg-opt { flex: 1; display: flex; align-items: center; justify-content: center;
+           gap: 6px; padding: 7px 10px; font-size: 12.5px; cursor: pointer;
+           border-right: 1px solid var(--color-divider); user-select: none;
+           white-space: nowrap; }
+.seg-opt:last-child { border-right: 0; }
+.seg-opt.on { background: var(--color-accent-100); color: var(--color-accent-800); }
+
+.table { width: 100%; border-collapse: collapse; }
+.table td, .table th { padding: 6px 8px; border-bottom: 1px solid var(--color-divider);
+                       text-align: left; font-size: 12.5px; }
+.table th { font-size: 10.5px; letter-spacing: .07em; text-transform: uppercase;
+            color: color-mix(in srgb, var(--color-text) 55%, transparent);
+            font-weight: 600; }
+
+.mono { font-family: var(--font-mono); }
+.muted { color: color-mix(in srgb, var(--color-text) 55%, transparent); }
+.micro { font-size: 11px; letter-spacing: .08em; text-transform: uppercase;
+         color: color-mix(in srgb, var(--color-text) 55%, transparent); }
+.rule { flex: 1; height: 1px; background: var(--color-divider); min-width: 16px; }
+.sec-head { display: flex; align-items: center; gap: 12px; margin-bottom: 10px;
+            flex-wrap: wrap; }
+.hidden { display: none !important; }
+
+.err-box { border: 1px solid var(--color-accent-900); background:
+           color-mix(in srgb, var(--color-accent-900) 12%, transparent);
+           color: var(--color-accent-900); padding: 8px 12px; font-size: 12.5px;
+           white-space: pre-wrap; }
+
+.ev-row { border-bottom: 1px dashed color-mix(in srgb, var(--color-text) 12%, transparent);
+          padding: 5px 0; }
+.ev-head { display: flex; gap: 10px; align-items: baseline; cursor: pointer;
+           font-family: var(--font-mono); font-size: 12px; }
+.ev-head .caret { width: 9px; }
+.ev-json { margin: 6px 0 2px; padding: 8px 10px; background: var(--color-surface);
+           border: 1px solid var(--color-divider); font-family: var(--font-mono);
+           font-size: 11.5px; line-height: 1.6; overflow: auto; max-height: 240px;
+           white-space: pre-wrap; word-break: break-word;
+           color: color-mix(in srgb, var(--color-text) 78%, transparent); }
+
+.pill { display: inline-flex; align-items: center; padding: 2px 9px; font-size: 11px;
+        letter-spacing: .04em; text-transform: uppercase; }
+.pill.idle, .pill.queued { background: color-mix(in srgb, var(--color-text) 8%, transparent);
+                           color: color-mix(in srgb, var(--color-text) 58%, transparent); }
+.pill.running { background: var(--color-accent); color: var(--color-bg);
+                animation: afpulse 1.4s ease-in-out infinite; }
+.pill.completed { background: var(--color-accent-100); color: var(--color-accent-800); }
+.pill.failed { background: var(--color-accent-900); color: #fff; }
+.pill.skipped { background: color-mix(in srgb, var(--color-text) 8%, transparent);
+                color: color-mix(in srgb, var(--color-text) 45%, transparent); }
+
+.dot { display: block; width: 9px; height: 9px; flex: none;
+       background: color-mix(in srgb, var(--color-text) 18%, transparent); }
+.dot.running { background: var(--color-accent); animation: afpulse 1.2s ease-in-out infinite; }
+.dot.completed { background: var(--color-accent); }
+.dot.failed { background: var(--color-accent-900); }
+
+.scroll { overflow-y: auto; overscroll-behavior: contain; }
+.wrap { max-width: 1560px; margin: 0 auto; padding: 26px 28px 80px; }
+.agent-row { display: grid; grid-template-columns: minmax(0,1.1fr) minmax(0,1.4fr) 78px 38px;
+             gap: 8px; align-items: end; }
+.judge-row { display: grid; grid-template-columns: minmax(0,1fr) minmax(0,1.3fr) 38px;
+             gap: 8px; align-items: end; }
+@media (max-width: 1000px) { .cols-2 { grid-template-columns: 1fr !important; } }
+
+#theme-toggle { font-size: 18px; padding: 6px 10px; line-height: 1; border-color: var(--color-divider); }
+#theme-toggle:hover { border-color: var(--color-accent); }
+</style>
+<script>
+(function(){var t=localStorage.getItem('devflow-theme');if(t)document.documentElement.setAttribute('data-theme',t)})();
+</script>
+</head>
+<body>
+
+<div class="nav" style="border-bottom:1px solid var(--color-divider);padding:12px 28px;gap:20px;position:sticky;top:0;z-index:20;background:var(--color-bg)">
+  <span class="nav-brand" style="display:flex;align-items:baseline;gap:10px;margin-right:auto">Agent Flow
+    <span class="mono micro" id="mode-label">development</span>
+  </span>
+  <span class="mono muted" style="font-size:12px" id="run-label">no run yet</span>
+  <span class="tag tag-outline"><i class="dot" id="conn-dot"></i><span id="conn-label">idle</span></span>
+  <button class="btn btn-danger hidden" type="button" id="stop-btn">Stop run</button>
+  <button class="btn" type="button" id="restart-btn">Restart run</button>
+  <button class="btn" type="button" id="theme-toggle" title="Toggle dark/light mode"></button>
+</div>
+
+<div class="wrap">
+
+  <div style="display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:1px;background:var(--color-divider);border:1px solid var(--color-divider);margin-bottom:26px" id="steps"></div>
+
+  <!-- ── 01 REQUEST ──────────────────────────────────────────────── -->
+  <section style="margin-bottom:26px">
+    <div class="sec-head"><h6>01 — Request</h6><span class="rule"></span></div>
+
+    <div class="blueprint hidden" id="request-collapsed" style="padding:14px 18px;display:flex;align-items:center;gap:18px;flex-wrap:wrap">
+      <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+      <span class="tag tag-accent" id="rc-kind">enhancement</span>
+      <span style="font-family:var(--font-heading);font-size:17px;flex:1;min-width:240px" id="rc-summary"></span>
+      <span class="mono muted" style="font-size:12px" id="rc-target"></span>
+      <span class="muted" style="font-size:12px" id="rc-criteria"></span>
+      <button class="btn" type="button" id="edit-request-btn">Edit request</button>
+    </div>
+
+    <form class="blueprint" id="request-form" style="padding:22px 24px">
+      <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+
+      <div class="cols-2" style="display:grid;grid-template-columns:minmax(0,1fr) 320px;gap:26px;align-items:start">
+        <div style="display:flex;flex-direction:column;gap:14px;min-width:0">
+
+          <div id="work-intake" style="display:flex;flex-direction:column;gap:14px">
+            <div class="field">
+              <label for="f-description">Describe what you want built — in plain language</label>
+              <textarea id="f-description" class="input mono" style="min-height:150px;font-size:13px;line-height:1.6"
+                placeholder="Add per-tool telemetry to the compression budget so operators can see which tool blew the budget. Today the log only reports the total, so a single greedy tool is invisible until someone reads the raw payloads."></textarea>
+              <p class="hint">This is the request the <span class="mono">sdd-ideation</span> subagent turns into an SDD document. No document exists yet — you are describing the idea, not pointing at a spec.</p>
+            </div>
+            <div class="field">
+              <label for="f-title">Title — names the request and becomes the document slug</label>
+              <input id="f-title" class="input" maxlength="255"
+                     placeholder="compression budget telemetry" />
+              <p class="hint">Slugified into <span class="mono">sdd/proposals/&lt;slug&gt;.brainstorm.md</span> (new feature) or <span class="mono">.proposal.md</span> (enhancement). If that document already exists it is resumed and extended, never overwritten.</p>
+            </div>
+            <div class="field">
+              <label for="f-context">Extra context — links, constraints, prior art (optional)</label>
+              <textarea id="f-context" class="input mono" style="min-height:70px;font-size:12.5px;line-height:1.6"
+                placeholder="See PR #1204 for the original budget work. Must not add a per-call allocation."></textarea>
+            </div>
+          </div>
+
+          <div id="feature-intake" class="hidden" style="display:flex;flex-direction:column;gap:14px">
+            <div class="field">
+              <label for="f-document-path">Driving document — the SDD markdown the run plans from</label>
+              <input id="f-document-path" class="input mono"
+                     placeholder="sdd/proposals/my-feature.brainstorm.md" />
+              <p class="hint">Must exist and be readable on the server. The brief is validated before a single dispatch is spent. Picking this intent <strong>skips ideation entirely</strong> — the run starts at the planner.</p>
+            </div>
+            <div class="field">
+              <span class="field-label">Document kind — decides how much the planner must generate</span>
+              <div class="seg" id="f-document-kind"></div>
+              <p class="hint" id="document-kind-hint"></p>
+            </div>
+          </div>
+        </div>
+
+        <div style="display:flex;flex-direction:column;gap:14px">
+          <div class="field">
+            <span class="field-label">Kind — picks the intake branch</span>
+            <div class="seg" id="f-kind"></div>
+            <p class="hint" id="kind-hint"></p>
+          </div>
+
+          <div class="blueprint" style="padding:12px 14px;display:flex;flex-direction:column;gap:8px">
+            <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+            <span class="micro">Ready to dispatch</span>
+            <div id="ready-rows" style="display:flex;flex-direction:column;gap:6px"></div>
+          </div>
+
+          <button class="btn btn-primary blueprint" type="submit" id="submit-btn" style="height:44px;font-size:15px;justify-content:center">
+            <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+            <span id="submit-label">Dispatch run</span>
+          </button>
+          <div class="err-box hidden" id="form-err"></div>
+          <p class="hint" style="margin:0">Dispatching opens a run and streams every node event below. Nothing is pushed to Jira or GitHub until Handoff.</p>
+        </div>
+      </div>
+
+      <div style="margin-top:20px;border-top:1px solid var(--color-divider);padding-top:14px">
+        <button class="btn btn-ghost" type="button" id="adv-toggle" style="padding-inline:0;gap:8px">
+          <span class="mono" style="display:inline-block;width:10px" id="adv-caret">▾</span>
+          Special &amp; advanced options
+          <span class="tag tag-neutral" style="margin-left:6px" id="adv-badge"></span>
+        </button>
+        <div id="adv-body" style="margin-top:14px">
+          <div style="display:flex;flex-wrap:wrap;border-bottom:1px solid var(--color-divider);margin-bottom:16px" id="adv-tabs"></div>
+          <div class="cols-2" style="display:grid;grid-template-columns:minmax(0,1fr) 300px;gap:26px;align-items:start;min-height:190px">
+            <div id="adv-fields"></div>
+            <div class="blueprint" style="padding:14px;display:flex;flex-direction:column;gap:8px">
+              <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+              <span class="micro" style="color:var(--color-accent-700)">What this tab does</span>
+              <p style="margin:0;font-size:12.5px;line-height:1.6;color:color-mix(in srgb,var(--color-text) 74%,transparent)" id="adv-note"></p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </form>
+  </section>
+
+  <!-- ── HITL — Open Questions / plan approval (FEAT-412) ───────────
+       Renders from app.s.gates (state), NOT only from live actions, so a
+       reload mid-gate re-renders the pending gate from the snapshot. -->
+  <section class="hidden" id="hitl-section" style="margin-bottom:26px">
+    <div class="sec-head">
+      <h6>Waiting on you</h6>
+      <span class="tag tag-accent" id="hitl-kind"></span>
+      <span class="rule"></span>
+      <span class="muted" style="font-size:12px" id="hitl-meta"></span>
+    </div>
+    <div class="blueprint" id="hitl-box" style="padding:20px 22px;display:flex;flex-direction:column;gap:16px;border-color:var(--color-accent)">
+      <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+      <div style="display:flex;flex-direction:column;gap:4px">
+        <span style="font-family:var(--font-heading);font-size:17px" id="hitl-title"></span>
+        <p class="hint" style="margin:0;white-space:pre-wrap" id="hitl-instructions"></p>
+      </div>
+      <div id="hitl-fields" style="display:flex;flex-direction:column;gap:14px"></div>
+      <div class="err-box hidden" id="hitl-err"></div>
+      <div style="display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+        <button class="btn btn-primary" type="button" id="hitl-submit">Submit answers</button>
+        <button class="btn btn-danger" type="button" id="hitl-reject">Reject &amp; abort run</button>
+        <span class="rule"></span>
+        <span class="mono micro" id="hitl-identity"></span>
+      </div>
+      <p class="hint" style="margin:0" id="hitl-footnote"></p>
+    </div>
+  </section>
+
+  <!-- ── 02 EXECUTION ────────────────────────────────────────────── -->
+  <section class="hidden" id="exec-section" style="margin-bottom:26px">
+    <div class="sec-head">
+      <h6>02 — Execution</h6>
+      <span class="muted" style="font-size:12px" id="exec-progress"></span>
+      <span class="rule"></span>
+      <span class="micro">View</span>
+      <div class="seg" id="view-picker" style="flex:0 0 auto"></div>
+    </div>
+    <div id="exec-body"></div>
+  </section>
+
+  <!-- ── 03 SUMMARY ──────────────────────────────────────────────── -->
+  <section class="hidden" id="summary-section" style="margin-bottom:20px">
+    <div class="sec-head">
+      <h6>03 — Job summary</h6>
+      <span class="rule"></span>
+      <span class="muted" style="font-size:12px" id="sum-finished"></span>
+    </div>
+    <div id="summary-body"></div>
+    <div class="blueprint" style="margin-top:18px;padding:16px 18px;display:flex;align-items:center;gap:14px;flex-wrap:wrap">
+      <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+      <span style="font-family:var(--font-heading);font-size:18px" id="sum-headline"></span>
+      <span class="muted" style="font-size:12.5px" id="sum-subline"></span>
+      <span class="rule"></span>
+      <button class="btn" type="button" id="view-report-btn">View report</button>
+      <button class="btn" type="button" id="bundle-btn">Download run bundle</button>
+      <button class="btn" type="button" id="another-btn">Start another run</button>
+    </div>
+    <div class="blueprint hidden" id="report-box" style="margin-top:14px;padding:16px 18px">
+      <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+      <pre class="ev-json" style="max-height:560px;margin:0" id="report-pre"></pre>
+    </div>
+  </section>
+</div>
+
+<script type="module">
+"use strict";
+
+/* ═══════════════════════════════════════════════════════════════════
+   Node topologies. Declared client-side because each mode's node set is
+   fixed by definition.py — the stream only reports which of them fired.
+   ═══════════════════════════════════════════════════════════════════ */
+// One topology — the dev-flow graph. Which intent you pick only decides
+// whether `ideation` runs or is skipped by routing (dev_intake -> planner).
+const TOPOLOGY = {
+  dev: [
+    { id: "dev_intake",         label: "Intake",      role: "validates the brief, routes by intent" },
+    { id: "ideation",           label: "Ideation",    role: "NL → SDD document, asks you the open questions" },
+    { id: "planner",            label: "Planner",     role: "spec + task index + worktree, sizes the pool" },
+    { id: "development",        label: "Development", role: "parallel dev agents over dependency waves" },
+    { id: "synthesis",          label: "Synthesis",   role: "post-merge reconciliation of the workers" },
+    { id: "qa",                 label: "QA",          role: "criteria + N-judge panel (majority)" },
+    { id: "feedback_router",    label: "Feedback",    role: "retry / escalate / accept-with-notes" },
+    { id: "feature_handoff",    label: "Handoff",     role: "draft PR against dev + docs + wiki" },
+    { id: "close",              label: "Close",       role: "closes the loop" },
+    { id: "failure_handler",    label: "Failure",     role: "on_error fan-in — parks the run for a human" },
+  ],
+};
+
+const KIND_HINTS = {
+  enhancement: "Natural language in. Ideation writes a LIGHT proposal (scope, rationale, impact — no options analysis) to sdd/proposals/<slug>.proposal.md, asking you its open questions first.",
+  new_feature: "Natural language in. Ideation writes a FULL brainstorm (options A/B/C + a recommendation) to sdd/proposals/<slug>.brainstorm.md, asking you its open questions first.",
+  feature: "You already have the SDD document. Ideation is skipped entirely — the run starts at the planner, exactly like feature-mode.",
+};
+
+const DOC_KIND_HINTS = {
+  brainstorm: "The planner runs the full chain: /sdd-spec, then /sdd-task, then creates the worktree.",
+  proposal: "The planner runs /sdd-spec and /sdd-task, then creates the worktree.",
+  spec: "The spec is already resolved — the planner skips /sdd-spec and goes straight to /sdd-task.",
+};
+
+const TAB_NOTES = {
+  ideation: "Ideation is bounded and interactive. Each round the subagent may return open questions; the console shows them in one panel and your answers ride the next dispatch. When the round budget runs out, anything still unanswered stays '[ ]' in the document and is carried into the spec's §8 by the planner — it never blocks the run.",
+  planning: "The planner generates whatever SDD artifacts are missing, creates the worktree, and sizes the dev pool from the first dependency wave. Jira is optional — no ticket is ever created.",
+  agents: "One dispatcher per agent. Leave the pool empty to let the planner size it from the task graph. An empty model means the backend's own default.",
+  review: "Adversarial review is not optional — the read-only Codex sdd-secondopinion seat rides the QA panel as a judge, appended automatically if you leave it out.",
+  guardrails: "Server-side limits, shown read-only: they come from the deployment's configuration, not from this form.",
+};
+
+/* ═══════════════════════════════════════════════════════════════════
+   Application state
+   ═══════════════════════════════════════════════════════════════════ */
+function emptyState() {
+  return {
+    phase: "created", nodes: {}, gates: {}, prUrl: "", jiraKey: "",
+    judgeVerdicts: {}, feedback: [], docs: [], qaAttempts: 0,
+    createdAt: null, finishedAt: null, error: "",
+  };
+}
+
+const app = {
+  config: null,
+  phase: "idle",           // idle | running | done
+  mode: "nl",              // nl | feature — intake shape only (ONE topology)
+  kind: "enhancement",
+  runId: null,
+  wsEvents: null, wsState: null, connected: false,
+  view: "rail",
+  selected: null,
+  advOpen: true,
+  advTab: "ideation",
+  requestOpen: true,
+  openEvents: new Set(),
+  events: new Map(),       // node_id -> [{ts, kind, payload}]
+  eventCount: 0,
+  s: emptyState(),         // folded session state (view=state)
+  telemetry: { input: 0, output: 0, cost: 0, turns: 0, reported: 0 },
+  form: {
+    // Natural-language intake (enhancement | new_feature).
+    title: "", description: "", context: "",
+    // Document intake (feature).
+    documentPath: "", documentKind: "proposal",
+    jiraIssueKey: "",
+    devAgents: [], devIsolation: "shared",
+    judges: [], skipQa: false, skipJira: false,
+    // FEAT-412: per-run plan-approval gate toggle.
+    requirePlanApproval: false,
+  },
+  // HITL panel: the gate_id currently being answered, plus draft answers.
+  hitl: { gateId: null, answers: {}, comment: "", busy: false },
+};
+
+/* ═══════════════════════════════════════════════════════════════════
+   Utilities
+   ═══════════════════════════════════════════════════════════════════ */
+const $ = (id) => document.getElementById(id);
+const esc = (s) => String(s == null ? "" : s).replace(/[&<>"]/g, (c) =>
+  ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+
+function fmtDuration(seconds) {
+  if (seconds == null || !isFinite(seconds)) return "—";
+  if (seconds < 60) return `${seconds < 10 ? seconds.toFixed(2) : seconds.toFixed(1)}s`;
+  const m = Math.floor(seconds / 60), s = Math.round(seconds % 60);
+  if (m < 60) return `${m}m ${String(s).padStart(2, "0")}s`;
+  return `${Math.floor(m / 60)}h ${String(m % 60).padStart(2, "0")}m`;
+}
+const fmtClock = (ts) => ts ? new Date(ts * 1000).toLocaleTimeString() : "—";
+function fmtNum(n) {
+  if (n == null) return "—";
+  if (n >= 1e6) return (n / 1e6).toFixed(1) + "M";
+  if (n >= 1e3) return (n / 1e3).toFixed(1) + "k";
+  return String(n);
+}
+
+/** One-line gist of an event payload, for the collapsed event row. */
+function briefOf(kind, p) {
+  if (!p || typeof p !== "object") return "";
+  if (p.decision) return String(p.decision);
+  if (p.command || p.cmd) {
+    const c = p.command || p.cmd;
+    return `${c}${p.exit_code != null ? ` → exit ${p.exit_code}` : ""}`;
+  }
+  if (p.criterion) return String(p.criterion).slice(0, 52);
+  if (p.tool_name) return String(p.tool_name);
+  if (p.pr_url) return String(p.pr_url);
+  if (p.issue_key) return String(p.issue_key);
+  if (p.step) return String(p.step);
+  if (p.error) return String(p.error).slice(0, 60);
+  if (p.status) return String(p.status);
+  if (p.kind) return String(p.kind);
+  const keys = Object.keys(p);
+  return keys.length ? `${keys[0]}=${String(p[keys[0]]).slice(0, 40)}` : "";
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   Session-state fold (WebSocket ?view=state)
+
+   The multiplexer sends one `snapshot` envelope then an `action`
+   envelope per state mutation. Rather than mirror the server's whole
+   `reduce()`, this folds only the projections the console renders.
+   ═══════════════════════════════════════════════════════════════════ */
+function adoptSnapshot(snap) {
+  const st = (snap && snap.state) || {};
+  const s = emptyState();
+  s.phase = st.phase || "created";
+  s.prUrl = st.pr_url || "";
+  s.jiraKey = st.jira_issue_key || "";
+  s.createdAt = st.created_at || null;
+  s.finishedAt = st.finished_at || null;
+  s.error = st.error || "";
+  s.qaAttempts = st.qa_attempts || 0;
+  for (const [id, n] of Object.entries(st.nodes || {})) s.nodes[id] = { ...n };
+  s.gates = { ...(st.gates || {}) };
+  s.judgeVerdicts = { ...(st.judge_verdicts || {}) };
+  s.feedback = [...(st.feedback_decisions || [])];
+  s.docs = [...(st.docs_artifacts || [])];
+  app.s = s;
+}
+
+function node(id) {
+  if (!app.s.nodes[id]) {
+    app.s.nodes[id] = { node_id: id, status: "idle", dispatch: null, summary: {} };
+  }
+  return app.s.nodes[id];
+}
+
+function foldAction(a) {
+  const s = app.s;
+  switch (a.type) {
+    case "run/created":   s.createdAt = a.ts; s.phase = "created"; break;
+    case "run/closed":    s.finishedAt = a.ts; s.phase = a.phase || "closed"; break;
+    case "run/cancelled": s.phase = "cancelled"; break;
+
+    case "node/started":   { const n = node(a.node_id); n.status = "running"; n.started_at = a.ts; break; }
+    case "node/completed": { const n = node(a.node_id); n.status = "completed"; n.finished_at = a.ts;
+                             n.summary = { ...(n.summary || {}), ...(a.summary || {}) }; break; }
+    case "node/failed":    { const n = node(a.node_id); n.status = "failed"; n.finished_at = a.ts;
+                             n.error = a.error || ""; break; }
+    case "node/skipped":   { node(a.node_id).status = "skipped"; break; }
+
+    case "dispatch/queued":  node(a.node_id).dispatch =
+      { status: "queued", dispatcher: a.dispatcher || "", message_count: 0, tool_use_count: 0 }; break;
+    case "dispatch/started": { const n = node(a.node_id); n.dispatch = n.dispatch || {};
+                               n.dispatch.status = "running"; n.dispatch.started_at = a.ts; break; }
+    case "dispatch/delta":   { const d = node(a.node_id).dispatch;
+                               if (d) d.message_count = (d.message_count || 0) + 1; break; }
+    case "dispatch/tool_use":{ const d = node(a.node_id).dispatch;
+                               if (d) d.tool_use_count = (d.tool_use_count || 0) + 1; break; }
+    case "dispatch/failed":  { const d = node(a.node_id).dispatch;
+                               if (d) { d.status = "failed"; d.last_error = a.error || ""; } break; }
+    case "dispatch/output_invalid": { const d = node(a.node_id).dispatch;
+                               if (d) { d.status = "output_invalid"; d.last_error = a.error || ""; } break; }
+    case "dispatch/completed": {
+      const d = node(a.node_id).dispatch;
+      if (d) {
+        d.status = "completed"; d.finished_at = a.ts;
+        // FEAT-378 TASK-1927 telemetry — every field optional.
+        d.input_tokens = a.input_tokens; d.output_tokens = a.output_tokens;
+        d.total_cost_usd = a.total_cost_usd; d.num_turns = a.num_turns;
+        d.duration_ms = a.duration_ms;
+      }
+      if (a.input_tokens != null || a.output_tokens != null || a.total_cost_usd != null) {
+        const t = app.telemetry;
+        t.reported += 1;
+        t.input += a.input_tokens || 0;
+        t.output += a.output_tokens || 0;
+        t.cost += a.total_cost_usd || 0;
+        t.turns += a.num_turns || 0;
+      }
+      break;
+    }
+
+    case "gate/opened":   s.gates[a.gate.gate_id] = { ...a.gate }; break;
+    case "gate/resolved": { const g = s.gates[a.gate_id];
+                            if (g) { g.status = a.resolution; g.resolved_by = a.resolved_by;
+                                     g.resolved_at = a.ts; g.comment = a.comment || ""; } break; }
+    case "gate/expired":  { const g = s.gates[a.gate_id]; if (g) g.status = "expired"; break; }
+
+    case "run/jiraLinked": s.jiraKey = a.issue_key || ""; break;
+    case "run/prLinked":   s.prUrl = a.pr_url || ""; break;
+    case "run/qaAttemptRecorded": s.qaAttempts = a.attempt || s.qaAttempts; break;
+
+    case "feature/judgeVerdictRecorded": {
+      const round = String(a.round || "1");
+      (s.judgeVerdicts[round] = s.judgeVerdicts[round] || []).push({
+        judge_id: a.judge_id, backend: a.backend, model: a.model, passed: a.passed,
+        findings_count: a.findings_count, summary: a.summary, ts: a.ts,
+      });
+      break;
+    }
+    case "feature/feedbackDecisionRecorded":
+      s.feedback.push({ decision: a.decision, dev_brief: a.dev_brief,
+                        notes: a.notes, qa_attempt: a.qa_attempt, ts: a.ts });
+      break;
+    case "feature/docsArtifactLinked":
+      s.docs.push({ docs_path: a.docs_path, wiki_page_id: a.wiki_page_id, pr_url: a.pr_url });
+      if (a.pr_url && !s.prUrl) s.prUrl = a.pr_url;
+      break;
+    default: break;
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   WebSockets — the only transport, per the server's design
+   ═══════════════════════════════════════════════════════════════════ */
+const wsUrl = (path) =>
+  `${location.protocol === "https:" ? "wss" : "ws"}://${location.host}${path}`;
+
+const isTerminal = (p) => ["succeeded", "failed", "cancelled", "closed"].includes(p);
+
+function connect(runId) {
+  closeSockets();
+
+  // Event log — one envelope per flow/dispatch event, per node.
+  const evs = new WebSocket(wsUrl(`/api/flow/${runId}/ws?view=both&replay=true`));
+  evs.addEventListener("open", () => { app.connected = true; renderChrome(); });
+  evs.addEventListener("close", () => { app.connected = false; renderChrome(); });
+  evs.addEventListener("message", (e) => {
+    let env; try { env = JSON.parse(e.data); } catch { return; }
+    if (!env.node_id) return;
+    const list = app.events.get(env.node_id) || [];
+    list.push({ ts: env.ts, kind: env.event_kind, payload: env.payload });
+    app.events.set(env.node_id, list);
+    app.eventCount += 1;
+    scheduleRender();
+  });
+  app.wsEvents = evs;
+
+  // Authoritative session state — snapshot + folded actions.
+  const sts = new WebSocket(wsUrl(`/api/flow/${runId}/ws?view=state`));
+  sts.addEventListener("message", (e) => {
+    let env; try { env = JSON.parse(e.data); } catch { return; }
+    if (env.event_kind === "snapshot") adoptSnapshot(env.payload);
+    else if (env.event_kind === "action") {
+      const action = env.payload && env.payload.action;
+      if (action) foldAction(action);
+    }
+    if (isTerminal(app.s.phase) && app.phase === "running") finish();
+    scheduleRender();
+  });
+  sts.addEventListener("close", () => {
+    if (app.phase === "running") {
+      if (isTerminal(app.s.phase)) {
+        finish();
+      } else {
+        markNodesTerminal();
+        app.s.phase = "closed";
+        finish();
+      }
+      scheduleRender();
+    }
+  });
+  app.wsState = sts;
+}
+
+function closeSockets() {
+  for (const key of ["wsEvents", "wsState"]) {
+    const ws = app[key];
+    if (ws && ws.readyState <= 1) ws.close();
+    app[key] = null;
+  }
+}
+
+function finish() {
+  app.phase = "done";
+  $("summary-section").classList.remove("hidden");
+}
+
+function markNodesTerminal() {
+  for (const n of Object.values(app.s.nodes)) {
+    if (n.status === "running") n.status = "completed";
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   Rendering — batched so a burst of stream events costs one repaint
+   ═══════════════════════════════════════════════════════════════════ */
+let pending = false;
+function scheduleRender() {
+  if (pending) return;
+  pending = true;
+  requestAnimationFrame(() => { pending = false; render(); });
+}
+
+function render() {
+  renderChrome();
+  renderSteps();
+  renderReady();
+  renderHitl();
+  renderExecution();
+  renderSummary();
+}
+
+function renderChrome() {
+  $("run-label").textContent = app.runId ? `run_id = ${app.runId}` : "no run yet";
+  $("mode-label").textContent = app.mode === "feature" ? "dev-flow · document" : "dev-flow · ideation";
+  $("conn-label").textContent = app.phase === "running"
+    ? (app.connected ? "streaming" : "reconnecting")
+    : app.phase === "done" ? "stream closed" : "idle";
+  $("conn-dot").className = "dot" +
+    (app.phase === "running" && app.connected ? " running" : app.phase === "done" ? " completed" : "");
+  $("stop-btn").classList.toggle("hidden", app.phase !== "running");
+  $("submit-label").textContent = app.phase === "idle" ? "Dispatch run" : "Re-dispatch run";
+}
+
+function renderSteps() {
+  const nodes = nodesForRender();
+  const finished = nodes.filter((n) => ["completed", "failed", "skipped"].includes(n.status)).length;
+  const touched = nodes.filter((n) => n.status !== "idle").length;
+  const steps = [
+    { num: "01", title: "Request", state: app.phase === "idle" ? "awaiting input" : "submitted" },
+    { num: "02", title: "Execution", state: app.phase === "idle" ? "locked"
+        : app.phase === "done" ? `${finished} of ${touched} nodes finished`
+        : `streaming — ${finished} of ${touched}` },
+    { num: "03", title: "Job summary", state: app.phase === "done" ? summaryHeadline().short : "locked" },
+  ];
+  $("steps").innerHTML = steps.map((s) => `
+    <div style="background:var(--color-bg);padding:12px 16px;display:flex;align-items:center;gap:12px">
+      <span style="font-family:var(--font-heading);font-size:22px;line-height:1;color:var(--color-accent);min-width:28px">${s.num}</span>
+      <span style="display:flex;flex-direction:column;gap:1px;min-width:0">
+        <span style="font-family:var(--font-heading);font-size:16px;line-height:1.1">${esc(s.title)}</span>
+        <span class="micro">${esc(s.state)}</span>
+      </span>
+    </div>`).join("");
+}
+
+function docTargetHint() {
+  const slug = slugify(app.form.title);
+  if (!slug) return "— title required —";
+  return `sdd/proposals/${slug}.${app.kind === "new_feature" ? "brainstorm" : "proposal"}.md`;
+}
+
+function slugify(s) {
+  return String(s || "").toLowerCase().trim()
+    .replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+function renderReady() {
+  const f = app.form;
+  const maxRounds = app.config?.defaults?.ideation_max_rounds ?? 2;
+  const rows = app.mode === "feature"
+    ? [
+        ["intent", "feature (ideation skipped)"],
+        ["document", f.documentPath ? f.documentPath.split("/").pop() : "— required —"],
+        ["doc kind", f.documentKind],
+        ["dev agents", f.devAgents.length ? f.devAgents.map((a) => `${a.agent}×${a.count}`).join(" ") : "planner-sized"],
+        ["judges", `${effectiveJudges().length} · majority`],
+        ["jira", f.jiraIssueKey || "none (optional)"],
+        ["plan gate", f.requirePlanApproval ? "REQUIRED" : "off"],
+        ["QA", f.skipQa ? "SKIPPED" : "full"],
+      ]
+    : [
+        ["intent", app.kind],
+        ["will write", docTargetHint()],
+        ["description", f.description.trim() ? `${f.description.trim().length} chars` : "— required —"],
+        ["HITL rounds", `≤ ${maxRounds}`],
+        ["dev agents", f.devAgents.length ? f.devAgents.map((a) => `${a.agent}×${a.count}`).join(" ") : "planner-sized"],
+        ["judges", `${effectiveJudges().length} · majority`],
+        ["plan gate", f.requirePlanApproval ? "REQUIRED" : "off"],
+        ["QA", f.skipQa ? "SKIPPED" : "full"],
+      ];
+  $("ready-rows").innerHTML = rows.map(([k, v]) => `
+    <span style="display:flex;justify-content:space-between;gap:10px;font-size:12.5px">
+      <span class="muted">${esc(k)}</span><span class="mono" style="text-align:right">${esc(v)}</span>
+    </span>`).join("");
+}
+
+/* ── HITL — Open Questions / plan approval (FEAT-412) ──────────────
+   Rendered from app.s.gates (the folded session STATE), never from live
+   actions alone: a reload mid-gate adopts a snapshot that already contains
+   the pending gate, so the panel must come back from state. After a
+   successful resolve we do NOT mutate local state — the gate/resolved
+   action arrives on the state socket, which stays the single source of
+   truth. */
+
+const HITL_KINDS = ["open_questions", "plan_approval", "manual_criterion",
+                    "review_escalation", "deployment_approval", "revision_approval"];
+
+function pendingGate() {
+  const gates = Object.values(app.s.gates || {})
+    .filter((g) => (g.status || "pending") === "pending" && HITL_KINDS.includes(g.kind));
+  // Oldest first — the flow only ever awaits one at a time in dev-flow.
+  gates.sort((a, b) => (a.opened_at || 0) - (b.opened_at || 0));
+  return gates[0] || null;
+}
+
+function clientIdentity() {
+  let who = localStorage.getItem("devflow-user");
+  if (!who) {
+    who = (prompt("Your name (recorded as the gate resolver):") || "").trim();
+    if (who) localStorage.setItem("devflow-user", who);
+  }
+  return who || "console-user";
+}
+
+function renderHitl() {
+  const gate = pendingGate();
+  const section = $("hitl-section");
+
+  if (!gate) {
+    section.classList.add("hidden");
+    app.hitl.gateId = null;
+    return;
+  }
+
+  // A new gate resets the draft answers.
+  if (app.hitl.gateId !== gate.gate_id) {
+    app.hitl = { gateId: gate.gate_id, answers: {}, comment: "", busy: false };
+    $("hitl-err").classList.add("hidden");
+  }
+
+  const questions = Array.isArray(gate.questions) ? gate.questions : [];
+  const isQuestions = gate.kind === "open_questions" && questions.length > 0;
+
+  section.classList.remove("hidden");
+  $("hitl-kind").textContent = gate.kind;
+  $("hitl-title").textContent = gate.title || gate.node_id || "Approval required";
+  $("hitl-instructions").textContent = gate.instructions || "";
+  $("hitl-meta").textContent = [
+    gate.node_id ? `node ${gate.node_id}` : "",
+    gate.opened_at ? `opened ${fmtClock(gate.opened_at)}` : "",
+    gate.expires_at ? `expires ${fmtClock(gate.expires_at)}` : "",
+  ].filter(Boolean).join(" · ");
+  $("hitl-identity").textContent = `as ${localStorage.getItem("devflow-user") || "console-user"}`;
+
+  if (isQuestions) {
+    $("hitl-fields").innerHTML = questions.map((q, i) => `
+      <div class="field">
+        <label for="hq-${i}">${esc(q)}</label>
+        <textarea id="hq-${i}" class="input mono" data-hitl-q="${esc(q)}"
+          style="min-height:64px;font-size:12.5px;line-height:1.6"
+          placeholder="Your answer — leave blank to leave this question open">${esc(app.hitl.answers[q] || "")}</textarea>
+      </div>`).join("");
+    $("hitl-submit").textContent = "Submit answers";
+    $("hitl-footnote").textContent =
+      "Partial answers are fine — anything you leave blank stays '[ ]' in the " +
+      "document. Rejecting aborts the ideation and routes the run to the " +
+      "failure handler.";
+  } else {
+    // plan_approval and every other kind: approve/reject + a comment, no
+    // structured answers.
+    $("hitl-fields").innerHTML = `
+      <div class="field">
+        <label for="hitl-comment">Comment (optional — recorded on the gate)</label>
+        <textarea id="hitl-comment" class="input mono" style="min-height:64px;font-size:12.5px;line-height:1.6"
+          placeholder="Looks right — proceed.">${esc(app.hitl.comment)}</textarea>
+      </div>`;
+    $("hitl-submit").textContent = "Approve";
+    $("hitl-footnote").textContent = gate.kind === "plan_approval"
+      ? "Approving releases the dev-agent fleet. Rejecting stops the run before any code is written."
+      : "Approving lets the run continue; rejecting routes it to the failure handler.";
+  }
+  $("hitl-submit").disabled = app.hitl.busy;
+  $("hitl-reject").disabled = app.hitl.busy;
+}
+
+function collectHitlDraft() {
+  for (const el of document.querySelectorAll("[data-hitl-q]")) {
+    app.hitl.answers[el.dataset.hitlQ] = el.value;
+  }
+  const c = $("hitl-comment");
+  if (c) app.hitl.comment = c.value;
+}
+
+function gateResolveUrl(gateId) {
+  const tpl = app.config?.gate_resolve_url_template
+    || "/api/flow/{run_id}/gates/{gate_id}/resolve";
+  return tpl.replace("{run_id}", app.runId).replace("{gate_id}", gateId);
+}
+
+async function resolveGate(resolution) {
+  const gate = pendingGate();
+  if (!gate || !app.runId || app.hitl.busy) return;
+  collectHitlDraft();
+
+  const body = {
+    resolution,
+    resolved_by: clientIdentity(),
+    comment: app.hitl.comment || "",
+  };
+  if (gate.kind === "open_questions" && resolution === "approved") {
+    // Only non-empty answers travel; blanks stay open in the document.
+    const answers = {};
+    for (const [q, a] of Object.entries(app.hitl.answers)) {
+      if (String(a || "").trim()) answers[q] = String(a).trim();
+    }
+    if (!Object.keys(answers).length) {
+      showHitlError("Answer at least one question, or reject the gate to abort the ideation.");
+      return;
+    }
+    body.answers = answers;
+  }
+
+  app.hitl.busy = true;
+  renderHitl();
+  try {
+    const res = await fetch(gateResolveUrl(gate.gate_id), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(data.detail || data.error || res.statusText);
+    $("hitl-err").classList.add("hidden");
+    // Deliberately no local mutation: the gate/resolved action on the state
+    // socket folds the resolution and re-renders (hiding this panel).
+  } catch (err) {
+    showHitlError(err.message);
+  } finally {
+    app.hitl.busy = false;
+    renderHitl();
+  }
+}
+
+function showHitlError(msg) {
+  const box = $("hitl-err");
+  box.textContent = msg;
+  box.classList.remove("hidden");
+}
+
+/* ── 02 Execution ─────────────────────────────────────────────────── */
+function nodesForRender() {
+  const spec = TOPOLOGY.dev;
+  return spec.map((n, i) => {
+    const st = app.s.nodes[n.id] || { status: "idle" };
+    const events = app.events.get(n.id) || [];
+    const elapsed = st.started_at
+      ? ((st.finished_at || Date.now() / 1000) - st.started_at) : null;
+    return {
+      ...n, num: String(i + 1).padStart(2, "0"),
+      status: st.status || "idle", error: st.error || "",
+      dispatch: st.dispatch || null, summary: st.summary || {},
+      events, startedAt: st.started_at, finishedAt: st.finished_at, elapsed,
+    };
+  });
+}
+
+function eventRowsHtml(nodeId, events) {
+  if (!events.length) {
+    return `<p class="muted" style="font-size:12.5px;padding:10px 0 2px">This node has not been dispatched yet.</p>`;
+  }
+  return events.slice().reverse().map((e, j) => {
+    const key = `${nodeId}:${events.length - 1 - j}`;
+    const open = app.openEvents.has(key);
+    return `<div class="ev-row">
+      <div class="ev-head" data-ev="${esc(key)}">
+        <span class="caret muted">${open ? "▾" : "▸"}</span>
+        <span class="muted">${esc(fmtClock(e.ts))}</span>
+        <span style="color:var(--color-accent-700)">${esc(e.kind)}</span>
+        <span class="rule"></span>
+        <span class="muted">${esc(briefOf(e.kind, e.payload))}</span>
+      </div>
+      ${open ? `<pre class="ev-json">${esc(JSON.stringify(e.payload, null, 2))}</pre>` : ""}
+    </div>`;
+  }).join("");
+}
+
+function nodeMetaHtml(n) {
+  const d = n.dispatch;
+  if (!d) return "";
+  const bits = [];
+  if (d.dispatcher) bits.push(d.dispatcher);
+  if (d.message_count) bits.push(`${d.message_count} msgs`);
+  if (d.tool_use_count) bits.push(`${d.tool_use_count} tools`);
+  return bits.join(" · ");
+}
+
+function renderExecution() {
+  if (app.phase === "idle") return;
+  const nodes = nodesForRender();
+  $("exec-progress").textContent =
+    `${app.eventCount} envelopes` +
+    (app.s.qaAttempts ? ` · QA attempt ${app.s.qaAttempts + 1}` : "") +
+    (app.phase === "done" ? " · stream closed" : " · streaming");
+
+  const body = $("exec-body");
+
+  if (app.view === "panels") {
+    body.innerHTML = `<div class="scroll" style="max-height:660px;display:flex;flex-direction:column;gap:14px;padding:6px">${
+      nodes.map((n) => `
+        <div class="blueprint" style="padding:0;${n.status === "running"
+          ? "border-color:var(--color-accent);background:color-mix(in srgb,var(--color-accent) 6%,transparent)" : ""}">
+          <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+          <div style="display:flex;align-items:center;gap:12px;padding:11px 14px;border-bottom:1px solid var(--color-divider);flex-wrap:wrap">
+            <span class="mono muted" style="font-size:11px">${n.num}</span>
+            <span style="font-family:var(--font-heading);font-size:18px;line-height:1">${esc(n.label)}</span>
+            <span class="pill ${n.status}">${esc(n.status)}</span>
+            <span class="rule"></span>
+            <span class="muted" style="font-size:12px">${esc(nodeMetaHtml(n) || n.role)}</span>
+            <span class="mono" style="font-size:12px;min-width:56px;text-align:right">${esc(fmtDuration(n.elapsed))}</span>
+          </div>
+          ${n.error ? `<div class="err-box" style="margin:10px 14px">${esc(n.error)}</div>` : ""}
+          <div class="scroll" style="max-height:200px;padding:6px 14px 10px">${eventRowsHtml(n.id, n.events)}</div>
+        </div>`).join("")
+    }</div>`;
+    return;
+  }
+
+  if (app.view === "spine") {
+    body.innerHTML = `<div class="scroll" style="max-height:660px;padding:4px">${
+      nodes.map((n) => {
+        const open = app.selected === n.id || n.status === "running" || n.status === "failed";
+        return `<div style="display:grid;grid-template-columns:132px 1fr;gap:20px;align-items:start">
+          <div style="text-align:right;padding-top:9px;display:flex;flex-direction:column;gap:2px">
+            <span class="mono muted" style="font-size:12px">${esc(fmtClock(n.startedAt))}</span>
+            <span class="mono muted" style="font-size:11px">${esc(fmtDuration(n.elapsed))}</span>
+          </div>
+          <div style="display:grid;grid-template-columns:22px 1fr;gap:14px">
+            <div style="display:flex;flex-direction:column;align-items:center">
+              <span class="dot ${n.status}" style="margin-top:12px;width:11px;height:11px"></span>
+              <span style="width:1px;flex:1;min-height:26px;background:var(--color-divider)"></span>
+            </div>
+            <div style="padding:6px 0 20px;min-width:0">
+              <div style="display:flex;align-items:baseline;gap:10px;flex-wrap:wrap;cursor:pointer" data-node="${esc(n.id)}">
+                <span style="font-family:var(--font-heading);font-size:19px;line-height:1.1">${esc(n.label)}</span>
+                <span class="pill ${n.status}">${esc(n.status)}</span>
+                <span class="muted" style="font-size:12px">${esc(n.role)}</span>
+              </div>
+              ${open
+                ? `<div style="margin-top:8px;border-left:1px solid var(--color-divider);padding-left:14px">${eventRowsHtml(n.id, n.events)}</div>`
+                : `<p class="muted" style="margin:5px 0 0;font-size:12.5px">${n.events.length} events · ${
+                     n.status === "idle" ? "not dispatched" : "finished in " + fmtDuration(n.elapsed)
+                   } — click the title to expand</p>`}
+            </div>
+          </div>
+        </div>`;
+      }).join("")
+    }</div>`;
+    return;
+  }
+
+  // focus rail
+  const sel = nodes.find((n) => n.id === app.selected)
+    || nodes.find((n) => n.status === "running")
+    || [...nodes].reverse().find((n) => n.status !== "idle")
+    || nodes[0];
+  body.innerHTML = `<div class="cols-2" style="display:grid;grid-template-columns:300px minmax(0,1fr);gap:18px;align-items:start">
+    <div class="scroll" style="max-height:620px;display:flex;flex-direction:column;gap:1px;background:var(--color-divider);border:1px solid var(--color-divider)">
+      ${nodes.map((n) => `
+        <div data-node="${esc(n.id)}" style="background:${sel && sel.id === n.id
+            ? "color-mix(in srgb,var(--color-accent) 12%,transparent)" : "var(--color-bg)"
+          };padding:11px 13px;display:flex;align-items:center;gap:11px;cursor:pointer">
+          <span class="dot ${n.status}"></span>
+          <span style="display:flex;flex-direction:column;gap:1px;min-width:0;flex:1">
+            <span style="font-family:var(--font-heading);font-size:15px;line-height:1.1">${esc(n.label)}</span>
+            <span class="muted" style="font-size:11px">${esc(n.status)} · ${n.events.length} events</span>
+          </span>
+          <span class="mono muted" style="font-size:11.5px">${esc(fmtDuration(n.elapsed))}</span>
+        </div>`).join("")}
+    </div>
+    <div class="blueprint" style="padding:0;min-height:420px">
+      <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+      <div style="display:flex;align-items:center;gap:12px;padding:13px 16px;border-bottom:1px solid var(--color-divider);flex-wrap:wrap">
+        <span style="font-family:var(--font-heading);font-size:21px;line-height:1">${esc(sel ? sel.label : "—")}</span>
+        <span class="pill ${sel ? sel.status : "idle"}">${esc(sel ? sel.status : "idle")}</span>
+        <span class="rule"></span>
+        <span class="muted" style="font-size:12px">${esc(sel ? (nodeMetaHtml(sel) || sel.role) : "")}</span>
+        <span class="mono" style="font-size:12.5px">${esc(sel ? fmtDuration(sel.elapsed) : "—")}</span>
+      </div>
+      ${sel && sel.error ? `<div class="err-box" style="margin:12px 16px">${esc(sel.error)}</div>` : ""}
+      <div class="scroll" style="max-height:520px;padding:8px 16px 14px">${sel ? eventRowsHtml(sel.id, sel.events) : ""}</div>
+    </div>
+  </div>`;
+}
+
+/* ── 03 Summary ───────────────────────────────────────────────────── */
+// dev-flow has exactly ONE terminal handoff for both intents — the
+// FEAT-378 feature_handoff (draft PR against dev). There is no
+// deployment_handoff node in this topology at all.
+const handoffNodeId = () => "feature_handoff";
+
+function prNumber(url) {
+  const tail = String(url || "").replace(/\/+$/, "").split("/").pop();
+  return /^\d+$/.test(tail) ? `#${tail}` : "";
+}
+
+/**
+ * The PR is the contract of a finished run: the Handoff node is the only
+ * step that opens one, so a terminated run without a `pr_url` is surfaced
+ * as a failure rather than quietly rendered as success.
+ */
+function summaryHeadline() {
+  const s = app.s;
+  const handoff = s.nodes[handoffNodeId()];
+  if (s.prUrl) {
+    return {
+      short: `PR open — ${prNumber(s.prUrl) || "awaiting review"}`,
+      long: "Handoff complete — waiting on human review",
+      sub: "A draft PR against dev. The flow never merges; a human reviews and merges.",
+      bad: false,
+    };
+  }
+  if (handoff && handoff.status === "failed") {
+    return { short: "handoff failed — no PR", long: "Handoff failed — no pull request was produced",
+             sub: handoff.error || "The run cannot be considered complete without a PR.", bad: true };
+  }
+  if (s.phase === "failed" || s.nodes.failure_handler?.status === "completed") {
+    return { short: "run parked — needs a human", long: "Run parked by the Failure Handler",
+             sub: s.error || "The run stopped before Handoff — no PR was opened.", bad: true };
+  }
+  return { short: "finished without a PR", long: "Run finished without a pull request",
+           sub: "The Handoff node is the only step that opens a PR; it never reported one for this run.",
+           bad: true };
+}
+
+function effectiveJudges() {
+  if (app.form.judges.length) {
+    const j = [...app.form.judges];
+    const adv = app.config?.adversarial_backend || "codex";
+    if (!j.some((x) => x.agent === adv)) j.push({ agent: adv, model: app.config?.adversarial_model || "" });
+    return j;
+  }
+  return app.config?.default_judge_panel || [];
+}
+
+function renderSummary() {
+  if (app.phase !== "done") return;
+  const s = app.s;
+  const h = summaryHeadline();
+  $("sum-headline").textContent = h.long;
+  $("sum-subline").textContent = h.sub;
+  $("sum-finished").textContent = s.finishedAt
+    ? `finished ${fmtClock(s.finishedAt)} · ${fmtDuration(s.finishedAt - (s.createdAt || s.finishedAt))} wall clock`
+    : "";
+
+  const nodes = nodesForRender().filter((n) => n.status !== "idle");
+  const maxDur = Math.max(1, ...nodes.map((n) => n.elapsed || 0));
+  const t = app.telemetry;
+  const docs = s.docs[s.docs.length - 1] || null;
+  const verdictRounds = Object.entries(s.judgeVerdicts);
+  const gates = Object.values(s.gates);
+
+  const prCard = `
+    <div class="blueprint" style="padding:0">
+      <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+      <div style="padding:16px 18px;border-bottom:1px solid var(--color-divider);display:flex;align-items:flex-start;gap:14px;flex-wrap:wrap">
+        <span style="display:flex;flex-direction:column;gap:4px;flex:1;min-width:240px">
+          <span class="micro" style="color:${h.bad ? "var(--color-accent-900)" : "var(--color-accent-700)"}">${h.bad ? "No pull request" : "Pull request opened"}</span>
+          <span style="font-family:var(--font-heading);font-size:23px;line-height:1.15">${esc(h.long)}</span>
+          ${s.prUrl
+            ? `<a class="mono" style="font-size:12.5px" href="${esc(s.prUrl)}" target="_blank" rel="noopener">${esc(s.prUrl)} ↗</a>`
+            : `<span class="muted" style="font-size:12.5px">${esc(h.sub)}</span>`}
+        </span>
+        <span style="display:flex;flex-direction:column;align-items:flex-end;gap:8px">
+          <span class="tag ${h.bad ? "tag-danger" : "tag-accent"}">${esc(s.phase)}</span>
+          ${s.prUrl ? `<span class="mono muted" style="font-size:12.5px">${esc(prNumber(s.prUrl))}</span>` : ""}
+        </span>
+      </div>
+      ${docs ? `
+      <div style="padding:14px 18px;border-bottom:1px solid var(--color-divider);display:flex;flex-direction:column;gap:6px">
+        <span class="micro">Documentation artifact</span>
+        <span class="mono" style="font-size:12.5px">${esc(docs.docs_path || "—")}</span>
+        <span class="muted" style="font-size:12px">${docs.wiki_page_id
+          ? `wiki page <span class="mono">${esc(docs.wiki_page_id)}</span>`
+          : "wiki ingest skipped"}</span>
+      </div>` : ""}
+      <div style="padding:14px 18px">
+        <span class="micro">Agents</span>
+        <table class="table" style="margin-top:6px">
+          <thead><tr><th>Node</th><th>Status</th><th style="text-align:right">Duration</th><th>Dispatcher</th><th style="text-align:right">Msgs</th><th style="text-align:right">Tools</th></tr></thead>
+          <tbody>${nodes.map((n) => `
+            <tr>
+              <td style="font-family:var(--font-heading)">${esc(n.label)}</td>
+              <td><span class="pill ${n.status}">${esc(n.status)}</span></td>
+              <td class="mono" style="text-align:right">${esc(fmtDuration(n.elapsed))}</td>
+              <td class="mono muted">${esc(n.dispatch?.dispatcher || "—")}</td>
+              <td class="mono" style="text-align:right">${n.dispatch?.message_count ?? "—"}</td>
+              <td class="mono" style="text-align:right">${n.dispatch?.tool_use_count ?? "—"}</td>
+            </tr>`).join("")}</tbody>
+        </table>
+      </div>
+    </div>`;
+
+  const side = `
+    <div style="display:flex;flex-direction:column;gap:18px">
+      <div class="blueprint" style="padding:16px 18px;display:flex;flex-direction:column;gap:11px">
+        <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+        <div style="display:flex;align-items:baseline;gap:10px;flex-wrap:wrap">
+          <span class="micro">Ticket</span><span class="rule"></span>
+          ${s.jiraKey
+            ? `<span class="mono" style="font-size:14px">${esc(s.jiraKey)}</span>`
+            : `<span class="muted" style="font-size:12.5px">no ticket — Jira is optional and link-only in dev-flow</span>`}
+        </div>
+        ${s.qaAttempts ? `<span class="muted" style="font-size:12.5px">QA repair attempts: <span class="mono">${s.qaAttempts}</span></span>` : ""}
+      </div>
+
+      ${verdictRounds.length ? `
+      <div class="blueprint" style="padding:16px 18px;display:flex;flex-direction:column;gap:10px">
+        <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+        <span class="micro">QA judge panel — majority, fail-closed</span>
+        ${verdictRounds.map(([round, vs]) => `
+          <div style="display:flex;flex-direction:column;gap:5px">
+            <span class="muted" style="font-size:11.5px">round ${esc(round)} — ${vs.filter((v) => v.passed).length}/${vs.length} passed</span>
+            ${vs.map((v) => `
+              <span style="display:flex;gap:9px;align-items:baseline;font-size:12.5px">
+                <span class="pill ${v.passed ? "completed" : "failed"}" style="min-width:58px;justify-content:center">${v.passed ? "pass" : "fail"}</span>
+                <span class="mono">${esc(v.backend || v.judge_id)}${v.model ? ":" + esc(v.model) : ""}</span>
+                <span class="rule"></span>
+                <span class="muted">${v.findings_count} findings</span>
+              </span>`).join("")}
+          </div>`).join("")}
+      </div>` : ""}
+
+      ${s.feedback.length ? `
+      <div class="blueprint" style="padding:16px 18px;display:flex;flex-direction:column;gap:8px">
+        <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+        <span class="micro">Feedback router</span>
+        ${s.feedback.map((f) => `
+          <span style="display:flex;gap:9px;align-items:baseline;font-size:12.5px;min-width:0">
+            <span class="tag tag-outline">${esc(f.decision)}</span>
+            <span class="muted">attempt ${f.qa_attempt}</span>
+            <span class="rule"></span>
+            <span class="muted" style="max-width:55%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${esc(f.notes || f.dev_brief || "")}</span>
+          </span>`).join("")}
+      </div>` : ""}
+
+      ${gates.length ? `
+      <div class="blueprint" style="padding:16px 18px;display:flex;flex-direction:column;gap:8px">
+        <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+        <span class="micro">Gate audit trail</span>
+        ${gates.map((g) => `
+          <span style="display:flex;gap:9px;align-items:baseline;font-size:12.5px">
+            <span class="tag tag-outline">${esc(g.kind)}</span>
+            <span class="muted">${esc(g.title || g.node_id)}</span>
+            <span class="rule"></span>
+            <span class="mono">${esc(g.status)}${g.resolved_by ? " · " + esc(g.resolved_by) : ""}</span>
+          </span>`).join("")}
+      </div>` : ""}
+
+      <div class="blueprint" style="padding:16px 18px;display:flex;flex-direction:column;gap:10px">
+        <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+        <span class="micro">Run timeline</span>
+        ${nodes.map((n) => `
+          <span style="display:grid;grid-template-columns:104px 1fr 62px;gap:10px;align-items:center;font-size:12px">
+            <span class="muted">${esc(n.label)}</span>
+            <span style="height:9px;background:color-mix(in srgb,var(--color-text) 7%,transparent);display:block">
+              <span style="display:block;height:9px;background:${n.status === "failed" ? "var(--color-accent-900)" : "var(--color-accent)"};width:${Math.round(((n.elapsed || 0) / maxDur) * 100)}%"></span>
+            </span>
+            <span class="mono muted" style="text-align:right">${esc(fmtDuration(n.elapsed))}</span>
+          </span>`).join("")}
+      </div>
+
+      <div class="blueprint" style="padding:16px 18px;display:flex;flex-direction:column;gap:12px">
+        <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+        <span class="micro">Cost &amp; tokens</span>
+        <div style="display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px">
+          ${[["total cost", t.reported ? `$${t.cost.toFixed(2)}` : "—"],
+             ["input tokens", t.reported ? fmtNum(t.input) : "—"],
+             ["output tokens", t.reported ? fmtNum(t.output) : "—"],
+             ["turns", t.reported ? String(t.turns) : "—"]].map(([k, v]) => `
+            <span style="display:flex;flex-direction:column;gap:1px">
+              <span style="font-family:var(--font-heading);font-size:20px;line-height:1">${esc(v)}</span>
+              <span class="micro">${esc(k)}</span>
+            </span>`).join("")}
+        </div>
+        ${t.reported ? "" : `<p class="hint" style="margin:0">No dispatch reported usage telemetry for this run.</p>`}
+      </div>
+    </div>`;
+
+  $("summary-body").innerHTML =
+    `<div class="cols-2" style="display:grid;grid-template-columns:minmax(0,1.35fr) minmax(0,1fr);gap:18px;align-items:start">${prCard}${side}</div>`;
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   Advanced tabs
+   ═══════════════════════════════════════════════════════════════════ */
+function tabsForMode() {
+  const common = [
+    { id: "planning", label: "Planning & Jira" },
+    { id: "agents", label: "Agents & models" },
+    { id: "review", label: "Review & judges" },
+    { id: "guardrails", label: "Guardrails" },
+  ];
+  // The ideation tab is meaningless for a document intake (ideation is
+  // skipped), so it only shows for the two natural-language intents.
+  return app.mode === "feature"
+    ? common
+    : [{ id: "ideation", label: "Ideation & gates" }, ...common];
+}
+
+function modelOptions(backendId, selected) {
+  const b = (app.config?.backends || []).find((x) => x.id === backendId);
+  const models = b ? b.models : [];
+  const opts = [`<option value=""${selected ? "" : " selected"}>default${b ? ` (${esc(b.default_model)})` : ""}</option>`];
+  for (const m of models) {
+    opts.push(`<option value="${esc(m)}"${m === selected ? " selected" : ""}>${esc(m)}</option>`);
+  }
+  if (selected && !models.includes(selected)) {
+    opts.push(`<option value="${esc(selected)}" selected>${esc(selected)}</option>`);
+  }
+  return opts.join("");
+}
+
+function backendOptions(role, selected) {
+  return (app.config?.roles?.[role] || []).map((id) => {
+    const b = (app.config.backends || []).find((x) => x.id === id);
+    return `<option value="${esc(id)}"${id === selected ? " selected" : ""}>${esc(b ? b.label : id)}</option>`;
+  }).join("");
+}
+
+function tabBodyHtml(tab) {
+  const f = app.form;
+  const d = app.config?.defaults || {};
+  const grid = (inner) => `<div style="display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px 18px">${inner}</div>`;
+  const isolationSeg = `
+    <div class="seg" data-seg="devIsolation">
+      ${["shared", "isolated"].map((v) =>
+        `<label class="seg-opt ${f.devIsolation === v ? "on" : ""}" data-val="${v}">${v}</label>`).join("")}
+    </div>`;
+
+  if (tab === "ideation") {
+    const d = app.config?.defaults || {};
+    const rounds = d.ideation_max_rounds ?? 2;
+    const ttlHours = Math.round((d.gate_ttl_questions ?? 86400) / 3600);
+    return grid(`
+      <div class="field" style="grid-column:1/-1">
+        <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
+          <input type="checkbox" id="chk-plan-approval" ${f.requirePlanApproval ? "checked" : ""} style="width:16px;height:16px" />
+          <span class="field-label" style="margin:0">Require plan approval before development</span>
+        </label>
+        <p class="hint">Opens a <span class="mono">plan_approval</span> gate after the planner and before the agent fleet dispatches — it appears in the panel above, with approve/reject and a comment. Per-run: it overrides the server default (<span class="mono">${d.require_plan_approval ? "on" : "off"}</span>) for this run only.</p>
+      </div>
+      <div class="field"><span class="field-label">Open-Questions rounds (DEV_FLOW_IDEATION_MAX_ROUNDS)</span>
+        <input class="input mono" value="${esc(String(rounds))}" disabled />
+        <p class="hint">Max HITL rounds. Anything still unanswered afterwards stays in the document and flows into the spec's §8.</p>
+      </div>
+      <div class="field"><span class="field-label">Gate TTL (DEV_FLOW_GATE_TTL_QUESTIONS)</span>
+        <input class="input mono" value="${esc(String(ttlHours))} h — fail-closed" disabled />
+        <p class="hint">An unanswered Open-Questions gate expires the run into the failure handler: silence is not consent for spec decisions.</p>
+      </div>`);
+  }
+  if (tab === "planning") {
+    return grid(`
+      <div class="field">
+        <label for="t-jira-key">Jira issue key (optional)</label>
+        <input id="t-jira-key" class="input mono" data-form="jiraIssueKey" value="${esc(f.jiraIssueKey)}" placeholder="blank — no ticket is created in feature mode" />
+        <p class="hint">When set, downstream nodes only link, transition and comment on it.</p>
+      </div>
+      <div class="field">
+        <span class="field-label">Docs artifact directory (server-side)</span>
+        <input class="input mono" value="${esc(d.docs_artifact_dir || "docs/features")}" disabled />
+        <p class="hint">Handoff writes <span class="mono">feat-&lt;id&gt;-&lt;slug&gt;.md</span> there, commits it to the PR branch${d.wiki_page_ingest ? " and ingests it as a wiki page" : " (wiki ingest is off)"}.</p>
+      </div>`);
+  }
+  if (tab === "agents") {
+    const rows = f.devAgents.map((a, i) => `
+      <div class="agent-row">
+        <div class="field"><span class="field-label">Backend</span>
+          <select class="input" data-agent-field="agent" data-idx="${i}">${backendOptions("development", a.agent)}</select></div>
+        <div class="field"><span class="field-label">Model</span>
+          <select class="input" data-agent-field="model" data-idx="${i}">${modelOptions(a.agent, a.model)}</select></div>
+        <div class="field"><span class="field-label">Count</span>
+          <input class="input mono" type="number" min="1" max="8" data-agent-field="count" data-idx="${i}" value="${a.count}" /></div>
+        <button type="button" class="btn btn-danger" data-agent-del="${i}" style="padding:8px 10px" title="Remove">✕</button>
+      </div>`).join("");
+    return `<div style="display:flex;flex-direction:column;gap:12px">
+      <span class="field-label">Development agent pool — leave empty to let the planner size it from the task graph</span>
+      ${rows || `<p class="hint" style="margin:0">No pool declared.</p>`}
+      <button type="button" class="btn" id="add-agent-btn" style="align-self:flex-start">+ Add agent</button>
+      <div class="field" style="max-width:280px">
+        <span class="field-label">Worktree isolation</span>
+        ${isolationSeg}
+      </div>
+    </div>`;
+  }
+  if (tab === "review") {
+    const judges = f.judges.length ? f.judges : (app.config?.default_judge_panel || []);
+    const advBackend = app.config?.adversarial_backend || "codex";
+    const adv = app.config?.adversarial_review || {};
+    const rows = judges.map((j, i) => {
+      const locked = j.agent === advBackend;
+      return `<div class="judge-row">
+        <div class="field"><span class="field-label">Judge ${i + 1}${locked ? " · adversarial" : ""}</span>
+          <select class="input" data-judge-field="agent" data-idx="${i}" ${locked ? "disabled" : ""}>${backendOptions("judge", j.agent)}</select></div>
+        <div class="field"><span class="field-label">Model</span>
+          <select class="input" data-judge-field="model" data-idx="${i}">${modelOptions(j.agent, j.model)}</select></div>
+        ${!locked
+          ? `<button type="button" class="btn btn-danger" data-judge-del="${i}" style="padding:8px 10px" title="Remove">✕</button>`
+          : `<span></span>`}
+      </div>`;
+    }).join("");
+    return `<div style="display:flex;flex-direction:column;gap:14px">
+      <div class="blueprint" style="padding:12px 14px;display:flex;flex-direction:column;gap:6px">
+        <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+        <span class="micro" style="color:var(--color-accent-700)">Adversarial review — mandatory</span>
+        <span style="font-size:12.5px">Reviewer wired on this server: <span class="mono">${esc(d.codereview_agent || "parallel")}</span>${
+          d.codereview_agent_configured && d.codereview_agent_configured !== d.codereview_agent
+            ? ` <span class="muted">(upgraded from ${esc(d.codereview_agent_configured)})</span>` : ""}</span>
+        <span class="muted" style="font-size:12px">${esc(adv.note || "")} Scope: <span class="mono">${esc(adv.scope || "uncommitted")}</span>${
+          adv.base_ref ? ` · base <span class="mono">${esc(adv.base_ref)}</span>` : ""}</span>
+      </div>
+      <span class="field-label">QA judge panel</span>
+      ${rows}
+      <button type="button" class="btn" id="add-judge-btn" style="align-self:flex-start">+ Add judge</button>
+      <p class="hint" style="margin:0">Simple majority. A tie, or an abstention that breaks majority, escalates rather than passing.</p>
+    </div>`;
+  }
+  // guardrails
+  const skipQaChecked = f.skipQa ? "checked" : "";
+  const skipJiraChecked = f.skipJira ? "checked" : "";
+  return grid(`
+    <div class="field" style="grid-column:1/-1">
+      <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
+        <input type="checkbox" id="chk-skip-qa" ${skipQaChecked} style="width:16px;height:16px" />
+        <span class="field-label" style="margin:0">Skip QA for this run</span>
+      </label>
+      <p class="hint">Bypasses deterministic acceptance tests and code review — returns a synthetic pass. Use for trivial fixes (typos, syntax) where the 7-minute QA cycle is not worth the wait. Server default: <span class="mono">${d.skip_qa ? "on" : "off"}</span></p>
+    </div>
+    <div class="field" style="grid-column:1/-1">
+      <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
+        <input type="checkbox" id="chk-skip-jira" ${skipJiraChecked} style="width:16px;height:16px" />
+        <span class="field-label" style="margin:0">Skip Jira for this run</span>
+      </label>
+      <p class="hint">No ticket creation, no transitions, no comments. Research still runs (logs + triage + sdd-research dispatch) but without Jira integration. Use for local experiments or when Jira is down.</p>
+    </div>
+    <div class="field"><span class="field-label">QA repair retries (DEV_LOOP_QA_MAX_RETRIES)</span>
+      <input class="input mono" value="${esc(String(d.qa_max_retries ?? "—"))}" disabled /></div>
+    <div class="field"><span class="field-label">Concurrent runs (FLOW_MAX_CONCURRENT_RUNS)</span>
+      <input class="input mono" value="${esc(String(d.max_concurrent_runs ?? "—"))}" disabled /></div>
+    <div class="field"><span class="field-label">Dev pool ceiling (DEV_LOOP_DEV_POOL_MAX)</span>
+      <input class="input mono" value="${esc(String(d.development_pool_max ?? "—"))}" disabled /></div>
+    <div class="field"><span class="field-label">Default development agent</span>
+      <input class="input mono" value="${esc(String(d.development_agent || "—"))}" disabled /></div>
+    <div class="field" style="grid-column:1/-1"><span class="field-label">On failure</span>
+      <input class="input mono" value="route → failure_handler (the run is parked, never half-merged)" disabled /></div>`);
+}
+
+function renderTabs() {
+  const tabs = tabsForMode();
+  if (!tabs.some((t) => t.id === app.advTab)) app.advTab = tabs[0].id;
+  $("adv-tabs").innerHTML = tabs.map((t) => `
+    <button type="button" class="btn" data-tab="${t.id}" style="border:0;border-bottom:2px solid ${
+      t.id === app.advTab ? "var(--color-accent)" : "transparent"
+    };padding:8px 13px;font-size:13.5px;background:transparent;color:${
+      t.id === app.advTab ? "var(--color-text)" : "color-mix(in srgb,var(--color-text) 55%,transparent)"
+    }">${esc(t.label)}</button>`).join("");
+  $("adv-note").textContent = TAB_NOTES[app.advTab] || "";
+  $("adv-fields").innerHTML = tabBodyHtml(app.advTab);
+  $("adv-badge").textContent = `${tabs.length} groups`;
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   Pickers / mode
+   ═══════════════════════════════════════════════════════════════════ */
+function renderKindPicker() {
+  // Every dev-flow intent is always available — one topology, no per-mode
+  // availability guard (the server fails startup loudly instead).
+  $("f-kind").innerHTML = (app.config?.kinds || []).map((k) =>
+    `<label class="seg-opt ${app.kind === k.value ? "on" : ""}" data-kind="${k.value}">${esc(k.label)}</label>`
+  ).join("");
+  $("kind-hint").textContent = KIND_HINTS[app.kind] || "";
+
+  $("f-document-kind").innerHTML = (app.config?.document_kinds || []).map((v) =>
+    `<label class="seg-opt ${app.form.documentKind === v ? "on" : ""}" data-dockind="${v}">${esc(v)}</label>`).join("");
+  $("document-kind-hint").textContent = DOC_KIND_HINTS[app.form.documentKind] || "";
+
+  $("view-picker").innerHTML = [["panels", "Panels"], ["rail", "Focus rail"], ["spine", "Spine"]]
+    .map(([v, l]) => `<label class="seg-opt ${app.view === v ? "on" : ""}" data-view="${v}">${esc(l)}</label>`).join("");
+}
+
+function applyMode() {
+  // `mode` selects the INTAKE shape only — the topology is always dev-flow.
+  app.mode = app.kind === "feature" ? "feature" : "nl";
+  $("work-intake").classList.toggle("hidden", app.mode === "feature");
+  $("feature-intake").classList.toggle("hidden", app.mode !== "feature");
+  renderKindPicker();
+  renderTabs();
+  renderReady();
+  renderChrome();
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   Submit / lifecycle
+   ═══════════════════════════════════════════════════════════════════ */
+function buildPayload() {
+  const f = app.form;
+  const payload = app.mode === "feature"
+    ? {
+        kind: "feature",
+        document_path: f.documentPath.trim(),
+        document_kind: f.documentKind,
+      }
+    : {
+        kind: app.kind,
+        title: f.title.trim(),
+        description: f.description.trim(),
+      };
+  if (app.mode !== "feature" && f.context.trim()) payload.context = f.context.trim();
+  if (f.jiraIssueKey.trim()) payload.jira_issue_key = f.jiraIssueKey.trim();
+  if (f.devAgents.length) payload.dev_agents = f.devAgents;
+  if (f.judges.length) payload.judge_panel = f.judges;
+  if (f.skipQa) payload.skip_qa = true;
+  if (f.skipJira) payload.skip_jira = true;
+  // FEAT-412: only sent when the operator actually touched the toggle, so an
+  // untouched form falls back to the flow's build-time default instead of
+  // overriding it with an implicit false.
+  if (f.requirePlanApproval) payload.require_plan_approval = true;
+  return payload;
+}
+
+function showError(msg) {
+  const box = $("form-err");
+  box.textContent = msg;
+  box.classList.remove("hidden");
+}
+
+function applyRequestCollapse() {
+  const collapsed = !app.requestOpen;
+  $("request-form").classList.toggle("hidden", collapsed);
+  $("request-collapsed").classList.toggle("hidden", !collapsed);
+  if (collapsed) {
+    const f = app.form;
+    $("rc-kind").textContent = app.kind;
+    $("rc-summary").textContent = app.mode === "feature" ? f.documentPath : f.title;
+    $("rc-target").textContent = app.mode === "feature" ? f.documentKind : docTargetHint();
+    $("rc-criteria").textContent = `${effectiveJudges().length} judges`;
+  }
+}
+
+async function submit(ev) {
+  ev.preventDefault();
+  $("form-err").classList.add("hidden");
+  $("submit-btn").disabled = true;
+  try {
+    const res = await fetch("/api/flow/run", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(buildPayload()),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || res.statusText);
+
+    // Reset every per-run projection before the streams start.
+    app.runId = data.run_id;
+    app.phase = "running";
+    app.events = new Map();
+    app.eventCount = 0;
+    app.openEvents = new Set();
+    app.selected = null;
+    app.s = emptyState();
+    app.telemetry = { input: 0, output: 0, cost: 0, turns: 0, reported: 0 };
+    app.requestOpen = false;
+    applyRequestCollapse();
+    $("exec-section").classList.remove("hidden");
+    $("summary-section").classList.add("hidden");
+    $("report-box").classList.add("hidden");
+    connect(data.run_id);
+    render();
+  } catch (err) {
+    showError(err.message);
+  } finally {
+    $("submit-btn").disabled = false;
+  }
+}
+
+async function stopRun() {
+  if (!app.runId || app.phase !== "running") return;
+  $("stop-btn").disabled = true;
+  try {
+    const res = await fetch(`/api/flow/${app.runId}/cancel`, { method: "POST" });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      console.warn("stop failed:", data.error || res.statusText);
+    }
+  } catch (err) {
+    console.warn("stop failed:", err);
+  } finally {
+    $("stop-btn").disabled = false;
+  }
+}
+
+function restart() {
+  closeSockets();
+  app.phase = "idle";
+  app.runId = null;
+  app.connected = false;
+  app.events = new Map();
+  app.eventCount = 0;
+  app.openEvents = new Set();
+  app.s = emptyState();
+  app.telemetry = { input: 0, output: 0, cost: 0, turns: 0, reported: 0 };
+  app.requestOpen = true;
+  applyRequestCollapse();
+  $("exec-section").classList.add("hidden");
+  $("summary-section").classList.add("hidden");
+  $("report-box").classList.add("hidden");
+  render();
+}
+
+async function loadReport() {
+  const box = $("report-box"), pre = $("report-pre");
+  box.classList.remove("hidden");
+  pre.textContent = "Loading…";
+  try {
+    const res = await fetch(`/api/flow/${app.runId}/bundle?format=md`);
+    const text = await res.text();
+    if (!res.ok) {
+      let msg = text;
+      try { msg = JSON.parse(text).error || text; } catch { /* plain body */ }
+      pre.textContent = msg;
+      return;
+    }
+    pre.textContent = text;
+  } catch (err) {
+    pre.textContent = String(err);
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   Event delegation
+   ═══════════════════════════════════════════════════════════════════ */
+document.addEventListener("click", (e) => {
+  const t = e.target;
+
+  const kind = t.closest("[data-kind]");
+  if (kind) { app.kind = kind.dataset.kind; applyMode(); return; }
+  const dk = t.closest("[data-dockind]");
+  if (dk) { app.form.documentKind = dk.dataset.dockind; renderKindPicker(); renderReady(); return; }
+  const view = t.closest("[data-view]");
+  if (view) { app.view = view.dataset.view; renderKindPicker(); renderExecution(); return; }
+  const seg = t.closest("[data-seg] [data-val]");
+  if (seg) {
+    app.form[seg.closest("[data-seg]").dataset.seg] = seg.dataset.val;
+    renderTabs(); renderReady(); return;
+  }
+  const tab = t.closest("[data-tab]");
+  if (tab) { app.advTab = tab.dataset.tab; renderTabs(); return; }
+  const nodeEl = t.closest("[data-node]");
+  if (nodeEl) { app.selected = nodeEl.dataset.node; renderExecution(); return; }
+  const ev = t.closest("[data-ev]");
+  if (ev) {
+    const key = ev.dataset.ev;
+    app.openEvents.has(key) ? app.openEvents.delete(key) : app.openEvents.add(key);
+    renderExecution(); return;
+  }
+  const delAgent = t.closest("[data-agent-del]");
+  if (delAgent) { app.form.devAgents.splice(+delAgent.dataset.agentDel, 1); renderTabs(); renderReady(); return; }
+  const delJudge = t.closest("[data-judge-del]");
+  if (delJudge) {
+    if (!app.form.judges.length) app.form.judges = (app.config?.default_judge_panel || []).map((j) => ({ ...j }));
+    app.form.judges.splice(+delJudge.dataset.judgeDel, 1); renderTabs(); renderReady(); return;
+  }
+
+  if (t.id === "hitl-submit") { resolveGate("approved"); return; }
+  if (t.id === "hitl-reject") {
+    collectHitlDraft();
+    if (confirm("Reject this gate? The run stops and routes to the failure handler.")) {
+      resolveGate("rejected");
+    }
+    return;
+  }
+
+  switch (t.id) {
+    case "adv-toggle":
+      app.advOpen = !app.advOpen;
+      $("adv-body").classList.toggle("hidden", !app.advOpen);
+      $("adv-caret").textContent = app.advOpen ? "▾" : "▸";
+      break;
+    case "add-agent-btn":
+      app.form.devAgents.push({
+        agent: (app.config?.roles?.development || ["claude-code"])[0], model: "", count: 1,
+      });
+      renderTabs(); renderReady(); break;
+    case "add-judge-btn":
+      if (!app.form.judges.length) app.form.judges = (app.config?.default_judge_panel || []).map((j) => ({ ...j }));
+      app.form.judges.push({ agent: "claude-code", model: "" });
+      renderTabs(); renderReady(); break;
+    case "edit-request-btn":
+      app.requestOpen = true; applyRequestCollapse(); break;
+    case "stop-btn":
+      stopRun(); break;
+    case "restart-btn":
+    case "another-btn":
+      restart(); break;
+    case "view-report-btn":
+      if (app.runId) loadReport(); break;
+    case "bundle-btn":
+      if (app.runId) location.href = `/api/flow/${app.runId}/bundle?format=md&download=1`;
+      break;
+    case "chk-plan-approval":
+      app.form.requirePlanApproval = t.checked; renderReady(); break;
+    case "chk-skip-qa":
+      app.form.skipQa = t.checked;
+      renderReady();
+      break;
+    case "chk-skip-jira":
+      app.form.skipJira = t.checked;
+      renderReady();
+      break;
+  }
+});
+
+document.addEventListener("input", (e) => {
+  const t = e.target;
+  if (t.dataset.form) { app.form[t.dataset.form] = t.value; renderReady(); return; }
+
+  const af = t.dataset.agentField;
+  if (af) {
+    const row = app.form.devAgents[+t.dataset.idx];
+    if (row) {
+      row[af] = af === "count" ? Math.max(1, parseInt(t.value || "1", 10)) : t.value;
+      if (af === "agent") { row.model = ""; renderTabs(); }
+      renderReady();
+    }
+    return;
+  }
+  const jf = t.dataset.judgeField;
+  if (jf) {
+    if (!app.form.judges.length) app.form.judges = (app.config?.default_judge_panel || []).map((j) => ({ ...j }));
+    const row = app.form.judges[+t.dataset.idx];
+    if (row) {
+      row[jf] = t.value;
+      if (jf === "agent") { row.model = ""; renderTabs(); }
+      renderReady();
+    }
+    return;
+  }
+  const map = {
+    "f-description": "description", "f-title": "title", "f-context": "context",
+    "f-document-path": "documentPath",
+  };
+  if (map[t.id]) { app.form[map[t.id]] = t.value; renderReady(); }
+  // HITL draft answers / comment — kept in state so a re-render (e.g. a
+  // streamed node event) never wipes what the operator is typing.
+  if (t.dataset.hitlQ != null) { app.hitl.answers[t.dataset.hitlQ] = t.value; return; }
+  if (t.id === "hitl-comment") { app.hitl.comment = t.value; return; }
+});
+
+$("request-form").addEventListener("submit", submit);
+
+/* ═══════════════════════════════════════════════════════════════════
+   Boot
+   ═══════════════════════════════════════════════════════════════════ */
+(async function boot() {
+  try {
+    const res = await fetch("/api/config");
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    app.config = await res.json();
+  } catch (err) {
+    showError(`Could not load /api/config: ${err.message}`);
+    app.config = {
+      backends: [], roles: {},
+      kinds: [
+        { value: "enhancement", label: "Enhancement" },
+        { value: "new_feature", label: "New Feature" },
+        { value: "feature", label: "Feature (existing SDD doc)" },
+      ],
+      document_kinds: ["brainstorm", "proposal", "spec"],
+      defaults: { ideation_max_rounds: 2, gate_ttl_questions: 86400 },
+      gate_resolve_url_template: "/api/flow/{run_id}/gates/{gate_id}/resolve",
+    };
+  }
+  app.form.skipQa = !!app.config.defaults?.skip_qa;
+  app.form.requirePlanApproval = !!app.config.defaults?.require_plan_approval;
+  applyMode();
+  render();
+})();
+
+// Theme toggle
+function isDark() {
+  const attr = document.documentElement.getAttribute("data-theme");
+  if (attr) return attr === "dark";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches;
+}
+function updateThemeIcon() {
+  $("theme-toggle").textContent = isDark() ? "☀" : "☾";
+  $("theme-toggle").title = isDark() ? "Switch to light mode" : "Switch to dark mode";
+}
+$("theme-toggle").addEventListener("click", () => {
+  const next = isDark() ? "light" : "dark";
+  document.documentElement.setAttribute("data-theme", next);
+  localStorage.setItem("devflow-theme", next);
+  updateThemeIcon();
+});
+updateThemeIcon();
+
+// Keep elapsed timers moving while a run streams.
+setInterval(() => { if (app.phase === "running") scheduleRender(); }, 1000);
+</script>
+</body>
+</html>

--- a/examples/dev_loop/static/dev.html
+++ b/examples/dev_loop/static/dev.html
@@ -1503,10 +1503,13 @@ function buildPayload() {
   if (f.judges.length) payload.judge_panel = f.judges;
   if (f.skipQa) payload.skip_qa = true;
   if (f.skipJira) payload.skip_jira = true;
-  // FEAT-412: only sent when the operator actually touched the toggle, so an
-  // untouched form falls back to the flow's build-time default instead of
-  // overriding it with an implicit false.
-  if (f.requirePlanApproval) payload.require_plan_approval = true;
+  // FEAT-412: ALWAYS send the boolean, both true and false.
+  // The checkbox is initialised from the server's own default at boot, so its
+  // state is always a deliberate, user-visible value — and the server only
+  // honours an override when the key is PRESENT. Sending only `true` would
+  // make it impossible to turn a server-default-on plan gate off for a run
+  // (the omitted key silently falls back to that same default).
+  payload.require_plan_approval = !!f.requirePlanApproval;
   return payload;
 }
 

--- a/examples/dev_loop/static/dev.html
+++ b/examples/dev_loop/static/dev.html
@@ -1124,6 +1124,11 @@ function renderSummary() {
   const maxDur = Math.max(1, ...nodes.map((n) => n.elapsed || 0));
   const t = app.telemetry;
   const docs = s.docs[s.docs.length - 1] || null;
+  // The ideation node returns the FeatureBrief it produced, and the
+  // node/completed action carries the serialised result as its summary — so
+  // the document this run wrote (or resumed) is available client-side.
+  const ideationSummary = (s.nodes.ideation && s.nodes.ideation.summary) || {};
+  const ideationDoc = ideationSummary.document_path || "";
   const verdictRounds = Object.entries(s.judgeVerdicts);
   const gates = Object.values(s.gates);
 
@@ -1143,6 +1148,16 @@ function renderSummary() {
           ${s.prUrl ? `<span class="mono muted" style="font-size:12.5px">${esc(prNumber(s.prUrl))}</span>` : ""}
         </span>
       </div>
+      ${ideationDoc ? `
+      <div style="padding:14px 18px;border-bottom:1px solid var(--color-divider);display:flex;flex-direction:column;gap:6px">
+        <span class="micro">SDD document written by ideation</span>
+        <span class="mono" style="font-size:12.5px">${esc(ideationDoc)}</span>
+        <span class="muted" style="font-size:12px">${
+          ideationSummary.document_kind ? `kind <span class="mono">${esc(ideationSummary.document_kind)}</span>` : ""
+        }${gates.some((g) => g.kind === "open_questions")
+            ? ` · ${gates.filter((g) => g.kind === "open_questions").length} Open-Questions round(s)`
+            : " · no open questions"}</span>
+      </div>` : ""}
       ${docs ? `
       <div style="padding:14px 18px;border-bottom:1px solid var(--color-divider);display:flex;flex-direction:column;gap:6px">
         <span class="micro">Documentation artifact</span>

--- a/packages/ai-parrot/pyproject.toml
+++ b/packages/ai-parrot/pyproject.toml
@@ -641,6 +641,9 @@ parrot = ["py.typed", "templates/*.tpl", "**/*.pyx", "**/*.pxd"]
 "parrot.knowledge.ontology.defaults" = ["*.yaml", "domains/*.yaml"]
 "parrot.forms.renderers" = ["templates/*.j2"]
 "parrot.flows.dev_loop" = ["_subagent_data/*.md"]
+# FEAT-412: dev_flow ships its own prompt set (sdd-ideation); the loader
+# reads it via importlib.resources, so it MUST be in the wheel.
+"parrot.flows.dev_flow" = ["_subagent_data/*.md"]
 # Interactive HTML artifact catalog (library specs + scaffold templates),
 # loaded from disk at runtime by parrot.tools.interactive.catalog_registry.
 "parrot.tools.interactive" = [

--- a/packages/ai-parrot/src/parrot/conf.py
+++ b/packages/ai-parrot/src/parrot/conf.py
@@ -1086,6 +1086,14 @@ DEV_LOOP_GATE_TTL_REVIEW_ESCALATION: int = config.getint(
 DEV_FLOW_GATE_TTL_QUESTIONS: int = config.getint(
     "DEV_FLOW_GATE_TTL_QUESTIONS", fallback=86400  # 24h, fail-closed
 )
+# FEAT-412: maximum number of HITL Open-Questions rounds (i.e. gates) the
+# dev-flow's IdeationNode may open per run. Once exhausted, questions still
+# `[ ]` in the document are NOT re-asked and do NOT block the run — they are
+# carried into the spec's §8 by the planner. Read at execute() time (not
+# import time) so tests can monkeypatch it per-case.
+DEV_FLOW_IDEATION_MAX_ROUNDS: int = config.getint(
+    "DEV_FLOW_IDEATION_MAX_ROUNDS", fallback=2
+)
 # Target ref for the adversarial reviewer when DEV_LOOP_ADVERSARIAL_SCOPE is
 # "base" (e.g. "dev" or "origin/main"). Required in that case — the server
 # bootstrap raises at startup rather than silently degrading every review if

--- a/packages/ai-parrot/src/parrot/conf.py
+++ b/packages/ai-parrot/src/parrot/conf.py
@@ -1078,6 +1078,14 @@ DEV_LOOP_CODEREVIEW_JUDGE: bool = config.getboolean(
 DEV_LOOP_GATE_TTL_REVIEW_ESCALATION: int = config.getint(
     "DEV_LOOP_GATE_TTL_REVIEW_ESCALATION", fallback=86400  # 24h, fail-closed
 )
+# HITL gate TTL for a dev-flow ideation Open-Questions round
+# (``GateKind="open_questions"``, FEAT-412). Fail-closed like the other
+# DEV_LOOP_GATE_TTL_* settings: silence is not consent for spec decisions,
+# so an unanswered round expires the run into the failure path rather than
+# auto-approving an under-specified document.
+DEV_FLOW_GATE_TTL_QUESTIONS: int = config.getint(
+    "DEV_FLOW_GATE_TTL_QUESTIONS", fallback=86400  # 24h, fail-closed
+)
 # Target ref for the adversarial reviewer when DEV_LOOP_ADVERSARIAL_SCOPE is
 # "base" (e.g. "dev" or "origin/main"). Required in that case — the server
 # bootstrap raises at startup rather than silently degrading every review if

--- a/packages/ai-parrot/src/parrot/flows/dev_flow/__init__.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_flow/__init__.py
@@ -41,11 +41,18 @@ __all__ = [
     "parse_dev_brief",
 ]
 
-# Lazily-resolved exports: attribute name -> submodule it lives in. Populated
-# as the topology lands (definition/flow/runner/nodes); keeping the mapping
-# here means ``from parrot.flows.dev_flow import X`` works without the
-# package init importing the heavy modules eagerly.
-_LAZY_EXPORTS: dict[str, str] = {}
+# Lazily-resolved exports: attribute name -> submodule it lives in. Keeping
+# the mapping here means ``from parrot.flows.dev_flow import X`` works
+# without the package init importing the heavy modules (topology, runner,
+# nodes) eagerly.
+_LAZY_EXPORTS: dict[str, str] = {
+    "build_dev_flow_definition": "parrot.flows.dev_flow.definition",
+    "build_dev_flow_node_factories": "parrot.flows.dev_flow.factories",
+    "build_dev_flow": "parrot.flows.dev_flow.flow",
+    "DevFlowRunner": "parrot.flows.dev_flow.runner",
+    "DevIntakeNode": "parrot.flows.dev_flow.nodes",
+    "IdeationNode": "parrot.flows.dev_flow.nodes",
+}
 
 
 def __getattr__(name: str) -> Any:

--- a/packages/ai-parrot/src/parrot/flows/dev_flow/__init__.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_flow/__init__.py
@@ -1,0 +1,78 @@
+"""Dev-flow — SDD-oriented AgentsFlow for feature development (FEAT-412).
+
+A sibling of the operations-oriented :mod:`parrot.flows.dev_loop`, modelling
+the *actual* SDD development cycle end-to-end::
+
+    NL request (enhancement | new_feature) ──► ideation (+ HITL Open Questions)
+            or an existing SDD document ─────► planner ──► development pool
+            ──► synthesis ──► qa ──► draft PR
+
+Only the intake nodes (``dev_flow.dev_intake``, ``dev_flow.ideation``) and
+the topology are new: node types, models, session state, streaming,
+dispatchers and the runner machinery are all imported from ``dev_loop``
+(spec §2 Overview). The flow terminates at a **draft PR against ``dev``** —
+never a merge.
+
+See ``sdd/specs/sdd-dev-flow.spec.md`` for the full specification.
+
+Import hygiene mirrors ``dev_loop.__init__``: the light Pydantic contracts
+are re-exported eagerly, while the heavier topology/runner symbols are
+resolved lazily through :func:`__getattr__` so importing the models never
+drags in aiohttp/redis/dispatcher machinery.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from parrot.flows.dev_flow.models import (
+    DevFlowBrief,
+    DevRequestBrief,
+    DevRequestKind,
+    IdeationOutput,
+    parse_dev_brief,
+)
+
+__all__ = [
+    "DevFlowBrief",
+    "DevRequestBrief",
+    "DevRequestKind",
+    "IdeationOutput",
+    "parse_dev_brief",
+]
+
+# Lazily-resolved exports: attribute name -> submodule it lives in. Populated
+# as the topology lands (definition/flow/runner/nodes); keeping the mapping
+# here means ``from parrot.flows.dev_flow import X`` works without the
+# package init importing the heavy modules eagerly.
+_LAZY_EXPORTS: dict[str, str] = {}
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve a lazily-exported dev-flow symbol on first access.
+
+    Args:
+        name: Attribute name requested on the ``parrot.flows.dev_flow``
+            package.
+
+    Returns:
+        The resolved attribute.
+
+    Raises:
+        AttributeError: If ``name`` is not a known lazy export.
+    """
+    module_name = _LAZY_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(
+            f"module {__name__!r} has no attribute {name!r}"
+        )
+    from importlib import import_module
+
+    value = getattr(import_module(module_name), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """Expose eager and lazy exports to ``dir()`` / autocompletion."""
+    return sorted(set(__all__) | set(_LAZY_EXPORTS))

--- a/packages/ai-parrot/src/parrot/flows/dev_flow/_subagent_data/sdd-ideation.md
+++ b/packages/ai-parrot/src/parrot/flows/dev_flow/_subagent_data/sdd-ideation.md
@@ -1,0 +1,320 @@
+---
+name: sdd-ideation
+description: |
+  Ideation-phase subagent for the dev-flow (FEAT-412). Turns a
+  natural-language development request into a committed SDD document,
+  resolving Open Questions with the human across bounded rounds.
+
+  DUAL-MODE — the dispatch payload carries a `mode` field:
+    * mode="brainstorm" (intent new_feature) → writes a full
+      sdd/proposals/<slug>.brainstorm.md with options analysis and a
+      recommendation.
+    * mode="proposal" (intent enhancement) → writes a LIGHT
+      sdd/proposals/<slug>.proposal.md (scope, rationale, impact, open
+      questions — no options analysis, NOT the deep /sdd-proposal
+      research artifact).
+
+  When the target document already exists the agent RESUMES/EXTENDS it in
+  place — never overwrites it, never creates a `-2`-suffixed copy.
+
+  The agent emits ONE final JSON object matching the IdeationOutput
+  Pydantic contract — no prose, no markdown fences, just JSON.
+
+  Examples:
+
+  Context: IdeationNode hands the agent a natural-language new_feature
+  request on round 1.
+  user: "DevRequestBrief: kind=new_feature, title='compression budget
+  telemetry', description='Add per-tool telemetry to the compression
+  budget so operators can see which tool blew the budget.'"
+  assistant: "I'll write sdd/proposals/compression-budget-telemetry.brainstorm.md
+  with options A/B/C plus a recommendation, commit it to dev, and emit the
+  IdeationOutput JSON listing my open questions."
+
+  Context: Round 2 — the human answered the previous round's questions.
+  user: "Resume sdd/proposals/compression-budget-telemetry.brainstorm.md.
+  answers={'Which store?': 'pgvector', 'Sync or async flush?': 'async'}"
+  assistant: "I'll flip those two questions to [x] with their answers,
+  fold the decisions into the document body, commit, and emit the
+  IdeationOutput JSON with the remaining open questions."
+
+model: sonnet
+color: cyan
+permissionMode: default
+tools: Read, Grep, Glob, Bash, Write, Edit
+---
+
+# SDD Ideation — Natural Language → Committed SDD Document
+
+You are the **ideation phase** of the `dev-flow`. Unlike `sdd-planner`
+(which consumes an SDD document that already exists), you are handed a
+developer's request in **plain natural language** and your job is to
+produce the document `sdd-planner` will later consume.
+
+You run in **bounded rounds**. On each dispatch you either create the
+document (round 1) or resume it with the human's answers (round 2+), then
+report your remaining Open Questions so the flow can ask the human.
+
+## Input
+
+The dispatch payload carries:
+
+| Field | Meaning |
+|---|---|
+| `mode` | `"brainstorm"` (new_feature) or `"proposal"` (enhancement) — **decides which document you write**. Never infer it from the text. |
+| `title` | Short name. The **slug source**. |
+| `description` | The natural-language request itself. |
+| `context` | Optional extra context/links/constraints. May be empty. |
+| `graph_context` | Optional pre-fetched knowledge-graph context (related modules, prior features). Read it before searching the codebase yourself. |
+| `answers` | Prior-round `question -> answer` mapping. Empty on round 1. |
+| `document_path` | Set on resume rounds: the document you must extend. |
+| `round` | 1-based round counter. |
+
+## Step 1 — Resolve the slug and target path
+
+Slugify `title`: lowercase, non-alphanumerics → single hyphens, no leading
+or trailing hyphen (e.g. `"Compression Budget Telemetry!"` →
+`compression-budget-telemetry`).
+
+The target path is decided **by `mode`**, not by your judgement:
+
+| `mode` | Target document |
+|---|---|
+| `brainstorm` | `sdd/proposals/<slug>.brainstorm.md` |
+| `proposal` | `sdd/proposals/<slug>.proposal.md` |
+
+## Step 2 — Existing-document policy (RESUME / EXTEND, never clobber)
+
+Check whether the target path already exists (`Read` it if so).
+
+- **Does not exist** → create it (Step 3). `resumed_existing: false`.
+- **Exists and is about the same request** → **RESUME/EXTEND IT IN PLACE**
+  using `Edit`. Add new sections/detail, fold in this round's `answers`,
+  keep the existing decision trail intact. Set
+  `resumed_existing: true`.
+- **Exists but its Problem Statement is clearly about something else**
+  (two different ideas slugified to the same name) → **DO NOT extend it
+  and DO NOT overwrite it.** Leave the file untouched, and return an
+  `IdeationOutput` whose `open_questions` contains ONE question naming the
+  collision explicitly, e.g.
+  `"sdd/proposals/<slug>.brainstorm.md already exists and describes <other
+  topic>, not <this request>. Use a different slug, or extend that
+  document anyway?"`
+  Set `committed: false` in that case — you wrote nothing.
+
+**Absolutely forbidden**: overwriting an existing document wholesale, or
+creating `<slug>-2.brainstorm.md` / `<slug>.brainstorm-2.md` style copies.
+The human resolves slug collisions, not you.
+
+## Step 3 — Write the document
+
+Every document you write starts with the FEAT-145 frontmatter, verbatim:
+
+```
+---
+# SDD flow type and base branch (FEAT-145).
+# - type: feature  (default)  → base_branch: dev (or any non-main branch)
+# - type: hotfix              → base_branch MUST be: main
+type: feature
+base_branch: dev
+---
+```
+
+### mode = "brainstorm"  (intent: new_feature)
+
+A full brainstorm — the reader must be able to see the alternatives you
+considered and why you picked one:
+
+```
+# Brainstorm: <Title>
+
+**Date**: <YYYY-MM-DD>
+**Author**: <requester> (with sdd-ideation)
+**Status**: draft
+
+## Problem Statement
+<what hurts today, in the requester's terms; quote the request>
+
+## Constraints & Requirements
+<hard constraints, existing conventions this must respect>
+
+## Options Explored
+
+### Option A: <Name>
+**Approach**: ...
+**Pros**: ...
+**Cons**: ...
+
+### Option B: <Name>
+...
+
+### Option C: <Name>            <!-- include when a third is genuinely distinct -->
+...
+
+## Recommendation
+<the chosen option and WHY, in terms of the constraints above>
+
+## Feature Description
+### User-Facing Behavior
+### Internal Behavior
+### Edge Cases & Error Handling
+
+## Impact & Integration
+<modules touched, integration points, migration/compat concerns>
+
+## Code Context
+<verified references only — see Cardinal rules>
+
+## Open Questions
+<see the Open-Questions convention below>
+```
+
+### mode = "proposal"  (intent: enhancement)
+
+A **light** proposal. An enhancement extends something that already
+exists, so options analysis is noise — scope, rationale and impact are the
+whole point. Do **NOT** produce the deep `/sdd-proposal` research artifact
+(no confidence maps, no hypothesis blocks, no research audit):
+
+```
+# Proposal: <Title>
+
+**Date**: <YYYY-MM-DD>
+**Author**: <requester> (with sdd-ideation)
+**Status**: draft
+
+## Origin
+<the request, quoted; what triggered it>
+
+## Scope
+### What Changes
+### What's New
+### What's Untouched (Non-Goals)
+
+## Rationale
+<why this is worth doing, and why THIS shape of change>
+
+## Impact
+<modules/files touched, integration points, backward-compatibility notes,
+ risks>
+
+## Code Context
+<verified references only — see Cardinal rules>
+
+## Open Questions
+<see the Open-Questions convention below>
+```
+
+Both formats deliberately share the frontmatter, the `## Open Questions`
+section and the `## Code Context` discipline, so `/sdd-spec` and
+`PlannerNode` treat them uniformly.
+
+## The Open-Questions convention (consumed by `/sdd-spec` §2b)
+
+Write questions as a flat list under `## Open Questions`:
+
+```
+- [ ] <Unresolved question> — *Owner: user*
+- [x] <Answered question> — *Resolved*: <answer text>
+```
+
+Rules:
+
+- `[ ]` = still open. `[x]` = answered by the human.
+- The answer is the text after the **final `:`** on the line — that is what
+  `/sdd-spec` parses, so never put a bare `:` after the answer.
+- When a prior-round `answers` entry matches a question, flip that
+  question to `[x]` and append `— *Resolved*: <answer>` **verbatim**.
+- **A resolved answer is not just bookkeeping**: fold the decision into the
+  document body where it actually applies (scope, recommendation, impact),
+  the same way `/sdd-spec` folds resolutions into the spec body. A `[x]`
+  question whose answer contradicts a paragraph you already wrote means
+  you must **update that paragraph**.
+- Questions the human did not answer stay `[ ]` — do not delete them and do
+  not silently rephrase them. Unanswered questions are carried into the
+  spec's §8 by the planner, which is the intended escape valve when the
+  round budget runs out.
+- Ask only questions that genuinely change the design. Anything decidable
+  during implementation belongs in the body as an implementation note, not
+  as an Open Question.
+
+## Step 4 — Commit the document
+
+The document **must be committed** before you return: `sdd-planner` runs
+later and creates its worktree from the base branch's HEAD, so an
+uncommitted document is invisible there and the run will fail.
+
+Stage **only** the document path — never `git add -A`, never `git add .`
+(other SDD sessions may have unrelated work in progress on this branch):
+
+```bash
+git add sdd/proposals/<slug>.<brainstorm|proposal>.md
+git commit -m "sdd: <create|extend> <brainstorm|proposal> for <slug>"
+```
+
+Report the outcome truthfully in `committed`. If the commit fails (hook
+rejection, nothing staged, detached HEAD), set `committed: false` and
+explain in `summary` — do **not** claim success.
+
+## Cardinal rules
+
+- **You write documents, not code.** Your only writes are the single
+  document under `sdd/proposals/` and its git commit. Never touch
+  production code, tests, `sdd/specs/`, or `sdd/tasks/`.
+- **Never invent codebase references.** Anything you put under
+  `## Code Context` must be verified with `Read`/`Grep`/`Glob` first.
+  Prefer "not verified" over a plausible-looking path. An
+  anti-hallucination note ("`X` does NOT exist today") is more valuable
+  than a guess.
+- **Never overwrite or suffix an existing document** (Step 2).
+- **Never fabricate an answer** on the human's behalf. If a question is
+  unanswered, it stays `[ ]`.
+- **`mode` decides the format.** Do not write a brainstorm in proposal
+  mode or vice versa, even if the request feels like the other kind.
+- Do not create, transition, or comment on a Jira ticket. If a
+  `jira_issue_key` is supplied it is link-only context.
+
+## Output Contract
+
+Your **final** assistant turn must be exactly ONE JSON object — no prose
+before or after it, no markdown fences:
+
+```json
+{
+  "document_path": "sdd/proposals/compression-budget-telemetry.brainstorm.md",
+  "document_kind": "brainstorm",
+  "slug": "compression-budget-telemetry",
+  "resumed_existing": false,
+  "open_questions": [
+    "Which store backs the telemetry?",
+    "Sync or async flush?"
+  ],
+  "summary": "Full brainstorm with three options; recommends B (in-process ring buffer).",
+  "committed": true
+}
+```
+
+Field rules:
+
+- `document_path` — the path you actually wrote (or the colliding path in
+  the Step 2 mismatch case).
+- `document_kind` — `"brainstorm"` when `mode="brainstorm"`, `"proposal"`
+  when `mode="proposal"`. It must agree with the path's suffix.
+- `slug` — the slug from Step 1.
+- `resumed_existing` — `true` only when you extended a pre-existing
+  document in place.
+- `open_questions` — the questions still `[ ]` in the document after this
+  round, as plain strings **matching the question text in the document
+  exactly** (the flow uses them as dictionary keys when it collects the
+  human's answers). Empty list when nothing is open.
+- `summary` — one or two sentences a human can read in a UI card.
+- `committed` — `true` only if the commit actually succeeded.
+
+## Failure handling
+
+If you cannot satisfy the contract (cannot write the file, cannot commit,
+slug collision per Step 2), still emit a **valid** `IdeationOutput` with
+`committed: false` and an explanatory `summary`. `IdeationNode` fails the
+run fast on `committed: false` and routes it to the failure handler — that
+is the intended, auditable outcome. Never emit prose instead of the JSON,
+and never claim a success you did not achieve.

--- a/packages/ai-parrot/src/parrot/flows/dev_flow/_subagent_defs.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_flow/_subagent_defs.py
@@ -1,0 +1,92 @@
+"""Loader for SDD subagent definitions used by the dev-flow dispatcher.
+
+The dev-flow owns its own prompt set — it deliberately does NOT extend
+``dev_loop._subagent_defs``'s name set (spec §3 Module 3), so the ops flow
+and the development flow can evolve their prompts independently:
+
+* ``sdd-ideation`` — turns a natural-language request into a committed SDD
+  document (FEAT-412). **Dual-mode**: the dispatch payload's ``mode`` field
+  selects a full ``.brainstorm.md`` (intent ``new_feature``) or a light
+  ``.proposal.md`` (intent ``enhancement``). Resolves Open Questions with
+  the human across bounded rounds and emits one ``IdeationOutput`` JSON.
+
+Everything downstream of ideation (``sdd-planner``, ``sdd-worker``,
+``sdd-qa``, ``sdd-codereview``, ``sdd-feedback``, …) is dispatched by the
+reused ``dev_loop`` nodes and therefore loaded by ``dev_loop``'s own
+loader — not this one.
+
+:func:`load_subagent_definition` reads **only** the package-shipped copy at
+``dev_flow/_subagent_data/<name>.md``, mirroring the ``dev_loop`` loader's
+contract: that copy is the canonical, always-available source for dispatch
+(it keeps working when ``ai-parrot`` is installed as a wheel outside the
+repo). It does NOT read ``.claude/agents/`` at runtime — the repo-level
+twin at ``.claude/agents/sdd-ideation.md`` exists for interactive Claude
+Code use with ``setting_sources=["project"]``.
+"""
+
+from __future__ import annotations
+
+from importlib.resources import files
+
+_VALID_NAMES: frozenset[str] = frozenset({"sdd-ideation"})
+
+
+def _strip_frontmatter(text: str) -> str:
+    """Strip a leading YAML frontmatter block (``---\\n...\\n---``).
+
+    Mirrors ``dev_loop._subagent_defs._strip_frontmatter`` exactly, including
+    its conservative failure mode.
+
+    Args:
+        text: Raw markdown file contents.
+
+    Returns:
+        The body with the frontmatter removed, or ``text`` unchanged when
+        there is no frontmatter block or the block is malformed (never
+        silently drops the whole file).
+    """
+    if not text.startswith("---"):
+        return text
+    lines = text.split("\n")
+    if not lines or lines[0].strip() != "---":
+        return text
+    closing = None
+    for idx in range(1, len(lines)):
+        if lines[idx].strip() == "---":
+            closing = idx
+            break
+    if closing is None:
+        # Malformed frontmatter — return text unchanged rather than
+        # silently dropping the whole file.
+        return text
+    return "\n".join(lines[closing + 1:]).lstrip("\n")
+
+
+def load_subagent_definition(name: str) -> str:
+    """Return the system-prompt body of a dev-flow SDD subagent.
+
+    Args:
+        name: Currently only ``"sdd-ideation"``.
+
+    Returns:
+        The Markdown body of the subagent definition with the YAML
+        frontmatter stripped, suitable for use as a plain ``system_prompt``
+        when constructing a programmatic ``AgentDefinition``.
+
+    Raises:
+        ValueError: If ``name`` is not a known dev-flow subagent.
+        FileNotFoundError: If the package-bundled data file is missing
+            (indicates a packaging error).
+    """
+    if name not in _VALID_NAMES:
+        raise ValueError(
+            f"Unknown subagent name {name!r}. Expected one of "
+            f"{sorted(_VALID_NAMES)}."
+        )
+    data_dir = files("parrot.flows.dev_flow") / "_subagent_data"
+    target = data_dir / f"{name}.md"
+    text = target.read_text(encoding="utf-8")
+    return _strip_frontmatter(text)
+
+
+__all__ = ["load_subagent_definition"]

--- a/packages/ai-parrot/src/parrot/flows/dev_flow/definition.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_flow/definition.py
@@ -1,0 +1,195 @@
+"""Declarative dev-flow topology (FEAT-412).
+
+Authors the ``dev-flow`` graph as a :class:`FlowDefinition` — the
+reference/validation/visualization source. Actual execution happens in the
+engine's **explicit-edge mode** (``build_dev_flow`` in ``flow.py``
+re-declares every edge imperatively) because the graph contains OR-joins the
+``from_definition`` AND-join scheduler cannot fire:
+
+* ``planner`` has TWO predecessors — ``dev_intake`` (a ``feature`` intake
+  whose document already exists) and ``ideation`` (a natural-language intake
+  whose document was just written).
+* ``feature_handoff`` has two (``qa`` on pass, ``feedback_router`` on
+  ``accept_with_notes``) and ``failure_handler`` is the on-error fan-in.
+
+Same engine limitation documented in ``dev_loop/definition.py``.
+
+Topology (spec §2 Component Diagram)::
+
+    dev_intake ─(enhancement|new_feature)→ ideation ─┐
+         └──────(feature)─────────────────────────────┤
+                                                      ▼
+    planner → development → synthesis → qa ─(passed)→ feature_handoff → close
+                    ↑                    │                  ▲
+                    └─(retry, bounded)───┤                  │
+                                         ▼                  │
+                                  feedback_router ──(accept_with_notes)
+                                         ├─(escalate)→ failure_handler
+                              (+ on_error fan-in from every middle node)
+
+Everything from ``planner`` onward is byte-identical in behavior to the
+FEAT-378 feature-mode graph: the same reused ``dev_loop.*`` node types, the
+same CEL predicates (imported, not re-spelled, so the two graphs cannot
+silently drift), and the same bounded repair loop — whose stop rule lives in
+``FeedbackRouterNode._retry_allowed()``, not on the edge.
+
+This module is pure: no env reads at import time.
+"""
+
+from __future__ import annotations
+
+from parrot.bots.flows.flow.definition import (
+    EdgeDefinition,
+    FlowDefinition,
+    NodeDefinition,
+)
+
+# Reuse the feature-mode node ids and CEL predicates verbatim. Importing them
+# (rather than re-declaring the strings) is deliberate: it makes a divergence
+# between the feature-mode chain and the dev-flow chain a compile-time
+# impossibility instead of a copy-paste hazard.
+from parrot.flows.dev_loop.definition import (
+    _CEL_FEEDBACK_ACCEPT,
+    _CEL_FEEDBACK_ESCALATE,
+    _CEL_FEEDBACK_RETRY,
+    _CEL_QA_FAILED,
+    _CEL_QA_PASSED,
+    CLOSE,
+    DEVELOPMENT,
+    FAILURE,
+    FEATURE_HANDOFF,
+    FEEDBACK_ROUTER,
+    PLANNER,
+    QA,
+    SYNTHESIS,
+)
+
+# Dev-flow's own intake node ids (node id == the type's short name).
+DEV_INTAKE = "dev_intake"
+IDEATION = "ideation"
+
+# CEL routing predicates for the intake fork (spec §2). The two
+# natural-language intents go to ideation; a document intake goes straight to
+# the planner.
+_CEL_IS_NL_REQUEST = 'result.kind == "enhancement" || result.kind == "new_feature"'
+_CEL_IS_FEATURE_DOC = 'result.kind == "feature"'
+
+# Middle nodes whose hard error routes to the failure handler (on_error
+# fan-in). Mirrors _FEATURE_ON_ERROR_SOURCES with the dev-flow intake pair
+# substituted for intent_classifier.
+_ON_ERROR_SOURCES = (
+    DEV_INTAKE,
+    IDEATION,
+    PLANNER,
+    DEVELOPMENT,
+    SYNTHESIS,
+    QA,
+    FEEDBACK_ROUTER,
+    FEATURE_HANDOFF,
+)
+
+# The reused chain's node ids, in declaration order.
+_REUSED_NODE_IDS = (
+    PLANNER,
+    DEVELOPMENT,
+    SYNTHESIS,
+    QA,
+    FEEDBACK_ROUTER,
+    FEATURE_HANDOFF,
+    FAILURE,
+    CLOSE,
+)
+
+
+def _dev_flow_node(node_id: str) -> NodeDefinition:
+    """Build a ``dev_flow.<id>`` NodeDefinition (the two new intake nodes)."""
+    return NodeDefinition(id=node_id, type=f"dev_flow.{node_id}")
+
+
+def _dev_loop_node(node_id: str) -> NodeDefinition:
+    """Build a ``dev_loop.<id>`` NodeDefinition (a reused node type).
+
+    Mirrors ``dev_loop.definition._node``: dev-flow consumes the FEAT-378
+    chain by **type name**, so these nodes resolve from the same engine
+    ``NODE_REGISTRY`` entries the ops flow uses.
+    """
+    return NodeDefinition(id=node_id, type=f"dev_loop.{node_id}")
+
+
+def build_dev_flow_definition() -> FlowDefinition:
+    """Return the declarative dev-flow :class:`FlowDefinition`.
+
+    Returns:
+        The ``flow="dev-flow"`` definition: 10 nodes (the 2 dev-flow intake
+        nodes + the 8 reused ``dev_loop`` nodes) and the edge set of spec §2.
+        Deliberately absent: ``bug_intake``, ``research``,
+        ``deployment_handoff``, ``revision_handoff`` and
+        ``intent_classifier`` — dev-flow front-loads no operations concerns.
+    """
+    nodes = [
+        _dev_flow_node(DEV_INTAKE),
+        _dev_flow_node(IDEATION),
+        *(_dev_loop_node(node_id) for node_id in _REUSED_NODE_IDS),
+    ]
+
+    edges = [
+        # -- intake fork -------------------------------------------------
+        EdgeDefinition(
+            **{"from": DEV_INTAKE}, to=IDEATION,
+            condition="on_condition", predicate=_CEL_IS_NL_REQUEST,
+        ),
+        EdgeDefinition(
+            **{"from": DEV_INTAKE}, to=PLANNER,
+            condition="on_condition", predicate=_CEL_IS_FEATURE_DOC,
+        ),
+        # IdeationNode returns the FeatureBrief it just produced, so the
+        # merge into planner needs no predicate — the OR-join is what makes
+        # explicit-edge execution mandatory.
+        EdgeDefinition(**{"from": IDEATION}, to=PLANNER, condition="on_success"),
+        # -- reused FEAT-378 chain (verbatim) ----------------------------
+        EdgeDefinition(**{"from": PLANNER}, to=DEVELOPMENT, condition="on_success"),
+        EdgeDefinition(**{"from": DEVELOPMENT}, to=SYNTHESIS, condition="on_success"),
+        EdgeDefinition(**{"from": SYNTHESIS}, to=QA, condition="on_success"),
+        EdgeDefinition(
+            **{"from": QA}, to=FEATURE_HANDOFF,
+            condition="on_condition", predicate=_CEL_QA_PASSED,
+        ),
+        EdgeDefinition(
+            **{"from": QA}, to=FEEDBACK_ROUTER,
+            condition="on_condition", predicate=_CEL_QA_FAILED,
+        ),
+        EdgeDefinition(
+            **{"from": FEEDBACK_ROUTER}, to=FAILURE,
+            condition="on_condition", predicate=_CEL_FEEDBACK_ESCALATE,
+        ),
+        EdgeDefinition(
+            **{"from": FEEDBACK_ROUTER}, to=FEATURE_HANDOFF,
+            condition="on_condition", predicate=_CEL_FEEDBACK_ACCEPT,
+        ),
+        # Bounded repair loop back-edge (FEAT-377/A). A genuine cycle,
+        # tolerated by FlowDefinition._validate_acyclic's on_condition
+        # exemption; the bound lives in FeedbackRouterNode._retry_allowed().
+        EdgeDefinition(
+            **{"from": FEEDBACK_ROUTER}, to=DEVELOPMENT,
+            condition="on_condition", predicate=_CEL_FEEDBACK_RETRY,
+        ),
+        EdgeDefinition(**{"from": FEATURE_HANDOFF}, to=CLOSE, condition="on_success"),
+    ]
+    edges.extend(
+        EdgeDefinition(**{"from": src}, to=FAILURE, condition="on_error")
+        for src in _ON_ERROR_SOURCES
+    )
+
+    return FlowDefinition(
+        flow="dev-flow",
+        description=(
+            "Declarative dev-flow topology (FEAT-412): natural-language or "
+            "document intake -> ideation with HITL Open Questions -> the "
+            "reused FEAT-378 planning/development/QA chain -> draft PR."
+        ),
+        nodes=nodes,
+        edges=edges,
+    )
+
+
+__all__ = ["build_dev_flow_definition"]

--- a/packages/ai-parrot/src/parrot/flows/dev_flow/factories.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_flow/factories.py
@@ -1,0 +1,132 @@
+"""Node factories for the dev-flow topology (FEAT-412).
+
+Binds live dependencies to the ``dev-flow`` node types. The eight reused
+``dev_loop.*`` types come straight from
+:func:`build_dev_loop_node_factories` — dev-flow does not re-implement or
+wrap them — and this module only adds the two dev-flow-owned intake types:
+
+* ``dev_flow.dev_intake`` → :class:`DevIntakeNode`
+* ``dev_flow.ideation``   → :class:`IdeationNode`
+
+Importing this module imports both node packages, which is what guarantees
+their ``@register_dev_loop_node`` decorators have run before the definition
+is materialized.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from parrot.bots.flows.flow.definition import NodeDefinition
+from parrot.flows.dev_flow.nodes.dev_intake import DevIntakeNode
+from parrot.flows.dev_flow.nodes.ideation import IdeationNode
+from parrot.flows.dev_loop.factories import (
+    NodeFactory,
+    build_dev_loop_node_factories,
+)
+from parrot.flows.dev_loop.nodes.base import DevLoopNode
+
+
+def _with_graph(node: DevLoopNode, deps: set, succs: set) -> DevLoopNode:
+    """Stamp the edge-derived ``dependencies``/``successors`` onto ``node``.
+
+    Same helper as ``dev_loop.factories._with_graph`` (kept local rather than
+    importing a private symbol across packages).
+    """
+    return node.model_copy(
+        update={"dependencies": set(deps), "successors": set(succs)}
+    )
+
+
+def build_dev_flow_node_factories(
+    *,
+    dispatcher: Any,
+    redis_url: str,
+    jira_toolkit: Any | None = None,
+    git_toolkit: Any | None = None,
+    wiki_toolkit: Any | None = None,
+    codereview_dispatcher: Any | None = None,
+    development_dispatcher_builder: Any | None = None,
+    development_pool_max: int = 4,
+    graph_memory: Any | None = None,
+    wiki_search: Any | None = None,
+    require_plan_approval: bool = False,
+    skip_qa: bool = False,
+    ideation_max_rounds: int | None = None,
+) -> dict[str, NodeFactory]:
+    """Return the ``{node type: factory}`` map for the dev-flow graph.
+
+    Args:
+        dispatcher: Shared ``ClaudeCodeDispatcher`` for ideation, planner,
+            synthesis, QA and the feedback router.
+        redis_url: Redis URL for the intake node's event stream.
+        jira_toolkit: Optional service-account ``JiraToolkit`` — dev-flow
+            Jira is link-only; ``None`` means zero Jira calls anywhere.
+        git_toolkit: Optional ``GitToolkit`` (parity with the ops flows).
+        wiki_toolkit: Optional ``LLMWikiToolkit`` for ``FeatureHandoffNode``'s
+            docs-page ingest.
+        codereview_dispatcher: Optional review dispatcher for ``QANode``
+            (typically a ``JudgePanelReviewDispatcher``).
+        development_dispatcher_builder: Optional ``(DevAgentSpec) ->
+            (dispatcher, profile)`` callable for the dev-agent pool.
+        development_pool_max: Hard cap on pool workers, also passed to
+            ``PlannerNode`` for its own pool sizing.
+        graph_memory: Optional ``DevLoopGraphMemory`` forwarded to the reused
+            QA/close/failure nodes.
+        wiki_search: Optional ``DevLoopWikiSearch``. Forwarded to BOTH the
+            reused ``dev_loop`` factories and :class:`IdeationNode`, which
+            uses it to inject ranked repo context into its dispatch.
+        require_plan_approval: Build-time default for ``DevelopmentNode``'s
+            ``plan_approval`` gate. A per-run
+            ``shared["require_plan_approval"]`` overrides it (FEAT-412).
+        skip_qa: Forwarded to the reused QA factory.
+        ideation_max_rounds: Override for ``conf.DEV_FLOW_IDEATION_MAX_ROUNDS``
+            on :class:`IdeationNode`. ``None`` reads the conf key at execute
+            time.
+
+    Returns:
+        A factory map covering the two ``dev_flow.*`` types plus every
+        ``dev_loop.*`` type (the reused chain).
+    """
+    factories: dict[str, NodeFactory] = dict(
+        build_dev_loop_node_factories(
+            dispatcher=dispatcher,
+            jira_toolkit=jira_toolkit,
+            redis_url=redis_url,
+            git_toolkit=git_toolkit,
+            wiki_toolkit=wiki_toolkit,
+            development_dispatcher_builder=development_dispatcher_builder,
+            development_pool_max=development_pool_max,
+            codereview_dispatcher=codereview_dispatcher,
+            graph_memory=graph_memory,
+            wiki_search=wiki_search,
+            require_plan_approval=require_plan_approval,
+            skip_qa=skip_qa,
+        )
+    )
+
+    def dev_intake_factory(
+        nd: NodeDefinition, deps: set, succs: set
+    ) -> DevLoopNode:
+        return _with_graph(
+            DevIntakeNode(redis_url=redis_url, name=nd.id), deps, succs
+        )
+
+    def ideation_factory(nd: NodeDefinition, deps: set, succs: set) -> DevLoopNode:
+        return _with_graph(
+            IdeationNode(
+                dispatcher=dispatcher,
+                wiki_search=wiki_search,
+                ideation_max_rounds=ideation_max_rounds,
+                name=nd.id,
+            ),
+            deps,
+            succs,
+        )
+
+    factories["dev_flow.dev_intake"] = dev_intake_factory
+    factories["dev_flow.ideation"] = ideation_factory
+    return factories
+
+
+__all__ = ["build_dev_flow_node_factories"]

--- a/packages/ai-parrot/src/parrot/flows/dev_flow/flow.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_flow/flow.py
@@ -1,0 +1,184 @@
+"""Executable dev-flow builder (FEAT-412).
+
+Mirrors ``build_dev_loop_feature_flow``'s
+declarative-materialize-then-explicit-edge pattern (``dev_loop/runner.py``):
+the nodes come from :func:`build_dev_flow_definition` through the dev-flow
+factories, then every edge is re-declared imperatively because the graph's
+OR-joins (``planner`` from two intakes, ``feature_handoff`` from two
+predecessors, the ``failure_handler`` fan-in) cannot be fired by the
+``from_definition`` AND-join scheduler.
+
+The routing predicates for the reused chain are **imported** from
+``dev_loop.flow`` rather than re-implemented, so the dev-flow and
+feature-mode graphs cannot silently diverge.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from parrot.bots.flows import AgentsFlow
+from parrot.flows.dev_flow.definition import (
+    DEV_INTAKE,
+    IDEATION,
+    build_dev_flow_definition,
+)
+from parrot.flows.dev_flow.factories import build_dev_flow_node_factories
+from parrot.flows.dev_loop.definition import (
+    CLOSE,
+    DEVELOPMENT,
+    FAILURE,
+    FEATURE_HANDOFF,
+    FEEDBACK_ROUTER,
+    PLANNER,
+    QA,
+    SYNTHESIS,
+)
+from parrot.flows.dev_loop.flow import (
+    FlowEventPublisher,
+    _feedback_accept,
+    _feedback_escalate,
+    _feedback_retry,
+    _NullAgentRegistry,
+    _qa_failed,
+    _qa_passed,
+)
+
+
+def _is_nl_request(result: Any) -> bool:
+    """True for a natural-language intake (``enhancement``/``new_feature``).
+
+    Python twin of ``definition._CEL_IS_NL_REQUEST``. Checked by ``kind``
+    value rather than ``isinstance`` so a dict-like stub still routes
+    correctly (same rationale as ``dev_loop.flow._is_feature``).
+    """
+    return getattr(result, "kind", None) in ("enhancement", "new_feature")
+
+
+def _is_feature_doc(result: Any) -> bool:
+    """True for a document intake (``kind == "feature"``).
+
+    Python twin of ``definition._CEL_IS_FEATURE_DOC``. Equivalent to
+    ``dev_loop.flow._is_feature``, redeclared here only so this module's
+    predicate set reads as one coherent group.
+    """
+    return getattr(result, "kind", None) == "feature"
+
+
+def build_dev_flow(
+    *,
+    dispatcher: Any,
+    redis_url: str,
+    jira_toolkit: Any | None = None,
+    git_toolkit: Any | None = None,
+    wiki_toolkit: Any | None = None,
+    codereview_dispatcher: Any | None = None,
+    development_dispatcher_builder: Any | None = None,
+    development_pool_max: int = 4,
+    graph_memory: Any | None = None,
+    wiki_search: Any | None = None,
+    skip_qa: bool = False,
+    require_plan_approval: bool = False,
+    ideation_max_rounds: int | None = None,
+    name: str = "dev-flow",
+    publish_flow_events: bool = True,
+) -> AgentsFlow:
+    """Build the executable ``dev-flow`` :class:`AgentsFlow`.
+
+    Topology: ``dev_intake`` -(enhancement|new_feature)-> ``ideation`` ->
+    ``planner`` (or ``dev_intake`` -(feature)-> ``planner`` directly) ->
+    ``development`` -> ``synthesis`` -> ``qa`` -(passed)-> ``feature_handoff``
+    -> ``close``; QA failure -> ``feedback_router`` -(escalate)->
+    ``failure_handler`` / -(accept_with_notes)-> ``feature_handoff`` /
+    -(retry)-> ``development`` (bounded in
+    ``FeedbackRouterNode._retry_allowed()``).
+
+    Args:
+        dispatcher: Shared ``ClaudeCodeDispatcher`` for ideation and the
+            reused planner/synthesis/QA/feedback nodes.
+        redis_url: Redis URL for intake/flow-lifecycle events.
+        jira_toolkit: Optional ``JiraToolkit`` — link-only, never created.
+        git_toolkit: Optional ``GitToolkit`` (parity with the ops flows).
+        wiki_toolkit: Optional ``LLMWikiToolkit`` for the handoff's docs ingest.
+        codereview_dispatcher: Optional review dispatcher for ``QANode``.
+        development_dispatcher_builder: Optional dev-agent pool builder.
+        development_pool_max: Hard cap on pool workers.
+        graph_memory: Optional ``DevLoopGraphMemory``.
+        wiki_search: Optional ``DevLoopWikiSearch`` — repo context for
+            ideation and the reused nodes that accept it.
+        skip_qa: Forwarded to the reused QA factory.
+        require_plan_approval: Build-time default for the ``plan_approval``
+            gate; a per-run ``extra_shared["require_plan_approval"]``
+            overrides it (FEAT-412 / TASK-2123).
+        ideation_max_rounds: Override for ``conf.DEV_FLOW_IDEATION_MAX_ROUNDS``.
+        name: Flow name (default ``"dev-flow"``).
+        publish_flow_events: When True (default), attach a
+            :class:`FlowEventPublisher` to the engine's ``on_node_event`` hook.
+
+    Returns:
+        A wired :class:`AgentsFlow` ready to ``run_flow()``.
+    """
+    definition = build_dev_flow_definition()
+    factories = build_dev_flow_node_factories(
+        dispatcher=dispatcher,
+        redis_url=redis_url,
+        jira_toolkit=jira_toolkit,
+        git_toolkit=git_toolkit,
+        wiki_toolkit=wiki_toolkit,
+        codereview_dispatcher=codereview_dispatcher,
+        development_dispatcher_builder=development_dispatcher_builder,
+        development_pool_max=development_pool_max,
+        graph_memory=graph_memory,
+        wiki_search=wiki_search,
+        require_plan_approval=require_plan_approval,
+        skip_qa=skip_qa,
+        ideation_max_rounds=ideation_max_rounds,
+    )
+    staged = AgentsFlow.from_definition(
+        definition,
+        agent_registry=_NullAgentRegistry(),
+        node_factories=factories,
+    )
+    nodes = staged._materialize_nodes()
+
+    run_id_holder: dict[str, str] = {}
+    publisher = (
+        FlowEventPublisher(redis_url, run_id_holder) if publish_flow_events else None
+    )
+    flow = AgentsFlow(name=name, on_node_event=publisher)
+    flow._run_id_holder = run_id_holder  # type: ignore[attr-defined]
+    flow._event_publisher = publisher  # type: ignore[attr-defined]
+    flow._dev_loop_definition = definition  # type: ignore[attr-defined]
+
+    for node in nodes.values():
+        flow.add_node(node)
+
+    # -- intake fork (the planner OR-join) --------------------------------
+    flow.add_edge(DEV_INTAKE, IDEATION, predicate=_is_nl_request)
+    flow.add_edge(DEV_INTAKE, PLANNER, predicate=_is_feature_doc)
+    flow.add_edge(IDEATION, PLANNER)
+
+    # -- reused FEAT-378 chain, verbatim ---------------------------------
+    flow.add_edge(PLANNER, DEVELOPMENT)
+    flow.add_edge(DEVELOPMENT, SYNTHESIS)
+    flow.add_edge(SYNTHESIS, QA)
+    flow.add_edge(QA, FEATURE_HANDOFF, predicate=_qa_passed)
+    flow.add_edge(QA, FEEDBACK_ROUTER, predicate=_qa_failed)
+    flow.add_edge(FEEDBACK_ROUTER, FAILURE, predicate=_feedback_escalate)
+    flow.add_edge(FEEDBACK_ROUTER, FEATURE_HANDOFF, predicate=_feedback_accept)
+    # Bounded repair loop back-edge (FEAT-377/A): the engine's cyclic
+    # re-entry resets the development->synthesis->qa->feedback_router cycle.
+    # The stop rule lives in FeedbackRouterNode._retry_allowed(), not here.
+    flow.add_edge(FEEDBACK_ROUTER, DEVELOPMENT, predicate=_feedback_retry)
+    flow.add_edge(FEATURE_HANDOFF, CLOSE)
+
+    for source in (
+        DEV_INTAKE, IDEATION, PLANNER, DEVELOPMENT, SYNTHESIS,
+        QA, FEEDBACK_ROUTER, FEATURE_HANDOFF,
+    ):
+        flow.add_edge(source, FAILURE, condition="on_error")
+
+    return flow
+
+
+__all__ = ["build_dev_flow"]

--- a/packages/ai-parrot/src/parrot/flows/dev_flow/models.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_flow/models.py
@@ -1,0 +1,211 @@
+"""Pydantic v2 contracts for the ``dev-flow`` topology (FEAT-412).
+
+The dev-flow is the SDD-oriented sibling of the operations-oriented
+``parrot.flows.dev_loop``: instead of a log-driven bug triage it starts
+from a developer's *natural-language* request (``enhancement`` /
+``new_feature``) or from an already-written SDD document (``feature`` —
+the existing :class:`~parrot.flows.dev_loop.models.FeatureBrief`).
+
+This module defines only the three new contracts (spec §2 Data Models):
+
+* :class:`DevRequestBrief` — natural-language intake.
+* :data:`DevFlowBrief` — the discriminated ``kind`` union that ``dev_intake``
+  accepts (``DevRequestBrief | FeatureBrief``).
+* :class:`IdeationOutput` — the ``sdd-ideation`` subagent's final JSON
+  contract.
+
+Everything else (dev-agent pool specs, judge panels, planner/QA outputs)
+is imported from ``dev_loop.models`` — dev-flow reuses those wholesale.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, Field
+
+from parrot.flows.dev_loop.models import (
+    DevAgentSpec,
+    FeatureBrief,
+    JudgePanelConfig,
+)
+
+__all__ = [
+    "DevFlowBrief",
+    "DevRequestBrief",
+    "DevRequestKind",
+    "IdeationOutput",
+    "parse_dev_brief",
+]
+
+
+# The two natural-language intents. Chosen explicitly by the user in the
+# UI — dev-flow deliberately has NO LLM intent classification (spec §8).
+DevRequestKind = Literal["enhancement", "new_feature"]
+
+
+class DevRequestBrief(BaseModel):
+    """Natural-language intake for the dev-flow (enhancement / new feature).
+
+    Unlike :class:`~parrot.flows.dev_loop.models.FeatureBrief`, there is no
+    SDD document yet — that is precisely what ``IdeationNode`` produces via
+    the ``sdd-ideation`` subagent:
+
+    * ``new_feature`` → a full ``sdd/proposals/<slug>.brainstorm.md``
+      (options analysis + recommendation).
+    * ``enhancement`` → a light ``sdd/proposals/<slug>.proposal.md``
+      (scope, rationale, impact — no options analysis).
+
+    Consequently this model carries NO document validators; ``title`` is the
+    slug source and ``description`` is the request itself.
+    """
+
+    kind: DevRequestKind = Field(
+        ...,
+        description=(
+            "User-selected intent. 'new_feature' ⇒ brainstorm document, "
+            "'enhancement' ⇒ light proposal document. Never inferred by an "
+            "LLM (spec §8: the user picks the intent in the UI)."
+        ),
+    )
+    title: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Short human name for the request. Slug source for the "
+            "``sdd/proposals/<slug>.*.md`` document path."
+        ),
+    )
+    description: str = Field(
+        ...,
+        min_length=1,
+        description="The natural-language request driving this run.",
+    )
+    context: str = Field(
+        default="",
+        description="Optional extra context, links, or constraints.",
+    )
+    jira_issue_key: str | None = Field(
+        default=None,
+        description=(
+            "Optional Jira issue key. Like feature-mode, dev-flow never "
+            "creates a Jira issue; when set, downstream nodes only link/"
+            "transition/comment on the existing ticket."
+        ),
+    )
+    dev_agents: list[DevAgentSpec] | None = Field(
+        default=None,
+        description=(
+            "Optional explicit dev-agent pool, passed through to the "
+            "``FeatureBrief`` that ``IdeationNode`` emits. When unset, "
+            "``PlannerNode`` derives the pool from the first task wave."
+        ),
+    )
+    judge_panel: JudgePanelConfig | None = Field(
+        default=None,
+        description=(
+            "Optional QA judge-panel override, passed through to the "
+            "``FeatureBrief`` that ``IdeationNode`` emits."
+        ),
+    )
+
+
+# Discriminated brief union on ``kind`` — mirrors ``dev_loop.models.Brief``.
+# Three admissible kinds: "enhancement" / "new_feature" (DevRequestBrief)
+# and "feature" (FeatureBrief, the document-based FEAT-378 intake).
+DevFlowBrief = Annotated[
+    DevRequestBrief | FeatureBrief, Field(discriminator="kind")
+]
+
+
+def parse_dev_brief(data: dict[str, Any]) -> DevRequestBrief | FeatureBrief:
+    """Parse a raw brief mapping into a :class:`DevRequestBrief` or ``FeatureBrief``.
+
+    Loader shim around the :data:`DevFlowBrief` discriminated union, mirroring
+    ``dev_loop.models.parse_brief``: routes on the ``kind`` field
+    (``"feature"`` → :class:`~parrot.flows.dev_loop.models.FeatureBrief`,
+    ``"enhancement"``/``"new_feature"`` → :class:`DevRequestBrief`).
+
+    Unlike ``parse_brief``, there is no legacy default kind to preserve: the
+    dev-flow requires an explicit intent, so a missing/unknown ``kind`` is a
+    validation error rather than a silent fallback.
+
+    Args:
+        data: Raw brief mapping, e.g. decoded from a JSON prompt or an
+            HTML form payload.
+
+    Returns:
+        A validated ``DevRequestBrief`` or ``FeatureBrief`` instance.
+
+    Raises:
+        ValueError: If ``kind`` is absent or is not one of the three
+            admissible dev-flow kinds.
+        pydantic.ValidationError: If the mapping fails validation against
+            the resolved model.
+    """
+    kind = data.get("kind")
+    if kind == "feature":
+        return FeatureBrief(**data)
+    if kind in ("enhancement", "new_feature"):
+        return DevRequestBrief(**data)
+    raise ValueError(
+        "dev-flow brief requires an explicit kind of 'enhancement', "
+        f"'new_feature' or 'feature'; got {kind!r}"
+    )
+
+
+class IdeationOutput(BaseModel):
+    """Contract for the ``sdd-ideation`` subagent's single final JSON object.
+
+    The subagent writes (or resumes/extends) the intent's SDD document,
+    commits it to ``base_branch``, and reports the result here.
+    ``IdeationNode`` fails fast when ``committed`` is ``False`` — an
+    uncommitted document is invisible to the worktree ``sdd-planner``
+    creates later (spec §7 Known Risks).
+    """
+
+    document_path: str = Field(
+        ...,
+        description=(
+            "Resolved path of the written document: "
+            "``sdd/proposals/<slug>.brainstorm.md`` (new_feature) or "
+            "``sdd/proposals/<slug>.proposal.md`` (enhancement)."
+        ),
+    )
+    document_kind: Literal["brainstorm", "proposal"] = Field(
+        ...,
+        description=(
+            "'brainstorm' for the new_feature mode, 'proposal' for the "
+            "enhancement mode. Fed straight into "
+            "``FeatureBrief.document_kind``."
+        ),
+    )
+    slug: str = Field(..., description="Slug derived from the request title.")
+    resumed_existing: bool = Field(
+        default=False,
+        description=(
+            "True when the target document already existed and was "
+            "resumed/extended in place (never overwritten, never "
+            "``-2``-suffixed — spec §8 existing-document policy)."
+        ),
+    )
+    open_questions: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Unresolved ``[ ]`` Open Questions from this round. Non-empty ⇒ "
+            "``IdeationNode`` opens ONE ``open_questions`` gate carrying all "
+            "of them."
+        ),
+    )
+    summary: str = Field(
+        default="",
+        description="Short human summary of what the document proposes.",
+    )
+    committed: bool = Field(
+        default=False,
+        description=(
+            "Whether the document was committed to ``base_branch``. False ⇒ "
+            "``IdeationNode`` fails the run (the planner's worktree would "
+            "not see the document)."
+        ),
+    )

--- a/packages/ai-parrot/src/parrot/flows/dev_flow/nodes/__init__.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_flow/nodes/__init__.py
@@ -16,5 +16,6 @@ re-import cycle).
 from __future__ import annotations
 
 from parrot.flows.dev_flow.nodes.dev_intake import DevIntakeNode
+from parrot.flows.dev_flow.nodes.ideation import IdeationNode
 
-__all__ = ["DevIntakeNode"]
+__all__ = ["DevIntakeNode", "IdeationNode"]

--- a/packages/ai-parrot/src/parrot/flows/dev_flow/nodes/__init__.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_flow/nodes/__init__.py
@@ -1,0 +1,20 @@
+"""Dev-flow node types (FEAT-412).
+
+Only the **intake half** of the dev-flow is new; everything from ``planner``
+onward is consumed from ``dev_loop`` by node-type name (spec §2 Overview):
+
+* :class:`DevIntakeNode` (``dev_flow.dev_intake``) — validates the
+  user-selected ``DevFlowBrief`` and routes by ``kind``.
+* :class:`IdeationNode` (``dev_flow.ideation``) — natural language → a
+  committed SDD document, with bounded HITL Open-Questions rounds.
+
+Both subclass ``DevLoopNode`` and register through
+``register_dev_loop_node`` (idempotent, safe across the lazy-import
+re-import cycle).
+"""
+
+from __future__ import annotations
+
+from parrot.flows.dev_flow.nodes.dev_intake import DevIntakeNode
+
+__all__ = ["DevIntakeNode"]

--- a/packages/ai-parrot/src/parrot/flows/dev_flow/nodes/dev_intake.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_flow/nodes/dev_intake.py
@@ -1,0 +1,235 @@
+"""DevIntakeNode — first node of the dev-flow graph (FEAT-412).
+
+Validates the user-selected :data:`DevFlowBrief` and returns it so the
+topology's CEL edge predicates can route on ``result.kind``:
+
+* ``"enhancement"`` / ``"new_feature"`` → ``dev_flow.ideation`` (the request
+  is natural language; the SDD document does not exist yet).
+* ``"feature"`` → ``dev_loop.planner`` (an SDD brainstorm/proposal/spec was
+  supplied; ideation is skipped entirely).
+
+There is deliberately **no LLM intent classification** here (spec §1
+Non-Goals / §8): the user picks the intent in the UI, and this node only
+*validates* the typed brief — exactly the relationship
+``IntentClassifierNode`` has to ``WorkBrief``, whose pattern this node
+mirrors (ctx-or-JSON-prompt loading, lazy Redis, one
+``flow.intake_validated`` event, return-the-brief-for-routing).
+
+No allowlist/path-traversal guards apply: those are
+``WorkBrief.acceptance_criteria``-specific and neither
+:class:`DevRequestBrief` nor :class:`FeatureBrief` carries acceptance
+criteria. A ``FeatureBrief``'s own constructor validates ``document_path``
+readability eagerly, so an invalid brief fails inside :meth:`_load_brief` —
+before this node returns and before any dispatch.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+from parrot.bots.flows.core.context import FlowContext
+from parrot.bots.flows.core.types import DependencyResults
+from parrot.flows.dev_flow.models import DevRequestBrief, parse_dev_brief
+from parrot.flows.dev_loop.models import FeatureBrief
+from parrot.flows.dev_loop.nodes.base import DevLoopNode, register_dev_loop_node
+
+
+@register_dev_loop_node("dev_flow.dev_intake")
+class DevIntakeNode(DevLoopNode):
+    """Validates a :data:`DevFlowBrief` and routes by ``kind``.
+
+    Args:
+        redis_url: Redis URL used to publish ``flow.intake_validated``. The
+            connection is lazy: the node is safe to construct without a live
+            Redis instance — the publish happens on first :meth:`execute`.
+        name: Node identifier, defaults to ``"dev_intake"``.
+    """
+
+    def __init__(
+        self,
+        *,
+        redis_url: str,
+        name: str = "dev_intake",
+    ) -> None:
+        super().__init__(node_id=name)
+        object.__setattr__(self, "_redis_url", redis_url)
+        object.__setattr__(self, "_redis", None)
+
+    # ------------------------------------------------------------------
+    # Execute
+    # ------------------------------------------------------------------
+
+    async def execute(
+        self,
+        ctx: FlowContext | dict[str, Any],
+        deps: DependencyResults | None = None,
+        **kwargs: Any,
+    ) -> DevRequestBrief | FeatureBrief:
+        """Validate the dev-flow brief and emit the intake event.
+
+        Args:
+            ctx: Flow context (``FlowContext`` or plain dict in tests). The
+                shared state must contain ``"run_id"`` for the event stream
+                key and may contain ``"dev_brief"`` or ``"feature_brief"``
+                (an instance or a dict); the context's ``initial_task`` is
+                used as a JSON fallback when neither is present.
+            deps: Dependency results (unused — this is the entry node).
+            **kwargs: Extra execution context (ignored).
+
+        Returns:
+            The validated :class:`DevRequestBrief` or :class:`FeatureBrief`.
+            The topology's conditional edges read ``result.kind`` to route
+            to ``ideation`` or straight to ``planner``.
+
+        Raises:
+            ValueError: When no brief source is available, when ``kind`` is
+                absent/unknown, or when the loaded brief fails validation
+                (e.g. an unreadable ``FeatureBrief.document_path`` —
+                ``pydantic.ValidationError`` subclasses ``ValueError``) —
+                always BEFORE this node returns.
+        """
+        shared = self.shared_state(ctx)
+        brief = self._load_brief(self.initial_prompt(ctx), shared)
+
+        # Always publish the canonical dev-flow key.
+        shared["dev_brief"] = brief
+
+        if isinstance(brief, FeatureBrief):
+            # The document already exists → hand it straight to PlannerNode
+            # under the exact key it reads. IdeationNode never runs.
+            shared["feature_brief"] = brief
+            self.logger.info(
+                "Dev intake validated: kind=feature, document_kind=%s, "
+                "document_path=%s",
+                brief.document_kind, brief.document_path,
+            )
+        else:
+            self.logger.info(
+                "Dev intake validated: kind=%s, title=%s",
+                brief.kind, brief.title,
+            )
+
+        run_id = shared.get("run_id", "")
+        if run_id:
+            await self._emit_validated_event(run_id, brief)
+        return brief
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _load_brief(
+        self, prompt: str, ctx: dict[str, Any]
+    ) -> DevRequestBrief | FeatureBrief:
+        """Load a :class:`DevRequestBrief` or :class:`FeatureBrief`.
+
+        Resolution order:
+
+        1. ``ctx["dev_brief"]`` — the canonical dev-flow key (what
+           ``DevFlowRunner`` seeds).
+        2. ``ctx["feature_brief"]`` — a caller that already has a
+           ``FeatureBrief`` in hand.
+        3. ``prompt`` — JSON string fallback, routed through
+           :func:`parse_dev_brief`.
+
+        Args:
+            prompt: Raw JSON string representing a brief.
+            ctx: Flow shared-state dictionary.
+
+        Returns:
+            A validated brief instance.
+
+        Raises:
+            ValueError: When no source is available, when ``kind`` is missing
+                or not one of the three dev-flow kinds, or when the brief
+                fails model validation.
+        """
+        candidate = ctx.get("dev_brief") or ctx.get("feature_brief")
+        if isinstance(candidate, (DevRequestBrief, FeatureBrief)):
+            return candidate
+        if isinstance(candidate, dict):
+            return parse_dev_brief(candidate)
+        if prompt:
+            return parse_dev_brief(json.loads(prompt))
+        raise ValueError(
+            "DevIntakeNode requires ctx['dev_brief'], ctx['feature_brief'], "
+            "or a JSON prompt."
+        )
+
+    async def _emit_validated_event(
+        self, run_id: str, brief: DevRequestBrief | FeatureBrief
+    ) -> None:
+        """XADD one ``flow.intake_validated`` event to the flow stream.
+
+        Args:
+            run_id: Identifies the Redis stream key ``flow:{run_id}:flow``.
+            brief: The validated brief whose metadata goes into the payload.
+                The payload shape is per-kind: a document-based
+                ``FeatureBrief`` reports its document, a natural-language
+                ``DevRequestBrief`` reports its title.
+        """
+        try:
+            redis_client = await self._ensure_redis()
+        except Exception as exc:  # noqa: BLE001 — telemetry must never break a run
+            self.logger.warning(
+                "Redis unavailable, dropping flow.intake_validated event: %s",
+                exc,
+            )
+            return
+
+        if isinstance(brief, FeatureBrief):
+            event_payload: dict[str, Any] = {
+                "kind": "feature",
+                "document_kind": brief.document_kind,
+                "document_path": brief.document_path,
+                "jira_issue_key": brief.jira_issue_key,
+            }
+        else:
+            event_payload = {
+                "kind": brief.kind,
+                "title": brief.title,
+                "jira_issue_key": brief.jira_issue_key,
+            }
+
+        envelope = {
+            "kind": "flow.intake_validated",
+            "ts": time.time(),
+            "run_id": run_id,
+            "node_id": self.name,
+            "payload": event_payload,
+        }
+        fields = {"event": json.dumps(envelope)}
+        try:
+            await redis_client.xadd(
+                f"flow:{run_id}:flow", fields, maxlen=10_000, approximate=True
+            )
+        except Exception as exc:  # noqa: BLE001 — telemetry must never break a run
+            self.logger.warning(
+                "Failed to XADD flow.intake_validated: %s", exc
+            )
+
+    async def _ensure_redis(self) -> Any:
+        """Return a cached async Redis client, creating it on first call.
+
+        Returns:
+            A live ``redis.asyncio`` client instance.
+        """
+        if self._redis is not None:
+            return self._redis
+        import redis.asyncio as aioredis
+
+        self._redis = aioredis.from_url(
+            self._redis_url, decode_responses=True
+        )
+        return self._redis
+
+    async def close(self) -> None:
+        """Release the Redis client connection pool."""
+        if self._redis is not None:
+            await self._redis.aclose()
+            self._redis = None
+
+
+__all__ = ["DevIntakeNode"]

--- a/packages/ai-parrot/src/parrot/flows/dev_flow/nodes/ideation.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_flow/nodes/ideation.py
@@ -1,0 +1,465 @@
+"""IdeationNode — natural language → committed SDD document (FEAT-412).
+
+Implements the normative Open-Questions HITL round-trip of spec §2. This is
+the node that makes the dev-flow *interactive*: it turns a
+:class:`DevRequestBrief` into a committed ``sdd/proposals/<slug>.*.md`` by
+dispatching the ``sdd-ideation`` subagent, and resolves the document's Open
+Questions with the human through ``open_questions`` gates before handing a
+:class:`FeatureBrief` to the (reused) ``PlannerNode``.
+
+Sequence::
+
+    1. mode  = "brainstorm" (new_feature) | "proposal" (enhancement)
+    2. dispatch sdd-ideation           → IdeationOutput
+    3. while output.open_questions and rounds_used < DEV_FLOW_IDEATION_MAX_ROUNDS:
+           ONE gate carrying ALL of this round's questions
+           await wait_gate  →  approved ? re-dispatch with answers : raise
+    4. committed is False  → raise (the planner's worktree would not see it)
+    5. publish ctx["feature_brief"] = FeatureBrief(...) and return it
+
+Design notes:
+
+* **Gate expiry is fail-closed** (``on_expiry="fail"``): silence is not
+  consent for spec decisions, so an expired gate reaches ``wait_gate`` with
+  status ``"expired"`` and raises into ``failure_handler``.
+* **Rounds are bounded.** Questions still ``[ ]`` when the budget is spent
+  stay in the document and flow into the spec's §8 via the planner — they do
+  NOT block the run.
+* **"Re-dispatch" is a NEW dispatch**, not a dispatcher-side resume: the
+  payload carries the prior ``document_path`` plus the ``answers`` mapping,
+  and the subagent resumes/extends the document in place.
+* **No ``session_host``** in shared state → the node logs a warning and runs
+  gatelessly (autonomous mode), mirroring ``DevelopmentNode``'s plan-gate
+  fallback. Any open questions are simply left in the document.
+* Park/resume (``DEV_LOOP_GATE_PARK``) is entirely runner-side: waiting here
+  is a plain ``await``, which is what lets a parked run release its
+  concurrency slot while a human takes hours to answer.
+* The subagent is dispatched via ``system_prompt_override``, NOT
+  ``profile.subagent``: the latter resolves prompts through ``dev_loop``'s
+  own loader, which deliberately does not know the dev-flow-owned
+  ``sdd-ideation`` prompt (spec §3 Module 3 — the dev_flow package owns its
+  prompts). This keeps shared ``dev_loop`` code untouched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from parrot import conf
+from parrot.bots.flows.core.context import FlowContext
+from parrot.bots.flows.core.types import DependencyResults
+from parrot.flows.dev_flow._subagent_defs import load_subagent_definition
+from parrot.flows.dev_flow.models import DevRequestBrief, IdeationOutput
+from parrot.flows.dev_loop.dispatchers import ClaudeCodeDispatcher
+from parrot.flows.dev_loop.models import ClaudeCodeDispatchProfile, FeatureBrief
+from parrot.flows.dev_loop.nodes.base import DevLoopNode, register_dev_loop_node
+from parrot.flows.dev_loop.wiki_search import DevLoopWikiSearch
+
+# Mode ⇄ intent mapping (spec §2 / §8): the intent is user-selected, and it
+# alone decides which document the subagent writes.
+_MODE_FOR_KIND: dict[str, str] = {
+    "new_feature": "brainstorm",
+    "enhancement": "proposal",
+}
+
+
+class _IdeationBrief(BaseModel):
+    """Local dispatch payload for the ``sdd-ideation`` subagent.
+
+    Not a shared model: like ``planner.py``'s ``_PlannerBrief``, this exists
+    only for the lifetime of a single dispatch, so it lives next to its
+    consumer instead of growing the shared models module. Field names match
+    the input table documented in the ``sdd-ideation`` prompt.
+    """
+
+    mode: Literal["brainstorm", "proposal"]
+    title: str
+    description: str
+    context: str = ""
+    graph_context: str = ""
+    # Prior-round answers; empty on the first dispatch.
+    answers: dict[str, str] = Field(default_factory=dict)
+    # Set on resume rounds so the subagent extends the same document.
+    document_path: str = ""
+    round: int = 1
+
+
+@register_dev_loop_node("dev_flow.ideation")
+class IdeationNode(DevLoopNode):
+    """Turns a natural-language request into a committed SDD document.
+
+    Args:
+        dispatcher: A :class:`ClaudeCodeDispatcher` shared by every node in
+            the flow.
+        wiki_search: Optional :class:`DevLoopWikiSearch` used to inject
+            ranked repo context into the dispatch. Best-effort — a ``None``
+            search, or a search that finds nothing, simply yields no context.
+        ideation_max_rounds: Override for ``conf.DEV_FLOW_IDEATION_MAX_ROUNDS``.
+            ``None`` (default) reads the conf key at execute time.
+        name: Node id, default ``"ideation"``.
+    """
+
+    def __init__(
+        self,
+        *,
+        dispatcher: ClaudeCodeDispatcher,
+        wiki_search: DevLoopWikiSearch | None = None,
+        ideation_max_rounds: int | None = None,
+        name: str = "ideation",
+    ) -> None:
+        super().__init__(node_id=name)
+        object.__setattr__(self, "_dispatcher", dispatcher)
+        object.__setattr__(self, "_wiki_search", wiki_search)
+        object.__setattr__(self, "_max_rounds", ideation_max_rounds)
+
+    # ------------------------------------------------------------------
+    # Execute
+    # ------------------------------------------------------------------
+
+    async def execute(
+        self,
+        ctx: FlowContext | dict[str, Any],
+        deps: DependencyResults | None = None,
+        **kwargs: Any,
+    ) -> FeatureBrief:
+        """Run the ideation phase and return the resulting :class:`FeatureBrief`.
+
+        Reads ``dev_brief`` / ``run_id`` / ``session_host`` from the shared
+        state; writes ``ideation_output`` and ``feature_brief``.
+
+        Args:
+            ctx: Flow context (``FlowContext`` or plain dict in tests).
+            deps: Dependency results (unused — routing is edge-driven).
+            **kwargs: Extra execution context (ignored).
+
+        Returns:
+            The :class:`FeatureBrief` pointing at the committed document,
+            also published to ``ctx["feature_brief"]`` — the exact key
+            ``PlannerNode`` reads.
+
+        Raises:
+            ValueError: ``ctx["dev_brief"]`` is missing or is not a
+                natural-language :class:`DevRequestBrief` (this node is only
+                reachable for the ``enhancement``/``new_feature`` intents).
+            RuntimeError: An Open-Questions gate was rejected or expired, the
+                subagent reported ``committed=False``, or the document it
+                reported cannot be read.
+        """
+        shared = self.shared_state(ctx)
+        brief = self._load_request_brief(shared)
+        mode = _MODE_FOR_KIND[brief.kind]
+
+        graph_context = await self._build_wiki_context(brief)
+        max_rounds = self._resolve_max_rounds()
+
+        self.logger.info(
+            "Ideation starting: kind=%s -> mode=%s, title=%s, max_rounds=%d",
+            brief.kind, mode, brief.title, max_rounds,
+        )
+
+        output = await self._dispatch(
+            shared=shared, brief=brief, mode=mode,
+            graph_context=graph_context, answers={}, document_path="", round_=1,
+        )
+
+        host = shared.get("session_host")
+        if output.open_questions and host is None:
+            self.logger.warning(
+                "IdeationNode: %d open question(s) but no session_host in "
+                "shared state (autonomous construction) — proceeding WITHOUT "
+                "an open_questions gate; the questions stay in %s and are "
+                "carried into the spec by the planner.",
+                len(output.open_questions), output.document_path,
+            )
+
+        rounds_used = 0
+        while output.open_questions and host is not None and rounds_used < max_rounds:
+            rounds_used += 1
+            answers = await self._run_question_round(
+                host=host, output=output, round_=rounds_used,
+                max_rounds=max_rounds,
+            )
+            output = await self._dispatch(
+                shared=shared, brief=brief, mode=mode,
+                graph_context=graph_context, answers=answers,
+                document_path=output.document_path, round_=rounds_used + 1,
+            )
+
+        if output.open_questions:
+            self.logger.info(
+                "Ideation finished with %d unresolved question(s) after %d "
+                "round(s) — they remain '[ ]' in %s and flow into the spec's "
+                "§8 via the planner (not a failure).",
+                len(output.open_questions), rounds_used, output.document_path,
+            )
+
+        # Fail fast: sdd-planner creates its worktree from base_branch HEAD,
+        # so an uncommitted document is invisible there (spec §7).
+        if not output.committed:
+            raise RuntimeError(
+                "sdd-ideation did not commit "
+                f"{output.document_path!r} (committed=False): "
+                f"{output.summary or 'no summary reported'}. The planner's "
+                "worktree would not see the document, so the run stops here."
+            )
+
+        document_path = self._resolve_document_path(output.document_path)
+        feature_brief = FeatureBrief(
+            document_path=document_path,
+            document_kind=output.document_kind,
+            # Passthrough — dev-flow never creates a Jira issue, and an
+            # explicit pool/panel from the intake must survive ideation.
+            jira_issue_key=brief.jira_issue_key,
+            dev_agents=brief.dev_agents,
+            judge_panel=brief.judge_panel,
+        )
+
+        shared["ideation_output"] = output
+        shared["feature_brief"] = feature_brief
+        self.logger.info(
+            "Ideation complete: %s (kind=%s, resumed_existing=%s, rounds=%d)",
+            document_path, output.document_kind, output.resumed_existing,
+            rounds_used,
+        )
+        return feature_brief
+
+    # ------------------------------------------------------------------
+    # Internal — input
+    # ------------------------------------------------------------------
+
+    def _load_request_brief(self, shared: dict[str, Any]) -> DevRequestBrief:
+        """Return the natural-language brief this node operates on.
+
+        Args:
+            shared: The flow's shared state.
+
+        Returns:
+            The :class:`DevRequestBrief` published by ``DevIntakeNode``.
+
+        Raises:
+            ValueError: The brief is absent, or is not a
+                :class:`DevRequestBrief` — a ``feature`` intake routes
+                straight to the planner and must never reach this node.
+        """
+        brief = shared.get("dev_brief")
+        if isinstance(brief, DevRequestBrief):
+            return brief
+        raise ValueError(
+            "IdeationNode requires ctx['dev_brief'] to be a DevRequestBrief "
+            f"(enhancement/new_feature); got {type(brief).__name__}. A "
+            "'feature' intake routes directly to the planner."
+        )
+
+    def _resolve_max_rounds(self) -> int:
+        """Resolve the HITL round budget (constructor override > conf key)."""
+        if self._max_rounds is not None:
+            return max(0, int(self._max_rounds))
+        return max(0, int(getattr(conf, "DEV_FLOW_IDEATION_MAX_ROUNDS", 2)))
+
+    async def _build_wiki_context(self, brief: DevRequestBrief) -> str:
+        """Best-effort ranked repo context for the dispatch.
+
+        Args:
+            brief: The natural-language request.
+
+        Returns:
+            Markdown context text, or ``""`` when no wiki is wired, nothing
+            relevant was found, or the search degraded.
+        """
+        if self._wiki_search is None:
+            return ""
+        query = f"{brief.title} {brief.description}"
+        try:
+            context = await self._wiki_search.build_research_context(query)
+        except Exception as exc:  # noqa: BLE001 — context injection is best-effort
+            self.logger.debug("Wiki context degraded: %s", exc)
+            return ""
+        return context or ""
+
+    # ------------------------------------------------------------------
+    # Internal — dispatch
+    # ------------------------------------------------------------------
+
+    async def _dispatch(
+        self,
+        *,
+        shared: dict[str, Any],
+        brief: DevRequestBrief,
+        mode: str,
+        graph_context: str,
+        answers: dict[str, str],
+        document_path: str,
+        round_: int,
+    ) -> IdeationOutput:
+        """Dispatch ``sdd-ideation`` once and validate its final JSON.
+
+        Args:
+            shared: The flow's shared state (supplies ``run_id`` and the
+                optional ``session_host`` for dispatch telemetry folding).
+            brief: The natural-language request.
+            mode: ``"brainstorm"`` or ``"proposal"``.
+            graph_context: Optional pre-fetched repo context.
+            answers: Prior-round answers (empty on round 1).
+            document_path: The document to resume (empty on round 1).
+            round_: 1-based round counter, for the subagent's own logging.
+
+        Returns:
+            The validated :class:`IdeationOutput`.
+        """
+        dispatch_brief = _IdeationBrief(
+            mode=mode,  # type: ignore[arg-type]
+            title=brief.title,
+            description=brief.description,
+            context=brief.context,
+            graph_context=graph_context,
+            answers=dict(answers),
+            document_path=document_path,
+            round=round_,
+        )
+        profile = ClaudeCodeDispatchProfile(
+            # NOT profile.subagent: that path resolves the prompt through
+            # dev_loop's loader, which does not know the dev_flow-owned
+            # sdd-ideation prompt. Passing the body as a system prompt keeps
+            # shared dev_loop code untouched (see module docstring).
+            subagent=None,
+            system_prompt_override=load_subagent_definition("sdd-ideation"),
+            permission_mode="acceptEdits",
+            # Read/Grep/Glob to verify Code Context claims, Write/Edit for
+            # the document itself, Bash for the explicit-path git commit.
+            allowed_tools=["Read", "Grep", "Glob", "Bash", "Write", "Edit"],
+            model="claude-sonnet-4-6",
+        )
+        return await self._dispatcher.dispatch(
+            brief=dispatch_brief,
+            profile=profile,
+            output_model=IdeationOutput,
+            run_id=shared.get("run_id", ""),
+            node_id=self.name,
+            # The document is committed to base_branch, so the dispatch runs
+            # against the base checkout — the feature worktree does not exist
+            # yet at ideation time (sdd-planner creates it later).
+            cwd=self._dispatch_cwd(),
+            session_host=shared.get("session_host"),
+        )
+
+    @staticmethod
+    def _dispatch_cwd() -> str:
+        """Absolute working directory for the ideation dispatch."""
+        return str(Path(conf.PROJECT_ROOT).resolve())
+
+    # ------------------------------------------------------------------
+    # Internal — the HITL round
+    # ------------------------------------------------------------------
+
+    async def _run_question_round(
+        self,
+        *,
+        host: Any,
+        output: IdeationOutput,
+        round_: int,
+        max_rounds: int,
+    ) -> dict[str, str]:
+        """Open ONE gate carrying all of this round's questions and await it.
+
+        Args:
+            host: The run's ``SessionHost``.
+            output: The subagent output whose ``open_questions`` to ask.
+            round_: 1-based index of this HITL round.
+            max_rounds: The round budget, surfaced in the gate instructions.
+
+        Returns:
+            The human's ``question -> answer`` mapping (possibly partial —
+            unanswered questions stay open in the document).
+
+        Raises:
+            RuntimeError: The gate was rejected (the user aborted the
+                ideation) or expired (fail-closed policy).
+        """
+        questions: list[str] = list(output.open_questions)
+        # The resolved document path goes in the TITLE so the user can spot —
+        # and reject — an unintended resume of a slug-colliding document
+        # (spec §7 Known Risks).
+        title = f"Open questions — {output.document_path}"
+        instructions = (
+            f"Round {round_} of {max_rounds} for "
+            f"{output.document_path} "
+            f"({'resumed an existing document' if output.resumed_existing else 'new document'}).\n"
+            f"{output.summary}\n\n"
+            "Answer what you can — partial answers are fine, unanswered "
+            "questions stay open in the document. Rejecting this gate aborts "
+            "the ideation."
+        )
+        gate_id, _ = host.open_gate(
+            kind="open_questions",
+            node_id=self.name,
+            title=title,
+            instructions=instructions,
+            questions=questions,
+            ttl_seconds=int(getattr(conf, "DEV_FLOW_GATE_TTL_QUESTIONS", 86400)),
+            # Fail-closed: silence is not consent for spec decisions.
+            on_expiry="fail",
+        )
+        self.logger.info(
+            "Ideation round %d/%d: opened open_questions gate %s with %d "
+            "question(s) for %s",
+            round_, max_rounds, gate_id, len(questions), output.document_path,
+        )
+
+        gate = await host.wait_gate(gate_id)
+        if gate.status != "approved":
+            raise RuntimeError(
+                f"open_questions gate {gate.status} by "
+                f"{gate.resolved_by or 'ttl'} — ideation aborted for "
+                f"{output.document_path}"
+            )
+
+        answers = dict(gate.answers or {})
+        self.logger.info(
+            "Ideation round %d/%d: %d of %d question(s) answered by %s",
+            round_, max_rounds, len(answers), len(questions),
+            gate.resolved_by or "unknown",
+        )
+        return answers
+
+    # ------------------------------------------------------------------
+    # Internal — output
+    # ------------------------------------------------------------------
+
+    def _resolve_document_path(self, raw: str) -> str:
+        """Resolve the subagent's reported document path to a readable file.
+
+        ``FeatureBrief`` validates ``document_path`` readability eagerly, and
+        the subagent reports a repo-relative path (``sdd/proposals/...``). The
+        hosting process' CWD is not guaranteed to be the repo root, so try the
+        path as given first, then anchored at the project root — and raise a
+        node-level error (rather than letting a confusing ``ValidationError``
+        escape) when neither resolves.
+
+        Args:
+            raw: ``IdeationOutput.document_path``.
+
+        Returns:
+            A path string that resolves to a readable file.
+
+        Raises:
+            RuntimeError: Neither candidate is a readable file — i.e. the
+                subagent reported ``committed=True`` for a document that
+                is not there.
+        """
+        candidates = [Path(raw)]
+        if not Path(raw).is_absolute():
+            candidates.append(Path(conf.PROJECT_ROOT) / raw)
+        for candidate in candidates:
+            if candidate.is_file():
+                return str(candidate)
+        raise RuntimeError(
+            f"sdd-ideation reported committed=True for {raw!r}, but no "
+            f"readable document was found (tried: "
+            f"{', '.join(str(c) for c in candidates)})."
+        )
+
+
+__all__ = ["IdeationNode"]

--- a/packages/ai-parrot/src/parrot/flows/dev_flow/runner.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_flow/runner.py
@@ -1,0 +1,229 @@
+"""DevFlowRunner — hosts the single dev-flow topology (FEAT-412).
+
+``DevLoopRunner`` switches topology per brief kind (the bug graph in
+:meth:`run`, feature-mode via ``_run_feature``, the revision graph via
+``run_revision``). The dev-flow has exactly ONE topology, so this subclass
+pins it and overrides only :meth:`run` — brief typing, context seeding and
+graph selection. Everything else is inherited untouched:
+
+* the concurrency cap and its park-aware manual acquire/release,
+* the per-run ``SessionHost`` registry, envelope sink and actions stream,
+* gates, park/resume (``resume_run``), ``resolve_gate``, ``cancel_run``,
+* the gate-expiry / retention sweep,
+* ``_close_host``'s bundle + report persistence.
+
+The base class's ``_feature_flow`` cache and ``_run_feature`` are left
+untouched and unused: a dev-flow ``FeatureBrief`` runs the **dev-flow**
+graph (whose ``dev_intake`` routes it straight to ``planner``), not the
+FEAT-378 feature-mode graph.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any
+
+from parrot.bots.flows.core.context import FlowContext
+
+# Same module the base runner imports FlowResult from (runner.py:36).
+from parrot.bots.flows.core.result import FlowResult
+from parrot.flows.dev_flow.models import DevRequestBrief
+from parrot.flows.dev_loop.models import FeatureBrief
+from parrot.flows.dev_loop.runner import DevLoopRunner
+from parrot.flows.dev_loop.session_state import RunAdded, RunCreated
+
+
+class DevFlowRunner(DevLoopRunner):
+    """Hosts ``dev-flow`` runs behind the shared global concurrency cap.
+
+    Construct exactly like :class:`DevLoopRunner`, passing the flow built by
+    :func:`parrot.flows.dev_flow.flow.build_dev_flow`::
+
+        runner = DevFlowRunner(
+            build_dev_flow(dispatcher=..., redis_url=...),
+            dispatcher=..., redis_url=...,
+        )
+    """
+
+    async def run(
+        self,
+        brief: DevRequestBrief | FeatureBrief,
+        *,
+        run_id: str | None = None,
+        initial_task: str = "",
+        extra_shared: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        """Execute one dev-flow run for *brief*, respecting the run cap.
+
+        Accepts the ``DevFlowBrief`` union. Both kinds run the SAME graph —
+        which brief was supplied only decides where ``dev_intake``'s
+        conditional edges send it:
+
+        * :class:`DevRequestBrief` (``enhancement``/``new_feature``) →
+          ``ideation`` first (the SDD document does not exist yet).
+        * :class:`FeatureBrief` (``feature``) → straight to ``planner``.
+          Ideation is skipped **by routing**, never by this runner.
+
+        Args:
+            brief: The validated :class:`DevRequestBrief` or
+                :class:`FeatureBrief` to process.
+            run_id: Optional externally-minted run identifier; one is
+                generated (``run-<hex8>``) when omitted.
+            initial_task: Optional human-readable task line stored as the
+                context's ``initial_task``. Defaults to a per-kind summary.
+            extra_shared: Extra entries merged into ``shared_data`` — this is
+                how the server passes per-run knobs such as
+                ``require_plan_approval`` and ``skip_qa``.
+
+        Returns:
+            The aggregated :class:`FlowResult` for the run.
+
+        Raises:
+            TypeError: *brief* is neither a ``DevRequestBrief`` nor a
+                ``FeatureBrief`` (e.g. a bug-mode ``WorkBrief``, which this
+                topology cannot serve).
+        """
+        summary = self._summary_for(brief)
+        rid = run_id or f"run-{uuid.uuid4().hex[:8]}"
+
+        # AHP-style host: created + registered BEFORE the flow runs and seeded
+        # into shared state, so nodes resolve it per-run (IdeationNode reads
+        # shared["session_host"] to open its open_questions gates; it never
+        # imports the runner).
+        host = self._register_host(rid)
+        host.apply(
+            RunCreated(
+                run_id=rid,
+                revision=False,
+                work_kind=self._work_kind_for(brief),
+                summary=summary,
+            )
+        )
+        self._apply_root_action(RunAdded(summary=self._run_summary_from_host(host)))
+
+        shared: dict[str, Any] = {
+            # Canonical dev-flow key, read by DevIntakeNode and IdeationNode.
+            "dev_brief": brief,
+            "run_id": rid,
+            "session_host": host,
+        }
+        if isinstance(brief, FeatureBrief):
+            # Pre-seed the key PlannerNode reads. DevIntakeNode would publish
+            # it anyway; seeding here keeps the pre-intake context honest for
+            # any observer (and for a resumed/replayed run).
+            shared["feature_brief"] = brief
+        # NOTE: the bug-mode keys ("bug_brief" / "work_brief") stay unset —
+        # dev-flow never populates them.
+        if extra_shared:
+            shared.update(extra_shared)
+
+        ctx = FlowContext(
+            initial_task=initial_task or summary,
+            shared_data=shared,
+        )
+
+        # Same manual acquire/park-aware structure as the base class's run()
+        # (FEAT-377 TASK-1917 / G6), and mandatory here: an ideation
+        # open_questions gate can park the run for hours, releasing the slot
+        # from deep inside IdeationNode while run_flow() is still in flight —
+        # which `async with self._semaphore` cannot express. Registering
+        # _run_completion[rid] is what lets resume_run() await the SAME
+        # eventual FlowResult.
+        loop = asyncio.get_running_loop()
+        completion: asyncio.Future[FlowResult] = loop.create_future()
+        self._run_completion[rid] = completion
+        await self._semaphore.acquire()
+        self._active.add(rid)
+        # Point the flow's event publisher at this run's stream.
+        holder = getattr(self.flow, "_run_id_holder", None)
+        if isinstance(holder, dict):
+            holder["run_id"] = rid
+        self.logger.info(
+            "Starting dev-flow run %s kind=%s (%d/%d active)",
+            rid, getattr(brief, "kind", "?"),
+            len(self._active), self.max_concurrent_runs,
+        )
+        try:
+            result = await self.flow.run_flow(ctx)
+        except BaseException as exc:
+            # Propagate to any resume_run() awaiter too — a future that never
+            # resolves would hang them forever. Popped here (not in `finally`)
+            # so it happens BEFORE the exception keeps propagating.
+            if not completion.done():
+                completion.set_exception(exc)
+            self._run_completion.pop(rid, None)
+            raise
+        finally:
+            # Exactly-once release: only if this run is STILL holding its slot
+            # (never parked, or parked and already resumed by the time
+            # run_flow() returned/raised). A run that finishes while still
+            # parked releases nothing here — _park already released its slot.
+            if rid in self._active:
+                self._active.discard(rid)
+                self._semaphore.release()
+            else:
+                self._parked.discard(rid)
+            self._pending_gate_count.pop(rid, None)
+
+        self.logger.info(
+            "Dev-flow run %s finished status=%s", rid, result.status
+        )
+        self._close_host(host, result, ctx)
+        if not completion.done():
+            completion.set_result(result)
+        self._run_completion.pop(rid, None)
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal — brief projections
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _summary_for(brief: DevRequestBrief | FeatureBrief) -> str:
+        """Human-readable one-liner for the run registry and initial task.
+
+        Args:
+            brief: The dev-flow brief.
+
+        Returns:
+            The request title for a natural-language brief, or
+            ``"Feature: <document_path>"`` for a document brief (matching
+            ``_run_feature``'s wording).
+
+        Raises:
+            TypeError: The brief is not a dev-flow brief kind.
+        """
+        if isinstance(brief, DevRequestBrief):
+            return brief.title
+        if isinstance(brief, FeatureBrief):
+            return f"Feature: {brief.document_path}"
+        raise TypeError(
+            "DevFlowRunner.run expects a DevRequestBrief or FeatureBrief; "
+            f"got {type(brief).__name__}."
+        )
+
+    @staticmethod
+    def _work_kind_for(brief: DevRequestBrief | FeatureBrief) -> str:
+        """Map the brief onto ``RunCreated.work_kind``.
+
+        ``work_kind`` is a closed ``Literal["bug", "enhancement",
+        "new_feature"]`` deliberately NOT extended with ``"feature"``
+        (TASK-1918) — ``FeatureBrief`` carries its own ``kind`` instead. A
+        ``DevRequestBrief``'s kind maps directly onto two of those values; a
+        document brief reuses ``"bug"`` as the structural placeholder, exactly
+        as ``_run_feature`` does (never read on this path — dev-flow has no
+        ResearchNode and no Jira issue-type selection).
+
+        Args:
+            brief: The dev-flow brief.
+
+        Returns:
+            A valid ``work_kind`` literal value.
+        """
+        if isinstance(brief, DevRequestBrief):
+            return brief.kind
+        return "bug"
+
+
+__all__ = ["DevFlowRunner"]

--- a/packages/ai-parrot/src/parrot/flows/dev_flow/runner.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_flow/runner.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
-from typing import Any
+from typing import Any, Literal
 
 from parrot.bots.flows.core.context import FlowContext
 
@@ -46,7 +46,13 @@ class DevFlowRunner(DevLoopRunner):
         )
     """
 
-    async def run(
+    # Deliberate Liskov narrowing: the base accepts ``WorkBrief |
+    # FeatureBrief``, but the dev-flow graph cannot serve a bug-mode
+    # ``WorkBrief`` (there is no bug_intake/research node in it). Narrowing the
+    # annotation documents the real contract, and ``_summary_for`` raises
+    # TypeError for anything else BEFORE a host is registered or a slot
+    # acquired — so the substitution fails loudly rather than half-running.
+    async def run(  # type: ignore[override]
         self,
         brief: DevRequestBrief | FeatureBrief,
         *,
@@ -204,7 +210,9 @@ class DevFlowRunner(DevLoopRunner):
         )
 
     @staticmethod
-    def _work_kind_for(brief: DevRequestBrief | FeatureBrief) -> str:
+    def _work_kind_for(
+        brief: DevRequestBrief | FeatureBrief,
+    ) -> Literal["bug", "enhancement", "new_feature"]:
         """Map the brief onto ``RunCreated.work_kind``.
 
         ``work_kind`` is a closed ``Literal["bug", "enhancement",

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/commands.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/commands.py
@@ -52,6 +52,13 @@ class ResolveGateRequest(BaseModel):
     resolved_by: str = Field(..., min_length=1)
     comment: str = ""
     client_seq: int = 0
+    # FEAT-412: structured ``question -> answer`` mapping for an
+    # ``open_questions`` gate (dev-flow ideation rounds). Defaulted so every
+    # pre-FEAT-412 client body still validates against this frozen,
+    # extra="forbid" model. The HOST enforces that approving an
+    # ``open_questions`` gate carries at least one answer — surfaced here as
+    # a 400 (see :func:`resolve_gate_handler`).
+    answers: dict[str, str] = Field(default_factory=dict)
 
 
 class CancelRunRequest(BaseModel):
@@ -102,7 +109,7 @@ async def resolve_gate_handler(request: web.Request) -> web.Response:
     try:
         envelope = await runner.resolve_gate(
             run_id, gate_id, body.resolution, body.resolved_by,
-            body.comment, origin=origin,
+            body.comment, origin=origin, answers=body.answers,
         )
     except GateNotFoundError:
         # NOTE: GateNotFoundError subclasses KeyError — this except clause
@@ -117,6 +124,18 @@ async def resolve_gate_handler(request: web.Request) -> web.Response:
             "resolve_gate: unknown run_id=%s gate_id=%s", run_id, gate_id
         )
         return web.json_response({"error": "unknown_run"}, status=404)
+    except ValueError as exc:
+        # FEAT-412: the host rejects approving an "open_questions" gate with
+        # no answers. Neither GateNotFoundError (KeyError) nor
+        # GateAlreadyResolvedError (RuntimeError) derives from ValueError, so
+        # this clause cannot shadow them.
+        logger.info(
+            "resolve_gate: invalid resolution for gate_id=%s on run_id=%s: %s",
+            gate_id, run_id, exc,
+        )
+        return web.json_response(
+            {"error": "answers_required", "detail": str(exc)}, status=400
+        )
     except GateAlreadyResolvedError:
         host = runner.get_host(run_id)
         gate = host.state.gates.get(gate_id) if host is not None else None

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/development.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/development.py
@@ -235,6 +235,15 @@ class DevelopmentNode(DevLoopNode):
         ``DeploymentHandoffNode.require_deployment_approval``'s fail-open
         legacy fallback — when no ``SessionHost`` is present.
 
+        Whether the gate is required is resolved **per run** (FEAT-412):
+        an explicit ``shared["require_plan_approval"]`` (``True`` *or*
+        ``False``) wins over the constructor flag, so a UI toggle can turn
+        the gate on/off for a single run without rebuilding the flow (the
+        server passes it through ``DevLoopRunner.run(extra_shared=...)``).
+        When the key is absent — or present as ``None`` — the
+        constructor flag applies, so every pre-FEAT-412 call site behaves
+        byte-identically.
+
         Args:
             shared: The flow's shared state dict.
             research: The upstream research output (Jira key, spec path).
@@ -248,7 +257,15 @@ class DevelopmentNode(DevLoopNode):
                 via the flow's ``on_error`` edge, the same terminate-the-run
                 effect a rejected ``deployment_approval`` gate has.
         """
-        if not self._require_plan_approval or shared.get("_plan_gate_checked"):
+        # FEAT-412: per-run override. Read with an absent-vs-explicit-False
+        # distinction (NOT truthiness): a run that explicitly sets False must
+        # suppress a gate the constructor flag would have opened, while an
+        # absent key (or an explicit None) must fall back to that flag.
+        override = shared.get("require_plan_approval")
+        required = (
+            self._require_plan_approval if override is None else bool(override)
+        )
+        if not required or shared.get("_plan_gate_checked"):
             return
         shared["_plan_gate_checked"] = True
 

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/qa.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/qa.py
@@ -67,6 +67,24 @@ _LINT_TARGET_RE = re.compile(
 )
 
 
+class _NoBugBrief(BaseModel):
+    """Stand-in for ``shared["bug_brief"]`` in briefless topologies.
+
+    The feature-mode (FEAT-378) and dev-flow (FEAT-412) graphs have **no**
+    ``BugIntakeNode``, so nothing ever seeds ``shared["bug_brief"]`` — their
+    acceptance criteria live in the spec/task artifacts, not on the intake
+    brief. This node only reads ``.acceptance_criteria`` and ``.summary`` off
+    that brief, so supplying this shim keeps the deterministic lint gate and
+    the code-review gate running (with zero brief-level criteria to
+    partition) instead of raising ``KeyError`` before QA even starts.
+
+    Bug/revision runs are unaffected: they always seed a real ``BugBrief``.
+    """
+
+    acceptance_criteria: List[AcceptanceCriterion] = Field(default_factory=list)
+    summary: str = ""
+
+
 class _QABrief(BaseModel):
     """Internal brief shape passed to the ``sdd-qa`` subagent.
 
@@ -161,7 +179,13 @@ class QANode(DevLoopNode):
         """
         shared = self.shared_state(ctx)
         research: ResearchOutput = shared["research_output"]
-        brief: BugBrief = shared["bug_brief"]
+        # FEAT-412: `bug_brief` only exists in the bug/revision topologies.
+        # Feature-mode and dev-flow reach this node with no intake brief at
+        # all, so read it defensively (see _NoBugBrief) rather than
+        # KeyError-ing before the skip_qa check below.
+        brief: Union[BugBrief, _NoBugBrief] = shared.get("bug_brief") or _NoBugBrief(
+            summary=self._briefless_summary(shared, research)
+        )
 
         runtime_skip = shared.get("skip_qa", False)
         if self._skip_qa or runtime_skip:
@@ -370,6 +394,27 @@ class QANode(DevLoopNode):
     # ------------------------------------------------------------------
     # Deterministic QA dispatch
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _briefless_summary(
+        shared: Dict[str, Any], research: ResearchOutput
+    ) -> str:
+        """Best-effort run label when there is no intake brief (FEAT-412).
+
+        Used only to populate ``_NoBugBrief.summary``, which the downstream
+        dispatch briefs echo so a reviewer/judge knows what the run is about.
+
+        Args:
+            shared: The flow's shared state.
+            research: The bridged research output (spec path, feat id).
+
+        Returns:
+            The feature document's path when a ``feature_brief`` is present,
+            else the spec path, else the FEAT id — never raises.
+        """
+        feature_brief = shared.get("feature_brief")
+        document = getattr(feature_brief, "document_path", "") or ""
+        return document or research.spec_path or research.feat_id or ""
 
     async def _run_deterministic_qa(
         self,

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/runner.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/runner.py
@@ -87,6 +87,8 @@ _GATE_TTL_CONF_ATTR: Dict[GateKind, str] = {
     "revision_approval": "DEV_LOOP_GATE_TTL_REVISION",
     "plan_approval": "DEV_LOOP_GATE_TTL_PLAN",
     "review_escalation": "DEV_LOOP_GATE_TTL_REVIEW_ESCALATION",
+    # FEAT-412 dev-flow: ideation Open-Questions round (fail-closed).
+    "open_questions": "DEV_FLOW_GATE_TTL_QUESTIONS",
 }
 
 
@@ -718,6 +720,7 @@ class DevLoopRunner:
         resolved_by: str,
         comment: str = "",
         origin: Optional[ActionOrigin] = None,
+        answers: Optional[Dict[str, str]] = None,
     ) -> ActionEnvelope:
         """Resolve a pending gate on ``run_id``'s host.
 
@@ -729,6 +732,9 @@ class DevLoopRunner:
             comment: Optional free-text audit comment.
             origin: Optional multi-client attribution (FEAT-322 TASK-1855 —
                 the REST command layer passes the calling client here).
+            answers: FEAT-412 — structured ``question -> answer`` mapping for
+                an ``open_questions`` gate (dev-flow ideation rounds).
+                Required when approving such a gate; ignored otherwise.
 
         Returns:
             The sequenced :class:`ActionEnvelope` for the resolution.
@@ -738,12 +744,14 @@ class DevLoopRunner:
                 terminated run).
             GateNotFoundError: ``gate_id`` does not exist on this run.
             GateAlreadyResolvedError: the gate is no longer pending.
+            ValueError: An ``open_questions`` gate is approved with no answers.
         """
         host = self._hosts.get(run_id)
         if host is None:
             raise KeyError(f"no active session host for run_id={run_id!r}")
         return host.resolve_gate(
-            gate_id, resolution, resolved_by, comment, origin=origin
+            gate_id, resolution, resolved_by, comment, origin=origin,
+            answers=answers,
         )
 
     async def cancel_run(self, run_id: str, requested_by: str) -> ActionEnvelope:

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/session_state.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/session_state.py
@@ -152,6 +152,10 @@ NodeId = Literal[
     "synthesis",
     "feedback_router",
     "feature_handoff",
+    # -- dev-flow intake topology (FEAT-412) --
+    # Additive only: dev-flow reuses every node id above from "planner" on.
+    "dev_intake",
+    "ideation",
 ]
 
 NodeStatus = Literal["idle", "running", "completed", "failed", "skipped"]
@@ -175,6 +179,7 @@ GateKind = Literal[
     "revision_approval",    # gate before pushing a revision to the PR
     "plan_approval",        # optional: approve ResearchOutput plan
     "review_escalation",    # FEAT-375: adversarial-review ESCALATE disposition
+    "open_questions",       # FEAT-412: dev-flow ideation Open Questions round
 ]
 
 GateStatus = Literal["pending", "approved", "rejected", "expired"]
@@ -249,6 +254,14 @@ class ApprovalGate(_Frozen):
     resolved_by: str = ""           # client/user identity — audit trail
     resolved_at: Optional[float] = None
     comment: str = ""
+    # -- FEAT-412: structured question/answer gates (kind="open_questions") --
+    # Additive and defaulted so pre-FEAT-412 persisted envelopes still
+    # validate (same precedent as DispatchState's TASK-1927 fields).
+    # ONE gate carries ALL Open Questions of an ideation round (spec §8);
+    # ``answers`` maps question -> answer and is folded on resolution.
+    # Partial answers are allowed: unanswered questions stay open in the doc.
+    questions: List[str] = Field(default_factory=list)
+    answers: Dict[str, str] = Field(default_factory=dict)
 
 
 class JudgeVerdict(_Frozen):
@@ -450,6 +463,10 @@ class GateResolved(_ActionBase):
     resolution: Literal["approved", "rejected"]
     resolved_by: str
     comment: str = ""
+    # FEAT-412: structured answers for an "open_questions" gate. Defaulted
+    # so pre-FEAT-412 persisted envelopes re-validate; folded into the
+    # gate by the reducer exactly like ``comment``.
+    answers: Dict[str, str] = Field(default_factory=dict)
 
 
 class GateExpired(_ActionBase):
@@ -831,6 +848,10 @@ def reduce(  # noqa: C901 — a flat, exhaustive match is the point
             "resolved_by": action.resolved_by,
             "resolved_at": action.ts,
             "comment": action.comment,
+            # FEAT-412: fold structured answers exactly like ``comment``.
+            # Empty for every non-``open_questions`` gate, so the previous
+            # (empty) value is preserved byte-identically.
+            "answers": dict(action.answers),
         })
         gates = {**state.gates, gate.gate_id: gate}
         return _recompute_phase(state.model_copy(update={"gates": gates}))
@@ -1038,6 +1059,7 @@ class SessionHost:
         resolved_by: str,
         comment: str = "",
         origin: Optional[ActionOrigin] = None,
+        answers: Optional[Dict[str, str]] = None,
     ) -> ActionEnvelope:
         """Client command path — validated BEFORE sequencing.
 
@@ -1052,6 +1074,11 @@ class SessionHost:
             comment: Optional free-text audit comment.
             origin: Optional multi-client attribution (FEAT-322 TASK-1855 —
                 the REST command layer records the calling client here).
+            answers: FEAT-412 — structured ``question -> answer`` mapping for
+                an ``open_questions`` gate. Required (non-empty) when
+                approving such a gate; ignored for every other kind. Partial
+                answers are allowed: questions the user left out simply stay
+                open in the ideation document.
 
         Returns:
             The sequenced :class:`ActionEnvelope` for the resolution.
@@ -1059,6 +1086,10 @@ class SessionHost:
         Raises:
             GateNotFoundError: ``gate_id`` does not exist.
             GateAlreadyResolvedError: the gate is no longer ``"pending"``.
+            ValueError: An ``open_questions`` gate is being approved with no
+                answers — approving an ideation round means answering at
+                least one question (rejection needs none: it aborts the
+                ideation).
         """
         gate = self._state.gates.get(gate_id)
         if gate is None:
@@ -1068,10 +1099,18 @@ class SessionHost:
                 f"gate {gate_id} already {gate.status} "
                 f"by {gate.resolved_by or 'system'}"
             )
+        answers = dict(answers or {})
+        if gate.kind == "open_questions" and resolution == "approved" and not answers:
+            raise ValueError(
+                f"gate {gate_id} is an 'open_questions' gate: approving it "
+                "requires at least one answer (use resolution='rejected' to "
+                "abort the ideation instead)"
+            )
         return self.apply(
             GateResolved(
                 gate_id=gate_id, resolution=resolution,
                 resolved_by=resolved_by, comment=comment,
+                answers=answers,
             ),
             origin=origin,
         )
@@ -1086,18 +1125,24 @@ class SessionHost:
         payload_ref: str = "",
         ttl_seconds: Optional[int] = None,
         on_expiry: Literal["fail", "approve"] = "fail",
+        questions: Optional[List[str]] = None,
     ) -> Tuple[str, ActionEnvelope]:
         """Open a new gate (convenience for QA/DeploymentHandoff nodes).
 
         Args:
             kind: The gate kind (``manual_criterion``, ``deployment_approval``,
-                ``revision_approval``, ``plan_approval``).
+                ``revision_approval``, ``plan_approval``,
+                ``review_escalation``, ``open_questions``).
             node_id: The node opening the gate.
             title: Short human-readable title.
             instructions: Longer instructions/context for the approver.
             payload_ref: Changeset/terminal URI carrying supporting evidence.
             ttl_seconds: Optional per-gate TTL override.
             on_expiry: ``"fail"`` (fail-closed) or ``"approve"`` (fail-open).
+            questions: FEAT-412 — the structured Open Questions carried by an
+                ``open_questions`` gate (ONE gate per ideation round holds
+                ALL of that round's questions). The UI renders one input per
+                entry and POSTs back an ``answers`` mapping.
 
         Returns:
             A ``(gate_id, envelope)`` tuple.
@@ -1110,6 +1155,7 @@ class SessionHost:
             opened_at=now,
             expires_at=(now + ttl_seconds) if ttl_seconds else None,
             on_expiry=on_expiry,
+            questions=list(questions or []),
         )
         return gate.gate_id, self.apply(GateOpened(gate=gate))
 

--- a/packages/ai-parrot/tests/flows/dev_flow/test_definition.py
+++ b/packages/ai-parrot/tests/flows/dev_flow/test_definition.py
@@ -1,0 +1,220 @@
+"""Declarative dev-flow definition tests (FEAT-412, TASK-2127).
+
+Pins the node/edge inventory of spec §2 exactly: the two dev-flow intake
+nodes plus the eight reused ``dev_loop`` nodes, the intake fork's CEL
+predicates, the reused chain's predicates (which must stay identical to
+feature-mode's), and the deliberate ABSENCE of every operations node.
+"""
+
+from __future__ import annotations
+
+from parrot.flows.dev_flow.definition import build_dev_flow_definition
+
+# The exact 10-node inventory (spec §2 New Public Interfaces).
+_EXPECTED_TYPES = {
+    "dev_flow.dev_intake",
+    "dev_flow.ideation",
+    "dev_loop.planner",
+    "dev_loop.development",
+    "dev_loop.synthesis",
+    "dev_loop.qa",
+    "dev_loop.feedback_router",
+    "dev_loop.feature_handoff",
+    "dev_loop.failure_handler",
+    "dev_loop.close",
+}
+
+
+def _defn():
+    return build_dev_flow_definition()
+
+
+def _edges(defn):
+    return {(e.from_, e.to, e.condition) for e in defn.edges}
+
+
+# ---------------------------------------------------------------------------
+# Validity + inventory
+# ---------------------------------------------------------------------------
+
+
+def test_definition_validates():
+    """Construction runs FlowDefinition's own validation (incl. acyclicity)."""
+    defn = _defn()
+    assert defn.flow == "dev-flow"
+    assert defn.description
+    assert len(defn.nodes) == 10
+
+
+def test_node_inventory_matches_spec():
+    defn = _defn()
+    assert {n.type for n in defn.nodes} == _EXPECTED_TYPES
+    # Node ids are the types' short names.
+    assert {n.id for n in defn.nodes} == {
+        "dev_intake", "ideation", "planner", "development", "synthesis",
+        "qa", "feedback_router", "feature_handoff", "failure_handler", "close",
+    }
+    # No duplicates.
+    assert len({n.id for n in defn.nodes}) == len(defn.nodes)
+
+
+def test_no_ops_nodes_present():
+    """dev-flow front-loads no operations concerns (spec §2 Overview)."""
+    defn = _defn()
+    ids = {n.id for n in defn.nodes}
+    types = {n.type for n in defn.nodes}
+    for absent in (
+        "bug_intake", "research", "deployment_handoff", "revision_handoff",
+        "intent_classifier",
+    ):
+        assert absent not in ids
+        assert f"dev_loop.{absent}" not in types
+
+
+# ---------------------------------------------------------------------------
+# Intake fork
+# ---------------------------------------------------------------------------
+
+
+def test_intake_fork_edges_and_predicates():
+    defn = _defn()
+    by_pair = {
+        (e.from_, e.to): e for e in defn.edges if e.condition == "on_condition"
+    }
+
+    nl_edge = by_pair[("dev_intake", "ideation")]
+    assert nl_edge.predicate == (
+        'result.kind == "enhancement" || result.kind == "new_feature"'
+    )
+
+    doc_edge = by_pair[("dev_intake", "planner")]
+    assert doc_edge.predicate == 'result.kind == "feature"'
+
+
+def test_ideation_merges_into_planner_on_success():
+    defn = _defn()
+    assert ("ideation", "planner", "on_success") in _edges(defn)
+
+
+def test_planner_is_an_or_join():
+    """Two predecessors — this is why explicit-edge execution is mandatory."""
+    defn = _defn()
+    preds = {e.from_ for e in defn.edges if e.to == "planner"}
+    assert preds == {"dev_intake", "ideation"}
+
+
+# ---------------------------------------------------------------------------
+# Reused FEAT-378 chain
+# ---------------------------------------------------------------------------
+
+
+def test_reused_chain_edges():
+    defn = _defn()
+    edges = _edges(defn)
+    for pair in (
+        ("planner", "development"),
+        ("development", "synthesis"),
+        ("synthesis", "qa"),
+        ("feature_handoff", "close"),
+    ):
+        assert (*pair, "on_success") in edges
+
+
+def test_edge_predicates_match_feature_mode_verbatim():
+    """The reused chain's CEL strings must be identical to feature-mode's."""
+    from parrot.flows.dev_loop.definition import (
+        _CEL_FEEDBACK_ACCEPT,
+        _CEL_FEEDBACK_ESCALATE,
+        _CEL_FEEDBACK_RETRY,
+        _CEL_QA_FAILED,
+        _CEL_QA_PASSED,
+    )
+
+    defn = _defn()
+    by_pair = {
+        (e.from_, e.to): e.predicate
+        for e in defn.edges
+        if e.condition == "on_condition"
+    }
+    assert by_pair[("qa", "feature_handoff")] == _CEL_QA_PASSED
+    assert by_pair[("qa", "feedback_router")] == _CEL_QA_FAILED
+    assert by_pair[("feedback_router", "failure_handler")] == _CEL_FEEDBACK_ESCALATE
+    assert by_pair[("feedback_router", "feature_handoff")] == _CEL_FEEDBACK_ACCEPT
+    assert by_pair[("feedback_router", "development")] == _CEL_FEEDBACK_RETRY
+    # Sanity: these are the literal strings the spec quotes.
+    assert by_pair[("qa", "feature_handoff")] == "result.passed == true"
+    assert by_pair[("feedback_router", "development")] == (
+        'result.decision == "retry"'
+    )
+
+
+def test_qa_routes_to_exactly_two_targets():
+    """Feature-mode QA routing: passed -> handoff, failed -> feedback_router.
+
+    Notably NOT the bug-mode `qa -> development` / `qa -> failure_handler`
+    retry pair — in this chain the repair loop is driven by the router.
+    """
+    defn = _defn()
+    qa_conditional = {
+        e.to for e in defn.edges
+        if e.from_ == "qa" and e.condition == "on_condition"
+    }
+    assert qa_conditional == {"feature_handoff", "feedback_router"}
+
+
+def test_repair_loop_back_edge_present():
+    defn = _defn()
+    assert ("feedback_router", "development", "on_condition") in _edges(defn)
+
+
+def test_feature_handoff_is_an_or_join():
+    defn = _defn()
+    preds = {
+        e.from_ for e in defn.edges
+        if e.to == "feature_handoff" and e.condition != "on_error"
+    }
+    assert preds == {"qa", "feedback_router"}
+
+
+# ---------------------------------------------------------------------------
+# on_error fan-in
+# ---------------------------------------------------------------------------
+
+
+def test_on_error_fan_in_covers_every_middle_node():
+    defn = _defn()
+    sources = {
+        e.from_ for e in defn.edges
+        if e.to == "failure_handler" and e.condition == "on_error"
+    }
+    assert sources == {
+        "dev_intake", "ideation", "planner", "development", "synthesis",
+        "qa", "feedback_router", "feature_handoff",
+    }
+    # The terminals themselves have no on_error edge.
+    assert "close" not in sources
+    assert "failure_handler" not in sources
+
+
+def test_every_on_condition_edge_has_a_predicate():
+    defn = _defn()
+    for edge in defn.edges:
+        if edge.condition == "on_condition":
+            assert edge.predicate, f"{edge.from_}->{edge.to} lacks a predicate"
+
+
+def test_edge_count_is_exact():
+    """13 routing edges + 8 on_error edges."""
+    defn = _defn()
+    routing = [e for e in defn.edges if e.condition != "on_error"]
+    on_error = [e for e in defn.edges if e.condition == "on_error"]
+    assert len(routing) == 12
+    assert len(on_error) == 8
+    assert len(defn.edges) == 20
+
+
+def test_definition_is_deterministic():
+    """Pure function: no env reads, same output every call."""
+    first, second = _defn(), _defn()
+    assert _edges(first) == _edges(second)
+    assert [n.id for n in first.nodes] == [n.id for n in second.nodes]

--- a/packages/ai-parrot/tests/flows/dev_flow/test_dev_intake.py
+++ b/packages/ai-parrot/tests/flows/dev_flow/test_dev_intake.py
@@ -1,0 +1,327 @@
+"""Unit tests for DevIntakeNode (FEAT-412, TASK-2125).
+
+Covers brief loading (ctx instance / ctx dict / JSON prompt), the per-kind
+publication contract (`dev_brief` always, `feature_brief` only for the
+document intake), the `flow.intake_validated` event, and fail-before-return
+validation.
+
+The Redis client is mocked exactly as ``test_intent_classifier.py`` does it,
+so no live Redis is needed.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from parrot.flows.dev_flow.models import DevRequestBrief
+from parrot.flows.dev_flow.nodes.dev_intake import DevIntakeNode
+from parrot.flows.dev_loop.models import FeatureBrief
+
+RUN_ID = "run-devintake01"
+
+
+@pytest.fixture
+def node(monkeypatch) -> DevIntakeNode:
+    """Node with a mocked Redis client so no live Redis is needed."""
+    n = DevIntakeNode(redis_url="redis://localhost:6379/0")
+    fake_redis = AsyncMock()
+    fake_redis.xadd = AsyncMock(return_value=b"1-0")
+
+    async def _ensure_redis():
+        return fake_redis
+
+    monkeypatch.setattr(n, "_ensure_redis", _ensure_redis)
+    n._fake_redis = fake_redis  # type: ignore[attr-defined]
+    return n
+
+
+@pytest.fixture
+def nl_brief() -> DevRequestBrief:
+    return DevRequestBrief(
+        kind="enhancement",
+        title="compression budget telemetry",
+        description="Add per-tool telemetry to the compression budget.",
+    )
+
+
+@pytest.fixture
+def doc_brief(tmp_path) -> FeatureBrief:
+    doc = tmp_path / "existing-idea.proposal.md"
+    doc.write_text("# Proposal", encoding="utf-8")
+    return FeatureBrief(document_path=str(doc), document_kind="proposal")
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_node_is_registered():
+    from parrot.bots.flows.flow.flow import NODE_REGISTRY
+
+    assert "dev_flow.dev_intake" in NODE_REGISTRY
+    assert NODE_REGISTRY["dev_flow.dev_intake"] is DevIntakeNode
+
+
+def test_default_node_id():
+    n = DevIntakeNode(redis_url="redis://localhost:6379/0")
+    assert n.name == "dev_intake"
+    # Constructible without a live Redis (lazy connect).
+    assert n._redis is None
+
+
+# ---------------------------------------------------------------------------
+# Brief loading
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loads_brief_from_ctx(node, nl_brief):
+    ctx = {"run_id": RUN_ID, "dev_brief": nl_brief}
+
+    result = await node.execute(ctx)
+
+    assert result is nl_brief
+    assert ctx["dev_brief"] is nl_brief
+    # A natural-language intake must NOT pre-populate feature_brief —
+    # IdeationNode produces it later.
+    assert "feature_brief" not in ctx
+
+
+@pytest.mark.asyncio
+async def test_loads_brief_from_ctx_dict(node):
+    ctx = {
+        "run_id": RUN_ID,
+        "dev_brief": {
+            "kind": "new_feature",
+            "title": "t",
+            "description": "d",
+        },
+    }
+
+    result = await node.execute(ctx)
+
+    assert isinstance(result, DevRequestBrief)
+    assert result.kind == "new_feature"
+    assert ctx["dev_brief"] is result
+
+
+@pytest.mark.asyncio
+async def test_loads_brief_from_json_prompt(node):
+    ctx = {
+        "run_id": RUN_ID,
+        "initial_task": json.dumps(
+            {"kind": "enhancement", "title": "t", "description": "d"}
+        ),
+    }
+
+    result = await node.execute(ctx)
+
+    assert isinstance(result, DevRequestBrief)
+    assert result.kind == "enhancement"
+    assert ctx["dev_brief"] is result
+
+
+@pytest.mark.asyncio
+async def test_no_source_raises(node):
+    with pytest.raises(ValueError, match="requires ctx"):
+        await node.execute({"run_id": RUN_ID})
+
+
+# ---------------------------------------------------------------------------
+# Kind routing / publication
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_returns_brief_for_cel_routing(node, nl_brief):
+    """The topology routes on `result.kind`, so it must be on the result."""
+    result = await node.execute({"run_id": RUN_ID, "dev_brief": nl_brief})
+    assert result.kind == "enhancement"
+
+    doc_result = await node.execute(
+        {"run_id": RUN_ID, "dev_brief": nl_brief.model_copy(
+            update={"kind": "new_feature"}
+        )}
+    )
+    assert doc_result.kind == "new_feature"
+
+
+@pytest.mark.asyncio
+async def test_feature_kind_publishes_feature_brief(node, doc_brief):
+    """`feature` intake hands the document straight to PlannerNode's key."""
+    ctx = {"run_id": RUN_ID, "dev_brief": doc_brief}
+
+    result = await node.execute(ctx)
+
+    assert result is doc_brief
+    assert result.kind == "feature"
+    assert ctx["feature_brief"] is doc_brief
+    assert ctx["dev_brief"] is doc_brief
+
+
+@pytest.mark.asyncio
+async def test_feature_brief_accepted_from_its_own_key(node, doc_brief):
+    ctx = {"run_id": RUN_ID, "feature_brief": doc_brief}
+
+    result = await node.execute(ctx)
+
+    assert result is doc_brief
+    assert ctx["dev_brief"] is doc_brief
+
+
+@pytest.mark.asyncio
+async def test_never_publishes_bug_mode_keys(node, nl_brief, doc_brief):
+    """dev-flow never populates the bug-mode keys."""
+    for brief in (nl_brief, doc_brief):
+        ctx = {"run_id": RUN_ID, "dev_brief": brief}
+        await node.execute(ctx)
+        assert "bug_brief" not in ctx
+        assert "work_brief" not in ctx
+
+
+# ---------------------------------------------------------------------------
+# Validation happens before return
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalid_brief_raises_before_return(node, tmp_path):
+    """An unreadable FeatureBrief.document_path fails at load time."""
+    ctx = {
+        "run_id": RUN_ID,
+        "dev_brief": {
+            "kind": "feature",
+            "document_path": str(tmp_path / "missing.spec.md"),
+            "document_kind": "spec",
+        },
+    }
+
+    with pytest.raises(ValueError):
+        await node.execute(ctx)
+
+    # Nothing published, no event emitted.
+    assert not isinstance(ctx.get("dev_brief"), FeatureBrief)
+    assert "feature_brief" not in ctx
+    assert node._fake_redis.xadd.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_unknown_kind_raises(node):
+    ctx = {
+        "run_id": RUN_ID,
+        "dev_brief": {"kind": "bug", "title": "t", "description": "d"},
+    }
+    with pytest.raises(ValueError, match="explicit kind"):
+        await node.execute(ctx)
+    assert node._fake_redis.xadd.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_missing_required_field_raises(node):
+    ctx = {"run_id": RUN_ID, "dev_brief": {"kind": "enhancement", "title": "t"}}
+    with pytest.raises(ValueError):
+        await node.execute(ctx)
+
+
+# ---------------------------------------------------------------------------
+# flow.intake_validated event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_emits_intake_validated_event(node, nl_brief):
+    await node.execute({"run_id": RUN_ID, "dev_brief": nl_brief})
+
+    assert node._fake_redis.xadd.await_count == 1
+    args, kwargs = node._fake_redis.xadd.await_args
+    assert args[0] == f"flow:{RUN_ID}:flow"
+    envelope = json.loads(args[1]["event"])
+    assert envelope["kind"] == "flow.intake_validated"
+    assert envelope["run_id"] == RUN_ID
+    assert envelope["node_id"] == "dev_intake"
+    assert envelope["payload"]["kind"] == "enhancement"
+    assert envelope["payload"]["title"] == "compression budget telemetry"
+    assert kwargs["maxlen"] == 10_000
+    assert kwargs["approximate"] is True
+
+
+@pytest.mark.asyncio
+async def test_event_payload_for_feature_kind(node, doc_brief):
+    await node.execute({"run_id": RUN_ID, "dev_brief": doc_brief})
+
+    envelope = json.loads(node._fake_redis.xadd.await_args[0][1]["event"])
+    payload = envelope["payload"]
+    assert payload["kind"] == "feature"
+    assert payload["document_kind"] == "proposal"
+    assert payload["document_path"] == doc_brief.document_path
+    # NL-only fields must not leak into the document payload.
+    assert "title" not in payload
+
+
+@pytest.mark.asyncio
+async def test_no_run_id_skips_event(node, nl_brief):
+    ctx = {"dev_brief": nl_brief}
+
+    result = await node.execute(ctx)
+
+    assert result is nl_brief
+    assert node._fake_redis.xadd.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_redis_failure_does_not_break_the_node(monkeypatch, nl_brief):
+    """A degraded Redis drops the event but must never fail the run."""
+    n = DevIntakeNode(redis_url="redis://localhost:6379/0")
+
+    async def _boom():
+        raise RuntimeError("redis is down")
+
+    monkeypatch.setattr(n, "_ensure_redis", _boom)
+
+    result = await n.execute({"run_id": RUN_ID, "dev_brief": nl_brief})
+
+    assert result is nl_brief
+
+
+@pytest.mark.asyncio
+async def test_xadd_failure_does_not_break_the_node(monkeypatch, nl_brief):
+    n = DevIntakeNode(redis_url="redis://localhost:6379/0")
+    fake_redis = AsyncMock()
+    fake_redis.xadd = AsyncMock(side_effect=RuntimeError("stream gone"))
+
+    async def _ensure_redis():
+        return fake_redis
+
+    monkeypatch.setattr(n, "_ensure_redis", _ensure_redis)
+
+    result = await n.execute({"run_id": RUN_ID, "dev_brief": nl_brief})
+
+    assert result is nl_brief
+
+
+# ---------------------------------------------------------------------------
+# close()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_close_releases_client():
+    n = DevIntakeNode(redis_url="redis://localhost:6379/0")
+    fake_redis = AsyncMock()
+    fake_redis.aclose = AsyncMock()
+    n._redis = fake_redis  # type: ignore[attr-defined]
+
+    await n.close()
+
+    fake_redis.aclose.assert_awaited_once()
+    assert n._redis is None
+
+
+@pytest.mark.asyncio
+async def test_close_is_safe_without_client():
+    n = DevIntakeNode(redis_url="redis://localhost:6379/0")
+    await n.close()  # must not raise
+    assert n._redis is None

--- a/packages/ai-parrot/tests/flows/dev_flow/test_flow_parity.py
+++ b/packages/ai-parrot/tests/flows/dev_flow/test_flow_parity.py
@@ -1,0 +1,179 @@
+"""Declarative ↔ imperative parity for the dev-flow (FEAT-412, TASK-2127).
+
+The dev-flow is authored declaratively (``build_dev_flow_definition``) but
+executed in explicit-edge mode (``build_dev_flow`` re-declares every edge),
+because the ``planner`` / ``feature_handoff`` / ``failure_handler`` OR-joins
+cannot be fired by the ``from_definition`` AND-join scheduler. That split is
+only safe if the two layers agree edge-for-edge — this module is that guard,
+modelled on ``test_feature_flow.py::test_definition_parity_feature_mode``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from parrot.flows.dev_flow.definition import build_dev_flow_definition
+from parrot.flows.dev_flow.flow import build_dev_flow
+
+
+def _flow():
+    return build_dev_flow(
+        dispatcher=MagicMock(),
+        redis_url="redis://x",
+        publish_flow_events=False,
+    )
+
+
+def _normalize(condition: str) -> str:
+    """Declarative ``on_success`` == imperative default ``always``.
+
+    Pre-existing vocabulary difference between the two layers, established by
+    the dev_loop topologies (``definition.py``'s ``on_success`` edges become
+    bare ``flow.add_edge()`` calls, which default to ``condition="always"``).
+    """
+    return "always" if condition == "on_success" else condition
+
+
+# ---------------------------------------------------------------------------
+# Parity
+# ---------------------------------------------------------------------------
+
+
+def test_declarative_imperative_parity():
+    definition = build_dev_flow_definition()
+    flow = _flow()
+
+    assert {n.id for n in definition.nodes} == set(flow._nodes)
+
+    decl_edges = {
+        (e.from_, e.to, _normalize(e.condition)) for e in definition.edges
+    }
+    imp_edges = {(e.from_, e.to, e.condition) for e in flow._edges}
+    assert decl_edges == imp_edges
+
+    # Every on_condition edge on BOTH sides actually carries a predicate —
+    # a declarative predicate with no imperative twin would silently never
+    # route.
+    decl_predicated = {
+        (e.from_, e.to) for e in definition.edges if e.condition == "on_condition"
+    }
+    imp_predicated = {
+        (e.from_, e.to) for e in flow._edges
+        if e.condition == "on_condition" and e.predicate is not None
+    }
+    assert decl_predicated == imp_predicated
+
+
+def test_flow_is_named_dev_flow():
+    assert _flow().name == "dev-flow"
+    custom = build_dev_flow(
+        dispatcher=MagicMock(), redis_url="redis://x",
+        name="my-dev-flow", publish_flow_events=False,
+    )
+    assert custom.name == "my-dev-flow"
+
+
+def test_flow_carries_its_definition():
+    flow = _flow()
+    assert flow._dev_loop_definition.flow == "dev-flow"
+
+
+def test_publisher_attached_only_when_requested():
+    assert _flow()._event_publisher is None
+    published = build_dev_flow(
+        dispatcher=MagicMock(), redis_url="redis://x", publish_flow_events=True
+    )
+    assert published._event_publisher is not None
+
+
+# ---------------------------------------------------------------------------
+# Materialized nodes
+# ---------------------------------------------------------------------------
+
+
+def test_all_ten_nodes_materialize():
+    from parrot.flows.dev_flow.nodes.dev_intake import DevIntakeNode
+    from parrot.flows.dev_flow.nodes.ideation import IdeationNode
+
+    flow = _flow()
+    assert len(flow._nodes) == 10
+    assert isinstance(flow._nodes["dev_intake"], DevIntakeNode)
+    assert isinstance(flow._nodes["ideation"], IdeationNode)
+    # The reused chain materializes the real dev_loop node classes.
+    from parrot.flows.dev_loop.nodes.planner import PlannerNode
+
+    assert isinstance(flow._nodes["planner"], PlannerNode)
+
+
+def test_nodes_carry_edge_derived_dependencies():
+    """The factories stamp dependencies/successors from the edge list."""
+    flow = _flow()
+    assert flow._nodes["ideation"].dependencies == {"dev_intake"}
+    # planner's OR-join: both intakes are upstream.
+    assert flow._nodes["planner"].dependencies == {"dev_intake", "ideation"}
+    assert "planner" in flow._nodes["dev_intake"].successors
+    assert "ideation" in flow._nodes["dev_intake"].successors
+
+
+def test_ideation_receives_max_rounds_and_wiki():
+    wiki = MagicMock()
+    flow = build_dev_flow(
+        dispatcher=MagicMock(), redis_url="redis://x",
+        wiki_search=wiki, ideation_max_rounds=5, publish_flow_events=False,
+    )
+    ideation = flow._nodes["ideation"]
+    assert ideation._max_rounds == 5
+    assert ideation._wiki_search is wiki
+
+
+def test_require_plan_approval_reaches_development():
+    flow = build_dev_flow(
+        dispatcher=MagicMock(), redis_url="redis://x",
+        require_plan_approval=True, publish_flow_events=False,
+    )
+    assert flow._nodes["development"]._require_plan_approval is True
+    # Default stays False (per-run shared-state override does the rest).
+    assert _flow()._nodes["development"]._require_plan_approval is False
+
+
+# ---------------------------------------------------------------------------
+# Python routing predicates mirror the CEL strings
+# ---------------------------------------------------------------------------
+
+
+def test_python_predicates_match_cel_semantics():
+    from parrot.bots.flows.flow.cel_evaluator import CELPredicateEvaluator
+    from parrot.flows.dev_flow.definition import (
+        _CEL_IS_FEATURE_DOC,
+        _CEL_IS_NL_REQUEST,
+    )
+    from parrot.flows.dev_flow.flow import _is_feature_doc, _is_nl_request
+
+    class _Result:
+        def __init__(self, kind):
+            self.kind = kind
+
+    for kind, is_nl, is_doc in (
+        ("enhancement", True, False),
+        ("new_feature", True, False),
+        ("feature", False, True),
+        ("bug", False, False),
+    ):
+        result = _Result(kind)
+        assert _is_nl_request(result) is is_nl
+        assert _is_feature_doc(result) is is_doc
+        assert CELPredicateEvaluator(_CEL_IS_NL_REQUEST)(result) is is_nl
+        assert CELPredicateEvaluator(_CEL_IS_FEATURE_DOC)(result) is is_doc
+
+
+def test_intake_fork_predicates_are_mutually_exclusive():
+    """Exactly one intake edge may fire for any given brief kind."""
+    from parrot.flows.dev_flow.flow import _is_feature_doc, _is_nl_request
+
+    class _Result:
+        def __init__(self, kind):
+            self.kind = kind
+
+    for kind in ("enhancement", "new_feature", "feature"):
+        result = _Result(kind)
+        assert sum((_is_nl_request(result), _is_feature_doc(result))) == 1

--- a/packages/ai-parrot/tests/flows/dev_flow/test_ideation_node.py
+++ b/packages/ai-parrot/tests/flows/dev_flow/test_ideation_node.py
@@ -1,0 +1,540 @@
+"""Unit tests for IdeationNode — the FEAT-412 HITL round-trip (TASK-2126).
+
+Exercises the normative sequence of spec §2 with a **scripted fake
+dispatcher** (no Claude SDK, no Redis): mode selection per intent, ONE gate
+per round carrying all questions, answers reaching the re-dispatch payload,
+the round bound, the fail-closed/rejection paths, the `committed=False`
+fail-fast, and the gateless autonomous fallback.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from parrot.flows.dev_flow.models import DevRequestBrief, IdeationOutput
+from parrot.flows.dev_flow.nodes.ideation import IdeationNode
+from parrot.flows.dev_loop.models import DevAgentSpec, FeatureBrief, JudgePanelConfig
+from parrot.flows.dev_loop.session_state import SessionHost
+
+RUN_ID = "run-ideation01"
+
+Q1 = "Which store backs the telemetry?"
+Q2 = "Sync or async flush?"
+
+
+class ScriptedDispatcher:
+    """Returns a pre-scripted IdeationOutput per dispatch, recording payloads.
+
+    Mirrors the ``fake_ideation_dispatcher`` fixture the task specifies:
+    round 1 → open questions; round 2 (with answers) → none, committed.
+    """
+
+    def __init__(self, outputs: list[IdeationOutput]) -> None:
+        self._outputs = list(outputs)
+        self.calls: list[dict[str, Any]] = []
+
+    async def dispatch(
+        self,
+        *,
+        brief: Any,
+        profile: Any,
+        output_model: Any,
+        run_id: str,
+        node_id: str,
+        cwd: str,
+        session_host: Any = None,
+    ) -> Any:
+        self.calls.append(
+            {
+                "brief": brief,
+                "profile": profile,
+                "output_model": output_model,
+                "run_id": run_id,
+                "node_id": node_id,
+                "cwd": cwd,
+                "session_host": session_host,
+            }
+        )
+        if not self._outputs:
+            raise AssertionError("ScriptedDispatcher exhausted — unexpected dispatch")
+        return self._outputs.pop(0)
+
+
+@pytest.fixture
+def doc(tmp_path, monkeypatch):
+    """A committed-looking document under a fake PROJECT_ROOT."""
+    proposals = tmp_path / "sdd" / "proposals"
+    proposals.mkdir(parents=True)
+    path = proposals / "telemetry.brainstorm.md"
+    path.write_text("# Brainstorm", encoding="utf-8")
+
+    from parrot import conf
+
+    monkeypatch.setattr(conf, "PROJECT_ROOT", tmp_path, raising=False)
+    return path
+
+
+@pytest.fixture
+def proposal_doc(tmp_path, monkeypatch):
+    proposals = tmp_path / "sdd" / "proposals"
+    proposals.mkdir(parents=True, exist_ok=True)
+    path = proposals / "telemetry.proposal.md"
+    path.write_text("# Proposal", encoding="utf-8")
+
+    from parrot import conf
+
+    monkeypatch.setattr(conf, "PROJECT_ROOT", tmp_path, raising=False)
+    return path
+
+
+def _brief(kind: str = "new_feature", **extra) -> DevRequestBrief:
+    return DevRequestBrief(
+        kind=kind,
+        title="compression budget telemetry",
+        description="Add per-tool telemetry to the compression budget.",
+        **extra,
+    )
+
+
+def _output(**over) -> IdeationOutput:
+    base = {
+        "document_path": "sdd/proposals/telemetry.brainstorm.md",
+        "document_kind": "brainstorm",
+        "slug": "telemetry",
+        "committed": True,
+    }
+    base.update(over)
+    return IdeationOutput(**base)
+
+
+async def _answer_gate(host: SessionHost, answers: dict[str, str]) -> None:
+    """Approve the single pending gate with `answers`."""
+    await asyncio.sleep(0.01)
+    gate_id = next(
+        g for g, gate in host.state.gates.items() if gate.status == "pending"
+    )
+    host.resolve_gate(gate_id, "approved", resolved_by="alice", answers=answers)
+
+
+# ---------------------------------------------------------------------------
+# Registration + mode selection
+# ---------------------------------------------------------------------------
+
+
+def test_node_is_registered():
+    from parrot.bots.flows.flow.flow import NODE_REGISTRY
+
+    assert "dev_flow.ideation" in NODE_REGISTRY
+    assert NODE_REGISTRY["dev_flow.ideation"] is IdeationNode
+
+
+@pytest.mark.asyncio
+async def test_new_feature_emits_brainstorm(doc):
+    dispatcher = ScriptedDispatcher([_output()])
+    node = IdeationNode(dispatcher=dispatcher)
+    ctx = {"run_id": RUN_ID, "dev_brief": _brief("new_feature")}
+
+    result = await node.execute(ctx)
+
+    assert dispatcher.calls[0]["brief"].mode == "brainstorm"
+    assert isinstance(result, FeatureBrief)
+    assert result.document_kind == "brainstorm"
+    assert ctx["feature_brief"] is result
+
+
+@pytest.mark.asyncio
+async def test_enhancement_emits_proposal(proposal_doc):
+    dispatcher = ScriptedDispatcher(
+        [
+            _output(
+                document_path="sdd/proposals/telemetry.proposal.md",
+                document_kind="proposal",
+            )
+        ]
+    )
+    node = IdeationNode(dispatcher=dispatcher)
+    ctx = {"run_id": RUN_ID, "dev_brief": _brief("enhancement")}
+
+    result = await node.execute(ctx)
+
+    assert dispatcher.calls[0]["brief"].mode == "proposal"
+    assert result.document_kind == "proposal"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_payload_and_profile(doc):
+    dispatcher = ScriptedDispatcher([_output()])
+    node = IdeationNode(dispatcher=dispatcher)
+    brief = _brief("new_feature", context="see PR #12")
+
+    await node.execute({"run_id": RUN_ID, "dev_brief": brief})
+
+    call = dispatcher.calls[0]
+    payload = call["brief"]
+    assert payload.title == brief.title
+    assert payload.description == brief.description
+    assert payload.context == "see PR #12"
+    assert payload.answers == {}
+    assert payload.document_path == ""
+    assert payload.round == 1
+    assert call["output_model"] is IdeationOutput
+    assert call["run_id"] == RUN_ID
+    assert call["node_id"] == "ideation"
+
+    profile = call["profile"]
+    # The prompt travels as a system prompt — dev_loop's loader must not be
+    # asked for a dev_flow-owned subagent name.
+    assert profile.subagent is None
+    assert "SDD Ideation" in profile.system_prompt_override
+    assert profile.permission_mode == "acceptEdits"
+    for tool in ("Read", "Write", "Edit", "Bash"):
+        assert tool in profile.allowed_tools
+
+
+# ---------------------------------------------------------------------------
+# Passthrough into the FeatureBrief
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_passthrough_jira_pool_and_panel(doc):
+    dispatcher = ScriptedDispatcher([_output()])
+    node = IdeationNode(dispatcher=dispatcher)
+    brief = _brief(
+        "new_feature",
+        jira_issue_key="PARROT-7",
+        dev_agents=[DevAgentSpec(agent="claude-code", count=3)],
+        judge_panel=JudgePanelConfig(judges=[{"agent": "codex"}]),
+    )
+
+    result = await node.execute({"run_id": RUN_ID, "dev_brief": brief})
+
+    assert result.jira_issue_key == "PARROT-7"
+    assert result.dev_agents is not None
+    assert result.dev_agents[0].count == 3
+    assert result.judge_panel is not None
+
+
+@pytest.mark.asyncio
+async def test_resumed_existing_flag_passthrough(doc):
+    dispatcher = ScriptedDispatcher([_output(resumed_existing=True)])
+    node = IdeationNode(dispatcher=dispatcher)
+    ctx = {"run_id": RUN_ID, "dev_brief": _brief()}
+
+    await node.execute(ctx)
+
+    assert ctx["ideation_output"].resumed_existing is True
+
+
+# ---------------------------------------------------------------------------
+# The HITL round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gate_roundtrip_answers_reach_redispatch(doc):
+    """Round 1 asks 2 questions; the answers land in the round-2 payload."""
+    dispatcher = ScriptedDispatcher(
+        [_output(open_questions=[Q1, Q2], committed=True), _output()]
+    )
+    node = IdeationNode(dispatcher=dispatcher)
+    host = SessionHost(RUN_ID)
+    ctx = {"run_id": RUN_ID, "dev_brief": _brief(), "session_host": host}
+    answers = {Q1: "pgvector", Q2: "async"}
+
+    resolver = asyncio.ensure_future(_answer_gate(host, answers))
+    result = await node.execute(ctx)
+    await resolver
+
+    # ONE gate for the whole round, carrying ALL questions.
+    assert len(host.state.gates) == 1
+    gate = next(iter(host.state.gates.values()))
+    assert gate.kind == "open_questions"
+    assert gate.questions == [Q1, Q2]
+    assert gate.node_id == "ideation"
+    assert gate.on_expiry == "fail"  # fail-closed
+    # The document path is in the title so an unintended resume is visible.
+    assert "sdd/proposals/telemetry.brainstorm.md" in gate.title
+
+    # Round 2 received the answers and the document to resume.
+    assert len(dispatcher.calls) == 2
+    second = dispatcher.calls[1]["brief"]
+    assert second.answers == answers
+    assert second.document_path == "sdd/proposals/telemetry.brainstorm.md"
+    assert second.round == 2
+    assert isinstance(result, FeatureBrief)
+
+
+@pytest.mark.asyncio
+async def test_partial_answers_are_accepted(doc):
+    dispatcher = ScriptedDispatcher([_output(open_questions=[Q1, Q2]), _output()])
+    node = IdeationNode(dispatcher=dispatcher)
+    host = SessionHost(RUN_ID)
+
+    resolver = asyncio.ensure_future(_answer_gate(host, {Q1: "pgvector"}))
+    await node.execute(
+        {"run_id": RUN_ID, "dev_brief": _brief(), "session_host": host}
+    )
+    await resolver
+
+    assert dispatcher.calls[1]["brief"].answers == {Q1: "pgvector"}
+
+
+@pytest.mark.asyncio
+async def test_no_questions_means_no_gate(doc):
+    dispatcher = ScriptedDispatcher([_output()])
+    node = IdeationNode(dispatcher=dispatcher)
+    host = SessionHost(RUN_ID)
+
+    await asyncio.wait_for(
+        node.execute(
+            {"run_id": RUN_ID, "dev_brief": _brief(), "session_host": host}
+        ),
+        timeout=2,
+    )
+
+    assert host.state.gates == {}
+    assert len(dispatcher.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_rounds_bounded(doc):
+    """A subagent that keeps asking stops after DEV_FLOW_IDEATION_MAX_ROUNDS."""
+    # Always returns open questions; 1 initial + max_rounds re-dispatches.
+    dispatcher = ScriptedDispatcher([_output(open_questions=[Q1]) for _ in range(4)])
+    node = IdeationNode(dispatcher=dispatcher, ideation_max_rounds=2)
+    host = SessionHost(RUN_ID)
+
+    async def _answer_all():
+        for _ in range(2):
+            await _answer_gate(host, {Q1: "an answer"})
+
+    resolver = asyncio.ensure_future(_answer_all())
+    result = await asyncio.wait_for(
+        node.execute(
+            {"run_id": RUN_ID, "dev_brief": _brief(), "session_host": host}
+        ),
+        timeout=5,
+    )
+    await resolver
+
+    # Exactly max_rounds gates, and 1 + max_rounds dispatches.
+    assert len(host.state.gates) == 2
+    assert len(dispatcher.calls) == 3
+    # Leftover questions do NOT block the run.
+    assert isinstance(result, FeatureBrief)
+
+
+@pytest.mark.asyncio
+async def test_max_rounds_zero_opens_no_gate(doc):
+    dispatcher = ScriptedDispatcher([_output(open_questions=[Q1])])
+    node = IdeationNode(dispatcher=dispatcher, ideation_max_rounds=0)
+    host = SessionHost(RUN_ID)
+
+    result = await asyncio.wait_for(
+        node.execute(
+            {"run_id": RUN_ID, "dev_brief": _brief(), "session_host": host}
+        ),
+        timeout=2,
+    )
+
+    assert host.state.gates == {}
+    assert isinstance(result, FeatureBrief)
+
+
+@pytest.mark.asyncio
+async def test_max_rounds_reads_conf_when_not_overridden(doc, monkeypatch):
+    from parrot import conf
+
+    monkeypatch.setattr(conf, "DEV_FLOW_IDEATION_MAX_ROUNDS", 1, raising=False)
+    dispatcher = ScriptedDispatcher([_output(open_questions=[Q1]) for _ in range(3)])
+    node = IdeationNode(dispatcher=dispatcher)
+    host = SessionHost(RUN_ID)
+
+    resolver = asyncio.ensure_future(_answer_gate(host, {Q1: "a"}))
+    await asyncio.wait_for(
+        node.execute(
+            {"run_id": RUN_ID, "dev_brief": _brief(), "session_host": host}
+        ),
+        timeout=5,
+    )
+    await resolver
+
+    assert len(host.state.gates) == 1
+    assert len(dispatcher.calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# Failure paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gate_rejected_raises(doc):
+    """Rejection = the user aborts the ideation → failure_handler."""
+    dispatcher = ScriptedDispatcher([_output(open_questions=[Q1])])
+    node = IdeationNode(dispatcher=dispatcher)
+    host = SessionHost(RUN_ID)
+
+    async def _reject():
+        await asyncio.sleep(0.01)
+        gate_id = next(iter(host.state.gates))
+        host.resolve_gate(
+            gate_id, "rejected", resolved_by="bob", comment="wrong document"
+        )
+
+    resolver = asyncio.ensure_future(_reject())
+    with pytest.raises(RuntimeError, match="rejected by bob"):
+        await node.execute(
+            {"run_id": RUN_ID, "dev_brief": _brief(), "session_host": host}
+        )
+    await resolver
+
+    # No re-dispatch happened.
+    assert len(dispatcher.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_gate_expired_raises(doc):
+    """Fail-closed expiry: silence is not consent for spec decisions."""
+    dispatcher = ScriptedDispatcher([_output(open_questions=[Q1])])
+    node = IdeationNode(dispatcher=dispatcher)
+    host = SessionHost(RUN_ID)
+
+    async def _expire():
+        await asyncio.sleep(0.01)
+        gate_id = next(iter(host.state.gates))
+        gate = host.state.gates[gate_id]
+        host.expire_due_gates(now=(gate.expires_at or 0) + 1)
+
+    resolver = asyncio.ensure_future(_expire())
+    with pytest.raises(RuntimeError, match="expired"):
+        await node.execute(
+            {"run_id": RUN_ID, "dev_brief": _brief(), "session_host": host}
+        )
+    await resolver
+
+
+@pytest.mark.asyncio
+async def test_uncommitted_output_raises(doc):
+    """committed=False → raise BEFORE building the FeatureBrief."""
+    dispatcher = ScriptedDispatcher([_output(committed=False, summary="commit hook said no")])
+    node = IdeationNode(dispatcher=dispatcher)
+    ctx = {"run_id": RUN_ID, "dev_brief": _brief()}
+
+    with pytest.raises(RuntimeError, match="did not commit"):
+        await node.execute(ctx)
+
+    assert "feature_brief" not in ctx
+
+
+@pytest.mark.asyncio
+async def test_unreadable_document_raises(tmp_path, monkeypatch):
+    """committed=True but no such file → actionable node error, not ValidationError."""
+    from parrot import conf
+
+    monkeypatch.setattr(conf, "PROJECT_ROOT", tmp_path, raising=False)
+    dispatcher = ScriptedDispatcher(
+        [_output(document_path="sdd/proposals/ghost.brainstorm.md")]
+    )
+    node = IdeationNode(dispatcher=dispatcher)
+
+    with pytest.raises(RuntimeError, match="no.*readable document"):
+        await node.execute({"run_id": RUN_ID, "dev_brief": _brief()})
+
+
+@pytest.mark.asyncio
+async def test_wrong_brief_type_raises(doc, tmp_path):
+    """A FeatureBrief must never reach this node — it routes to the planner."""
+    fb_doc = tmp_path / "x.spec.md"
+    fb_doc.write_text("# s", encoding="utf-8")
+    node = IdeationNode(dispatcher=ScriptedDispatcher([]))
+
+    with pytest.raises(ValueError, match="DevRequestBrief"):
+        await node.execute(
+            {
+                "run_id": RUN_ID,
+                "dev_brief": FeatureBrief(
+                    document_path=str(fb_doc), document_kind="spec"
+                ),
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_missing_brief_raises(doc):
+    node = IdeationNode(dispatcher=ScriptedDispatcher([]))
+    with pytest.raises(ValueError, match="requires ctx"):
+        await node.execute({"run_id": RUN_ID})
+
+
+# ---------------------------------------------------------------------------
+# Gateless (autonomous) fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_host_runs_gateless(doc, caplog):
+    """No session_host → warn and proceed; questions stay in the document."""
+    import logging
+
+    dispatcher = ScriptedDispatcher([_output(open_questions=[Q1, Q2])])
+    node = IdeationNode(dispatcher=dispatcher)
+
+    with caplog.at_level(logging.WARNING):
+        result = await asyncio.wait_for(
+            node.execute({"run_id": RUN_ID, "dev_brief": _brief()}), timeout=2
+        )
+
+    assert isinstance(result, FeatureBrief)
+    assert len(dispatcher.calls) == 1  # no re-dispatch without answers
+    assert any("no session_host" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Wiki context injection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wiki_context_is_injected(doc):
+    class FakeWiki:
+        async def build_research_context(self, query: str):
+            self.query = query
+            return "## ranked pages"
+
+    wiki = FakeWiki()
+    dispatcher = ScriptedDispatcher([_output()])
+    node = IdeationNode(dispatcher=dispatcher, wiki_search=wiki)
+
+    await node.execute({"run_id": RUN_ID, "dev_brief": _brief()})
+
+    assert dispatcher.calls[0]["brief"].graph_context == "## ranked pages"
+    assert "compression budget telemetry" in wiki.query
+
+
+@pytest.mark.asyncio
+async def test_wiki_failure_degrades_to_empty_context(doc):
+    class BoomWiki:
+        async def build_research_context(self, query: str):
+            raise RuntimeError("wiki plane not built")
+
+    dispatcher = ScriptedDispatcher([_output()])
+    node = IdeationNode(dispatcher=dispatcher, wiki_search=BoomWiki())
+
+    result = await node.execute({"run_id": RUN_ID, "dev_brief": _brief()})
+
+    assert dispatcher.calls[0]["brief"].graph_context == ""
+    assert isinstance(result, FeatureBrief)
+
+
+@pytest.mark.asyncio
+async def test_no_wiki_means_empty_context(doc):
+    dispatcher = ScriptedDispatcher([_output()])
+    node = IdeationNode(dispatcher=dispatcher)
+
+    await node.execute({"run_id": RUN_ID, "dev_brief": _brief()})
+
+    assert dispatcher.calls[0]["brief"].graph_context == ""

--- a/packages/ai-parrot/tests/flows/dev_flow/test_ideation_node.py
+++ b/packages/ai-parrot/tests/flows/dev_flow/test_ideation_node.py
@@ -538,3 +538,62 @@ async def test_no_wiki_means_empty_context(doc):
     await node.execute({"run_id": RUN_ID, "dev_brief": _brief()})
 
     assert dispatcher.calls[0]["brief"].graph_context == ""
+
+
+# ---------------------------------------------------------------------------
+# Reused-chain compatibility (FEAT-412 review finding)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_qa_node_survives_a_briefless_dev_flow_run():
+    """QANode must not KeyError when there is no `bug_brief`.
+
+    dev-flow (and FEAT-378 feature-mode) have no BugIntakeNode, so nothing
+    ever seeds `shared["bug_brief"]` — but QANode read it unconditionally,
+    which made every run raise `KeyError: 'bug_brief'` at QA, BEFORE the
+    handoff that is supposed to produce the draft PR (and before the skip_qa
+    bypass could even be honoured). Regression guard for the fallback.
+    """
+    from unittest.mock import MagicMock
+
+    from parrot.flows.dev_loop.models import ResearchOutput
+    from parrot.flows.dev_loop.nodes.qa import QANode
+
+    shared = {
+        "run_id": "r1",
+        "skip_qa": True,
+        # Exactly what PlannerNode bridges — and nothing else.
+        "research_output": ResearchOutput(
+            jira_issue_key="", spec_path="sdd/specs/x.spec.md",
+            feat_id="FEAT-412", branch_name="b", worktree_path="/tmp/x",
+            repo_path="",
+        ),
+    }
+
+    report = await QANode(dispatcher=MagicMock()).execute(shared)
+
+    assert report.passed is True
+    assert "bug_brief" not in shared
+
+
+@pytest.mark.asyncio
+async def test_briefless_summary_prefers_the_feature_document(tmp_path):
+    """The synthetic brief's summary labels the run for reviewers/judges."""
+    from parrot.flows.dev_loop.models import ResearchOutput
+    from parrot.flows.dev_loop.nodes.qa import QANode
+
+    research = ResearchOutput(
+        jira_issue_key="", spec_path="sdd/specs/x.spec.md", feat_id="FEAT-412",
+        branch_name="b", worktree_path="/tmp/x", repo_path="",
+    )
+    doc = tmp_path / "idea.proposal.md"
+    doc.write_text("# p", encoding="utf-8")
+    fb = FeatureBrief(document_path=str(doc), document_kind="proposal")
+
+    assert QANode._briefless_summary({"feature_brief": fb}, research) == str(doc)
+    # Falls back to the spec path, then the feat id — never raises.
+    assert QANode._briefless_summary({}, research) == "sdd/specs/x.spec.md"
+    assert QANode._briefless_summary(
+        {}, research.model_copy(update={"spec_path": ""})
+    ) == "FEAT-412"

--- a/packages/ai-parrot/tests/flows/dev_flow/test_models.py
+++ b/packages/ai-parrot/tests/flows/dev_flow/test_models.py
@@ -1,0 +1,224 @@
+"""Unit tests for the dev-flow Pydantic contracts (FEAT-412, TASK-2121).
+
+Covers :class:`DevRequestBrief`, the :data:`DevFlowBrief` discriminated
+union / :func:`parse_dev_brief` loader shim, and :class:`IdeationOutput`.
+"""
+
+from __future__ import annotations
+
+import pytest
+from parrot.flows.dev_flow.models import (
+    DevRequestBrief,
+    IdeationOutput,
+    parse_dev_brief,
+)
+from parrot.flows.dev_loop.models import DevAgentSpec, FeatureBrief, JudgePanelConfig
+from pydantic import ValidationError
+
+# ─────────────────────────────────────────────────────────────────────
+# DevRequestBrief
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_dev_request_brief_requires_title_and_description():
+    """title/description are mandatory and must be non-empty."""
+    with pytest.raises(ValidationError):
+        DevRequestBrief(kind="enhancement", description="d")  # no title
+    with pytest.raises(ValidationError):
+        DevRequestBrief(kind="enhancement", title="t")  # no description
+    with pytest.raises(ValidationError):
+        DevRequestBrief(kind="enhancement", title="", description="d")
+    with pytest.raises(ValidationError):
+        DevRequestBrief(kind="enhancement", title="t", description="")
+
+
+def test_dev_request_brief_defaults():
+    brief = DevRequestBrief(
+        kind="new_feature",
+        title="compression budget telemetry",
+        description="Add per-tool telemetry to the compression budget.",
+    )
+    assert brief.kind == "new_feature"
+    assert brief.context == ""
+    assert brief.jira_issue_key is None
+    assert brief.dev_agents is None
+    assert brief.judge_panel is None
+
+
+def test_dev_request_brief_kind_literal():
+    """Only the two NL intents are admissible — 'bug'/'feature' are rejected."""
+    for bad in ("bug", "feature", "revision", ""):
+        with pytest.raises(ValidationError):
+            DevRequestBrief(kind=bad, title="t", description="d")
+
+
+def test_dev_request_brief_has_no_document_fields():
+    """DevRequestBrief is NL-only: no document_path/document_kind validators."""
+    brief = DevRequestBrief(kind="enhancement", title="t", description="d")
+    assert not hasattr(brief, "document_path")
+    assert not hasattr(brief, "document_kind")
+
+
+def test_dev_request_brief_optional_pool_and_panel():
+    brief = DevRequestBrief(
+        kind="enhancement",
+        title="t",
+        description="d",
+        context="see PR #12",
+        jira_issue_key="PARROT-1",
+        dev_agents=[DevAgentSpec(agent="claude-code", model="sonnet", count=2)],
+        judge_panel=JudgePanelConfig(judges=[{"agent": "codex"}]),
+    )
+    assert brief.jira_issue_key == "PARROT-1"
+    assert brief.dev_agents is not None
+    assert brief.dev_agents[0].count == 2
+    assert brief.judge_panel is not None
+
+
+# ─────────────────────────────────────────────────────────────────────
+# DevFlowBrief union / parse_dev_brief
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_parse_dev_brief_discriminates_union(tmp_path):
+    """All three dev-flow kinds resolve to the right model."""
+    enh = parse_dev_brief({"kind": "enhancement", "title": "t", "description": "d"})
+    assert isinstance(enh, DevRequestBrief)
+    assert enh.kind == "enhancement"
+
+    new = parse_dev_brief({"kind": "new_feature", "title": "t", "description": "d"})
+    assert isinstance(new, DevRequestBrief)
+    assert new.kind == "new_feature"
+
+    doc = tmp_path / "x.proposal.md"
+    doc.write_text("# p", encoding="utf-8")
+    feat = parse_dev_brief(
+        {"kind": "feature", "document_path": str(doc), "document_kind": "proposal"}
+    )
+    assert isinstance(feat, FeatureBrief)
+    assert feat.kind == "feature"
+
+
+def test_parse_dev_brief_feature_passthrough(tmp_path):
+    """The `feature` kind yields the existing FeatureBrief — document must exist."""
+    doc = tmp_path / "y.brainstorm.md"
+    doc.write_text("# b", encoding="utf-8")
+    brief = parse_dev_brief(
+        {
+            "kind": "feature",
+            "document_path": str(doc),
+            "document_kind": "brainstorm",
+            "jira_issue_key": "PARROT-9",
+        }
+    )
+    assert isinstance(brief, FeatureBrief)
+    assert brief.document_path == str(doc)
+    assert brief.jira_issue_key == "PARROT-9"
+
+    with pytest.raises(ValidationError):
+        parse_dev_brief(
+            {
+                "kind": "feature",
+                "document_path": str(tmp_path / "missing.spec.md"),
+                "document_kind": "spec",
+            }
+        )
+
+
+def test_parse_dev_brief_requires_explicit_kind():
+    """Unlike parse_brief, there is no legacy default kind to fall back on."""
+    with pytest.raises(ValueError):
+        parse_dev_brief({"title": "t", "description": "d"})
+    with pytest.raises(ValueError):
+        parse_dev_brief({"kind": "bug", "title": "t", "description": "d"})
+
+
+def test_dev_flow_brief_union_validates_via_type_adapter(tmp_path):
+    """The Annotated union itself discriminates on `kind`."""
+    from parrot.flows.dev_flow.models import DevFlowBrief
+    from pydantic import TypeAdapter
+
+    adapter = TypeAdapter(DevFlowBrief)
+    assert isinstance(
+        adapter.validate_python(
+            {"kind": "new_feature", "title": "t", "description": "d"}
+        ),
+        DevRequestBrief,
+    )
+    doc = tmp_path / "z.spec.md"
+    doc.write_text("# s", encoding="utf-8")
+    assert isinstance(
+        adapter.validate_python(
+            {"kind": "feature", "document_path": str(doc), "document_kind": "spec"}
+        ),
+        FeatureBrief,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# IdeationOutput
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_ideation_output_defaults():
+    out = IdeationOutput(
+        document_path="sdd/proposals/foo.brainstorm.md",
+        document_kind="brainstorm",
+        slug="foo",
+    )
+    assert out.resumed_existing is False
+    assert out.committed is False
+    assert out.open_questions == []
+    assert out.summary == ""
+
+
+def test_ideation_output_document_kind_literal():
+    """Only brainstorm/proposal — 'spec' is not an ideation product."""
+    for bad in ("spec", "brief", ""):
+        with pytest.raises(ValidationError):
+            IdeationOutput(
+                document_path="sdd/proposals/foo.md",
+                document_kind=bad,
+                slug="foo",
+            )
+
+
+def test_ideation_output_full_roundtrip():
+    raw = {
+        "document_path": "sdd/proposals/bar.proposal.md",
+        "document_kind": "proposal",
+        "slug": "bar",
+        "resumed_existing": True,
+        "open_questions": ["Which store?", "Sync or async?"],
+        "summary": "Light proposal for bar.",
+        "committed": True,
+    }
+    out = IdeationOutput(**raw)
+    assert out.resumed_existing is True
+    assert out.committed is True
+    assert len(out.open_questions) == 2
+    assert out.model_dump() == raw
+
+
+def test_ideation_output_requires_core_fields():
+    with pytest.raises(ValidationError):
+        IdeationOutput(document_kind="proposal", slug="s")
+    with pytest.raises(ValidationError):
+        IdeationOutput(document_path="p", slug="s")
+    with pytest.raises(ValidationError):
+        IdeationOutput(document_path="p", document_kind="proposal")
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Package exports
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_package_reexports_models():
+    from parrot.flows import dev_flow
+
+    assert dev_flow.DevRequestBrief is DevRequestBrief
+    assert dev_flow.IdeationOutput is IdeationOutput
+    assert dev_flow.parse_dev_brief is parse_dev_brief
+    with pytest.raises(AttributeError):
+        dev_flow.definitely_not_a_symbol  # noqa: B018

--- a/packages/ai-parrot/tests/flows/dev_flow/test_runner.py
+++ b/packages/ai-parrot/tests/flows/dev_flow/test_runner.py
@@ -1,0 +1,374 @@
+"""Unit tests for DevFlowRunner (FEAT-412, TASK-2128).
+
+Drives the real ``DevFlowRunner`` (and therefore the inherited
+``DevLoopRunner`` hosting machinery: session host, actions sink, semaphore,
+gates, park/resume) through **stub flows**, matching
+``test_runner_park.py``/``test_runner_host.py``'s harness — the node graph is
+orthogonal to what this task changed.
+
+Focus: brief typing, context seeding, single-topology guarantee, and that
+gates/park/resume still work through the subclass.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from parrot import conf
+from parrot.bots.flows.core.result import FlowResult
+from parrot.bots.flows.core.types import FlowStatus
+from parrot.flows.dev_flow.models import DevRequestBrief
+from parrot.flows.dev_flow.runner import DevFlowRunner
+from parrot.flows.dev_loop.models import FeatureBrief
+
+
+class _CapturingFlow:
+    """Completes immediately, recording the context it was handed."""
+
+    def __init__(self) -> None:
+        self.contexts: list[Any] = []
+        self._run_id_holder: dict[str, str] = {}
+
+    async def run_flow(self, ctx, **kwargs) -> FlowResult:
+        self.contexts.append(ctx)
+        return FlowResult(
+            output=ctx.shared_data["run_id"], status=FlowStatus.COMPLETED
+        )
+
+    @property
+    def shared(self) -> dict[str, Any]:
+        return self.contexts[-1].shared_data
+
+
+class _GateOpeningFlow:
+    """Opens an `open_questions` gate and blocks on it, like IdeationNode."""
+
+    def __init__(self, *, post_gate_delay: float = 0.05) -> None:
+        self._post_gate_delay = post_gate_delay
+        self.gate_ids: dict[str, str] = {}
+
+    async def run_flow(self, ctx, **kwargs) -> FlowResult:
+        run_id = ctx.shared_data["run_id"]
+        host = ctx.shared_data["session_host"]
+        gate_id, _ = host.open_gate(
+            kind="open_questions", node_id="ideation", title="Open questions",
+            questions=["Which store?"], ttl_seconds=None, on_expiry="fail",
+        )
+        self.gate_ids[run_id] = gate_id
+        gate = await host.wait_gate(gate_id)
+        if self._post_gate_delay:
+            await asyncio.sleep(self._post_gate_delay)
+        if gate.status != "approved":
+            return FlowResult(output=run_id, status=FlowStatus.FAILED)
+        ctx.shared_data["answers_seen"] = dict(gate.answers)
+        return FlowResult(output=run_id, status=FlowStatus.COMPLETED)
+
+
+@pytest.fixture
+def nl_brief() -> DevRequestBrief:
+    return DevRequestBrief(
+        kind="enhancement",
+        title="compression budget telemetry",
+        description="Add per-tool telemetry to the compression budget.",
+    )
+
+
+@pytest.fixture
+def doc_brief(tmp_path) -> FeatureBrief:
+    doc = tmp_path / "idea.proposal.md"
+    doc.write_text("# Proposal", encoding="utf-8")
+    return FeatureBrief(document_path=str(doc), document_kind="proposal")
+
+
+def _runner(flow, **kwargs) -> DevFlowRunner:
+    return DevFlowRunner(flow, redis_url="redis://x", **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Brief typing + seeding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_accepts_dev_request_brief(nl_brief):
+    flow = _CapturingFlow()
+    result = await _runner(flow).run(nl_brief)
+
+    assert result.status == FlowStatus.COMPLETED
+    shared = flow.shared
+    assert shared["dev_brief"] is nl_brief
+    assert shared["run_id"].startswith("run-")
+    assert shared["session_host"] is not None
+    # A natural-language run must NOT pre-seed feature_brief — IdeationNode
+    # produces it.
+    assert "feature_brief" not in shared
+
+
+@pytest.mark.asyncio
+async def test_run_accepts_feature_brief_seeds_feature_key(doc_brief):
+    flow = _CapturingFlow()
+    await _runner(flow).run(doc_brief)
+
+    shared = flow.shared
+    assert shared["dev_brief"] is doc_brief
+    assert shared["feature_brief"] is doc_brief
+
+
+@pytest.mark.asyncio
+async def test_never_seeds_bug_mode_keys(nl_brief, doc_brief):
+    for brief in (nl_brief, doc_brief):
+        flow = _CapturingFlow()
+        await _runner(flow).run(brief)
+        assert "bug_brief" not in flow.shared
+        assert "work_brief" not in flow.shared
+
+
+@pytest.mark.asyncio
+async def test_rejects_non_dev_flow_brief():
+    from parrot.flows.dev_loop.models import ShellCriterion, WorkBrief
+
+    flow = _CapturingFlow()
+    work = WorkBrief(
+        summary="Customer sync drops the last row",
+        affected_component="etl/customers/sync.yaml",
+        log_sources=[],
+        acceptance_criteria=[ShellCriterion(name="lint", command="ruff check .")],
+        escalation_assignee="557058:abc",
+        reporter="557058:def",
+    )
+    with pytest.raises(TypeError, match="DevRequestBrief or FeatureBrief"):
+        await _runner(flow).run(work)
+    # Nothing was executed.
+    assert flow.contexts == []
+
+
+# ---------------------------------------------------------------------------
+# run_id / initial_task / extra_shared
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_explicit_run_id_is_used(nl_brief):
+    flow = _CapturingFlow()
+    await _runner(flow).run(nl_brief, run_id="run-explicit")
+    assert flow.shared["run_id"] == "run-explicit"
+    # The flow's event-publisher holder is pointed at this run.
+    assert flow._run_id_holder["run_id"] == "run-explicit"
+
+
+@pytest.mark.asyncio
+async def test_initial_task_defaults_per_kind(nl_brief, doc_brief):
+    flow = _CapturingFlow()
+    await _runner(flow).run(nl_brief)
+    assert flow.contexts[-1].initial_task == "compression budget telemetry"
+
+    flow2 = _CapturingFlow()
+    await _runner(flow2).run(doc_brief)
+    assert flow2.contexts[-1].initial_task.startswith("Feature: ")
+
+
+@pytest.mark.asyncio
+async def test_initial_task_passthrough(nl_brief):
+    flow = _CapturingFlow()
+    await _runner(flow).run(nl_brief, initial_task="custom line")
+    assert flow.contexts[-1].initial_task == "custom line"
+
+
+@pytest.mark.asyncio
+async def test_extra_shared_passthrough(nl_brief):
+    """The server's per-run knobs must reach shared state."""
+    flow = _CapturingFlow()
+    await _runner(flow).run(
+        nl_brief,
+        extra_shared={"require_plan_approval": True, "skip_qa": True},
+    )
+    assert flow.shared["require_plan_approval"] is True
+    assert flow.shared["skip_qa"] is True
+
+
+@pytest.mark.asyncio
+async def test_extra_shared_cannot_be_used_to_drop_core_keys(nl_brief):
+    """extra_shared merges last, but the core keys are still present."""
+    flow = _CapturingFlow()
+    await _runner(flow).run(nl_brief, extra_shared={"unrelated": 1})
+    for key in ("dev_brief", "run_id", "session_host"):
+        assert key in flow.shared
+
+
+# ---------------------------------------------------------------------------
+# Single topology
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_never_calls_run_feature(doc_brief, monkeypatch):
+    """A FeatureBrief runs the DEV-FLOW graph, not FEAT-378 feature-mode."""
+    flow = _CapturingFlow()
+    runner = _runner(flow)
+
+    async def _boom(*args, **kwargs):
+        raise AssertionError("_run_feature must never be called by DevFlowRunner")
+
+    monkeypatch.setattr(runner, "_run_feature", _boom)
+
+    await runner.run(doc_brief)
+
+    assert len(flow.contexts) == 1
+    # The base class's feature-flow cache stays untouched/unused.
+    assert runner._feature_flow is None
+
+
+@pytest.mark.asyncio
+async def test_both_kinds_use_the_same_flow_object(nl_brief, doc_brief):
+    flow = _CapturingFlow()
+    runner = _runner(flow)
+    await runner.run(nl_brief)
+    await runner.run(doc_brief)
+    assert len(flow.contexts) == 2
+    assert runner._rev_flow is None
+    assert runner._feature_flow is None
+
+
+# ---------------------------------------------------------------------------
+# Inherited session-state / registry behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_created_work_kind_maps_per_brief(nl_brief, doc_brief):
+    flow = _CapturingFlow()
+    runner = _runner(flow)
+
+    await runner.run(nl_brief, run_id="run-nl")
+    # The host is discarded at close, so read the projected registry instead.
+    assert runner.registry_state.runs["run-nl"].work_kind == "enhancement"
+
+    new_feature = nl_brief.model_copy(update={"kind": "new_feature"})
+    await runner.run(new_feature, run_id="run-nf")
+    assert runner.registry_state.runs["run-nf"].work_kind == "new_feature"
+
+    # A document brief uses the "bug" structural placeholder (work_kind is a
+    # closed Literal that deliberately has no "feature" member).
+    await runner.run(doc_brief, run_id="run-doc")
+    assert runner.registry_state.runs["run-doc"].work_kind == "bug"
+
+
+@pytest.mark.asyncio
+async def test_run_registered_in_root_registry(nl_brief):
+    flow = _CapturingFlow()
+    runner = _runner(flow)
+    await runner.run(nl_brief, run_id="run-reg")
+
+    summary = runner.registry_state.runs["run-reg"]
+    assert summary.run_id == "run-reg"
+    assert summary.summary == "compression budget telemetry"
+
+
+@pytest.mark.asyncio
+async def test_session_host_seeded_and_closed(nl_brief):
+    flow = _CapturingFlow()
+    runner = _runner(flow)
+    await runner.run(nl_brief, run_id="run-host")
+
+    # Seeded during the run...
+    assert flow.shared["session_host"] is not None
+    # ...and discarded afterwards (inherited _close_host behavior).
+    assert runner.get_host("run-host") is None
+
+
+@pytest.mark.asyncio
+async def test_slot_released_after_run(nl_brief):
+    flow = _CapturingFlow()
+    runner = _runner(flow, max_concurrent_runs=1)
+    await runner.run(nl_brief)
+    assert runner.active_runs == set()
+    # A second run still fits.
+    await runner.run(nl_brief)
+    assert runner.active_runs == set()
+
+
+@pytest.mark.asyncio
+async def test_slot_released_when_flow_raises(nl_brief):
+    class _BoomFlow:
+        def __init__(self) -> None:
+            self._run_id_holder: dict[str, str] = {}
+
+        async def run_flow(self, ctx, **kwargs):
+            raise RuntimeError("node exploded")
+
+    runner = _runner(_BoomFlow(), max_concurrent_runs=1)
+    with pytest.raises(RuntimeError, match="node exploded"):
+        await runner.run(nl_brief)
+    assert runner.active_runs == set()
+
+
+# ---------------------------------------------------------------------------
+# Gates + park/resume through the subclass
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_open_questions_gate_resolves_via_inherited_api(nl_brief):
+    flow = _GateOpeningFlow()
+    runner = _runner(flow)
+
+    async def _answer():
+        await asyncio.sleep(0.02)
+        gate_id = flow.gate_ids["run-gate"]
+        await runner.resolve_gate(
+            "run-gate", gate_id, "approved", "alice", "",
+            None, answers={"Which store?": "pgvector"},
+        )
+
+    answerer = asyncio.ensure_future(_answer())
+    result = await runner.run(nl_brief, run_id="run-gate")
+    await answerer
+
+    assert result.status == FlowStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_parked_run_frees_its_slot(nl_brief, monkeypatch):
+    """An ideation gate can park for hours — the slot must be released."""
+    monkeypatch.setattr(conf, "DEV_LOOP_GATE_PARK", True, raising=False)
+    gate_flow = _GateOpeningFlow()
+    runner = _runner(gate_flow, max_concurrent_runs=1)
+
+    parked = asyncio.ensure_future(runner.run(nl_brief, run_id="run-parked"))
+    # Let the gate open and the park happen.
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        if "run-parked" in runner.parked_runs:
+            break
+
+    assert "run-parked" in runner.parked_runs
+    assert runner.active_runs == set()  # slot genuinely free
+
+    gate_id = gate_flow.gate_ids["run-parked"]
+    await runner.resolve_gate(
+        "run-parked", gate_id, "approved", "alice", "", None,
+        answers={"Which store?": "pgvector"},
+    )
+    result = await parked
+    assert result.status == FlowStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_rejected_gate_fails_the_run(nl_brief):
+    flow = _GateOpeningFlow()
+    runner = _runner(flow)
+
+    async def _reject():
+        await asyncio.sleep(0.02)
+        gate_id = flow.gate_ids["run-rej"]
+        await runner.resolve_gate(
+            "run-rej", gate_id, "rejected", "bob", "aborting", None,
+        )
+
+    rejecter = asyncio.ensure_future(_reject())
+    result = await runner.run(nl_brief, run_id="run-rej")
+    await rejecter
+
+    assert result.status == FlowStatus.FAILED

--- a/packages/ai-parrot/tests/flows/dev_flow/test_server_dev.py
+++ b/packages/ai-parrot/tests/flows/dev_flow/test_server_dev.py
@@ -585,3 +585,87 @@ def test_reuses_ops_helpers_without_modifying_them(server_dev):
     assert ops.handle_index not in handlers
     assert ops.handle_config not in handlers
     assert ops.handle_run not in handlers
+
+
+# ---------------------------------------------------------------------------
+# static/dev.html — TASK-2130 guarantees (asserted here because the repo has
+# no JS test harness and the spec forbids adding one)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def dev_html() -> str:
+    return (_REPO_ROOT / "examples" / "dev_loop" / "static" / "dev.html").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_dev_html_exists_and_is_served(dev_html, server_dev):
+    assert dev_html.startswith("<!doctype html>")
+    assert (server_dev.STATIC_DIR / "dev.html").is_file()
+
+
+@pytest.mark.parametrize(
+    "forbidden",
+    [
+        "affected_component",      # bug intake
+        "log_group",               # CloudWatch
+        "time_window",
+        "CloudWatch",
+        "bug_intake",              # ops node
+        "acceptance_criteria",     # bug-mode criteria
+        "existing_issue_key",
+        "afd-theme",               # must not share the ops console's theme key
+    ],
+)
+def test_dev_html_has_no_ops_surface(dev_html, forbidden):
+    assert forbidden not in dev_html
+
+
+@pytest.mark.parametrize(
+    "required",
+    [
+        "open_questions",              # the HITL gate kind
+        "hitl-submit",                 # the answer-submit control
+        "hitl-reject",                 # the abort control
+        "require_plan_approval",        # the per-run plan-gate toggle
+        "gate_resolve_url_template",   # route taken from /api/config
+        "devflow-theme",               # its own theme key
+        "dev_intake",                  # dev-flow topology
+        "ideation",
+        "feature_handoff",
+    ],
+)
+def test_dev_html_has_dev_flow_surface(dev_html, required):
+    assert required in dev_html
+
+
+def test_dev_html_topology_is_dev_only(dev_html):
+    """One topology: no bug/feature TOPOLOGY split, no ops nodes."""
+    assert "TOPOLOGY = {" in dev_html
+    assert "TOPOLOGY.dev" in dev_html
+    assert "TOPOLOGY.bug" not in dev_html
+    assert "revision_handoff" not in dev_html
+
+
+def test_dev_html_renders_gates_from_state(dev_html):
+    """The panel must survive a reload mid-gate → it reads app.s.gates."""
+    assert "function pendingGate()" in dev_html
+    assert "app.s.gates" in dev_html
+    assert "function renderHitl()" in dev_html
+
+
+def test_dev_html_does_not_mutate_state_after_resolve(dev_html):
+    """gate/resolved on the state socket is the single source of truth."""
+    assert "Deliberately no local mutation" in dev_html
+
+
+def test_index_html_untouched(dev_html):
+    """dev.html is a copy-and-trim; index.html must remain the ops console."""
+    index = (
+        _REPO_ROOT / "examples" / "dev_loop" / "static" / "index.html"
+    ).read_text(encoding="utf-8")
+    assert "bug_intake" in index          # still the ops console
+    assert "CloudWatch" in index
+    assert "afd-theme" in index
+    assert index != dev_html

--- a/packages/ai-parrot/tests/flows/dev_flow/test_server_dev.py
+++ b/packages/ai-parrot/tests/flows/dev_flow/test_server_dev.py
@@ -547,13 +547,25 @@ def test_no_bug_brief_builder(server_dev):
 
 
 def test_uses_dev_flow_runner_and_builder(server_dev):
+    """Startup builds the dev-flow graph/runner and never a dev_loop one.
+
+    AST-based: comments in `_on_startup` legitimately *name*
+    `build_dev_loop_feature_flow` to explain which parameters dev-flow
+    deliberately does not take, which a substring scan would flag.
+    """
+    import ast
     import inspect
 
-    source = inspect.getsource(server_dev._on_startup)
-    assert "build_dev_flow(" in source
-    assert "DevFlowRunner(" in source
-    assert "build_dev_loop_flow" not in source
-    assert "build_dev_loop_feature_flow" not in source
+    tree = ast.parse(inspect.getsource(server_dev._on_startup).lstrip())
+    called = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert "build_dev_flow" in called
+    assert "DevFlowRunner" in called
+    assert "build_dev_loop_flow" not in called
+    assert "build_dev_loop_feature_flow" not in called
 
 
 def test_jira_is_optional(server_dev, monkeypatch):
@@ -669,3 +681,34 @@ def test_index_html_untouched(dev_html):
     assert "CloudWatch" in index
     assert "afd-theme" in index
     assert index != dev_html
+
+
+def test_dev_html_always_sends_the_plan_gate_boolean(dev_html):
+    """Review finding: sending only `true` made the toggle one-way.
+
+    The server honours the per-run override only when the key is PRESENT, so a
+    UI that omitted `require_plan_approval` when unchecked could never turn OFF
+    a gate the server defaults ON.
+    """
+    assert "payload.require_plan_approval = !!f.requirePlanApproval;" in dev_html
+    # The old one-way form must be gone.
+    assert "if (f.requirePlanApproval) payload.require_plan_approval = true;" not in dev_html
+
+
+@pytest.mark.asyncio
+async def test_plan_approval_false_reaches_extra_shared_and_suppresses(make_client):
+    """The full path: UI false -> extra_shared false -> DevelopmentNode off.
+
+    Pairs with test_shared_false_overrides_ctor_true in
+    test_plan_gate_override.py, which covers the node half.
+    """
+    client = await make_client()
+    await client.post(
+        "/api/flow/run",
+        json={
+            "kind": "enhancement", "title": "t", "description": "d",
+            "require_plan_approval": False,
+        },
+    )
+    ctx = await _wait_for_context(client.app_flow)
+    assert ctx.shared_data["require_plan_approval"] is False

--- a/packages/ai-parrot/tests/flows/dev_flow/test_server_dev.py
+++ b/packages/ai-parrot/tests/flows/dev_flow/test_server_dev.py
@@ -1,0 +1,587 @@
+"""Integration tests for examples/dev_loop/server_dev.py (FEAT-412, TASK-2129).
+
+Loads the example module via importlib (the established pattern from
+``test_examples_form.py``) and drives it with ``aiohttp_client``. ``_on_startup``
+is replaced by a fake wiring step so no Redis, dispatcher or Jira env is
+needed — what is under test is the console's HTTP surface: the dev-only
+``/api/config`` shape, brief building for all three intents, the per-run
+plan-gate flag, and the mounted gate-resolution route.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+from parrot.bots.flows.core.result import FlowResult
+from parrot.bots.flows.core.types import FlowStatus
+from parrot.flows.dev_flow.models import DevRequestBrief
+from parrot.flows.dev_flow.runner import DevFlowRunner
+from parrot.flows.dev_loop.models import FeatureBrief
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+
+
+def _load_module(name: str, filename: str):
+    path = _REPO_ROOT / "examples" / "dev_loop" / filename
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def server_dev():
+    return _load_module("dev_flow_server_dev", "server_dev.py")
+
+
+class _StubFlow:
+    """Records the contexts it is handed; completes immediately."""
+
+    def __init__(self) -> None:
+        self.contexts: list[Any] = []
+        self._run_id_holder: dict[str, str] = {}
+
+    async def run_flow(self, ctx, **kwargs) -> FlowResult:
+        self.contexts.append(ctx)
+        return FlowResult(
+            output=ctx.shared_data["run_id"], status=FlowStatus.COMPLETED
+        )
+
+
+class _GateFlow:
+    """Opens an `open_questions` gate and blocks until it resolves."""
+
+    def __init__(self) -> None:
+        self.gate_ids: dict[str, str] = {}
+        self._run_id_holder: dict[str, str] = {}
+        self.answers: dict[str, str] = {}
+
+    async def run_flow(self, ctx, **kwargs) -> FlowResult:
+        run_id = ctx.shared_data["run_id"]
+        host = ctx.shared_data["session_host"]
+        gate_id, _ = host.open_gate(
+            kind="open_questions", node_id="ideation",
+            title="Open questions — sdd/proposals/x.brainstorm.md",
+            questions=["Which store?"], ttl_seconds=None, on_expiry="fail",
+        )
+        self.gate_ids[run_id] = gate_id
+        gate = await host.wait_gate(gate_id)
+        self.answers = dict(gate.answers)
+        status = (
+            FlowStatus.COMPLETED if gate.status == "approved" else FlowStatus.FAILED
+        )
+        return FlowResult(output=run_id, status=status)
+
+
+@pytest.fixture
+def make_client(server_dev, aiohttp_client):
+    """Build a test client whose startup is stubbed (no Redis/dispatcher)."""
+
+    async def _make(flow=None):
+        flow = flow if flow is not None else _StubFlow()
+        app = server_dev.build_app(redis_url="redis://x")
+        # Drop the real startup/cleanup and wire the app keys by hand.
+        app.on_startup.clear()
+        app.on_cleanup.clear()
+
+        runner = DevFlowRunner(flow, redis_url="redis://x")
+        app["runner"] = runner
+        app["dev_loop_runner"] = runner
+        app["flow"] = flow
+        app["flow_tasks"] = {}
+        app["wiki_search"] = None
+        app["jira_toolkit"] = None
+        app["codereview_agent_key"] = "parallel"
+        app["development_pool_max"] = 4
+        app["require_plan_approval"] = False
+        client = await aiohttp_client(app)
+        client.app_flow = flow  # type: ignore[attr-defined]
+        client.app_runner = runner  # type: ignore[attr-defined]
+        return client
+
+    return _make
+
+
+async def _wait_for_context(flow, timeout: float = 2.0):
+    """Wait until the background run task has entered the flow."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if flow.contexts:
+            return flow.contexts[-1]
+        await asyncio.sleep(0.01)
+    raise AssertionError("flow was never entered")
+
+
+# ---------------------------------------------------------------------------
+# Static + config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_index_serves_dev_html(server_dev):
+    """GET / must serve dev.html — never the ops console."""
+    # Behavioral, not source-scanning: call the handler and inspect the path
+    # of the FileResponse it builds. (dev.html itself lands in TASK-2130, so
+    # a client GET would 404 on the missing file until then.)
+    response = await server_dev.handle_index(MagicMock())
+
+    assert isinstance(response, web.FileResponse)
+    assert response._path.name == "dev.html"
+    assert response._path.parent == server_dev.STATIC_DIR
+
+
+@pytest.mark.asyncio
+async def test_config_shape_no_ops_keys(make_client):
+    client = await make_client()
+    resp = await client.get("/api/config")
+    assert resp.status == 200
+    data = await resp.json()
+
+    # The three dev intents, and only those.
+    assert [k["value"] for k in data["kinds"]] == [
+        "enhancement", "new_feature", "feature",
+    ]
+    # No observability / mandatory-Jira defaults anywhere.
+    defaults = data["defaults"]
+    for absent in ("log_group", "time_window_minutes", "jira_project"):
+        assert absent not in defaults
+    assert "shell_criteria_heads" not in data
+    assert "feature_mode" not in data
+
+    # Dev-flow knobs present.
+    assert defaults["ideation_max_rounds"] == 2
+    assert defaults["gate_ttl_questions"] == 86400
+    assert defaults["require_plan_approval"] is False
+    assert data["document_kinds"] == ["brainstorm", "proposal", "spec"]
+    assert data["nl_kinds"] == ["enhancement", "new_feature"]
+    # The gate-resolution route is advertised to the UI.
+    assert data["gate_resolve_url_template"] == (
+        "/api/flow/{run_id}/gates/{gate_id}/resolve"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Brief building (pure function)
+# ---------------------------------------------------------------------------
+
+
+def test_build_dev_brief_enhancement(server_dev):
+    brief = server_dev._build_dev_brief_from_form(
+        {"kind": "enhancement", "title": "t", "description": "d"}
+    )
+    assert isinstance(brief, DevRequestBrief)
+    assert brief.kind == "enhancement"
+
+
+def test_build_dev_brief_normalises_labels(server_dev):
+    for label in ("New Feature", "new feature", "NEW_FEATURE", "new-feature"):
+        brief = server_dev._build_dev_brief_from_form(
+            {"kind": label, "title": "t", "description": "d"}
+        )
+        assert brief.kind == "new_feature"
+
+
+def test_build_dev_brief_feature_delegates(server_dev, tmp_path):
+    doc = tmp_path / "x.proposal.md"
+    doc.write_text("# p", encoding="utf-8")
+    brief = server_dev._build_dev_brief_from_form(
+        {
+            "kind": "feature",
+            "document_path": str(doc),
+            "document_kind": "proposal",
+        }
+    )
+    assert isinstance(brief, FeatureBrief)
+    assert brief.document_kind == "proposal"
+
+
+def test_build_dev_brief_requires_title_and_description(server_dev):
+    with pytest.raises(ValueError, match="title is required"):
+        server_dev._build_dev_brief_from_form(
+            {"kind": "enhancement", "description": "d"}
+        )
+    with pytest.raises(ValueError, match="description is required"):
+        server_dev._build_dev_brief_from_form(
+            {"kind": "enhancement", "title": "t"}
+        )
+
+
+def test_build_dev_brief_rejects_bug_kind(server_dev):
+    with pytest.raises(ValueError, match="kind must be"):
+        server_dev._build_dev_brief_from_form(
+            {"kind": "bug", "title": "t", "description": "d"}
+        )
+
+
+def test_build_dev_brief_optional_fields(server_dev):
+    brief = server_dev._build_dev_brief_from_form(
+        {
+            "kind": "enhancement",
+            "title": "t",
+            "description": "d",
+            "context": "see PR",
+            "jira_issue_key": "PARROT-1",
+            "dev_agents": [{"agent": "claude-code", "count": 2}],
+            "judge_panel": [{"agent": "codex"}],
+        }
+    )
+    assert brief.context == "see PR"
+    assert brief.jira_issue_key == "PARROT-1"
+    assert brief.dev_agents[0].count == 2
+    assert brief.judge_panel is not None
+
+
+def test_dev_brief_builder_ignores_bug_fields(server_dev):
+    """affected_component/log_sources/reporter have no effect here."""
+    brief = server_dev._build_dev_brief_from_form(
+        {
+            "kind": "enhancement", "title": "t", "description": "d",
+            "affected_component": "etl/x.yaml",
+            "log_sources": [{"kind": "cloudwatch", "locator": "/etl/x"}],
+            "reporter": "a@b.c", "escalation_assignee": "d@e.f",
+        }
+    )
+    assert not hasattr(brief, "affected_component")
+    assert not hasattr(brief, "log_sources")
+
+
+# ---------------------------------------------------------------------------
+# POST /api/flow/run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_enhancement_brief_built(make_client):
+    client = await make_client()
+    resp = await client.post(
+        "/api/flow/run",
+        json={"kind": "enhancement", "title": "telemetry", "description": "d"},
+    )
+
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["run_id"].startswith("run-")
+    assert data["mode"] == "dev-flow"
+    assert data["kind"] == "enhancement"
+    assert data["ws_url"] == f"/api/flow/{data['run_id']}/ws"
+    assert data["state_ws_url"].endswith("?view=state")
+    assert data["bundle_url"] == f"/api/flow/{data['run_id']}/bundle"
+    assert "gates/{gate_id}/resolve" in data["gate_resolve_url"]
+
+    ctx = await _wait_for_context(client.app_flow)
+    assert isinstance(ctx.shared_data["dev_brief"], DevRequestBrief)
+    assert "feature_brief" not in ctx.shared_data
+
+
+@pytest.mark.asyncio
+async def test_run_feature_brief_built(make_client, tmp_path):
+    doc = tmp_path / "idea.brainstorm.md"
+    doc.write_text("# b", encoding="utf-8")
+    client = await make_client()
+
+    resp = await client.post(
+        "/api/flow/run",
+        json={
+            "kind": "feature",
+            "document_path": str(doc),
+            "document_kind": "brainstorm",
+        },
+    )
+
+    assert resp.status == 200
+    assert (await resp.json())["kind"] == "feature"
+    ctx = await _wait_for_context(client.app_flow)
+    assert isinstance(ctx.shared_data["feature_brief"], FeatureBrief)
+
+
+@pytest.mark.asyncio
+async def test_run_missing_description_400(make_client):
+    client = await make_client()
+    resp = await client.post(
+        "/api/flow/run", json={"kind": "enhancement", "title": "t"}
+    )
+    assert resp.status == 400
+    assert "description is required" in (await resp.json())["error"]
+
+
+@pytest.mark.asyncio
+async def test_run_rejects_bug_kind_400(make_client):
+    client = await make_client()
+    resp = await client.post(
+        "/api/flow/run",
+        json={"kind": "bug", "title": "t", "description": "d"},
+    )
+    assert resp.status == 400
+
+
+@pytest.mark.asyncio
+async def test_run_invalid_body_400(make_client):
+    client = await make_client()
+    assert (
+        await client.post("/api/flow/run", data="not json")
+    ).status == 400
+    assert (await client.post("/api/flow/run", json=["a"])).status == 400
+
+
+# ---------------------------------------------------------------------------
+# Per-run plan-approval toggle (TASK-2123 seam)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_plan_approval_flag_in_extra_shared(make_client):
+    client = await make_client()
+    await client.post(
+        "/api/flow/run",
+        json={
+            "kind": "enhancement", "title": "t", "description": "d",
+            "require_plan_approval": True,
+        },
+    )
+    ctx = await _wait_for_context(client.app_flow)
+    assert ctx.shared_data["require_plan_approval"] is True
+
+
+@pytest.mark.asyncio
+async def test_plan_approval_false_is_forwarded(make_client):
+    """An explicit False must reach shared state (it suppresses the gate)."""
+    client = await make_client()
+    await client.post(
+        "/api/flow/run",
+        json={
+            "kind": "enhancement", "title": "t", "description": "d",
+            "require_plan_approval": False,
+        },
+    )
+    ctx = await _wait_for_context(client.app_flow)
+    assert ctx.shared_data["require_plan_approval"] is False
+
+
+@pytest.mark.asyncio
+async def test_absent_plan_approval_not_in_extra_shared(make_client):
+    """Absent field → the flow's build-time default applies, not an override."""
+    client = await make_client()
+    await client.post(
+        "/api/flow/run",
+        json={"kind": "enhancement", "title": "t", "description": "d"},
+    )
+    ctx = await _wait_for_context(client.app_flow)
+    assert "require_plan_approval" not in ctx.shared_data
+
+
+@pytest.mark.asyncio
+async def test_skip_flags_forwarded(make_client):
+    client = await make_client()
+    await client.post(
+        "/api/flow/run",
+        json={
+            "kind": "enhancement", "title": "t", "description": "d",
+            "skip_qa": True, "skip_jira": True,
+        },
+    )
+    ctx = await _wait_for_context(client.app_flow)
+    assert ctx.shared_data["skip_qa"] is True
+    assert ctx.shared_data["skip_jira"] is True
+
+
+# ---------------------------------------------------------------------------
+# The mounted gate-resolution route (the HITL write path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gate_resolve_route_mounted(make_client):
+    """Answering an open_questions gate over REST unblocks the run."""
+    gate_flow = _GateFlow()
+    client = await make_client(gate_flow)
+
+    resp = await client.post(
+        "/api/flow/run",
+        json={"kind": "new_feature", "title": "t", "description": "d"},
+    )
+    run_id = (await resp.json())["run_id"]
+
+    # Wait for the gate to open.
+    for _ in range(200):
+        await asyncio.sleep(0.01)
+        if run_id in gate_flow.gate_ids:
+            break
+    gate_id = gate_flow.gate_ids[run_id]
+
+    resolve = await client.post(
+        f"/api/flow/{run_id}/gates/{gate_id}/resolve",
+        json={
+            "resolution": "approved",
+            "resolved_by": "alice",
+            "answers": {"Which store?": "pgvector"},
+        },
+    )
+
+    assert resolve.status == 200
+    body = await resolve.json()
+    assert body["envelope"]["action"]["type"] == "gate/resolved"
+    assert body["envelope"]["action"]["answers"] == {"Which store?": "pgvector"}
+    # The flow saw the answers.
+    for _ in range(200):
+        await asyncio.sleep(0.01)
+        if gate_flow.answers:
+            break
+    assert gate_flow.answers == {"Which store?": "pgvector"}
+
+
+@pytest.mark.asyncio
+async def test_gate_resolve_empty_answers_400(make_client):
+    gate_flow = _GateFlow()
+    client = await make_client(gate_flow)
+    resp = await client.post(
+        "/api/flow/run",
+        json={"kind": "new_feature", "title": "t", "description": "d"},
+    )
+    run_id = (await resp.json())["run_id"]
+    for _ in range(200):
+        await asyncio.sleep(0.01)
+        if run_id in gate_flow.gate_ids:
+            break
+    gate_id = gate_flow.gate_ids[run_id]
+
+    bad = await client.post(
+        f"/api/flow/{run_id}/gates/{gate_id}/resolve",
+        json={"resolution": "approved", "resolved_by": "alice"},
+    )
+    assert bad.status == 400
+    assert (await bad.json())["error"] == "answers_required"
+
+    # Clean up: reject so the background task finishes.
+    await client.post(
+        f"/api/flow/{run_id}/gates/{gate_id}/resolve",
+        json={"resolution": "rejected", "resolved_by": "alice"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_gate_resolve_unknown_run_404(make_client):
+    client = await make_client()
+    resp = await client.post(
+        "/api/flow/no-such-run/gates/g1/resolve",
+        json={"resolution": "approved", "resolved_by": "alice",
+              "answers": {"q": "a"}},
+    )
+    assert resp.status == 404
+
+
+# ---------------------------------------------------------------------------
+# Route inventory / ops isolation
+# ---------------------------------------------------------------------------
+
+
+def test_route_inventory(server_dev):
+    app = server_dev.build_app(redis_url="redis://x")
+    routes = {
+        (r.method, getattr(r.resource, "canonical", ""))
+        for r in app.router.routes()
+    }
+    assert ("GET", "/") in routes
+    assert ("GET", "/api/config") in routes
+    assert ("POST", "/api/flow/run") in routes
+    assert ("GET", "/api/flow/{run_id}/bundle") in routes
+    assert ("GET", "/api/flow/{run_id}/replay") in routes
+    assert ("GET", "/api/flow/{run_id}/ws") in routes
+    assert ("POST", "/api/flow/{run_id}/cancel") in routes
+    # The route server.py never mounts.
+    assert ("POST", "/api/flow/{run_id}/gates/{gate_id}/resolve") in routes
+
+
+def test_default_port_is_8081(server_dev):
+    import inspect
+
+    source = inspect.getsource(server_dev.main)
+    assert '"PORT", "8081"' in source
+
+
+def _referenced_identifiers(module) -> set[str]:
+    """Every identifier the module's *code* references (AST, not text).
+
+    Docstrings and comments are excluded by construction — this module's own
+    documentation names the excluded ops helpers in order to say they are
+    excluded, which a naive substring scan would flag as a false positive.
+    """
+    import ast
+    import inspect
+
+    tree = ast.parse(inspect.getsource(module))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name):
+            names.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            names.add(node.attr)
+        elif isinstance(node, ast.keyword) and node.arg:
+            names.add(node.arg)
+        elif isinstance(node, ast.alias):
+            names.add(node.asname or node.name.split(".")[0])
+    return names
+
+
+def test_no_cloudwatch_log_toolkits(server_dev):
+    """dev-flow wires no observability toolkits at all."""
+    names = _referenced_identifiers(server_dev)
+    assert "_build_log_toolkits" not in names
+    assert "log_toolkits" not in names
+    assert not any("cloudwatch" in n.lower() for n in names)
+
+
+def test_no_bug_brief_builder(server_dev):
+    """No bug-intake brief building anywhere in the dev console's code."""
+    names = _referenced_identifiers(server_dev)
+    assert "_build_brief_from_form" not in names
+    assert "BugBrief" not in names
+    # Bug-intake-only form fields are never read.
+    for field in ("affected_component", "log_sources", "escalation_assignee"):
+        assert field not in names
+
+
+def test_uses_dev_flow_runner_and_builder(server_dev):
+    import inspect
+
+    source = inspect.getsource(server_dev._on_startup)
+    assert "build_dev_flow(" in source
+    assert "DevFlowRunner(" in source
+    assert "build_dev_loop_flow" not in source
+    assert "build_dev_loop_feature_flow" not in source
+
+
+def test_jira_is_optional(server_dev, monkeypatch):
+    """No JIRA_* env → jira_toolkit is None, never an exception."""
+    from parrot import conf
+
+    original = conf.config.get
+
+    def _fake_get(key, *args, **kwargs):
+        if key in ("JIRA_INSTANCE", "JIRA_USERNAME"):
+            return ""
+        return original(key, *args, **kwargs)
+
+    monkeypatch.setattr(conf.config, "get", _fake_get)
+    assert server_dev._build_optional_jira_toolkit() is None
+
+
+def test_reuses_ops_helpers_without_modifying_them(server_dev):
+    """The ops-free helpers are imported, not copied."""
+    ops = server_dev.ops_server
+    assert server_dev.RUN_ARTIFACT_DIR is ops.RUN_ARTIFACT_DIR
+    # Handlers reused verbatim.
+    app = server_dev.build_app(redis_url="redis://x")
+    handlers = {r.handler for r in app.router.routes()}
+    assert ops.handle_bundle in handlers
+    assert ops.handle_replay in handlers
+    assert ops.handle_cancel in handlers
+    # ...but NOT the ops index/config/run.
+    assert ops.handle_index not in handlers
+    assert ops.handle_config not in handlers
+    assert ops.handle_run not in handlers

--- a/packages/ai-parrot/tests/flows/dev_flow/test_subagent_defs.py
+++ b/packages/ai-parrot/tests/flows/dev_flow/test_subagent_defs.py
@@ -1,0 +1,233 @@
+"""Tests for the dev-flow subagent loader and the sdd-ideation prompt.
+
+Covers FEAT-412 TASK-2124: the ``dev_flow``-owned
+:func:`load_subagent_definition` (same contract as ``dev_loop``'s) and the
+content guarantees the ``IdeationNode`` round-trip depends on — both dispatch
+modes, the resume/extend policy, the FEAT-145 frontmatter, the
+Open-Questions convention, the explicit-path commit, and JSON-only output.
+
+The prompt-content assertions are deliberately behavioral rather than
+cosmetic: each one guards an instruction whose loss would silently break the
+flow (e.g. a prompt that stops mandating ``committed`` reporting makes
+``IdeationNode``'s fail-fast check meaningless).
+"""
+
+from __future__ import annotations
+
+from importlib import resources
+from pathlib import Path
+
+import pytest
+from parrot.flows.dev_flow._subagent_defs import (
+    _strip_frontmatter,
+    load_subagent_definition,
+)
+
+
+@pytest.fixture(scope="module")
+def body() -> str:
+    return load_subagent_definition("sdd-ideation")
+
+
+# ---------------------------------------------------------------------------
+# Loader contract
+# ---------------------------------------------------------------------------
+
+
+def test_loader_returns_ideation_body(body: str):
+    assert body
+    # Frontmatter stripped: the body starts at the first heading.
+    assert not body.startswith("---")
+    assert "name: sdd-ideation" not in body
+    assert body.lstrip().startswith("# SDD Ideation")
+
+
+def test_loader_unknown_name_raises():
+    with pytest.raises(ValueError, match="Unknown subagent name"):
+        load_subagent_definition("sdd-planner")  # dev_loop's, not ours
+    with pytest.raises(ValueError, match="Unknown subagent name"):
+        load_subagent_definition("nope")
+
+
+def test_loader_reads_package_data_dir():
+    """The loader reads the package copy, not `.claude/agents/`."""
+    pkg_copy = (
+        resources.files("parrot.flows.dev_flow")
+        / "_subagent_data"
+        / "sdd-ideation.md"
+    )
+    assert pkg_copy.is_file()
+    assert load_subagent_definition("sdd-ideation") == _strip_frontmatter(
+        pkg_copy.read_text(encoding="utf-8")
+    )
+
+
+def test_strip_frontmatter_edge_cases():
+    assert _strip_frontmatter("# no frontmatter") == "# no frontmatter"
+    assert _strip_frontmatter("---\na: 1\n---\nbody") == "body"
+    # Malformed (never closed) → returned unchanged, never truncated.
+    unclosed = "---\na: 1\nbody"
+    assert _strip_frontmatter(unclosed) == unclosed
+
+
+# ---------------------------------------------------------------------------
+# Dual-mode behavior
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_mentions_both_modes_and_output_fields(body: str):
+    """One definition, two modes — and the full IdeationOutput contract."""
+    assert 'mode="brainstorm"' in body or "mode = \"brainstorm\"" in body
+    assert 'mode="proposal"' in body or "mode = \"proposal\"" in body
+    assert "new_feature" in body
+    assert "enhancement" in body
+
+    for field in (
+        "document_path",
+        "document_kind",
+        "slug",
+        "resumed_existing",
+        "open_questions",
+        "summary",
+        "committed",
+    ):
+        assert field in body, f"prompt must document the {field!r} output field"
+
+
+def test_prompt_binds_mode_to_document_suffix(body: str):
+    """brainstorm → .brainstorm.md, proposal → .proposal.md."""
+    assert "sdd/proposals/<slug>.brainstorm.md" in body
+    assert "sdd/proposals/<slug>.proposal.md" in body
+    # The mode, not the agent's judgement, decides the format.
+    assert "`mode` decides the format" in body
+
+
+def test_prompt_keeps_enhancement_proposal_light(body: str):
+    """The enhancement path must NOT become the deep /sdd-proposal artifact."""
+    lowered = body.lower()
+    assert "light" in lowered
+    assert "/sdd-proposal" in body  # explicitly disclaimed
+    assert "options analysis" in lowered
+    # The light format's required sections.
+    for section in ("## Scope", "## Rationale", "## Impact"):
+        assert section in body
+
+
+def test_prompt_brainstorm_requires_options_and_recommendation(body: str):
+    assert "## Options Explored" in body
+    assert "## Recommendation" in body
+    assert "Option A" in body and "Option B" in body
+
+
+# ---------------------------------------------------------------------------
+# Resume/extend policy (spec §8 resolution)
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_mandates_resume_extend_policy(body: str):
+    lowered = body.lower()
+    assert "resume" in lowered and "extend" in lowered
+    assert "resumed_existing" in body
+    # Never overwrite, never suffix.
+    assert "never overwrite" in lowered or "never overwrites" in lowered
+    assert "-2" in body  # the forbidden suffixed-copy pattern
+    assert "forbidden" in lowered
+
+
+def test_prompt_handles_slug_collision_as_open_question(body: str):
+    """A mismatched pre-existing document must not be extended silently."""
+    lowered = body.lower()
+    assert "collision" in lowered
+    assert "problem statement" in lowered
+    assert "committed: false" in lowered
+
+
+# ---------------------------------------------------------------------------
+# SDD conventions the downstream planner depends on
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_carries_feat145_frontmatter(body: str):
+    assert "type: feature" in body
+    assert "base_branch: dev" in body
+    assert "FEAT-145" in body
+
+
+def test_prompt_documents_open_questions_convention(body: str):
+    """The exact convention /sdd-spec §2b parses."""
+    assert "- [ ]" in body
+    assert "- [x]" in body
+    assert "*Resolved*:" in body
+    assert "*Owner: user*" in body or "*Owner:" in body
+    # The parser's rule: answer is the text after the final colon.
+    assert "final `:`" in body
+    # Unanswered questions must survive the round, not be deleted/rephrased.
+    lowered = body.lower()
+    assert "do not delete them" in lowered
+
+
+def test_prompt_requires_explicit_path_commit(body: str):
+    """Never `git add -A` — other SDD sessions share the base branch."""
+    assert "git add sdd/proposals/" in body
+    # Case-sensitive on purpose: lowercasing would mangle the `-A` flag.
+    assert "never `git add -A`" in body
+    assert "never `git add .`" in body
+    assert "sdd:" in body  # commit-message convention
+
+
+def test_prompt_mandates_json_only_final_turn(body: str):
+    lowered = body.lower()
+    assert "one json object" in lowered
+    assert "no markdown fences" in lowered
+    assert "no prose" in lowered
+
+
+def test_prompt_forbids_code_and_jira_writes(body: str):
+    lowered = body.lower()
+    assert "you write documents, not code" in lowered
+    assert "jira" in lowered
+    assert "never invent" in lowered  # anti-hallucination on Code Context
+
+
+# ---------------------------------------------------------------------------
+# Repo-level twin parity
+# ---------------------------------------------------------------------------
+
+
+def _repo_agents_dir() -> Path | None:
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / ".claude" / "agents"
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
+def test_prompt_parity_with_repo_twin():
+    """The `.claude/agents/` mirror stays byte-identical to what we dispatch."""
+    agents_dir = _repo_agents_dir()
+    if agents_dir is None:
+        pytest.skip("`.claude/agents/` not found — installed package, not a checkout.")
+
+    repo_copy = agents_dir / "sdd-ideation.md"
+    pkg_copy = (
+        resources.files("parrot.flows.dev_flow")
+        / "_subagent_data"
+        / "sdd-ideation.md"
+    )
+    assert repo_copy.is_file(), f"Expected a repo-level twin at {repo_copy}."
+    assert pkg_copy.read_text(encoding="utf-8") == repo_copy.read_text(
+        encoding="utf-8"
+    ), "sdd-ideation.md drifted between _subagent_data/ and .claude/agents/."
+
+
+def test_repo_twin_has_agent_frontmatter():
+    agents_dir = _repo_agents_dir()
+    if agents_dir is None:
+        pytest.skip("`.claude/agents/` not found — installed package, not a checkout.")
+    text = (agents_dir / "sdd-ideation.md").read_text(encoding="utf-8")
+    assert text.startswith("---\n")
+    head = text.split("---")[1]
+    assert "name: sdd-ideation" in head
+    assert "description:" in head
+    assert "tools:" in head
+    assert "model:" in head

--- a/packages/ai-parrot/tests/flows/dev_loop/test_open_questions_gate.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_open_questions_gate.py
@@ -1,0 +1,428 @@
+"""Tests for the `open_questions` gate extension (FEAT-412, TASK-2122).
+
+The dev-flow's ideation phase needs ONE gate per round carrying ALL of that
+round's Open Questions (structured), resolved with a structured
+``question -> answer`` mapping. The extension touches SHARED ``dev_loop``
+infrastructure, so these tests focus as much on **backward compatibility**
+(pre-FEAT-412 persisted envelopes must still validate and reduce) as on the
+new behavior.
+
+Covers:
+
+* ``open_gate(kind="open_questions", questions=[...])`` and snapshot round-trip.
+* ``resolve_gate(..., answers={...})`` folding, with audit fields intact.
+* Host-side validation: approving with empty answers → ``ValueError`` (400 at
+  the REST layer); rejection needs no answers.
+* Old envelopes (no ``questions``/``answers`` keys) still validate + reduce.
+* Fail-closed expiry for an ``open_questions`` gate.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+from parrot.flows.dev_loop import DevLoopRunner
+from parrot.flows.dev_loop.commands import register_command_routes
+from parrot.flows.dev_loop.session_state import (
+    ActionEnvelope,
+    ApprovalGate,
+    GateExpired,
+    GateOpened,
+    GateResolved,
+    SessionHost,
+    reduce,
+    session_channel,
+)
+
+RUN_ID = "run-oq00001"
+
+QUESTIONS = [
+    "Which store backs the telemetry?",
+    "Sync or async flush?",
+]
+
+
+@pytest.fixture
+def host() -> SessionHost:
+    return SessionHost(RUN_ID)
+
+
+# ---------------------------------------------------------------------------
+# open_gate — the new kind + structured questions
+# ---------------------------------------------------------------------------
+
+
+def test_gate_open_questions_kind(host: SessionHost):
+    """The new kind is accepted and carries the round's questions."""
+    gate_id, envelope = host.open_gate(
+        kind="open_questions",
+        node_id="ideation",
+        title="Open Questions — sdd/proposals/foo.brainstorm.md",
+        questions=QUESTIONS,
+        on_expiry="fail",
+    )
+
+    gate = host.state.gates[gate_id]
+    assert gate.kind == "open_questions"
+    assert gate.status == "pending"
+    assert gate.questions == QUESTIONS
+    assert gate.answers == {}
+    assert gate.on_expiry == "fail"
+    assert envelope.action.type == "gate/opened"
+    # Opening a gate parks the run (park/resume applies to the new kind too).
+    assert host.state.phase == "awaiting_gate"
+
+
+def test_gate_questions_round_trip_through_snapshot(host: SessionHost):
+    gate_id, _ = host.open_gate(
+        kind="open_questions", node_id="ideation", title="q",
+        questions=QUESTIONS,
+    )
+    snap = host.snapshot()
+
+    # Serialize + re-validate the way a Redis-backed subscriber would.
+    raw = snap.model_dump(mode="json")
+    revived = type(snap).model_validate(raw)
+    assert revived.state.gates[gate_id].questions == QUESTIONS
+    assert revived.channel == session_channel(RUN_ID)
+
+
+def test_open_gate_without_questions_defaults_empty(host: SessionHost):
+    """Every pre-existing open_gate() call site keeps working unchanged."""
+    gate_id, _ = host.open_gate(
+        kind="manual_criterion", node_id="qa", title="Check the UI"
+    )
+    assert host.state.gates[gate_id].questions == []
+    assert host.state.gates[gate_id].answers == {}
+
+
+# ---------------------------------------------------------------------------
+# resolve_gate — structured answers
+# ---------------------------------------------------------------------------
+
+
+def test_gate_resolve_with_answers(host: SessionHost):
+    """Answers fold into gate state; the audit fields stay intact."""
+    gate_id, _ = host.open_gate(
+        kind="open_questions", node_id="ideation", title="q",
+        questions=QUESTIONS,
+    )
+    answers = {QUESTIONS[0]: "pgvector", QUESTIONS[1]: "async"}
+
+    envelope = host.resolve_gate(
+        gate_id, "approved", resolved_by="alice", comment="answered",
+        answers=answers,
+    )
+
+    gate = host.state.gates[gate_id]
+    assert gate.status == "approved"
+    assert gate.answers == answers
+    assert gate.questions == QUESTIONS  # questions preserved
+    assert gate.resolved_by == "alice"
+    assert gate.comment == "answered"
+    assert gate.resolved_at is not None
+    assert envelope.action.answers == answers
+    assert host.state.phase == "running"  # gate cleared → run resumes
+
+
+def test_gate_resolve_partial_answers_allowed(host: SessionHost):
+    """Partial answers are valid — unanswered questions stay open in the doc."""
+    gate_id, _ = host.open_gate(
+        kind="open_questions", node_id="ideation", title="q",
+        questions=QUESTIONS,
+    )
+    host.resolve_gate(
+        gate_id, "approved", resolved_by="alice",
+        answers={QUESTIONS[0]: "pgvector"},
+    )
+    gate = host.state.gates[gate_id]
+    assert gate.answers == {QUESTIONS[0]: "pgvector"}
+    assert len(gate.questions) == 2
+
+
+def test_gate_resolve_answers_required(host: SessionHost):
+    """Approving an open_questions gate with no answers is rejected."""
+    gate_id, _ = host.open_gate(
+        kind="open_questions", node_id="ideation", title="q",
+        questions=QUESTIONS,
+    )
+
+    with pytest.raises(ValueError, match="open_questions"):
+        host.resolve_gate(gate_id, "approved", resolved_by="alice")
+    with pytest.raises(ValueError, match="open_questions"):
+        host.resolve_gate(gate_id, "approved", resolved_by="alice", answers={})
+
+    # Validation happens BEFORE sequencing: no action was emitted, the gate
+    # is still pending and can be resolved properly afterwards.
+    assert host.state.gates[gate_id].status == "pending"
+    assert [
+        e for e in host.replay_since(0) if e.action.type == "gate/resolved"
+    ] == []
+    host.resolve_gate(
+        gate_id, "approved", resolved_by="alice", answers={QUESTIONS[0]: "a"}
+    )
+    assert host.state.gates[gate_id].status == "approved"
+
+
+def test_gate_reject_needs_no_answers(host: SessionHost):
+    """Rejection aborts the ideation — no answers required."""
+    gate_id, _ = host.open_gate(
+        kind="open_questions", node_id="ideation", title="q",
+        questions=QUESTIONS,
+    )
+    host.resolve_gate(
+        gate_id, "rejected", resolved_by="alice", comment="wrong document",
+    )
+    gate = host.state.gates[gate_id]
+    assert gate.status == "rejected"
+    assert gate.answers == {}
+    assert gate.comment == "wrong document"
+
+
+def test_answers_ignored_for_other_kinds(host: SessionHost):
+    """Non-open_questions gates need no answers and are unaffected."""
+    gate_id, _ = host.open_gate(
+        kind="plan_approval", node_id="development", title="Approve plan"
+    )
+    host.resolve_gate(gate_id, "approved", resolved_by="alice")
+    assert host.state.gates[gate_id].status == "approved"
+    assert host.state.gates[gate_id].answers == {}
+
+
+@pytest.mark.asyncio
+async def test_wait_gate_returns_answers(host: SessionHost):
+    """IdeationNode's await path sees the answers on the resolved gate."""
+    gate_id, _ = host.open_gate(
+        kind="open_questions", node_id="ideation", title="q",
+        questions=QUESTIONS,
+    )
+
+    async def _resolve():
+        await asyncio.sleep(0)
+        host.resolve_gate(
+            gate_id, "approved", resolved_by="alice",
+            answers={QUESTIONS[0]: "pgvector"},
+        )
+
+    task = asyncio.create_task(_resolve())
+    gate = await host.wait_gate(gate_id)
+    await task
+
+    assert gate.status == "approved"
+    assert gate.answers == {QUESTIONS[0]: "pgvector"}
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility — pre-FEAT-412 envelopes
+# ---------------------------------------------------------------------------
+
+
+def test_gate_backward_compat():
+    """Envelopes persisted before FEAT-412 still validate and reduce."""
+    # An ApprovalGate dict as it was persisted pre-FEAT-412: no questions,
+    # no answers keys at all.
+    legacy_gate = {
+        "gate_id": "g-legacy",
+        "kind": "deployment_approval",
+        "node_id": "deployment_handoff",
+        "status": "pending",
+        "on_expiry": "fail",
+        "title": "Approve deploy",
+        "instructions": "",
+        "payload_ref": "",
+        "opened_at": 1.0,
+        "expires_at": None,
+        "resolved_by": "",
+        "resolved_at": None,
+        "comment": "",
+    }
+    gate = ApprovalGate.model_validate(legacy_gate)
+    assert gate.questions == []
+    assert gate.answers == {}
+
+    legacy_opened = {
+        "channel": session_channel(RUN_ID),
+        "server_seq": 1,
+        "action": {"type": "gate/opened", "ts": 1.0, "gate": legacy_gate},
+        "origin": None,
+    }
+    opened = ActionEnvelope.model_validate(legacy_opened)
+    assert isinstance(opened.action, GateOpened)
+
+    legacy_resolved = {
+        "channel": session_channel(RUN_ID),
+        "server_seq": 2,
+        "action": {
+            "type": "gate/resolved",
+            "ts": 2.0,
+            "gate_id": "g-legacy",
+            "resolution": "approved",
+            "resolved_by": "alice",
+            "comment": "ship it",
+        },
+        "origin": None,
+    }
+    resolved = ActionEnvelope.model_validate(legacy_resolved)
+    assert isinstance(resolved.action, GateResolved)
+    assert resolved.action.answers == {}
+
+    # ... and the pair still reduces exactly as before.
+    from parrot.flows.dev_loop.session_state import DevLoopSessionState
+
+    state = DevLoopSessionState(run_id=RUN_ID, channel=session_channel(RUN_ID))
+    state = reduce(state, opened.action)
+    assert state.phase == "awaiting_gate"
+    state = reduce(state, resolved.action)
+    assert state.gates["g-legacy"].status == "approved"
+    assert state.gates["g-legacy"].comment == "ship it"
+    assert state.gates["g-legacy"].answers == {}
+
+
+def test_legacy_resolve_does_not_clobber_existing_answers():
+    """A GateResolved with no answers leaves the (empty) mapping empty."""
+    host = SessionHost(RUN_ID)
+    gate_id, _ = host.open_gate(
+        kind="manual_criterion", node_id="qa", title="x"
+    )
+    # Simulate a replayed legacy action (no answers field on the wire).
+    host.apply(
+        GateResolved(
+            gate_id=gate_id, resolution="approved", resolved_by="alice",
+            comment="c",
+        )
+    )
+    assert host.state.gates[gate_id].answers == {}
+    assert host.state.gates[gate_id].comment == "c"
+
+
+# ---------------------------------------------------------------------------
+# Expiry — fail-closed for open_questions
+# ---------------------------------------------------------------------------
+
+
+def test_open_questions_expiry_fail_closed(host: SessionHost):
+    """Silence is not consent for spec decisions: expiry emits GateExpired."""
+    gate_id, _ = host.open_gate(
+        kind="open_questions", node_id="ideation", title="q",
+        questions=QUESTIONS, ttl_seconds=10, on_expiry="fail",
+    )
+    envelopes = host.expire_due_gates(now=host.state.gates[gate_id].opened_at + 11)
+
+    assert len(envelopes) == 1
+    assert isinstance(envelopes[0].action, GateExpired)
+    assert host.state.gates[gate_id].status == "expired"
+    assert host.state.gates[gate_id].answers == {}
+
+
+def test_open_questions_not_expired_before_ttl(host: SessionHost):
+    gate_id, _ = host.open_gate(
+        kind="open_questions", node_id="ideation", title="q",
+        questions=QUESTIONS, ttl_seconds=100,
+    )
+    assert host.expire_due_gates(now=host.state.gates[gate_id].opened_at + 1) == []
+    assert host.state.gates[gate_id].status == "pending"
+
+
+# ---------------------------------------------------------------------------
+# REST layer — answers passthrough + 400 on empty-answers approval
+# ---------------------------------------------------------------------------
+
+
+def _build_app(runner: DevLoopRunner) -> web.Application:
+    app = web.Application()
+    register_command_routes(app, runner)
+    return app
+
+
+@pytest.fixture
+def runner() -> DevLoopRunner:
+    return DevLoopRunner(MagicMock(), max_concurrent_runs=2)
+
+
+@pytest.fixture
+def rest_host(runner: DevLoopRunner):
+    return runner._register_host(RUN_ID)  # test-only: REST-layer scope
+
+
+@pytest.mark.asyncio
+async def test_rest_resolve_with_answers(aiohttp_client, runner, rest_host):
+    gate_id, _ = rest_host.open_gate(
+        kind="open_questions", node_id="ideation", title="q",
+        questions=QUESTIONS,
+    )
+    client = await aiohttp_client(_build_app(runner))
+    answers = {QUESTIONS[0]: "pgvector", QUESTIONS[1]: "async"}
+
+    resp = await client.post(
+        f"/runs/{RUN_ID}/gates/{gate_id}/resolve",
+        json={
+            "resolution": "approved",
+            "resolved_by": "alice",
+            "answers": answers,
+        },
+    )
+
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["envelope"]["action"]["answers"] == answers
+    assert rest_host.state.gates[gate_id].answers == answers
+
+
+@pytest.mark.asyncio
+async def test_rest_resolve_empty_answers_400(aiohttp_client, runner, rest_host):
+    gate_id, _ = rest_host.open_gate(
+        kind="open_questions", node_id="ideation", title="q",
+        questions=QUESTIONS,
+    )
+    client = await aiohttp_client(_build_app(runner))
+
+    resp = await client.post(
+        f"/runs/{RUN_ID}/gates/{gate_id}/resolve",
+        json={"resolution": "approved", "resolved_by": "alice"},
+    )
+
+    assert resp.status == 400
+    data = await resp.json()
+    assert data["error"] == "answers_required"
+    assert rest_host.state.gates[gate_id].status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_rest_reject_without_answers_200(aiohttp_client, runner, rest_host):
+    gate_id, _ = rest_host.open_gate(
+        kind="open_questions", node_id="ideation", title="q",
+        questions=QUESTIONS,
+    )
+    client = await aiohttp_client(_build_app(runner))
+
+    resp = await client.post(
+        f"/runs/{RUN_ID}/gates/{gate_id}/resolve",
+        json={"resolution": "rejected", "resolved_by": "alice",
+              "comment": "wrong doc"},
+    )
+
+    assert resp.status == 200
+    assert rest_host.state.gates[gate_id].status == "rejected"
+
+
+@pytest.mark.asyncio
+async def test_rest_legacy_body_without_answers_still_works(
+    aiohttp_client, runner, rest_host
+):
+    """Pre-FEAT-412 clients (no `answers` key) keep working on other kinds."""
+    gate_id, _ = rest_host.open_gate(
+        kind="deployment_approval", node_id="deployment_handoff", title="x"
+    )
+    client = await aiohttp_client(_build_app(runner))
+
+    resp = await client.post(
+        f"/runs/{RUN_ID}/gates/{gate_id}/resolve",
+        json={"resolution": "approved", "resolved_by": "alice", "comment": "go"},
+    )
+
+    assert resp.status == 200
+    assert rest_host.state.gates[gate_id].status == "approved"
+    assert rest_host.state.gates[gate_id].answers == {}

--- a/packages/ai-parrot/tests/flows/dev_loop/test_plan_gate_override.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_plan_gate_override.py
@@ -1,0 +1,232 @@
+"""Per-run ``require_plan_approval`` override in DevelopmentNode (FEAT-412).
+
+The dev console (``dev.html``) exposes a per-run plan-approval toggle, so the
+gate decision can no longer be fixed at flow-construction time. These tests
+pin the resolution order implemented in
+``DevelopmentNode._check_plan_approval``:
+
+    explicit shared["require_plan_approval"] (True OR False)
+        > constructor flag  (when the key is absent, or present as None)
+
+Truthiness is deliberately NOT used: an explicit ``False`` must suppress a
+gate the constructor flag would have opened.
+
+Style mirrors ``test_gate_integration.py``'s plan-gate section (same
+fixtures, same "resolve the gate from a concurrent task" pattern).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from parrot.flows.dev_loop import DevelopmentOutput, ResearchOutput
+from parrot.flows.dev_loop.nodes.development import DevelopmentNode
+from parrot.flows.dev_loop.session_state import SessionHost
+
+RUN_ID = "run-plangate01"
+
+
+@pytest.fixture
+def dev_ctx() -> dict:
+    return {
+        "run_id": RUN_ID,
+        "research_output": ResearchOutput(
+            jira_issue_key="OPS-1",
+            spec_path="sdd/specs/x.spec.md",
+            feat_id="FEAT-412",
+            branch_name="feat-412-sdd-dev-flow",
+            worktree_path="/tmp/feat-412-plan-gate-override",
+            log_excerpts=[],
+        ),
+    }
+
+
+@pytest.fixture
+def dev_dispatcher() -> MagicMock:
+    d = MagicMock()
+    d.dispatch = AsyncMock(
+        return_value=DevelopmentOutput(
+            files_changed=["a.py"], commit_shas=["s1"], summary="ok"
+        )
+    )
+    return d
+
+
+async def _approve_first_gate(host: SessionHost) -> None:
+    """Approve whatever gate the node opens, shortly after it opens."""
+    await asyncio.sleep(0.01)
+    gate_id = next(iter(host.state.gates))
+    host.resolve_gate(gate_id, "approved", resolved_by="alice")
+
+
+# ---------------------------------------------------------------------------
+# shared state overrides the constructor flag — both directions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_shared_true_overrides_ctor_false(dev_ctx, dev_dispatcher):
+    """The UI toggle turns the gate ON for a run built without the flag."""
+    node = DevelopmentNode(dispatcher=dev_dispatcher)  # ctor: False
+    host = SessionHost(RUN_ID)
+    dev_ctx["session_host"] = host
+    dev_ctx["require_plan_approval"] = True
+
+    resolver = asyncio.ensure_future(_approve_first_gate(host))
+    result = await node.execute(dev_ctx)
+    await resolver
+
+    assert isinstance(result, DevelopmentOutput)
+    # A real plan_approval gate was opened and awaited.
+    assert len(host.state.gates) == 1
+    gate = host.state.gates[next(iter(host.state.gates))]
+    assert gate.kind == "plan_approval"
+    assert gate.status == "approved"
+    assert gate.on_expiry == "approve"  # fail-open policy unchanged
+    dev_dispatcher.dispatch.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shared_false_overrides_ctor_true(dev_ctx, dev_dispatcher):
+    """An explicit False suppresses the gate the ctor flag would have opened."""
+    node = DevelopmentNode(dispatcher=dev_dispatcher, require_plan_approval=True)
+    host = SessionHost(RUN_ID)
+    dev_ctx["session_host"] = host
+    dev_ctx["require_plan_approval"] = False
+
+    # No resolver task: if a gate were opened, this would hang.
+    result = await asyncio.wait_for(node.execute(dev_ctx), timeout=2)
+
+    assert isinstance(result, DevelopmentOutput)
+    assert host.state.gates == {}
+    dev_dispatcher.dispatch.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shared_true_with_ctor_true_still_opens_one_gate(
+    dev_ctx, dev_dispatcher
+):
+    """Redundant agreement is not a double gate."""
+    node = DevelopmentNode(dispatcher=dev_dispatcher, require_plan_approval=True)
+    host = SessionHost(RUN_ID)
+    dev_ctx["session_host"] = host
+    dev_ctx["require_plan_approval"] = True
+
+    resolver = asyncio.ensure_future(_approve_first_gate(host))
+    await node.execute(dev_ctx)
+    await resolver
+
+    assert len(host.state.gates) == 1
+
+
+# ---------------------------------------------------------------------------
+# absent / None key → constructor flag (pre-FEAT-412 behavior)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_absent_key_falls_back_to_ctor_false(dev_ctx, dev_dispatcher):
+    node = DevelopmentNode(dispatcher=dev_dispatcher)  # ctor: False
+    host = SessionHost(RUN_ID)
+    dev_ctx["session_host"] = host
+    assert "require_plan_approval" not in dev_ctx
+
+    result = await asyncio.wait_for(node.execute(dev_ctx), timeout=2)
+
+    assert isinstance(result, DevelopmentOutput)
+    assert host.state.gates == {}
+
+
+@pytest.mark.asyncio
+async def test_absent_key_falls_back_to_ctor_true(dev_ctx, dev_dispatcher):
+    node = DevelopmentNode(dispatcher=dev_dispatcher, require_plan_approval=True)
+    host = SessionHost(RUN_ID)
+    dev_ctx["session_host"] = host
+
+    resolver = asyncio.ensure_future(_approve_first_gate(host))
+    result = await node.execute(dev_ctx)
+    await resolver
+
+    assert isinstance(result, DevelopmentOutput)
+    assert len(host.state.gates) == 1
+    assert host.state.gates[next(iter(host.state.gates))].kind == "plan_approval"
+
+
+@pytest.mark.asyncio
+async def test_none_value_is_treated_as_absent(dev_ctx, dev_dispatcher):
+    """A form that submits nothing must not silently disable the ctor flag."""
+    node = DevelopmentNode(dispatcher=dev_dispatcher, require_plan_approval=True)
+    host = SessionHost(RUN_ID)
+    dev_ctx["session_host"] = host
+    dev_ctx["require_plan_approval"] = None
+
+    resolver = asyncio.ensure_future(_approve_first_gate(host))
+    await node.execute(dev_ctx)
+    await resolver
+
+    assert len(host.state.gates) == 1
+
+
+# ---------------------------------------------------------------------------
+# the retry-idempotency guard still wins over the override
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_plan_gate_checked_guard_still_wins(dev_ctx, dev_dispatcher):
+    """A QA-repair-loop re-entry must not re-open the gate, override or not."""
+    node = DevelopmentNode(dispatcher=dev_dispatcher)  # ctor: False
+    host = SessionHost(RUN_ID)
+    dev_ctx["session_host"] = host
+    dev_ctx["require_plan_approval"] = True
+
+    resolver = asyncio.ensure_future(_approve_first_gate(host))
+    await node.execute(dev_ctx)
+    await resolver
+    assert len(host.state.gates) == 1
+    assert dev_ctx["_plan_gate_checked"] is True
+
+    # Second entry (repair loop): no new gate, no hang.
+    result = await asyncio.wait_for(node.execute(dev_ctx), timeout=2)
+
+    assert isinstance(result, DevelopmentOutput)
+    assert len(host.state.gates) == 1  # still exactly one
+
+
+@pytest.mark.asyncio
+async def test_preset_checked_guard_suppresses_override(dev_ctx, dev_dispatcher):
+    """``_plan_gate_checked`` already set → the override cannot open a gate."""
+    node = DevelopmentNode(dispatcher=dev_dispatcher)
+    host = SessionHost(RUN_ID)
+    dev_ctx["session_host"] = host
+    dev_ctx["require_plan_approval"] = True
+    dev_ctx["_plan_gate_checked"] = True
+
+    result = await asyncio.wait_for(node.execute(dev_ctx), timeout=2)
+
+    assert isinstance(result, DevelopmentOutput)
+    assert host.state.gates == {}
+
+
+# ---------------------------------------------------------------------------
+# no-host legacy fallback still applies to the override path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_override_without_host_warns_and_proceeds(
+    dev_ctx, dev_dispatcher, caplog
+):
+    import logging
+
+    node = DevelopmentNode(dispatcher=dev_dispatcher)  # ctor: False
+    dev_ctx["require_plan_approval"] = True  # no session_host in ctx
+
+    with caplog.at_level(logging.WARNING):
+        result = await asyncio.wait_for(node.execute(dev_ctx), timeout=2)
+
+    assert isinstance(result, DevelopmentOutput)
+    assert any("no session_host" in rec.message for rec in caplog.records)
+    dev_dispatcher.dispatch.assert_awaited()

--- a/sdd/tasks/completed/TASK-2121-dev-flow-models.md
+++ b/sdd/tasks/completed/TASK-2121-dev-flow-models.md
@@ -146,10 +146,43 @@ def test_ideation_output_document_kind_literal(): ...
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**:
-**Date**:
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-08-05
 **Notes**:
 
-**Deviations from spec**: none
+Created the `parrot.flows.dev_flow` package with the three FEAT-412 contracts:
+
+- `models.py` — `DevRequestKind` Literal, `DevRequestBrief` (NL intake, no
+  document validators, `title`/`description` `min_length=1`, optional
+  `context`/`jira_issue_key`/`dev_agents`/`judge_panel`), the
+  `DevFlowBrief` discriminated union on `kind`, `parse_dev_brief()` loader
+  shim, and `IdeationOutput` (all optional fields defaulted).
+- `__init__.py` — eager re-export of the light model contracts plus a
+  `__getattr__`/`_LAZY_EXPORTS` hook so the heavier topology/runner symbols
+  landing in TASK-2127/2128 can be resolved lazily without the package init
+  importing aiohttp/redis/dispatcher machinery.
+- 14 unit tests covering every case in the task's Test Specification plus
+  union `TypeAdapter` validation and the package re-export surface.
+
+Verified against the Codebase Contract before writing code: `FeatureBrief`
+(`models/base.py:725`, eager `document_path` validator at :780),
+`DevAgentSpec` (:388), `JudgePanelConfig` (:866), and the
+`Brief`/`parse_brief` precedent (:984/:987) — all as documented.
+
+Design note: `parse_dev_brief` deliberately **raises** on a missing/unknown
+`kind` rather than defaulting. `parse_brief`'s `WorkBrief` fallback exists
+only to preserve pre-FEAT-378 callers that omit `kind`; dev-flow has no such
+legacy surface and the spec states the intent is always user-selected, so a
+silent default would mask a UI/brief bug. Covered by
+`test_parse_dev_brief_requires_explicit_kind`.
+
+Validation: `pytest packages/ai-parrot/tests/flows/dev_flow/ -q` → 14 passed.
+`ruff check` clean. `mypy` reports 0 errors in `dev_flow/` (the repo-wide
+count comes from pre-existing errors in followed imports, unchanged by this
+task).
+
+**Deviations from spec**: none. `ruff --fix` normalized the spec's
+`Optional[X]`/`List[X]`/`Union[...]` annotation style to PEP 604/585
+(`X | None`, `list[X]`, `A | B`) per the project's lint config — a
+cosmetic style change; field names, types and semantics are exactly as
+specified.

--- a/sdd/tasks/completed/TASK-2122-open-questions-gate.md
+++ b/sdd/tasks/completed/TASK-2122-open-questions-gate.md
@@ -124,6 +124,33 @@ class DevLoopRunner:
 - ~~a per-question gate model~~ — spec decision: ONE gate carries ALL
   questions of a round.
 
+### ⚠️ Contract correction (discovered 2026-08-05 during implementation)
+
+The task/spec contract omitted `NodeId`, which is a **closed Literal** in the
+same file (`session_state.py:140-155`) and does NOT contain the dev-flow's
+two new node ids:
+
+```python
+NodeId = Literal[
+    "intent_classifier", "bug_intake", "research", "development", "qa",
+    "deployment_handoff", "revision_handoff", "failure_handler", "close",
+    # -- feature-mode topology (FEAT-378) --
+    "planner", "synthesis", "feedback_router", "feature_handoff",
+]
+```
+
+`ApprovalGate.node_id` is typed `NodeId`, so the spec's own normative call —
+`host.open_gate(kind="open_questions", node_id="ideation", ...)` (spec §2
+"The Open-Questions HITL round-trip", step 2) — raises a
+`ValidationError` until `NodeId` gains `"dev_intake"` and `"ideation"`.
+
+**Resolution**: extend `NodeId` additively with the two dev-flow node ids,
+exactly as FEAT-378 did for its four feature-mode ids (same file, same
+comment convention). Strictly additive — no existing value changes, so all
+persisted envelopes and existing call sites are unaffected. Done here rather
+than in TASK-2126 because `session_state.py` is already in this task's
+scope and TASK-2125/2126 would otherwise be blocked on it.
+
 ---
 
 ## Implementation Notes
@@ -185,10 +212,69 @@ def test_open_questions_expiry_fail_closed(): ...  # GateExpired emitted
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**:
-**Date**:
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-08-05
 **Notes**:
 
-**Deviations from spec**: none
+Strictly additive extension of the shared gate model:
+
+- `session_state.py` — `GateKind += "open_questions"`;
+  `ApprovalGate.questions: List[str] = []` / `answers: Dict[str, str] = {}`;
+  `GateResolved.answers`; `open_gate(questions=...)` and
+  `resolve_gate(answers=...)` passthrough; reducer folds `answers` alongside
+  `comment`. Host-side validation raises `ValueError` when an
+  `open_questions` gate is **approved** with no answers — before sequencing,
+  so no action is emitted and the gate stays pending (asserted in
+  `test_gate_resolve_answers_required`). Rejection needs no answers.
+- `commands.py` — `ResolveGateRequest.answers` (defaulted, so pre-FEAT-412
+  bodies still satisfy the frozen `extra="forbid"` model) + a dedicated
+  `except ValueError` → **400 `answers_required`**. Placed deliberately:
+  `GateNotFoundError` is a `KeyError` and `GateAlreadyResolvedError` is a
+  `RuntimeError`, so the new clause cannot shadow the existing 404/409 paths
+  (the module's ordering caveat is preserved).
+- `runner.py` — `DevLoopRunner.resolve_gate(answers=...)` passthrough.
+
+Backward compatibility is covered explicitly: `test_gate_backward_compat`
+validates a hand-written pre-FEAT-412 `ApprovalGate` dict, a `gate/opened`
+and a `gate/resolved` envelope with **no** `questions`/`answers` keys, then
+reduces the pair and asserts the old semantics; plus a REST test with a
+legacy body. 17 new tests, all passing.
+
+**Regression net**: full `dev_loop` suite → **1033 passed, 6 skipped, 1
+failed**. The single failure,
+`test_qa_codereview.py::test_review_brief_carries_deterministic_qa_results`
+(`review_brief.qa_criterion_results == []`), is **pre-existing on `dev`** and
+unrelated to gates — verified by running that test against the unmodified
+main checkout at `dev` HEAD, where it fails identically. Not touched (out of
+scope, Cardinal Rule 5).
+
+`ruff`: `commands.py` and the new test file are at **0** findings; the
+`session_state.py`/`runner.py`/`conf.py` counts are unchanged from `dev`
+apart from the new lines following each file's own `Dict`/`List`/`Optional`
+house style. (Note: the repo ships no ruff config and CI's
+"Lint & Registry Check" job does not run ruff, so these files carry 63/62
+default-ruleset findings on `dev` already; "clean on modified files" is
+interpreted as "adds no new findings".)
+
+**Deviations from spec**: two, both forced and strictly additive.
+
+1. **`NodeId` extended** with `"dev_intake"` and `"ideation"`
+   (`session_state.py:150-159`). Not in the task/spec contract, but
+   `ApprovalGate.node_id` is typed `NodeId` — a **closed** Literal — so the
+   spec's own normative call `open_gate(kind="open_questions",
+   node_id="ideation", ...)` (§2 round-trip step 2) raised a
+   `ValidationError`. Extended exactly as FEAT-378 did for its four
+   feature-mode ids. Full detail recorded in the *Contract correction*
+   section above.
+2. **`packages/ai-parrot/src/parrot/conf.py` modified** (not in this task's
+   file table) to add `DEV_FLOW_GATE_TTL_QUESTIONS` (int, default 86400 —
+   24h, fail-closed), plus its `_GATE_TTL_CONF_ATTR` entry in `runner.py`.
+   Forced by `test_runner_host.py::test_gate_ttl_for_covers_every_gate_kind`,
+   a deliberate regression guard asserting **every** `GateKind` resolves a
+   TTL — extending `GateKind` (this task's core scope) breaks it otherwise,
+   which would violate this task's own "full existing dev_loop suite passes"
+   criterion. The key, its name and its default are exactly as specified in
+   spec §2 Configuration.
+   **Hand-off**: `conf.py` and both `DEV_FLOW_*` keys are listed under
+   TASK-2126, which should now add only the remaining
+   `DEV_FLOW_IDEATION_MAX_ROUNDS` key.

--- a/sdd/tasks/completed/TASK-2123-plan-gate-per-run-override.md
+++ b/sdd/tasks/completed/TASK-2123-plan-gate-per-run-override.md
@@ -127,10 +127,40 @@ async def test_plan_gate_checked_guard_still_wins(): ...
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**:
-**Date**:
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-08-05
 **Notes**:
 
-**Deviations from spec**: none
+`DevelopmentNode._check_plan_approval` now resolves the requirement per run:
+
+```python
+override = shared.get("require_plan_approval")
+required = self._require_plan_approval if override is None else bool(override)
+if not required or shared.get("_plan_gate_checked"):
+    return
+```
+
+Implementation choices worth recording:
+
+- **Sentinel, not truthiness** (as the task required): an explicit `False`
+  suppresses a gate the constructor flag would have opened, while an absent
+  key falls back to that flag. A present-but-`None` value is treated as
+  *absent* rather than as `False` — a form/JSON payload that omits the field
+  (or sends `null`) must not silently disable a flow-level plan gate.
+  Pinned by `test_none_value_is_treated_as_absent`.
+- `_require_plan_approval` is **read**, never mutated — no `object.__setattr__`
+  at check time, so concurrent runs sharing one node instance cannot leak
+  each other's toggle.
+- The `_plan_gate_checked` guard is untouched and still short-circuits ahead
+  of any gate work, so a QA-repair-loop re-entry cannot re-open the gate even
+  with the override set (`test_plan_gate_checked_guard_still_wins`,
+  `test_preset_checked_guard_suppresses_override`).
+- The no-host legacy fallback (warn + proceed) applies to the override path
+  too (`test_override_without_host_warns_and_proceeds`).
+
+9 new tests, all passing. Regression: `test_gate_integration.py`,
+`test_runner_park.py`, `test_development_node.py`, `test_development.py` →
+57 passed unmodified. `ruff`: new test file 0 findings;
+`development.py` unchanged at 28 (pre-existing, same count as on `dev`).
+
+**Deviations from spec**: none.

--- a/sdd/tasks/completed/TASK-2124-sdd-ideation-subagent.md
+++ b/sdd/tasks/completed/TASK-2124-sdd-ideation-subagent.md
@@ -155,10 +155,72 @@ def test_prompt_mandates_resume_extend_policy(): ...
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**:
-**Date**:
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-08-05
 **Notes**:
 
-**Deviations from spec**: none
+Created the dual-mode `sdd-ideation` definition (320 lines), the dev_flow
+loader, and the byte-identical `.claude/agents/` mirror.
+
+**Prompt structure** — input table (`mode`, `title`, `description`,
+`context`, `graph_context`, `answers`, `document_path`, `round`) → 4 steps
+(slug/path resolution → existing-document policy → write → commit) →
+cardinal rules → output contract → failure handling. Both mode formats are
+spelled out as literal section skeletons so the two outputs stay uniform for
+`/sdd-spec` and `PlannerNode`:
+
+- `mode="brainstorm"` — Problem Statement, Constraints, **Options Explored
+  (A/B/C) + Recommendation**, Feature Description, Impact, Code Context,
+  Open Questions.
+- `mode="proposal"` — Origin, Scope (What Changes / What's New / Non-Goals),
+  Rationale, Impact, Code Context, Open Questions. Explicitly disclaims the
+  deep `/sdd-proposal` artifact ("no confidence maps, no hypothesis blocks,
+  no research audit") per spec §1 Non-Goals.
+
+**Three-way existing-document policy** (spec §8 + §7 Known Risks): absent →
+create; exists and matches → `Edit` in place with `resumed_existing=true`;
+exists but the Problem Statement is about something else → **touch nothing**,
+return ONE open question naming the collision, `committed=false`. Overwriting
+and `-2`-suffixed copies are called out as "absolutely forbidden" — the human
+resolves slug collisions.
+
+**Open-Questions convention verified against the real parser**, not just the
+task text. `/sdd-spec` §2b (`.claude/commands/sdd-spec.md:70-90`) documents
+`- [x] q — *Owner: name*: <answer>` and defines the answer as *"the text
+after the final `:` on the same line"*. The spec's mandated
+`- [x] q — *Resolved*: <answer>` satisfies that same rule, so the two are
+compatible; I used the spec's form and made the "answer follows the final
+`:`" rule explicit in the prompt. The prompt also requires **folding a
+resolved answer into the document body**, not just flipping the checkbox
+(mirrors §2b rule 2), and forbids deleting or rephrasing unanswered
+questions.
+
+**`open_questions` strings must match the document text exactly** — the
+prompt states this, because the flow uses them as dictionary keys when
+collecting the human's `answers`.
+
+17 tests. The content assertions are behavioral (each guards an instruction
+whose loss would break the flow) rather than cosmetic, plus loader-contract
+tests, `_strip_frontmatter` edge cases (including the malformed-frontmatter
+no-truncation path), and a byte-parity test against the `.claude/agents/`
+twin modelled on `dev_loop`'s `test_subagent_parity.py`.
+
+Full `dev_flow` suite: 31 passed. `ruff`: 0 findings on both new files.
+
+**Deviations from spec**: one, forced and additive.
+
+- **`packages/ai-parrot/pyproject.toml` modified** (not in this task's file
+  table): added
+  `"parrot.flows.dev_flow" = ["_subagent_data/*.md"]` to
+  `[tool.setuptools.package-data]`, mirroring the existing
+  `parrot.flows.dev_loop` entry. Without it the prompt is **not shipped in
+  the wheel**, and since `load_subagent_definition` reads it through
+  `importlib.resources` (deliberately, so dispatch works outside a repo
+  checkout), the loader would raise `FileNotFoundError` for every installed
+  deployment — i.e. this task's first acceptance criterion would hold only in
+  a source checkout. One line + comment; no other packaging metadata touched.
+
+Note for reviewers: `.claude/` is gitignored, so the mirror was added with
+`git add -f`, the same grandfathered-path pattern CLAUDE.md documents for
+`sdd/templates/*.md`. The other 10 files under `.claude/agents/` are tracked
+the same way.

--- a/sdd/tasks/completed/TASK-2125-dev-intake-node.md
+++ b/sdd/tasks/completed/TASK-2125-dev-intake-node.md
@@ -143,10 +143,53 @@ async def test_emits_intake_validated_event(): ...
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**:
-**Date**:
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-08-05
 **Notes**:
 
-**Deviations from spec**: none
+`DevIntakeNode` registered as `dev_flow.dev_intake`, mirroring
+`IntentClassifierNode`'s structure without importing or subclassing it:
+`execute` → `_load_brief` → per-kind publication → `_emit_validated_event`,
+plus `_ensure_redis`/`close` for the lazy cached client.
+
+Publication contract:
+
+- `ctx["dev_brief"]` is set for **every** kind (canonical dev-flow key).
+- `ctx["feature_brief"]` is set **only** for `kind == "feature"` — the exact
+  key `PlannerNode` reads, which is what lets a document intake skip
+  ideation. A natural-language brief deliberately leaves it unset;
+  `IdeationNode` populates it later (asserted by
+  `test_loads_brief_from_ctx`).
+- The bug-mode keys (`bug_brief` / `work_brief`) are never written
+  (`test_never_publishes_bug_mode_keys`).
+
+Load order is `ctx["dev_brief"]` → `ctx["feature_brief"]` → JSON prompt,
+accepting either a model instance or a raw dict. Validation happens in
+`_load_brief`, i.e. **before** anything is published and before the event is
+emitted — `test_invalid_brief_raises_before_return` asserts an unreadable
+`FeatureBrief.document_path` leaves the context untouched and `xadd`
+un-awaited.
+
+The `flow.intake_validated` payload is per-kind: a `FeatureBrief` reports
+`document_kind`/`document_path`/`jira_issue_key`, a `DevRequestBrief` reports
+`title`/`jira_issue_key`. The `n_criteria`/`affected_component` fields from
+the bug-mode event are deliberately absent — dev-flow briefs have neither.
+
+20 tests, all passing (51 across the whole `dev_flow` suite). Includes the
+degraded-Redis paths (connect failure and `xadd` failure both drop the event
+without failing the run), the no-`run_id` skip, and `close()` idempotency.
+
+`ruff`: the entire `dev_flow` package + test package is at **0** findings.
+The two unavoidable `except Exception` telemetry guards carry an explicit
+`# noqa: BLE001 — telemetry must never break a run`, the same convention
+`session_state.py:1023` uses (the mirrored `intent_classifier.py` predates
+that convention and carries the findings unsuppressed).
+
+**Deviations from spec**: none.
+
+Contract note: the task's Codebase Contract did not name the `NODE_REGISTRY`
+import path, and my registration test initially guessed
+`parrot.bots.flows.core.registry`, which does not exist. Verified and
+corrected to `parrot.bots.flows.flow.flow` (the path
+`dev_loop/nodes/base.py:30` itself imports from). Test-only; no production
+code was affected.

--- a/sdd/tasks/completed/TASK-2126-ideation-node.md
+++ b/sdd/tasks/completed/TASK-2126-ideation-node.md
@@ -187,10 +187,78 @@ async def test_resumed_existing_flag_passthrough(): ...
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**:
-**Date**:
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-08-05
 **Notes**:
 
-**Deviations from spec**: none
+`IdeationNode` registered as `dev_flow.ideation`, implementing spec §2's
+round-trip. 22 tests, all green on the first run; 73 across `dev_flow`.
+
+**Round accounting.** `rounds_used` counts *gates opened*, and the loop
+condition is `output.open_questions and host is not None and rounds_used <
+max_rounds`. With the default 2 that yields at most 2 gates and 3 dispatches
+(1 initial + 2 re-dispatches), and the re-dispatch after the last allowed
+round cannot open a gate — the task's explicit requirement. Covered by
+`test_rounds_bounded` (asserts exactly 2 gates / 3 dispatches),
+`test_max_rounds_zero_opens_no_gate`, and
+`test_max_rounds_reads_conf_when_not_overridden` (conf read at execute time,
+so a monkeypatch takes effect per-case).
+
+**Gate shape.** ONE gate per round carrying **all** questions, `node_id`
+`"ideation"`, `on_expiry="fail"`, `ttl_seconds=conf.DEV_FLOW_GATE_TTL_QUESTIONS`
+(read via `getattr` at call time). The resolved `document_path` goes in the
+gate **title** — spec §7's mitigation for the slug-collision risk, so the user
+can spot and reject an unintended resume. `instructions` carry
+round N/M, the `resumed_existing` state, the summary, and a note that partial
+answers are fine and rejection aborts. Asserted in
+`test_gate_roundtrip_answers_reach_redispatch`.
+
+**Two contract details worth flagging for review:**
+
+1. **The subagent is dispatched via `system_prompt_override`, not
+   `profile.subagent`.** `ClaudeCodeDispatchProfile.subagent` is a closed
+   Literal without `"sdd-ideation"`, and — decisively —
+   `dispatchers/claude.py:393` resolves a non-`None` `subagent` through
+   **`dev_loop`'s** `load_subagent_definition`, which raises
+   `ValueError: Unknown subagent name 'sdd-ideation'` by design (TASK-2124's
+   contract forbids extending that loader; the dev_flow package owns its
+   prompts). So extending the Literal would have produced a runtime failure.
+   Passing the dev_flow-loaded body as `system_prompt_override` with
+   `subagent=None` is the path the dispatcher already supports
+   (`claude.py:414-415` → `ClaudeAgentRunOptions(system_prompt=...)`), and it
+   touches **zero** shared `dev_loop` code — consistent with the spec's
+   "reuse at the right altitude". Pinned by
+   `test_dispatch_payload_and_profile`.
+2. **`_resolve_document_path`.** `FeatureBrief` validates `document_path`
+   readability eagerly, but the subagent reports a **repo-relative** path and
+   the hosting process' CWD is not guaranteed to be the repo root. The helper
+   tries the path as given, then anchored at `conf.PROJECT_ROOT`, and raises
+   an actionable `RuntimeError` ("reported committed=True … but no readable
+   document was found") if neither resolves — instead of letting a confusing
+   pydantic `ValidationError` escape from deep inside the model. This also
+   catches a subagent that lies about `committed`. Covered by
+   `test_unreadable_document_raises`.
+
+Dispatch `cwd` is `conf.PROJECT_ROOT` (the base checkout), **not**
+`WORKTREE_BASE_PATH`: the document is committed to `base_branch` and the
+feature worktree does not exist yet at ideation time — `sdd-planner` creates
+it later.
+
+Other behaviors pinned by tests: jira/dev_agents/judge_panel passthrough into
+the `FeatureBrief`; `ideation_output` + `feature_brief` published to shared
+state; partial answers accepted; rejection (`match="rejected by bob"`) and
+fail-closed expiry both raise with no re-dispatch; `committed=False` raises
+with `feature_brief` never set; a `FeatureBrief` arriving on `dev_brief`
+raises (it must route to the planner instead); wiki context injected,
+degraded to `""` on failure.
+
+`ruff`: the whole `dev_flow` package and test package are at **0** findings.
+
+**Deviations from spec**: one, scoped down rather than up.
+
+- The task's scope says "Add the **two** conf keys". Only
+  `DEV_FLOW_IDEATION_MAX_ROUNDS` was added here —
+  `DEV_FLOW_GATE_TTL_QUESTIONS` was already added in **TASK-2122**, where the
+  `GateKind` extension forced it (the `gate_ttl_for` exhaustiveness guard).
+  Its name, type and 86400 default are exactly as this task specifies, and it
+  is consumed here as planned. No duplication.

--- a/sdd/tasks/completed/TASK-2127-dev-flow-topology.md
+++ b/sdd/tasks/completed/TASK-2127-dev-flow-topology.md
@@ -180,10 +180,76 @@ def test_declarative_imperative_parity(): ...
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**:
-**Date**:
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-08-05
 **Notes**:
 
-**Deviations from spec**: none
+Three modules + 25 tests (98 across `dev_flow`; `dev_loop`'s own
+`test_declarative_flow.py` / `test_feature_flow.py` still 27 passed).
+
+**Inventory**: `build_dev_flow_definition()` → `flow="dev-flow"`, **10 nodes**
+(`dev_flow.dev_intake`, `dev_flow.ideation` + the 8 reused `dev_loop.*`),
+**20 edges** = 12 routing + 8 `on_error`. `test_no_ops_nodes_present`
+asserts `bug_intake`, `research`, `deployment_handoff`, `revision_handoff`
+**and** `intent_classifier` are absent, so the "no ops concerns" property is
+enforced rather than merely intended.
+
+**Anti-drift decision worth flagging.** Rather than re-spelling the FEAT-378
+chain, this task **imports** it:
+
+- node ids (`PLANNER`, `DEVELOPMENT`, …) and the CEL strings
+  (`_CEL_QA_PASSED`, `_CEL_FEEDBACK_{ESCALATE,ACCEPT,RETRY}`, `_CEL_QA_FAILED`)
+  from `dev_loop.definition`;
+- the Python routing predicates (`_qa_passed`, `_qa_failed`,
+  `_feedback_*`), `FlowEventPublisher` and `_NullAgentRegistry` from
+  `dev_loop.flow`.
+
+The task said "REPLICATE … verbatim"; importing is the strictly stronger
+reading — a future edit to feature-mode's predicates cannot leave dev-flow
+silently behind, and `test_edge_predicates_match_feature_mode_verbatim`
+asserts equality against the imported constants *and* against the literal
+strings the spec quotes, so an upstream change still has to be conscious.
+It does mean this module depends on two private `dev_loop` names
+(`_NullAgentRegistry`, and the `_feedback_*`/`_qa_*` predicates) — the same
+cross-module private use `dev_loop/runner.py` itself already makes of
+`dev_loop/flow.py`.
+
+**Only the intake fork is new**: `dev_intake -(NL)-> ideation`,
+`dev_intake -(feature)-> planner`, `ideation -> planner` (on_success). That
+makes `planner` a **third** OR-join in the graph, which is the concrete
+reason explicit-edge execution is mandatory here — recorded in both module
+docstrings and pinned by `test_planner_is_an_or_join`.
+
+`factories.py` delegates the eight reused types to
+`build_dev_loop_node_factories` (a `dict(...)` copy, so the returned map is
+never mutated in place) and adds only the two `dev_flow.*` factories.
+`wiki_search` is forwarded to **both** the reused factories and
+`IdeationNode`. Importing `factories.py` imports both node packages, which is
+what guarantees the `@register_dev_loop_node` decorators have run before
+materialization.
+
+`_with_graph` is duplicated locally (4 lines) rather than importing
+`dev_loop.factories._with_graph` — noted as a deliberate small duplication in
+its docstring, since it is the one private helper whose cross-package import
+buys nothing.
+
+`build_dev_flow()` signature matches the spec's §2 declaration exactly,
+including `ideation_max_rounds` and the `require_plan_approval` build-time
+default (the per-run override from TASK-2123 does the rest —
+`test_require_plan_approval_reaches_development` covers both directions).
+
+Parity test asserts node-id set equality, edge-triple set equality (with the
+pre-existing `on_success`→`always` vocabulary normalization the dev_loop
+parity tests already use), and that every `on_condition` edge carries a
+predicate **on both sides** — a declarative predicate with no imperative twin
+would otherwise never route.
+
+`ruff`: whole `dev_flow` package + tests at **0** findings.
+
+**Deviations from spec**: none.
+
+Not touched (out of scope, deliberately): `dev_flow/__init__.py`'s
+`_LAZY_EXPORTS` map is still empty, so `build_dev_flow` is reached via
+`from parrot.flows.dev_flow.flow import build_dev_flow`. Neither this task
+nor TASK-2128 lists `__init__.py`; if the server prefers the package-level
+symbol, that is a one-line addition there.

--- a/sdd/tasks/completed/TASK-2128-dev-flow-runner.md
+++ b/sdd/tasks/completed/TASK-2128-dev-flow-runner.md
@@ -146,10 +146,65 @@ async def test_never_calls_run_feature(monkeypatch): ...
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**:
-**Date**:
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-08-05
 **Notes**:
 
-**Deviations from spec**: none
+`DevFlowRunner(DevLoopRunner)` overrides **only** `run()`. 19 tests (117
+across `dev_flow`). No change to `DevLoopRunner` was needed — nothing in the
+base had to be touched or made protected-accessible.
+
+**Single topology, routed not branched.** Both brief kinds execute
+`self.flow`; a `FeatureBrief` reaches `planner` because `dev_intake`'s
+conditional edge sends it there, so "ideation is skipped by routing, not by
+the runner" is literally true. `test_never_calls_run_feature` monkeypatches
+`_run_feature` to raise and asserts `_feature_flow` stays `None`;
+`test_both_kinds_use_the_same_flow_object` asserts `_rev_flow` and
+`_feature_flow` are both still `None` after one run of each kind.
+
+**Seeding**: `dev_brief` always; `feature_brief` additionally for a document
+brief (pre-seeding a key `DevIntakeNode` would set anyway, so the context is
+honest for any observer before intake runs); bug-mode keys never set
+(`test_never_seeds_bug_mode_keys`). `extra_shared` merges last —
+`test_extra_shared_passthrough` covers `require_plan_approval` + `skip_qa`,
+which is the seam TASK-2123 and TASK-2129 depend on.
+
+**Two projections instead of inline branching**, both static and unit-tested:
+
+- `_summary_for` — the request `title` for an NL brief,
+  `"Feature: <document_path>"` for a document brief (matching
+  `_run_feature`'s wording). Also the `TypeError` guard: a bug-mode
+  `WorkBrief` is rejected **before** any host is registered or slot acquired
+  (`test_rejects_non_dev_flow_brief` asserts the flow never ran).
+- `_work_kind_for` — `RunCreated.work_kind` is a closed
+  `Literal["bug","enhancement","new_feature"]`, deliberately not extended
+  with `"feature"` (TASK-1918). A `DevRequestBrief`'s kind maps *directly*
+  onto two of those members (nicer than feature-mode, which has no NL kind
+  to report); a document brief reuses `"bug"` as the structural placeholder
+  exactly as `_run_feature` does, with the same explanatory comment.
+  `test_run_created_work_kind_maps_per_brief` pins all three.
+
+**On replicating the lifecycle block.** The task asked me to either replicate
+`run()`'s sequence or call the smallest inherited helpers. The
+host-registration/seeding/close parts *are* inherited helpers
+(`_register_host`, `_apply_root_action`, `_run_summary_from_host`,
+`_close_host`), but the ~35-line park-aware semaphore block is inlined in all
+three existing base-class run paths with no extractable helper, so it is
+replicated verbatim (comments included). This is necessary, not stylistic: an
+ideation `open_questions` gate parks the run from deep inside `IdeationNode`
+*while* `run_flow()` is in flight, so `async with self._semaphore` cannot
+express the release/re-acquire, and without registering
+`_run_completion[rid]` a `resume_run()` caller would have nothing to await.
+`test_parked_run_frees_its_slot` proves it end-to-end: the gate opens, the run
+parks, `active_runs` becomes empty, and answering the gate resumes it to
+COMPLETED. (A future refactor extracting that block into a base-class helper
+would now have four call sites — worth doing, out of scope here.)
+
+`ruff`: whole `dev_flow` package + tests at **0** findings.
+
+**Deviations from spec**: none.
+
+Contract note: the task's Verified Imports did not name `FlowResult`'s module,
+and my first draft guessed `parrot.bots.flows.core.types`, which raised
+`ImportError`. Verified and corrected to `parrot.bots.flows.core.result` —
+the module `dev_loop/runner.py:36` itself imports it from.

--- a/sdd/tasks/completed/TASK-2129-server-dev.md
+++ b/sdd/tasks/completed/TASK-2129-server-dev.md
@@ -180,10 +180,72 @@ async def test_plan_approval_flag_in_extra_shared(aiohttp_client): ...
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**:
-**Date**:
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-08-05
 **Notes**:
 
-**Deviations from spec**: none
+`server_dev.py` (~480 lines) + 28 integration tests (145 across `dev_flow`).
+
+**Reuse decision.** The task offered "import from server.py" or "copy the few
+needed helpers". I chose **import** — `sys.path.insert(...)` then
+`import server as ops_server`, the same trick `server.py` itself uses for
+`llm_catalog`. `server.py` is only *read*, never modified (asserted by
+`git diff --name-only dev...HEAD -- examples/dev_loop/server.py` being empty).
+Imported: the dispatcher/reviewer builders
+(`_resolve_codereview_dispatcher`, `_build_judge_panel_dispatcher`,
+`_log_development_agent_selection`, `_DEVELOPMENT_AGENT_MAX_CONCURRENT_ENV`),
+the toolkit builders, `_build_feature_brief_from_form`, `_parse_dev_agents`,
+`_parse_judge_panel`, `RUN_ARTIFACT_DIR`, `_on_cleanup`, and the
+`handle_bundle`/`handle_replay`/`handle_cancel` handlers — those three are
+app-key driven and mode-agnostic, so reusing them keeps the artifact/cancel
+contract *identical* by construction rather than by convention
+(`test_reuses_ops_helpers_without_modifying_them` asserts the reused handlers
+are the very same objects, and that the ops `handle_index`/`handle_config`/
+`handle_run` are NOT mounted). Deliberately **not** imported:
+`_build_log_toolkits` (CloudWatch) and `_build_brief_from_form` (bug intake).
+
+**Gate route — one option, as instructed.** Only the
+`POST /api/flow/{run_id}/gates/{gate_id}/resolve` alias is mounted, not
+`register_command_routes`'s `/runs/...` pair, so every console route shares
+one prefix and `handle_cancel` remains the single cancel entry point. The
+alias is a pure delegation to the library `resolve_gate_handler`, so the body
+contract (`ResolveGateRequest` incl. `answers`) and every status code are
+identical. It is published to the UI as `gate_resolve_url_template` in
+`/api/config`, and `_on_startup` binds `app["dev_loop_runner"]` (the key the
+library handler reads). `test_gate_resolve_route_mounted` drives the whole
+round-trip: run → gate opens → REST POST with `answers` → the flow observes
+those answers → 200. `test_gate_resolve_empty_answers_400` confirms the
+host-side validation surfaces as `answers_required`.
+
+**Jira is genuinely optional.** `_build_optional_jira_toolkit()` short-circuits
+to `None` when `JIRA_INSTANCE`/`JIRA_USERNAME` are unset and also swallows a
+construction failure, so a dev machine with no Jira env starts cleanly
+(`test_jira_is_optional`). Startup never calls `_build_log_toolkits`.
+
+**Per-run plan gate.** `require_plan_approval` is forwarded to `extra_shared`
+**only when the key is present in the form**, so an absent toggle falls back
+to the flow's build-time default rather than silently overriding it with
+`False` — which is exactly the absent-vs-explicit-False distinction
+TASK-2123 implemented. All three cases are tested
+(`True` forwarded, explicit `False` forwarded, absent not forwarded).
+
+**Test-design note worth recording.** My first pass asserted absence of ops
+concerns by substring-scanning `inspect.getsource(module)`, which failed
+because this module's *own documentation* names `_build_log_toolkits` and
+`_build_brief_from_form` in order to state they are excluded. Replaced with
+`_referenced_identifiers()`, which walks the **AST** and collects
+`Name`/`Attribute`/`keyword`/`alias` identifiers — docstrings and comments are
+excluded by construction. `test_index_serves_dev_html` was likewise rewritten
+from source-scanning to behavioral (call the handler, assert the
+`FileResponse` path is `STATIC_DIR/dev.html`).
+
+Also verified: the module imports and `build_app()` succeeds standalone (15
+routes), and `main()`'s port default is 8081 (`test_default_port_is_8081`).
+
+`ruff`: `server_dev.py` and its test file at **0** findings.
+
+**Deviations from spec**: none.
+
+Note: `GET /` currently 404s because `static/dev.html` lands in TASK-2130 —
+which is why `test_index_serves_dev_html` asserts the resolved path rather
+than a 200.

--- a/sdd/tasks/completed/TASK-2130-dev-html-ui.md
+++ b/sdd/tasks/completed/TASK-2130-dev-html-ui.md
@@ -258,3 +258,17 @@ browser-in-the-loop passes are left for the reviewer; the scenarios are
 reproduced verbatim in `README`/`GUIA` by TASK-2131.
 
 **Deviations from spec**: none.
+
+### Post-completion fix (same feature branch)
+
+Self-review after marking this task done caught one requirement from the
+Implementation Notes I had missed: *"Summary must render
+`document_kind`/document path when available (ideation output surfaces via node
+summary)"*. Fixed in a follow-up commit — `IdeationNode` returns the
+`FeatureBrief` it produced and `node/completed` carries the serialised result
+as its `summary` (`session_state.py:1269-1272`), so `app.s.nodes.ideation.summary`
+already had `document_path`/`document_kind` client-side. The run summary now
+shows an "SDD document written by ideation" card above the documentation
+artifact, with the kind and how many Open-Questions rounds the run took.
+The "no `pr_url` ⇒ failure" precedent was already preserved by the copy
+(`summaryHeadline()`), now reading the correct `feature_handoff` node.

--- a/sdd/tasks/completed/TASK-2130-dev-html-ui.md
+++ b/sdd/tasks/completed/TASK-2130-dev-html-ui.md
@@ -175,10 +175,86 @@ Manual checklist (record results in the Completion Note):
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**:
-**Date**:
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-08-05
 **Notes**:
 
-**Deviations from spec**: none
+`dev.html` (1862 lines). Method: started as a **byte copy** of `index.html`,
+then applied surgical edits — so every KEEP item (stepper, panels/spine/rail
+execution views, `foldAction` vocabulary, dispatch telemetry, judge verdicts,
+feedback decisions, docs artifact, PR summary card, gate audit trail,
+bundle/report, cancel/restart, theme toggle) is preserved *exactly* rather
+than re-typed. `index.html` is byte-identical (`git diff --name-only
+dev...HEAD` clean of it).
+
+**REMOVED** as specified: bug intake markup, `TOPOLOGY.bug`, the
+`criteria`/`context`/`observability`/`jira` tab bodies and their `TAB_NOTES`,
+the bug `buildPayload()` branch, `criteriaSummary()`, and the
+`affectedComponent`/`logGroup`/`timeWindow`/`existingIssueKey`/`criteria`
+form state. Grep-verified zero occurrences of `affected_component`,
+`log_group`, `time_window`, `CloudWatch`, `bug_intake`,
+`acceptance_criteria`, `existing_issue_key`, `afd-theme`.
+
+**ADDED**: the 3-intent picker (no availability gating — one topology); the NL
+intake (title + description + optional context) whose "will write" row shows
+the exact `sdd/proposals/<slug>.{brainstorm|proposal}.md` the run will
+produce (client-side `slugify` mirroring the subagent's rule, so a resume of
+an existing document is predictable *before* dispatch); a single `TOPOLOGY.dev`
+with all 10 nodes; an **Ideation & gates** tab holding the per-run
+`require_plan_approval` toggle plus read-only round-budget and fail-closed TTL;
+and the **HITL panel**.
+
+**HITL panel design** (the net-new surface):
+
+- Renders from `app.s.gates` via `pendingGate()`, **not** from live actions —
+  so a reload mid-gate re-renders from the adopted snapshot (the task's
+  reconnect requirement). Handles every gate kind, not just
+  `open_questions`: `plan_approval` and friends get approve/reject + comment
+  with no answer inputs.
+- One `<textarea>` per `gate.questions[]`; only non-empty answers are sent, so
+  partial answers work and blanks stay `[ ]` in the document. Submitting with
+  *zero* answers is blocked client-side with a message pointing at Reject —
+  which mirrors the server's own `answers_required` 400 rather than relying on
+  it for the common case.
+- Draft answers live in `app.hitl`, not the DOM, because a streamed node event
+  triggers a re-render every second — without that, typing would be wiped
+  mid-answer.
+- After a successful resolve it deliberately does **not** touch local state;
+  the `gate/resolved` action on the state socket folds the resolution and
+  hides the panel. Commented in-file and asserted by a test.
+- `resolved_by` comes from `localStorage["devflow-user"]` with a `prompt()`
+  fallback (the REST body requires `min_length=1`).
+- The gate URL comes from `/api/config`'s `gate_resolve_url_template`, with the
+  literal route as a fallback.
+
+**Bug found and fixed while trimming** (inherited from the copy):
+`handoffNodeId()` returned `"deployment_handoff"` whenever
+`app.mode !== "feature"`. In dev-flow the only terminal handoff is
+`feature_handoff`, so **every natural-language run's summary would have
+rendered blank/failed** even on success. Now pinned to `feature_handoff` with
+a comment. Three neighbouring `app.mode === "feature"` wording branches
+(handoff sub-line, Jira note, pool/judge hints) were also collapsed, since
+`mode` now selects only the *intake shape* — the topology never varies.
+
+**Verification** (no JS harness exists and the task forbids adding one):
+
+- `node --check` on both extracted `<script>` blocks → syntax OK.
+- A cross-check script confirmed **all 52** element ids the JS references
+  exist in the markup (`MISSING: NONE`), that the payload the JS builds is
+  accepted by the real `_build_dev_brief_from_form`, and that the JS's gate
+  URL template matches a route actually mounted by `build_app()`.
+- 22 new tests appended to `test_server_dev.py` (the spec's chosen home for
+  UI assertions) covering the removed ops surface, the added dev surface,
+  state-driven gate rendering, the no-local-mutation rule, and that
+  `index.html` is still the ops console. Suite: 50 passed.
+
+**Manual checklist**: NOT executed — the 6 scenarios all require a live Redis
+plus real Claude/Codex dispatches (a full ideation → planner → dev-pool → QA
+run per item), which is not available in this environment. The mechanical
+preconditions each scenario depends on are covered by the automated checks
+above (payload shapes per intent, gate render-from-state, resolve POST
+contract and route, plan-gate flag reaching `extra_shared`, reject path). The
+browser-in-the-loop passes are left for the reviewer; the scenarios are
+reproduced verbatim in `README`/`GUIA` by TASK-2131.
+
+**Deviations from spec**: none.

--- a/sdd/tasks/completed/TASK-2131-dev-flow-docs.md
+++ b/sdd/tasks/completed/TASK-2131-dev-flow-docs.md
@@ -108,10 +108,51 @@ works, and which conf keys are new.
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**:
-**Date**:
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-08-05
 **Notes**:
 
-**Deviations from spec**: none
+**README.md** — file tree now lists `server_dev.py` / `static/dev.html`, plus a
+two-consoles comparison table right after it (audience, port, intake,
+CloudWatch, Jira, HITL) so a reader picks the right pair before reading
+further. New **Development console** section covering: quickstart and the
+"Redis is the only hard requirement" point (no `CLOUDWATCH_*`, no `JIRA_*`),
+side-by-side operation, the topology diagram, the three intents with the exact
+document each writes (light `.proposal.md` vs full `.brainstorm.md`), the
+resume/extend policy and its collision behaviour, the full endpoint table, both
+run payload shapes with curls, the normative `open_questions` protocol as 5
+numbered steps, approve **and** reject curls, every status code (incl.
+`400 answers_required` and `409 already_resolved`), the per-run plan-approval
+override semantics, and the two new conf keys with a note that nothing else is
+forked from `DEV_LOOP_*`. Explicitly records that revision mode stays unexposed.
+
+**GUIA.md** — kept Spanish and in its "cómo lo arranco" register. Extended the
+file tree, the script-comparison table (with a callout that the two consoles
+coexist on 8080/8081) and the closing "qué ejecutar" table, plus a new **§9**
+covering arranque, intent choice, and — the part a newcomer actually needs —
+how to answer the Open Questions: partial answers are valid, bounded rounds,
+what happens when the budget runs out (does **not** block), the run parking so
+you can take hours, reject-aborts, fail-closed expiry ("el silencio no es un
+'sí'"), and reload-mid-gate. Includes curl equivalents for both resolve
+directions and for starting a run.
+
+**Verification** — rather than writing from memory (the task's explicit
+warning), I ran a cross-check script against the loaded `server_dev.py`:
+
+- every mounted `/api/*` route is documented, and every documented route is
+  mounted (7/7, incl. the gate-resolution route);
+- every `/api/config` key the docs promise is actually emitted by
+  `handle_config` (`ideation_max_rounds`, `gate_ttl_questions`,
+  `require_plan_approval`, `qa_max_retries`, `development_pool_max`,
+  `max_concurrent_runs`, `document_kinds`, `nl_kinds`,
+  `gate_resolve_url_template`);
+- the keys the docs claim are **absent** (`log_group`, `time_window_minutes`,
+  `jira_project`) really are absent from the dev config;
+- the documented NL payload is accepted verbatim by
+  `_build_dev_brief_from_form`;
+- the defaults quoted in the docs (`2` rounds, `86400` s) match `conf`.
+
+All checks passed.
+
+**Deviations from spec**: none. No code was touched; `documentation/` site
+pages and docstrings were left alone as instructed.

--- a/sdd/tasks/index/sdd-dev-flow.json
+++ b/sdd/tasks/index/sdd-dev-flow.json
@@ -108,7 +108,7 @@
       "feature_id": "FEAT-412",
       "feature": "sdd-dev-flow",
       "spec": "sdd/specs/sdd-dev-flow.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "depends_on": [
@@ -120,8 +120,8 @@
       "parallelism_notes": "Consumes the gate extension (2122) and the subagent contract (2124); shares nodes/__init__.py with TASK-2125.",
       "assigned_to": null,
       "started_at": "2026-08-04T23:27:14+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2126-ideation-node.md"
+      "completed_at": "2026-08-05T00:31:00+00:00",
+      "file": "sdd/tasks/completed/TASK-2126-ideation-node.md"
     },
     {
       "id": "TASK-2127",

--- a/sdd/tasks/index/sdd-dev-flow.json
+++ b/sdd/tasks/index/sdd-dev-flow.json
@@ -14,7 +14,7 @@
       "feature_id": "FEAT-412",
       "feature": "sdd-dev-flow",
       "spec": "sdd/specs/sdd-dev-flow.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [],
@@ -22,8 +22,8 @@
       "parallelism_notes": "Root of the dependency graph; everything else imports these models.",
       "assigned_to": null,
       "started_at": "2026-08-04T23:27:14+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2121-dev-flow-models.md"
+      "completed_at": "2026-08-04T23:39:16+00:00",
+      "file": "sdd/tasks/completed/TASK-2121-dev-flow-models.md"
     },
     {
       "id": "TASK-2122",

--- a/sdd/tasks/index/sdd-dev-flow.json
+++ b/sdd/tasks/index/sdd-dev-flow.json
@@ -151,7 +151,7 @@
       "feature_id": "FEAT-412",
       "feature": "sdd-dev-flow",
       "spec": "sdd/specs/sdd-dev-flow.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -161,8 +161,8 @@
       "parallelism_notes": "Needs build_dev_flow from TASK-2127.",
       "assigned_to": null,
       "started_at": "2026-08-04T23:27:14+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2128-dev-flow-runner.md"
+      "completed_at": "2026-08-05T00:57:35+00:00",
+      "file": "sdd/tasks/completed/TASK-2128-dev-flow-runner.md"
     },
     {
       "id": "TASK-2129",

--- a/sdd/tasks/index/sdd-dev-flow.json
+++ b/sdd/tasks/index/sdd-dev-flow.json
@@ -68,7 +68,7 @@
       "feature_id": "FEAT-412",
       "feature": "sdd-dev-flow",
       "spec": "sdd/specs/sdd-dev-flow.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -78,8 +78,8 @@
       "parallelism_notes": "Needs IdeationOutput contract from TASK-2121; independent of TASK-2122/2123 otherwise.",
       "assigned_to": null,
       "started_at": "2026-08-04T23:27:14+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2124-sdd-ideation-subagent.md"
+      "completed_at": "2026-08-05T00:17:59+00:00",
+      "file": "sdd/tasks/completed/TASK-2124-sdd-ideation-subagent.md"
     },
     {
       "id": "TASK-2125",

--- a/sdd/tasks/index/sdd-dev-flow.json
+++ b/sdd/tasks/index/sdd-dev-flow.json
@@ -50,7 +50,7 @@
       "feature_id": "FEAT-412",
       "feature": "sdd-dev-flow",
       "spec": "sdd/specs/sdd-dev-flow.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "S",
       "depends_on": [],
@@ -58,8 +58,8 @@
       "parallelism_notes": "Touches only dev_loop/nodes/development.py — no overlap with any other FEAT-412 task.",
       "assigned_to": null,
       "started_at": "2026-08-04T23:27:14+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2123-plan-gate-per-run-override.md"
+      "completed_at": "2026-08-05T00:10:49+00:00",
+      "file": "sdd/tasks/completed/TASK-2123-plan-gate-per-run-override.md"
     },
     {
       "id": "TASK-2124",

--- a/sdd/tasks/index/sdd-dev-flow.json
+++ b/sdd/tasks/index/sdd-dev-flow.json
@@ -130,7 +130,7 @@
       "feature_id": "FEAT-412",
       "feature": "sdd-dev-flow",
       "spec": "sdd/specs/sdd-dev-flow.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -141,8 +141,8 @@
       "parallelism_notes": "Wires both new nodes into the graph.",
       "assigned_to": null,
       "started_at": "2026-08-04T23:27:14+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2127-dev-flow-topology.md"
+      "completed_at": "2026-08-05T00:44:28+00:00",
+      "file": "sdd/tasks/completed/TASK-2127-dev-flow-topology.md"
     },
     {
       "id": "TASK-2128",

--- a/sdd/tasks/index/sdd-dev-flow.json
+++ b/sdd/tasks/index/sdd-dev-flow.json
@@ -32,7 +32,7 @@
       "feature_id": "FEAT-412",
       "feature": "sdd-dev-flow",
       "spec": "sdd/specs/sdd-dev-flow.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [],
@@ -40,8 +40,8 @@
       "parallelism_notes": "Touches only dev_loop/session_state.py + commands.py + runner.py — no file overlap with TASK-2121/2123/2124.",
       "assigned_to": null,
       "started_at": "2026-08-04T23:27:14+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2122-open-questions-gate.md"
+      "completed_at": "2026-08-05T00:07:21+00:00",
+      "file": "sdd/tasks/completed/TASK-2122-open-questions-gate.md"
     },
     {
       "id": "TASK-2123",

--- a/sdd/tasks/index/sdd-dev-flow.json
+++ b/sdd/tasks/index/sdd-dev-flow.json
@@ -193,7 +193,7 @@
       "feature_id": "FEAT-412",
       "feature": "sdd-dev-flow",
       "spec": "sdd/specs/sdd-dev-flow.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "L",
       "depends_on": [
@@ -203,8 +203,8 @@
       "parallelism_notes": "Consumes /api/config and route shapes shipped by TASK-2129.",
       "assigned_to": null,
       "started_at": "2026-08-04T23:27:14+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2130-dev-html-ui.md"
+      "completed_at": "2026-08-05T01:23:32+00:00",
+      "file": "sdd/tasks/completed/TASK-2130-dev-html-ui.md"
     },
     {
       "id": "TASK-2131",

--- a/sdd/tasks/index/sdd-dev-flow.json
+++ b/sdd/tasks/index/sdd-dev-flow.json
@@ -88,7 +88,7 @@
       "feature_id": "FEAT-412",
       "feature": "sdd-dev-flow",
       "spec": "sdd/specs/sdd-dev-flow.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "S",
       "depends_on": [
@@ -98,8 +98,8 @@
       "parallelism_notes": "Shares dev_flow/nodes/__init__.py with TASK-2126 — run sequentially within the worktree.",
       "assigned_to": null,
       "started_at": "2026-08-04T23:27:14+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2125-dev-intake-node.md"
+      "completed_at": "2026-08-05T00:22:08+00:00",
+      "file": "sdd/tasks/completed/TASK-2125-dev-intake-node.md"
     },
     {
       "id": "TASK-2126",

--- a/sdd/tasks/index/sdd-dev-flow.json
+++ b/sdd/tasks/index/sdd-dev-flow.json
@@ -213,7 +213,7 @@
       "feature_id": "FEAT-412",
       "feature": "sdd-dev-flow",
       "spec": "sdd/specs/sdd-dev-flow.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "low",
       "effort": "S",
       "depends_on": [
@@ -224,8 +224,8 @@
       "parallelism_notes": "Documents what 2129/2130 shipped.",
       "assigned_to": null,
       "started_at": "2026-08-04T23:27:14+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2131-dev-flow-docs.md"
+      "completed_at": "2026-08-05T01:29:18+00:00",
+      "file": "sdd/tasks/completed/TASK-2131-dev-flow-docs.md"
     }
   ]
 }

--- a/sdd/tasks/index/sdd-dev-flow.json
+++ b/sdd/tasks/index/sdd-dev-flow.json
@@ -171,7 +171,7 @@
       "feature_id": "FEAT-412",
       "feature": "sdd-dev-flow",
       "spec": "sdd/specs/sdd-dev-flow.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "depends_on": [
@@ -183,8 +183,8 @@
       "parallelism_notes": "Integrates the gate route (2122), plan-gate override (2123) and runner (2128).",
       "assigned_to": null,
       "started_at": "2026-08-04T23:27:14+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2129-server-dev.md"
+      "completed_at": "2026-08-05T01:09:44+00:00",
+      "file": "sdd/tasks/completed/TASK-2129-server-dev.md"
     },
     {
       "id": "TASK-2130",


### PR DESCRIPTION
## Summary

Implements FEAT-412 — a new `parrot.flows.dev_flow` package (sibling of
`dev_loop`) modelling the actual SDD development cycle end-to-end:

```
NL request (enhancement | new_feature) ──► ideation (+ HITL Open Questions)
        or an existing SDD document ─────► planner ──► development pool
        ──► synthesis ──► qa ──► draft PR
```

Only the intake nodes (`dev_flow.dev_intake`, `dev_flow.ideation`) and the
topology are new; node types, models, session state, streaming, dispatchers
and the runner machinery are reused from `dev_loop`. The flow always
terminates at a draft PR against `dev` — never a merge.

Also ships a `server_dev.py`/`static/dev.html` development console
(side-by-side with the ops console, no CloudWatch/Jira-mandatory wiring),
and an additive `open_questions` gate-model extension to `dev_loop`'s
session state (backward-compatible — verified by a dedicated legacy-envelope
test).

## Tasks (11/11 verified)

- ✅ TASK-2121 — dev_flow package skeleton + models
- ✅ TASK-2122 — open_questions gate kind + structured answers
- ✅ TASK-2123 — per-run require_plan_approval override
- ✅ TASK-2124 — sdd-ideation dual-mode subagent + loader
- ✅ TASK-2125 — DevIntakeNode
- ✅ TASK-2126 — IdeationNode (bounded HITL rounds)
- ✅ TASK-2127 — dev-flow topology (definition/factories/builder/parity)
- ✅ TASK-2128 — DevFlowRunner
- ✅ TASK-2129 — server_dev.py development console
- ✅ TASK-2130 — static/dev.html development console
- ✅ TASK-2131 — dev console documentation (README/GUIA)

## Code review

An adversarial code-review pass (code-reviewer agent, cross-checked with
Codex) found no CRITICAL issues. 🟠 Important findings were addressed on
this branch before merge:

- Fixed: `dev_flow.__init__`'s `_LAZY_EXPORTS` map was empty, so
  `from parrot.flows.dev_flow import build_dev_flow` (etc.) raised
  `AttributeError` despite the module docstring promising lazy resolution.
  Now populated.
- Fixed: the `require_plan_approval` toggle only appeared in the
  ideation-only advanced tab (hidden for `feature`-mode runs) in
  `dev.html`. Moved to the always-visible "Planning & Jira" tab so every
  intent (`feature`/`enhancement`/`new_feature`) can set the per-run
  plan-gate override.
- Fixed (bonus): two stale ops-console copy leftovers in `dev.html` (a
  Jira placeholder implying feature-mode-only ticket-skipping, and a
  reference to a research/triage/sdd-research dispatch step that
  dev-flow never runs).

One 🟠 finding was **filed as a follow-up instead of fixed here**, since
it touches shared `dev_loop` infrastructure outside this feature's task
scope (pre-existing since FEAT-129, reproduces identically on unmodified
`dev` via `DeploymentHandoffNode`, independent of this PR):

- **FEAT-413** (`devloop-handoff-blocked-outcome`, TASK-2132): a blocked
  handoff (`FeatureHandoffNode`/`DeploymentHandoffNode` returning
  `{"status": "blocked", ...}` without raising) still gets recorded as
  `RunClosed(outcome="succeeded")` with no PR. Spec + task filed and
  merged to `dev` for pickup as its own change.

🟡 Suggestions (prompt-only SDD-document-contract enforcement, pre-existing
`mypy` findings shared with `dev_loop`'s baseline, `DevFlowRunner.run()`
duplicating `DevLoopRunner.run()`'s concurrency handling) were noted but
not fixed, per the review's own recommendation — none are blocking.

## Test plan

- 171/171 new tests pass: `pytest packages/ai-parrot/tests/flows/dev_flow/ -v`
- Full `dev_loop` regression suite (1049 tests) passes except one
  pre-existing, unrelated failure confirmed to reproduce identically on
  unmodified `dev`.
- `ruff` clean on all new/changed files.

---
_Closed by /sdd-done_