### PR TITLE
fix(FEAT-415): restore async context manager on SOAPClient + WorkdayRestClient

### DIFF
--- a/packages/ai-parrot-tools/src/parrot_tools/interfaces/workday/rest.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/interfaces/workday/rest.py
@@ -25,12 +25,16 @@ Example::
     from parrot_tools.interfaces.workday.config import WorkdayConfig
     from parrot_tools.interfaces.workday.rest import WorkdayRestClient
 
-    client = WorkdayRestClient(config=WorkdayConfig(env="sandbox"))
-    try:
+    async with WorkdayRestClient(config=WorkdayConfig(env="sandbox")) as client:
         workers = await client.find_worker("123456")
         events = await client.get_time_clock_events(workers[0]["id"])
-    finally:
-        await client.close()
+
+The ``aiohttp`` session is long-lived — the flowtask implementation this
+replaces opened a throwaway HTTP client per call and so needed no teardown,
+whereas here the session MUST be released: use the context manager above, or
+call ``close()`` in a ``finally``. A client kept as a module-level singleton
+needs its ``close()`` registered on application shutdown (``app.on_cleanup``)
+— otherwise aiohttp logs "Unclosed client session" at exit.
 """
 
 from __future__ import annotations
@@ -38,7 +42,7 @@ from __future__ import annotations
 import base64
 import logging
 import time as _time
-from typing import Any
+from typing import Any, Self
 
 import aiohttp
 
@@ -102,6 +106,29 @@ class WorkdayRestClient:
         if self._session is not None and not self._session.closed:
             await self._session.close()
         self._session = None
+
+    async def __aenter__(self) -> Self:
+        """Enter the async context; the session is still created lazily.
+
+        The predecessor implementation opened a throwaway HTTP client per call
+        and needed no teardown; this one keeps a long-lived ``aiohttp`` session
+        that MUST be closed. Prefer this context manager, or an explicit
+        ``close()`` in a ``finally``; a client held in a module-level singleton
+        needs its ``close()`` wired into the application shutdown hook (e.g.
+        ``app.on_cleanup``), otherwise aiohttp reports "Unclosed client
+        session" at exit.
+
+        Returns:
+            This client.
+        """
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Exit the async context, closing the shared session.
+
+        Returns ``None`` so any in-flight exception propagates.
+        """
+        await self.close()
 
     # ------------------------------------------------------------------
     # Auth

--- a/packages/ai-parrot-tools/tests/workday/test_rest_client.py
+++ b/packages/ai-parrot-tools/tests/workday/test_rest_client.py
@@ -192,6 +192,59 @@ class TestLifecycle:
         await client.close()
         assert client._session is None
 
+    async def test_close_is_idempotent(self, aiohttp_server):
+        async def token_handler(request):
+            return web.json_response({"access_token": "tok", "expires_in": 300})
+
+        app = web.Application()
+        app.router.add_post("/token", token_handler)
+        server = await aiohttp_server(app)
+
+        client = WorkdayRestClient(config=_make_config(str(server.make_url(""))))
+        await client.get_token()
+
+        await client.close()
+        await client.close()  # must not raise
+        assert client._session is None
+
+    async def test_async_context_manager_closes_session(self, aiohttp_server):
+        """FEAT-415: the aiohttp session is long-lived, so the client offers the
+        context manager protocol the per-call predecessor did not need."""
+        async def token_handler(request):
+            return web.json_response({"access_token": "tok", "expires_in": 300})
+
+        app = web.Application()
+        app.router.add_post("/token", token_handler)
+        server = await aiohttp_server(app)
+
+        cfg = _make_config(str(server.make_url("")))
+        async with WorkdayRestClient(config=cfg) as client:
+            await client.get_token()
+            assert client._session is not None
+            assert not client._session.closed
+            leaked = client._session
+
+        assert client._session is None
+        assert leaked.closed
+
+    async def test_async_context_manager_closes_on_exception(self, aiohttp_server):
+        async def token_handler(request):
+            return web.json_response({"access_token": "tok", "expires_in": 300})
+
+        app = web.Application()
+        app.router.add_post("/token", token_handler)
+        server = await aiohttp_server(app)
+
+        cfg = _make_config(str(server.make_url("")))
+        client = WorkdayRestClient(config=cfg)
+
+        with pytest.raises(ValueError, match="inner"):
+            async with client:
+                await client.get_token()
+                raise ValueError("inner")
+
+        assert client._session is None
+
     def test_module_does_not_import_httpx(self):
         import parrot_tools.interfaces.workday.rest as mod
 

--- a/packages/ai-parrot/src/parrot/interfaces/soap.py
+++ b/packages/ai-parrot/src/parrot/interfaces/soap.py
@@ -2,7 +2,7 @@
 
 import base64
 from abc import ABC
-from typing import Any, Optional, Union
+from typing import Any, Optional, Self, Union
 from pathlib import Path
 import httpx
 import redis.asyncio as aioredis
@@ -250,8 +250,40 @@ class SOAPClient(ABC):
     async def close(self) -> None:
         """
         Cleanup HTTP session and Redis connection.
+
+        Idempotent: the transport and Redis handles are dropped after being
+        released, so a second call (e.g. an explicit ``close()`` inside a
+        ``finally`` nested in an ``async with`` block) is a no-op.
         """
         if self._transport and hasattr(self._transport, "session"):
             await self._transport.session.aclose()
+            self._transport = None
         if self._redis:
             await self._redis.close()
+            self._redis = None
+
+    async def __aenter__(self) -> Self:
+        """
+        Enter the async context, running :meth:`start`.
+
+        If ``start()`` raises, whatever it had already opened is released
+        before the exception propagates — Python does not call ``__aexit__``
+        when ``__aenter__`` fails, so the cleanup has to happen here.
+
+        Returns:
+            This client, already started.
+        """
+        try:
+            await self.start()
+        except BaseException:
+            await self.close()
+            raise
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        """
+        Exit the async context, running :meth:`close`.
+
+        Returns ``None`` so any in-flight exception propagates.
+        """
+        await self.close()

--- a/packages/ai-parrot/tests/interfaces/test_soap.py
+++ b/packages/ai-parrot/tests/interfaces/test_soap.py
@@ -1,0 +1,160 @@
+"""Unit tests for parrot.interfaces.soap.SOAPClient lifecycle.
+
+Regression coverage for FEAT-415 (Workday flowtask homologation): the
+flowtask ``SOAPClient`` supports ``async with client:`` and consumer code —
+including the ``WorkdayService`` docstring example — relies on it. The parrot
+port shipped only ``start()``/``close()``, so swapping the import broke every
+``async with svc:`` call site with ``TypeError: 'WorkdayService' object does
+not support the asynchronous context manager protocol``.
+
+These tests exercise the real protocol methods rather than mocking them, and
+pin the teardown guarantees (idempotent ``close()``, cleanup when ``start()``
+itself fails) that a drop-in replacement has to hold.
+"""
+from __future__ import annotations
+
+import pytest
+
+# soap.py imports zeep at module level; zeep ships only with the optional
+# extras (agents / workday), so skip cleanly on a bare install.
+pytest.importorskip("zeep", reason="requires the zeep[async] optional extra")
+
+from parrot.interfaces.soap import SOAPClient
+
+CREDENTIALS = {
+    "client_id": "cid",
+    "client_secret": "secret",
+    "token_url": "https://example.test/oauth/token",
+    "wsdl_path": "/tmp/fake.wsdl",
+    "refresh_token": "refresh",
+}
+
+
+class _RecordingClient(SOAPClient):
+    """SOAPClient whose start/close only record their invocation order."""
+
+    def __init__(self, *, fail_start: bool = False, **kwargs) -> None:
+        super().__init__(credentials=CREDENTIALS, **kwargs)
+        self.calls: list[str] = []
+        self._fail_start = fail_start
+
+    async def start(self) -> None:
+        self.calls.append("start")
+        if self._fail_start:
+            raise RuntimeError("token endpoint unreachable")
+
+    async def close(self) -> None:
+        self.calls.append("close")
+
+
+class _FakeSession:
+    """Stand-in for the httpx.AsyncClient held by the Zeep transport."""
+
+    def __init__(self) -> None:
+        self.aclose_calls = 0
+
+    async def aclose(self) -> None:
+        self.aclose_calls += 1
+
+
+class _FakeTransport:
+    def __init__(self) -> None:
+        self.session = _FakeSession()
+
+
+class _FakeRedis:
+    def __init__(self) -> None:
+        self.close_calls = 0
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+class TestAsyncContextManagerProtocol:
+    def test_protocol_methods_exist(self):
+        """The flowtask surface consumer code binds against."""
+        assert hasattr(SOAPClient, "__aenter__")
+        assert hasattr(SOAPClient, "__aexit__")
+
+    async def test_async_with_starts_then_closes(self):
+        client = _RecordingClient()
+
+        async with client as entered:
+            assert entered is client
+            assert client.calls == ["start"]
+
+        assert client.calls == ["start", "close"]
+
+    async def test_exception_inside_block_still_closes_and_propagates(self):
+        client = _RecordingClient()
+
+        with pytest.raises(ValueError, match="inner"):
+            async with client:
+                raise ValueError("inner")
+
+        assert client.calls == ["start", "close"]
+
+    async def test_subclass_start_taking_kwargs_is_callable(self):
+        """``WorkdayService.start`` is declared ``start(self, **_kwargs)``, so
+        __aenter__ must call start() with no positional arguments."""
+
+        class _KwargsStartClient(SOAPClient):
+            def __init__(self) -> None:
+                super().__init__(credentials=CREDENTIALS)
+                self.started = False
+
+            async def start(self, **_kwargs) -> None:
+                self.started = True
+
+            async def close(self) -> None:
+                pass
+
+        client = _KwargsStartClient()
+        async with client:
+            assert client.started
+
+    async def test_failed_start_releases_resources_and_propagates(self):
+        """__aexit__ is never called when __aenter__ raises, so __aenter__
+        must clean up after a partially-completed start() itself."""
+        client = _RecordingClient(fail_start=True)
+
+        with pytest.raises(RuntimeError, match="token endpoint unreachable"):
+            async with client:
+                pytest.fail("body must not run when start() fails")
+
+        assert client.calls == ["start", "close"]
+
+
+class TestClose:
+    async def test_close_releases_transport_session_and_redis(self):
+        client = SOAPClient(credentials=CREDENTIALS)
+        transport = _FakeTransport()
+        redis = _FakeRedis()
+        client._transport = transport
+        client._redis = redis
+
+        await client.close()
+
+        assert transport.session.aclose_calls == 1
+        assert redis.close_calls == 1
+
+    async def test_close_is_idempotent(self):
+        """An explicit close() nested inside an ``async with`` must not
+        double-release the session."""
+        client = SOAPClient(credentials=CREDENTIALS)
+        transport = _FakeTransport()
+        redis = _FakeRedis()
+        client._transport = transport
+        client._redis = redis
+
+        await client.close()
+        await client.close()
+
+        assert transport.session.aclose_calls == 1
+        assert redis.close_calls == 1
+
+    async def test_close_without_start_is_a_noop(self):
+        """Cleanup after a start() that never got as far as opening anything."""
+        client = SOAPClient(credentials=CREDENTIALS)
+
+        await client.close()  # must not raise


### PR DESCRIPTION
## Problem

Two homologation regressions surfaced when consumer code swaps
`flowtask.interfaces` for `parrot.interfaces` / `parrot_tools.interfaces`.

**B1 — `async with svc:` raised `TypeError`.** flowtask's `SOAPClient`
(`flowtask/interfaces/SOAPClient.py:347-352`) implements the async context
manager protocol; the parrot port shipped only `start()`/`close()`. Every
`async with WorkdayService(...) as svc:` call site broke — including the
example in `WorkdayService`'s own docstring (`service.py:133`).

Reproduced on `dev`:
```
TypeError: 'WorkdayService' object does not support the asynchronous
context manager protocol
```

Note: `sdd/state/FEAT-230/findings/F002-parrot-interfaces-soap.md` claimed
the parrot `SOAPClient` already exposed `__aenter__`/`__aexit__`. It does
not — that finding is likely why the homologation assumed parity.

**B2 — `WorkdayRestClient` tightened its lifecycle contract silently.** The
flowtask original has **no `close()` at all** (`async with
httpx.AsyncClient(...)` per request, `rest.py:106,144`). The aiohttp port
keeps a long-lived `ClientSession` requiring an explicit `close()`, so a
call site ported verbatim leaks it — aiohttp then logs "Unclosed client
session" at shutdown. This is a contract change, not just a forgotten
`close()`.

## Changes

`parrot/interfaces/soap.py` — adds `__aenter__`/`__aexit__` to `SOAPClient`,
with two improvements over the flowtask version:

- `__aenter__` releases partially-opened resources when `start()` raises.
  Python skips `__aexit__` when `__aenter__` fails, so a `start()` that dies
  after connecting Redis but before fetching the token used to leak the
  connection. flowtask has the same hole.
- `close()` is now idempotent (`_transport`/`_redis` reset to `None`), so an
  explicit `close()` nested inside an `async with` no longer double-releases.
  Verified no consumer reads either attribute after close.

`parrot_tools/interfaces/workday/rest.py` — adds `__aenter__`/`__aexit__` to
`WorkdayRestClient` and documents the teardown requirement in both the module
and method docstrings, including the singleton → `app.on_cleanup` case.

## Verification

- Bug reproduced on `dev`; with the fix, `async with WorkdayService(...) as
  svc:` runs `start` → `close` in order.
- 11 new tests, all passing: 8 in `packages/ai-parrot/tests/interfaces/test_soap.py`
  (skipped via `importorskip` without the `zeep[async]` extra), 3 in
  `tests/workday/test_rest_client.py`. One pins the `start(self, **_kwargs)`
  override signature `WorkdayService` uses.
- **No regressions**: the 41 pre-existing `FAILED`/`ERROR` entries in the
  workday suite are byte-identical before and after; ruff reports the same 11
  pre-existing findings in `soap.py` with none added.

## Out of scope

The real leak is in a downstream consumer: `fieldsync/apps/workday_timeclock/service.py:58`
holds a module-level `_rest_client` singleton that never closes. It still
imports from `flowtask.interfaces.workday` today, so it does not leak yet —
the leak lands when those imports move to `parrot_tools`. That fix belongs in
the fieldsync repo (a fail-soft `close_rest_client` on `app.on_cleanup`,
following `apps/time_capture/__init__.py:267`) and is not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)