### PR TITLE
fix(formdesigner): make the DELETE response guard reachable, and delete storage before memory

### DIFF
--- a/packages/parrot-formdesigner/CHANGELOG.md
+++ b/packages/parrot-formdesigner/CHANGELOG.md
@@ -31,6 +31,40 @@ All notable changes to `parrot-formdesigner` will be documented in this file.
     deployments, replace `_STORE` with a shared backend such as Redis.
     A module-level warning is logged at import time to surface this limitation.
 
+- **`FormSubmissionStorage.has_submissions(form_uid, *, tenant=None)`** —
+  existence probe that reports whether a form has at least one submission.
+  Counts every revision, including rows with `is_valid = FALSE`: an invalid
+  submission is still a response.
+- **`has_responses=` hook on `setup_form_api()` and `FormAPIHandler`** — makes
+  the FEAT-300 §8 delete guard ("a form with ≥1 response can never be
+  deleted") reachable from the public API. Previously `FormVersionService`
+  accepted the hook but no consumer could supply one through
+  `setup_form_api`, so `can_delete()` always returned `True`. The parameter is
+  optional and overrides the default hook; pass it to enforce a policy wider
+  than "has submissions".
+
+### Changed
+
+- **`DELETE /api/v1/forms/{form_uid}` now enforces the delete guard when a
+  `submission_storage` is configured.** The default `has_responses` hook is
+  derived from `submission_storage.has_submissions`, so a consumer that
+  passes `submission_storage=` to `setup_form_api()` starts receiving `409`
+  for forms that have submissions where it previously received `204`. This is
+  the FEAT-300 §8 invariant taking effect. Consumers that configure no
+  `submission_storage` are unaffected — deletion stays unguarded. To keep the
+  old behaviour with a submission storage configured, pass a permissive hook:
+  `has_responses=lambda form_uid, tenant: False` (as a coroutine function).
+
+### Fixed
+
+- **`DELETE /api/v1/forms/{form_uid}` no longer reports success for a failed
+  storage delete.** The handler unregistered the form from the in-memory
+  registry *before* deleting the persisted row, and swallowed any storage
+  exception, so a failed database delete returned `204` while the form
+  reappeared on the next restart or registry hydration. The storage delete
+  now runs first and returns `500` on failure, leaving the registry untouched
+  so memory and database cannot diverge.
+
 ## [0.2.0] — 2026-05-07 — Structural Refactor (FEAT-152)
 
 ### Breaking Changes

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/api/handlers.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/api/handlers.py
@@ -83,6 +83,8 @@ def extract_uid(request: web.Request, param: str) -> _uuid.UUID:
         )
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
     from parrot.clients.base import AbstractClient
 
     from ..core.partial import PartialFormData
@@ -127,6 +129,14 @@ class FormAPIHandler:
             form endpoints runs in **shadow mode** — it logs permission checks
             but never blocks requests. Set to ``True`` only when nav-auth
             policies are fully configured. Consistent with ``Policy.enforcing=False``.
+        has_responses: Optional async ``(form_uid, tenant) -> bool`` hook that
+            reports whether a form has responses; it gates ``DELETE
+            /forms/{form_uid}`` (FEAT-300 §8). Overrides the default hook,
+            which is derived from ``submission_storage`` when one is given.
+            Pass this to apply a policy wider than "has submissions" — for
+            example a reference check against consumer-owned tables. When
+            this is ``None`` and no ``submission_storage`` is configured,
+            deletion stays unguarded.
     """
 
     def __init__(
@@ -142,10 +152,12 @@ class FormAPIHandler:
         workday_adapter: "WorkdayIdentitySyncAdapter | None" = None,
         venue_service: "VenueService | None" = None,
         rbac_enforcing: bool = False,
+        has_responses: "Callable[[_uuid.UUID, str], Awaitable[bool]] | None" = None,
     ) -> None:
         self.registry = registry
         self._client = client
         self._submission_storage = submission_storage
+        self._has_responses = has_responses
         self._forwarder = forwarder
         self._partial_store = partial_store
         # FEAT-302 — Org Graph services
@@ -1263,11 +1275,18 @@ class FormAPIHandler:
     async def delete_form(self, request: web.Request) -> web.Response:
         """DELETE /api/v1/forms/{form_uid} — Remove a registered form.
 
-        Unregisters the form from the in-memory registry and, when a
-        ``FormStorage`` backend is configured, deletes the persisted row as
-        well (scoped by the form's tenant so per-tenant Postgres schemas
-        resolve correctly). Returns ``204 No Content`` on success, ``404``
-        when no form with the given id exists.
+        When a ``FormStorage`` backend is configured, deletes the persisted
+        row first (scoped by the form's tenant so per-tenant Postgres schemas
+        resolve correctly), then unregisters the form from the in-memory
+        registry. The order matters: the registry is memory-only, so a
+        failed storage delete must leave it untouched.
+
+        Returns:
+            ``204 No Content`` on success; ``404`` when no form with the
+            given ``form_uid`` exists; ``409`` when the form has responses
+            and a ``has_responses`` hook is active (FEAT-300 §8 — deactivate
+            it instead); ``500`` when the storage delete fails, in which
+            case the form stays registered.
         """
         # FEAT-302: RBAC gate-keeping (shadow mode by default)
         await self._rbac_shadow_gate(request, "delete_form")
@@ -1296,16 +1315,26 @@ class FormAPIHandler:
                 status=409,
             )
 
-        await self.registry.unregister(form_uid, tenant=tenant)
-
+        # Durable store first, memory second. ``registry.unregister()`` is
+        # memory-only, so unregistering before a failed DELETE would report
+        # success for a form that reappears on the next restart or
+        # hydration. Persist the deletion, or change nothing at all.
         storage = self.registry.storage
         if storage is not None:
             try:
                 await storage.delete(form_uid, tenant=existing.tenant)
             except Exception as exc:
-                self.logger.warning(
-                    "FormStorage.delete failed for %s: %s", form_uid, exc
+                self.logger.error(
+                    "FormStorage.delete failed for %s: %s — form retained",
+                    form_uid,
+                    exc,
                 )
+                return JSONResponse(
+                    {"error": f"Failed to delete form '{form_uid}'"},
+                    status=500,
+                )
+
+        await self.registry.unregister(form_uid, tenant=tenant)
 
         self.logger.info("DELETE form_uid=%s", form_uid)
         return web.Response(status=204)
@@ -1660,15 +1689,55 @@ class FormAPIHandler:
     # FEAT-300 helpers — version service + question bank
     # ------------------------------------------------------------------
 
+    def _build_has_responses_hook(
+        self,
+    ) -> "Callable[[_uuid.UUID, str], Awaitable[bool]] | None":
+        """Return the ``has_responses`` hook for ``FormVersionService``.
+
+        Resolution order:
+
+        1. An explicit ``has_responses=`` passed at construction wins — a
+           consumer may implement any policy it likes (for example a
+           reference check against its own tables).
+        2. Otherwise, when a ``submission_storage`` is configured, the hook
+           is derived from :meth:`FormSubmissionStorage.has_submissions`.
+        3. Otherwise ``None``, which leaves ``can_delete()`` permissive —
+           the pre-existing behaviour for consumers that configure no
+           submission storage.
+
+        Returns:
+            An async ``(form_uid, tenant) -> bool`` callable, or ``None``
+            when this handler has no way to answer the question.
+        """
+        if self._has_responses is not None:
+            return self._has_responses
+        storage = self._submission_storage
+        if storage is None:
+            return None
+
+        async def _has_responses(form_uid: _uuid.UUID, tenant: str) -> bool:
+            return await storage.has_submissions(form_uid, tenant=tenant)
+
+        return _has_responses
+
     def _get_version_service(self) -> "FormVersionService":
         """Return the shared FormVersionService, initialising it lazily.
+
+        The service is wired with a ``has_responses`` hook whenever this
+        handler can answer the question (see
+        :meth:`_build_has_responses_hook`), which is what makes the FEAT-300
+        §8 delete guard reachable through the public ``setup_form_api``
+        seam rather than only by patching a private attribute.
 
         Returns:
             Configured ``FormVersionService`` instance.
         """
         if self._version_service is None:
             from ..services.form_version import FormVersionService
-            self._version_service = FormVersionService(self.registry)
+            self._version_service = FormVersionService(
+                self.registry,
+                has_responses=self._build_has_responses_hook(),
+            )
         return self._version_service
 
     def _make_question_bank(self, tenant: str) -> "QuestionBankService":

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/api/routes.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/api/routes.py
@@ -43,6 +43,8 @@ from .handlers import FormAPIHandler
 
 
 if TYPE_CHECKING:
+    import uuid
+
     from parrot.clients.base import AbstractClient
     from parrot.core.ws_auth import TokenValidator
     from parrot.voice.tts.synthesizer import VoiceSynthesizer
@@ -111,6 +113,7 @@ def setup_form_api(
     workday_adapter: "WorkdayIdentitySyncAdapter | None" = None,
     venue_service: "VenueService | None" = None,
     rbac_enforcing: bool = False,
+    has_responses: "Callable[[uuid.UUID, str], Awaitable[bool]] | None" = None,
 ) -> None:
     """Mount the JSON REST surface on ``app`` under ``base_path``.
 
@@ -155,6 +158,13 @@ def setup_form_api(
             ``POST /org/sync/workday``.
         rbac_enforcing: When ``False`` (default), RBAC gate-keeping on existing
             form endpoints runs in shadow mode (log only, never block).
+        has_responses: Optional async ``(form_uid, tenant) -> bool`` hook that
+            gates ``DELETE /forms/{form_uid}`` (FEAT-300 §8: a form with
+            responses is deactivated, never deleted). Leave it unset to get
+            the default hook, which reports whether ``submission_storage``
+            holds any submission for the form. Pass it to apply a wider
+            policy, such as a reference check against consumer-owned tables.
+            With no hook and no ``submission_storage``, deletion is unguarded.
     """
     # Stash the registry on the app for the dispatcher / operations handler.
     # Guard: skip if already set (FormRegistry.__init__ sets it when app= is
@@ -199,6 +209,7 @@ def setup_form_api(
         workday_adapter=workday_adapter,
         venue_service=venue_service,
         rbac_enforcing=rbac_enforcing,
+        has_responses=has_responses,
     )
 
     bp = base_path.rstrip("/")

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/submissions.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/submissions.py
@@ -451,3 +451,35 @@ class FormSubmissionStorage:
         async with self._pool.acquire() as conn:
             rows = await conn.fetch(sql, root_submission_id)
         return [self._row_to_submission(row) for row in rows]
+
+    async def has_submissions(
+        self,
+        form_uid: uuid.UUID,
+        *,
+        tenant: str | None = None,
+    ) -> bool:
+        """Return ``True`` when at least one submission exists for a form.
+
+        Existence probe for the delete guard described in FEAT-300 §8: a
+        form with one or more responses must never be deleted, only
+        deactivated. ``FormVersionService`` consumes this method through its
+        ``has_responses`` hook, so the invariant it documents becomes
+        enforceable by a consumer that configures a submission storage.
+
+        Counts every revision of every submission, including rows marked
+        ``is_valid = FALSE``. An invalid submission is still a response, and
+        deleting the form it belongs to would orphan it.
+
+        Args:
+            form_uid: ``form_uid`` (immutable UUID) of the parent form.
+                NOT ``form_id`` — the slug is not stable across a rename.
+            tenant: Optional per-call tenant override (schema resolution).
+
+        Returns:
+            ``True`` if the form has at least one submission row.
+        """
+        qt = self._qualified(tenant)
+        sql = f"SELECT 1 FROM {qt} WHERE form_uid = $1 LIMIT 1"
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(sql, form_uid)
+        return row is not None

--- a/packages/parrot-formdesigner/tests/unit/api/test_delete_form_response_guard.py
+++ b/packages/parrot-formdesigner/tests/unit/api/test_delete_form_response_guard.py
@@ -1,0 +1,355 @@
+"""``DELETE /api/v1/forms/{form_uid}`` — response guard and delete ordering.
+
+Two contracts live here, both exercised over a real HTTP round trip against
+an app built by the public ``setup_form_api()`` entry point:
+
+1. **The FEAT-300 §8 response guard is reachable from the public API.**
+   ``FormVersionService`` has always accepted a ``has_responses`` hook, but
+   until ``setup_form_api()`` grew a way to supply one, ``can_delete()``
+   returned ``True`` for every caller. Configuring ``submission_storage=``
+   now derives the hook from
+   ``FormSubmissionStorage.has_submissions``. A consumer that configures no
+   submission storage keeps the old, unguarded behaviour.
+
+2. **Storage is deleted before the registry is unregistered.**
+   ``FormRegistry.unregister()`` is memory-only, so unregistering first and
+   swallowing a storage error reports ``204`` for a form that returns on the
+   next restart or hydration.
+
+Why this module goes through ``setup_form_api`` instead of calling the
+handler directly (the dominant pattern in this suite, documented in
+``tests/test_form_uid_integration.py``): the behaviour under test IS the
+wiring that ``setup_form_api`` performs. A direct
+``FormAPIHandler(has_responses=...)`` construction, or an injected private
+``_version_service``, would pass even if ``setup_form_api`` forwarded
+nothing. Reaching the handler over HTTP means neutralising the
+navigator-auth decorators that ``_wrap_auth`` applies at registration time;
+the ``_noop_auth`` fixture below does that and nothing else.
+
+The submission storage is a real ``FormSubmissionStorage`` driven by the
+recording asyncpg stubs the rest of the suite uses, so the guard is proved
+through the production query path rather than a hand-written double.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+from aiohttp import web
+
+from parrot_formdesigner.api import routes as routes_module
+from parrot_formdesigner.api import setup_form_api
+from parrot_formdesigner.core.schema import FormField, FormSchema, FormSection
+from parrot_formdesigner.core.types import FieldType
+from parrot_formdesigner.services.registry import FormRegistry, FormStorage
+from parrot_formdesigner.services.submissions import FormSubmissionStorage
+
+from tests.unit.test_storage_schema_tenant import _RecordingPool
+from tests.unit.test_submission_revisions import _RowsPool
+
+TENANT = "t1"
+FORM_UID = uuid.UUID("550e8400-e29b-41d4-a716-446655440000")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _noop_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace the navigator-auth route decorators with pass-throughs.
+
+    ``api/routes.py`` binds ``is_authenticated`` / ``user_session`` with a
+    ``from ... import`` at module load, so the names must be patched on the
+    ``routes`` module itself, and before ``setup_form_api()`` runs.
+    """
+
+    def _factory(*_args: Any, **_kwargs: Any):
+        def _passthrough(handler):
+            return handler
+
+        return _passthrough
+
+    monkeypatch.setattr(routes_module, "is_authenticated", _factory)
+    monkeypatch.setattr(routes_module, "user_session", _factory)
+
+
+def _make_form() -> FormSchema:
+    """A minimal form pinned to a fixed ``form_uid``."""
+    return FormSchema(
+        form_id="guarded-form",
+        title="Guarded Form",
+        version="1.0",
+        tenant=TENANT,
+        sections=[
+            FormSection(
+                section_id="s1",
+                fields=[FormField(field_id="q1", field_type=FieldType.TEXT, label="Q1")],
+            )
+        ],
+    ).model_copy(update={"form_uid": FORM_UID})
+
+
+async def _make_client(aiohttp_client, registry: FormRegistry, **kwargs):
+    """Mount the REST surface via the public seam and return a test client."""
+    app = web.Application()
+    setup_form_api(app, registry, **kwargs)
+    return await aiohttp_client(app)
+
+
+async def _registry_with_form(
+    storage: FormStorage | None = None,
+) -> tuple[FormRegistry, FormSchema]:
+    registry = FormRegistry(storage, default_tenant=TENANT, require_tenant=False)
+    form = _make_form()
+    # persist=False — the form is seeded straight into the in-memory index so
+    # no storage write is attempted here.
+    await registry.register(form, persist=False, tenant=TENANT)
+    return registry, form
+
+
+def _storage_with_submissions() -> FormSubmissionStorage:
+    """A real submission storage whose probe finds a row."""
+    return FormSubmissionStorage(pool=_RowsPool(row={"exists": 1}))
+
+
+def _storage_without_submissions() -> FormSubmissionStorage:
+    """A real submission storage whose probe finds nothing."""
+    return FormSubmissionStorage(pool=_RecordingPool())
+
+
+# ---------------------------------------------------------------------------
+# Form storage doubles
+# ---------------------------------------------------------------------------
+
+
+class _BaseStorage(FormStorage):
+    """No-op FormStorage; subclasses override the one method under test."""
+
+    async def save(self, form, style=None, *, tenant=None) -> str:
+        return str(form.form_uid)
+
+    async def load(self, form_uid, version=None, *, tenant=None):
+        return None
+
+    async def delete(self, form_uid, *, tenant=None) -> bool:
+        return True
+
+    async def list_forms(self, *, tenant=None) -> list[dict[str, Any]]:
+        return []
+
+
+class _DeleteFailsStorage(_BaseStorage):
+    """Storage whose delete always fails — simulates an unreachable DB."""
+
+    async def delete(self, form_uid, *, tenant=None) -> bool:
+        raise ConnectionError("database unreachable")
+
+
+class _OrderRecordingStorage(_BaseStorage):
+    """Storage that records whether the form was still registered on delete.
+
+    This is how the ordering contract is observed rather than assumed: the
+    registry is queried from inside ``storage.delete()``, so a handler that
+    unregistered first would record ``False``.
+    """
+
+    def __init__(self) -> None:
+        self.registry: FormRegistry | None = None
+        self.form_present_at_delete: bool | None = None
+
+    async def delete(self, form_uid, *, tenant=None) -> bool:
+        assert self.registry is not None
+        found = await self.registry.get(form_uid, tenant=TENANT)
+        self.form_present_at_delete = found is not None
+        return True
+
+
+# ---------------------------------------------------------------------------
+# 1. The response guard, through setup_form_api
+# ---------------------------------------------------------------------------
+
+
+class TestResponseGuardViaPublicSeam:
+    async def test_form_with_submissions_is_refused(self, aiohttp_client, _noop_auth) -> None:
+        """409 — FEAT-300 §8: deactivate a form with responses, never delete."""
+        registry, form = await _registry_with_form()
+        client = await _make_client(
+            aiohttp_client,
+            registry,
+            submission_storage=_storage_with_submissions(),
+        )
+
+        resp = await client.delete(f"/api/v1/forms/{FORM_UID}")
+
+        assert resp.status == 409
+        body = await resp.json()
+        assert "cannot be deleted" in body["error"]
+        # The form survives the refusal.
+        assert await registry.get(FORM_UID, tenant=TENANT) is not None
+
+    async def test_form_without_submissions_is_deleted(self, aiohttp_client, _noop_auth) -> None:
+        """204 — the guard permits deletion when the probe finds no rows."""
+        registry, form = await _registry_with_form()
+        client = await _make_client(
+            aiohttp_client,
+            registry,
+            submission_storage=_storage_without_submissions(),
+        )
+
+        resp = await client.delete(f"/api/v1/forms/{FORM_UID}")
+
+        assert resp.status == 204
+        assert await registry.get(FORM_UID, tenant=TENANT) is None
+
+    async def test_explicit_hook_overrides_the_derived_one(self, aiohttp_client, _noop_auth) -> None:
+        """An explicit ``has_responses=`` wins over ``submission_storage``.
+
+        The storage here reports a submission, so the derived hook would
+        refuse; the override permits, and the override is what applies.
+        """
+        registry, form = await _registry_with_form()
+
+        async def _never_has_responses(form_uid, tenant) -> bool:
+            return False
+
+        client = await _make_client(
+            aiohttp_client,
+            registry,
+            submission_storage=_storage_with_submissions(),
+            has_responses=_never_has_responses,
+        )
+
+        resp = await client.delete(f"/api/v1/forms/{FORM_UID}")
+
+        assert resp.status == 204
+
+    async def test_explicit_hook_works_without_submission_storage(self, aiohttp_client, _noop_auth) -> None:
+        """A consumer may enforce its own policy with no submission storage."""
+        registry, form = await _registry_with_form()
+
+        async def _always_has_responses(form_uid, tenant) -> bool:
+            return True
+
+        client = await _make_client(aiohttp_client, registry, has_responses=_always_has_responses)
+
+        resp = await client.delete(f"/api/v1/forms/{FORM_UID}")
+
+        assert resp.status == 409
+        assert await registry.get(FORM_UID, tenant=TENANT) is not None
+
+    async def test_hook_receives_the_request_tenant(self, aiohttp_client, _noop_auth) -> None:
+        """The hook is called with the form_uid and the resolved tenant."""
+        registry, form = await _registry_with_form()
+        seen: list[tuple[Any, Any]] = []
+
+        async def _record(form_uid, tenant) -> bool:
+            seen.append((form_uid, tenant))
+            return False
+
+        client = await _make_client(aiohttp_client, registry, has_responses=_record)
+
+        resp = await client.delete(f"/api/v1/forms/{FORM_UID}")
+
+        assert resp.status == 204
+        assert seen == [(FORM_UID, TENANT)]
+
+
+# ---------------------------------------------------------------------------
+# 2. Backward compatibility — no submission_storage means no guard
+# ---------------------------------------------------------------------------
+
+
+class TestNoSubmissionStorageKeepsOldBehaviour:
+    async def test_delete_allowed_when_no_submission_storage_configured(self, aiohttp_client, _noop_auth) -> None:
+        """The compatibility guarantee.
+
+        A consumer that never passes ``submission_storage`` (and no explicit
+        hook) must see exactly what it saw before the guard was wired up:
+        deletion proceeds and returns 204. This is the test that fails if the
+        default hook is ever made unconditional.
+        """
+        registry, form = await _registry_with_form()
+        client = await _make_client(aiohttp_client, registry)
+
+        resp = await client.delete(f"/api/v1/forms/{FORM_UID}")
+
+        assert resp.status == 204
+        assert await registry.get(FORM_UID, tenant=TENANT) is None
+
+    async def test_version_service_has_no_hook_when_nothing_configured(
+        self,
+    ) -> None:
+        """``can_delete`` stays permissive with nothing configured.
+
+        Pins the resolution order at the unit level: no submission storage
+        and no explicit hook must leave ``has_responses`` unset, which is
+        what keeps ``FormVersionService.can_delete()`` returning ``True``.
+        """
+        from parrot_formdesigner.api.handlers import FormAPIHandler
+
+        registry, _ = await _registry_with_form()
+        handler = FormAPIHandler(registry=registry)
+
+        assert handler._build_has_responses_hook() is None
+        assert await handler._get_version_service().can_delete(FORM_UID, tenant=TENANT) is True
+
+
+# ---------------------------------------------------------------------------
+# 3. Delete ordering — storage first, registry second
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteOrdering:
+    async def test_storage_failure_returns_500_and_keeps_the_form(self, aiohttp_client, _noop_auth) -> None:
+        """A failed storage delete must not report success.
+
+        Before the fix the handler unregistered first and swallowed the
+        exception, returning 204 for a form that reappeared on the next
+        restart or registry hydration.
+        """
+        registry, form = await _registry_with_form(_DeleteFailsStorage())
+        client = await _make_client(aiohttp_client, registry)
+
+        resp = await client.delete(f"/api/v1/forms/{FORM_UID}")
+
+        assert resp.status == 500
+        body = await resp.json()
+        assert "Failed to delete" in body["error"]
+        # The registry is untouched, so memory and database still agree.
+        assert await registry.get(FORM_UID, tenant=TENANT) is not None
+
+    async def test_storage_delete_runs_before_unregister(self, aiohttp_client, _noop_auth) -> None:
+        """Observed ordering, not assumed: the form is still registered when
+        ``storage.delete()`` is called."""
+        storage = _OrderRecordingStorage()
+        registry, form = await _registry_with_form(storage)
+        storage.registry = registry
+        client = await _make_client(aiohttp_client, registry)
+
+        resp = await client.delete(f"/api/v1/forms/{FORM_UID}")
+
+        assert resp.status == 204
+        assert storage.form_present_at_delete is True
+        assert await registry.get(FORM_UID, tenant=TENANT) is None
+
+    async def test_successful_delete_removes_form_with_storage_configured(self, aiohttp_client, _noop_auth) -> None:
+        registry, form = await _registry_with_form(_BaseStorage())
+        client = await _make_client(aiohttp_client, registry)
+
+        resp = await client.delete(f"/api/v1/forms/{FORM_UID}")
+
+        assert resp.status == 204
+        assert await registry.get(FORM_UID, tenant=TENANT) is None
+
+    async def test_unknown_form_still_404s(self, aiohttp_client, _noop_auth) -> None:
+        """The reorder must not change the not-found path."""
+        registry, _ = await _registry_with_form()
+        client = await _make_client(aiohttp_client, registry)
+
+        resp = await client.delete("/api/v1/forms/00000000-0000-0000-0000-000000000000")
+
+        assert resp.status == 404

--- a/packages/parrot-formdesigner/tests/unit/test_submission_has_submissions.py
+++ b/packages/parrot-formdesigner/tests/unit/test_submission_has_submissions.py
@@ -1,0 +1,110 @@
+"""Tests for ``FormSubmissionStorage.has_submissions``.
+
+``has_submissions`` answers one question — does this form have at least one
+submission row? — so that ``FormVersionService`` can enforce the FEAT-300 §8
+invariant ("a form with >=1 response can never be deleted") through its
+``has_responses`` hook.
+
+These tests reuse the recording asyncpg stubs from
+``test_storage_schema_tenant`` / ``test_submission_revisions``, so the
+connection surface stays the one the rest of the suite already models:
+``execute`` / ``fetchrow`` / ``fetch``. No real PostgreSQL is required.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from parrot_formdesigner.services.submissions import FormSubmissionStorage
+
+from .test_storage_schema_tenant import _RecordingPool
+from .test_submission_revisions import _RowsPool
+
+_TEST_FORM_UID = uuid.UUID("550e8400-e29b-41d4-a716-446655440000")
+
+
+class TestHasSubmissionsResult:
+    """The boolean contract."""
+
+    async def test_false_when_no_row_matches(self) -> None:
+        # _RecordingConn.fetchrow() returns None — the "no submissions" case.
+        storage = FormSubmissionStorage(pool=_RecordingPool())
+        assert await storage.has_submissions(_TEST_FORM_UID) is False
+
+    async def test_true_when_a_row_matches(self) -> None:
+        storage = FormSubmissionStorage(pool=_RowsPool(row={"exists": 1}))
+        assert await storage.has_submissions(_TEST_FORM_UID) is True
+
+
+class TestHasSubmissionsQuery:
+    """The SQL it issues."""
+
+    async def test_binds_form_uid_as_the_only_parameter(self) -> None:
+        pool = _RecordingPool()
+        await FormSubmissionStorage(pool=pool).has_submissions(_TEST_FORM_UID)
+
+        sql, args = pool.conn.fetched[0]
+        assert args == (_TEST_FORM_UID,)
+        assert "WHERE form_uid = $1" in sql
+
+    async def test_stops_at_the_first_row(self) -> None:
+        """An existence probe must not scan the whole partition."""
+        pool = _RecordingPool()
+        await FormSubmissionStorage(pool=pool).has_submissions(_TEST_FORM_UID)
+
+        sql, _ = pool.conn.fetched[0]
+        assert "LIMIT 1" in sql
+
+    async def test_matches_form_uid_not_the_slug(self) -> None:
+        """``form_id`` is renameable; ``form_uid`` is the stable identity."""
+        pool = _RecordingPool()
+        await FormSubmissionStorage(pool=pool).has_submissions(_TEST_FORM_UID)
+
+        sql, _ = pool.conn.fetched[0]
+        assert "form_id" not in sql
+
+    async def test_counts_invalid_submissions_too(self) -> None:
+        """An invalid submission is still a response.
+
+        Filtering on ``is_valid`` would let a form be deleted out from under
+        rows that failed validation, orphaning them.
+        """
+        pool = _RecordingPool()
+        await FormSubmissionStorage(pool=pool).has_submissions(_TEST_FORM_UID)
+
+        sql, _ = pool.conn.fetched[0]
+        assert "is_valid" not in sql
+
+
+class TestHasSubmissionsSchemaResolution:
+    """Tenant / schema resolution, consistent with the other read methods."""
+
+    async def test_defaults_to_navigator_form_data(self) -> None:
+        pool = _RecordingPool()
+        await FormSubmissionStorage(pool=pool).has_submissions(_TEST_FORM_UID)
+
+        sql, _ = pool.conn.fetched[0]
+        assert '"navigator"."form_data"' in sql
+
+    async def test_per_call_tenant_overrides_the_schema(self) -> None:
+        pool = _RecordingPool()
+        await FormSubmissionStorage(pool=pool).has_submissions(_TEST_FORM_UID, tenant="epson")
+
+        sql, _ = pool.conn.fetched[0]
+        assert '"epson"."form_data"' in sql
+
+    async def test_constructor_tenant_is_the_default(self) -> None:
+        pool = _RecordingPool()
+        storage = FormSubmissionStorage(pool=pool, tenant="epson")
+        await storage.has_submissions(_TEST_FORM_UID)
+
+        sql, _ = pool.conn.fetched[0]
+        assert '"epson"."form_data"' in sql
+
+    async def test_configured_table_name_is_honoured(self) -> None:
+        pool = _RecordingPool()
+        storage = FormSubmissionStorage(pool=pool, table_name="form_submissions")
+        await storage.has_submissions(_TEST_FORM_UID)
+
+        sql, _ = pool.conn.fetched[0]
+        assert '"navigator"."form_submissions"' in sql


### PR DESCRIPTION
## Summary

`DELETE /api/v1/forms/{form_uid}` in `parrot-formdesigner` has two defects. This PR fixes both. The change is additive: one new storage method, one new optional keyword argument, and a reordering inside one handler.

cc @phenobarbital — I only have read access on this repo, so I cannot assign you as a reviewer. Mentioning you instead.

---

## Defect 1 — an invariant the library documents but cannot enforce

`services/form_version.py` accepts an optional `has_responses` hook, and `can_delete()` returns `True` when no hook is set:

```python
# services/form_version.py:371-374
if self._has_responses is None:
    return True
has = await self._has_responses(form_uid, tenant)
return not has
```

The handler calls that guard and documents the invariant it is meant to enforce:

```python
# api/handlers.py:1282-1288
# Spec invariant (FEAT-300 §8, Vision IQ parity): a form with ≥1
# response can never be deleted — only deactivated.
version_svc = self._get_version_service()
if not await version_svc.can_delete(form_uid, tenant=tenant):
```

But nothing can supply the hook. `_get_version_service()` builds the service with no hook at all (`api/handlers.py:1671`):

```python
self._version_service = FormVersionService(self.registry)
```

`setup_form_api()` has no parameter for it, and the `FormAPIHandler` it builds is a local variable that is never stashed on the app (`api/routes.py:190-202`; the only `app[...]` assignments are `form_registry`, `blob_storage`, `rest_resolver`, `partial_store`). So `can_delete()` returns `True` for every consumer, and the documented invariant is unreachable from the public API.

The existing tests are themselves the evidence — they reach the guard only by assigning a **private attribute** (`tests/unit/test_feat300_review_fixes.py:146` and `:163`):

```python
handler._version_service = FormVersionService(
    registry, has_responses=has_responses
)
```

## Defect 2 — unregister-before-delete, with the storage error swallowed

```python
# api/handlers.py:1299-1311 (before)
await self.registry.unregister(form_uid, tenant=tenant)

storage = self.registry.storage
if storage is not None:
    try:
        await storage.delete(form_uid, tenant=existing.tenant)
    except Exception as exc:
        self.logger.warning(
            "FormStorage.delete failed for %s: %s", form_uid, exc
        )

self.logger.info("DELETE form_uid=%s", form_uid)
return web.Response(status=204)
```

`services/registry.py:583` `unregister()` is memory-only. So when the database delete fails the caller is told `204 No Content`, and the form comes back on the next restart or registry hydration. The **order** is the defect, not only the swallowed exception: un-swallowing alone would still leave the in-memory registry and the database disagreeing.

---

## What changed

**1. `FormSubmissionStorage.has_submissions(form_uid, *, tenant=None) -> bool`** (`services/submissions.py`)

An existence probe, alongside the existing `store` / `get_submission` / `list_revisions`:

```python
sql = f"SELECT 1 FROM {qt} WHERE form_uid = $1 LIMIT 1"
```

- Matches on `form_uid`, not the renameable `form_id` slug.
- Applies **no** `is_valid` filter. An invalid submission is still a response, and deleting the form it belongs to would orphan it.
- Uses `fetchrow`, not `fetchval`, and plain `SELECT 1` rather than `SELECT EXISTS(...)`, because that is the connection surface the package already uses everywhere (`fetchval` and `SELECT EXISTS` appear 0 times in `src/`). The existing recording asyncpg stubs therefore work against it unchanged.

`FormSubmissionStorage` is the only submission-storage implementation in the package — there is no ABC to extend. The `FormResultStorage` ABC named in `sdd/specs/parrot-formdesigner-post-method.spec.md` was planned but never built (`class FormResultStorage` appears 0 times in any tracked `.py`), so there was no interface to add the method to.

**2. The hook is built from the storage the handler already has** (`api/handlers.py`, `api/routes.py`)

`setup_form_api()` already takes `submission_storage` and already passes it to `FormAPIHandler`. `_get_version_service()` now wires a `has_responses` hook derived from it. Resolution order:

1. An explicit `has_responses=` wins.
2. Otherwise, when `submission_storage` is configured, derive the hook from `submission_storage.has_submissions`.
3. Otherwise `None` — `can_delete()` stays permissive, exactly as before.

`has_responses=` is a new **optional** keyword argument on `setup_form_api()` and `FormAPIHandler`, appended last so no positional caller changes. It exists so a consumer wanting a wider policy (for example a reference check against its own tables) can supply one.

**3. The delete is reordered** (`api/handlers.py`)

Storage delete first; on failure return `500` and leave the registry untouched. `registry.unregister()` runs only after the durable delete succeeds. This matches what `FormVersionService.safe_delete()` already does (`form_version.py:387-390`).

---

## Compatibility

**A consumer that configures no `submission_storage` sees byte-identical behaviour.** This is pinned by a test that fails if the default hook is ever made unconditional:

- `TestNoSubmissionStorageKeepsOldBehaviour::test_delete_allowed_when_no_submission_storage_configured` — real HTTP `DELETE` through `setup_form_api()` with nothing configured, asserts `204` and that the form is gone.
- `TestNoSubmissionStorageKeepsOldBehaviour::test_version_service_has_no_hook_when_nothing_configured` — asserts `_build_has_responses_hook()` is `None` and `can_delete()` is `True`.

The existing pinning test `tests/unit/test_form_version.py::test_form_version_delete_no_hook_allowed` ("safe_delete is always allowed when no has_responses hook is provided") is **untouched and still green**.

## Behaviour change (please read)

**A consumer that DOES pass `submission_storage=` now gets the guard where it previously did not**, and receives `409` instead of `204` when deleting a form that has submissions. That is the FEAT-300 §8 invariant finally taking effect, and it is the point of the PR — but it is a behaviour change, not a pure bug fix, so it is called out here and recorded under `### Changed` in `packages/parrot-formdesigner/CHANGELOG.md`. A consumer that wants the old behaviour with a submission storage configured can pass a permissive hook.

Separately, a failed storage delete now returns `500` where it previously returned `204`. A client that treated that `204` as success was being misinformed.

---

## Tests

New tests go through the public `setup_form_api()` seam over a real HTTP round trip, not the private-attribute injection — the wiring is the thing under test, so a test that constructed `FormAPIHandler(has_responses=...)` directly would pass even if `setup_form_api()` forwarded nothing.

Reaching an auth-wrapped route over HTTP requires neutralising the navigator-auth decorators that `_wrap_auth` applies at registration time. No existing test in this package does that, so the `_noop_auth` fixture is a new pattern here; the module docstring explains why. The submission storage in these tests is a **real** `FormSubmissionStorage` driven by the suite's existing recording asyncpg stubs, so the guard is proved through the production query path rather than a hand-written double.

- `tests/unit/test_submission_has_submissions.py` — 11 tests: the boolean contract, the SQL issued, and schema/tenant resolution.
- `tests/unit/api/test_delete_form_response_guard.py` — 10 tests: the guard via the public seam, the compatibility guarantee, and the delete ordering.

**Counts** (package suite, `packages/parrot-formdesigner`, Python 3.11):

| | before | after |
|---|---|---|
| passed | 1815 | **1836** (+21) |
| failed | 25 | 25 |
| errors | 48 | 48 |

The 25 failures and 48 errors are pre-existing on `main` in my environment (missing optional voice/LLM extras plus some count-drift assertions). I verified the failing/erroring **test-ID set is identical** before and after this branch, so it introduces no new failure.

**Lint**: `flake8` with the repo's `.flake8` reports **0 findings** on both new files. The three findings on `api/handlers.py` (`E305` line 85, `C901 submit_data` complexity 36, `W391`) and the one on `api/routes.py` (`C901 setup_form_api` complexity 19) are present unchanged on `main` — I introduced none, and `setup_form_api`'s complexity is still 19. Both new files are `black --check` clean at the repo's configured `line-length = 120`. I did **not** run `black` over the three modified source files: they are not black-clean on `main`, so reformatting them would bury a 156-line change in unrelated churn.

**Mutation-verified.** Every new assertion was checked by reverting the change and confirming RED, then restoring and confirming the file was byte-identical:

| Mutation | Result |
|---|---|
| Unwire the hook (`FormVersionService(self.registry)`) | RED — 3 guard tests fail |
| Restore unregister-before-delete + swallow | RED — 2 ordering tests fail |
| Make the default hook unconditional | RED — both compatibility tests fail |
| `has_submissions` always returns `False` | RED |
| Filter the probe on `is_valid = TRUE` | RED |
| Drop `LIMIT 1` | RED |
| `setup_form_api` drops `has_responses` | RED |

The ordering test observes the order rather than assuming it: the storage double queries the registry from inside its own `delete()`, so a handler that unregistered first records `False`.

**Note on CI:** `packages/parrot-formdesigner` is not covered by `.github/workflows/ci.yml` (`formdesigner` appears 0 times in it; the jobs are `ai-parrot`, `navrules`, `ai-parrot-tools`, `ai-parrot-loaders`), and `lint-and-registry` runs the registry/TASK-ID checks rather than a linter. So CI will not exercise these tests — the counts above are local runs.

---

## Deliberately NOT done

- **No reference-veto beyond submissions.** The hook checks submissions only. Vetoing a delete against actions or catalog tables is consumer policy; a consumer wanting it passes its own `has_responses`.
- **No new required parameter**, and no change to any existing signature's positional order.
- **`FormVersionService` type annotations left alone.** Its hook is annotated `Callable[[str, str], Awaitable[bool]]` and `can_delete(form_uid: str, ...)`, but `extract_form_uid()` returns a `uuid.UUID`, so the handler has always passed a UUID there. That mismatch predates this PR (the existing tests declare `has_responses(form_uid: str, ...)` while receiving a UUID). Correcting it touches the FEAT-300/389 rekey and the pinning test, so it belongs in its own change.
- **No `FormResultStorage` ABC.** Introducing the planned-but-absent ABC to hang one method on would be a much larger refactor than this fix needs.
- **No `app["form_handler"]` stash.** Exposing the handler on the app would fix the reachability problem a second way, but it adds public surface this fix does not need.
- **No reformatting** of the modified source files (see Lint above).
