### PR TITLE
feat(sdd-done-merge-conflict-fix): FEAT-414 — Fix sdd-done Merge Conflicts

### DIFF
--- a/.claude/commands/sdd-done.md
+++ b/.claude/commands/sdd-done.md
@@ -161,27 +161,40 @@ If any tasks are ⚠️ PARTIAL or ❌ NO EVIDENCE:
 If `--dry-run`, show the report and STOP.
 If `--force`, close all tasks regardless.
 
-### 7. Close Tasks (on `<BASE_BRANCH>`)
+### 7. Stamp Verification (on feature branch)
 
-For each task being closed, update the per-spec index in place. We are
-already on `BASE_BRANCH` (verified in Step 1).
+Stamp verification metadata on each closed task in the worktree's per-spec
+index. The feature branch already carries the task files in `completed/` and
+the index with `status: "done"` — this step only adds the `verification`
+field and the feature-level `completed_at`.
 
-> **CRITICAL — use the script, do NOT hand-roll the move.** See the note in
-> `/sdd-start`: closing a task is a *move*, and agents that copy instead leave
-> `active/` orphans that survive the merge. `scripts/sdd/close_task.sh` does the
-> `git mv` + index stamp + a hard post-condition (exit 3 if an `active/` copy
-> survives).
+> **Why not close_task.sh?** The feature branch already moved files
+> `active/` → `completed/` and set status/completed_at/file during
+> `sdd-worker`/`sdd-start`. Running `close_task.sh` again on `base_branch`
+> would create duplicate state that conflicts on merge (FEAT-414).
 
 ```bash
-# Close each task being closed (idempotent; stamps the index header when the
-# whole feature is done). Repeat per task id:
-scripts/sdd/close_task.sh TASK-<NNN> <feature-slug> verified
+WORKTREE_PATH=".claude/worktrees/feat-<FEAT-ID>-<slug>"
+INDEX="sdd/tasks/index/${FEATURE_SLUG}.json"
+NOW="$(date -u +%Y-%m-%dT%H:%M:%S+00:00)"
 
-# Update task file headers (Status/Completed/Verification) in the completed/ copy.
+# Stamp verification on each task being closed.
+# Use "verified" for ✅ VERIFIED tasks, "partial" for ⚠️ PARTIAL, "forced" for --force.
+for TASK_ID in "${TASK_IDS[@]}"; do
+  jq --arg id "$TASK_ID" --arg ver "$VERIFICATION" '
+    (.tasks[] | select(.id == $id) | .verification) = $ver
+  ' "$WORKTREE_PATH/$INDEX" > tmp && mv tmp "$WORKTREE_PATH/$INDEX"
+done
 
-# Commit ONLY the staged SDD state — never "git add ." / "git add -A".
-git diff --cached --name-only      # sanity-check: only index + task files
-git commit -m "sdd: close tasks for FEAT-<ID> — <title>"
+# Stamp feature-level completed_at if all tasks are done.
+jq --arg now "$NOW" '
+  if all(.tasks[]; .status == "done") then .completed_at = $now else . end
+' "$WORKTREE_PATH/$INDEX" > tmp && mv tmp "$WORKTREE_PATH/$INDEX"
+
+# Commit on the feature branch (inside the worktree) — never on base_branch.
+git -C "$WORKTREE_PATH" add "$INDEX"
+git -C "$WORKTREE_PATH" diff --cached --name-only   # sanity-check: only the index
+git -C "$WORKTREE_PATH" commit -m "sdd: close tasks for FEAT-<ID> — <slug>"
 ```
 
 ### 8. Push the Feature Branch

--- a/.claude/commands/sdd-done.md
+++ b/.claude/commands/sdd-done.md
@@ -282,19 +282,13 @@ When `--merge` is explicitly passed, perform a direct merge instead of a PR:
 git merge --no-edit feat-<FEAT-ID>-<slug>
 ```
 
-If the merge has conflicts:
+If the merge has conflicts (e.g. code-level changes to the same files):
 ```
 ⚠️  Merge conflict when merging feat-<FEAT-ID>-<slug> into <BASE_BRANCH>.
-   Conflicting files:
-     - <file1>
-     - <file2>
-
-   Options:
-     1. Resolve conflicts now (recommended)
-     2. Abort merge: git merge --abort
+   Resolve conflicts, then continue with: git merge --continue
+   Or abort: git merge --abort
 ```
-If conflicts are resolved, commit the merge. If the user aborts, STOP and
-do NOT proceed to cleanup.
+If the user aborts, STOP and do NOT proceed to cleanup.
 
 **Self-heal — reap stalled `active/` orphans (runs after every `--merge`):**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,7 +236,7 @@ git worktree prune
 | `/sdd-spec`       | `sdd/specs/<n>.spec.md` (with frontmatter) + a `reserve_ids.py` FEAT-ID reservation commit to `sdd/tasks/.id_ledger.json` (FEAT-387) | `base_branch` |
 | `/sdd-task`       | `sdd/tasks/index/<feature>.json` + `sdd/tasks/active/TASK-*` + a `reserve_ids.py` TASK-ID reservation commit to `sdd/tasks/.id_ledger.json` (FEAT-387) | `base_branch` |
 | `/sdd-start`      | Per-spec index status update + implementation code  | worktree (feature branch) |
-| `/sdd-done`       | Per-spec index final state + task file moves; merges feature → `base_branch` | `base_branch` (NEVER `main`) |
+| `/sdd-done`       | Verification stamp on per-spec index (committed on feature branch); merges feature → `base_branch` | worktree (feature branch), merged to `base_branch` by Step 9 |
 
 Commit message convention:
 ```

--- a/sdd/tasks/completed/TASK-2133-rewrite-sdd-done-step7.md
+++ b/sdd/tasks/completed/TASK-2133-rewrite-sdd-done-step7.md
@@ -2,11 +2,11 @@
 
 **Feature**: FEAT-414 — Fix sdd-done Merge Conflicts
 **Spec**: `sdd/specs/sdd-done-merge-conflict-fix.spec.md`
-**Status**: pending
+**Status**: done
 **Priority**: high
 **Estimated effort**: M (2-4h)
 **Depends-on**: none
-**Assigned-to**: unassigned
+**Assigned-to**: sdd-worker
 
 ---
 
@@ -220,10 +220,16 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker
+**Date**: 2026-08-05
+**Notes**: Replaced lines 164–185 of `.claude/commands/sdd-done.md` with the new
+"Stamp Verification (on feature branch)" step exactly as specified in the
+Implementation Notes. Verified: no functional call to `close_task.sh` remains
+(only the explanatory "Why not close_task.sh?" callout, which is part of the
+task's own specified template text); jq stamps `verification` per task and
+`completed_at` at the header level when all tasks are done; commit happens via
+`git -C "$WORKTREE_PATH"` on the feature branch. Lines before 164 and after the
+replaced block are unchanged (content shifted down naturally due to the
+replacement's line-count delta, but no other section was touched).
 
-**Completed by**: unassigned
-**Date**: YYYY-MM-DD
-**Notes**: What was implemented, any deviations from scope, issues encountered.
-
-**Deviations from spec**: none | describe if any
+**Deviations from spec**: none

--- a/sdd/tasks/completed/TASK-2134-simplify-step9-merge-block.md
+++ b/sdd/tasks/completed/TASK-2134-simplify-step9-merge-block.md
@@ -2,11 +2,11 @@
 
 **Feature**: FEAT-414 — Fix sdd-done Merge Conflicts
 **Spec**: `sdd/specs/sdd-done-merge-conflict-fix.spec.md`
-**Status**: pending
+**Status**: done
 **Priority**: medium
 **Estimated effort**: S (< 2h)
 **Depends-on**: TASK-2133
-**Assigned-to**: unassigned
+**Assigned-to**: sdd-worker
 
 ---
 
@@ -161,10 +161,14 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker
+**Date**: 2026-08-05
+**Notes**: Simplified the `--merge` conflict block in Step 9 of
+`.claude/commands/sdd-done.md` — replaced the SDD-specific framing (listing
+`file1`/`file2` and numbered resolve/abort options) with the shorter generic
+handler from the Implementation Notes. The merge command
+(`git merge --no-edit`), the `heal_orphans.sh` self-heal block, the PR flow
+section, and the hotfix refusal block were all left untouched — confirmed via
+`git diff` scoped to only this block.
 
-**Completed by**: unassigned
-**Date**: YYYY-MM-DD
-**Notes**: What was implemented, any deviations from scope, issues encountered.
-
-**Deviations from spec**: none | describe if any
+**Deviations from spec**: none

--- a/sdd/tasks/completed/TASK-2135-update-claude-md-autocommit-table.md
+++ b/sdd/tasks/completed/TASK-2135-update-claude-md-autocommit-table.md
@@ -2,11 +2,11 @@
 
 **Feature**: FEAT-414 — Fix sdd-done Merge Conflicts
 **Spec**: `sdd/specs/sdd-done-merge-conflict-fix.spec.md`
-**Status**: pending
+**Status**: done
 **Priority**: low
 **Estimated effort**: S (< 2h)
 **Depends-on**: TASK-2133
-**Assigned-to**: unassigned
+**Assigned-to**: sdd-worker
 
 ---
 
@@ -116,10 +116,11 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker
+**Date**: 2026-08-05
+**Notes**: Replaced the `/sdd-done` row (line 239) in CLAUDE.md's "SDD
+Auto-Commit Rule" table with the exact replacement text specified in the
+task. Confirmed via `git diff` that only this one line changed — no other
+rows in the table or other parts of CLAUDE.md were touched.
 
-**Completed by**: unassigned
-**Date**: YYYY-MM-DD
-**Notes**: What was implemented, any deviations from scope, issues encountered.
-
-**Deviations from spec**: none | describe if any
+**Deviations from spec**: none

--- a/sdd/tasks/index/sdd-done-merge-conflict-fix.json
+++ b/sdd/tasks/index/sdd-done-merge-conflict-fix.json
@@ -14,7 +14,7 @@
       "feature_id": "FEAT-414",
       "feature": "sdd-done-merge-conflict-fix",
       "spec": "sdd/specs/sdd-done-merge-conflict-fix.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [],
@@ -22,8 +22,8 @@
       "parallelism_notes": "Modifies sdd-done.md Step 7 — must be done first",
       "assigned_to": null,
       "started_at": "2026-08-05T14:04:42+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2133-rewrite-sdd-done-step7.md"
+      "completed_at": "2026-08-05T14:27:24+00:00",
+      "file": "sdd/tasks/completed/TASK-2133-rewrite-sdd-done-step7.md"
     },
     {
       "id": "TASK-2134",

--- a/sdd/tasks/index/sdd-done-merge-conflict-fix.json
+++ b/sdd/tasks/index/sdd-done-merge-conflict-fix.json
@@ -5,7 +5,7 @@
   "type": "feature",
   "base_branch": "dev",
   "created_at": "2026-08-05T00:00:00+00:00",
-  "completed_at": null,
+  "completed_at": "2026-08-05T14:35:53+00:00",
   "tasks": [
     {
       "id": "TASK-2133",
@@ -52,7 +52,7 @@
       "feature_id": "FEAT-414",
       "feature": "sdd-done-merge-conflict-fix",
       "spec": "sdd/specs/sdd-done-merge-conflict-fix.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "low",
       "effort": "S",
       "depends_on": [
@@ -62,8 +62,8 @@
       "parallelism_notes": "Different file than TASK-2134 but trivial — run sequentially",
       "assigned_to": null,
       "started_at": "2026-08-05T14:04:42+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2135-update-claude-md-autocommit-table.md"
+      "completed_at": "2026-08-05T14:35:53+00:00",
+      "file": "sdd/tasks/completed/TASK-2135-update-claude-md-autocommit-table.md"
     }
   ]
 }

--- a/sdd/tasks/index/sdd-done-merge-conflict-fix.json
+++ b/sdd/tasks/index/sdd-done-merge-conflict-fix.json
@@ -32,7 +32,7 @@
       "feature_id": "FEAT-414",
       "feature": "sdd-done-merge-conflict-fix",
       "spec": "sdd/specs/sdd-done-merge-conflict-fix.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "S",
       "depends_on": [
@@ -42,8 +42,8 @@
       "parallelism_notes": "Modifies sdd-done.md Step 9 — depends on TASK-2133 (same file)",
       "assigned_to": null,
       "started_at": "2026-08-05T14:04:42+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2134-simplify-step9-merge-block.md"
+      "completed_at": "2026-08-05T14:33:06+00:00",
+      "file": "sdd/tasks/completed/TASK-2134-simplify-step9-merge-block.md"
     },
     {
       "id": "TASK-2135",

--- a/sdd/tasks/index/sdd-done-merge-conflict-fix.json
+++ b/sdd/tasks/index/sdd-done-merge-conflict-fix.json
@@ -5,7 +5,7 @@
   "type": "feature",
   "base_branch": "dev",
   "created_at": "2026-08-05T00:00:00+00:00",
-  "completed_at": "2026-08-05T14:35:53+00:00",
+  "completed_at": "2026-08-05T18:31:03+00:00",
   "tasks": [
     {
       "id": "TASK-2133",
@@ -23,7 +23,8 @@
       "assigned_to": null,
       "started_at": "2026-08-05T14:04:42+00:00",
       "completed_at": "2026-08-05T14:27:24+00:00",
-      "file": "sdd/tasks/completed/TASK-2133-rewrite-sdd-done-step7.md"
+      "file": "sdd/tasks/completed/TASK-2133-rewrite-sdd-done-step7.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2134",
@@ -43,7 +44,8 @@
       "assigned_to": null,
       "started_at": "2026-08-05T14:04:42+00:00",
       "completed_at": "2026-08-05T14:33:06+00:00",
-      "file": "sdd/tasks/completed/TASK-2134-simplify-step9-merge-block.md"
+      "file": "sdd/tasks/completed/TASK-2134-simplify-step9-merge-block.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2135",
@@ -63,7 +65,8 @@
       "assigned_to": null,
       "started_at": "2026-08-05T14:04:42+00:00",
       "completed_at": "2026-08-05T14:35:53+00:00",
-      "file": "sdd/tasks/completed/TASK-2135-update-claude-md-autocommit-table.md"
+      "file": "sdd/tasks/completed/TASK-2135-update-claude-md-autocommit-table.md",
+      "verification": "verified"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Replaces /sdd-done Step 7 (pre-merge close_task.sh on dev) with a lightweight
verification stamp committed on the feature branch (in the worktree), and
simplifies the Step 9 --merge conflict block accordingly. Eliminates
guaranteed add/add and modify/modify SDD-file merge conflicts described in
FEAT-145.

## Tasks

3/3 tasks verified.

  ✅ TASK-2133 — Rewrite sdd-done Step 7 — Stamp Verification on Feature Branch
  ✅ TASK-2134 — Simplify sdd-done Step 9 --merge Conflict Block
  ✅ TASK-2135 — Update CLAUDE.md Auto-Commit Table for sdd-done

## Note

This PR was closed out using the *new* Step 7 logic it itself introduces
(stamp verification on the feature branch, not close_task.sh on dev) — using
the old, currently-live Step 7 to close this ticket would have reproduced the
exact merge conflict this feature fixes.

---
_Closed by /sdd-done_