### PR TITLE
feat(execution-plan-tool): FEAT-419 — ExecutionPlanToolkit — deterministic tool-call DAGs for a BasicAgent

### DIFF
--- a/docs/toolkits/execution_plan_toolkit.md
+++ b/docs/toolkits/execution_plan_toolkit.md
@@ -1,0 +1,221 @@
+# ExecutionPlanToolkit — Reference
+
+**Feature**: FEAT-419
+**Module**: `parrot/tools/execution_plan/`
+**Class**: `ExecutionPlanToolkit(AbstractToolkit)`
+
+---
+
+## Overview
+
+`ExecutionPlanToolkit` lets a plain `BasicAgent` run a deterministic
+tool-call DAG (an `ExecutionPlan`) through one bounded tool call, with
+**zero LLM tokens spent while the plan executes**. A *thinking* model (or a
+versioned file) authors the plan once; the toolkit validates it statically
+against the live `ToolManager`, compiles it to a `FlowDefinition`, and runs
+it on `AgentsFlow`. Tool payloads never enter the agent's context — they
+land in `WorkingMemory` under keys the plan itself chose, and only small,
+bounded `ArtifactRef`s and an `ExecutionManifest` travel back.
+
+The invoking agent stays a normal `BasicAgent`. It does **not** become a
+Flow or a Crew — it *invokes* a flow through a tool.
+
+This is the wrapper around the frozen `parrot.bots.flows.plan` module
+(`ExecutionPlan`, `PlanNode`, `PlanToolNode`, `validate_plan`,
+`to_flow_definition`, …) — that module's schema and executor semantics are
+constraints, not design space, for anything built on top of it.
+
+---
+
+## Wiring
+
+```python
+from parrot.bots.agent import BasicAgent
+from parrot.tools.execution_plan import ExecutionPlanToolkit
+from parrot.tools.working_memory import WorkingMemoryToolkit
+
+working_memory = WorkingMemoryToolkit()
+
+toolkit = ExecutionPlanToolkit(
+    tool_manager=agent.tool_manager,   # SAME manager the agent's other tools use
+    working_memory=working_memory,     # SAME instance the analyst reads back from
+    planner_llm="google:gemini-2.5-flash",  # enables `objective` mode; omit to disable it
+    plans_dir="examples/plans",             # enables `plan_name` mode; omit to disable it
+    allowed_tools=["s3_filter_reports", "s3_get_latest_report", "compare_scans"],
+    soft_timeout=60.0,
+)
+
+agent.tool_manager.register_tool(toolkit)
+# Also register `working_memory` with the agent so the analyst can read
+# back artifacts under the keys the plan chose — constructor injection,
+# never auto-detected: `BasicAgent._inject_answer_memory_into_toolkits()`
+# does not match wrapped `ToolkitTool`s.
+agent.tool_manager.register_tool(working_memory)
+```
+
+Both `planner_llm` and `plans_dir` are optional and independent — set
+either, both, or neither. Neither one being set means the toolkit only
+exposes `plan_status`/`plan_artifacts` (nothing to acquire a plan from).
+`allowed_tools=None` (the default) means every tool registered on
+`tool_manager` is allowed; setting it is both the security boundary (a plan
+naming a tool outside the list fails validation before anything runs) and
+the planner's tool catalog.
+
+---
+
+## Tools
+
+### `plan_execute(objective=None, plan_name=None, params=None)`
+
+Acquire → validate → compile → run. Exactly one of `objective` (planner-
+authored) or `plan_name` (versioned file under `plans_dir`) must be given.
+
+- **`objective` mode**: the toolkit's internal `PlanPlanner` makes one
+  structured-output LLM call to author the plan. If validation fails, the
+  planner is re-prompted exactly once with the full `ValidationReport`
+  (whose messages are written for this) — then the toolkit gives up.
+- **`plan_name` mode**: loads `plans_dir/<plan_name>.(yaml|yml|json)` with
+  load-time `{params.<name>}` substitution, then validates. **No repair
+  round** — a persisted plan that fails validation is a broken file to fix,
+  not something to patch at runtime.
+
+Returns the full `ExecutionManifest` if the run finishes within
+`soft_timeout`, else `{run_id, status: "running", nodes_total, nodes_done}`
+while execution continues in the background — poll `plan_status(run_id)`.
+
+**Failure semantics**: the manifest is *always* the success payload —
+`status` is `completed | partial | failed` with per-node errors inside
+(capped at 20). A plan that partially failed is data the agent inspects
+and reacts to, not an exception. Tool-level errors are reserved for
+structural failures: both/neither plan source given, `params` combined
+with `objective`, `objective` without a configured `planner_llm`,
+`plan_name` without a configured `plans_dir`, an unreadable plan file, and
+**an invalid plan after the repair round** (nothing to run).
+
+### `plan_status(run_id)`
+
+Progress counts (`nodes_total`/`nodes_done`) while a run is still
+executing; the final `ExecutionManifest` once it has finished.
+
+### `plan_artifacts(run_id)`
+
+The `ArtifactRef` list produced so far — the WorkingMemory key map the
+analyst reads back from, available even while the run is still going.
+
+### `plan_validate(objective=None, plan_name=None, params=None)`
+
+Dry run: same arbitration, acquisition and (in `objective` mode) repair
+round as `plan_execute`, but **never executes a tool**. Returns the
+acquired plan JSON **verbatim** — including a planner-generated plan in
+`objective` mode — plus the full `ValidationReport` (`ok` flag and every
+issue's `node_id`/`code`/`message`/`severity`). Because the response
+always includes the plan JSON, even when `ok` is `false`, this is also the
+save-and-promote workflow: inspect what the planner produced, fix it by
+hand if needed, and drop it into `plans_dir` as a new versioned
+`plan_name`.
+
+---
+
+## The plan file + `{params.<name>}` contract
+
+A `plan_name`-mode file is a plain YAML or JSON document matching
+`ExecutionPlan.model_json_schema()` (see
+`sdd/artifacts/execution_plan.schema.json`), with one addition: string
+leaves may contain `{params.<name>}` placeholders, substituted **before**
+validation:
+
+- A leaf that is *exactly* one placeholder resolves to the parameter's
+  native value (an `int` param stays an `int`).
+- A leaf with an embedded placeholder is interpolated as text.
+- Every placeholder in the file must have a matching key in `params`, and
+  every key in `params` must be referenced somewhere in the file — nothing
+  is silently missing or silently unused.
+
+`{params.<name>}` is a **load-time-only** concept, handled entirely by
+`PlanFileStore` before the plan ever reaches the executor. It is distinct
+from — and never touches — the executor's own runtime placeholder
+families, which are resolved per-node while the plan runs:
+
+| Placeholder | Resolved by | When |
+|---|---|---|
+| `{params.<name>}` | `PlanFileStore.load()` | Load time, `plan_name` mode only |
+| `{nodes.<id>.output}` | `PlanToolNode._resolve_args` | Runtime — the small published `ArtifactRef` |
+| `{artifacts.<id>}` | `PlanToolNode._resolve_args` | Runtime — the full stored body (code reads it, never a model) |
+| `{item}` / `{item.<field>}` / `{index}` | `PlanToolNode._resolve_args` | Runtime, inside a `for_each` node |
+
+See `examples/plans/daily_security_sweep.json` for a complete example
+(4-node plan: list reports → fan out and fetch each → diff against the
+previous scan → map new findings to SOC2 controls), using `{params.date}`.
+
+```python
+result = await toolkit.plan_execute(
+    plan_name="daily_security_sweep",
+    params={"date": "2026-08-06"},
+)
+```
+
+---
+
+## Soft-timeout / `run_id` flow
+
+`plan_execute` waits up to `soft_timeout` seconds (default `60.0`) for the
+run to finish. If it finishes in time, the full manifest comes back
+directly. If not, the run keeps going in the background — the timeout
+**never cancels it** — and the tool call returns a small summary instead:
+
+```json
+{"run_id": "run_ab12cd", "status": "running", "nodes_total": 4, "nodes_done": 1}
+```
+
+The agent then polls:
+
+```python
+status = await toolkit.plan_status(run_id="run_ab12cd")
+# → RunningSummary again while it's still going, or the final
+#   ExecutionManifest once it's done.
+```
+
+This is how a 300-item fan-out over minutes of wall-clock time coexists
+with a normal per-tool-call timeout on the agent side.
+
+---
+
+## v1 caveats (read before relying on this in production)
+
+- **`WorkingMemory` is in-RAM, with no guardrail.** Every payload a plan
+  fetches — including a 300-item fan-out over hundreds of MB of scanner
+  reports — lives in the process's memory for the whole run and beyond,
+  until something explicitly drops it. There is no size cap, no eviction,
+  no spill-to-disk. `bytes_stored` (per `ArtifactRef`) and
+  `total_bytes_stored` (on the manifest) make the cost *visible*; they do
+  not bound it. A persistent `WorkingMemory` backend is a separate,
+  future feature.
+- **The run registry is lost on a process restart.** `RunRecord`s and the
+  live `asyncio.Task`s behind them are toolkit-instance state, not
+  persisted anywhere. There is **no `plan_resume(run_id)`** — do not build
+  workflows that assume one exists.
+- **Recovery is re-issue + `skip_existing`, not resume.** If a process
+  dies mid-run, re-issuing the *same* `plan_execute(plan_name=..., params=
+  ...)` call redoes only the work that never got stored — every `for_each`
+  node defaults to `skip_existing=True`, so a `store_as` key already
+  present in `WorkingMemory` is not re-fetched. This is idempotence, not
+  checkpoint/resume; a plan with no `for_each` nodes has no such recovery
+  story and simply re-runs from the top.
+- **Run-registry bounds**: completed/failed runs beyond
+  `max_completed_runs` (default `50`) are evicted oldest-first. In-flight
+  runs are never evicted, and there is no cap on concurrent runs in v1.
+- **`allowed_tools=None` means "trust every tool on this `ToolManager`".**
+  If the manager is shared with components that register tools you would
+  not want a planner-authored plan to invoke, set `allowed_tools`
+  explicitly.
+
+---
+
+## See also
+
+- `sdd/specs/execution-plan-tool.spec.md` — the full design spec (FEAT-419).
+- `parrot/bots/flows/plan/` — the frozen plan schema/validator/compiler/executor.
+- `examples/plans/daily_security_sweep.json` — the shipped example plan.
+- `packages/ai-parrot/tests/tools/execution_plan/test_integration.py` — the
+  end-to-end proof (zero-token execution, resumable fan-out, allowlist
+  enforcement, `AgentCrew.add_tool_node()` regression).

--- a/docs/toolkits/execution_plan_toolkit.md
+++ b/docs/toolkits/execution_plan_toolkit.md
@@ -193,7 +193,11 @@ with a normal per-tool-call timeout on the agent side.
 - **The run registry is lost on a process restart.** `RunRecord`s and the
   live `asyncio.Task`s behind them are toolkit-instance state, not
   persisted anywhere. There is **no `plan_resume(run_id)`** — do not build
-  workflows that assume one exists.
+  workflows that assume one exists. The toolkit explicitly disables
+  `AgentsFlow`'s own flow-level checkpointing (FEAT-399) for every plan
+  run — that mechanism defaults to a Redis-backed checkpoint store, which
+  would otherwise be a silent, undocumented external dependency
+  contradicting the "pure in-RAM, no persistent backend" design above.
 - **Recovery is re-issue + `skip_existing`, not resume.** If a process
   dies mid-run, re-issuing the *same* `plan_execute(plan_name=..., params=
   ...)` call redoes only the work that never got stored — every `for_each`

--- a/examples/plans/daily_security_sweep.json
+++ b/examples/plans/daily_security_sweep.json
@@ -1,0 +1,90 @@
+{
+  "name": "daily_security_sweep",
+  "objective": "Ingest yesterday's Prowler reports, diff against the previous scan, and map new critical findings to SOC2 controls.",
+  "nodes": [
+    {
+      "id": "listing",
+      "tool": "s3_filter_reports",
+      "args": {
+        "scanner": "prowler",
+        "date": "{params.date}"
+      },
+      "store_as": "listing",
+      "facets": {
+        "counts": {
+          "n_reports": "keys[]"
+        }
+      },
+      "description": "Catalog yesterday's report objects"
+    },
+    {
+      "id": "fetch",
+      "tool": "s3_get_latest_report",
+      "args": {
+        "key": "{item}"
+      },
+      "store_as": "report_{index}",
+      "depends_on": [
+        "listing"
+      ],
+      "when": "ctx.artifacts.listing.n_reports > 0",
+      "for_each": {
+        "source": "{artifacts.listing}",
+        "select": "keys[]",
+        "max_concurrency": 16
+      },
+      "facets": {
+        "counts": {
+          "n_findings": "findings[]"
+        },
+        "group_counts": {
+          "by_severity": "findings[].severity"
+        }
+      },
+      "timeout": 120.0,
+      "description": "Fetch every report body into working memory"
+    },
+    {
+      "id": "diff",
+      "tool": "compare_scans",
+      "args": {
+        "current": "{artifacts.fetch}",
+        "window_days": 1
+      },
+      "store_as": "deltas",
+      "depends_on": [
+        "fetch"
+      ],
+      "when": "ctx.status.fetch != \"error\"",
+      "facets": {
+        "counts": {
+          "n_new": "new[]",
+          "n_resolved": "resolved[]"
+        }
+      },
+      "description": "Deterministic drift between scans"
+    },
+    {
+      "id": "soc2",
+      "tool": "map_report_to_soc2",
+      "args": {
+        "findings": "{artifacts.diff}"
+      },
+      "store_as": "soc2_mapping",
+      "depends_on": [
+        "diff"
+      ],
+      "when": "ctx.artifacts.diff.n_new > 0",
+      "facets": {
+        "group_counts": {
+          "by_control": "mappings[].control_id"
+        }
+      },
+      "description": "Map new findings to TSC controls (no LLM)"
+    }
+  ],
+  "metadata": {
+    "max_parallel_tasks": 16,
+    "durable": true
+  }
+}

--- a/packages/ai-parrot/src/parrot/bots/flows/flow/flow.py
+++ b/packages/ai-parrot/src/parrot/bots/flows/flow/flow.py
@@ -732,10 +732,26 @@ class AgentsFlow(PersistenceMixin):
                     successors=succs,
                 )
             elif node_type in ("start", "end"):
-                fresh[nid] = cls(
+                # StartNode/EndNode declare no `fsm` field (only AgentNode
+                # does), yet `_run_node()` unconditionally calls
+                # `node.fsm.schedule()/.start()/.succeed()/.fail()` for
+                # EVERY dispatched node. The programmatic branch above
+                # (`self._definition is None`) already papers over this via
+                # `node.model_copy(update={"fsm": new_fsm})`; the
+                # definition-driven branch never did, because no existing
+                # FlowDefinition-based flow in this codebase used "start"/
+                # "end" node types before FEAT-419's `plan/compile.py::
+                # to_flow_definition()` started emitting `__start__`/
+                # `__end__` sentinels unconditionally. Mirror the same
+                # model_copy patch here so a defined-then-run flow with
+                # start/end sentinels does not crash on its first dispatch.
+                start_end_node = cls(
                     node_id=nid,
                     dependencies=deps,
                     successors=succs,
+                )
+                fresh[nid] = start_end_node.model_copy(
+                    update={"fsm": AgentTaskMachine(agent_name=nid)}
                 )
             else:
                 # Custom node type: prefer a registered factory so the node can

--- a/packages/ai-parrot/src/parrot/bots/flows/plan/__init__.py
+++ b/packages/ai-parrot/src/parrot/bots/flows/plan/__init__.py
@@ -1,0 +1,78 @@
+"""Deterministic execution plans for ai-parrot agents.
+
+A thinking model authors an :class:`~.models.ExecutionPlan` once; the plan is
+validated statically against the live ``ToolManager``, compiled to a
+``FlowDefinition`` and executed by ``AgentsFlow`` with no LLM in the loop.
+Tool payloads land in ``WorkingMemory``; only :class:`~.models.ArtifactRef`
+facets travel back through the flow context.
+
+Intended location in the repo::
+
+    packages/ai-parrot/src/parrot/bots/flows/plan/
+"""
+from .compile import (
+    END_NODE_ID,
+    PLAN_NODE_TYPE,
+    START_NODE_ID,
+    ensure_tool_node_registered,
+    to_flow_definition,
+)
+from .facets import estimate_bytes, extract_facets, merge_facets
+from .guards import GuardCompilationError, PlanGuard, compile_guard
+from .models import (
+    ArtifactRef,
+    ExecutionManifest,
+    ExecutionPlan,
+    FacetSpec,
+    ForEach,
+    PlanMetadata,
+    PlanNode,
+    RetryPolicy,
+)
+from .node import (
+    PlanToolNode,
+    ToolExecutionError,
+    build_manifest,
+    make_tool_node_factory,
+)
+from .paths import PathError, compile_path, render_key, select
+from .validator import (
+    PlanValidationError,
+    ValidationIssue,
+    ValidationReport,
+    validate_plan,
+)
+
+__all__ = (
+    "ArtifactRef",
+    "END_NODE_ID",
+    "ExecutionManifest",
+    "ExecutionPlan",
+    "FacetSpec",
+    "ForEach",
+    "GuardCompilationError",
+    "PLAN_NODE_TYPE",
+    "PathError",
+    "PlanGuard",
+    "PlanMetadata",
+    "PlanNode",
+    "PlanToolNode",
+    "PlanValidationError",
+    "RetryPolicy",
+    "ToolExecutionError",
+    "START_NODE_ID",
+    "ValidationIssue",
+    "ValidationReport",
+    "build_manifest",
+    "compile_guard",
+    "compile_path",
+    "ensure_tool_node_registered",
+    "estimate_bytes",
+    "extract_facets",
+    "make_tool_node_factory",
+    "merge_facets",
+    "render_key",
+    "select",
+    "to_flow_definition",
+    "validate_plan",
+)

--- a/packages/ai-parrot/src/parrot/bots/flows/plan/compile.py
+++ b/packages/ai-parrot/src/parrot/bots/flows/plan/compile.py
@@ -1,0 +1,154 @@
+"""Compile an ExecutionPlan into a runnable ``FlowDefinition``.
+
+An :class:`~models.ExecutionPlan` is the planner-facing surface: flat, small,
+and easy for a model to emit correctly. ``FlowDefinition`` is the executor's
+surface: nodes plus explicit edges, with ``start``/``end`` sentinels and the
+checkpointing metadata block. This module is the (deterministic) bridge.
+
+Every plan node becomes a ``NodeDefinition`` of type ``"tool"`` whose
+``config`` carries the plan node verbatim. The live ``ToolManager`` and
+``WorkingMemoryToolkit`` are *not* serialised into config — they reach the
+node through the ``node_factories`` closure that ``AgentsFlow.from_definition``
+invokes per run.
+
+Note:
+    ``"tool"`` must be present in ``NODE_REGISTRY`` before
+    ``AgentsFlow.from_definition`` will accept these definitions; see
+    :func:`ensure_tool_node_registered`.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .models import ExecutionPlan
+
+__all__ = (
+    "PLAN_NODE_TYPE",
+    "END_NODE_ID",
+    "START_NODE_ID",
+    "ensure_tool_node_registered",
+    "to_flow_definition",
+)
+
+PLAN_NODE_TYPE = "tool"
+START_NODE_ID = "__start__"
+END_NODE_ID = "__end__"
+
+
+def to_flow_definition(plan: ExecutionPlan) -> Any:
+    """Build a ``FlowDefinition`` from ``plan``.
+
+    Edges are derived from ``depends_on`` with ``condition="always"`` rather
+    than the default ``on_success``: a guarded node that skips must not block
+    its dependents, and per-node failure policy is expressed by
+    ``PlanNode.retry`` / ``ForEach.on_item_error``, not by edge conditions.
+
+    Args:
+        plan: A validated execution plan.
+
+    Returns:
+        A ``FlowDefinition`` ready for ``AgentsFlow.from_definition``.
+
+    Raises:
+        ImportError: If the flow package is unavailable.
+    """
+    from parrot.bots.flows.flow.definition import (  # noqa: PLC0415
+        EdgeDefinition,
+        FlowDefinition,
+        FlowMetadata,
+        NodeDefinition,
+    )
+
+    nodes: List[Any] = [
+        NodeDefinition(id=START_NODE_ID, type="start", label="start"),
+        NodeDefinition(id=END_NODE_ID, type="end", label="end"),
+    ]
+    edges: List[Any] = []
+
+    roots = [n.id for n in plan.nodes if not n.depends_on]
+    leaves = _leaf_ids(plan)
+
+    for plan_node in plan.nodes:
+        nodes.append(
+            NodeDefinition(
+                id=plan_node.id,
+                type=PLAN_NODE_TYPE,
+                label=plan_node.description or plan_node.tool,
+                max_retries=max(0, plan_node.retry.max_attempts - 1),
+                config=node_config(plan_node),
+                metadata={"plan": plan.name, "tool": plan_node.tool},
+            )
+        )
+        for dep in plan_node.depends_on:
+            edges.append(
+                EdgeDefinition(**{"from": dep, "to": plan_node.id, "condition": "always"})
+            )
+
+    for root in roots:
+        edges.append(
+            EdgeDefinition(**{"from": START_NODE_ID, "to": root, "condition": "always"})
+        )
+    for leaf in leaves:
+        edges.append(
+            EdgeDefinition(**{"from": leaf, "to": END_NODE_ID, "condition": "always"})
+        )
+
+    return FlowDefinition(
+        flow=plan.name,
+        nodes=nodes,
+        edges=edges,
+        metadata=FlowMetadata(
+            max_parallel_tasks=plan.metadata.max_parallel_tasks,
+            execution_timeout=plan.metadata.execution_timeout,
+            checkpoint=plan.metadata.checkpoint,
+            durable=plan.metadata.durable,
+            # Node outputs are ArtifactRefs, already small — truncating them
+            # would corrupt the manifest rather than save anything.
+            truncation_length=None,
+        ),
+    )
+
+
+def node_config(plan_node: Any) -> Dict[str, Any]:
+    """Serialise a :class:`~models.PlanNode` into ``NodeDefinition.config``.
+
+    Kept as a plain dict (not the model) so a ``FlowDefinition`` stays JSON
+    round-trippable for checkpointing and UI editors.
+
+    Args:
+        plan_node: The plan node to serialise.
+
+    Returns:
+        A JSON-safe config dict consumed by the ``tool`` node factory.
+    """
+    return plan_node.model_dump(mode="json", exclude_none=False)
+
+
+def _leaf_ids(plan: ExecutionPlan) -> List[str]:
+    """Return ids of nodes nothing depends on."""
+    depended_on = {dep for node in plan.nodes for dep in node.depends_on}
+    return [node.id for node in plan.nodes if node.id not in depended_on]
+
+
+def ensure_tool_node_registered(node_cls: Any) -> None:
+    """Register ``node_cls`` under ``"tool"`` in ``NODE_REGISTRY``, once.
+
+    ``ToolNode`` ships as an ``AgentCrew`` concept and is absent from
+    ``AgentsFlow``'s ``NODE_REGISTRY``; ``from_definition`` rejects unknown
+    node types, so registration must happen before the first compile.
+    Idempotent, because ``register_node`` raises on a duplicate name.
+
+    Args:
+        node_cls: The ``Node`` subclass to register (a ``ToolNode`` subclass
+            that stores payloads to working memory).
+    """
+    from parrot.bots.flows.flow.flow import NODE_REGISTRY, register_node  # noqa: PLC0415
+
+    if NODE_REGISTRY.get(PLAN_NODE_TYPE) is node_cls:
+        return
+    if PLAN_NODE_TYPE in NODE_REGISTRY:
+        raise ValueError(
+            f"NODE_REGISTRY[{PLAN_NODE_TYPE!r}] is already "
+            f"{NODE_REGISTRY[PLAN_NODE_TYPE].__name__}, not {node_cls.__name__}"
+        )
+    register_node(PLAN_NODE_TYPE)(node_cls)

--- a/packages/ai-parrot/src/parrot/bots/flows/plan/facets.py
+++ b/packages/ai-parrot/src/parrot/bots/flows/plan/facets.py
@@ -1,0 +1,175 @@
+"""Facet extraction — the only thing a model ever learns about a payload.
+
+A facet is a small, structural, cheap-to-compute value pulled out of a tool
+result before the result is put away in working memory. Facets are what
+``PlanNode.when`` guards read and what appears in the
+:class:`~.models.ExecutionManifest`, so they are also the *entire* budget for
+data-dependent control flow. Everything here is bounded by construction:
+group counts are capped, strings are clipped, and nothing recurses into a
+payload body.
+"""
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Dict, Iterable, List, Mapping
+
+from .models import FacetSpec
+from .paths import PathError, select
+
+__all__ = ("MAX_FACET_STR", "estimate_bytes", "extract_facets", "merge_facets")
+
+# Longest string value kept verbatim in a facet. Facets exist to be cheap;
+# a long one defeats the purpose.
+MAX_FACET_STR = 200
+
+
+def extract_facets(payload: Any, spec: FacetSpec) -> Dict[str, Any]:
+    """Extract facets from one payload.
+
+    A path that does not resolve yields no facet rather than a ``None``
+    entry, so a guard reading it fails safe (and the validator is what warns
+    about the typo — see ``validator._check_guard``).
+
+    Args:
+        payload: The tool result.
+        spec: What to extract.
+
+    Returns:
+        A flat ``{facet_name: value}`` mapping.
+    """
+    facets: Dict[str, Any] = {}
+
+    for name, path in spec.paths.items():
+        value = _safe_select(payload, path)
+        if value is not None:
+            facets[name] = _clip(value)
+
+    for name, path in spec.counts.items():
+        value = _safe_select(payload, path)
+        facets[name] = len(value) if isinstance(value, (list, tuple)) else 0
+
+    for name, path in spec.group_counts.items():
+        value = _safe_select(payload, path)
+        if isinstance(value, (list, tuple)):
+            facets[name] = _top_counts(value, spec.max_group_keys)
+        else:
+            facets[name] = {}
+
+    return facets
+
+
+def merge_facets(
+    per_item: Iterable[Mapping[str, Any]], spec: FacetSpec
+) -> Dict[str, Any]:
+    """Combine per-item facets from a ``for_each`` node into one mapping.
+
+    Counts sum, group counts merge key-wise (re-capped after merging), and
+    plain paths collapse to the set of distinct values seen — capped, because
+    a per-item path over 3.000 items is not a facet any more.
+
+    Args:
+        per_item: Facet mappings, one per successfully executed item.
+        spec: The spec they were extracted with.
+
+    Returns:
+        The merged mapping.
+    """
+    items: List[Mapping[str, Any]] = [dict(entry) for entry in per_item]
+    merged: Dict[str, Any] = {}
+
+    for name in spec.counts:
+        merged[name] = sum(int(entry.get(name, 0) or 0) for entry in items)
+
+    for name in spec.group_counts:
+        counter: Counter = Counter()
+        for entry in items:
+            group = entry.get(name)
+            if isinstance(group, Mapping):
+                counter.update({k: int(v) for k, v in group.items()})
+        merged[name] = _top_counts_from_counter(counter, spec.max_group_keys)
+
+    for name in spec.paths:
+        distinct: List[Any] = []
+        for entry in items:
+            value = entry.get(name)
+            if value is not None and value not in distinct:
+                distinct.append(value)
+            if len(distinct) > spec.max_group_keys:
+                break
+        if len(distinct) == 1:
+            merged[name] = distinct[0]
+        elif distinct:
+            merged[name] = distinct[: spec.max_group_keys]
+
+    return merged
+
+
+def estimate_bytes(payload: Any) -> int:
+    """Approximate the serialized size of ``payload``.
+
+    Used only to surface rehydration cost in the manifest, so an estimate is
+    enough — and it must never raise on an exotic object.
+
+    Args:
+        payload: Any tool result.
+
+    Returns:
+        Approximate size in bytes; ``0`` when it cannot be measured.
+    """
+    if payload is None:
+        return 0
+    if isinstance(payload, (bytes, bytearray, memoryview)):
+        return len(payload)
+    if isinstance(payload, str):
+        return len(payload.encode("utf-8", errors="ignore"))
+    try:
+        import json  # noqa: PLC0415
+
+        return len(json.dumps(payload, default=str).encode("utf-8", errors="ignore"))
+    except Exception:  # noqa: BLE001 - never fail a run over a size estimate
+        try:
+            return len(repr(payload).encode("utf-8", errors="ignore"))
+        except Exception:  # noqa: BLE001  # pragma: no cover
+            return 0
+
+
+def _safe_select(payload: Any, path: str) -> Any:
+    """Resolve ``path``, returning ``None`` on a malformed path.
+
+    Paths are already checked by the validator; this guards the case where a
+    plan was constructed programmatically and never validated.
+    """
+    try:
+        return select(payload, path)
+    except PathError:
+        return None
+
+
+def _top_counts(values: Iterable[Any], limit: int) -> Dict[str, int]:
+    """Count occurrences of hashable-ish values, keeping the ``limit`` largest."""
+    counter: Counter = Counter(_key_of(value) for value in values)
+    return _top_counts_from_counter(counter, limit)
+
+
+def _top_counts_from_counter(counter: Counter, limit: int) -> Dict[str, int]:
+    """Return the ``limit`` most common entries, ties broken by key for stability."""
+    ordered = sorted(counter.items(), key=lambda kv: (-kv[1], str(kv[0])))
+    return {str(key): int(count) for key, count in ordered[:limit]}
+
+
+def _key_of(value: Any) -> str:
+    """Coerce a grouping value into a stable string key."""
+    if isinstance(value, str):
+        return value[:MAX_FACET_STR]
+    if isinstance(value, (int, float, bool)) or value is None:
+        return str(value)
+    return repr(value)[:MAX_FACET_STR]
+
+
+def _clip(value: Any) -> Any:
+    """Clip a scalar facet so one long string cannot bloat the manifest."""
+    if isinstance(value, str) and len(value) > MAX_FACET_STR:
+        return value[:MAX_FACET_STR] + "…"
+    if isinstance(value, (list, tuple)):
+        return [_clip(item) for item in value[:MAX_FACET_STR]]
+    return value

--- a/packages/ai-parrot/src/parrot/bots/flows/plan/guards.py
+++ b/packages/ai-parrot/src/parrot/bots/flows/plan/guards.py
@@ -1,0 +1,142 @@
+"""CEL guards for ExecutionPlan nodes.
+
+``PlanNode.when`` reuses the CEL evaluator the flow package already ships
+(``parrot.bots.flows.flow.cel_evaluator.CELPredicateEvaluator``) rather than
+introducing a second predicate language. CEL is sandboxed, has no arbitrary
+code execution, and compiles at construction time — which is exactly what a
+fail-fast plan validator needs.
+
+Activation
+----------
+
+A guard sees only cheap, structural values:
+
+``ctx.artifacts.<node_id>.<facet>``
+    Facets published by upstream nodes.
+``ctx.status.<node_id>``
+    ``"ok" | "skipped" | "partial" | "error"``.
+``ctx.errors``
+    Number of failed nodes so far.
+
+There is deliberately no way to reach a payload body from a guard: branching
+must stay free.
+
+Examples::
+
+    ctx.artifacts.triage.critical > 0
+    ctx.artifacts.listing.n_reports > 0 && ctx.errors == 0
+    ctx.status.fetch_reports == "ok"
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Mapping, Optional
+
+__all__ = ("GuardCompilationError", "PlanGuard", "compile_guard")
+
+logger = logging.getLogger("parrot.plan.guards")
+
+
+class GuardCompilationError(ValueError):
+    """Raised when a ``when`` expression fails to compile."""
+
+
+def _load_evaluator():
+    """Import ``CELPredicateEvaluator`` lazily.
+
+    Kept lazy so the schema and validator remain importable in environments
+    without ``cel-python`` installed; only guard *evaluation* needs it.
+
+    Returns:
+        The ``CELPredicateEvaluator`` class.
+
+    Raises:
+        GuardCompilationError: If the dependency is unavailable.
+    """
+    try:
+        from parrot.bots.flows.flow.cel_evaluator import (  # noqa: PLC0415
+            CELPredicateEvaluator,
+        )
+    except ImportError:  # pragma: no cover - exercised only without celpy
+        try:
+            from cel_evaluator import CELPredicateEvaluator  # type: ignore # noqa: PLC0415
+        except ImportError as exc:
+            raise GuardCompilationError(
+                "CEL guards require 'cel-python'. Install it, or omit 'when'."
+            ) from exc
+    return CELPredicateEvaluator
+
+
+class PlanGuard:
+    """A compiled ``when`` expression.
+
+    Compilation happens in ``__init__`` so an invalid guard is caught during
+    plan validation — before a single tool runs — rather than mid-flight.
+
+    Args:
+        expression: The CEL expression.
+
+    Raises:
+        GuardCompilationError: If the expression does not compile.
+    """
+
+    __slots__ = ("expression", "_evaluator")
+
+    def __init__(self, expression: str) -> None:
+        self.expression = expression
+        evaluator_cls = _load_evaluator()
+        try:
+            self._evaluator = evaluator_cls(expression)
+        except ValueError as exc:
+            raise GuardCompilationError(
+                f"Invalid 'when' expression {expression!r}: {exc}"
+            ) from exc
+
+    def evaluate(
+        self,
+        artifacts: Mapping[str, Mapping[str, Any]],
+        statuses: Optional[Mapping[str, str]] = None,
+        errors: int = 0,
+    ) -> bool:
+        """Evaluate the guard against the accumulated facet map.
+
+        Evaluation is fail-safe in the underlying evaluator: a runtime error
+        yields ``False``. That is the right default here — an unevaluable
+        guard skips its node rather than running it on unknown state — but it
+        does mean a typo in a facet name reads as "condition not met", so the
+        validator warns about facets no node publishes.
+
+        Args:
+            artifacts: ``{node_id: {facet: value}}`` published so far.
+            statuses: ``{node_id: status}`` for completed nodes.
+            errors: Count of failed nodes so far.
+
+        Returns:
+            ``True`` when the node should run.
+        """
+        activation: Dict[str, Any] = {
+            "artifacts": {k: dict(v) for k, v in artifacts.items()},
+            "status": dict(statuses or {}),
+            "errors": errors,
+        }
+        return bool(self._evaluator(None, None, **activation))
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"PlanGuard({self.expression!r})"
+
+
+def compile_guard(expression: Optional[str]) -> Optional[PlanGuard]:
+    """Compile ``expression`` into a :class:`PlanGuard`, or ``None``.
+
+    Args:
+        expression: A CEL expression, or ``None`` for an unguarded node.
+
+    Returns:
+        The compiled guard, or ``None`` when no expression was given.
+
+    Raises:
+        GuardCompilationError: If the expression does not compile.
+    """
+    if expression is None or not expression.strip():
+        return None
+    return PlanGuard(expression)

--- a/packages/ai-parrot/src/parrot/bots/flows/plan/models.py
+++ b/packages/ai-parrot/src/parrot/bots/flows/plan/models.py
@@ -1,0 +1,493 @@
+"""ExecutionPlan — declarative, tool-only DAG authored by a thinking model.
+
+A plan is written **once** by a long-context model (planner phase), validated
+statically against the live ``ToolManager``, and then executed by
+``AgentsFlow`` with **zero LLM tokens in the loop**. Tool payloads are stored
+in ``WorkingMemory`` under keys the planner itself chose; only small
+``facets`` travel back through ``FlowContext.results``.
+
+Design invariants
+-----------------
+
+1. **Tool-only by construction.** ``PlanNode`` carries a ``tool`` name and has
+   no ``agent_ref``. A plan therefore cannot contain an agent node, which
+   makes the agent → tool → flow → agent recursion structurally impossible
+   rather than merely forbidden by a validator.
+2. **Payloads never enter a context.** Every node writes its result to
+   working memory under ``store_as``; the value published to
+   ``FlowContext.results`` is an :class:`ArtifactRef`, not the body.
+3. **Guards read facets, never bodies.** ``when`` is a CEL expression
+   evaluated against the accumulated facet map, so branching costs nothing.
+4. **Cardinality is discovered at run time.** ``for_each`` fans out *inside*
+   a single DAG node, so the graph stays static and exportable/checkpointable
+   while the item count is only known once the source node has run.
+
+Placeholder conventions (two, deliberately distinct)
+----------------------------------------------------
+
+``{nodes.<id>.output}``
+    The *small* published value of a prior node — its :class:`ArtifactRef`.
+    This is the placeholder syntax already understood by
+    ``parrot.bots.flows.crew.tool_node.resolve_templates``.
+
+``{artifacts.<id>}``
+    The *full body* stored in working memory. Resolved by the executor
+    reading the catalog directly (code, zero token cost). Only legal inside
+    ``ForEach.source`` and ``PlanNode.args`` — never published anywhere a
+    model can see it.
+
+Keeping the two syntaxes separate makes the expensive reference visible in
+the plan text itself.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+__all__ = (
+    "ARTIFACT_REF_RE",
+    "NODE_REF_RE",
+    "ArtifactRef",
+    "ExecutionManifest",
+    "ExecutionPlan",
+    "FacetSpec",
+    "ForEach",
+    "PlanNode",
+    "PlanMetadata",
+    "RetryPolicy",
+)
+
+# ``{artifacts.<node_id>}`` — the full body in working memory.
+ARTIFACT_REF_RE = re.compile(r"\{artifacts\.([A-Za-z0-9_\-]+)\}")
+# ``{nodes.<node_id>.output}`` — the published ArtifactRef (crew convention).
+NODE_REF_RE = re.compile(r"\{nodes\.([A-Za-z0-9_\-]+)\.output\}")
+# Substitutions legal inside ``store_as`` for a for_each node.
+_STORE_KEY_VAR_RE = re.compile(r"\{(index|item(?:\.[A-Za-z0-9_]+)*)\}")
+
+_IDENT_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]*$")
+
+
+class RetryPolicy(BaseModel):
+    """Per-node retry behaviour for transient tool failures."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    max_attempts: int = Field(default=1, ge=1, le=10)
+    backoff_seconds: float = Field(default=0.0, ge=0.0, le=60.0)
+
+
+class FacetSpec(BaseModel):
+    """What the executor extracts from a payload into the manifest.
+
+    Facets are the *only* thing a model ever sees about a stored payload, so
+    they must be small, structural and cheap to compute. They are what
+    ``when`` guards read.
+
+    Attributes:
+        paths: Dotted paths whose values are copied verbatim. Use for scalars
+            and short strings, e.g. ``"metadata.scanner"``.
+        counts: ``{facet_name: dotted_path}`` where the path resolves to a
+            list; the facet holds its length. e.g. ``{"n_findings":
+            "findings[]"}``.
+        group_counts: ``{facet_name: dotted_path}`` where the path resolves to
+            a list of scalars; the facet holds a ``{value: occurrences}`` map.
+            e.g. ``{"by_severity": "findings[].severity"}`` →
+            ``{"critical": 12, "high": 341}``.
+        max_group_keys: Cap on distinct keys retained per group count, so a
+            high-cardinality field cannot blow up the manifest.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    paths: Dict[str, str] = Field(default_factory=dict)
+    counts: Dict[str, str] = Field(default_factory=dict)
+    group_counts: Dict[str, str] = Field(default_factory=dict)
+    max_group_keys: int = Field(default=25, ge=1, le=200)
+
+
+class ForEach(BaseModel):
+    """Fan-out spec: run this node's tool once per item of ``source``.
+
+    The expansion happens **inside** one DAG node, not by mutating the graph.
+    That keeps ``FlowDefinition`` static — so ``to_definition()`` export and
+    checkpointing keep working — while the item count stays unknown until the
+    source node has actually run.
+
+    Per-item resumability comes from idempotence rather than from
+    checkpointing: when ``skip_existing`` is set, an item whose ``store_as``
+    key is already present in working memory is not re-executed, so a
+    re-run after a crash only does the missing work.
+
+    Attributes:
+        source: ``{artifacts.<node_id>}`` — the working-memory body to
+            iterate. Must reference a node listed in ``depends_on``.
+        select: Optional dotted path into the source, with ``[]`` marking a
+            list to flatten. ``"findings[].id"`` yields the list of ids.
+            Omit to iterate the source itself (it must then be a list).
+        max_items: Hard ceiling on expansion. Exceeding it is an execution
+            error, never a silent truncation.
+        max_concurrency: Concurrent in-flight tool calls for this node.
+        on_item_error: ``fail`` aborts the node on the first item error;
+            ``collect`` records per-item errors and continues (default);
+            ``skip`` drops failed items without recording them.
+        skip_existing: Skip items whose ``store_as`` key already exists.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    source: str = Field(
+        ...,
+        description="'{artifacts.<node_id>}' reference to the body to iterate",
+    )
+    select: Optional[str] = Field(
+        default=None,
+        description="Dotted path with '[]' list markers, e.g. 'findings[].id'",
+    )
+    alias: str = Field(
+        default="item",
+        alias="as",
+        description="Name bound to the current item inside args templates",
+    )
+    max_items: int = Field(default=1000, ge=1, le=100_000)
+    max_concurrency: int = Field(default=8, ge=1, le=64)
+    on_item_error: Literal["fail", "collect", "skip"] = "collect"
+    skip_existing: bool = True
+
+    @model_validator(mode="after")
+    def _check_source(self) -> "ForEach":
+        if not ARTIFACT_REF_RE.fullmatch(self.source.strip()):
+            raise ValueError(
+                f"ForEach.source must be exactly '{{artifacts.<node_id>}}', "
+                f"got {self.source!r}"
+            )
+        return self
+
+    @property
+    def source_node(self) -> str:
+        """The node id referenced by ``source``."""
+        match = ARTIFACT_REF_RE.fullmatch(self.source.strip())
+        assert match is not None  # guaranteed by the validator
+        return match.group(1)
+
+
+class PlanNode(BaseModel):
+    """A single deterministic tool invocation (or fan-out of invocations).
+
+    Attributes:
+        id: Unique node identifier; also the handle used by
+            ``{nodes.<id>.output}`` and ``{artifacts.<id>}``.
+        tool: Registered tool name. Validated against the live ``ToolManager``
+            at plan-validation time, not at execution time.
+        args: Keyword arguments for the tool. String leaves may contain
+            ``{nodes.<id>.output}``, ``{artifacts.<id>}`` and — inside a
+            ``for_each`` node — ``{item}`` / ``{item.<field>}`` / ``{index}``.
+        store_as: Working-memory key template for the result. For a
+            ``for_each`` node it MUST vary per item (contain ``{index}`` or an
+            ``{item...}`` reference), otherwise every item would overwrite the
+            previous one — ``WorkingMemoryCatalog.put_generic`` overwrites
+            silently.
+        depends_on: Node ids that must complete first. Every id referenced by
+            a placeholder or by ``for_each.source`` must appear here; the
+            validator enforces it rather than inferring edges silently.
+        when: Optional CEL guard. Evaluated against
+            ``ctx.artifacts.<node_id>.<facet>`` and ``ctx.errors``. When it
+            evaluates false the node is skipped and publishes a skipped
+            :class:`ArtifactRef`.
+        facets: What to extract into the manifest. Defaults to a structural
+            summary when omitted.
+        timeout: Per-call timeout in seconds (per item under ``for_each``).
+        retry: Retry policy for transient failures.
+        description: Free text for auditability; ignored at run time.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    tool: str
+    args: Dict[str, Any] = Field(default_factory=dict)
+    store_as: str
+    depends_on: List[str] = Field(default_factory=list)
+    when: Optional[str] = None
+    for_each: Optional[ForEach] = None
+    facets: FacetSpec = Field(default_factory=FacetSpec)
+    timeout: Optional[float] = Field(default=None, gt=0.0)
+    retry: RetryPolicy = Field(default_factory=RetryPolicy)
+    description: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _check_node(self) -> "PlanNode":
+        if not _IDENT_RE.match(self.id):
+            raise ValueError(
+                f"PlanNode.id {self.id!r} must match {_IDENT_RE.pattern}"
+            )
+        if not self.store_as.strip():
+            raise ValueError(f"Node {self.id!r}: store_as must be non-empty")
+
+        has_var = bool(_STORE_KEY_VAR_RE.search(self.store_as))
+        if self.for_each is not None and not has_var:
+            raise ValueError(
+                f"Node {self.id!r}: store_as {self.store_as!r} is constant but "
+                "the node fans out with for_each — every item would overwrite "
+                "the previous one. Include '{index}' or '{item.<field>}'."
+            )
+        if self.for_each is None and has_var:
+            raise ValueError(
+                f"Node {self.id!r}: store_as {self.store_as!r} uses a per-item "
+                "variable but the node has no for_each."
+            )
+        if self.id in self.depends_on:
+            raise ValueError(f"Node {self.id!r} cannot depend on itself")
+        if len(set(self.depends_on)) != len(self.depends_on):
+            raise ValueError(f"Node {self.id!r}: duplicate ids in depends_on")
+        return self
+
+    def referenced_nodes(self) -> set[str]:
+        """Node ids this node references through placeholders or ``for_each``.
+
+        Returns:
+            The set of referenced node ids (excluding ``depends_on`` itself).
+        """
+        found: set[str] = set()
+        for text in _iter_strings(self.args):
+            found.update(ARTIFACT_REF_RE.findall(text))
+            found.update(NODE_REF_RE.findall(text))
+        if self.for_each is not None:
+            found.add(self.for_each.source_node)
+        return found
+
+
+class PlanMetadata(BaseModel):
+    """Flow-level execution defaults carried into ``FlowMetadata``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    max_parallel_tasks: int = Field(default=10, ge=1, le=128)
+    execution_timeout: Optional[float] = Field(default=None, gt=0.0)
+    checkpoint: bool = True
+    durable: bool = False
+
+
+class ExecutionPlan(BaseModel):
+    """A validated, tool-only DAG ready to compile into a ``FlowDefinition``.
+
+    Example:
+        >>> plan = ExecutionPlan(
+        ...     name="daily_security_sweep",
+        ...     objective="Ingest yesterday's scanner reports and diff them.",
+        ...     nodes=[
+        ...         PlanNode(id="list", tool="s3_filter_reports",
+        ...                  args={"prefix": "prowler/"}, store_as="listing",
+        ...                  facets=FacetSpec(counts={"n": "keys[]"})),
+        ...         PlanNode(id="fetch", tool="s3_get_latest_report",
+        ...                  args={"key": "{item}"}, store_as="report_{index}",
+        ...                  depends_on=["list"],
+        ...                  when="ctx.artifacts.list.n > 0",
+        ...                  for_each=ForEach(source="{artifacts.list}",
+        ...                                   select="keys[]")),
+        ...     ],
+        ... )
+        >>> plan.topological_order()
+        ['list', 'fetch']
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    objective: str = Field(
+        ...,
+        description="What this plan achieves; carried into the manifest for audit",
+    )
+    nodes: List[PlanNode] = Field(..., min_length=1)
+    metadata: PlanMetadata = Field(default_factory=PlanMetadata)
+
+    @model_validator(mode="after")
+    def _check_plan(self) -> "ExecutionPlan":
+        ids = [node.id for node in self.nodes]
+        duplicates = {i for i in ids if ids.count(i) > 1}
+        if duplicates:
+            raise ValueError(f"Duplicate node ids: {sorted(duplicates)}")
+        known = set(ids)
+
+        # Every dependency and every placeholder target must exist, and every
+        # placeholder target must be declared as a dependency. Inferring the
+        # edge silently would let a plan read an artifact that has not been
+        # scheduled yet.
+        for node in self.nodes:
+            for dep in node.depends_on:
+                if dep not in known:
+                    raise ValueError(
+                        f"Node {node.id!r} depends on unknown node {dep!r}"
+                    )
+            undeclared = node.referenced_nodes() - set(node.depends_on)
+            if undeclared:
+                raise ValueError(
+                    f"Node {node.id!r} references {sorted(undeclared)} but does "
+                    "not list them in depends_on"
+                )
+
+        # Static artifact keys must be unique. Templated keys (for_each) are
+        # checked for a distinct prefix instead, since their expansion is
+        # unknown until run time.
+        static: dict[str, str] = {}
+        for node in self.nodes:
+            if node.for_each is not None:
+                continue
+            owner = static.get(node.store_as)
+            if owner is not None:
+                raise ValueError(
+                    f"Nodes {owner!r} and {node.id!r} both store to key "
+                    f"{node.store_as!r}; working memory would overwrite silently"
+                )
+            static[node.store_as] = node.id
+
+        self._assert_acyclic()
+        return self
+
+    def _assert_acyclic(self) -> None:
+        """Raise ``ValueError`` naming a cycle if the dependency graph has one."""
+        deps = {node.id: set(node.depends_on) for node in self.nodes}
+        state: dict[str, int] = {}  # 0 = visiting, 1 = done
+        stack: list[str] = []
+
+        def visit(node_id: str) -> None:
+            mark = state.get(node_id)
+            if mark == 1:
+                return
+            if mark == 0:
+                cycle = stack[stack.index(node_id):] + [node_id]
+                raise ValueError(f"Dependency cycle: {' -> '.join(cycle)}")
+            state[node_id] = 0
+            stack.append(node_id)
+            for dep in sorted(deps[node_id]):
+                visit(dep)
+            stack.pop()
+            state[node_id] = 1
+
+        for node_id in sorted(deps):
+            visit(node_id)
+
+    def topological_order(self) -> List[str]:
+        """Return node ids in a stable dependency-respecting order.
+
+        Ties are broken by the order nodes appear in the plan, so the result
+        is deterministic and diffable.
+
+        Returns:
+            Node ids, dependencies before dependents.
+        """
+        deps = {node.id: set(node.depends_on) for node in self.nodes}
+        position = {node.id: index for index, node in enumerate(self.nodes)}
+        ordered: List[str] = []
+        done: set[str] = set()
+        while len(ordered) < len(deps):
+            ready = sorted(
+                (nid for nid, d in deps.items() if nid not in done and d <= done),
+                key=position.__getitem__,
+            )
+            if not ready:  # pragma: no cover — _assert_acyclic prevents this
+                raise ValueError("Dependency cycle detected during ordering")
+            ordered.extend(ready)
+            done.update(ready)
+        return ordered
+
+    def node(self, node_id: str) -> PlanNode:
+        """Look up a node by id.
+
+        Args:
+            node_id: The node identifier.
+
+        Returns:
+            The matching :class:`PlanNode`.
+
+        Raises:
+            KeyError: If no node has that id.
+        """
+        for node in self.nodes:
+            if node.id == node_id:
+                return node
+        raise KeyError(f"No node {node_id!r} in plan {self.name!r}")
+
+
+class ArtifactRef(BaseModel):
+    """What a node publishes to ``FlowContext.results`` — never the body.
+
+    Attributes:
+        node_id: The producing node.
+        keys: Working-memory keys written by this node (one, or many under
+            ``for_each``).
+        entry_type: ``WorkingMemory`` entry type of the payload(s).
+        facets: Small structural values extracted per :class:`FacetSpec`;
+            what ``when`` guards read.
+        status: ``ok``, ``skipped`` (guard was false), ``partial`` (some
+            items failed under ``on_item_error="collect"``) or ``error``.
+        item_count: Items expanded, for ``for_each`` nodes.
+        errors: Per-item or node-level error messages, truncated by the
+            executor.
+        bytes_stored: Total payload bytes written to working memory — the
+            number that makes rehydration cost visible before it is paid.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    node_id: str
+    keys: List[str] = Field(default_factory=list)
+    entry_type: Optional[str] = None
+    facets: Dict[str, Any] = Field(default_factory=dict)
+    status: Literal["ok", "skipped", "partial", "error"] = "ok"
+    item_count: Optional[int] = None
+    errors: List[str] = Field(default_factory=list)
+    bytes_stored: int = 0
+
+
+class ExecutionManifest(BaseModel):
+    """The complete, context-safe result of running a plan.
+
+    This is what the ``run_execution_plan`` tool returns to the agent. It is
+    bounded by construction: facets are capped, errors are truncated and no
+    payload body appears anywhere.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    plan_name: str
+    objective: str
+    session_id: Optional[str] = None
+    artifacts: List[ArtifactRef] = Field(default_factory=list)
+    nodes_total: int = 0
+    nodes_ok: int = 0
+    nodes_skipped: int = 0
+    nodes_failed: int = 0
+    duration_seconds: float = 0.0
+    total_bytes_stored: int = 0
+
+    def artifact(self, node_id: str) -> Optional[ArtifactRef]:
+        """Return the artifact produced by ``node_id``, if any."""
+        for ref in self.artifacts:
+            if ref.node_id == node_id:
+                return ref
+        return None
+
+    def facet_map(self) -> Dict[str, Dict[str, Any]]:
+        """Return ``{node_id: facets}`` — the activation for ``when`` guards."""
+        return {ref.node_id: dict(ref.facets) for ref in self.artifacts}
+
+
+def _iter_strings(value: Any):
+    """Yield every string leaf inside a nested structure.
+
+    Args:
+        value: Any nested combination of dicts, lists, tuples and scalars.
+
+    Yields:
+        Each string leaf encountered.
+    """
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from _iter_strings(item)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            yield from _iter_strings(item)

--- a/packages/ai-parrot/src/parrot/bots/flows/plan/node.py
+++ b/packages/ai-parrot/src/parrot/bots/flows/plan/node.py
@@ -1,0 +1,604 @@
+"""``PlanToolNode`` — the executor for a plan node inside ``AgentsFlow``.
+
+This is where the architecture's central invariant is actually enforced: a
+tool payload goes **to working memory**, and what enters ``FlowContext`` — and
+therefore anything a model can ever see — is an :class:`~.models.ArtifactRef`.
+
+Differences from the stock ``parrot.bots.flows.crew.tool_node.ToolNode``, all
+deliberate:
+
+``execute_tool`` instead of ``tool.execute``
+    ``ToolNode._invoke`` calls the tool object directly, bypassing
+    ``ToolManager.execute_tool`` and with it ``_postprocess_result``, the
+    result hooks, and permission/credential propagation. A plan node goes
+    through the manager.
+
+``ArtifactRef`` instead of ``extract_tool_output``
+    ``extract_tool_output`` JSON-encodes the payload into ``ctx.results``.
+    For a 40 MB scanner report that is precisely the failure this design
+    exists to prevent.
+
+fan-out and guards
+    ``for_each`` expands *inside* this node, so the DAG stays static and
+    exportable; ``when`` is evaluated here against accumulated facets.
+
+The node is constructed by a ``node_factories["tool"]`` closure (see
+:func:`make_tool_node_factory`) so the live ``ToolManager`` and
+``WorkingMemoryToolkit`` reach it without being serialised into
+``NodeDefinition.config``.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Set, Tuple
+
+from pydantic import Field, PrivateAttr
+
+from .facets import estimate_bytes, extract_facets, merge_facets
+from .guards import PlanGuard, compile_guard
+from .models import ARTIFACT_REF_RE, NODE_REF_RE, ArtifactRef, PlanNode
+from .paths import render_key, select
+
+__all__ = ("MAX_RECORDED_ERRORS", "PlanToolNode", "make_tool_node_factory")
+
+# Per-node cap on error strings kept in the manifest. Unbounded error lists
+# are the classic way a "small" manifest stops being small.
+MAX_RECORDED_ERRORS = 20
+_MAX_ERROR_CHARS = 300
+
+from parrot.bots.flows.core.node import Node as _BaseNode
+
+
+class ToolExecutionError(RuntimeError):
+    """A plan node's tool call failed after exhausting its retries."""
+
+
+class PlanToolNode(_BaseNode):
+    """Execute one :class:`~.models.PlanNode`, storing payloads out of context.
+
+    Frozen Pydantic, like every ``Node``: mutable per-run state lives in
+    private attributes. The FSM lifecycle is driven by the scheduler — this
+    class must not touch it.
+
+    Attributes:
+        plan_node: The node specification being executed.
+        tool_manager: Live manager used to dispatch the tool.
+        working_memory: Toolkit whose catalog receives the payloads.
+        dependencies: Node ids that must complete first.
+        successors: Node ids dispatched afterwards.
+        permission_context: Optional context forwarded to ``execute_tool``.
+    """
+
+    model_config = {"frozen": True, "arbitrary_types_allowed": True}
+
+    plan_node: PlanNode
+    tool_manager: Any
+    working_memory: Any
+    dependencies: Set[str] = Field(default_factory=set)
+    successors: Set[str] = Field(default_factory=set)
+    permission_context: Optional[Any] = None
+    is_configured: bool = True
+    fsm: Optional[Any] = None
+
+    _guard: Optional[PlanGuard] = PrivateAttr(default=None)
+    _refs_cache: Dict[str, ArtifactRef] = PrivateAttr(default_factory=dict)
+
+    def model_post_init(self, __context: Any) -> None:
+        """Compile the guard and create the FSM if the base class did not."""
+        super().model_post_init(__context)
+        if self.fsm is None:
+            from parrot.bots.flows.core.fsm import (  # noqa: PLC0415
+                AgentTaskMachine,
+            )
+            object.__setattr__(self, "fsm", AgentTaskMachine(agent_name=self.node_id))
+        # Compiling here rather than at first use keeps a broken guard from
+        # surfacing mid-flight; validate_plan() already compiled it once, so
+        # this is belt-and-braces for programmatically built plans.
+        object.__setattr__(self, "_guard", compile_guard(self.plan_node.when))
+
+    # ── Node contract ─────────────────────────────────────────────────────
+
+    @property
+    def name(self) -> str:
+        """Node identity."""
+        return self.node_id
+
+    @property
+    def agent(self) -> "PlanToolNode":
+        """Self-reference for flow plumbing that reads ``node.agent``."""
+        return self
+
+    async def configure(self) -> None:
+        """No-op — a tool node needs no LLM configuration."""
+
+    # ── Execution ─────────────────────────────────────────────────────────
+
+    async def execute(self, ctx: Any, deps: Any = None, **kwargs: Any) -> ArtifactRef:
+        """Run this node and return its :class:`~.models.ArtifactRef`.
+
+        The return value becomes ``ctx.results[node_id]``, so it must stay
+        small: no payload, no unbounded error list.
+
+        Args:
+            ctx: The live ``FlowContext``.
+            deps: Dependency results (unused; state is read from ``ctx``).
+            **kwargs: Forwarded to pre/post actions.
+
+        Returns:
+            An :class:`~.models.ArtifactRef` describing what was stored.
+        """
+        started = time.monotonic()
+        prior = _artifact_refs(ctx)
+        # {artifacts.<id>} resolution needs the published keys; cache them
+        # before any argument is resolved.
+        self._remember(prior)
+
+        if not self._guard_allows(prior):
+            ref = ArtifactRef(
+                node_id=self.node_id,
+                status="skipped",
+                facets={},
+            )
+            self.logger.info(
+                "Node %r skipped: guard %r evaluated false",
+                self.node_id,
+                self.plan_node.when,
+            )
+            await self.run_post_actions(result=ref, **kwargs)
+            return ref
+
+        await self.run_pre_actions(prompt=self.plan_node.tool, **kwargs)
+        try:
+            if self.plan_node.for_each is None:
+                ref = await self._run_single(prior)
+            else:
+                ref = await self._run_fan_out(prior)
+        except Exception as exc:  # noqa: BLE001 - recorded, then re-raised
+            self.logger.error("Node %r failed: %s", self.node_id, exc)
+            raise
+        finally:
+            self.logger.debug(
+                "Node %r finished in %.3fs", self.node_id, time.monotonic() - started
+            )
+
+        await self.run_post_actions(result=ref, **kwargs)
+        return ref
+
+    # ── Single call ───────────────────────────────────────────────────────
+
+    async def _run_single(self, prior: Mapping[str, ArtifactRef]) -> ArtifactRef:
+        """Execute the node's tool once."""
+        args = self._resolve_args(self.plan_node.args, prior)
+        payload = await self._call_with_retry(args)
+        key = self.plan_node.store_as
+        size = await self._store(key, payload, index=None)
+        return ArtifactRef(
+            node_id=self.node_id,
+            keys=[key],
+            entry_type=_entry_type(payload),
+            facets=extract_facets(payload, self.plan_node.facets),
+            status="ok",
+            bytes_stored=size,
+        )
+
+    # ── Fan-out ───────────────────────────────────────────────────────────
+
+    async def _run_fan_out(self, prior: Mapping[str, ArtifactRef]) -> ArtifactRef:
+        """Execute the node's tool once per item of ``for_each.source``.
+
+        Expansion happens inside this single DAG node so the graph stays
+        static. Concurrency is bounded by ``for_each.max_concurrency``;
+        per-item failures are handled per ``for_each.on_item_error``.
+
+        Returns:
+            One :class:`~.models.ArtifactRef` covering every item.
+
+        Raises:
+            ToolExecutionError: If expansion exceeds ``max_items``, or an item
+                fails under ``on_item_error="fail"``.
+        """
+        spec = self.plan_node.for_each
+        assert spec is not None  # guaranteed by the caller
+
+        source_body = self._read_artifact(spec.source_node)
+        items = select(source_body, spec.select, default=[])
+        if not isinstance(items, (list, tuple)):
+            items = [items]
+
+        if len(items) > spec.max_items:
+            # Never truncate silently: a plan that quietly processed 1.000 of
+            # 5.000 reports would read as a complete run.
+            raise ToolExecutionError(
+                f"Node {self.node_id!r}: for_each expanded to {len(items)} items, "
+                f"above max_items={spec.max_items}. Raise the cap or narrow "
+                "'select'."
+            )
+
+        semaphore = asyncio.Semaphore(spec.max_concurrency)
+        keys: List[Optional[str]] = [None] * len(items)
+        facets: List[Optional[Dict[str, Any]]] = [None] * len(items)
+        sizes: List[int] = [0] * len(items)
+        errors: List[str] = []
+        entry_types: List[str] = []
+
+        async def run_item(index: int, item: Any) -> None:
+            async with semaphore:
+                key = render_key(self.plan_node.store_as, item=item, index=index)
+                if spec.skip_existing and self._has_key(key):
+                    # Idempotent re-run: this is what gives per-item resume
+                    # without any scheduler involvement.
+                    keys[index] = key
+                    self.logger.debug("Node %r: key %r exists, skipping", self.node_id, key)
+                    return
+                args = self._resolve_args(
+                    self.plan_node.args, prior, item=item, index=index
+                )
+                payload = await self._call_with_retry(args)
+                sizes[index] = await self._store(key, payload, index=index)
+                keys[index] = key
+                facets[index] = extract_facets(payload, self.plan_node.facets)
+                entry_types.append(_entry_type(payload))
+
+        async def guarded(index: int, item: Any) -> None:
+            try:
+                await run_item(index, item)
+            except Exception as exc:  # noqa: BLE001
+                if spec.on_item_error == "fail":
+                    raise
+                if spec.on_item_error == "collect" and len(errors) < MAX_RECORDED_ERRORS:
+                    errors.append(f"[{index}] {str(exc)[:_MAX_ERROR_CHARS]}")
+
+        await asyncio.gather(*(guarded(i, item) for i, item in enumerate(items)))
+
+        stored = [key for key in keys if key is not None]
+        collected = [entry for entry in facets if entry is not None]
+        status = "ok" if not errors else "partial"
+        if items and not stored:
+            status = "error"
+
+        return ArtifactRef(
+            node_id=self.node_id,
+            keys=stored,
+            entry_type=entry_types[0] if entry_types else None,
+            facets=merge_facets(collected, self.plan_node.facets),
+            status=status,
+            item_count=len(items),
+            errors=errors,
+            bytes_stored=sum(sizes),
+        )
+
+    # ── Guard ─────────────────────────────────────────────────────────────
+
+    def _guard_allows(self, prior: Mapping[str, ArtifactRef]) -> bool:
+        """Evaluate ``when`` against accumulated facets and statuses."""
+        if self._guard is None:
+            return True
+        artifacts = {nid: ref.facets for nid, ref in prior.items()}
+        statuses = {nid: ref.status for nid, ref in prior.items()}
+        failures = sum(1 for ref in prior.values() if ref.status == "error")
+        return self._guard.evaluate(artifacts, statuses, failures)
+
+    # ── Argument resolution ───────────────────────────────────────────────
+
+    def _resolve_args(
+        self,
+        value: Any,
+        prior: Mapping[str, ArtifactRef],
+        *,
+        item: Any = None,
+        index: Optional[int] = None,
+    ) -> Any:
+        """Resolve every placeholder inside ``value``.
+
+        Three substitutions, with different costs made deliberately visible in
+        the plan text:
+
+        * ``{nodes.<id>.output}`` → that node's :class:`ArtifactRef` (small).
+        * ``{artifacts.<id>}`` → the stored body, read from working memory.
+        * ``{item}`` / ``{item.<field>}`` / ``{index}`` → the current item.
+
+        A string that is *exactly* one placeholder resolves to the native
+        value; an embedded one is interpolated as text.
+
+        Args:
+            value: The (possibly nested) argument structure.
+            prior: Completed nodes' artifact refs.
+            item: Current item, inside a ``for_each`` node.
+            index: Current item position, inside a ``for_each`` node.
+
+        Returns:
+            The resolved structure.
+        """
+        if isinstance(value, dict):
+            return {
+                key: self._resolve_args(inner, prior, item=item, index=index)
+                for key, inner in value.items()
+            }
+        if isinstance(value, (list, tuple)):
+            return [
+                self._resolve_args(inner, prior, item=item, index=index)
+                for inner in value
+            ]
+        if not isinstance(value, str):
+            return value
+
+        exact_artifact = ARTIFACT_REF_RE.fullmatch(value)
+        if exact_artifact:
+            return self._read_artifact(exact_artifact.group(1))
+        exact_node = NODE_REF_RE.fullmatch(value)
+        if exact_node:
+            ref = prior.get(exact_node.group(1))
+            return ref.model_dump(mode="json") if ref is not None else None
+
+        text = value
+        if index is not None:
+            text = render_key(text, item=item, index=index)
+        text = NODE_REF_RE.sub(
+            lambda m: str(_ref_summary(prior.get(m.group(1)))), text
+        )
+        text = ARTIFACT_REF_RE.sub(
+            lambda m: str(self._read_artifact(m.group(1))), text
+        )
+        return text
+
+    # ── Working memory ────────────────────────────────────────────────────
+
+    async def _store(self, key: str, payload: Any, *, index: Optional[int]) -> int:
+        """Write ``payload`` to working memory and return its size in bytes."""
+        suffix = "" if index is None else f"[{index}]"
+        await self.working_memory.store_result(
+            key=key,
+            data=payload,
+            data_type="auto",
+            description=f"{self.node_id}{suffix} via {self.plan_node.tool}",
+            metadata={
+                "plan_node": self.node_id,
+                "tool": self.plan_node.tool,
+                "index": index,
+            },
+        )
+        return estimate_bytes(payload)
+
+    def _read_artifact(self, node_id: str) -> Any:
+        """Read a stored body back out of working memory.
+
+        Reading is free here: this is code, not a model, so the payload never
+        touches a context window.
+
+        Args:
+            node_id: The producing plan node.
+
+        Returns:
+            The stored payload, or a list of them for a fan-out node.
+
+        Raises:
+            ToolExecutionError: If nothing was stored under that node.
+        """
+        keys = self._keys_for(node_id)
+        if not keys:
+            raise ToolExecutionError(
+                f"Node {self.node_id!r}: no working-memory artifact for "
+                f"{node_id!r}. Did it run and store a result?"
+            )
+        bodies = [self._read_key(key) for key in keys]
+        return bodies[0] if len(bodies) == 1 else bodies
+
+    def _keys_for(self, node_id: str) -> List[str]:
+        """Return the working-memory keys a completed node published."""
+        ref = self._refs_cache.get(node_id)
+        return list(ref.keys) if ref is not None else []
+
+    def _read_key(self, key: str) -> Any:
+        """Read one working-memory entry by key.
+
+        The catalog is the documented programmatic access point — the toolkit
+        exposes only summarising *tools*, which is exactly what we must not
+        go through here.
+        """
+        catalog = getattr(self.working_memory, "_catalog", None)
+        if catalog is None:  # pragma: no cover - defensive
+            raise ToolExecutionError(
+                "WorkingMemoryToolkit exposes no catalog to read artifacts from."
+            )
+        entry = catalog.get(key)
+        return getattr(entry, "data", None) if not hasattr(entry, "df") else entry.df
+
+    def _has_key(self, key: str) -> bool:
+        """Whether ``key`` already exists in the catalog."""
+        catalog = getattr(self.working_memory, "_catalog", None)
+        return bool(catalog is not None and key in catalog)
+
+    # ── Tool dispatch ─────────────────────────────────────────────────────
+
+    async def _call_with_retry(self, args: Dict[str, Any]) -> Any:
+        """Dispatch the tool, retrying transient failures per ``retry``.
+
+        Args:
+            args: Fully resolved keyword arguments.
+
+        Returns:
+            The tool's payload.
+
+        Raises:
+            ToolExecutionError: If every attempt failed.
+        """
+        policy = self.plan_node.retry
+        last: Optional[BaseException] = None
+
+        for attempt in range(1, policy.max_attempts + 1):
+            try:
+                coro = self.tool_manager.execute_tool(
+                    self.plan_node.tool,
+                    args,
+                    permission_context=self.permission_context,
+                )
+                payload = (
+                    await asyncio.wait_for(coro, self.plan_node.timeout)
+                    if self.plan_node.timeout
+                    else await coro
+                )
+                # execute_tool returns a ToolResult (rather than raising) when
+                # the tool is not registered — the one path where a failure
+                # arrives as a value.
+                if _is_failed_tool_result(payload):
+                    raise ToolExecutionError(
+                        f"Tool {self.plan_node.tool!r} failed: "
+                        f"{getattr(payload, 'error', payload)}"
+                    )
+                return payload
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                last = exc
+                if attempt < policy.max_attempts:
+                    self.logger.warning(
+                        "Node %r attempt %d/%d failed (%s); retrying",
+                        self.node_id, attempt, policy.max_attempts, exc,
+                    )
+                    if policy.backoff_seconds:
+                        await asyncio.sleep(policy.backoff_seconds * attempt)
+
+        raise ToolExecutionError(
+            f"Node {self.node_id!r}: tool {self.plan_node.tool!r} failed after "
+            f"{policy.max_attempts} attempt(s): {last}"
+        ) from last
+
+    # ── Internal caches ───────────────────────────────────────────────────
+
+    def _remember(self, refs: Mapping[str, ArtifactRef]) -> None:
+        """Cache the run's artifact refs for ``{artifacts.*}`` resolution."""
+        self._refs_cache.clear()
+        self._refs_cache.update(refs)
+
+
+def _artifact_refs(ctx: Any) -> Dict[str, ArtifactRef]:
+    """Recover ``{node_id: ArtifactRef}`` from a ``FlowContext``.
+
+    Entries that are not artifact refs (a ``start`` node's output, say) are
+    ignored rather than coerced.
+
+    Args:
+        ctx: The live ``FlowContext``.
+
+    Returns:
+        Artifact refs for every completed plan node.
+    """
+    refs: Dict[str, ArtifactRef] = {}
+    for node_id, value in (getattr(ctx, "results", None) or {}).items():
+        if isinstance(value, ArtifactRef):
+            refs[node_id] = value
+        elif isinstance(value, Mapping) and "node_id" in value and "keys" in value:
+            try:
+                refs[node_id] = ArtifactRef.model_validate(value)
+            except Exception:  # noqa: BLE001 - not an artifact; skip
+                continue
+    return refs
+
+
+def _ref_summary(ref: Optional[ArtifactRef]) -> Any:
+    """Render an artifact ref for interpolation into a string argument."""
+    if ref is None:
+        return ""
+    return ref.model_dump(mode="json")
+
+
+def _entry_type(payload: Any) -> str:
+    """Mirror ``WorkingMemory``'s type detection for the manifest."""
+    if isinstance(payload, str):
+        return "text"
+    if isinstance(payload, (bytes, bytearray)):
+        return "binary"
+    if isinstance(payload, (dict, list)):
+        return "json"
+    if hasattr(payload, "content") and hasattr(payload, "role"):
+        return "message"
+    if type(payload).__name__ == "DataFrame":
+        return "dataframe"
+    return "object"
+
+
+def _is_failed_tool_result(payload: Any) -> bool:
+    """Whether ``payload`` is a ``ToolResult`` reporting failure."""
+    return (
+        hasattr(payload, "success")
+        and hasattr(payload, "status")
+        and payload.success is False
+    )
+
+
+def make_tool_node_factory(
+    tool_manager: Any,
+    working_memory: Any,
+    *,
+    permission_context: Optional[Any] = None,
+) -> Callable[[Any, Set[str], Set[str]], PlanToolNode]:
+    """Build the ``node_factories["tool"]`` callable for ``from_definition``.
+
+    The live ``ToolManager`` and ``WorkingMemoryToolkit`` reach each node
+    through this closure rather than through ``NodeDefinition.config``, which
+    is a plain JSON dict — that is exactly the case ``node_factories`` exists
+    for, and it is what lets the analyst agent read the same catalog the
+    executor wrote.
+
+    Args:
+        tool_manager: The agent's manager; nodes dispatch through it.
+        working_memory: The shared ``WorkingMemoryToolkit`` instance.
+        permission_context: Optional context forwarded to ``execute_tool``.
+
+    Returns:
+        A factory called as ``factory(node_def, deps, succs) -> PlanToolNode``
+        once per ``run_flow()``.
+    """
+
+    def factory(node_def: Any, deps: Set[str], succs: Set[str]) -> PlanToolNode:
+        return PlanToolNode(
+            node_id=node_def.id,
+            plan_node=PlanNode.model_validate(node_def.config),
+            tool_manager=tool_manager,
+            working_memory=working_memory,
+            dependencies=set(deps or ()),
+            successors=set(succs or ()),
+            permission_context=permission_context,
+        )
+
+    return factory
+
+
+def build_manifest(
+    plan: Any,
+    refs: Sequence[ArtifactRef],
+    *,
+    session_id: Optional[str] = None,
+    duration_seconds: float = 0.0,
+) -> Any:
+    """Project a run's artifact refs into an :class:`ExecutionManifest`.
+
+    This is the projection the ``run_execution_plan`` tool must apply instead
+    of returning ``FlowContext.results`` — which, for a flow of ordinary
+    nodes, would carry payload bodies straight back into the agent's context.
+
+    Args:
+        plan: The executed :class:`~.models.ExecutionPlan`.
+        refs: Artifact refs produced by the run.
+        session_id: Optional session identifier.
+        duration_seconds: Wall-clock duration of the run.
+
+    Returns:
+        The populated :class:`~.models.ExecutionManifest`.
+    """
+    from .models import ExecutionManifest  # noqa: PLC0415
+
+    ordered = list(refs)
+    return ExecutionManifest(
+        plan_name=plan.name,
+        objective=plan.objective,
+        session_id=session_id,
+        artifacts=ordered,
+        nodes_total=len(plan.nodes),
+        nodes_ok=sum(1 for r in ordered if r.status == "ok"),
+        nodes_skipped=sum(1 for r in ordered if r.status == "skipped"),
+        nodes_failed=sum(1 for r in ordered if r.status in ("error", "partial")),
+        duration_seconds=duration_seconds,
+        total_bytes_stored=sum(r.bytes_stored for r in ordered),
+    )

--- a/packages/ai-parrot/src/parrot/bots/flows/plan/paths.py
+++ b/packages/ai-parrot/src/parrot/bots/flows/plan/paths.py
@@ -1,0 +1,170 @@
+"""Dotted-path selection and per-item templating for ExecutionPlan.
+
+Deliberately *not* JSONPath. The grammar is three constructs — dotted keys,
+``[]`` to flatten a list, and ``[n]`` to index one — which is enough for
+``for_each.select`` and :class:`~models.FacetSpec`, small enough to audit,
+and has no evaluator to sandbox.
+
+Grammar::
+
+    path    := segment ( '.' segment )*
+    segment := key | key '[]' | key '[' int ']'
+
+Examples::
+
+    "keys[]"                  -> the list at .keys
+    "findings[].severity"     -> severity of every finding
+    "metadata.scanner"        -> a scalar
+    "findings[0].id"          -> id of the first finding
+"""
+from __future__ import annotations
+
+import re
+from typing import Any, List
+
+__all__ = ("PathError", "compile_path", "render_key", "select")
+
+_SEGMENT_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_\-]*)(\[\]|\[(\d+)\])?$")
+_ITEM_VAR_RE = re.compile(r"\{(index|item(?:\.[A-Za-z0-9_]+)*)\}")
+
+
+class PathError(ValueError):
+    """Raised when a path is malformed or cannot be resolved."""
+
+
+def compile_path(path: str) -> List[tuple[str, str, int]]:
+    """Parse ``path`` into segments, raising on malformed input.
+
+    Parsing is separated from evaluation so a plan's paths can be checked at
+    validation time, before any tool runs.
+
+    Args:
+        path: A dotted path, e.g. ``"findings[].severity"``.
+
+    Returns:
+        A list of ``(key, mode, index)`` triples where ``mode`` is one of
+        ``"get"``, ``"flatten"`` or ``"index"``.
+
+    Raises:
+        PathError: If the path is empty or a segment is malformed.
+    """
+    text = path.strip()
+    if not text:
+        raise PathError("Empty path")
+    segments: List[tuple[str, str, int]] = []
+    for raw in text.split("."):
+        match = _SEGMENT_RE.match(raw)
+        if match is None:
+            raise PathError(f"Malformed path segment {raw!r} in {path!r}")
+        key, bracket, digits = match.group(1), match.group(2), match.group(3)
+        if bracket is None:
+            segments.append((key, "get", 0))
+        elif digits is None:
+            segments.append((key, "flatten", 0))
+        else:
+            segments.append((key, "index", int(digits)))
+    return segments
+
+
+def select(data: Any, path: str | None, *, default: Any = None) -> Any:
+    """Resolve ``path`` against ``data``.
+
+    A path containing ``[]`` always yields a list (flattened one level per
+    marker); a path without one yields a single value. Missing keys resolve to
+    ``default`` rather than raising, so a facet spec that does not match a
+    particular payload degrades to a missing facet instead of failing the run.
+
+    Args:
+        data: The payload to read.
+        path: A dotted path, or ``None`` to return ``data`` unchanged.
+        default: Value returned when the path does not resolve.
+
+    Returns:
+        The selected value, a list when the path flattens, or ``default``.
+
+    Raises:
+        PathError: If the path is malformed.
+    """
+    if path is None:
+        return data
+
+    segments = compile_path(path)
+    # Whether the result is a list is a property of the *path*, not of the
+    # data: "findings[].id" against a payload with no findings must yield [],
+    # not the scalar default. Otherwise a for_each over an empty result would
+    # fan out over `None` instead of doing nothing.
+    yields_list = any(mode == "flatten" for _, mode, _ in segments)
+
+    current: Any = [data]
+    for key, mode, index in segments:
+        nxt: List[Any] = []
+        for item in current:
+            if not isinstance(item, dict) or key not in item:
+                continue
+            value = item[key]
+            if mode == "get":
+                nxt.append(value)
+            elif mode == "flatten":
+                if isinstance(value, (list, tuple)):
+                    nxt.extend(value)
+                else:
+                    nxt.append(value)
+            else:  # index
+                if isinstance(value, (list, tuple)) and -len(value) <= index < len(value):
+                    nxt.append(value[index])
+        current = nxt
+        if not current:
+            break
+
+    if yields_list:
+        return current
+    if not current:
+        return default
+    return current[0]
+
+
+def render_key(template: str, *, item: Any, index: int) -> str:
+    """Expand ``{index}``, ``{item}`` and ``{item.<field>}`` in a key template.
+
+    Used for ``PlanNode.store_as`` under ``for_each``. Anything not matching a
+    known variable is left untouched, so a literal brace in a key is
+    preserved rather than silently mangled.
+
+    Args:
+        template: The key template, e.g. ``"report_{item.id}"``.
+        item: The current item.
+        index: The current zero-based position.
+
+    Returns:
+        The expanded key.
+
+    Raises:
+        PathError: If an ``{item.<field>}`` reference does not resolve.
+    """
+
+    def _substitute(match: re.Match) -> str:
+        expr = match.group(1)
+        if expr == "index":
+            return str(index)
+        if expr == "item":
+            return str(item)
+        field_path = expr[len("item."):]
+        value = select(item, field_path, default=_MISSING)
+        if value is _MISSING:
+            raise PathError(
+                f"Key template {template!r}: '{{{expr}}}' does not resolve "
+                f"for item {item!r}"
+            )
+        return str(value)
+
+    return _ITEM_VAR_RE.sub(_substitute, template)
+
+
+class _Missing:
+    """Sentinel distinguishing 'absent' from a legitimate ``None``."""
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return "<missing>"
+
+
+_MISSING = _Missing()

--- a/packages/ai-parrot/src/parrot/bots/flows/plan/validator.py
+++ b/packages/ai-parrot/src/parrot/bots/flows/plan/validator.py
@@ -1,0 +1,393 @@
+"""Static validation of an ExecutionPlan against a live ToolManager.
+
+The point of the planner/executor split is that a bad plan fails *before* any
+tool runs. Pydantic already enforces the plan's internal consistency (ids,
+cycles, declared dependencies, key collisions); this module adds everything
+that needs the runtime environment:
+
+* every ``tool`` name is registered
+* declared ``args`` fit the tool's ``args_schema`` (required keys present, no
+  unknown keys) — shape only, since placeholder strings resolve to other
+  types at run time
+* every ``when`` expression compiles
+* every ``select`` / facet path parses
+* guards only reference facets some upstream node actually publishes
+
+That last check matters more than it looks: ``CELPredicateEvaluator`` is
+fail-safe, so a typo in a facet name evaluates to ``False`` and silently
+skips the node. Catching it here turns a silent no-op into a loud error.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Iterable, List, Optional, Protocol, Sequence
+
+from .guards import GuardCompilationError, compile_guard
+from .models import ExecutionPlan, PlanNode
+from .paths import PathError, compile_path
+
+__all__ = ("PlanValidationError", "ValidationIssue", "ValidationReport", "validate_plan")
+
+# ``ctx.artifacts.<node>.<facet>`` inside a guard expression.
+_GUARD_FACET_RE = re.compile(r"\bctx\.artifacts\.([A-Za-z0-9_\-]+)\.([A-Za-z0-9_]+)")
+_GUARD_STATUS_RE = re.compile(r"\bctx\.status\.([A-Za-z0-9_\-]+)")
+
+
+class ToolManagerLike(Protocol):
+    """The slice of ``ToolManager`` this validator needs."""
+
+    def get_tool(self, tool_name: str) -> Optional[Any]:
+        ...
+
+    def list_tools(self) -> List[str]:
+        ...
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    """A single validation finding.
+
+    Attributes:
+        node_id: The offending node, or ``None`` for plan-level issues.
+        code: Stable machine-readable identifier.
+        message: Human-readable explanation, phrased so a planner model can
+            correct the plan from it directly.
+        severity: ``error`` blocks execution; ``warning`` does not.
+    """
+
+    node_id: Optional[str]
+    code: str
+    message: str
+    severity: str = "error"
+
+    def __str__(self) -> str:
+        where = f"node {self.node_id!r}: " if self.node_id else ""
+        return f"[{self.severity}:{self.code}] {where}{self.message}"
+
+
+@dataclass
+class ValidationReport:
+    """Aggregated validation result."""
+
+    issues: List[ValidationIssue] = field(default_factory=list)
+
+    @property
+    def errors(self) -> List[ValidationIssue]:
+        """Blocking issues."""
+        return [i for i in self.issues if i.severity == "error"]
+
+    @property
+    def warnings(self) -> List[ValidationIssue]:
+        """Non-blocking issues."""
+        return [i for i in self.issues if i.severity == "warning"]
+
+    @property
+    def ok(self) -> bool:
+        """``True`` when nothing blocks execution."""
+        return not self.errors
+
+    def raise_for_errors(self) -> None:
+        """Raise :class:`PlanValidationError` when blocking issues exist."""
+        if self.errors:
+            raise PlanValidationError(self.errors)
+
+    def __str__(self) -> str:
+        if not self.issues:
+            return "plan ok"
+        return "\n".join(str(issue) for issue in self.issues)
+
+
+class PlanValidationError(ValueError):
+    """Raised when a plan cannot be executed as written."""
+
+    def __init__(self, issues: Sequence[ValidationIssue]) -> None:
+        self.issues = list(issues)
+        super().__init__(
+            "ExecutionPlan validation failed:\n"
+            + "\n".join(f"  - {issue}" for issue in self.issues)
+        )
+
+
+def validate_plan(
+    plan: ExecutionPlan,
+    tool_manager: Optional[ToolManagerLike] = None,
+    *,
+    check_guards: bool = True,
+) -> ValidationReport:
+    """Validate ``plan`` and return every issue found.
+
+    All checks run before returning — a planner model gets the complete list
+    to fix in one pass instead of one error per round trip.
+
+    Args:
+        plan: The plan to validate. Already structurally valid (Pydantic).
+        tool_manager: Live manager used to resolve tool names and schemas.
+            When ``None``, tool checks are skipped and reported as warnings.
+        check_guards: Compile ``when`` expressions. Disable only where
+            ``cel-python`` is unavailable.
+
+    Returns:
+        A :class:`ValidationReport`; call ``raise_for_errors()`` to enforce.
+    """
+    report = ValidationReport()
+    known_ids = {node.id for node in plan.nodes}
+
+    if tool_manager is None:
+        report.issues.append(
+            ValidationIssue(
+                None,
+                "no_tool_manager",
+                "No ToolManager supplied — tool names and argument schemas "
+                "were not verified.",
+                severity="warning",
+            )
+        )
+
+    published = _published_facets(plan)
+
+    for node in plan.nodes:
+        _check_tool(node, tool_manager, report)
+        _check_paths(node, report)
+        if check_guards:
+            _check_guard(node, plan, known_ids, published, report)
+        _check_for_each(node, plan, report)
+
+    return report
+
+
+def _check_tool(
+    node: PlanNode,
+    tool_manager: Optional[ToolManagerLike],
+    report: ValidationReport,
+) -> None:
+    """Verify the tool exists and the declared args fit its schema."""
+    if tool_manager is None:
+        return
+
+    tool = tool_manager.get_tool(node.tool)
+    if tool is None:
+        available = sorted(tool_manager.list_tools() or [])
+        suggestion = _closest(node.tool, available)
+        hint = f" Did you mean {suggestion!r}?" if suggestion else ""
+        report.issues.append(
+            ValidationIssue(
+                node.id,
+                "unknown_tool",
+                f"Tool {node.tool!r} is not registered.{hint}",
+            )
+        )
+        return
+
+    schema = getattr(tool, "args_schema", None)
+    fields = getattr(schema, "model_fields", None)
+    if not fields:
+        return  # untyped tool — nothing to check against
+
+    # ``for_each.alias`` names a template variable usable inside arg values
+    # ({item}, {item.id}) — it is not itself a tool parameter.
+    unknown = set(node.args) - set(fields) - _CONTEXT_ARGS
+    if unknown:
+        report.issues.append(
+            ValidationIssue(
+                node.id,
+                "unknown_args",
+                f"Tool {node.tool!r} has no parameter(s) {sorted(unknown)}. "
+                f"Accepted: {sorted(fields)}.",
+            )
+        )
+
+    missing = [
+        name
+        for name, info in fields.items()
+        if info.is_required() and name not in node.args
+    ]
+    if missing:
+        report.issues.append(
+            ValidationIssue(
+                node.id,
+                "missing_args",
+                f"Tool {node.tool!r} requires {sorted(missing)}, not provided.",
+            )
+        )
+
+
+def _check_paths(node: PlanNode, report: ValidationReport) -> None:
+    """Verify every ``select`` and facet path parses."""
+    candidates: list[tuple[str, str]] = []
+    if node.for_each is not None and node.for_each.select:
+        candidates.append(("for_each.select", node.for_each.select))
+    for label, mapping in (
+        ("facets.paths", node.facets.paths),
+        ("facets.counts", node.facets.counts),
+        ("facets.group_counts", node.facets.group_counts),
+    ):
+        for name, path in mapping.items():
+            candidates.append((f"{label}.{name}", path))
+
+    for where, path in candidates:
+        try:
+            compile_path(path)
+        except PathError as exc:
+            report.issues.append(
+                ValidationIssue(node.id, "bad_path", f"{where}: {exc}")
+            )
+
+    for name, path in node.facets.counts.items():
+        if "[]" not in path:
+            report.issues.append(
+                ValidationIssue(
+                    node.id,
+                    "count_not_a_list",
+                    f"facets.counts.{name} = {path!r} does not contain '[]', so "
+                    "it does not resolve to a list and cannot be counted.",
+                )
+            )
+    for name, path in node.facets.group_counts.items():
+        if "[]" not in path:
+            report.issues.append(
+                ValidationIssue(
+                    node.id,
+                    "group_count_not_a_list",
+                    f"facets.group_counts.{name} = {path!r} does not contain "
+                    "'[]', so there is nothing to group.",
+                )
+            )
+
+
+def _check_guard(
+    node: PlanNode,
+    plan: ExecutionPlan,
+    known_ids: set[str],
+    published: dict[str, set[str]],
+    report: ValidationReport,
+) -> None:
+    """Compile the guard and verify the facets/nodes it references exist."""
+    if node.when is None:
+        return
+
+    try:
+        compile_guard(node.when)
+    except GuardCompilationError as exc:
+        report.issues.append(ValidationIssue(node.id, "bad_guard", str(exc)))
+        return
+
+    upstream = _ancestors(node.id, plan)
+
+    for ref_node, facet in _GUARD_FACET_RE.findall(node.when):
+        if ref_node not in known_ids:
+            report.issues.append(
+                ValidationIssue(
+                    node.id,
+                    "guard_unknown_node",
+                    f"'when' references ctx.artifacts.{ref_node} but no such "
+                    "node exists.",
+                )
+            )
+            continue
+        if ref_node not in upstream:
+            report.issues.append(
+                ValidationIssue(
+                    node.id,
+                    "guard_not_upstream",
+                    f"'when' reads ctx.artifacts.{ref_node} but {ref_node!r} is "
+                    f"not an ancestor of {node.id!r}, so its facets may not "
+                    "exist yet when the guard runs.",
+                )
+            )
+            continue
+        if facet not in published.get(ref_node, set()):
+            report.issues.append(
+                ValidationIssue(
+                    node.id,
+                    "guard_unknown_facet",
+                    f"'when' reads ctx.artifacts.{ref_node}.{facet} but node "
+                    f"{ref_node!r} publishes {sorted(published.get(ref_node, ())) or 'no facets'}. "
+                    "CEL is fail-safe, so this would silently evaluate to false "
+                    "and skip the node.",
+                )
+            )
+
+    for ref_node in _GUARD_STATUS_RE.findall(node.when):
+        if ref_node not in known_ids:
+            report.issues.append(
+                ValidationIssue(
+                    node.id,
+                    "guard_unknown_node",
+                    f"'when' references ctx.status.{ref_node} but no such node "
+                    "exists.",
+                )
+            )
+
+
+def _check_for_each(
+    node: PlanNode, plan: ExecutionPlan, report: ValidationReport
+) -> None:
+    """Verify the fan-out source is a declared dependency."""
+    if node.for_each is None:
+        return
+    source = node.for_each.source_node
+    if source not in node.depends_on:
+        report.issues.append(
+            ValidationIssue(
+                node.id,
+                "for_each_not_dependency",
+                f"for_each iterates {{artifacts.{source}}} but {source!r} is not "
+                "in depends_on, so it may not have run yet.",
+            )
+        )
+    if node.for_each.max_concurrency > plan.metadata.max_parallel_tasks:
+        report.issues.append(
+            ValidationIssue(
+                node.id,
+                "concurrency_above_flow_cap",
+                f"for_each.max_concurrency={node.for_each.max_concurrency} "
+                f"exceeds metadata.max_parallel_tasks="
+                f"{plan.metadata.max_parallel_tasks}; the flow cap wins.",
+                severity="warning",
+            )
+        )
+
+
+def _published_facets(plan: ExecutionPlan) -> dict[str, set[str]]:
+    """Return ``{node_id: {facet names it publishes}}``."""
+    return {
+        node.id: set(node.facets.paths)
+        | set(node.facets.counts)
+        | set(node.facets.group_counts)
+        for node in plan.nodes
+    }
+
+
+def _ancestors(node_id: str, plan: ExecutionPlan) -> set[str]:
+    """Return every node that must complete before ``node_id`` runs."""
+    deps = {node.id: set(node.depends_on) for node in plan.nodes}
+    seen: set[str] = set()
+    stack = list(deps.get(node_id, ()))
+    while stack:
+        current = stack.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        stack.extend(deps.get(current, ()))
+    return seen
+
+
+def _closest(name: str, candidates: Iterable[str]) -> Optional[str]:
+    """Return the nearest candidate name, for a 'did you mean' hint."""
+    import difflib  # noqa: PLC0415
+
+    matches = difflib.get_close_matches(name, list(candidates), n=1, cutoff=0.7)
+    return matches[0] if matches else None
+
+
+# Injected by ToolManager.execute_tool rather than declared in a plan.
+_CONTEXT_ARGS = frozenset(
+    {
+        "_permission_context",
+        "_resolver",
+        "_broker",
+        "_cred_channel",
+        "_cred_user_id",
+    }
+)

--- a/packages/ai-parrot/src/parrot/tools/execution_plan/__init__.py
+++ b/packages/ai-parrot/src/parrot/tools/execution_plan/__init__.py
@@ -5,11 +5,14 @@ design. This package wraps the frozen ``parrot.bots.flows.plan`` module
 (FEAT-419 TASK-2179) with the agent-facing toolkit.
 """
 from .models import PlanArtifactsArgs, PlanStatusArgs, RunningSummary, RunRecord
+from .store import PlanFileStore, PlanLoadError
 from .toolkit import ExecutionPlanToolkit
 
 __all__ = (
     "ExecutionPlanToolkit",
     "PlanArtifactsArgs",
+    "PlanFileStore",
+    "PlanLoadError",
     "PlanStatusArgs",
     "RunRecord",
     "RunningSummary",

--- a/packages/ai-parrot/src/parrot/tools/execution_plan/__init__.py
+++ b/packages/ai-parrot/src/parrot/tools/execution_plan/__init__.py
@@ -11,7 +11,14 @@ from .catalog import (
     check_allowlist,
     validate_with_allowlist,
 )
-from .models import PlanArtifactsArgs, PlanStatusArgs, RunningSummary, RunRecord
+from .models import (
+    PlanArtifactsArgs,
+    PlanExecuteArgs,
+    PlanStatusArgs,
+    PlanValidateArgs,
+    RunningSummary,
+    RunRecord,
+)
 from .planner import PlanAuthoringError, PlanPlanner, resolve_planner_client
 from .store import PlanFileStore, PlanLoadError
 from .toolkit import ExecutionPlanToolkit
@@ -21,10 +28,12 @@ __all__ = (
     "ExecutionPlanToolkit",
     "PlanArtifactsArgs",
     "PlanAuthoringError",
+    "PlanExecuteArgs",
     "PlanFileStore",
     "PlanLoadError",
     "PlanPlanner",
     "PlanStatusArgs",
+    "PlanValidateArgs",
     "RunRecord",
     "RunningSummary",
     "ToolCatalogEntry",

--- a/packages/ai-parrot/src/parrot/tools/execution_plan/__init__.py
+++ b/packages/ai-parrot/src/parrot/tools/execution_plan/__init__.py
@@ -4,11 +4,19 @@ See ``sdd/specs/execution-plan-tool.spec.md`` (FEAT-419) for the full
 design. This package wraps the frozen ``parrot.bots.flows.plan`` module
 (FEAT-419 TASK-2179) with the agent-facing toolkit.
 """
+from .catalog import (
+    ArgSummary,
+    ToolCatalogEntry,
+    build_catalog,
+    check_allowlist,
+    validate_with_allowlist,
+)
 from .models import PlanArtifactsArgs, PlanStatusArgs, RunningSummary, RunRecord
 from .store import PlanFileStore, PlanLoadError
 from .toolkit import ExecutionPlanToolkit
 
 __all__ = (
+    "ArgSummary",
     "ExecutionPlanToolkit",
     "PlanArtifactsArgs",
     "PlanFileStore",
@@ -16,4 +24,8 @@ __all__ = (
     "PlanStatusArgs",
     "RunRecord",
     "RunningSummary",
+    "ToolCatalogEntry",
+    "build_catalog",
+    "check_allowlist",
+    "validate_with_allowlist",
 )

--- a/packages/ai-parrot/src/parrot/tools/execution_plan/__init__.py
+++ b/packages/ai-parrot/src/parrot/tools/execution_plan/__init__.py
@@ -1,0 +1,16 @@
+"""``ExecutionPlanToolkit`` — deterministic tool-call DAGs for a ``BasicAgent``.
+
+See ``sdd/specs/execution-plan-tool.spec.md`` (FEAT-419) for the full
+design. This package wraps the frozen ``parrot.bots.flows.plan`` module
+(FEAT-419 TASK-2179) with the agent-facing toolkit.
+"""
+from .models import PlanArtifactsArgs, PlanStatusArgs, RunningSummary, RunRecord
+from .toolkit import ExecutionPlanToolkit
+
+__all__ = (
+    "ExecutionPlanToolkit",
+    "PlanArtifactsArgs",
+    "PlanStatusArgs",
+    "RunRecord",
+    "RunningSummary",
+)

--- a/packages/ai-parrot/src/parrot/tools/execution_plan/__init__.py
+++ b/packages/ai-parrot/src/parrot/tools/execution_plan/__init__.py
@@ -12,6 +12,7 @@ from .catalog import (
     validate_with_allowlist,
 )
 from .models import PlanArtifactsArgs, PlanStatusArgs, RunningSummary, RunRecord
+from .planner import PlanAuthoringError, PlanPlanner, resolve_planner_client
 from .store import PlanFileStore, PlanLoadError
 from .toolkit import ExecutionPlanToolkit
 
@@ -19,13 +20,16 @@ __all__ = (
     "ArgSummary",
     "ExecutionPlanToolkit",
     "PlanArtifactsArgs",
+    "PlanAuthoringError",
     "PlanFileStore",
     "PlanLoadError",
+    "PlanPlanner",
     "PlanStatusArgs",
     "RunRecord",
     "RunningSummary",
     "ToolCatalogEntry",
     "build_catalog",
     "check_allowlist",
+    "resolve_planner_client",
     "validate_with_allowlist",
 )

--- a/packages/ai-parrot/src/parrot/tools/execution_plan/catalog.py
+++ b/packages/ai-parrot/src/parrot/tools/execution_plan/catalog.py
@@ -1,0 +1,196 @@
+"""Tool catalog + allowlist validation layering (spec §3 Module 5).
+
+An ``ExecutionPlan`` is code written by a model that may share its
+``ToolManager`` with writers, so the explicit ``allowed_tools`` allowlist is
+both the security boundary — a plan naming a non-allowlisted tool fails
+validation before any tool runs — and the planner's tool catalog (the
+planner only ever sees allowlisted tools). The frozen
+``parrot.bots.flows.plan.validator`` module knows nothing about allowlists;
+the ``tool_not_allowed`` check is layered on top here, never patched into
+it.
+"""
+from __future__ import annotations
+
+from typing import Any, List, Optional, Sequence, Type
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from parrot.bots.flows.plan import ExecutionPlan
+from parrot.bots.flows.plan.validator import ValidationIssue, ValidationReport, validate_plan
+from ..abstract import AbstractToolArgsSchema
+
+__all__ = (
+    "ArgSummary",
+    "ToolCatalogEntry",
+    "build_catalog",
+    "check_allowlist",
+    "validate_with_allowlist",
+)
+
+# Bounds so the catalog stays small enough for a planner prompt (spec §2:
+# "description + args_schema summary per tool", never a full JSON schema).
+_MAX_DESCRIPTION_CHARS = 200
+_MAX_ARG_DESCRIPTION_CHARS = 120
+
+
+class ArgSummary(BaseModel):
+    """Compact rendering of one tool argument — never the full JSON schema."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    type: str
+    required: bool
+    description: str = ""
+
+
+class ToolCatalogEntry(BaseModel):
+    """One tool the planner (and the allowlist) may reference.
+
+    Attributes:
+        name: Registered tool name.
+        description: Tool description, bounded to
+            :data:`_MAX_DESCRIPTION_CHARS`.
+        args_summary: Compact per-argument summaries; empty for a tool with
+            no declared ``args_schema`` (or the default
+            ``AbstractToolArgsSchema``).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    description: str
+    args_summary: List[ArgSummary] = Field(default_factory=list)
+
+
+def build_catalog(
+    tool_manager: Any, allowed_tools: Optional[Sequence[str]] = None
+) -> List[ToolCatalogEntry]:
+    """Build the catalog = ``allowed_tools`` ∩ ``tool_manager.list_tools()``.
+
+    Args:
+        tool_manager: Live manager exposing ``list_tools()``/``get_tool()``.
+        allowed_tools: Explicit allowlist. ``None`` means every manager
+            tool is allowed.
+
+    Returns:
+        Catalog entries, in ``tool_manager.list_tools()`` order (stable —
+        never re-sorted by allowlist order or set iteration).
+
+    Raises:
+        ValueError: If ``allowed_tools`` names a tool the manager does not
+            have registered — a misconfigured allowlist must not fail
+            silently.
+    """
+    available = list(tool_manager.list_tools() or [])
+
+    if allowed_tools is None:
+        names = available
+    else:
+        allowed_set = set(allowed_tools)
+        unregistered = sorted(allowed_set - set(available))
+        if unregistered:
+            raise ValueError(
+                f"allowed_tools names not registered on tool_manager: {unregistered}"
+            )
+        names = [name for name in available if name in allowed_set]
+
+    entries: List[ToolCatalogEntry] = []
+    for name in names:
+        tool = tool_manager.get_tool(name)
+        description = (getattr(tool, "description", None) or "")[:_MAX_DESCRIPTION_CHARS]
+        args_schema = getattr(tool, "args_schema", None)
+        entries.append(
+            ToolCatalogEntry(
+                name=name,
+                description=description,
+                args_summary=_build_args_summary(args_schema),
+            )
+        )
+    return entries
+
+
+def check_allowlist(
+    plan: ExecutionPlan, allowed_tools: Optional[Sequence[str]]
+) -> List[ValidationIssue]:
+    """Return one ``tool_not_allowed`` issue per node outside ``allowed_tools``.
+
+    Args:
+        plan: The plan being validated.
+        allowed_tools: Explicit allowlist. ``None`` means every tool is
+            allowed (no issues raised).
+
+    Returns:
+        Error-severity :class:`ValidationIssue`s, phrased so a planner
+        model can correct the plan directly.
+    """
+    if allowed_tools is None:
+        return []
+
+    allowed_set = set(allowed_tools)
+    issues: List[ValidationIssue] = []
+    for node in plan.nodes:
+        if node.tool not in allowed_set:
+            issues.append(
+                ValidationIssue(
+                    node.id,
+                    "tool_not_allowed",
+                    f"Tool {node.tool!r} is not in the allowed_tools list. "
+                    f"Allowed: {sorted(allowed_set)}.",
+                )
+            )
+    return issues
+
+
+def validate_with_allowlist(
+    plan: ExecutionPlan,
+    tool_manager: Optional[Any],
+    allowed_tools: Optional[Sequence[str]] = None,
+    *,
+    check_guards: bool = True,
+) -> ValidationReport:
+    """Run ``validate_plan`` and append allowlist issues into the same report.
+
+    Args:
+        plan: The plan to validate.
+        tool_manager: Live manager, forwarded to ``validate_plan``.
+        allowed_tools: Explicit allowlist forwarded to :func:`check_allowlist`.
+        check_guards: Forwarded to ``validate_plan``.
+
+    Returns:
+        The single, combined :class:`ValidationReport` — validator issues
+        and allowlist issues in one pass, one list.
+    """
+    report = validate_plan(plan, tool_manager, check_guards=check_guards)
+    report.issues.extend(check_allowlist(plan, allowed_tools))
+    return report
+
+
+def _build_args_summary(args_schema: Optional[Type[BaseModel]]) -> List[ArgSummary]:
+    """Render an ``args_schema`` into bounded :class:`ArgSummary` entries."""
+    if args_schema is None or args_schema is AbstractToolArgsSchema:
+        return []
+
+    context_fields = getattr(args_schema, "_context_fields", frozenset())
+    summaries: List[ArgSummary] = []
+    for field_name, field_info in args_schema.model_fields.items():
+        if field_name in context_fields:
+            continue
+        description = (field_info.description or "")[:_MAX_ARG_DESCRIPTION_CHARS]
+        summaries.append(
+            ArgSummary(
+                name=field_name,
+                type=_type_name(field_info.annotation),
+                required=field_info.is_required(),
+                description=description,
+            )
+        )
+    return summaries
+
+
+def _type_name(annotation: Any) -> str:
+    """Render a type annotation as a short, prompt-friendly string."""
+    name = getattr(annotation, "__name__", None)
+    if name:
+        return name
+    return str(annotation).replace("typing.", "")

--- a/packages/ai-parrot/src/parrot/tools/execution_plan/models.py
+++ b/packages/ai-parrot/src/parrot/tools/execution_plan/models.py
@@ -45,6 +45,10 @@ class RunRecord(BaseModel):
         nodes_total: Total plan nodes (bound for progress reporting).
         nodes_done: Nodes that have reached a terminal per-node status
             (``ok``/``skipped``/``partial``/``error``) so far.
+        flow_error: Set when the run failed at the FLOW level (before any
+            manifest could be built) — e.g. an infrastructure error, not a
+            per-node tool failure (those show up inside ``manifest``
+            instead). Bounded to 500 chars.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -58,6 +62,7 @@ class RunRecord(BaseModel):
     manifest: Optional[ExecutionManifest] = None
     nodes_total: int
     nodes_done: int = 0
+    flow_error: Optional[str] = None
 
 
 class RunningSummary(BaseModel):

--- a/packages/ai-parrot/src/parrot/tools/execution_plan/models.py
+++ b/packages/ai-parrot/src/parrot/tools/execution_plan/models.py
@@ -6,15 +6,15 @@ is deliberately NOT a field here — it stays out-of-band in the toolkit's
 own internal dict so this model stays a plain, ``extra="forbid"``
 serializable record.
 
-Tool-argument schemas (``PlanStatusArgs``, ``PlanArtifactsArgs``) follow the
-repo's ``AbstractToolArgsSchema`` convention (see
-``.agent/workflows/create-parrot-tool.md``). ``PlanExecuteArgs`` /
-``PlanValidateArgs`` are added by TASK-2184, not here.
+Tool-argument schemas (``PlanStatusArgs``, ``PlanArtifactsArgs``,
+``PlanExecuteArgs``, ``PlanValidateArgs``) follow the repo's
+``AbstractToolArgsSchema`` convention (see
+``.agent/workflows/create-parrot-tool.md``).
 """
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Literal, Optional
+from typing import Any, Dict, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -23,7 +23,9 @@ from parrot.bots.flows.plan import ExecutionManifest
 
 __all__ = (
     "PlanArtifactsArgs",
+    "PlanExecuteArgs",
     "PlanStatusArgs",
+    "PlanValidateArgs",
     "RunRecord",
     "RunningSummary",
 )
@@ -85,3 +87,47 @@ class PlanArtifactsArgs(AbstractToolArgsSchema):
     model_config = ConfigDict(extra="forbid")
 
     run_id: str = Field(..., description="Run id returned by plan_execute.")
+
+
+class PlanExecuteArgs(AbstractToolArgsSchema):
+    """Arguments for the ``plan_execute`` tool.
+
+    Exactly one of ``objective``/``plan_name`` must be set.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    objective: Optional[str] = Field(
+        default=None,
+        description="Natural-language objective for objective mode (planner-authored).",
+    )
+    plan_name: Optional[str] = Field(
+        default=None,
+        description="Versioned plan filename (no extension) under plans_dir.",
+    )
+    params: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="{params.<name>} values for plan_name mode; not valid with objective.",
+    )
+
+
+class PlanValidateArgs(AbstractToolArgsSchema):
+    """Arguments for the ``plan_validate`` tool.
+
+    Same shape as :class:`PlanExecuteArgs` — a dry run never executes.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    objective: Optional[str] = Field(
+        default=None,
+        description="Natural-language objective for objective mode (planner-authored).",
+    )
+    plan_name: Optional[str] = Field(
+        default=None,
+        description="Versioned plan filename (no extension) under plans_dir.",
+    )
+    params: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="{params.<name>} values for plan_name mode; not valid with objective.",
+    )

--- a/packages/ai-parrot/src/parrot/tools/execution_plan/models.py
+++ b/packages/ai-parrot/src/parrot/tools/execution_plan/models.py
@@ -1,0 +1,87 @@
+"""Toolkit-internal models for ``ExecutionPlanToolkit``.
+
+``RunRecord``/``RunningSummary`` are the run-registry data models (spec
+§2 Data Models). The live ``asyncio.Task``/``AgentsFlow`` handle for a run
+is deliberately NOT a field here — it stays out-of-band in the toolkit's
+own internal dict so this model stays a plain, ``extra="forbid"``
+serializable record.
+
+Tool-argument schemas (``PlanStatusArgs``, ``PlanArtifactsArgs``) follow the
+repo's ``AbstractToolArgsSchema`` convention (see
+``.agent/workflows/create-parrot-tool.md``). ``PlanExecuteArgs`` /
+``PlanValidateArgs`` are added by TASK-2184, not here.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ..abstract import AbstractToolArgsSchema
+from parrot.bots.flows.plan import ExecutionManifest
+
+__all__ = (
+    "PlanArtifactsArgs",
+    "PlanStatusArgs",
+    "RunRecord",
+    "RunningSummary",
+)
+
+
+class RunRecord(BaseModel):
+    """Registry entry for one plan run (toolkit-internal).
+
+    Attributes:
+        run_id: Short unique id, e.g. ``"run_ab12cd"``.
+        plan_name: The executed plan's ``name``.
+        source: Which acquisition mode produced the plan.
+        status: Current run status.
+        started_at: When the run's background task was created.
+        finished_at: When the run reached a terminal status, if it has.
+        manifest: The final :class:`ExecutionManifest`, set on completion.
+        nodes_total: Total plan nodes (bound for progress reporting).
+        nodes_done: Nodes that have reached a terminal per-node status
+            (``ok``/``skipped``/``partial``/``error``) so far.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str
+    plan_name: str
+    source: Literal["objective", "plan_name"]
+    status: Literal["running", "completed", "partial", "failed"]
+    started_at: datetime
+    finished_at: Optional[datetime] = None
+    manifest: Optional[ExecutionManifest] = None
+    nodes_total: int
+    nodes_done: int = 0
+
+
+class RunningSummary(BaseModel):
+    """What ``plan_execute`` returns when ``soft_timeout`` elapses first."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str
+    status: Literal["running"] = "running"
+    plan_name: str
+    nodes_total: int
+    nodes_done: int
+    hint: str = "poll plan_status(run_id)"
+
+
+class PlanStatusArgs(AbstractToolArgsSchema):
+    """Arguments for the ``plan_status`` tool."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str = Field(..., description="Run id returned by plan_execute.")
+
+
+class PlanArtifactsArgs(AbstractToolArgsSchema):
+    """Arguments for the ``plan_artifacts`` tool."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str = Field(..., description="Run id returned by plan_execute.")

--- a/packages/ai-parrot/src/parrot/tools/execution_plan/planner.py
+++ b/packages/ai-parrot/src/parrot/tools/execution_plan/planner.py
@@ -1,0 +1,278 @@
+"""``PlanPlanner`` — ``objective`` mode: one structured LLM call authors an
+``ExecutionPlan``, with at most one bounded repair round on validation
+failure (spec §3 Module 4).
+
+``resolve_planner_client`` accepts the exact same ``planner_llm`` formats
+bots accept for ``llm``/``secondary_llm``
+(``ModelSwitchingMixin.secondary_llm``, ``model_switching.py:92``): a
+``"provider:model"`` string, an ``AbstractClient`` subclass or instance, or
+a ``model_config`` dict. There is no implicit default model anywhere in
+this module — ``objective`` mode without a configured ``planner_llm`` is a
+structural error the toolkit (TASK-2184) raises before ``PlanPlanner`` is
+ever constructed.
+
+Parsing is done here rather than through ``AbstractClient.ask(structured_
+output=...)``: that base-class path silently falls back to returning the
+raw response text on a parse/validation failure (see
+``AbstractClient._parse_structured_output``), which would hide exactly the
+failures a repair round needs to detect. Instead the schema is embedded in
+the prompt and the response is parsed/validated here, raising a typed
+:class:`PlanAuthoringError` on failure.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any, Dict, List, Sequence, Type, Union
+
+from pydantic import ValidationError
+
+from parrot.bots.flows.plan import ExecutionPlan
+from parrot.bots.flows.plan.validator import ValidationReport
+from parrot.clients.base import AbstractClient
+from parrot.clients.factory import SUPPORTED_CLIENTS, LLMFactory
+
+from .catalog import ToolCatalogEntry
+
+__all__ = ("PlanAuthoringError", "PlanPlanner", "resolve_planner_client")
+
+_PLANNING_RULES = """\
+You are authoring an ExecutionPlan: a tool-only, deterministic DAG. Rules:
+- Every node names a `tool` from the catalog below and a `store_as` key.
+- Nodes may reference prior nodes ONLY via these placeholder families:
+  `{nodes.<id>.output}` (the small published ArtifactRef), `{artifacts.<id>}`
+  (the full stored body — legal only inside `for_each.source` and node
+  `args`), and inside a `for_each` node: `{item}` / `{item.<field>}` /
+  `{index}`.
+- Every node referenced by a placeholder or by `for_each.source` MUST also
+  appear in that node's `depends_on`.
+- A `for_each` node's `store_as` MUST vary per item (contain `{index}` or
+  an `{item...}` reference); a non-`for_each` node's `store_as` MUST NOT.
+- Never invent a tool not in the catalog. Never add an `agent` node — plans
+  are tool-only by construction."""
+
+
+class PlanAuthoringError(RuntimeError):
+    """Raised when a planner response cannot be parsed into an ExecutionPlan."""
+
+
+def resolve_planner_client(
+    planner_llm: Union[str, Dict[str, Any], Type[AbstractClient], AbstractClient],
+) -> AbstractClient:
+    """Resolve ``planner_llm`` into a live, not-yet-entered ``AbstractClient``.
+
+    Args:
+        planner_llm: ``"provider:model"`` string, an ``AbstractClient``
+            subclass or instance, or a ``model_config`` dict (same keys as
+            ``AbstractBot._parse_model_config``: ``name``/``llm``/
+            ``provider``, ``model``, ``temperature``, ``top_k``, ``top_p``,
+            ``max_tokens``, plus any extra client kwargs).
+
+    Returns:
+        A live ``AbstractClient``.
+
+    Raises:
+        ValueError: If ``planner_llm`` is none of the accepted formats, or
+            a dict/string names an unsupported provider.
+    """
+    if isinstance(planner_llm, AbstractClient):
+        return planner_llm
+    if isinstance(planner_llm, type) and issubclass(planner_llm, AbstractClient):
+        return planner_llm()
+    if isinstance(planner_llm, dict):
+        return _client_from_model_config(planner_llm)
+    if isinstance(planner_llm, str):
+        return LLMFactory.create(planner_llm)
+
+    raise ValueError(
+        "planner_llm must be one of: a 'provider:model' string, an "
+        "AbstractClient instance or subclass, or a model_config dict "
+        f"(name/llm/provider + model + params). Got {type(planner_llm).__name__}."
+    )
+
+
+def _client_from_model_config(model_config: Dict[str, Any]) -> AbstractClient:
+    """Build a client from a ``model_config`` dict (navigator.bots-style)."""
+    cfg = dict(model_config)
+    provider = cfg.pop("name", None) or cfg.pop("llm", None) or cfg.pop("provider", None)
+    if not provider:
+        raise ValueError(
+            "planner_llm model_config dict must set one of 'name'/'llm'/'provider'."
+        )
+    if isinstance(provider, str) and ":" in provider:
+        provider, parsed_model = LLMFactory.parse_llm_string(provider)
+        cfg.setdefault("model", parsed_model)
+    provider = provider.lower()
+
+    if provider not in SUPPORTED_CLIENTS:
+        raise ValueError(
+            f"Unsupported LLM provider in planner_llm model_config: {provider!r}. "
+            f"Supported: {list(SUPPORTED_CLIENTS.keys())}"
+        )
+    client_class = SUPPORTED_CLIENTS[provider]
+    if callable(client_class) and not isinstance(client_class, type):
+        client_class = client_class()  # resolve lazy loader
+
+    return client_class(
+        model=cfg.pop("model", None),
+        temperature=cfg.pop("temperature", 0.1),
+        top_k=cfg.pop("top_k", 41),
+        top_p=cfg.pop("top_p", 0.9),
+        max_tokens=cfg.pop("max_tokens", None),
+        **cfg,
+    )
+
+
+class PlanPlanner:
+    """Authors/repairs an :class:`ExecutionPlan` via exactly one LLM call
+    per round.
+
+    Attributes:
+        client: The resolved planner client.
+        catalog: Allowlist-scoped tool catalog embedded in every prompt.
+    """
+
+    def __init__(
+        self, planner_llm: Union[str, Dict[str, Any], Type[AbstractClient], AbstractClient],
+        catalog: Sequence[ToolCatalogEntry],
+    ) -> None:
+        """Resolve the planner client and bind the tool catalog.
+
+        Args:
+            planner_llm: See :func:`resolve_planner_client`.
+            catalog: The allowlist-scoped catalog (TASK-2182's
+                ``build_catalog``) embedded in every prompt.
+        """
+        self.client = resolve_planner_client(planner_llm)
+        self.catalog: List[ToolCatalogEntry] = list(catalog)
+        self.logger = logging.getLogger(f"{__name__}.PlanPlanner")
+
+    async def author(self, objective: str) -> ExecutionPlan:
+        """Author a plan for ``objective`` in one LLM call.
+
+        Args:
+            objective: The natural-language objective to plan for.
+
+        Returns:
+            The parsed :class:`ExecutionPlan` (not yet validated against a
+            live ``ToolManager`` — the caller runs ``validate_plan``).
+
+        Raises:
+            PlanAuthoringError: If the response is not valid JSON, or does
+                not validate as an ``ExecutionPlan``.
+        """
+        self.logger.info(
+            "Authoring plan: objective_len=%d catalog_size=%d",
+            len(objective), len(self.catalog),
+        )
+        response_text = await self._call(self._authoring_prompt(objective))
+        plan = self._parse_plan(response_text)
+        self.logger.info("Authoring round produced plan %r", plan.name)
+        return plan
+
+    async def repair(
+        self, plan_json: Dict[str, Any], report: ValidationReport
+    ) -> ExecutionPlan:
+        """Re-prompt once with ``report``'s text embedded verbatim.
+
+        Args:
+            plan_json: The invalid plan's JSON document.
+            report: The validation failure to repair from.
+
+        Returns:
+            The corrected :class:`ExecutionPlan`.
+
+        Raises:
+            PlanAuthoringError: If the repaired response still fails to
+                parse/validate.
+        """
+        self.logger.info("Repairing plan: %d issue(s)", len(report.issues))
+        response_text = await self._call(self._repair_prompt(plan_json, report))
+        plan = self._parse_plan(response_text)
+        self.logger.info("Repair round produced plan %r", plan.name)
+        return plan
+
+    # ── LLM call ─────────────────────────────────────────────────────────
+
+    async def _call(self, prompt: str) -> str:
+        """Make exactly one call to the resolved client and return its text."""
+        async with self.client as entered:
+            response = await entered.ask(
+                prompt=prompt, model=getattr(entered, "model", None), temperature=0.0,
+            )
+        return _response_text(response)
+
+    # ── Prompt construction ──────────────────────────────────────────────
+
+    def _authoring_prompt(self, objective: str) -> str:
+        return (
+            f"{_PLANNING_RULES}\n\n"
+            f"Tool catalog:\n{self._render_catalog()}\n\n"
+            f"ExecutionPlan JSON Schema:\n{json.dumps(ExecutionPlan.model_json_schema())}\n\n"
+            f"Objective: {objective}\n\n"
+            "Respond with ONLY the ExecutionPlan JSON document — no prose, "
+            "no markdown code fences."
+        )
+
+    def _repair_prompt(self, plan_json: Dict[str, Any], report: ValidationReport) -> str:
+        return (
+            f"{_PLANNING_RULES}\n\n"
+            f"Tool catalog:\n{self._render_catalog()}\n\n"
+            f"ExecutionPlan JSON Schema:\n{json.dumps(ExecutionPlan.model_json_schema())}\n\n"
+            f"The following plan failed validation:\n{json.dumps(plan_json)}\n\n"
+            f"Validation report:\n{report}\n\n"
+            "Correct the plan and respond with ONLY the corrected "
+            "ExecutionPlan JSON document — no prose, no markdown code fences."
+        )
+
+    def _render_catalog(self) -> str:
+        if not self.catalog:
+            return "(no tools in catalog)"
+        lines = []
+        for entry in self.catalog:
+            args = ", ".join(
+                f"{arg.name}:{arg.type}{'' if arg.required else '?'}"
+                for arg in entry.args_summary
+            )
+            lines.append(f"- {entry.name}({args}): {entry.description}")
+        return "\n".join(lines)
+
+    # ── Response parsing ─────────────────────────────────────────────────
+
+    def _parse_plan(self, response_text: str) -> ExecutionPlan:
+        """Parse+validate one planner response into an ``ExecutionPlan``."""
+        text = _extract_json_text(response_text)
+        try:
+            document = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise PlanAuthoringError(
+                f"Planner response was not valid JSON: {exc}. "
+                f"Response started with: {response_text[:200]!r}"
+            ) from exc
+        try:
+            return ExecutionPlan.model_validate(document)
+        except ValidationError as exc:
+            raise PlanAuthoringError(
+                f"Planner response failed ExecutionPlan validation: {exc}"
+            ) from exc
+
+
+def _extract_json_text(text: str) -> str:
+    """Strip a leading/trailing markdown code fence, if present."""
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        stripped = re.sub(r"^```[a-zA-Z]*\n?", "", stripped)
+        stripped = re.sub(r"\n?```$", "", stripped)
+    return stripped.strip()
+
+
+def _response_text(response: Any) -> str:
+    """Extract the text payload of a client response, defensively."""
+    output = getattr(response, "output", None)
+    if output:
+        return str(output)
+    content = getattr(response, "content", None)
+    if content:
+        return str(content)
+    return str(response)

--- a/packages/ai-parrot/src/parrot/tools/execution_plan/store.py
+++ b/packages/ai-parrot/src/parrot/tools/execution_plan/store.py
@@ -107,11 +107,37 @@ class PlanFileStore:
     # ── Path resolution ──────────────────────────────────────────────────
 
     def _resolve_path(self, plan_name: str) -> Path:
-        """Resolve ``plan_name`` to a file, preferring yaml > yml > json."""
+        """Resolve ``plan_name`` to a file, preferring yaml > yml > json.
+
+        ``plan_name`` is an agent/LLM-controlled argument
+        (``PlanExecuteArgs``/``PlanValidateArgs``), so it is rejected
+        outright if it could ever escape ``plans_dir`` — no path
+        separators, no ``..``, and the resolved candidate must stay a
+        direct child of ``plans_dir``. Without this, a plan file naming
+        arbitrary local files (e.g. ``"../../etc/passwd"``) would be read
+        and, via ``plan_validate``, returned verbatim to the agent.
+
+        Raises:
+            PlanLoadError: If ``plan_name`` is not a bare filename stem,
+                or names no known plan.
+        """
+        if any(sep in plan_name for sep in ("/", "\\")) or ".." in plan_name:
+            raise PlanLoadError(
+                f"Invalid plan_name {plan_name!r}: must be a bare filename "
+                "stem (no path separators or '..')."
+            )
+
+        plans_dir_resolved = self.plans_dir.resolve()
         for ext in _EXTENSIONS:
             candidate = self.plans_dir / f"{plan_name}.{ext}"
-            if candidate.is_file():
-                return candidate
+            if not candidate.is_file():
+                continue
+            resolved = candidate.resolve()
+            if resolved.parent != plans_dir_resolved:
+                raise PlanLoadError(
+                    f"Invalid plan_name {plan_name!r}: resolves outside plans_dir."
+                )
+            return candidate
 
         available = sorted(
             {
@@ -126,11 +152,19 @@ class PlanFileStore:
         )
 
     def _parse(self, path: Path) -> Any:
-        """Parse a YAML or JSON plan document into a plain dict."""
+        """Parse a YAML or JSON plan document into a plain dict.
+
+        Raises:
+            PlanLoadError: If the file is not valid JSON/YAML — never lets
+                a raw parser exception escape the tool boundary.
+        """
         text = path.read_text(encoding="utf-8")
-        if path.suffix == ".json":
-            return json.loads(text)
-        return yaml.safe_load(text)
+        try:
+            if path.suffix == ".json":
+                return json.loads(text)
+            return yaml.safe_load(text)
+        except (json.JSONDecodeError, yaml.YAMLError) as exc:
+            raise PlanLoadError(f"Plan file {path} is not valid {path.suffix}: {exc}") from exc
 
     # ── {params.<name>} substitution ──────────────────────────────────────
 

--- a/packages/ai-parrot/src/parrot/tools/execution_plan/store.py
+++ b/packages/ai-parrot/src/parrot/tools/execution_plan/store.py
@@ -1,0 +1,195 @@
+"""``PlanFileStore`` — versioned ``plans_dir`` loader for ``plan_name`` mode.
+
+A plan file is a git-diffable, versioned document (the daily Security
+Advisory pipeline's use case). Per-run parameters use
+``{params.<name>}`` placeholders substituted at **load time**, before
+``ExecutionPlan.model_validate()`` — the frozen executor
+(``PlanToolNode._resolve_args``) resolves exactly three runtime
+placeholder families (``{nodes.<id>.output}``, ``{artifacts.<id>}``,
+``{item}``/``{item.<field>}``/``{index}``) and must never be extended for
+a fourth. See spec §3 Module 3.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+import yaml
+from pydantic import ValidationError
+
+from parrot.bots.flows.plan import ExecutionPlan
+
+__all__ = ("PlanFileStore", "PlanLoadError")
+
+# ``{params.<name>}`` — load-time-only placeholder, substituted here and
+# never seen by the executor.
+_PARAMS_RE = re.compile(r"\{params\.([A-Za-z_][A-Za-z0-9_]*)\}")
+
+_EXTENSIONS = ("yaml", "yml", "json")
+
+
+class PlanLoadError(ValueError):
+    """Raised when a plan file cannot be resolved, parsed or parameterised."""
+
+
+class PlanFileStore:
+    """Resolves ``plans_dir/<name>.(yaml|yml|json)`` and applies ``params``.
+
+    Attributes:
+        plans_dir: Directory containing versioned plan files.
+    """
+
+    def __init__(self, plans_dir: Path) -> None:
+        """Bind the store to ``plans_dir``.
+
+        Args:
+            plans_dir: Directory to resolve plan names against.
+
+        Raises:
+            PlanLoadError: If ``plans_dir`` does not exist or is not a
+                directory.
+        """
+        self.plans_dir = Path(plans_dir)
+        if not self.plans_dir.is_dir():
+            raise PlanLoadError(
+                f"plans_dir {self.plans_dir} does not exist or is not a directory"
+            )
+
+    def load(
+        self, plan_name: str, params: Optional[Dict[str, Any]] = None
+    ) -> ExecutionPlan:
+        """Load, parameterise and validate a plan file.
+
+        Args:
+            plan_name: Base filename (without extension) under ``plans_dir``.
+            params: Values for every ``{params.<name>}`` placeholder in the
+                file. Every referenced name must be supplied and every
+                supplied name must be referenced — nothing silent.
+
+        Returns:
+            The validated :class:`ExecutionPlan`.
+
+        Raises:
+            PlanLoadError: Unknown plan name, missing/unused params, or a
+                validation failure after substitution.
+        """
+        path = self._resolve_path(plan_name)
+        document = self._parse(path)
+
+        supplied = dict(params or {})
+        referenced: Set[str] = set()
+        missing: Set[str] = set()
+
+        substituted = self._substitute(document, supplied, referenced, missing)
+        unused = set(supplied) - referenced
+
+        if missing or unused:
+            problems: List[str] = []
+            if missing:
+                problems.append(f"missing params: {sorted(missing)}")
+            if unused:
+                problems.append(f"unused params: {sorted(unused)}")
+            raise PlanLoadError(
+                f"Plan {plan_name!r} ({path}) parameter mismatch — "
+                + "; ".join(problems)
+            )
+
+        try:
+            return ExecutionPlan.model_validate(substituted)
+        except ValidationError as exc:
+            raise PlanLoadError(
+                f"Plan {plan_name!r} ({path}) failed validation after "
+                f"param substitution: {exc}"
+            ) from exc
+
+    # ── Path resolution ──────────────────────────────────────────────────
+
+    def _resolve_path(self, plan_name: str) -> Path:
+        """Resolve ``plan_name`` to a file, preferring yaml > yml > json."""
+        for ext in _EXTENSIONS:
+            candidate = self.plans_dir / f"{plan_name}.{ext}"
+            if candidate.is_file():
+                return candidate
+
+        available = sorted(
+            {
+                p.stem
+                for p in self.plans_dir.iterdir()
+                if p.is_file() and p.suffix.lstrip(".") in _EXTENSIONS
+            }
+        )
+        raise PlanLoadError(
+            f"Unknown plan {plan_name!r} in {self.plans_dir}. "
+            f"Available: {available}"
+        )
+
+    def _parse(self, path: Path) -> Any:
+        """Parse a YAML or JSON plan document into a plain dict."""
+        text = path.read_text(encoding="utf-8")
+        if path.suffix == ".json":
+            return json.loads(text)
+        return yaml.safe_load(text)
+
+    # ── {params.<name>} substitution ──────────────────────────────────────
+
+    def _substitute(
+        self,
+        value: Any,
+        params: Dict[str, Any],
+        referenced: Set[str],
+        missing: Set[str],
+    ) -> Any:
+        """Walk ``value``, substituting every ``{params.<name>}`` string leaf.
+
+        Mirrors the walking pattern in
+        ``parrot.bots.flows.plan.models._iter_strings`` but rebuilds the
+        structure instead of only yielding leaves. An exact-match
+        placeholder (the whole string is one placeholder) resolves to the
+        param's native value; an embedded one is interpolated as text —
+        the same exact-match convention ``paths.render_key`` uses for
+        runtime placeholders. Names referenced but missing from ``params``
+        are recorded in ``missing`` rather than raising immediately, so
+        every issue in the document is collected in one pass.
+
+        Args:
+            value: The (possibly nested) document node.
+            params: Supplied parameter values.
+            referenced: Accumulator for every ``{params.<name>}`` name seen.
+            missing: Accumulator for referenced names absent from ``params``.
+
+        Returns:
+            The substituted structure (unchanged in shape otherwise).
+        """
+        if isinstance(value, dict):
+            return {
+                key: self._substitute(inner, params, referenced, missing)
+                for key, inner in value.items()
+            }
+        if isinstance(value, list):
+            return [
+                self._substitute(inner, params, referenced, missing)
+                for inner in value
+            ]
+        if not isinstance(value, str):
+            return value
+
+        exact = _PARAMS_RE.fullmatch(value)
+        if exact:
+            name = exact.group(1)
+            referenced.add(name)
+            if name not in params:
+                missing.add(name)
+                return value
+            return params[name]
+
+        def _sub(match: "re.Match") -> str:
+            name = match.group(1)
+            referenced.add(name)
+            if name not in params:
+                missing.add(name)
+                return match.group(0)
+            return str(params[name])
+
+        return _PARAMS_RE.sub(_sub, value)

--- a/packages/ai-parrot/src/parrot/tools/execution_plan/toolkit.py
+++ b/packages/ai-parrot/src/parrot/tools/execution_plan/toolkit.py
@@ -193,6 +193,16 @@ class ExecutionPlanToolkit(AbstractToolkit):
             definition,
             agent_registry=agent_registry,
             node_factories={"tool": factory},
+            # FEAT-399 flow-level checkpointing defaults to
+            # PlanMetadata.checkpoint=True and would otherwise require a
+            # live checkpoint store (Redis by default) before the first
+            # node ever dispatches — silently contradicting this feature's
+            # own "pure in-RAM v1, no persistent backend" design (spec §1
+            # Non-Goals). The toolkit's RunRecord registry is the v1
+            # resumability story; explicitly disable flow-level
+            # checkpointing regardless of what a plan file's `metadata`
+            # block says.
+            checkpoint=False,
         )
 
         plan_node_ids: Set[str] = {node.id for node in plan.nodes}
@@ -230,12 +240,13 @@ class ExecutionPlanToolkit(AbstractToolkit):
                 return ToolResult(
                     status="success", result=record.manifest.model_dump(mode="json")
                 )
+            reason = record.flow_error or (str(exc) if exc is not None else None)
             return ToolResult(
                 status="error",
                 success=False,
                 result=None,
                 error=f"Plan run {run_id!r} finished without a manifest"
-                + (f": {exc}" if exc is not None else ""),
+                + (f": {reason}" if reason else ""),
             )
 
         summary = RunningSummary(
@@ -293,6 +304,7 @@ class ExecutionPlanToolkit(AbstractToolkit):
             if record is not None:
                 record.status = "failed"
                 record.finished_at = datetime.now(timezone.utc)
+                record.flow_error = str(exc)[:500]
             self._evict_completed_runs()
             return
 
@@ -311,6 +323,21 @@ class ExecutionPlanToolkit(AbstractToolkit):
                 refs.append(
                     ArtifactRef(node_id=node.id, status="error", errors=[str(error)[:300]])
                 )
+                continue
+            # Neither a result nor a recorded error: the node was never
+            # dispatched at all — a hard upstream failure blocked it (the
+            # scheduler's AND-join gate only advances past a dependency
+            # that reached `completed`; a `mark_failed` dependency leaves
+            # dependents un-dispatched, with no "skipped"/"error" event of
+            # their own). Without this branch such a node would silently
+            # vanish from the manifest instead of showing up as blocked.
+            refs.append(
+                ArtifactRef(
+                    node_id=node.id,
+                    status="error",
+                    errors=["node never dispatched: blocked by a failed dependency"],
+                )
+            )
 
         duration = time.monotonic() - started_monotonic
         manifest = build_manifest(plan, refs, duration_seconds=duration)
@@ -527,8 +554,14 @@ class ExecutionPlanToolkit(AbstractToolkit):
                 "plan_name mode requires the toolkit to be constructed with "
                 "plans_dir=<path>."
             )
+        def _load() -> ExecutionPlan:
+            # PlanFileStore (construction + load) is sync file I/O.
+            return PlanFileStore(self.plans_dir).load(plan_name, params)
+
         try:
-            plan = PlanFileStore(self.plans_dir).load(plan_name, params)
+            # This is an async method — offload the sync I/O to a worker
+            # thread rather than blocking the event loop.
+            plan = await asyncio.to_thread(_load)
         except PlanLoadError as exc:
             raise _StructuralError(str(exc)) from exc
 

--- a/packages/ai-parrot/src/parrot/tools/execution_plan/toolkit.py
+++ b/packages/ai-parrot/src/parrot/tools/execution_plan/toolkit.py
@@ -33,11 +33,29 @@ from parrot.tools.decorators import tool_schema
 from parrot.tools.toolkit import AbstractToolkit
 
 from ..abstract import ToolResult
-from .models import PlanArtifactsArgs, PlanStatusArgs, RunningSummary, RunRecord
+from .catalog import build_catalog, validate_with_allowlist
+from .models import (
+    PlanArtifactsArgs,
+    PlanExecuteArgs,
+    PlanStatusArgs,
+    PlanValidateArgs,
+    RunningSummary,
+    RunRecord,
+)
+from .planner import PlanAuthoringError, PlanPlanner
+from .store import PlanFileStore, PlanLoadError
 
 if TYPE_CHECKING:
     from parrot.auth.permission import PermissionContext
     from parrot.tools.working_memory.tool import WorkingMemoryToolkit
+
+
+class _StructuralError(Exception):
+    """Internal signal for a structural (non-manifest) tool-error condition.
+
+    Raised by the arbitration/acquisition helpers and caught at the
+    `plan_execute`/`plan_validate` tool boundary — never crosses it.
+    """
 
 
 class ExecutionPlanToolkit(AbstractToolkit):
@@ -382,3 +400,171 @@ class ExecutionPlanToolkit(AbstractToolkit):
             ]
 
         return ToolResult(status="success", result={"run_id": run_id, "artifacts": artifacts})
+
+    @tool_schema(PlanExecuteArgs)
+    async def plan_execute(
+        self,
+        objective: Optional[str] = None,
+        plan_name: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> ToolResult:
+        """Acquire, validate and run an ExecutionPlan.
+
+        Provide exactly one of `objective` (planner-authored) or
+        `plan_name` (versioned file). Returns the full manifest, or a
+        `run_id` summary if still running after `soft_timeout`.
+        """
+        try:
+            plan, _plan_json, report, source = await self._acquire_and_validate(
+                objective, plan_name, params
+            )
+        except _StructuralError as exc:
+            return ToolResult(status="error", success=False, result=None, error=str(exc))
+
+        if not report.ok:
+            return ToolResult(
+                status="error",
+                success=False,
+                result=None,
+                error=f"Plan {plan.name!r} is invalid — nothing executed:\n{report}",
+            )
+
+        return await self._run_plan(plan, source=source)
+
+    @tool_schema(PlanValidateArgs)
+    async def plan_validate(
+        self,
+        objective: Optional[str] = None,
+        plan_name: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> ToolResult:
+        """Dry-run: acquire and validate an ExecutionPlan without running it.
+
+        Returns the acquired plan JSON verbatim plus the full validation
+        report (`ok` + per-issue node_id/code/message/severity). Never
+        calls a tool.
+        """
+        try:
+            plan, plan_json, report, _source = await self._acquire_and_validate(
+                objective, plan_name, params
+            )
+        except _StructuralError as exc:
+            return ToolResult(status="error", success=False, result=None, error=str(exc))
+
+        return ToolResult(
+            status="success",
+            result={
+                "plan": plan_json,
+                "ok": report.ok,
+                "issues": [
+                    {
+                        "node_id": issue.node_id,
+                        "code": issue.code,
+                        "message": issue.message,
+                        "severity": issue.severity,
+                    }
+                    for issue in report.issues
+                ],
+            },
+        )
+
+    # ── Acquisition + validation (shared by plan_execute/plan_validate) ────
+
+    async def _acquire_and_validate(
+        self,
+        objective: Optional[str],
+        plan_name: Optional[str],
+        params: Optional[Dict[str, Any]],
+    ) -> "tuple[ExecutionPlan, Dict[str, Any], Any, str]":
+        """Arbitrate inputs, acquire the plan, and validate (+ repair once).
+
+        Never raises for "the plan is invalid" — that is data returned to
+        the caller (`report.ok=False`); `plan_execute` converts it into a
+        tool error itself, `plan_validate` returns it as its whole point.
+        Only genuine structural problems (bad arbitration, an unreadable
+        plan file, an unconfigured `planner_llm`/`plans_dir`, or a planner
+        response that never parses even after one repair round) raise
+        `_StructuralError`.
+
+        Returns:
+            ``(plan, plan_json, report, source)``.
+
+        Raises:
+            _StructuralError: On any structural acquisition failure.
+        """
+        self._check_arbitration(objective, plan_name, params)
+        if plan_name is not None:
+            return await self._acquire_from_file(plan_name, params)
+        return await self._acquire_from_objective(objective)
+
+    def _check_arbitration(
+        self,
+        objective: Optional[str],
+        plan_name: Optional[str],
+        params: Optional[Dict[str, Any]],
+    ) -> None:
+        """Enforce exactly one of objective/plan_name, and params only with plan_name."""
+        if objective is not None and plan_name is not None:
+            raise _StructuralError(
+                "Provide exactly one of 'objective' or 'plan_name', not both."
+            )
+        if objective is None and plan_name is None:
+            raise _StructuralError(
+                "Provide exactly one of 'objective' or 'plan_name'."
+            )
+        if objective is not None and params is not None:
+            raise _StructuralError(
+                "'params' is a plan_name-mode concept ({params.<name>} load-time "
+                "substitution) and cannot be combined with 'objective'."
+            )
+
+    async def _acquire_from_file(
+        self, plan_name: str, params: Optional[Dict[str, Any]]
+    ) -> "tuple[ExecutionPlan, Dict[str, Any], Any, str]":
+        """``plan_name`` mode: load from ``plans_dir``, validate, no repair."""
+        if self.plans_dir is None:
+            raise _StructuralError(
+                "plan_name mode requires the toolkit to be constructed with "
+                "plans_dir=<path>."
+            )
+        try:
+            plan = PlanFileStore(self.plans_dir).load(plan_name, params)
+        except PlanLoadError as exc:
+            raise _StructuralError(str(exc)) from exc
+
+        plan_json = plan.model_dump(mode="json")
+        report = validate_with_allowlist(plan, self._tool_manager, self.allowed_tools)
+        return plan, plan_json, report, "plan_name"
+
+    async def _acquire_from_objective(
+        self, objective: str
+    ) -> "tuple[ExecutionPlan, Dict[str, Any], Any, str]":
+        """``objective`` mode: author via the planner, validate, ≤1 repair."""
+        if self.planner_llm is None:
+            raise _StructuralError(
+                "objective mode requires the toolkit to be constructed with "
+                "planner_llm=<...>."
+            )
+        catalog = build_catalog(self._tool_manager, self.allowed_tools)
+        planner = PlanPlanner(self.planner_llm, catalog)
+
+        try:
+            plan = await planner.author(objective)
+        except PlanAuthoringError as exc:
+            raise _StructuralError(f"Planner failed to author a plan: {exc}") from exc
+
+        plan_json = plan.model_dump(mode="json")
+        report = validate_with_allowlist(plan, self._tool_manager, self.allowed_tools)
+
+        if not report.ok:
+            try:
+                plan = await planner.repair(plan_json, report)
+            except PlanAuthoringError as exc:
+                raise _StructuralError(
+                    "Planner repair round failed to produce a parseable plan: "
+                    f"{exc}\nOriginal validation report:\n{report}"
+                ) from exc
+            plan_json = plan.model_dump(mode="json")
+            report = validate_with_allowlist(plan, self._tool_manager, self.allowed_tools)
+
+        return plan, plan_json, report, "objective"

--- a/packages/ai-parrot/src/parrot/tools/execution_plan/toolkit.py
+++ b/packages/ai-parrot/src/parrot/tools/execution_plan/toolkit.py
@@ -1,0 +1,384 @@
+"""``ExecutionPlanToolkit`` — lets a plain ``BasicAgent`` trigger a deterministic
+tool-call DAG (``ExecutionPlan``) through a bounded tool call, with zero LLM
+tokens spent while it executes.
+
+This module implements the toolkit's core (spec §3 Module 2): constructor
+wiring, the bounded run registry, and the soft-timeout execution path over
+``AgentsFlow``. The plan-acquisition front (``plan_execute``/``plan_validate``)
+is added by TASK-2184; the plan file store, planner client and
+allowlist/catalog layering are added by TASK-2181/2182/2183 respectively.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Sequence, Set, Union
+
+from parrot.bots.flows.core.context import FlowContext
+from parrot.bots.flows.flow.flow import AgentsFlow
+from parrot.bots.flows.plan import (
+    ArtifactRef,
+    ExecutionPlan,
+    PlanToolNode,
+    build_manifest,
+    ensure_tool_node_registered,
+    make_tool_node_factory,
+    to_flow_definition,
+)
+from parrot.registry.registry import AgentRegistry
+from parrot.tools.decorators import tool_schema
+from parrot.tools.toolkit import AbstractToolkit
+
+from ..abstract import ToolResult
+from .models import PlanArtifactsArgs, PlanStatusArgs, RunningSummary, RunRecord
+
+if TYPE_CHECKING:
+    from parrot.auth.permission import PermissionContext
+    from parrot.tools.working_memory.tool import WorkingMemoryToolkit
+
+
+class ExecutionPlanToolkit(AbstractToolkit):
+    """Runs a validated :class:`ExecutionPlan` on ``AgentsFlow`` with no LLM
+    tokens in the loop and returns a bounded manifest to the agent.
+
+    One instance is initialized with live dependencies (the FEAT-207
+    shared-state toolkit pattern) and shared across every tool call:
+    the run registry, plan store and tool catalog all live on ``self``.
+
+    Attributes:
+        planner_llm: Raw ``planner_llm`` constructor value, consumed by
+            TASK-2183's ``PlanPlanner``.
+        plans_dir: Resolved ``Path`` for ``plan_name`` mode, consumed by
+            TASK-2181's ``PlanFileStore``.
+        allowed_tools: Explicit allowlist, or ``None`` for "all manager
+            tools" — consumed by TASK-2182's catalog/allowlist layering.
+        soft_timeout: Seconds ``plan_execute`` waits before returning a
+            :class:`RunningSummary` instead of the full manifest.
+        permission_context: Optional constructor-level default forwarded
+            to every plan node's ``ToolManager.execute_tool`` call.
+        max_completed_runs: Bound on completed/failed run-registry
+            entries; oldest evicted first. In-flight runs are never
+            evicted.
+    """
+
+    name: str = "execution_plan"
+    description: str = (
+        "Runs a deterministic tool-call DAG (an ExecutionPlan) with zero "
+        "LLM tokens spent during execution. Tool payloads never enter the "
+        "conversation — only small ArtifactRefs and a bounded manifest "
+        "come back."
+    )
+
+    def __init__(
+        self,
+        *,
+        tool_manager: Any,
+        working_memory: "WorkingMemoryToolkit",
+        planner_llm: Union[str, dict, Any, None] = None,
+        plans_dir: Union[str, Path, None] = None,
+        allowed_tools: Optional[Sequence[str]] = None,
+        soft_timeout: float = 60.0,
+        permission_context: Optional["PermissionContext"] = None,
+        on_node_event: Optional[Callable[..., Any]] = None,
+        max_completed_runs: int = 50,
+        **kwargs: Any,
+    ) -> None:
+        """Initialise the toolkit with its live dependencies.
+
+        Args:
+            tool_manager: Shared ``ToolManager`` — every plan node dispatches
+                through it (never ``tool.execute()`` directly).
+            working_memory: The SAME ``WorkingMemoryToolkit`` instance the
+                analyst agent uses; plan payloads land here.
+            planner_llm: Enables ``objective`` mode when set. Same accepted
+                formats as bots' ``llm``/``secondary_llm``. Consumed by
+                TASK-2183.
+            plans_dir: Enables ``plan_name`` mode when set. Consumed by
+                TASK-2181.
+            allowed_tools: Explicit tool allowlist. ``None`` means every
+                tool registered on ``tool_manager`` is allowed. Consumed by
+                TASK-2182.
+            soft_timeout: Seconds to await a run before returning a
+                ``RunningSummary``. Never cancels the run.
+            permission_context: Optional default forwarded to
+                ``ToolManager.execute_tool`` for every plan node.
+            on_node_event: Optional flow-lifecycle listener, forwarded to
+                every run's ``AgentsFlow`` in addition to this toolkit's
+                own progress-tracking listener.
+            max_completed_runs: Bound on completed/failed run-registry
+                entries.
+            **kwargs: Forwarded to :class:`AbstractToolkit`.
+        """
+        super().__init__(**kwargs)
+        self._tool_manager = tool_manager
+        self._working_memory = working_memory
+        self.planner_llm = planner_llm
+        self.plans_dir: Optional[Path] = Path(plans_dir) if plans_dir is not None else None
+        self.allowed_tools: Optional[list] = (
+            list(allowed_tools) if allowed_tools is not None else None
+        )
+        self.soft_timeout = soft_timeout
+        self.permission_context = permission_context
+        self._on_node_event = on_node_event
+        self.max_completed_runs = max_completed_runs
+
+        # Run registry (bounded) — toolkit-internal state, never travels
+        # through NodeDefinition.config.
+        self._runs: Dict[str, RunRecord] = {}
+        # Live handles kept OUT of RunRecord (non-serializable).
+        self._run_tasks: Dict[str, "asyncio.Task"] = {}
+        self._run_contexts: Dict[str, FlowContext] = {}
+        # Lazily created, empty AgentRegistry — AgentsFlow.from_definition
+        # requires one unconditionally even though a plan can never contain
+        # an agent-type node (PlanNode has no agent_ref field at all).
+        self._agent_registry: Optional[AgentRegistry] = None
+
+    # ── Internal executor path (spec §3 Module 2) ──────────────────────────
+
+    def _get_agent_registry(self) -> AgentRegistry:
+        """Return the cached empty ``AgentRegistry``, creating it once."""
+        if self._agent_registry is None:
+            self._agent_registry = AgentRegistry()
+        return self._agent_registry
+
+    async def _run_plan(
+        self, plan: ExecutionPlan, *, source: str
+    ) -> ToolResult:
+        """Compile, run and bound the response to ``soft_timeout``.
+
+        Callers are responsible for validating ``plan`` first (TASK-2184's
+        ``plan_execute``/``plan_validate`` layer) — this method executes
+        unconditionally.
+
+        Args:
+            plan: A structurally valid :class:`ExecutionPlan`.
+            source: ``"objective"`` or ``"plan_name"`` — recorded on the
+                run for observability.
+
+        Returns:
+            A ``ToolResult`` whose ``result`` is either the full
+            ``ExecutionManifest`` (run finished within ``soft_timeout``) or
+            a :class:`RunningSummary` (run continues in the background).
+        """
+        ensure_tool_node_registered(PlanToolNode)
+        definition = to_flow_definition(plan)
+        factory = make_tool_node_factory(
+            self._tool_manager,
+            self._working_memory,
+            permission_context=self.permission_context,
+        )
+        agent_registry = self._get_agent_registry()
+        flow = AgentsFlow.from_definition(
+            definition,
+            agent_registry=agent_registry,
+            node_factories={"tool": factory},
+        )
+
+        plan_node_ids: Set[str] = {node.id for node in plan.nodes}
+        run_id = f"run_{uuid.uuid4().hex[:8]}"
+        ctx = FlowContext(initial_task=plan.objective, agent_registry=agent_registry)
+        started_monotonic = time.monotonic()
+        record = RunRecord(
+            run_id=run_id,
+            plan_name=plan.name,
+            source=source,
+            status="running",
+            started_at=datetime.now(timezone.utc),
+            nodes_total=len(plan.nodes),
+            nodes_done=0,
+        )
+        self._runs[run_id] = record
+        self._run_contexts[run_id] = ctx
+
+        flow.add_node_event_listener(self._make_progress_listener(run_id, plan_node_ids))
+        if self._on_node_event is not None:
+            flow.add_node_event_listener(self._on_node_event)
+
+        task = asyncio.create_task(
+            self._execute_flow(run_id, flow, plan, ctx, started_monotonic)
+        )
+        self._run_tasks[run_id] = task
+
+        done, _pending = await asyncio.wait({task}, timeout=self.soft_timeout)
+        if task in done:
+            # Surface a background-task exception (defensive: _execute_flow
+            # already catches everything it can and marks the run "failed").
+            exc = task.exception()
+            record = self._runs.get(run_id, record)
+            if record.manifest is not None:
+                return ToolResult(
+                    status="success", result=record.manifest.model_dump(mode="json")
+                )
+            return ToolResult(
+                status="error",
+                success=False,
+                result=None,
+                error=f"Plan run {run_id!r} finished without a manifest"
+                + (f": {exc}" if exc is not None else ""),
+            )
+
+        summary = RunningSummary(
+            run_id=run_id,
+            plan_name=plan.name,
+            nodes_total=record.nodes_total,
+            nodes_done=record.nodes_done,
+        )
+        return ToolResult(status="success", result=summary.model_dump(mode="json"))
+
+    def _make_progress_listener(
+        self, run_id: str, plan_node_ids: Set[str]
+    ) -> Callable[[str, str, Dict[str, Any]], None]:
+        """Build an ``on_node_event`` callback that updates ``nodes_done``.
+
+        Args:
+            run_id: The run this listener tracks.
+            plan_node_ids: Node ids belonging to the plan (excludes the
+                synthetic ``__start__``/``__end__`` sentinels).
+
+        Returns:
+            A sync callback matching ``AgentsFlow``'s listener contract.
+        """
+
+        def _listener(event: str, node_id: str, _info: Dict[str, Any]) -> None:
+            if node_id not in plan_node_ids:
+                return
+            if event in ("node_completed", "node_failed", "node_skipped"):
+                record = self._runs.get(run_id)
+                if record is not None:
+                    record.nodes_done += 1
+
+        return _listener
+
+    async def _execute_flow(
+        self,
+        run_id: str,
+        flow: AgentsFlow,
+        plan: ExecutionPlan,
+        ctx: FlowContext,
+        started_monotonic: float,
+    ) -> None:
+        """Run ``flow`` to completion and populate the final manifest.
+
+        Runs as a background ``asyncio.Task`` — soft-timeout must NOT
+        cancel this. Any failure (per-node or flow-level) is recorded as
+        data on the ``RunRecord``, never re-raised: partial failure is
+        data, not an exception (spec §1 Goals).
+        """
+        record = self._runs.get(run_id)
+        try:
+            await flow.run_flow(ctx)
+        except Exception as exc:  # noqa: BLE001 - recorded, never re-raised
+            self.logger.error("Plan run %r failed at the flow level: %s", run_id, exc)
+            if record is not None:
+                record.status = "failed"
+                record.finished_at = datetime.now(timezone.utc)
+            self._evict_completed_runs()
+            return
+
+        refs = []
+        for node in plan.nodes:
+            value = ctx.results.get(node.id)
+            if isinstance(value, ArtifactRef):
+                refs.append(value)
+                continue
+            error = ctx.errors.get(node.id)
+            if error is not None:
+                # A hard node failure (retry exhaustion, on_item_error="fail")
+                # never returns an ArtifactRef; synthesize one so the
+                # manifest's counts stay honest instead of silently
+                # dropping the node.
+                refs.append(
+                    ArtifactRef(node_id=node.id, status="error", errors=[str(error)[:300]])
+                )
+
+        duration = time.monotonic() - started_monotonic
+        manifest = build_manifest(plan, refs, duration_seconds=duration)
+
+        if record is not None:
+            record.manifest = manifest
+            record.nodes_done = len(refs)
+            record.finished_at = datetime.now(timezone.utc)
+            if manifest.nodes_failed == 0:
+                record.status = "completed"
+            elif manifest.nodes_ok > 0 or manifest.nodes_skipped > 0:
+                record.status = "partial"
+            else:
+                record.status = "failed"
+
+        self._evict_completed_runs()
+
+    def _evict_completed_runs(self) -> None:
+        """Evict oldest completed/failed runs beyond ``max_completed_runs``.
+
+        In-flight (``status == "running"``) runs are never evicted.
+        """
+        finished = [
+            (run_id, rec)
+            for run_id, rec in self._runs.items()
+            if rec.status != "running"
+        ]
+        overflow = len(finished) - self.max_completed_runs
+        if overflow <= 0:
+            return
+
+        finished.sort(key=lambda pair: pair[1].finished_at or pair[1].started_at)
+        for run_id, _rec in finished[:overflow]:
+            self._runs.pop(run_id, None)
+            self._run_tasks.pop(run_id, None)
+            self._run_contexts.pop(run_id, None)
+            self.logger.debug(
+                "Evicted completed run %r (max_completed_runs=%d)",
+                run_id, self.max_completed_runs,
+            )
+
+    # ── Agent-facing tools ───────────────────────────────────────────────────
+
+    @tool_schema(PlanStatusArgs)
+    async def plan_status(self, run_id: str) -> ToolResult:
+        """Return progress while a plan run executes, or its final manifest."""
+        record = self._runs.get(run_id)
+        if record is None:
+            return ToolResult(
+                status="error",
+                success=False,
+                result=None,
+                error=f"Unknown run_id {run_id!r}. Known: {sorted(self._runs)}",
+            )
+
+        if record.status == "running" or record.manifest is None:
+            summary = RunningSummary(
+                run_id=run_id,
+                plan_name=record.plan_name,
+                nodes_total=record.nodes_total,
+                nodes_done=record.nodes_done,
+            )
+            return ToolResult(status="success", result=summary.model_dump(mode="json"))
+
+        return ToolResult(status="success", result=record.manifest.model_dump(mode="json"))
+
+    @tool_schema(PlanArtifactsArgs)
+    async def plan_artifacts(self, run_id: str) -> ToolResult:
+        """Return the ArtifactRef list a run has produced so far."""
+        record = self._runs.get(run_id)
+        if record is None:
+            return ToolResult(
+                status="error",
+                success=False,
+                result=None,
+                error=f"Unknown run_id {run_id!r}. Known: {sorted(self._runs)}",
+            )
+
+        if record.manifest is not None:
+            artifacts = [ref.model_dump(mode="json") for ref in record.manifest.artifacts]
+        else:
+            ctx = self._run_contexts.get(run_id)
+            artifacts = [
+                value.model_dump(mode="json")
+                for value in (ctx.results.values() if ctx is not None else ())
+                if isinstance(value, ArtifactRef)
+            ]
+
+        return ToolResult(status="success", result={"run_id": run_id, "artifacts": artifacts})

--- a/packages/ai-parrot/tests/bots/flows/plan/test_node.py
+++ b/packages/ai-parrot/tests/bots/flows/plan/test_node.py
@@ -1,0 +1,540 @@
+"""Tests for PlanToolNode — the payload-never-enters-context executor."""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from parrot.bots.flows.plan.facets import estimate_bytes, extract_facets, merge_facets
+from parrot.bots.flows.plan.models import ArtifactRef, FacetSpec, ForEach, PlanNode
+from parrot.bots.flows.plan.node import PlanToolNode, ToolExecutionError, make_tool_node_factory
+
+
+# ── fakes mirroring the real contracts ───────────────────────────────────────
+
+class _Entry:
+    def __init__(self, data: Any) -> None:
+        self.data = data
+
+
+class _Catalog:
+    """Stands in for WorkingMemoryCatalog: a flat dict, overwrite-on-collision."""
+
+    def __init__(self) -> None:
+        self._store: Dict[str, _Entry] = {}
+
+    def get(self, key: str) -> _Entry:
+        if key not in self._store:
+            raise KeyError(f"No entry {key!r}. Available: {sorted(self._store)}")
+        return self._store[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._store
+
+    def __len__(self) -> int:
+        return len(self._store)
+
+
+class _WorkingMemory:
+    def __init__(self) -> None:
+        self._catalog = _Catalog()
+        self.writes: List[str] = []
+
+    async def store_result(self, key: str, data: Any, **_: Any) -> dict:
+        self._catalog._store[key] = _Entry(data)
+        self.writes.append(key)
+        return {"status": "stored"}
+
+
+class _ToolManager:
+    """Records dispatches; returns a payload per tool name."""
+
+    def __init__(self, payloads: Dict[str, Any]) -> None:
+        self._payloads = payloads
+        self.calls: List[tuple[str, Dict[str, Any]]] = []
+        self.max_in_flight = 0
+        self._in_flight = 0
+        self.fail_times: Dict[str, int] = {}
+
+    async def execute_tool(
+        self, tool_name: str, parameters: Dict[str, Any],
+        permission_context: Optional[Any] = None,
+    ) -> Any:
+        self.calls.append((tool_name, dict(parameters)))
+        self._in_flight += 1
+        self.max_in_flight = max(self.max_in_flight, self._in_flight)
+        try:
+            await asyncio.sleep(0)
+            remaining = self.fail_times.get(tool_name, 0)
+            if remaining:
+                self.fail_times[tool_name] = remaining - 1
+                raise RuntimeError(f"transient failure in {tool_name}")
+            payload = self._payloads[tool_name]
+            return payload(parameters) if callable(payload) else payload
+        finally:
+            self._in_flight -= 1
+
+
+class _Ctx:
+    def __init__(self, results: Optional[Dict[str, Any]] = None) -> None:
+        self.results = results or {}
+        self.initial_task = ""
+
+
+def _node(plan_node: PlanNode, manager: _ToolManager, wm: _WorkingMemory) -> PlanToolNode:
+    return PlanToolNode(
+        node_id=plan_node.id,
+        plan_node=plan_node,
+        tool_manager=manager,
+        working_memory=wm,
+    )
+
+
+# ── the central invariant ────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_payload_goes_to_working_memory_not_into_the_result():
+    big = {"findings": [{"id": f"f{i}", "severity": "high"} for i in range(5000)]}
+    wm, manager = _WorkingMemory(), _ToolManager({"get_report": big})
+    node = _node(
+        PlanNode(id="fetch", tool="get_report", store_as="report",
+                 facets=FacetSpec(counts={"n": "findings[]"})),
+        manager, wm,
+    )
+
+    ref = await node.execute(_Ctx())
+
+    assert isinstance(ref, ArtifactRef)
+    assert ref.keys == ["report"]
+    assert ref.facets["n"] == 5000
+    assert wm._catalog.get("report").data is big
+
+    # The published value must stay small: no payload anywhere inside it.
+    published = ref.model_dump_json()
+    assert "f4999" not in published
+    assert len(published) < 1000
+    assert ref.bytes_stored > 100_000
+
+
+@pytest.mark.asyncio
+async def test_dispatch_goes_through_the_tool_manager():
+    # Not tool.execute(): the manager path is what runs result hooks,
+    # dataframe extraction and permission propagation.
+    wm, manager = _WorkingMemory(), _ToolManager({"t": {"ok": True}})
+    node = _node(PlanNode(id="n", tool="t", args={"a": 1}, store_as="k"), manager, wm)
+
+    await node.execute(_Ctx())
+
+    assert manager.calls == [("t", {"a": 1})]
+
+
+# ── guards ───────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_guard_false_skips_without_calling_the_tool():
+    wm, manager = _WorkingMemory(), _ToolManager({"t": {"x": 1}})
+    ctx = _Ctx({"listing": ArtifactRef(node_id="listing", facets={"n": 0})})
+    node = _node(
+        PlanNode(id="n", tool="t", store_as="k", depends_on=["listing"],
+                 when="ctx.artifacts.listing.n > 0"),
+        manager, wm,
+    )
+
+    ref = await node.execute(ctx)
+
+    assert ref.status == "skipped"
+    assert manager.calls == []
+    assert wm.writes == []
+
+
+@pytest.mark.asyncio
+async def test_guard_true_runs():
+    wm, manager = _WorkingMemory(), _ToolManager({"t": {"x": 1}})
+    ctx = _Ctx({"listing": ArtifactRef(node_id="listing", facets={"n": 3})})
+    node = _node(
+        PlanNode(id="n", tool="t", store_as="k", depends_on=["listing"],
+                 when="ctx.artifacts.listing.n > 0"),
+        manager, wm,
+    )
+
+    assert (await node.execute(ctx)).status == "ok"
+    assert len(manager.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_guard_can_branch_on_upstream_status():
+    wm, manager = _WorkingMemory(), _ToolManager({"t": {"x": 1}})
+    ctx = _Ctx({"fetch": ArtifactRef(node_id="fetch", status="error")})
+    node = _node(
+        PlanNode(id="n", tool="t", store_as="k", depends_on=["fetch"],
+                 when='ctx.status.fetch == "ok"'),
+        manager, wm,
+    )
+
+    assert (await node.execute(ctx)).status == "skipped"
+
+
+# ── fan-out ──────────────────────────────────────────────────────────────────
+
+def _fanout_setup(payload_fn=None, **for_each_kw):
+    wm = _WorkingMemory()
+    wm._catalog._store["listing"] = _Entry({"keys": ["a.json", "b.json", "c.json"]})
+    manager = _ToolManager(
+        {"get": payload_fn or (lambda p: {"findings": [{"severity": "high"}],
+                                          "src": p["key"]})}
+    )
+    node = _node(
+        PlanNode(
+            id="fetch", tool="get", args={"key": "{item}"},
+            store_as="report_{index}", depends_on=["listing"],
+            for_each=ForEach(source="{artifacts.listing}", select="keys[]",
+                             **for_each_kw),
+            facets=FacetSpec(group_counts={"by_sev": "findings[].severity"}),
+        ),
+        manager, wm,
+    )
+    ctx = _Ctx({"listing": ArtifactRef(node_id="listing", keys=["listing"])})
+    return node, manager, wm, ctx
+
+
+@pytest.mark.asyncio
+async def test_for_each_expands_over_the_stored_body():
+    node, manager, wm, ctx = _fanout_setup()
+
+    ref = await node.execute(ctx)
+
+    assert ref.item_count == 3
+    assert sorted(ref.keys) == ["report_0", "report_1", "report_2"]
+    assert sorted(c[1]["key"] for c in manager.calls) == ["a.json", "b.json", "c.json"]
+    # Facets merge across items rather than reporting only the last one.
+    assert ref.facets["by_sev"] == {"high": 3}
+
+
+@pytest.mark.asyncio
+async def test_for_each_respects_max_concurrency():
+    node, manager, _, ctx = _fanout_setup(max_concurrency=1)
+    await node.execute(ctx)
+    assert manager.max_in_flight == 1
+
+    node, manager, _, ctx = _fanout_setup(max_concurrency=8)
+    await node.execute(ctx)
+    assert manager.max_in_flight > 1
+
+
+@pytest.mark.asyncio
+async def test_for_each_over_empty_source_does_nothing_rather_than_fanning_out_on_none():
+    wm = _WorkingMemory()
+    wm._catalog._store["listing"] = _Entry({"other": 1})  # no 'keys' at all
+    manager = _ToolManager({"get": {"x": 1}})
+    node = _node(
+        PlanNode(id="fetch", tool="get", args={"key": "{item}"},
+                 store_as="r_{index}", depends_on=["listing"],
+                 for_each=ForEach(source="{artifacts.listing}", select="keys[]")),
+        manager, wm,
+    )
+
+    ref = await node.execute(_Ctx({"listing": ArtifactRef(node_id="listing",
+                                                          keys=["listing"])}))
+
+    assert ref.item_count == 0
+    assert manager.calls == []
+
+
+@pytest.mark.asyncio
+async def test_exceeding_max_items_raises_instead_of_truncating_silently():
+    node, _, _, ctx = _fanout_setup(max_items=2)
+    with pytest.raises(ToolExecutionError, match="above max_items"):
+        await node.execute(ctx)
+
+
+@pytest.mark.asyncio
+async def test_item_errors_are_collected_and_marked_partial():
+    def payload(params):
+        if params["key"] == "b.json":
+            raise RuntimeError("boom")
+        return {"findings": []}
+
+    node, _, wm, ctx = _fanout_setup(payload)
+    ref = await node.execute(ctx)
+
+    assert ref.status == "partial"
+    assert len(ref.keys) == 2
+    assert any("boom" in e for e in ref.errors)
+
+
+@pytest.mark.asyncio
+async def test_on_item_error_fail_propagates():
+    def payload(params):
+        raise RuntimeError("boom")
+
+    node, _, _, ctx = _fanout_setup(payload, on_item_error="fail")
+    with pytest.raises(ToolExecutionError):
+        await node.execute(ctx)
+
+
+@pytest.mark.asyncio
+async def test_skip_existing_makes_a_rerun_idempotent():
+    node, manager, wm, ctx = _fanout_setup()
+    await node.execute(ctx)
+    first = len(manager.calls)
+
+    node2, manager2, _, ctx2 = _fanout_setup()
+    # Same working memory: simulate resuming after a crash with 2 of 3 done.
+    object.__setattr__(node2, "working_memory", wm)
+    wm._catalog._store.pop("report_2")
+    await node2.execute(ctx2)
+
+    assert first == 3
+    assert len(manager2.calls) == 1  # only the missing item re-ran
+
+
+# ── retries ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_retry_recovers_from_a_transient_failure():
+    wm, manager = _WorkingMemory(), _ToolManager({"t": {"ok": True}})
+    manager.fail_times["t"] = 2
+    node = _node(
+        PlanNode(id="n", tool="t", store_as="k",
+                 retry={"max_attempts": 3, "backoff_seconds": 0.0}),
+        manager, wm,
+    )
+
+    assert (await node.execute(_Ctx())).status == "ok"
+    assert len(manager.calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_retry_exhaustion_raises_with_the_last_error():
+    wm, manager = _WorkingMemory(), _ToolManager({"t": {"ok": True}})
+    manager.fail_times["t"] = 5
+    node = _node(
+        PlanNode(id="n", tool="t", store_as="k", retry={"max_attempts": 2}),
+        manager, wm,
+    )
+
+    with pytest.raises(ToolExecutionError, match="after 2 attempt"):
+        await node.execute(_Ctx())
+
+
+# ── argument resolution ──────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_artifact_placeholder_passes_the_body_by_value():
+    body = {"deltas": [1, 2, 3]}
+    wm, manager = _WorkingMemory(), _ToolManager({"t": {"ok": True}})
+    wm._catalog._store["deltas"] = _Entry(body)
+    node = _node(
+        PlanNode(id="n", tool="t", args={"payload": "{artifacts.diff}"},
+                 store_as="k", depends_on=["diff"]),
+        manager, wm,
+    )
+
+    await node.execute(_Ctx({"diff": ArtifactRef(node_id="diff", keys=["deltas"])}))
+
+    assert manager.calls[0][1]["payload"] is body
+
+
+@pytest.mark.asyncio
+async def test_node_placeholder_passes_the_small_ref_not_the_body():
+    wm, manager = _WorkingMemory(), _ToolManager({"t": {"ok": True}})
+    wm._catalog._store["deltas"] = _Entry({"huge": "x" * 10_000})
+    node = _node(
+        PlanNode(id="n", tool="t", args={"ref": "{nodes.diff.output}"},
+                 store_as="k", depends_on=["diff"]),
+        manager, wm,
+    )
+
+    await node.execute(
+        _Ctx({"diff": ArtifactRef(node_id="diff", keys=["deltas"], facets={"n": 3})})
+    )
+
+    passed = manager.calls[0][1]["ref"]
+    assert passed["facets"] == {"n": 3}
+    assert "huge" not in str(passed)
+
+
+@pytest.mark.asyncio
+async def test_missing_artifact_is_a_clear_error():
+    wm, manager = _WorkingMemory(), _ToolManager({"t": {}})
+    node = _node(
+        PlanNode(id="n", tool="t", args={"p": "{artifacts.absent}"},
+                 store_as="k", depends_on=["absent"]),
+        manager, wm,
+    )
+
+    with pytest.raises(ToolExecutionError, match="no working-memory artifact"):
+        await node.execute(_Ctx())
+
+
+@pytest.mark.asyncio
+async def test_item_field_templating_in_key_and_args():
+    wm = _WorkingMemory()
+    wm._catalog._store["src"] = _Entry({"items": [{"id": "alpha"}, {"id": "beta"}]})
+    manager = _ToolManager({"t": {"ok": True}})
+    node = _node(
+        PlanNode(id="n", tool="t", args={"which": "id-{item.id}"},
+                 store_as="out_{item.id}", depends_on=["src"],
+                 for_each=ForEach(source="{artifacts.src}", select="items[]")),
+        manager, wm,
+    )
+
+    ref = await node.execute(_Ctx({"src": ArtifactRef(node_id="src", keys=["src"])}))
+
+    assert sorted(ref.keys) == ["out_alpha", "out_beta"]
+    assert sorted(c[1]["which"] for c in manager.calls) == ["id-alpha", "id-beta"]
+
+
+# ── factory ──────────────────────────────────────────────────────────────────
+
+def test_factory_injects_live_dependencies_through_the_closure():
+    # This is the mechanism that lets the analyst agent read the same catalog
+    # the executor wrote: neither object is serialisable into node config.
+    wm, manager = _WorkingMemory(), _ToolManager({})
+    factory = make_tool_node_factory(manager, wm)
+
+    class _Def:
+        id = "fetch"
+        config = PlanNode(id="fetch", tool="t", store_as="k").model_dump(mode="json")
+
+    node = factory(_Def(), {"listing"}, {"diff"})
+
+    assert node.tool_manager is manager
+    assert node.working_memory is wm
+    assert node.dependencies == {"listing"}
+    assert node.successors == {"diff"}
+    assert node.plan_node.tool == "t"
+
+
+# ── facets ───────────────────────────────────────────────────────────────────
+
+def test_group_counts_are_capped():
+    payload = {"f": [{"k": f"v{i}"} for i in range(100)]}
+    spec = FacetSpec(group_counts={"by_k": "f[].k"}, max_group_keys=5)
+    assert len(extract_facets(payload, spec)["by_k"]) == 5
+
+
+def test_long_string_facets_are_clipped():
+    payload = {"note": "x" * 5000}
+    facets = extract_facets(payload, FacetSpec(paths={"note": "note"}))
+    assert len(facets["note"]) < 300
+
+
+def test_merge_sums_counts_and_merges_groups():
+    spec = FacetSpec(counts={"n": "f[]"}, group_counts={"g": "f[].s"})
+    merged = merge_facets(
+        [{"n": 2, "g": {"high": 2}}, {"n": 3, "g": {"high": 1, "low": 3}}], spec
+    )
+    assert merged == {"n": 5, "g": {"low": 3, "high": 3}}
+
+
+def test_estimate_bytes_never_raises_on_exotic_objects():
+    class _Weird:
+        def __repr__(self) -> str:
+            return "weird"
+
+    assert estimate_bytes(_Weird()) > 0
+    assert estimate_bytes(None) == 0
+    assert estimate_bytes(b"1234") == 4
+
+
+# ── end-to-end over a scheduler stand-in ─────────────────────────────────────
+
+async def _drive(plan, manager, wm):
+    """Execute a plan the way AgentsFlow's scheduler does.
+
+    Mirrors the real contract: fresh nodes, execute(ctx, deps), the return
+    value stored into ctx.results, dependencies before dependents.
+    """
+    from parrot.bots.flows.plan.compile import to_flow_definition
+    from parrot.bots.flows.plan.node import build_manifest, make_tool_node_factory
+
+    fd = to_flow_definition(plan)
+    factory = make_tool_node_factory(manager, wm)
+    by_id = {n.id: n for n in fd.nodes if n.type == "tool"}
+
+    ctx = _Ctx()
+    refs = []
+    for node_id in plan.topological_order():
+        node_def = by_id[node_id]
+        deps = {e.from_ for e in fd.edges if e.to == node_id}
+        node = factory(node_def, deps, set())
+        ref = await node.execute(ctx, {})
+        ctx.results[node_id] = ref     # what mark_completed() stores
+        refs.append(ref)
+    return build_manifest(plan, refs), ctx
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_plan_produces_a_bounded_manifest():
+    from parrot.bots.flows.plan.models import ExecutionPlan
+
+    reports = {
+        "a.json": {"findings": [{"severity": "critical"}, {"severity": "low"}]},
+        "b.json": {"findings": [{"severity": "critical"}]},
+    }
+    plan = ExecutionPlan(
+        name="sweep",
+        objective="Fetch reports and map criticals.",
+        nodes=[
+            PlanNode(id="listing", tool="list_reports", args={"prefix": "p/"},
+                     store_as="listing",
+                     facets=FacetSpec(counts={"n_reports": "keys[]"})),
+            PlanNode(id="fetch", tool="get_report", args={"key": "{item}"},
+                     store_as="report_{index}", depends_on=["listing"],
+                     when="ctx.artifacts.listing.n_reports > 0",
+                     for_each=ForEach(source="{artifacts.listing}", select="keys[]"),
+                     facets=FacetSpec(group_counts={"by_sev": "findings[].severity"})),
+            PlanNode(id="soc2", tool="map_soc2", args={"bodies": "{artifacts.fetch}"},
+                     store_as="mapping", depends_on=["fetch"],
+                     when="ctx.artifacts.fetch.by_sev.critical > 0",
+                     facets=FacetSpec(counts={"n_controls": "controls[]"})),
+        ],
+    )
+    wm = _WorkingMemory()
+    manager = _ToolManager({
+        "list_reports": {"keys": list(reports)},
+        "get_report": lambda p: reports[p["key"]],
+        "map_soc2": lambda p: {"controls": [{"id": "CC6.1"}, {"id": "CC7.2"}]},
+    })
+
+    manifest, ctx = await _drive(plan, manager, wm)
+
+    assert manifest.nodes_ok == 3 and manifest.nodes_skipped == 0
+    assert manifest.artifact("fetch").item_count == 2
+    assert manifest.artifact("fetch").facets["by_sev"] == {"critical": 2, "low": 1}
+    assert manifest.artifact("soc2").facets["n_controls"] == 2
+
+    # Bodies live only in working memory.
+    assert set(wm.writes) == {"listing", "report_0", "report_1", "mapping"}
+    # And the whole manifest stays tiny regardless of payload size.
+    assert len(manifest.model_dump_json()) < 2000
+    assert all(isinstance(v, ArtifactRef) for v in ctx.results.values())
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_guard_skips_downstream_without_failing_the_run():
+    from parrot.bots.flows.plan.models import ExecutionPlan
+
+    plan = ExecutionPlan(
+        name="sweep",
+        objective="Nothing to do when the listing is empty.",
+        nodes=[
+            PlanNode(id="listing", tool="list_reports", args={"prefix": "p/"},
+                     store_as="listing",
+                     facets=FacetSpec(counts={"n_reports": "keys[]"})),
+            PlanNode(id="fetch", tool="get_report", args={"key": "{item}"},
+                     store_as="report_{index}", depends_on=["listing"],
+                     when="ctx.artifacts.listing.n_reports > 0",
+                     for_each=ForEach(source="{artifacts.listing}", select="keys[]")),
+        ],
+    )
+    wm = _WorkingMemory()
+    manager = _ToolManager({"list_reports": {"keys": []}, "get_report": {}})
+
+    manifest, _ = await _drive(plan, manager, wm)
+
+    assert manifest.nodes_skipped == 1
+    assert manifest.nodes_failed == 0
+    assert [c[0] for c in manager.calls] == ["list_reports"]

--- a/packages/ai-parrot/tests/bots/flows/plan/test_plan.py
+++ b/packages/ai-parrot/tests/bots/flows/plan/test_plan.py
@@ -1,0 +1,418 @@
+"""Tests for the ExecutionPlan schema, selector, guards and validator."""
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+import pytest
+from pydantic import BaseModel, Field, ValidationError
+
+from parrot.bots.flows.plan.guards import PlanGuard, compile_guard
+from parrot.bots.flows.plan.models import ExecutionPlan, FacetSpec, ForEach, PlanNode
+from parrot.bots.flows.plan.paths import PathError, render_key, select
+from parrot.bots.flows.plan.validator import validate_plan
+
+
+# ── fakes ────────────────────────────────────────────────────────────────────
+
+class _FilterArgs(BaseModel):
+    prefix: str
+    limit: int = 100
+
+
+class _GetArgs(BaseModel):
+    key: str
+
+
+class _FakeTool:
+    def __init__(self, name: str, schema: type[BaseModel]) -> None:
+        self.name = name
+        self.args_schema = schema
+
+
+class _FakeManager:
+    def __init__(self, tools: dict[str, Any]) -> None:
+        self._tools = tools
+
+    def get_tool(self, tool_name: str) -> Optional[Any]:
+        return self._tools.get(tool_name)
+
+    def list_tools(self) -> List[str]:
+        return list(self._tools)
+
+
+@pytest.fixture
+def manager() -> _FakeManager:
+    return _FakeManager(
+        {
+            "s3_filter_reports": _FakeTool("s3_filter_reports", _FilterArgs),
+            "s3_get_latest_report": _FakeTool("s3_get_latest_report", _GetArgs),
+        }
+    )
+
+
+def _sweep_plan(**overrides: Any) -> ExecutionPlan:
+    nodes = overrides.pop(
+        "nodes",
+        [
+            PlanNode(
+                id="listing",
+                tool="s3_filter_reports",
+                args={"prefix": "prowler/"},
+                store_as="listing",
+                facets=FacetSpec(counts={"n_reports": "keys[]"}),
+            ),
+            PlanNode(
+                id="fetch",
+                tool="s3_get_latest_report",
+                args={"key": "{item}"},
+                store_as="report_{index}",
+                depends_on=["listing"],
+                when="ctx.artifacts.listing.n_reports > 0",
+                for_each=ForEach(source="{artifacts.listing}", select="keys[]"),
+                facets=FacetSpec(group_counts={"by_severity": "findings[].severity"}),
+            ),
+        ],
+    )
+    return ExecutionPlan(
+        name=overrides.pop("name", "daily_sweep"),
+        objective=overrides.pop("objective", "Ingest and diff scanner reports."),
+        nodes=nodes,
+        **overrides,
+    )
+
+
+# ── paths ────────────────────────────────────────────────────────────────────
+
+def test_select_flatten_returns_list():
+    data = {"findings": [{"severity": "critical"}, {"severity": "high"}]}
+    assert select(data, "findings[].severity") == ["critical", "high"]
+
+
+def test_select_scalar_returns_value_not_list():
+    assert select({"metadata": {"scanner": "prowler"}}, "metadata.scanner") == "prowler"
+
+
+def test_select_index_picks_one_element():
+    assert select({"findings": [{"id": "a"}, {"id": "b"}]}, "findings[1].id") == "b"
+
+
+def test_select_missing_path_returns_default_not_raises():
+    assert select({"a": 1}, "b.c", default="fallback") == "fallback"
+
+
+def test_select_flatten_on_missing_key_returns_empty_list():
+    assert select({"a": 1}, "findings[].id") == []
+
+
+def test_malformed_path_raises():
+    with pytest.raises(PathError):
+        select({}, "findings[[]].id")
+
+
+def test_render_key_expands_index_and_item_field():
+    assert render_key("report_{index}", item={"id": "x"}, index=7) == "report_7"
+    assert render_key("report_{item.id}", item={"id": "x"}, index=0) == "report_x"
+
+
+def test_render_key_unresolvable_field_raises():
+    with pytest.raises(PathError):
+        render_key("report_{item.missing}", item={"id": "x"}, index=0)
+
+
+# ── schema invariants ────────────────────────────────────────────────────────
+
+def test_for_each_requires_varying_store_as():
+    with pytest.raises(ValidationError, match="overwrite"):
+        PlanNode(
+            id="fetch",
+            tool="t",
+            store_as="constant_key",
+            depends_on=["listing"],
+            for_each=ForEach(source="{artifacts.listing}"),
+        )
+
+
+def test_item_variable_without_for_each_rejected():
+    with pytest.raises(ValidationError, match="no for_each"):
+        PlanNode(id="fetch", tool="t", store_as="report_{index}")
+
+
+def test_for_each_source_must_be_artifact_reference():
+    with pytest.raises(ValidationError, match="artifacts"):
+        ForEach(source="{nodes.listing.output}")
+
+
+def test_placeholder_target_must_be_declared_dependency():
+    with pytest.raises(ValidationError, match="depends_on"):
+        _sweep_plan(
+            nodes=[
+                PlanNode(id="a", tool="t", store_as="ka"),
+                PlanNode(id="b", tool="t", args={"x": "{artifacts.a}"}, store_as="kb"),
+            ]
+        )
+
+
+def test_duplicate_static_store_as_rejected():
+    with pytest.raises(ValidationError, match="overwrite silently"):
+        _sweep_plan(
+            nodes=[
+                PlanNode(id="a", tool="t", store_as="same"),
+                PlanNode(id="b", tool="t", store_as="same"),
+            ]
+        )
+
+
+def test_cycle_is_named_in_the_error():
+    with pytest.raises(ValidationError, match="Dependency cycle"):
+        _sweep_plan(
+            nodes=[
+                PlanNode(id="a", tool="t", store_as="ka", depends_on=["b"]),
+                PlanNode(id="b", tool="t", store_as="kb", depends_on=["a"]),
+            ]
+        )
+
+
+def test_self_dependency_rejected():
+    with pytest.raises(ValidationError, match="cannot depend on itself"):
+        PlanNode(id="a", tool="t", store_as="ka", depends_on=["a"])
+
+
+def test_topological_order_is_dependency_respecting_and_stable():
+    plan = _sweep_plan(
+        nodes=[
+            PlanNode(id="c", tool="t", store_as="kc", depends_on=["a", "b"]),
+            PlanNode(id="a", tool="t", store_as="ka"),
+            PlanNode(id="b", tool="t", store_as="kb", depends_on=["a"]),
+        ]
+    )
+    order = plan.topological_order()
+    assert order.index("a") < order.index("b") < order.index("c")
+    assert plan.topological_order() == order
+
+
+def test_referenced_nodes_finds_both_placeholder_styles():
+    node = PlanNode(
+        id="x",
+        tool="t",
+        args={"a": "{artifacts.p}", "nested": ["{nodes.q.output}"]},
+        store_as="kx",
+        depends_on=["p", "q"],
+    )
+    assert node.referenced_nodes() == {"p", "q"}
+
+
+def test_plan_cannot_express_an_agent_node():
+    # Recursion (agent -> tool -> flow -> agent) is impossible by type, not
+    # merely forbidden by a validator: PlanNode has no agent_ref field.
+    assert "agent_ref" not in PlanNode.model_fields
+    with pytest.raises(ValidationError):
+        PlanNode(id="a", tool="t", store_as="k", agent_ref="security_agent")
+
+
+# ── validator ────────────────────────────────────────────────────────────────
+
+def test_valid_plan_passes(manager):
+    report = validate_plan(_sweep_plan(), manager)
+    assert report.ok, str(report)
+    assert not report.warnings
+
+
+def test_unknown_tool_is_reported_with_suggestion(manager):
+    plan = _sweep_plan(
+        nodes=[
+            PlanNode(
+                id="listing",
+                tool="s3_filter_report",  # typo: missing 's'
+                args={"prefix": "p/"},
+                store_as="listing",
+            )
+        ]
+    )
+    report = validate_plan(plan, manager)
+    assert not report.ok
+    issue = report.errors[0]
+    assert issue.code == "unknown_tool"
+    assert "s3_filter_reports" in issue.message
+
+
+def test_missing_and_unknown_args_reported(manager):
+    plan = _sweep_plan(
+        nodes=[
+            PlanNode(
+                id="listing",
+                tool="s3_filter_reports",
+                args={"bucket": "x"},  # 'prefix' missing, 'bucket' unknown
+                store_as="listing",
+            )
+        ]
+    )
+    codes = {i.code for i in validate_plan(plan, manager).errors}
+    assert codes == {"missing_args", "unknown_args"}
+
+
+def test_guard_referencing_unpublished_facet_is_an_error(manager):
+    plan = _sweep_plan(
+        nodes=[
+            PlanNode(id="listing", tool="s3_filter_reports",
+                     args={"prefix": "p/"}, store_as="listing"),
+            PlanNode(id="fetch", tool="s3_get_latest_report",
+                     args={"key": "k"}, store_as="report",
+                     depends_on=["listing"],
+                     when="ctx.artifacts.listing.n_reports > 0"),
+        ]
+    )
+    issues = [i for i in validate_plan(plan, manager).errors
+              if i.code == "guard_unknown_facet"]
+    assert issues, "a fail-safe guard on a missing facet must not pass silently"
+
+
+def test_guard_on_non_ancestor_is_an_error(manager):
+    plan = _sweep_plan(
+        nodes=[
+            PlanNode(id="a", tool="s3_filter_reports", args={"prefix": "p/"},
+                     store_as="ka", facets=FacetSpec(counts={"n": "keys[]"})),
+            PlanNode(id="b", tool="s3_filter_reports", args={"prefix": "q/"},
+                     store_as="kb", when="ctx.artifacts.a.n > 0"),
+        ]
+    )
+    codes = {i.code for i in validate_plan(plan, manager).errors}
+    assert "guard_not_upstream" in codes
+
+
+def test_bad_guard_expression_is_reported(manager):
+    plan = _sweep_plan(
+        nodes=[
+            PlanNode(id="listing", tool="s3_filter_reports",
+                     args={"prefix": "p/"}, store_as="listing",
+                     when="ctx.artifacts.listing.n >>> 0"),
+        ]
+    )
+    codes = {i.code for i in validate_plan(plan, manager).errors}
+    assert "bad_guard" in codes
+
+
+def test_count_facet_without_list_marker_is_an_error(manager):
+    plan = _sweep_plan(
+        nodes=[
+            PlanNode(id="listing", tool="s3_filter_reports",
+                     args={"prefix": "p/"}, store_as="listing",
+                     facets=FacetSpec(counts={"n": "keys"})),
+        ]
+    )
+    codes = {i.code for i in validate_plan(plan, manager).errors}
+    assert "count_not_a_list" in codes
+
+
+def test_missing_tool_manager_is_a_warning_not_an_error():
+    report = validate_plan(_sweep_plan(), None)
+    assert report.ok
+    assert [w.code for w in report.warnings] == ["no_tool_manager"]
+
+
+def test_report_lists_every_issue_in_one_pass(manager):
+    plan = _sweep_plan(
+        nodes=[
+            PlanNode(id="a", tool="nope", args={"x": 1}, store_as="ka",
+                     facets=FacetSpec(counts={"n": "keys"})),
+        ]
+    )
+    codes = {i.code for i in validate_plan(plan, manager).errors}
+    assert {"unknown_tool", "count_not_a_list"} <= codes
+
+
+# ── guards ───────────────────────────────────────────────────────────────────
+
+def test_guard_evaluates_against_facets():
+    guard = compile_guard("ctx.artifacts.listing.n_reports > 0")
+    assert isinstance(guard, PlanGuard)
+    assert guard.evaluate({"listing": {"n_reports": 3}}) is True
+    assert guard.evaluate({"listing": {"n_reports": 0}}) is False
+
+
+def test_guard_can_read_status_and_error_count():
+    guard = compile_guard('ctx.status.fetch == "ok" && ctx.errors == 0')
+    assert guard.evaluate({}, {"fetch": "ok"}, 0) is True
+    assert guard.evaluate({}, {"fetch": "error"}, 1) is False
+
+
+def test_guard_is_fail_safe_on_unknown_reference():
+    # Documents the behaviour the validator exists to catch.
+    guard = compile_guard("ctx.artifacts.absent.count > 0")
+    assert guard.evaluate({}) is False
+
+
+def test_no_guard_compiles_to_none():
+    assert compile_guard(None) is None
+    assert compile_guard("   ") is None
+
+
+# ── compile to FlowDefinition ────────────────────────────────────────────────
+
+def test_compiles_to_a_valid_flow_definition():
+    from parrot.bots.flows.plan.compile import END_NODE_ID, PLAN_NODE_TYPE, START_NODE_ID, to_flow_definition
+
+    fd = to_flow_definition(_sweep_plan())
+    by_id = {n.id: n for n in fd.nodes}
+
+    assert by_id[START_NODE_ID].type == "start"
+    assert by_id[END_NODE_ID].type == "end"
+    assert by_id["listing"].type == PLAN_NODE_TYPE
+    # No agent nodes can exist: the plan schema has no agent_ref at all.
+    assert all(n.agent_ref is None for n in fd.nodes)
+
+    pairs = {(e.from_, e.to) for e in fd.edges}
+    assert (START_NODE_ID, "listing") in pairs      # root wired to start
+    assert ("listing", "fetch") in pairs            # depends_on -> edge
+    assert ("fetch", END_NODE_ID) in pairs          # leaf wired to end
+
+
+def test_compiled_edges_are_always_so_a_skipped_node_does_not_block():
+    from parrot.bots.flows.plan.compile import to_flow_definition
+
+    fd = to_flow_definition(_sweep_plan())
+    assert {e.condition for e in fd.edges} == {"always"}
+
+
+def test_node_config_round_trips_through_json():
+    import json
+
+    from parrot.bots.flows.plan.compile import to_flow_definition
+    from parrot.bots.flows.plan.models import PlanNode
+
+    fd = to_flow_definition(_sweep_plan())
+    config = next(n for n in fd.nodes if n.id == "fetch").config
+    restored = PlanNode.model_validate(json.loads(json.dumps(config)))
+
+    assert restored.for_each is not None
+    assert restored.for_each.source == "{artifacts.listing}"
+    assert restored.for_each.select == "keys[]"
+    assert restored.store_as == "report_{index}"
+    assert restored.when == "ctx.artifacts.listing.n_reports > 0"
+
+
+def test_flow_metadata_carries_plan_execution_settings():
+    from parrot.bots.flows.plan.compile import to_flow_definition
+    from parrot.bots.flows.plan.models import PlanMetadata
+
+    plan = _sweep_plan(metadata=PlanMetadata(max_parallel_tasks=32, checkpoint=True))
+    fd = to_flow_definition(plan)
+    assert fd.metadata.max_parallel_tasks == 32
+    assert fd.metadata.checkpoint is True
+    # ArtifactRefs are already small; truncating them would corrupt the manifest.
+    assert fd.metadata.truncation_length is None
+
+
+# ── package landing (TASK-2179) ─────────────────────────────────────────────
+
+def test_public_api_exports():
+    import parrot.bots.flows.plan as plan
+
+    for name in plan.__all__:
+        assert getattr(plan, name, None) is not None
+
+
+def test_tool_not_registered_on_import():
+    from parrot.bots.flows.flow.flow import NODE_REGISTRY
+    import parrot.bots.flows.plan  # noqa: F401
+
+    assert "tool" not in NODE_REGISTRY

--- a/packages/ai-parrot/tests/tools/execution_plan/test_catalog.py
+++ b/packages/ai-parrot/tests/tools/execution_plan/test_catalog.py
@@ -1,0 +1,158 @@
+"""Unit tests for the tool catalog + allowlist validation layering
+(TASK-2182).
+"""
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+import pytest
+from pydantic import BaseModel, Field
+
+from parrot.bots.flows.plan import ExecutionPlan, PlanNode
+from parrot.tools.execution_plan.catalog import (
+    ToolCatalogEntry,
+    build_catalog,
+    check_allowlist,
+    validate_with_allowlist,
+)
+
+
+class _FilterArgs(BaseModel):
+    prefix: str = Field(..., description="S3 key prefix to filter on, quite a long one indeed")
+    limit: int = 100
+
+
+class _FakeTool:
+    def __init__(self, name: str, description: str, args_schema: Optional[type] = None) -> None:
+        self.name = name
+        self.description = description
+        self.args_schema = args_schema
+
+
+class _FakeToolManager:
+    def __init__(self, tools: dict) -> None:
+        self._tools = tools
+
+    def get_tool(self, name: str) -> Optional[Any]:
+        return self._tools.get(name)
+
+    def list_tools(self) -> List[str]:
+        return list(self._tools)
+
+
+@pytest.fixture
+def manager() -> _FakeToolManager:
+    return _FakeToolManager(
+        {
+            "s3_filter_reports": _FakeTool(
+                "s3_filter_reports", "Filter S3 report objects", _FilterArgs
+            ),
+            "s3_get_latest_report": _FakeTool("s3_get_latest_report", "Fetch one report"),
+            "delete_everything": _FakeTool("delete_everything", "Dangerous — not allowlisted"),
+        }
+    )
+
+
+def _sweep_plan(**overrides: Any) -> ExecutionPlan:
+    nodes = overrides.pop(
+        "nodes",
+        [
+            PlanNode(
+                id="listing", tool="s3_filter_reports",
+                args={"prefix": "prowler/"}, store_as="listing",
+            ),
+        ],
+    )
+    return ExecutionPlan(
+        name=overrides.pop("name", "sweep"),
+        objective=overrides.pop("objective", "test plan"),
+        nodes=nodes,
+        **overrides,
+    )
+
+
+class TestBuildCatalog:
+    def test_none_allowlist_is_all_tools(self, manager: _FakeToolManager) -> None:
+        catalog = build_catalog(manager, None)
+        assert [entry.name for entry in catalog] == list(manager.list_tools())
+
+    def test_subset_intersection(self, manager: _FakeToolManager) -> None:
+        catalog = build_catalog(manager, ["s3_get_latest_report", "s3_filter_reports"])
+        # Order-stable relative to tool_manager.list_tools(), not allowlist order.
+        assert [entry.name for entry in catalog] == ["s3_filter_reports", "s3_get_latest_report"]
+
+    def test_unregistered_allowlisted_name_raises(self, manager: _FakeToolManager) -> None:
+        with pytest.raises(ValueError, match="not_a_real_tool"):
+            build_catalog(manager, ["s3_filter_reports", "not_a_real_tool"])
+
+    def test_args_summary_bounded(self, manager: _FakeToolManager) -> None:
+        catalog = build_catalog(manager, ["s3_filter_reports"])
+        entry = catalog[0]
+        assert isinstance(entry, ToolCatalogEntry)
+        names = {arg.name for arg in entry.args_summary}
+        assert names == {"prefix", "limit"}
+        prefix_arg = next(a for a in entry.args_summary if a.name == "prefix")
+        assert prefix_arg.required is True
+        assert len(prefix_arg.description) <= 120
+        limit_arg = next(a for a in entry.args_summary if a.name == "limit")
+        assert limit_arg.required is False
+
+    def test_args_summary_empty_for_untyped_tool(self, manager: _FakeToolManager) -> None:
+        catalog = build_catalog(manager, ["s3_get_latest_report"])
+        assert catalog[0].args_summary == []
+
+
+class TestAllowlistValidation:
+    def test_tool_not_allowed_issue(self, manager: _FakeToolManager) -> None:
+        plan = _sweep_plan(
+            nodes=[
+                PlanNode(
+                    id="wipe", tool="delete_everything", store_as="wipe_result",
+                ),
+            ],
+        )
+        issues = check_allowlist(plan, ["s3_filter_reports", "s3_get_latest_report"])
+        assert len(issues) == 1
+        assert issues[0].code == "tool_not_allowed"
+        assert issues[0].node_id == "wipe"
+
+    def test_allowlist_none_means_no_allowlist_issues(self) -> None:
+        plan = _sweep_plan(
+            nodes=[PlanNode(id="wipe", tool="delete_everything", store_as="k")],
+        )
+        assert check_allowlist(plan, None) == []
+
+    def test_combined_report_single_pass(self, manager: _FakeToolManager) -> None:
+        plan = _sweep_plan(
+            nodes=[
+                # Unknown tool AND not on the allowlist — two independent
+                # issues, both in the same report.
+                PlanNode(id="bad", tool="totally_unregistered", store_as="k"),
+            ],
+        )
+        report = validate_with_allowlist(
+            plan, manager, allowed_tools=["s3_filter_reports"],
+        )
+        codes = {issue.code for issue in report.errors}
+        assert codes == {"unknown_tool", "tool_not_allowed"}
+        assert report.ok is False
+
+    def test_allowlist_none_passes_everything_registered(self, manager: _FakeToolManager) -> None:
+        plan = _sweep_plan(
+            nodes=[PlanNode(id="listing", tool="s3_filter_reports",
+                             args={"prefix": "p/"}, store_as="listing")],
+        )
+        report = validate_with_allowlist(plan, manager, allowed_tools=None)
+        assert report.ok
+
+    def test_registered_but_not_allowlisted_fails_pre_execution(
+        self, manager: _FakeToolManager
+    ) -> None:
+        plan = _sweep_plan(
+            nodes=[PlanNode(id="wipe", tool="delete_everything", store_as="k")],
+        )
+        report = validate_with_allowlist(
+            plan, manager, allowed_tools=["s3_filter_reports"],
+        )
+        assert not report.ok
+        assert any(issue.code == "tool_not_allowed" for issue in report.errors)

--- a/packages/ai-parrot/tests/tools/execution_plan/test_execute_validate.py
+++ b/packages/ai-parrot/tests/tools/execution_plan/test_execute_validate.py
@@ -1,0 +1,307 @@
+"""Unit tests for ``plan_execute``/``plan_validate`` — acquisition front and
+pipeline wiring (TASK-2184).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from parrot.clients.base import AbstractClient
+from parrot.tools.execution_plan.toolkit import ExecutionPlanToolkit
+from parrot.tools.working_memory.tool import WorkingMemoryToolkit
+
+
+class _FakeToolManager:
+    def __init__(self, tools: Dict[str, Any]) -> None:
+        self._tools = tools
+        self.calls: List[tuple] = []
+
+    def get_tool(self, name: str) -> Optional[Any]:
+        return self._tools.get(name)
+
+    def list_tools(self) -> List[str]:
+        return list(self._tools)
+
+    async def execute_tool(
+        self, tool_name: str, parameters: Dict[str, Any],
+        permission_context: Optional[Any] = None,
+    ) -> Any:
+        self.calls.append((tool_name, dict(parameters)))
+        payload = self._tools[tool_name]
+        return payload(parameters) if callable(payload) else payload
+
+
+class _ScriptedPlannerClient(AbstractClient):
+    """AbstractClient double returning scripted `ask()` responses."""
+
+    def __init__(self, responses: List[str], **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._responses = list(responses)
+        self.calls: List[str] = []
+
+    async def get_client(self) -> Any:
+        return self
+
+    async def __aenter__(self) -> "_ScriptedPlannerClient":
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+        return False
+
+    async def ask(self, prompt: str, model: Optional[str] = None, **kwargs: Any) -> Any:
+        self.calls.append(prompt)
+        return SimpleNamespace(output=self._responses.pop(0))
+
+    async def ask_stream(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    async def resume(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    async def invoke(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+
+@pytest.fixture
+def wm_toolkit() -> WorkingMemoryToolkit:
+    return WorkingMemoryToolkit()
+
+
+@pytest.fixture
+def manager() -> _FakeToolManager:
+    return _FakeToolManager({"fast": {"ok": True}})
+
+
+@pytest.fixture
+def plans_dir(tmp_path: Path) -> Path:
+    valid_plan = {
+        "name": "valid_sweep",
+        "objective": "a valid file plan",
+        "nodes": [{"id": "n1", "tool": "fast", "store_as": "k1"}],
+    }
+    (tmp_path / "valid_sweep.json").write_text(json.dumps(valid_plan))
+
+    invalid_plan = {
+        "name": "invalid_sweep",
+        "objective": "references an unregistered tool",
+        "nodes": [{"id": "n1", "tool": "nope_not_registered", "store_as": "k1"}],
+    }
+    (tmp_path / "invalid_sweep.json").write_text(json.dumps(invalid_plan))
+    return tmp_path
+
+
+_VALID_PLAN_JSON = {
+    "name": "authored_plan",
+    "objective": "authored",
+    "nodes": [{"id": "n1", "tool": "fast", "store_as": "k1"}],
+}
+_INVALID_PLAN_JSON = {
+    "name": "authored_plan",
+    "objective": "authored",
+    "nodes": [{"id": "n1", "tool": "nope_not_registered", "store_as": "k1"}],
+}
+
+
+def _toolkit(manager: _FakeToolManager, wm_toolkit: WorkingMemoryToolkit, **kwargs: Any) -> ExecutionPlanToolkit:
+    return ExecutionPlanToolkit(
+        tool_manager=manager, working_memory=wm_toolkit, soft_timeout=5.0, **kwargs
+    )
+
+
+class TestArbitration:
+    async def test_both_sources_error(self, manager, wm_toolkit, plans_dir) -> None:
+        toolkit = _toolkit(manager, wm_toolkit, plans_dir=plans_dir, planner_llm="google:x")
+        result = await toolkit.plan_execute(objective="do x", plan_name="y")
+        assert result.status == "error"
+        assert "exactly one" in result.error
+
+    async def test_neither_source_error(self, manager, wm_toolkit) -> None:
+        toolkit = _toolkit(manager, wm_toolkit)
+        result = await toolkit.plan_execute()
+        assert result.status == "error"
+        assert "exactly one" in result.error
+
+    async def test_objective_without_planner_error(self, manager, wm_toolkit) -> None:
+        toolkit = _toolkit(manager, wm_toolkit)  # no planner_llm configured
+        result = await toolkit.plan_execute(objective="do x")
+        assert result.status == "error"
+        assert "planner_llm" in result.error
+
+    async def test_plan_name_without_plans_dir_error(self, manager, wm_toolkit) -> None:
+        toolkit = _toolkit(manager, wm_toolkit)  # no plans_dir configured
+        result = await toolkit.plan_execute(plan_name="sweep")
+        assert result.status == "error"
+        assert "plans_dir" in result.error
+
+    async def test_params_with_objective_error(self, manager, wm_toolkit) -> None:
+        toolkit = _toolkit(manager, wm_toolkit, planner_llm="google:x")
+        result = await toolkit.plan_execute(objective="do x", params={"date": "2026"})
+        assert result.status == "error"
+        assert "params" in result.error
+
+    async def test_arbitration_checked_before_any_llm_call(
+        self, manager, wm_toolkit, plans_dir
+    ) -> None:
+        client = _ScriptedPlannerClient([json.dumps(_VALID_PLAN_JSON)])
+        toolkit = _toolkit(manager, wm_toolkit, planner_llm=client, plans_dir=plans_dir)
+        await toolkit.plan_execute(objective="do x", plan_name="y")
+        assert client.calls == []
+
+
+class TestPlanExecute:
+    async def test_plan_name_happy_path_manifest(self, manager, wm_toolkit, plans_dir) -> None:
+        toolkit = _toolkit(manager, wm_toolkit, plans_dir=plans_dir)
+        result = await toolkit.plan_execute(plan_name="valid_sweep")
+        assert result.status == "success"
+        assert result.result["nodes_ok"] == 1
+
+    async def test_plan_name_invalid_no_repair_tool_error(self, manager, wm_toolkit, plans_dir) -> None:
+        toolkit = _toolkit(manager, wm_toolkit, plans_dir=plans_dir)
+        result = await toolkit.plan_execute(plan_name="invalid_sweep")
+        assert result.status == "error"
+        assert "invalid" in result.error.lower()
+        assert manager.calls == []  # nothing executed
+
+    async def test_plan_name_load_error_verbatim(self, manager, wm_toolkit, plans_dir) -> None:
+        toolkit = _toolkit(manager, wm_toolkit, plans_dir=plans_dir)
+        result = await toolkit.plan_execute(plan_name="does_not_exist")
+        assert result.status == "error"
+        assert "Unknown plan" in result.error
+
+    async def test_objective_repair_round_then_execute(self, manager, wm_toolkit) -> None:
+        client = _ScriptedPlannerClient(
+            [json.dumps(_INVALID_PLAN_JSON), json.dumps(_VALID_PLAN_JSON)]
+        )
+        toolkit = _toolkit(manager, wm_toolkit, planner_llm=client)
+
+        result = await toolkit.plan_execute(objective="sweep reports")
+
+        assert result.status == "success"
+        assert result.result["nodes_ok"] == 1
+        assert len(client.calls) == 2  # author + exactly one repair
+
+    async def test_objective_repair_exhausted_tool_error(self, manager, wm_toolkit) -> None:
+        client = _ScriptedPlannerClient(
+            [json.dumps(_INVALID_PLAN_JSON), json.dumps(_INVALID_PLAN_JSON)]
+        )
+        toolkit = _toolkit(manager, wm_toolkit, planner_llm=client)
+
+        result = await toolkit.plan_execute(objective="sweep reports")
+
+        assert result.status == "error"
+        assert len(client.calls) == 2  # author + exactly one repair, then give up
+        assert manager.calls == []  # nothing executed
+
+    async def test_partial_manifest_is_success(self, manager, wm_toolkit, tmp_path) -> None:
+        def get(params: Dict[str, Any]) -> Dict[str, Any]:
+            if params["key"] == "b":
+                raise RuntimeError("boom")
+            return {"ok": True}
+
+        manager_with_fanout = _FakeToolManager(
+            {"listing": {"keys": ["a", "b"]}, "get": get}
+        )
+        toolkit = _toolkit(manager_with_fanout, wm_toolkit, plans_dir=tmp_path)
+        plan_json = {
+            "name": "partial-plan",
+            "objective": "induce a partial failure",
+            "nodes": [
+                {"id": "listing", "tool": "listing", "store_as": "listing"},
+                {
+                    "id": "fetch", "tool": "get", "args": {"key": "{item}"},
+                    "store_as": "report_{index}", "depends_on": ["listing"],
+                    "for_each": {"source": "{artifacts.listing}", "select": "keys[]"},
+                },
+            ],
+        }
+        (tmp_path / "partial-plan.json").write_text(json.dumps(plan_json))
+
+        result = await toolkit.plan_execute(plan_name="partial-plan")
+
+        assert result.status == "success"
+        assert result.result["nodes_failed"] >= 1
+
+    async def test_soft_timeout_from_plan_execute_returns_running_summary(
+        self, manager, wm_toolkit, tmp_path
+    ) -> None:
+        def slow(_params: Dict[str, Any]) -> Dict[str, Any]:
+            raise AssertionError("sync callable should not be reached")
+
+        class _SlowManager(_FakeToolManager):
+            async def execute_tool(self, tool_name, parameters, permission_context=None):
+                self.calls.append((tool_name, dict(parameters)))
+                import asyncio
+                await asyncio.sleep(0.3)
+                return {"ok": True}
+
+        slow_manager = _SlowManager({"slow": {"ok": True}})
+        toolkit = ExecutionPlanToolkit(
+            tool_manager=slow_manager, working_memory=wm_toolkit,
+            soft_timeout=0.01, plans_dir=tmp_path,
+        )
+        plan_json = {
+            "name": "slow-plan", "objective": "slow",
+            "nodes": [{"id": "n1", "tool": "slow", "store_as": "k1"}],
+        }
+        (tmp_path / "slow-plan.json").write_text(json.dumps(plan_json))
+
+        result = await toolkit.plan_execute(plan_name="slow-plan")
+
+        assert result.status == "success"
+        assert result.result["status"] == "running"
+        assert "run_id" in result.result
+        import asyncio
+        await asyncio.sleep(0.6)  # let the background run finish
+
+
+class TestPlanValidate:
+    async def test_dry_run_returns_plan_verbatim_and_report(
+        self, manager, wm_toolkit, plans_dir
+    ) -> None:
+        toolkit = _toolkit(manager, wm_toolkit, plans_dir=plans_dir)
+
+        result = await toolkit.plan_validate(plan_name="valid_sweep")
+
+        assert result.status == "success"
+        assert result.result["ok"] is True
+        assert result.result["plan"]["name"] == "valid_sweep"
+        assert result.result["issues"] == []
+
+    async def test_dry_run_reports_invalid_plan_without_erroring(
+        self, manager, wm_toolkit, plans_dir
+    ) -> None:
+        toolkit = _toolkit(manager, wm_toolkit, plans_dir=plans_dir)
+
+        result = await toolkit.plan_validate(plan_name="invalid_sweep")
+
+        assert result.status == "success"
+        assert result.result["ok"] is False
+        assert any(issue["code"] == "unknown_tool" for issue in result.result["issues"])
+
+    async def test_dry_run_never_executes(self, manager, wm_toolkit, plans_dir) -> None:
+        toolkit = _toolkit(manager, wm_toolkit, plans_dir=plans_dir)
+
+        await toolkit.plan_validate(plan_name="valid_sweep")
+
+        assert manager.calls == []
+        assert toolkit._runs == {}
+
+    async def test_dry_run_objective_mode_includes_repair_and_verbatim_plan(
+        self, manager, wm_toolkit
+    ) -> None:
+        client = _ScriptedPlannerClient(
+            [json.dumps(_INVALID_PLAN_JSON), json.dumps(_VALID_PLAN_JSON)]
+        )
+        toolkit = _toolkit(manager, wm_toolkit, planner_llm=client)
+
+        result = await toolkit.plan_validate(objective="sweep reports")
+
+        assert result.status == "success"
+        assert result.result["ok"] is True
+        assert result.result["plan"]["name"] == "authored_plan"
+        assert len(client.calls) == 2
+        assert manager.calls == []

--- a/packages/ai-parrot/tests/tools/execution_plan/test_integration.py
+++ b/packages/ai-parrot/tests/tools/execution_plan/test_integration.py
@@ -1,0 +1,289 @@
+"""End-to-end integration tests for FEAT-419 (TASK-2185).
+
+Proves the whole design holds together: zero LLM tokens during plan
+execution, payloads only in WorkingMemory, `for_each` resumability via
+`skip_existing`, allowlist enforcement, and the `AgentCrew.add_tool_node()`
+regression (crew's own `ToolNode` is untouched by
+`ensure_tool_node_registered(PlanToolNode)`).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock
+
+import pytest
+
+from parrot.bots.flows.crew import AgentCrew, ToolNode
+from parrot.bots.flows.plan import ArtifactRef, ensure_tool_node_registered, PlanToolNode
+from parrot.bots.flows.flow.flow import NODE_REGISTRY
+from parrot.clients.base import AbstractClient
+from parrot.tools.execution_plan.toolkit import ExecutionPlanToolkit
+from parrot.tools.working_memory.tool import WorkingMemoryToolkit
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_EXAMPLE_PLANS_DIR = _REPO_ROOT / "examples" / "plans"
+
+
+# ── Shared fakes ─────────────────────────────────────────────────────────────
+
+
+class _FakeToolManager:
+    """``ToolManagerLike`` fake: get_tool/list_tools/execute_tool, records calls."""
+
+    def __init__(self, tools: Dict[str, Any]) -> None:
+        self._tools = tools
+        self.calls: List[tuple] = []
+
+    def get_tool(self, name: str) -> Optional[Any]:
+        return self._tools.get(name)
+
+    def list_tools(self) -> List[str]:
+        return list(self._tools)
+
+    async def execute_tool(
+        self, tool_name: str, parameters: Dict[str, Any],
+        permission_context: Optional[Any] = None,
+    ) -> Any:
+        self.calls.append((tool_name, dict(parameters)))
+        payload = self._tools[tool_name]
+        return payload(parameters) if callable(payload) else payload
+
+
+class _ScriptedPlannerClient(AbstractClient):
+    """AbstractClient double returning scripted `ask()` responses."""
+
+    def __init__(self, responses: List[str], **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._responses = list(responses)
+        self.calls: List[str] = []
+
+    async def get_client(self) -> Any:
+        return self
+
+    async def __aenter__(self) -> "_ScriptedPlannerClient":
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+        return False
+
+    async def ask(self, prompt: str, model: Optional[str] = None, **kwargs: Any) -> Any:
+        self.calls.append(prompt)
+        return SimpleNamespace(output=self._responses.pop(0))
+
+    async def ask_stream(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    async def resume(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    async def invoke(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+
+@pytest.fixture
+def wm_toolkit() -> WorkingMemoryToolkit:
+    return WorkingMemoryToolkit()
+
+
+async def _s3_filter_reports(scanner: str, date: str) -> Dict[str, Any]:
+    return {"keys": ["r1.json", "r2.json"]}
+
+
+async def _s3_get_latest_report(key: str) -> Dict[str, Any]:
+    return {"findings": [{"severity": "critical"}], "source": key}
+
+
+async def _compare_scans(current: Any, window_days: int) -> Dict[str, Any]:
+    return {"new": [{"id": "f1"}], "resolved": []}
+
+
+async def _map_report_to_soc2(findings: Any) -> Dict[str, Any]:
+    return {"mappings": [{"control_id": "CC6.1"}]}
+
+
+class TestEndToEnd:
+    async def test_basicagent_end_to_end_zero_tokens_in_loop(self, wm_toolkit) -> None:
+        """A real BasicAgent, wired but never asked — the toolkit runs the
+        example plan with zero calls to the agent's own LLM client."""
+        from parrot.bots.agent import BasicAgent
+
+        agent = BasicAgent(name="SweepAgent")
+
+        # Explicit fail-loud guard: the agent's own LLM must never be
+        # touched by plan execution (the feature's headline claim), not
+        # just "never observed to be called".
+        agent.client.ask = AsyncMock(
+            side_effect=AssertionError("agent LLM must never be called during plan execution")
+        )
+
+        for name, fn in (
+            ("s3_filter_reports", _s3_filter_reports),
+            ("s3_get_latest_report", _s3_get_latest_report),
+            ("compare_scans", _compare_scans),
+            ("map_report_to_soc2", _map_report_to_soc2),
+        ):
+            agent.tool_manager.register_tool(
+                name=name, description=name,
+                input_schema={"type": "object", "properties": {}}, function=fn,
+            )
+
+        example_plan_path = _EXAMPLE_PLANS_DIR / "daily_security_sweep.json"
+        assert example_plan_path.exists(), f"missing example plan at {example_plan_path}"
+        example_plan_text = example_plan_path.read_text().replace(
+            "{params.date}", "2026-08-06"
+        )
+        planner = _ScriptedPlannerClient([example_plan_text])
+
+        toolkit = ExecutionPlanToolkit(
+            tool_manager=agent.tool_manager,
+            working_memory=wm_toolkit,
+            planner_llm=planner,
+            soft_timeout=10.0,
+        )
+
+        result = await toolkit.plan_execute(objective="run the daily security sweep")
+
+        assert result.status == "success"
+        # Exactly one authoring call — the example plan is valid as-is, no
+        # repair round needed. Bounded well under the spec's "≤2" ceiling.
+        assert len(planner.calls) == 1
+        # Manifest stays small regardless of the payload sizes it summarizes.
+        manifest_json = json.dumps(result.result)
+        assert len(manifest_json) < 2000
+        # No payload BODY leaked. "critical"/"n_findings"/"findings" all
+        # legitimately appear (the plan's own `objective` text, and small
+        # structural facet names/values) — the report *filename* below is
+        # the actual payload marker: it only exists inside the fake tool's
+        # returned body, never in a facet, node id, or the objective text.
+        assert "r1.json" not in manifest_json
+        assert "r2.json" not in manifest_json
+        assert result.result["nodes_ok"] == 4
+        # BasicAgent's class body is untouched — no monkeypatching of the
+        # class itself (only an instance-level test double on this one
+        # instance's client.ask, guarding the assertion above).
+        assert "plan_execute" not in type(agent).__dict__
+        assert "plan_status" not in type(agent).__dict__
+
+    async def test_300_item_fanout_resumable(self, wm_toolkit) -> None:
+        """A crash mid-run (simulated: half the keys already stored) only
+        re-executes the missing items, via `for_each.skip_existing`."""
+        manager = _FakeToolManager(
+            {
+                "list_items": {"keys": [f"item_{i}" for i in range(300)]},
+                "get_item": {"ok": True},
+            }
+        )
+        toolkit = ExecutionPlanToolkit(
+            tool_manager=manager, working_memory=wm_toolkit, soft_timeout=30.0,
+        )
+        plan_json = {
+            "name": "fanout-300",
+            "objective": "resumable 300-item fan-out",
+            "nodes": [
+                {"id": "listing", "tool": "list_items", "store_as": "listing"},
+                {
+                    "id": "fetch", "tool": "get_item", "args": {"key": "{item}"},
+                    "store_as": "report_{index}", "depends_on": ["listing"],
+                    "for_each": {"source": "{artifacts.listing}", "select": "keys[]"},
+                },
+            ],
+        }
+
+        # Simulate a prior run that died after storing 150 of 300 items.
+        for i in range(150):
+            wm_toolkit._catalog.put_generic(f"report_{i}", {"ok": True})
+
+        from parrot.bots.flows.plan import ExecutionPlan
+
+        plan = ExecutionPlan.model_validate(plan_json)
+        result = await toolkit._run_plan(plan, source="plan_name")
+
+        assert result.status == "success"
+        assert result.result["nodes_ok"] == 2  # listing + fetch, both fully "ok"
+        # Only the 150 missing items were actually dispatched.
+        get_item_calls = [c for c in manager.calls if c[0] == "get_item"]
+        assert len(get_item_calls) == 150
+        # The fan-out node's manifest artifact still reports all 300 items.
+        run_id = next(iter(toolkit._runs))
+        fetch_ref = next(
+            ref for ref in toolkit._runs[run_id].manifest.artifacts if ref.node_id == "fetch"
+        )
+        assert fetch_ref.item_count == 300
+        assert len(fetch_ref.keys) == 300
+
+    async def test_no_payload_in_flowcontext_results(self, wm_toolkit) -> None:
+        """Every `ctx.results` value for a plan node is an ArtifactRef."""
+        big_payload = {"findings": [{"id": i} for i in range(500)]}
+        manager = _FakeToolManager({"fast": big_payload})
+        toolkit = ExecutionPlanToolkit(
+            tool_manager=manager, working_memory=wm_toolkit, soft_timeout=5.0,
+        )
+        from parrot.bots.flows.plan import ExecutionPlan, PlanNode
+
+        plan = ExecutionPlan(
+            name="single", objective="single node",
+            nodes=[PlanNode(id="n1", tool="fast", store_as="k1")],
+        )
+
+        await toolkit._run_plan(plan, source="plan_name")
+        run_id = next(iter(toolkit._runs))
+        ctx = toolkit._run_contexts[run_id]
+
+        plan_node_ids = {node.id for node in plan.nodes}
+        for node_id, value in ctx.results.items():
+            if node_id in plan_node_ids:
+                assert isinstance(value, ArtifactRef)
+        assert "findings" not in str(ctx.results)
+
+    async def test_agentcrew_add_tool_node_regression(self) -> None:
+        """`ensure_tool_node_registered(PlanToolNode)` must not affect
+        `AgentCrew.add_tool_node()`, which builds crew's own `ToolNode`
+        directly — never through `NODE_REGISTRY`."""
+        from _crew_test_helpers import DummyAgent, DummyTool  # noqa: PLC0415
+
+        ensure_tool_node_registered(PlanToolNode)
+        assert NODE_REGISTRY["tool"] is PlanToolNode
+
+        crew = AgentCrew(
+            name="RegressionCrew", agents=[DummyAgent("a")],
+            auto_configure=False, persist_results=False,
+            enable_execution_wiki=False,
+        )
+        tool = DummyTool("fetcher", result="REGRESSION-PAYLOAD")
+        node = crew.add_tool_node(tool, "fetch")
+
+        assert isinstance(node, ToolNode)
+        assert not isinstance(node, PlanToolNode)
+
+        result = await crew.run_sequential(
+            "start", agent_sequence=["a", "fetch"], generate_summary=False,
+        )
+        assert result.status == "completed"
+        assert len(tool.calls) == 1
+
+    async def test_allowlist_blocks_before_execution(self, wm_toolkit, tmp_path) -> None:
+        """A plan naming a registered-but-not-allowlisted tool never runs,
+        exercised end-to-end through `plan_execute(plan_name=...)`."""
+        manager = _FakeToolManager(
+            {"safe_tool": {"ok": True}, "dangerous_tool": {"ok": True}}
+        )
+        toolkit = ExecutionPlanToolkit(
+            tool_manager=manager, working_memory=wm_toolkit,
+            allowed_tools=["safe_tool"], plans_dir=tmp_path, soft_timeout=5.0,
+        )
+        plan_json = {
+            "name": "blocked-plan",
+            "objective": "uses a non-allowlisted tool",
+            "nodes": [{"id": "n1", "tool": "dangerous_tool", "store_as": "k1"}],
+        }
+        (tmp_path / "blocked-plan.json").write_text(json.dumps(plan_json))
+
+        result = await toolkit.plan_execute(plan_name="blocked-plan")
+
+        assert result.status == "error"
+        assert "invalid" in result.error.lower()
+        assert manager.calls == []
+        assert toolkit._runs == {}

--- a/packages/ai-parrot/tests/tools/execution_plan/test_planner.py
+++ b/packages/ai-parrot/tests/tools/execution_plan/test_planner.py
@@ -1,0 +1,181 @@
+"""Unit tests for ``PlanPlanner`` and ``resolve_planner_client`` (TASK-2183).
+
+The canned client double is a real ``AbstractClient`` subclass (so
+``isinstance`` checks in ``resolve_planner_client`` pass) with every
+abstract method stubbed and ``ask()`` returning scripted responses — no
+network, no real provider.
+"""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any, List, Optional
+
+import pytest
+
+from parrot.bots.flows.plan import ExecutionPlan
+from parrot.bots.flows.plan.validator import validate_plan
+from parrot.clients.base import AbstractClient
+from parrot.clients.claude import AnthropicClient
+from parrot.tools.execution_plan.catalog import ToolCatalogEntry
+from parrot.tools.execution_plan.planner import (
+    PlanAuthoringError,
+    PlanPlanner,
+    resolve_planner_client,
+)
+
+_VALID_PLAN = {
+    "name": "sweep",
+    "objective": "test objective",
+    "nodes": [
+        {"id": "n1", "tool": "s3_filter_reports", "store_as": "k1"},
+    ],
+}
+
+
+class _FakeClient(AbstractClient):
+    """Minimal AbstractClient double: scripted ask() responses, no network."""
+
+    def __init__(self, responses: List[str], **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._responses = list(responses)
+        self.calls: List[str] = []
+
+    async def get_client(self) -> Any:
+        return self
+
+    async def __aenter__(self) -> "_FakeClient":
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+        return False
+
+    async def ask(self, prompt: str, model: Optional[str] = None, **kwargs: Any) -> Any:
+        self.calls.append(prompt)
+        text = self._responses.pop(0)
+        return SimpleNamespace(output=text)
+
+    async def ask_stream(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    async def resume(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    async def invoke(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+
+def _catalog() -> List[ToolCatalogEntry]:
+    return [ToolCatalogEntry(name="s3_filter_reports", description="List reports", args_summary=[])]
+
+
+class TestResolvePlannerClient:
+    def test_provider_model_string(self) -> None:
+        client = resolve_planner_client("google:gemini-2.5-flash")
+        assert client.model == "gemini-2.5-flash"
+
+    def test_instance_passthrough(self) -> None:
+        instance = _FakeClient(["{}"])
+        assert resolve_planner_client(instance) is instance
+
+    def test_class_passthrough_instantiates(self) -> None:
+        client = resolve_planner_client(AnthropicClient)
+        assert isinstance(client, AnthropicClient)
+
+    def test_dict_config(self) -> None:
+        client = resolve_planner_client(
+            {"name": "openai", "model": "gpt-5", "temperature": 0.2}
+        )
+        assert client.model == "gpt-5"
+        assert client.temperature == 0.2
+
+    def test_dict_config_provider_model_in_name(self) -> None:
+        client = resolve_planner_client({"llm": "anthropic:claude-sonnet-5"})
+        assert client.model == "claude-sonnet-5"
+
+    def test_invalid_format_raises(self) -> None:
+        with pytest.raises(ValueError, match="planner_llm must be one of"):
+            resolve_planner_client(123)  # type: ignore[arg-type]
+
+    def test_dict_missing_provider_raises(self) -> None:
+        with pytest.raises(ValueError, match="name.*llm.*provider"):
+            resolve_planner_client({"model": "x"})
+
+    def test_dict_unsupported_provider_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported"):
+            resolve_planner_client({"name": "not-a-real-provider"})
+
+
+class TestPlanPlanner:
+    async def test_author_valid_plan(self) -> None:
+        client = _FakeClient([json.dumps(_VALID_PLAN)])
+        planner = PlanPlanner(client, _catalog())
+
+        plan = await planner.author("sweep reports")
+
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.name == "sweep"
+        assert len(client.calls) == 1
+
+    async def test_author_invalid_json_raises_typed(self) -> None:
+        client = _FakeClient(["not json at all {"])
+        planner = PlanPlanner(client, _catalog())
+
+        with pytest.raises(PlanAuthoringError, match="not valid JSON"):
+            await planner.author("sweep reports")
+
+    async def test_author_schema_invalid_raises_typed(self) -> None:
+        # Valid JSON, but fails ExecutionPlan's own validators (no nodes).
+        client = _FakeClient([json.dumps({"name": "x", "objective": "y", "nodes": []})])
+        planner = PlanPlanner(client, _catalog())
+
+        with pytest.raises(PlanAuthoringError, match="failed ExecutionPlan validation"):
+            await planner.author("sweep reports")
+
+    async def test_author_strips_markdown_fence(self) -> None:
+        fenced = f"```json\n{json.dumps(_VALID_PLAN)}\n```"
+        client = _FakeClient([fenced])
+        planner = PlanPlanner(client, _catalog())
+
+        plan = await planner.author("sweep reports")
+        assert plan.name == "sweep"
+
+    async def test_repair_embeds_report_and_returns_plan(self) -> None:
+        bad_plan = {
+            "name": "sweep",
+            "objective": "test",
+            "nodes": [{"id": "n1", "tool": "unknown_tool", "store_as": "k1"}],
+        }
+        report = validate_plan(ExecutionPlan.model_validate(bad_plan), tool_manager=None)
+
+        client = _FakeClient([json.dumps(_VALID_PLAN)])
+        planner = PlanPlanner(client, _catalog())
+
+        plan = await planner.repair(bad_plan, report)
+
+        assert isinstance(plan, ExecutionPlan)
+        assert len(client.calls) == 1
+        # The repair prompt must embed the report text verbatim.
+        assert str(report) in client.calls[0]
+        assert json.dumps(bad_plan) in client.calls[0]
+
+    async def test_single_call_per_round(self) -> None:
+        client = _FakeClient([json.dumps(_VALID_PLAN), json.dumps(_VALID_PLAN)])
+        planner = PlanPlanner(client, _catalog())
+
+        await planner.author("objective one")
+        assert len(client.calls) == 1
+
+        report = validate_plan(ExecutionPlan.model_validate(_VALID_PLAN), tool_manager=None)
+        await planner.repair(_VALID_PLAN, report)
+        assert len(client.calls) == 2
+
+    async def test_no_default_model_anywhere(self) -> None:
+        import parrot.tools.execution_plan.planner as planner_module
+
+        source = planner_module.__file__
+        with open(source, encoding="utf-8") as fh:
+            text = fh.read()
+        assert "anthropic:claude" not in text.lower()
+        assert "gpt-" not in text.lower()
+        assert "gemini" not in text.lower()

--- a/packages/ai-parrot/tests/tools/execution_plan/test_store.py
+++ b/packages/ai-parrot/tests/tools/execution_plan/test_store.py
@@ -1,0 +1,154 @@
+"""Unit tests for ``PlanFileStore`` — plans_dir loader with load-time
+``{params.<name>}`` substitution (TASK-2181).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from parrot.bots.flows.plan import ExecutionPlan
+from parrot.tools.execution_plan.store import PlanFileStore, PlanLoadError
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_EXAMPLE_PLAN = _REPO_ROOT / "examples" / "plans" / "daily_security_sweep.json"
+
+
+@pytest.fixture
+def plans_dir(tmp_path: Path) -> Path:
+    """Writes daily_security_sweep.{yaml,json} with {params.date}."""
+    yaml_plan = {
+        "name": "daily_security_sweep",
+        "objective": "yaml variant",
+        "nodes": [
+            {
+                "id": "listing",
+                "tool": "s3_filter_reports",
+                "args": {"date": "{params.date}", "note": "sweep on {params.date}"},
+                "store_as": "listing",
+            }
+        ],
+    }
+    (tmp_path / "daily_security_sweep.yaml").write_text(yaml.safe_dump(yaml_plan))
+
+    json_plan = {
+        "name": "json_variant",
+        "objective": "json variant",
+        "nodes": [
+            {
+                "id": "n1",
+                "tool": "t",
+                "args": {"limit": "{params.limit}"},
+                "store_as": "k1",
+            }
+        ],
+    }
+    (tmp_path / "json_variant.json").write_text(json.dumps(json_plan))
+
+    mixed_plan = {
+        "name": "mixed_placeholders",
+        "objective": "mixes load-time and runtime placeholders",
+        "nodes": [
+            {
+                "id": "a",
+                "tool": "t",
+                "args": {"scope": "{params.scope}"},
+                "store_as": "ka",
+            },
+            {
+                "id": "b",
+                "tool": "t",
+                "args": {
+                    "prior": "{artifacts.a}",
+                    "current": "{item}",
+                    "pos": "{index}",
+                    "scope": "{params.scope}",
+                },
+                "store_as": "kb_{index}",
+                "depends_on": ["a"],
+                "for_each": {"source": "{artifacts.a}"},
+            },
+        ],
+    }
+    (tmp_path / "mixed_placeholders.json").write_text(json.dumps(mixed_plan))
+
+    unused_plan = {
+        "name": "no_placeholders",
+        "objective": "no placeholders at all",
+        "nodes": [{"id": "n1", "tool": "t", "store_as": "k1"}],
+    }
+    (tmp_path / "no_placeholders.json").write_text(json.dumps(unused_plan))
+
+    return tmp_path
+
+
+class TestPlanFileStore:
+    def test_loads_yaml_and_json(self, plans_dir: Path) -> None:
+        store = PlanFileStore(plans_dir)
+
+        yaml_result = store.load("daily_security_sweep", params={"date": "2026-08-06"})
+        assert isinstance(yaml_result, ExecutionPlan)
+        assert yaml_result.name == "daily_security_sweep"
+
+        json_result = store.load("json_variant", params={"limit": 5})
+        assert isinstance(json_result, ExecutionPlan)
+        assert json_result.name == "json_variant"
+
+    def test_exact_placeholder_native_value(self, plans_dir: Path) -> None:
+        store = PlanFileStore(plans_dir)
+        plan = store.load("json_variant", params={"limit": 5})
+        assert plan.node("n1").args["limit"] == 5  # int, not "5"
+
+    def test_embedded_placeholder_interpolates(self, plans_dir: Path) -> None:
+        store = PlanFileStore(plans_dir)
+        plan = store.load("daily_security_sweep", params={"date": "2026-08-06"})
+        assert plan.node("listing").args["note"] == "sweep on 2026-08-06"
+        assert plan.node("listing").args["date"] == "2026-08-06"
+
+    def test_missing_param_raises(self, plans_dir: Path) -> None:
+        store = PlanFileStore(plans_dir)
+        with pytest.raises(PlanLoadError, match="missing params"):
+            store.load("daily_security_sweep", params={})
+
+    def test_unused_param_raises(self, plans_dir: Path) -> None:
+        store = PlanFileStore(plans_dir)
+        with pytest.raises(PlanLoadError, match="unused params"):
+            store.load("no_placeholders", params={"date": "2026-08-06"})
+
+    def test_unknown_plan_lists_available(self, plans_dir: Path) -> None:
+        store = PlanFileStore(plans_dir)
+        with pytest.raises(PlanLoadError, match="Available"):
+            store.load("does_not_exist")
+
+    def test_runtime_placeholders_untouched(self, plans_dir: Path) -> None:
+        store = PlanFileStore(plans_dir)
+        plan = store.load("mixed_placeholders", params={"scope": "prod"})
+
+        node_b = plan.node("b")
+        assert node_b.args["prior"] == "{artifacts.a}"
+        assert node_b.args["current"] == "{item}"
+        assert node_b.args["pos"] == "{index}"
+        assert node_b.args["scope"] == "prod"
+        assert plan.node("a").args["scope"] == "prod"
+
+    def test_migrated_example_loads(self) -> None:
+        assert _EXAMPLE_PLAN.exists(), f"missing example plan at {_EXAMPLE_PLAN}"
+        raw_text = _EXAMPLE_PLAN.read_text()
+        assert "{input}" not in raw_text
+
+        store = PlanFileStore(_EXAMPLE_PLAN.parent)
+        plan = store.load("daily_security_sweep", params={"date": "2026-08-06"})
+        assert plan.name == "daily_security_sweep"
+        assert plan.node("listing").args["date"] == "2026-08-06"
+
+    def test_no_params_placeholder_survives_load(self, plans_dir: Path) -> None:
+        store = PlanFileStore(plans_dir)
+        plan = store.load("mixed_placeholders", params={"scope": "prod"})
+        dumped = plan.model_dump_json()
+        assert "{params." not in dumped
+
+    def test_nonexistent_plans_dir_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(PlanLoadError):
+            PlanFileStore(tmp_path / "does-not-exist")

--- a/packages/ai-parrot/tests/tools/execution_plan/test_store.py
+++ b/packages/ai-parrot/tests/tools/execution_plan/test_store.py
@@ -152,3 +152,41 @@ class TestPlanFileStore:
     def test_nonexistent_plans_dir_raises(self, tmp_path: Path) -> None:
         with pytest.raises(PlanLoadError):
             PlanFileStore(tmp_path / "does-not-exist")
+
+    def test_path_traversal_rejected(self, tmp_path: Path) -> None:
+        """`plan_name` is agent/LLM-controlled — must never escape plans_dir."""
+        outside_dir = tmp_path.parent / "outside_dir_for_traversal_test"
+        outside_dir.mkdir(exist_ok=True)
+        secret_plan = {
+            "name": "leaked-plan", "objective": "outside plans_dir",
+            "nodes": [{"id": "n1", "tool": "t", "store_as": "k1"}],
+        }
+        (outside_dir / "secret.json").write_text(json.dumps(secret_plan))
+
+        plans_dir = tmp_path / "plans"
+        plans_dir.mkdir()
+        store = PlanFileStore(plans_dir)
+
+        for traversal_name in ("../outside_dir_for_traversal_test/secret", "../../etc/passwd", "sub/dir"):
+            with pytest.raises(PlanLoadError, match="Invalid plan_name"):
+                store.load(traversal_name)
+
+    def test_malformed_json_raises_plan_load_error_not_raw_exception(
+        self, tmp_path: Path
+    ) -> None:
+        """A corrupt plan file must surface as PlanLoadError, never a raw
+        JSONDecodeError/YAMLError escaping the store's public API."""
+        plans_dir = tmp_path
+        (plans_dir / "broken.json").write_text("{ this is not valid json !!")
+        store = PlanFileStore(plans_dir)
+
+        with pytest.raises(PlanLoadError, match="not valid"):
+            store.load("broken")
+
+    def test_malformed_yaml_raises_plan_load_error(self, tmp_path: Path) -> None:
+        plans_dir = tmp_path
+        (plans_dir / "broken.yaml").write_text("key: [unterminated\n  - nested: :::")
+        store = PlanFileStore(plans_dir)
+
+        with pytest.raises(PlanLoadError, match="not valid"):
+            store.load("broken")

--- a/packages/ai-parrot/tests/tools/execution_plan/test_toolkit_core.py
+++ b/packages/ai-parrot/tests/tools/execution_plan/test_toolkit_core.py
@@ -135,6 +135,68 @@ class TestExecutorPath:
         assert result.status == "success"
         assert result.result["nodes_failed"] >= 1
 
+    async def test_hard_failed_node_downstream_dependent_shows_as_error(
+        self, wm_toolkit
+    ):
+        """A hard (non-`for_each`) node failure must not silently drop its
+        downstream dependent from the manifest — every plan node must be
+        accounted for, even one the scheduler never dispatched."""
+
+        def fail(_params: Dict[str, Any]) -> Dict[str, Any]:
+            raise RuntimeError("boom")
+
+        manager = _FakeToolManager({"fail_tool": fail, "ok_tool": {"ok": True}})
+        toolkit = ExecutionPlanToolkit(
+            tool_manager=manager, working_memory=wm_toolkit, soft_timeout=5.0,
+        )
+        plan = ExecutionPlan(
+            name="linear-hard-failure",
+            objective="n1 fails hard; n2 depends on it",
+            nodes=[
+                PlanNode(id="n1", tool="fail_tool", store_as="k1"),
+                PlanNode(id="n2", tool="ok_tool", store_as="k2", depends_on=["n1"]),
+            ],
+        )
+
+        result = await toolkit._run_plan(plan, source="plan_name")
+
+        assert result.status == "success"
+        assert result.result["nodes_total"] == 2
+        node_ids = {ref["node_id"] for ref in result.result["artifacts"]}
+        assert node_ids == {"n1", "n2"}  # n2 must not vanish
+        n2_ref = next(r for r in result.result["artifacts"] if r["node_id"] == "n2")
+        assert n2_ref["status"] == "error"
+        assert result.result["nodes_failed"] == 2
+        # ok_tool (n2's tool) was never actually dispatched.
+        assert not any(c[0] == "ok_tool" for c in manager.calls)
+
+    async def test_checkpoint_disabled_no_redis_dependency(self, wm_toolkit):
+        """The toolkit must disable AgentsFlow's flow-level checkpointing —
+        it defaults to requiring a live checkpoint store (Redis) before the
+        first node ever dispatches, contradicting v1's pure-in-RAM design."""
+        from unittest.mock import patch
+
+        manager = _FakeToolManager({"fast": {"ok": True}})
+        toolkit = ExecutionPlanToolkit(
+            tool_manager=manager, working_memory=wm_toolkit, soft_timeout=5.0,
+        )
+        plan = ExecutionPlan(
+            name="no-checkpoint-plan", objective="must not touch a checkpoint store",
+            nodes=[PlanNode(id="n1", tool="fast", store_as="k1")],
+        )
+
+        with patch(
+            "parrot.bots.flows.flow.flow.get_checkpoint_store",
+            side_effect=AssertionError(
+                "get_checkpoint_store must never be called — checkpointing "
+                "must be disabled for plan runs"
+            ),
+        ):
+            result = await toolkit._run_plan(plan, source="plan_name")
+
+        assert result.status == "success"
+        assert result.result["nodes_ok"] == 1
+
     async def test_payloads_only_in_working_memory(self, wm_toolkit):
         big_payload = {"findings": [{"id": i} for i in range(1000)]}
         manager = _FakeToolManager({"fast": big_payload})

--- a/packages/ai-parrot/tests/tools/execution_plan/test_toolkit_core.py
+++ b/packages/ai-parrot/tests/tools/execution_plan/test_toolkit_core.py
@@ -1,0 +1,232 @@
+"""Unit tests for ExecutionPlanToolkit's core executor path and run registry.
+
+TASK-2180 scope: constructor wiring, `_run_plan`, `plan_status`,
+`plan_artifacts`, and run-registry bounds. Plan acquisition
+(`plan_execute`/`plan_validate`) is TASK-2184 — these tests call
+`_run_plan` directly with programmatically built `ExecutionPlan`s.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from parrot.bots.flows.plan import ArtifactRef, ExecutionPlan, ForEach, PlanNode
+from parrot.bots.flows.flow.flow import NODE_REGISTRY
+from parrot.tools.execution_plan.toolkit import ExecutionPlanToolkit
+from parrot.tools.working_memory.tool import WorkingMemoryToolkit
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeToolManager:
+    """``ToolManagerLike`` fake: get_tool/list_tools/execute_tool, records calls."""
+
+    def __init__(
+        self,
+        tools: Dict[str, Any],
+        *,
+        delays: Optional[Dict[str, float]] = None,
+    ) -> None:
+        self._tools = tools
+        self._delays = delays or {}
+        self.calls: List[tuple] = []
+
+    def get_tool(self, name: str) -> Optional[Any]:
+        return object() if name in self._tools else None
+
+    def list_tools(self) -> List[str]:
+        return list(self._tools)
+
+    async def execute_tool(
+        self, tool_name: str, parameters: Dict[str, Any],
+        permission_context: Optional[Any] = None,
+    ) -> Any:
+        self.calls.append((tool_name, dict(parameters)))
+        delay = self._delays.get(tool_name)
+        if delay:
+            await asyncio.sleep(delay)
+        payload = self._tools[tool_name]
+        return payload(parameters) if callable(payload) else payload
+
+
+@pytest.fixture
+def wm_toolkit() -> WorkingMemoryToolkit:
+    """Real WorkingMemoryToolkit over an in-memory catalog."""
+    return WorkingMemoryToolkit()
+
+
+def _single_node_plan(tool: str = "fast", node_id: str = "n1") -> ExecutionPlan:
+    return ExecutionPlan(
+        name="single-node-plan",
+        objective="unit test plan",
+        nodes=[PlanNode(id=node_id, tool=tool, store_as=f"{node_id}_out")],
+    )
+
+
+class TestExecutorPath:
+    async def test_toolkit_constructible_with_only_required_deps(self, wm_toolkit):
+        toolkit = ExecutionPlanToolkit(
+            tool_manager=_FakeToolManager({}), working_memory=wm_toolkit,
+        )
+        assert toolkit.soft_timeout == 60.0
+        assert toolkit.allowed_tools is None
+        assert toolkit.plans_dir is None
+
+    async def test_manifest_within_soft_timeout(self, wm_toolkit):
+        manager = _FakeToolManager({"fast": {"x": 1}})
+        toolkit = ExecutionPlanToolkit(
+            tool_manager=manager, working_memory=wm_toolkit, soft_timeout=5.0,
+        )
+        plan = _single_node_plan(tool="fast")
+
+        result = await toolkit._run_plan(plan, source="plan_name")
+
+        assert result.status == "success"
+        assert result.result["nodes_total"] == 1
+        assert result.result["nodes_ok"] == 1
+        assert manager.calls == [("fast", {})]
+
+    async def test_soft_timeout_returns_running_summary_and_completes(self, wm_toolkit):
+        manager = _FakeToolManager({"slow": {"ok": True}}, delays={"slow": 0.3})
+        toolkit = ExecutionPlanToolkit(
+            tool_manager=manager, working_memory=wm_toolkit, soft_timeout=0.01,
+        )
+        plan = _single_node_plan(tool="slow")
+
+        result = await toolkit._run_plan(plan, source="plan_name")
+
+        assert result.result["status"] == "running"
+        run_id = result.result["run_id"]
+
+        # Let the background run finish.
+        await asyncio.sleep(0.6)
+
+        status_result = await toolkit.plan_status(run_id=run_id)
+        assert status_result.result["nodes_ok"] == 1
+        assert status_result.result["nodes_total"] == 1
+
+    async def test_partial_failure_is_manifest_not_exception(self, wm_toolkit):
+        def get(params: Dict[str, Any]) -> Dict[str, Any]:
+            if params["key"] == "b":
+                raise RuntimeError("boom")
+            return {"ok": True}
+
+        manager = _FakeToolManager({"listing": {"keys": ["a", "b"]}, "get": get})
+        toolkit = ExecutionPlanToolkit(
+            tool_manager=manager, working_memory=wm_toolkit, soft_timeout=5.0,
+        )
+        plan = ExecutionPlan(
+            name="partial-plan",
+            objective="induce a partial failure",
+            nodes=[
+                PlanNode(id="listing", tool="listing", store_as="listing"),
+                PlanNode(
+                    id="fetch", tool="get", args={"key": "{item}"},
+                    store_as="report_{index}", depends_on=["listing"],
+                    for_each=ForEach(source="{artifacts.listing}", select="keys[]"),
+                ),
+            ],
+        )
+
+        result = await toolkit._run_plan(plan, source="plan_name")
+
+        assert result.status == "success"
+        assert result.result["nodes_failed"] >= 1
+
+    async def test_payloads_only_in_working_memory(self, wm_toolkit):
+        big_payload = {"findings": [{"id": i} for i in range(1000)]}
+        manager = _FakeToolManager({"fast": big_payload})
+        toolkit = ExecutionPlanToolkit(
+            tool_manager=manager, working_memory=wm_toolkit, soft_timeout=5.0,
+        )
+        plan = _single_node_plan(tool="fast")
+
+        result = await toolkit._run_plan(plan, source="plan_name")
+        run_id = next(iter(toolkit._runs))
+
+        ctx = toolkit._run_contexts[run_id]
+        tool_ref = ctx.results["n1"]
+        assert isinstance(tool_ref, ArtifactRef)
+        assert tool_ref.keys == ["n1_out"]
+        # The payload body lives only in working memory — never in
+        # ctx.results (checked against the whole context, not just the
+        # tool node's own ArtifactRef) nor in the bounded manifest response.
+        assert "findings" not in str(ctx.results)
+        assert len(str(result.result)) < 1000
+
+    async def test_tool_registered_lazily_not_at_import(self, wm_toolkit):
+        # NODE_REGISTRY is process-global; the toolkit's constructor alone
+        # must not register "tool" — only the first _run_plan call does.
+        # Save/restore so this test does not leak state into others.
+        previous = NODE_REGISTRY.pop("tool", None)
+        try:
+            toolkit = ExecutionPlanToolkit(
+                tool_manager=_FakeToolManager({}), working_memory=wm_toolkit,
+            )
+            assert "tool" not in NODE_REGISTRY
+
+            plan = _single_node_plan(tool="noop")
+            manager = _FakeToolManager({"noop": {"ok": True}})
+            toolkit._tool_manager = manager
+            await toolkit._run_plan(plan, source="plan_name")
+            assert "tool" in NODE_REGISTRY
+        finally:
+            if previous is not None:
+                NODE_REGISTRY["tool"] = previous
+
+
+class TestRunRegistry:
+    async def test_eviction_bounds(self, wm_toolkit):
+        manager = _FakeToolManager({"fast": {"ok": True}})
+        toolkit = ExecutionPlanToolkit(
+            tool_manager=manager, working_memory=wm_toolkit,
+            soft_timeout=5.0, max_completed_runs=3,
+        )
+
+        for i in range(6):
+            plan = _single_node_plan(tool="fast", node_id=f"n{i}")
+            await toolkit._run_plan(plan, source="plan_name")
+
+        assert len(toolkit._runs) == 3
+        assert all(rec.status != "running" or True for rec in toolkit._runs.values())
+
+    async def test_in_flight_run_never_evicted(self, wm_toolkit):
+        manager = _FakeToolManager({"slow": {"ok": True}}, delays={"slow": 0.3})
+        toolkit = ExecutionPlanToolkit(
+            tool_manager=manager, working_memory=wm_toolkit,
+            soft_timeout=0.01, max_completed_runs=1,
+        )
+
+        slow_plan = _single_node_plan(tool="slow", node_id="slow_node")
+        slow_result = await toolkit._run_plan(slow_plan, source="plan_name")
+        slow_run_id = slow_result.result["run_id"]
+
+        fast_manager = manager
+        fast_manager._tools["fast"] = {"ok": True}
+        for i in range(3):
+            plan = _single_node_plan(tool="fast", node_id=f"fast_{i}")
+            await toolkit._run_plan(plan, source="plan_name")
+
+        # The still-running slow run must survive eviction regardless of
+        # max_completed_runs, since eviction only ever considers non-running
+        # entries.
+        assert slow_run_id in toolkit._runs
+        assert toolkit._runs[slow_run_id].status == "running"
+
+        await asyncio.sleep(0.6)  # let it finish before the fixture tears down
+
+    async def test_unknown_run_id_tool_error(self, wm_toolkit):
+        toolkit = ExecutionPlanToolkit(
+            tool_manager=_FakeToolManager({}), working_memory=wm_toolkit,
+        )
+
+        result = await toolkit.plan_status(run_id="does-not-exist")
+
+        assert result.status == "error"
+        assert result.success is False
+        assert "does-not-exist" in result.error
+
+        artifacts_result = await toolkit.plan_artifacts(run_id="does-not-exist")
+        assert artifacts_result.status == "error"

--- a/sdd/specs/execution-plan-tool.spec.md
+++ b/sdd/specs/execution-plan-tool.spec.md
@@ -384,44 +384,44 @@ def plans_dir(tmp_path):
 
 > This feature is complete when ALL of the following are true:
 
-- [ ] The `plan/` module lives at
+- [x] The `plan/` module lives at
   `packages/ai-parrot/src/parrot/bots/flows/plan/`, `_shim.py` is not
   shipped, and all 60 attached tests pass against real imports.
-- [ ] `ExecutionPlanToolkit` exposes exactly `plan_execute`, `plan_status`,
+- [x] `ExecutionPlanToolkit` exposes exactly `plan_execute`, `plan_status`,
   `plan_artifacts`, `plan_validate`; response payloads are bounded (an
   `ExecutionManifest` for the 4-node example plan serializes to <2 KB).
-- [ ] No payload body ever appears in `FlowContext.results` or in any tool
+- [x] No payload body ever appears in `FlowContext.results` or in any tool
   response — asserted by integration test.
-- [ ] Zero LLM calls occur between validation success and manifest
+- [x] Zero LLM calls occur between validation success and manifest
   construction — asserted by integration test (planner mock call count ≤2:
   one authoring + at most one repair).
-- [ ] All plan-node dispatch goes through `ToolManager.execute_tool()` with
+- [x] All plan-node dispatch goes through `ToolManager.execute_tool()` with
   the constructor `permission_context` forwarded — never `tool.execute()`.
-- [ ] A plan with failing nodes returns a `partial` manifest as a
+- [x] A plan with failing nodes returns a `partial` manifest as a
   SUCCESSFUL tool call; structural failures (invalid plan, bad args,
   unknown `run_id`/`plan_name`, unconfigured planner) are tool errors.
-- [ ] `plan_execute` returns within `soft_timeout` (default 60 s): full
+- [x] `plan_execute` returns within `soft_timeout` (default 60 s): full
   manifest if done, else `run_id` summary with execution continuing;
   `plan_status(run_id)` returns the final manifest after completion.
-- [ ] An invalid plan fails at validation with ALL issues in one report —
+- [x] An invalid plan fails at validation with ALL issues in one report —
   including `tool_not_allowed` for tools outside `allowed_tools` — and no
   tool is ever executed.
-- [ ] `plan_validate` returns the acquired plan JSON verbatim (both modes)
+- [x] `plan_validate` returns the acquired plan JSON verbatim (both modes)
   plus the complete `ValidationReport`, and never calls
   `ToolManager.execute_tool`.
-- [ ] `plan_name` mode loads YAML/JSON from `plans_dir` with load-time
+- [x] `plan_name` mode loads YAML/JSON from `plans_dir` with load-time
   `{params.<name>}` substitution; missing or unused params fail the load;
   the executor's runtime placeholders are untouched.
-- [ ] `planner_llm` accepts `"provider:model"` | instance | dict; unset +
+- [x] `planner_llm` accepts `"provider:model"` | instance | dict; unset +
   `objective` yields a clear structural error; `plan_name` mode works
   without any planner configured.
-- [ ] Registering `"tool"` in `NODE_REGISTRY` breaks neither existing node
+- [x] Registering `"tool"` in `NODE_REGISTRY` breaks neither existing node
   types nor `AgentCrew.add_tool_node()` (regression test green).
-- [ ] The example plan ships as a valid `plans_dir` file using
+- [x] The example plan ships as a valid `plans_dir` file using
   `{params.date}` (no `{input}`).
-- [ ] All unit + integration tests pass (`pytest` on the touched packages);
+- [x] All unit + integration tests pass (`pytest` on the touched packages);
   no changes to `BasicAgent`'s class body.
-- [ ] Documentation updated in `docs/` (usage + the v1 RAM caveat for
+- [x] Documentation updated in `docs/` (usage + the v1 RAM caveat for
   WorkingMemory).
 
 ---

--- a/sdd/tasks/completed/TASK-2179-land-plan-module.md
+++ b/sdd/tasks/completed/TASK-2179-land-plan-module.md
@@ -149,10 +149,48 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (autonomous)
+**Date**: 2026-08-07
+**Notes**: Verbatim drop-in of `sdd/artifacts/plan/{models,paths,guards,facets,
+validator,compile,node,__init__}.py` into
+`packages/ai-parrot/src/parrot/bots/flows/plan/`. `_shim.py` not shipped.
+Collapsed the `try/except ImportError` fallbacks in `node.py`
+(`Node`, `AgentTaskMachine`) and `compile.py` (`EdgeDefinition`,
+`FlowDefinition`, `FlowMetadata`, `NodeDefinition`) to plain
+`parrot.bots.flows.*` imports. Relocated `test_plan.py`/`test_node.py` to
+`packages/ai-parrot/tests/bots/flows/plan/` (with `__init__.py`, mirroring
+sibling `tests/bots/flows/` convention), rewriting `from plan.X import`
+to `from parrot.bots.flows.plan.X import`; no shim-based fixtures existed
+in the tests to begin with (they build their own fakes for
+`ToolManager`/`WorkingMemoryToolkit`/`FlowContext`), so nothing else
+changed there. Added the two extra tests from the task's Test
+Specification (`test_public_api_exports`, `test_tool_not_registered_on_import`)
+to `test_plan.py`. All 62 tests pass
+(`pytest packages/ai-parrot/tests/bots/flows/plan/ -v`): 60 relocated +
+2 new. `"tool" not in NODE_REGISTRY` verified after plain import.
 
-**Completed by**:
-**Date**:
-**Notes**:
+Environment notes (not code changes): the shared dev venv's `ormsgpack`
+install was missing its compiled `.so` (broke `import
+parrot.bots.flows` repo-wide, unrelated to this feature) — fixed via
+`uv pip install --reinstall --no-deps ormsgpack==1.12.2`. The compiled
+`parrot/utils/types*.so` and `parrot/utils/parsers/toml*.so` build
+artifacts (gitignored, not present in a fresh worktree checkout) were
+copied from the main repo into this worktree purely to make the editable
+install resolve against the worktree's `packages/ai-parrot/src` (via
+`PYTHONPATH` prepended ahead of the main-repo editable-install path) for
+local test execution — neither is committed.
+
+`ruff check packages/ai-parrot/src/parrot/bots/flows/plan/` reports only
+style-modernization findings (`UP006`/`UP035`/`UP045` `Optional`/`List`/
+`Dict`/`Set` → PEP 604/585 spellings, `RUF022`/`RUF023` sort suggestions,
+one inherited `F401` unused `Tuple` import in `node.py`) — all inherited
+verbatim from the frozen `sdd/artifacts/plan/` source. The repo has no
+`[tool.ruff]` config, so `ruff check` runs under ruff 0.16's full default
+ruleset; the same ruleset reports comparable pre-existing findings against
+untouched sibling files (e.g. `bots/flows/core/node.py`, `bots/flows/flow/
+loader.py`), confirming this is not something introduced here. Per this
+task's own "verbatim drop-in: no renames, no 'improvements'" constraint
+and spec §7 ("the `plan/` module is frozen"), these were left unmodified
+rather than "fixed" — fixing them would violate Cardinal Rule 1.
 
 **Deviations from spec**: none

--- a/sdd/tasks/completed/TASK-2180-executionplan-toolkit-core.md
+++ b/sdd/tasks/completed/TASK-2180-executionplan-toolkit-core.md
@@ -207,10 +207,69 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (autonomous)
+**Date**: 2026-08-07
+**Notes**: Implemented `ExecutionPlanToolkit` core in
+`packages/ai-parrot/src/parrot/tools/execution_plan/{__init__,models,
+toolkit}.py`: constructor wiring (only `tool_manager`+`working_memory`
+required, spec defaults for the rest), `RunRecord`/`RunningSummary`
+(models.py, plain `BaseModel`, `extra="forbid"`; the live `asyncio.Task`
+handle is kept OUT of the pydantic model in a separate toolkit-internal
+dict per spec's "non-serialized runtime handle" note), `PlanStatusArgs`/
+`PlanArtifactsArgs` (`AbstractToolArgsSchema` subclasses), the
+`_run_plan()` executor path (`ensure_tool_node_registered` called lazily
+on first run only, `to_flow_definition` → `AgentsFlow.from_definition`
+with a lazily-created cached empty `AgentRegistry` + `node_factories=
+{"tool": make_tool_node_factory(...)}` → background `asyncio.Task` →
+`asyncio.wait(..., timeout=soft_timeout)` → full manifest or
+`RunningSummary`, never cancelling the task), an internal
+`on_node_event` progress listener updating `RunRecord.nodes_done`, and
+bounded run-registry eviction (oldest completed/failed beyond
+`max_completed_runs`, in-flight never evicted). `plan_status`/
+`plan_artifacts` tools implemented per spec. 9/9 new unit tests pass
+(`pytest packages/ai-parrot/tests/tools/execution_plan/ -v`); the
+relocated TASK-2179 plan/ suite (62 tests) still passes alongside it.
 
-**Completed by**:
-**Date**:
-**Notes**:
+**Found-and-fixed pre-existing bug (outside this task's declared file
+list — flagged for explicit review):**
+`packages/ai-parrot/src/parrot/bots/flows/flow/flow.py`'s
+`AgentsFlow._materialize_nodes()` definition-driven branch (used by
+`from_definition()`) constructs `StartNode`/`EndNode` via
+`cls(node_id=nid, dependencies=deps, successors=succs)` with no `fsm` —
+those classes declare no `fsm` field (only `AgentNode` does) — yet
+`_run_node()` unconditionally calls `node.fsm.schedule()/.start()/
+.succeed()/.fail()` for every dispatched node, crashing on
+`AttributeError: 'StartNode' object has no attribute 'fsm'` the instant
+any `from_definition()`-built flow with start/end sentinel nodes is
+actually `run_flow()`'d. Confirmed via `git grep` that NO existing test
+or production caller in the repo (dev_loop/dev_flow's own
+`from_definition()` usages use only "agent"/"decision" node types, never
+"start"/"end") ever combined `from_definition()` + `run_flow()` with
+start/end sentinels before — `plan/compile.py::to_flow_definition()`
+(FEAT-419, frozen module, cannot be changed) is the first caller to do
+so unconditionally. Fixed by mirroring the EXACT same
+`model_copy(update={"fsm": AgentTaskMachine(...)})` patch the
+programmatic (`add_node`) branch of `_materialize_nodes()` already
+applies, just applied to the definition-driven "start"/"end"
+construction too. Verified non-regressive: the full pre-existing
+`pytest packages/ai-parrot/tests/bots/flows/` suite (301 tests) still
+passes after the fix.
+
+**Unrelated, pre-existing test-isolation hazard observed (not fixed,
+out of scope):** running `packages/ai-parrot/tests/bots/flows/
+test_storage_parity.py::...test_no_legacy_storage_import_in_test_
+orchestrator` (which does `import tests.test_orchestrator_agent`) in the
+same pytest session BEFORE this feature's tests causes
+`sys.modules["parrot.bots.flows.core.node"]` (and the `flow.py` module
+that already cached a reference to its `Node` class) to end up bound to
+two different module/class objects, breaking `issubclass()` checks in
+`register_node()` for any class imported before that point. Reproduced
+and confirmed via `git blame`-free bisection that this is triggered by
+`test_orchestrator_agent.py`'s import chain / `packages/ai-parrot/tests/
+conftest.py`'s documented sys.modules stubbing (FEAT-268 note in that
+conftest), not by anything in FEAT-419. Does not affect either this
+task's or TASK-2179's own specified test commands (each scoped to its
+own package); only appears when combining unrelated test directories in
+one session. Flagging for a separate ticket rather than fixing here.
 
 **Deviations from spec**: none

--- a/sdd/tasks/completed/TASK-2181-plan-file-store.md
+++ b/sdd/tasks/completed/TASK-2181-plan-file-store.md
@@ -172,10 +172,29 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**:
-**Date**:
-**Notes**:
+**Completed by**: sdd-worker (autonomous)
+**Date**: 2026-08-07
+**Notes**: Implemented `PlanFileStore`/`PlanLoadError` in
+`packages/ai-parrot/src/parrot/tools/execution_plan/store.py`.
+`_resolve_path` tries `yaml` > `yml` > `json` in that order; `_parse`
+dispatches on suffix (`json.loads` vs `yaml.safe_load`); `_substitute`
+walks the parsed document exactly like `models._iter_strings` (rebuilding
+structure) applying the same exact-match-native-value / embedded-string-
+interpolation convention `paths.render_key` uses for runtime placeholders,
+via a dedicated `{params.<name>}` regex distinct from the executor's own
+`ARTIFACT_REF_RE`/`NODE_REF_RE`/`_ITEM_VAR_RE`, so `{artifacts.x}`/
+`{item}`/`{item.field}`/`{index}` pass through completely untouched.
+Missing and unused params are collected in one pass and reported together
+in a single `PlanLoadError`. Migrated `sdd/artifacts/example_plan.json` to
+`examples/plans/daily_security_sweep.json` (`"date": "{input}"` →
+`"date": "{params.date}"`; verified not gitignored via `git check-ignore`
+before adding). 10/10 new tests pass (`pytest packages/ai-parrot/tests/
+tools/execution_plan/test_store.py -v`), including the migrated example
+loading through the real store and the mixed-placeholder test proving
+runtime placeholders survive substitution byte-for-byte. `ruff check
+--select F,E9` clean (full default ruleset reports only the same
+style-preference nits — `Optional`/`Dict`/`List` spellings — already
+present repo-wide with no `[tool.ruff]` config; see TASK-2179/2180
+Completion Notes for the baseline comparison).
 
 **Deviations from spec**: none

--- a/sdd/tasks/completed/TASK-2182-tool-catalog-allowlist.md
+++ b/sdd/tasks/completed/TASK-2182-tool-catalog-allowlist.md
@@ -163,10 +163,25 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**:
-**Date**:
-**Notes**:
+**Completed by**: sdd-worker (autonomous)
+**Date**: 2026-08-07
+**Notes**: Implemented `ArgSummary`/`ToolCatalogEntry`/`build_catalog`/
+`check_allowlist`/`validate_with_allowlist` in
+`packages/ai-parrot/src/parrot/tools/execution_plan/catalog.py`.
+`build_catalog` preserves `tool_manager.list_tools()` order (not
+allowlist order) for a stable catalog; unregistered allowlisted names
+raise `ValueError` naming them. `check_allowlist` layers one
+`tool_not_allowed` `ValidationIssue` per offending node on top of the
+frozen validator (never patches `validator.py`). `validate_with_allowlist`
+calls `validate_plan()` then appends into the SAME `report.issues` list
+(mutates the dataclass in place, per the task's "do not subclass"
+constraint) so the combined report is genuinely one pass. `args_summary`
+is bounded (120-char description cap per arg, no JSON-schema dumps) and
+empty for both `args_schema=None` and the default
+`AbstractToolArgsSchema`. 10/10 new tests pass (`pytest packages/ai-
+parrot/tests/tools/execution_plan/test_catalog.py -v`), including the
+shared-ToolManager scenario (tool registered but not allowlisted → error
+pre-execution) and the combined-report single-pass test (`unknown_tool` +
+`tool_not_allowed` together). `ruff check --select F,E9` clean.
 
 **Deviations from spec**: none

--- a/sdd/tasks/completed/TASK-2183-plan-planner-client.md
+++ b/sdd/tasks/completed/TASK-2183-plan-planner-client.md
@@ -186,10 +186,46 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (autonomous)
+**Date**: 2026-08-07
+**Notes**: Implemented `resolve_planner_client`/`PlanPlanner`/
+`PlanAuthoringError` in `packages/ai-parrot/src/parrot/tools/
+execution_plan/planner.py`. `resolve_planner_client` mirrors
+`ModelSwitchingMixin`'s `secondary_llm` resolution priority (instance
+passthrough, class instantiation, `model_config` dict, "provider:model"
+string) but adapted into a standalone function — the mixin's own
+`_resolve_llm_config`/`_parse_model_config`/`_create_llm_client` are all
+bound to a live `AbstractBot` instance (`self.logger`, `self._default_llm`,
+`self.tool_manager`, `self.conversation_memory`) and have no reusable
+free function, so the dict/string paths are built directly on
+`parrot.clients.factory.LLMFactory.create` (string case) and
+`SUPPORTED_CLIENTS` (dict case, mirroring `_parse_model_config`'s
+name/llm/provider extraction) rather than copying bot-bound code. No
+implicit default model anywhere in the module (verified by a dedicated
+test scanning the module source for provider:model literals).
 
-**Completed by**:
-**Date**:
-**Notes**:
+Deliberately does NOT use `AbstractClient.ask(structured_output=...)`:
+that base-class path (`_parse_structured_output`) silently falls back to
+returning the raw response text on a parse/validation failure instead of
+raising, which would hide exactly the failure this task's AC requires
+surfacing ("malformed JSON or schema-invalid plan raises a typed error").
+Instead the `ExecutionPlan.model_json_schema()` is embedded directly in
+the prompt and the response is parsed (with markdown-fence stripping)
+and validated here, raising `PlanAuthoringError` on either failure.
+Confirmed via `client.ask(prompt=..., model=..., temperature=0.0)` inside
+`async with self.client as entered:` — matches the real calling
+convention used elsewhere in `bots/abstract.py` (client is an async
+context manager; `ask()` requires `model=` as a real kwarg, not
+`question=`). Exactly one `entered.ask()` call per `author()`/`repair()`.
+
+15/15 new tests pass (`pytest packages/ai-parrot/tests/tools/
+execution_plan/test_planner.py -v`), using a real `AbstractClient`
+subclass double (`_FakeClient`, all abstract methods stubbed) rather than
+a duck-typed fake, so `isinstance(planner_llm, AbstractClient)` passthrough
+is exercised for real; `resolve_planner_client("google:gemini-2.5-flash")`
+and `resolve_planner_client({"name": "openai", ...})` were smoke-tested
+against the real `GoogleGenAIClient`/`OpenAIClient` classes too (no
+network — client construction alone does not call any provider API).
+`ruff check --select F,E9` clean.
 
 **Deviations from spec**: none

--- a/sdd/tasks/completed/TASK-2184-plan-execute-validate-wiring.md
+++ b/sdd/tasks/completed/TASK-2184-plan-execute-validate-wiring.md
@@ -190,10 +190,52 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (autonomous)
+**Date**: 2026-08-07
+**Notes**: Added `plan_execute`/`plan_validate` to
+`packages/ai-parrot/src/parrot/tools/execution_plan/toolkit.py`, plus
+`PlanExecuteArgs`/`PlanValidateArgs` in `models.py`. Shared
+`_acquire_and_validate`/`_check_arbitration`/`_acquire_from_file`/
+`_acquire_from_objective` helpers implement arbitration (both/neither/
+objective-without-planner/plan_name-without-plans_dir/params-with-
+objective, all checked BEFORE any acquisition or LLM call, via a private
+`_StructuralError` signal caught only at the two tool-method boundaries)
+then acquisition+validation (no repair in `plan_name` mode; exactly one
+`PlanPlanner.repair()` round in `objective` mode).
 
-**Completed by**:
-**Date**:
-**Notes**:
+**Key design decision beyond the task's literal wording** (flagged
+per spec Axis 4's actual scope, not a deviation from it): the shared
+acquisition helper does NOT raise when the validation report ends up
+`not ok` — it returns `(plan, plan_json, report, source)` regardless, so
+`report.ok=False` is DATA. `plan_execute` then converts a not-ok report
+into a tool error itself (satisfying "invalid plan after the repair round"
+as a structural failure — spec §2's Axis-4 paragraph, which is specifically
+about `plan_execute`'s manifest-vs-error framing). `plan_validate` never
+does that conversion — it always returns success with `{"plan":
+<verbatim JSON>, "ok": <bool>, "issues": [...]}`, because a dry-run whose
+entire purpose is "show me what's wrong so I can fix the file before
+promoting it" (spec's confirmed plan_validate decision) must be able to
+report `ok=False` as data, not swallow it into an opaque tool error.
+Verified with `test_dry_run_reports_invalid_plan_without_erroring`. A
+`PlanAuthoringError` from the planner (malformed JSON / schema-invalid
+response, TASK-2183's own error type) at either the authoring OR the
+repair call IS treated as structural (nothing to validate) — there is no
+second attempt at repairing a repair failure, consistent with "≤1 repair
+round" the spec allows, since a repair-round parse failure has no
+`ValidationReport` companion around which a THIRD call could be framed.
 
-**Deviations from spec**: none
+17/17 new tests pass (`pytest packages/ai-parrot/tests/tools/
+execution_plan/test_execute_validate.py -v`), covering the full
+arbitration matrix, plan_name happy/invalid/load-error paths, objective
+repair-succeeds/repair-exhausted paths (asserting exact LLM call counts:
+1 for a clean author, 2 for one repair round, never 3), the partial-
+manifest-is-success path (reusing TASK-2180's fan-out fixture), the
+soft-timeout-from-plan_execute path, and plan_validate's dry-run
+guarantees (verbatim plan JSON in both an ok and a not-ok case, zero
+`ToolManager.execute_tool` calls, zero run-registry entries). Full FEAT-419
+suite (`packages/ai-parrot/tests/bots/flows/plan/` + `packages/ai-parrot/
+tests/tools/execution_plan/`) — 123 tests — passes. `ruff check --select
+F,E9` clean.
+
+**Deviations from spec**: none (see design-decision note above — an
+elaboration within Axis 4's stated scope, not a departure from it).

--- a/sdd/tasks/completed/TASK-2185-e2e-integration-docs.md
+++ b/sdd/tasks/completed/TASK-2185-e2e-integration-docs.md
@@ -246,4 +246,52 @@ pre-existing `packages/ai-parrot/tests/bots/flows/` suite (301 tests,
 unrelated to the crew hang above) still green after TASK-2180's fsm fix.
 `ruff check --select F,E9` clean.
 
+**Post-completion addendum — adversarial code review (feature-level, after
+all 7 tasks landed):** the `code-reviewer` agent (cross-checked against an
+independent `codex exec review --base dev`) found and both independently
+confirmed with live exploits/repros 4 CRITICAL issues, all fixed in a
+follow-up commit (`fix(execution-plan-tool): address code-review CRITICAL
+findings`) on top of this task's own commit:
+1. `plan_name` path traversal (`store.py::_resolve_path`) — an
+   LLM-controlled argument with no traversal guard let `plan_validate`
+   read and return verbatim any YAML/JSON file on disk. Fixed: reject any
+   `plan_name` containing a path separator or `..`, and verify the
+   resolved candidate's parent is exactly `plans_dir`.
+2. A malformed plan file crashed `plan_execute` with a raw uncaught
+   `JSONDecodeError`/`yaml.YAMLError` instead of the promised structural
+   `ToolResult` error. Fixed: `PlanFileStore._parse` now wraps both into
+   `PlanLoadError`.
+3. `AgentsFlow.from_definition`'s flow-level checkpointing defaults to
+   `True` (`PlanMetadata.checkpoint`), which requires a live Redis-backed
+   checkpoint store before the first node ever dispatches — silently
+   contradicting this feature's own "pure in-RAM v1, no persistent
+   backend" Non-Goal. All 133 tests passed only because this dev sandbox
+   happens to run `redis-server`. Fixed: `_run_plan` now passes
+   `checkpoint=False` explicitly to `AgentsFlow.from_definition`.
+4. A node's hard failure (not a `for_each` per-item failure) left its
+   downstream dependent neither in `ctx.results` nor `ctx.errors` (never
+   dispatched by the scheduler's AND-join gate) — silently vanishing from
+   the manifest instead of showing up as blocked. Fixed: `_execute_flow`
+   now synthesizes a `status="error"` `ArtifactRef` for any plan node in
+   neither bucket, so `nodes_total` accounting stays honest.
+
+Also fixed the accompanying 🟠 Important finding: `PlanFileStore`'s
+synchronous file I/O was called directly from an `async def` toolkit
+method (blocking-I/O-in-async-context violation) — now wrapped in
+`asyncio.to_thread`. Each of the 4 fixes has a dedicated regression test
+(`test_store.py::test_path_traversal_rejected`,
+`test_malformed_json_raises_plan_load_error_not_raw_exception`,
+`test_malformed_yaml_raises_plan_load_error`;
+`test_toolkit_core.py::test_hard_failed_node_downstream_dependent_shows_
+as_error`, `test_checkpoint_disabled_no_redis_dependency`). Full suite
+after the fix: 133 passed (up from 128); `ruff check --select F,E9`
+clean. Docs (`docs/toolkits/execution_plan_toolkit.md`) updated to note
+the checkpoint-disable decision under the v1 caveats.
+
+Findings NOT fixed (noted, not blocking): 🟠 "uninformative tool error on
+flow-level crash" was folded into fix #3/#4's `RunRecord.flow_error`
+field as a byproduct. All 🟡/💡 suggestions (nitpicks on comment
+placement, a redundant `.get(..., record)` fallback, `MAX_FACET_STR`
+double-duty naming) were left as-is — cosmetic, no functional risk.
+
 **Deviations from spec**: none

--- a/sdd/tasks/completed/TASK-2185-e2e-integration-docs.md
+++ b/sdd/tasks/completed/TASK-2185-e2e-integration-docs.md
@@ -168,10 +168,82 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (autonomous)
+**Date**: 2026-08-07
+**Notes**: Implemented all five integration tests in
+`packages/ai-parrot/tests/tools/execution_plan/test_integration.py`:
 
-**Completed by**:
-**Date**:
-**Notes**:
+- `test_basicagent_end_to_end_zero_tokens_in_loop` — a REAL
+  `BasicAgent(name=...)` (not a lightweight harness), with the daily
+  security sweep example plan run through a canned `PlanPlanner` client
+  double + 4 fake tools registered on the agent's own real
+  `tool_manager` via `ToolManager.register_tool(name=..., description=...,
+  input_schema=..., function=...)`. `agent.client.ask` is replaced with an
+  `AsyncMock` that raises `AssertionError` if ever called — a hard,
+  fail-loud guard on the "zero LLM tokens during execution" claim, not a
+  log grep. Asserts exactly 1 planner call (no repair needed), manifest
+  <2 KB, no payload-body leakage (verified via a report *filename* marker
+  that only exists inside the fake tool's raw body, not any facet or
+  the plan's own `objective` text — see the two false-positive iterations
+  noted below), and `"plan_execute" not in type(agent).__dict__` proving
+  no monkeypatching of the class.
+- `test_300_item_fanout_resumable` — simulates a crash by pre-populating
+  150 of 300 expected WorkingMemory keys before calling `_run_plan`;
+  asserts exactly 150 `get_item` tool calls (not 300) and a complete
+  300-item manifest artifact, proving `for_each.skip_existing` recovery.
+- `test_no_payload_in_flowcontext_results` — every plan-node value in
+  `ctx.results` is an `ArtifactRef`.
+- `test_agentcrew_add_tool_node_regression` — after
+  `ensure_tool_node_registered(PlanToolNode)`, `AgentCrew.add_tool_node()`
+  still builds crew's own `ToolNode` (not `PlanToolNode`) and
+  `run_sequential()` still works.
+- `test_allowlist_blocks_before_execution` — a plan naming a
+  registered-but-not-allowlisted tool, run through the real
+  `plan_execute(plan_name=...)` entry point, never calls
+  `ToolManager.execute_tool` and registers no run.
+
+Documentation added at `docs/toolkits/execution_plan_toolkit.md`,
+following the repo's existing `docs/toolkits/<name>.md` convention (see
+`docs/toolkits/infographic_toolkit.md`): wiring snippet, all four tools,
+the `{params.<name>}` load-time-vs-runtime placeholder table, the
+soft-timeout/`run_id` flow, failure semantics, and every v1 caveat
+(in-RAM WorkingMemory with no guardrail, run registry lost on restart,
+recovery = re-issue + `skip_existing`, no `plan_resume`). Spec §5
+Acceptance Criteria checkboxes all flipped to `[x]` in this commit.
+
+**Debugging note** (test-writing artifact, not a code defect): two
+iterations of `test_basicagent_end_to_end_zero_tokens_in_loop`'s
+no-payload-leak assertion were themselves wrong before landing on the
+filename-marker check — `"findings" not in manifest_json` false-failed on
+the legitimate facet name `"n_findings"`, and `"critical" not in
+manifest_json` false-failed on the word "critical" inside the *plan's own
+`objective` field text* ("...map new critical findings..."), not a
+payload leak. Documented here so a future reader doesn't misread either
+assertion's history as evidence of a real leak.
+
+**Confirmed pre-existing, unrelated hang (not fixed — out of scope):**
+`packages/ai-parrot/tests/test_crew_tool_node_regression.py` (an
+existing FEAT-137 file, not owned by this feature) hangs indefinitely
+when its `TestSequentialToolNode`/`TestFlowToolNode`/
+`TestParallelToolNode`/`TestLoopToolNode` classes are run — reproduced
+identically on plain `dev` with zero FEAT-419 changes applied
+(`cd <main-repo-checkout> && pytest test_crew_tool_node_regression.py::
+TestSequentialToolNode::test_agent_tool_agent_pipeline` hangs there too).
+Confirmed NOT caused by TASK-2180's flow.py fsm fix — that fix only
+touches the definition-driven branch of `_materialize_nodes()`
+(`self._definition is not None`), and this crew suite exclusively uses
+the programmatic `add_node()`/`add_edge()` branch (`self._definition is
+None`), which was already correct and untouched. This feature's own
+regression coverage (`test_agentcrew_add_tool_node_regression` above)
+exercises the same `add_tool_node()` + `run_sequential()` path
+successfully in under a second, so the acceptance criterion is
+independently satisfied without needing that file to run. Flagging for a
+separate ticket.
+
+Full FEAT-419 suite: `pytest packages/ai-parrot/tests/bots/flows/plan/
+packages/ai-parrot/tests/tools/execution_plan/ -v` → 128 passed. Full
+pre-existing `packages/ai-parrot/tests/bots/flows/` suite (301 tests,
+unrelated to the crew hang above) still green after TASK-2180's fsm fix.
+`ruff check --select F,E9` clean.
 
 **Deviations from spec**: none

--- a/sdd/tasks/index/execution-plan-tool.json
+++ b/sdd/tasks/index/execution-plan-tool.json
@@ -113,7 +113,7 @@
       "feature_id": "FEAT-419",
       "feature": "execution-plan-tool",
       "spec": "sdd/specs/execution-plan-tool.spec.md",
-      "status": "pending",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "depends_on": [
@@ -126,8 +126,8 @@
       "parallelism_notes": "Integration point: wires store, catalog and planner into the toolkit's entry tools.",
       "assigned_to": null,
       "started_at": null,
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2184-plan-execute-validate-wiring.md"
+      "completed_at": "2026-08-07T00:50:48+00:00",
+      "file": "sdd/tasks/completed/TASK-2184-plan-execute-validate-wiring.md"
     },
     {
       "id": "TASK-2185",

--- a/sdd/tasks/index/execution-plan-tool.json
+++ b/sdd/tasks/index/execution-plan-tool.json
@@ -5,7 +5,7 @@
   "type": "feature",
   "base_branch": "dev",
   "created_at": "2026-08-07T01:50:00+02:00",
-  "completed_at": "2026-08-07T01:12:19+00:00",
+  "completed_at": "2026-08-07T08:18:04+00:00",
   "tasks": [
     {
       "id": "TASK-2179",
@@ -23,7 +23,8 @@
       "assigned_to": null,
       "started_at": null,
       "completed_at": "2026-08-07T00:10:42+00:00",
-      "file": "sdd/tasks/completed/TASK-2179-land-plan-module.md"
+      "file": "sdd/tasks/completed/TASK-2179-land-plan-module.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2180",
@@ -43,7 +44,8 @@
       "assigned_to": null,
       "started_at": null,
       "completed_at": "2026-08-07T00:32:36+00:00",
-      "file": "sdd/tasks/completed/TASK-2180-executionplan-toolkit-core.md"
+      "file": "sdd/tasks/completed/TASK-2180-executionplan-toolkit-core.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2181",
@@ -63,7 +65,8 @@
       "assigned_to": null,
       "started_at": null,
       "completed_at": "2026-08-07T00:36:05+00:00",
-      "file": "sdd/tasks/completed/TASK-2181-plan-file-store.md"
+      "file": "sdd/tasks/completed/TASK-2181-plan-file-store.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2182",
@@ -83,7 +86,8 @@
       "assigned_to": null,
       "started_at": null,
       "completed_at": "2026-08-07T00:38:21+00:00",
-      "file": "sdd/tasks/completed/TASK-2182-tool-catalog-allowlist.md"
+      "file": "sdd/tasks/completed/TASK-2182-tool-catalog-allowlist.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2183",
@@ -104,7 +108,8 @@
       "assigned_to": null,
       "started_at": null,
       "completed_at": "2026-08-07T00:44:51+00:00",
-      "file": "sdd/tasks/completed/TASK-2183-plan-planner-client.md"
+      "file": "sdd/tasks/completed/TASK-2183-plan-planner-client.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2184",
@@ -127,7 +132,8 @@
       "assigned_to": null,
       "started_at": null,
       "completed_at": "2026-08-07T00:50:48+00:00",
-      "file": "sdd/tasks/completed/TASK-2184-plan-execute-validate-wiring.md"
+      "file": "sdd/tasks/completed/TASK-2184-plan-execute-validate-wiring.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2185",
@@ -152,7 +158,8 @@
       "assigned_to": null,
       "started_at": null,
       "completed_at": "2026-08-07T01:12:19+00:00",
-      "file": "sdd/tasks/completed/TASK-2185-e2e-integration-docs.md"
+      "file": "sdd/tasks/completed/TASK-2185-e2e-integration-docs.md",
+      "verification": "verified"
     }
   ]
 }

--- a/sdd/tasks/index/execution-plan-tool.json
+++ b/sdd/tasks/index/execution-plan-tool.json
@@ -5,7 +5,7 @@
   "type": "feature",
   "base_branch": "dev",
   "created_at": "2026-08-07T01:50:00+02:00",
-  "completed_at": null,
+  "completed_at": "2026-08-07T01:12:19+00:00",
   "tasks": [
     {
       "id": "TASK-2179",
@@ -136,7 +136,7 @@
       "feature_id": "FEAT-419",
       "feature": "execution-plan-tool",
       "spec": "sdd/specs/execution-plan-tool.spec.md",
-      "status": "pending",
+      "status": "done",
       "priority": "medium",
       "effort": "M",
       "depends_on": [
@@ -151,8 +151,8 @@
       "parallelism_notes": "Closes the spec §5 checklist; needs everything landed.",
       "assigned_to": null,
       "started_at": null,
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2185-e2e-integration-docs.md"
+      "completed_at": "2026-08-07T01:12:19+00:00",
+      "file": "sdd/tasks/completed/TASK-2185-e2e-integration-docs.md"
     }
   ]
 }

--- a/sdd/tasks/index/execution-plan-tool.json
+++ b/sdd/tasks/index/execution-plan-tool.json
@@ -92,7 +92,7 @@
       "feature_id": "FEAT-419",
       "feature": "execution-plan-tool",
       "spec": "sdd/specs/execution-plan-tool.spec.md",
-      "status": "pending",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -103,8 +103,8 @@
       "parallelism_notes": "Consumes ToolCatalogEntry from 2182; same-package edits.",
       "assigned_to": null,
       "started_at": null,
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2183-plan-planner-client.md"
+      "completed_at": "2026-08-07T00:44:51+00:00",
+      "file": "sdd/tasks/completed/TASK-2183-plan-planner-client.md"
     },
     {
       "id": "TASK-2184",

--- a/sdd/tasks/index/execution-plan-tool.json
+++ b/sdd/tasks/index/execution-plan-tool.json
@@ -72,7 +72,7 @@
       "feature_id": "FEAT-419",
       "feature": "execution-plan-tool",
       "spec": "sdd/specs/execution-plan-tool.spec.md",
-      "status": "pending",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -82,8 +82,8 @@
       "parallelism_notes": "Same package-file overlap as 2181; sequential in the per-spec worktree per spec Worktree Strategy.",
       "assigned_to": null,
       "started_at": null,
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2182-tool-catalog-allowlist.md"
+      "completed_at": "2026-08-07T00:38:21+00:00",
+      "file": "sdd/tasks/completed/TASK-2182-tool-catalog-allowlist.md"
     },
     {
       "id": "TASK-2183",

--- a/sdd/tasks/index/execution-plan-tool.json
+++ b/sdd/tasks/index/execution-plan-tool.json
@@ -32,7 +32,7 @@
       "feature_id": "FEAT-419",
       "feature": "execution-plan-tool",
       "spec": "sdd/specs/execution-plan-tool.spec.md",
-      "status": "pending",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "depends_on": [
@@ -42,8 +42,8 @@
       "parallelism_notes": "Creates parrot/tools/execution_plan/ package (__init__, models, toolkit) that 2181/2182/2183/2184 all touch or import.",
       "assigned_to": null,
       "started_at": null,
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2180-executionplan-toolkit-core.md"
+      "completed_at": "2026-08-07T00:32:36+00:00",
+      "file": "sdd/tasks/completed/TASK-2180-executionplan-toolkit-core.md"
     },
     {
       "id": "TASK-2181",

--- a/sdd/tasks/index/execution-plan-tool.json
+++ b/sdd/tasks/index/execution-plan-tool.json
@@ -52,7 +52,7 @@
       "feature_id": "FEAT-419",
       "feature": "execution-plan-tool",
       "spec": "sdd/specs/execution-plan-tool.spec.md",
-      "status": "pending",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -62,8 +62,8 @@
       "parallelism_notes": "Logically independent of 2180 (only imports plan models) but edits the shared parrot/tools/execution_plan/ package __init__ — kept sequential in the per-spec worktree.",
       "assigned_to": null,
       "started_at": null,
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2181-plan-file-store.md"
+      "completed_at": "2026-08-07T00:36:05+00:00",
+      "file": "sdd/tasks/completed/TASK-2181-plan-file-store.md"
     },
     {
       "id": "TASK-2182",

--- a/sdd/tasks/index/execution-plan-tool.json
+++ b/sdd/tasks/index/execution-plan-tool.json
@@ -14,7 +14,7 @@
       "feature_id": "FEAT-419",
       "feature": "execution-plan-tool",
       "spec": "sdd/specs/execution-plan-tool.spec.md",
-      "status": "pending",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [],
@@ -22,8 +22,8 @@
       "parallelism_notes": "Foundation task: every other task imports parrot.bots.flows.plan from here.",
       "assigned_to": null,
       "started_at": null,
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2179-land-plan-module.md"
+      "completed_at": "2026-08-07T00:10:42+00:00",
+      "file": "sdd/tasks/completed/TASK-2179-land-plan-module.md"
     },
     {
       "id": "TASK-2180",
@@ -35,7 +35,9 @@
       "status": "pending",
       "priority": "high",
       "effort": "L",
-      "depends_on": ["TASK-2179"],
+      "depends_on": [
+        "TASK-2179"
+      ],
       "parallel": false,
       "parallelism_notes": "Creates parrot/tools/execution_plan/ package (__init__, models, toolkit) that 2181/2182/2183/2184 all touch or import.",
       "assigned_to": null,
@@ -53,7 +55,9 @@
       "status": "pending",
       "priority": "high",
       "effort": "M",
-      "depends_on": ["TASK-2179"],
+      "depends_on": [
+        "TASK-2179"
+      ],
       "parallel": false,
       "parallelism_notes": "Logically independent of 2180 (only imports plan models) but edits the shared parrot/tools/execution_plan/ package __init__ — kept sequential in the per-spec worktree.",
       "assigned_to": null,
@@ -71,7 +75,9 @@
       "status": "pending",
       "priority": "high",
       "effort": "M",
-      "depends_on": ["TASK-2179"],
+      "depends_on": [
+        "TASK-2179"
+      ],
       "parallel": false,
       "parallelism_notes": "Same package-file overlap as 2181; sequential in the per-spec worktree per spec Worktree Strategy.",
       "assigned_to": null,
@@ -89,7 +95,10 @@
       "status": "pending",
       "priority": "high",
       "effort": "M",
-      "depends_on": ["TASK-2179", "TASK-2182"],
+      "depends_on": [
+        "TASK-2179",
+        "TASK-2182"
+      ],
       "parallel": false,
       "parallelism_notes": "Consumes ToolCatalogEntry from 2182; same-package edits.",
       "assigned_to": null,
@@ -107,7 +116,12 @@
       "status": "pending",
       "priority": "high",
       "effort": "L",
-      "depends_on": ["TASK-2180", "TASK-2181", "TASK-2182", "TASK-2183"],
+      "depends_on": [
+        "TASK-2180",
+        "TASK-2181",
+        "TASK-2182",
+        "TASK-2183"
+      ],
       "parallel": false,
       "parallelism_notes": "Integration point: wires store, catalog and planner into the toolkit's entry tools.",
       "assigned_to": null,
@@ -125,7 +139,14 @@
       "status": "pending",
       "priority": "medium",
       "effort": "M",
-      "depends_on": ["TASK-2179", "TASK-2180", "TASK-2181", "TASK-2182", "TASK-2183", "TASK-2184"],
+      "depends_on": [
+        "TASK-2179",
+        "TASK-2180",
+        "TASK-2181",
+        "TASK-2182",
+        "TASK-2183",
+        "TASK-2184"
+      ],
       "parallel": false,
       "parallelism_notes": "Closes the spec §5 checklist; needs everything landed.",
       "assigned_to": null,


### PR DESCRIPTION
## Summary

Lands the frozen `plan/` execution-plan module (`packages/ai-parrot/src/parrot/bots/flows/plan/`)
and the new `ExecutionPlanToolkit` (`packages/ai-parrot/src/parrot/tools/execution_plan/`) that
lets a plain `BasicAgent` trigger a deterministic tool-call DAG through one bounded tool-call,
with zero LLM tokens spent during execution and no tool payload ever entering `FlowContext.results`
or any LLM context.

## Tasks

7/7 tasks verified:
- ✅ TASK-2179 — Land the `plan/` module (verbatim drop-in, shim collapsed, 62 tests)
- ✅ TASK-2180 — `ExecutionPlanToolkit` core (constructor, run registry, executor path) — also
  fixed a pre-existing latent bug in `AgentsFlow._materialize_nodes()` (Start/EndNode never got an `fsm`)
- ✅ TASK-2181 — `PlanFileStore` with `{params.<name>}` load-time substitution
- ✅ TASK-2182 — Tool catalog + allowlist validation layering
- ✅ TASK-2183 — `PlanPlanner` objective-mode planner client
- ✅ TASK-2184 — `plan_execute`/`plan_validate` acquisition front
- ✅ TASK-2185 — End-to-end integration tests + documentation

## Code review

Adversarial code-reviewer + independent codex cross-check ran before push:
- 🔴 4 Critical — all fixed: `plan_name` path-traversal on file reads, malformed plan file
  crashing the tool call with a raw parser exception, a hard default dependency on a live
  Redis checkpoint store (contradicted the "pure in-RAM v1" design), a hard node failure
  silently dropping its downstream dependent from the manifest.
- 🟠 2 Important — addressed alongside the critical fixes (blocking I/O moved to
  `asyncio.to_thread`; flow-crash errors now carry the real reason via `RunRecord.flow_error`).
- 🟡 Suggestions/nitpicks — noted in TASK-2185's completion note, not fixed (cosmetic).

Each critical fix has a dedicated regression test. Full suite green: 133 tests in the new
`bots/flows/plan/` + `tools/execution_plan/` test dirs, plus the pre-existing 301-test
`bots/flows/` suite confirmed unaffected.

## Known pre-existing issue (not introduced by this PR)

`packages/ai-parrot/tests/test_crew_tool_node_regression.py` hangs indefinitely on certain
invocations — reproduced identically on plain `dev` with zero FEAT-419 changes applied.
Flagging for a separate ticket; out of scope here.

---
_Closed by /sdd-done_