### PR TITLE
feat(devloop-handoff-blocked-outcome): FEAT-413 — devloop-handoff-blocked-outcome

### DIFF
--- a/packages/ai-parrot/src/parrot/flows/dev_loop/runner.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/runner.py
@@ -113,6 +113,21 @@ def gate_ttl_for(kind: GateKind) -> int:
 # Actions-stream expiry/retention sweep cadence (seconds).
 _SWEEP_INTERVAL_SECONDS = 30
 
+# Terminal node ids whose status dict may signal a non-success close
+# (FEAT-413). These nodes never raise on failure by design — they return
+# a status dict instead — so `_close_host` must scan their responses
+# explicitly rather than rely on `FlowResult.status`/`AgentsFlow`'s
+# completed/failed bookkeeping, which only reflects whether a node raised.
+_TERMINAL_NODE_IDS = (
+    "deployment_handoff", "feature_handoff", "revision_handoff", "failure_handler",
+)
+_FAILED_TERMINAL_STATUSES = frozenset({
+    "blocked",                    # all three handoff nodes: nothing delivered
+    "escalated",                  # failure_handler: QA failed, run escalated
+    "escalated_without_ticket",   # failure_handler, no Jira / skip_jira
+    "escalation_failed",          # failure_handler, Jira call raised
+})
+
 
 def build_dev_loop_revision_flow(
     *,
@@ -1358,6 +1373,26 @@ class DevLoopRunner:
         pr_url = ""
         if isinstance(handoff_resp, dict):
             pr_url = str(handoff_resp.get("pr_url", "") or "")
+
+        # FEAT-413: none of the terminal nodes raise on failure — they
+        # return a status dict instead — so a blocked handoff or an
+        # escalated failure_handler still lands in FlowResult.status ==
+        # "completed" (AgentsFlow only tracks whether a node raised).
+        # Scan the explicit terminal-node allowlist directly against
+        # result.responses (NOT handoff_resp, which is None when the
+        # handoff node was skipped, e.g. the failure_handler case) and
+        # force outcome="failed" when any of them reported a failure
+        # status.
+        for _nid in _TERMINAL_NODE_IDS:
+            _resp = result.responses.get(_nid)
+            if isinstance(_resp, dict) and _resp.get("status") in _FAILED_TERMINAL_STATUSES:
+                self.logger.warning(
+                    "Run %s: terminal node %s reported status=%s — recording "
+                    "outcome=failed (FlowResult.status=%s)",
+                    run_id, _nid, _resp.get("status"), result.status,
+                )
+                outcome = "failed"
+                break
 
         host.apply(RunClosed(
             outcome=outcome, jira_issue_key=jira_issue_key, pr_url=pr_url,

--- a/packages/ai-parrot/tests/flows/dev_loop/test_run_bundle_export.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_run_bundle_export.py
@@ -149,6 +149,65 @@ async def test_bundle_export_failure_never_breaks_teardown(tmp_path, brief, monk
     assert snapshot_path.exists()
 
 
+@pytest.mark.parametrize(
+    "case_id, node_id, response, expected_outcome",
+    [
+        # FAILED — nothing was delivered.
+        ("blocked-deployment", "deployment_handoff",
+         {"status": "blocked", "error": "push failed"}, "failed"),
+        ("blocked-feature", "feature_handoff",
+         {"status": "blocked", "error": "PR create failed"}, "failed"),
+        ("blocked-revision", "revision_handoff",
+         {"status": "blocked", "error": "push: boom", "branch": "b"}, "failed"),
+        # FAILED — QA failed and the run escalated; the handoff node was
+        # SKIPPED, so there is no handoff response at all.
+        ("escalated", "failure_handler",
+         {"status": "escalated", "issue_key": "OPS-1"}, "failed"),
+        # SUCCEEDED — degraded but delivered: the revision WAS pushed, only
+        # the courtesy PR comment failed.
+        ("comment-failed", "revision_handoff",
+         {"status": "comment_failed", "pr_number": 7, "branch": "b"}, "succeeded"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_close_host_outcome_from_terminal_status(
+    tmp_path, brief, case_id, node_id, response, expected_outcome,
+):
+    flow = _FakeFlow(responses={node_id: response})
+    runner = DevLoopRunner(flow, max_concurrent_runs=2)  # type: ignore[arg-type]
+    run_id = f"run-terminal-{case_id}"
+
+    result = await runner.run(brief, run_id=run_id)
+    # The terminal node never raises, so the flow itself still reports
+    # COMPLETED — that is deliberate (spec Non-Goals); only the RECORDED
+    # outcome is corrected.
+    assert result.status == FlowStatus.COMPLETED
+
+    bundle_path, _ = _bundle_paths(run_id)
+    bundle = RunBundle.model_validate(json.loads(bundle_path.read_text()))
+    assert bundle.outcome == expected_outcome
+    # No PR url in any of these canned payloads.
+    assert bundle.developed.pr_url == ""
+
+
+@pytest.mark.asyncio
+async def test_close_host_ignores_blocked_status_on_non_terminal_node(tmp_path, brief):
+    """A non-terminal node using the same status vocabulary must NOT flip
+    the run outcome — the scan is an explicit node-id allowlist."""
+    flow = _FakeFlow(responses={
+        "development": {"status": "blocked", "error": "not a terminal node"},
+        "deployment_handoff": {"status": "ready_to_deploy", "pr_url": "http://pr/9"},
+    })
+    runner = DevLoopRunner(flow, max_concurrent_runs=2)  # type: ignore[arg-type]
+
+    await runner.run(brief, run_id="run-terminal-allowlist")
+
+    bundle_path, _ = _bundle_paths("run-terminal-allowlist")
+    bundle = RunBundle.model_validate(json.loads(bundle_path.read_text()))
+    assert bundle.outcome == "succeeded"
+    assert bundle.developed.pr_url == "http://pr/9"
+
+
 def test_package_exports():
     """`from parrot.flows.dev_loop import RunBundle, build_run_bundle,
     render_markdown` must work (TASK-1929 package-export requirement)."""

--- a/sdd/tasks/completed/TASK-2132-close-host-blocked-outcome.md
+++ b/sdd/tasks/completed/TASK-2132-close-host-blocked-outcome.md
@@ -415,10 +415,43 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (Claude Sonnet, autonomous)
+**Date**: 2026-08-05
+**Notes**: Implemented exactly as specified. Added `_TERMINAL_NODE_IDS` and
+`_FAILED_TERMINAL_STATUSES` module-level constants next to
+`_SWEEP_INTERVAL_SECONDS`, and inserted the terminal-status scan in
+`_close_host` immediately after the existing `pr_url` extraction block
+(left byte-for-byte unchanged, verified via `git diff`). The scan iterates
+`_TERMINAL_NODE_IDS` against `result.responses` directly (not
+`handoff_resp`), guards each lookup with `isinstance(resp, dict)`, emits
+the required WARNING log naming the node id and status, and forces
+`outcome = "failed"` on match. Added 6 regression tests to
+`test_run_bundle_export.py` (5 parametrized terminal-status cases —
+blocked deployment/feature/revision handoff, escalated failure_handler,
+comment_failed control — plus 1 non-terminal-node allowlist-isolation
+test) using the existing `_FakeFlow` harness. All 10 tests in the file
+pass (4 pre-existing + 6 new), asserting `bundle.developed.pr_url`
+(never `bundle.pr_url`) per the contract.
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
-**Notes**: What was implemented, any deviations from scope, issues encountered.
+Ran the full `pytest packages/ai-parrot/tests/flows/dev_loop/ -q -m "not
+live"` suite in the worktree and cross-checked against an unmodified
+`dev` checkout: both report the identical pre-existing 22 failed / 13
+errors (missing/misconfigured server-wiring fixtures unrelated to this
+change — `test_adversarial_server_wiring.py`, `test_code_review.py`,
+`test_server_repo_wiring.py`, `test_qa_codereview.py`,
+`test_examples_form.py`); the only delta is the 6 new passing tests
+added here. No regression introduced.
 
-**Deviations from spec**: none | describe if any
+The worktree's `.venv` was missing several optional runtime deps needed
+just to import `parrot.flows.dev_loop` for collection (`aioquic`,
+`rustworkx`, `networkx`, `google-genai`, `hypothesis`) — pre-existing
+environment gaps unrelated to this task's diff; installed them via `uv
+pip install` in the shared `.venv` to unblock test collection. No
+project files were changed to work around this.
+
+`ruff check` on both changed files shows only pre-existing findings
+(64 in `runner.py`, 5 in the test file) — none fall within the lines
+this task added (verified by line-range cross-reference); the new code
+is ruff-clean.
+
+**Deviations from spec**: none.

--- a/sdd/tasks/index/devloop-handoff-blocked-outcome.json
+++ b/sdd/tasks/index/devloop-handoff-blocked-outcome.json
@@ -5,7 +5,7 @@
   "type": "feature",
   "base_branch": "dev",
   "created_at": "2026-08-05T11:38:38+00:00",
-  "completed_at": null,
+  "completed_at": "2026-08-05T19:12:45+00:00",
   "tasks": [
     {
       "id": "TASK-2132",
@@ -14,7 +14,7 @@
       "feature_id": "FEAT-413",
       "feature": "devloop-handoff-blocked-outcome",
       "spec": "sdd/specs/devloop-handoff-blocked-outcome.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "S",
       "depends_on": [],
@@ -22,8 +22,8 @@
       "parallelism_notes": "Single-task spec; the only task touches runner.py + its test file together.",
       "assigned_to": null,
       "started_at": "2026-08-05T14:38:24+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2132-close-host-blocked-outcome.md"
+      "completed_at": "2026-08-05T19:12:45+00:00",
+      "file": "sdd/tasks/completed/TASK-2132-close-host-blocked-outcome.md"
     }
   ]
 }

--- a/sdd/tasks/index/devloop-handoff-blocked-outcome.json
+++ b/sdd/tasks/index/devloop-handoff-blocked-outcome.json
@@ -14,14 +14,14 @@
       "feature_id": "FEAT-413",
       "feature": "devloop-handoff-blocked-outcome",
       "spec": "sdd/specs/devloop-handoff-blocked-outcome.spec.md",
-      "status": "pending",
+      "status": "in-progress",
       "priority": "medium",
       "effort": "S",
       "depends_on": [],
       "parallel": false,
       "parallelism_notes": "Single-task spec; the only task touches runner.py + its test file together.",
       "assigned_to": null,
-      "started_at": null,
+      "started_at": "2026-08-05T14:38:24+00:00",
       "completed_at": null,
       "file": "sdd/tasks/active/TASK-2132-close-host-blocked-outcome.md"
     }

--- a/sdd/tasks/index/devloop-handoff-blocked-outcome.json
+++ b/sdd/tasks/index/devloop-handoff-blocked-outcome.json
@@ -5,7 +5,7 @@
   "type": "feature",
   "base_branch": "dev",
   "created_at": "2026-08-05T11:38:38+00:00",
-  "completed_at": "2026-08-05T19:12:45+00:00",
+  "completed_at": "2026-08-05T22:59:18+00:00",
   "tasks": [
     {
       "id": "TASK-2132",
@@ -23,7 +23,8 @@
       "assigned_to": null,
       "started_at": "2026-08-05T14:38:24+00:00",
       "completed_at": "2026-08-05T19:12:45+00:00",
-      "file": "sdd/tasks/completed/TASK-2132-close-host-blocked-outcome.md"
+      "file": "sdd/tasks/completed/TASK-2132-close-host-blocked-outcome.md",
+      "verification": "verified"
     }
   ]
 }


### PR DESCRIPTION
## Summary

`DevLoopRunner._close_host` now records `RunClosed(outcome="failed")` when
any dev_loop terminal node (`deployment_handoff`, `feature_handoff`,
`revision_handoff`, `failure_handler`) reported a non-success status dict,
even though `FlowResult.status == "completed"` (these nodes are designed to
never raise on failure).

Adds module-level `_TERMINAL_NODE_IDS` + `_FAILED_TERMINAL_STATUSES`
constants and a scan in `_close_host` (after the existing, untouched
`pr_url` extraction) that forces `outcome="failed"` + emits a required
WARNING log when a terminal node's response matches. The scan is keyed on
`result.responses` directly (not `handoff_resp`, which is `None` when the
handoff node was skipped — the `failure_handler` escalation case) and an
explicit node-id allowlist, so a non-terminal node using the same status
vocabulary can never flip the outcome.

## Tasks

1/1 tasks verified.

  ✅ TASK-2132 — `_close_host` must record `outcome="failed"` for a failed terminal node (verified)

## Verification

- 10/10 tests pass in `test_run_bundle_export.py` (4 pre-existing + 6 new:
  5 parametrized terminal-status cases + 1 non-terminal allowlist-isolation
  case).
- Full `pytest packages/ai-parrot/tests/flows/dev_loop/ -q -m "not live"`
  cross-checked against unmodified `dev`: identical pre-existing 22
  failed / 13 errors (unrelated server-wiring fixtures) on both — no
  regression introduced.
- `ruff check` clean on every line this diff added (pre-existing findings
  in both files are outside the diff).
- Adversarial code review (code-reviewer agent + codex cross-check):
  0 critical, 0 important. 3 suggestions noted (not blocking): guard the
  status-membership check against a non-string status for future-proofing,
  add regression tests for `escalated_without_ticket`/`escalation_failed`,
  add a `caplog` assertion for the WARNING log content.

---
_Closed by /sdd-done_