### PR TITLE
Release 0.25.35 — parrot-formdesigner 0.8.21 (tenant context, jsonb fix, slug suffix, registry read-through)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,3 +390,11 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
+          # Every release builds ALL 12 packages, but only the ones whose
+          # version moved since the last release can be uploaded — PyPI
+          # rejects re-uploads of an existing version, and without this
+          # flag ONE unchanged sibling fails the WHOLE deploy (observed:
+          # the 0.25.34 and 0.25.32 releases both failed exactly here
+          # while all 12 build jobs were green). With it, unchanged
+          # packages are skipped and only the bumped ones publish.
+          skip-existing: true

--- a/packages/ai-parrot/src/parrot/version.py
+++ b/packages/ai-parrot/src/parrot/version.py
@@ -5,7 +5,7 @@ __description__ = (
     "Complete Framework for AI Chatbots and Agents, "
     "Supporting A2A, MCP, RAG and more."
 )
-__version__ = "0.25.34"
+__version__ = "0.25.35"
 __author__ = "Jesus Lara"
 __author_email__ = "jesuslarag@gmail.com"
 __license__ = "MIT"

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/api/_utils.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/api/_utils.py
@@ -18,6 +18,17 @@ def _get_request_tenant(request: "web.Request") -> str | None:
 
     Resolution order:
 
+    0. ``request["tenant_context"]`` — a tenant the HOST APPLICATION
+       resolved, authorized and declared for this request (e.g. a
+       navigator middleware validating a ``?program_slug=`` claim
+       against the caller's entitlements before setting the key).
+       Declaring the tenant is the host's job precisely because
+       AUTHORIZING it cannot be this library's: parrot knows nothing
+       about the host's entitlement model. When set, it wins over the
+       session inference below — ``programs[0]`` is an arbitrarily
+       ordered default (a caller with eleven programmes is a member of
+       all eleven), never a statement of which programme this request
+       is about.
     1. First program slug from the navigator-auth session
        (``request.session["session"]["programs"][0]``).
     2. ``request.app["form_registry"].default_tenant`` when the registry
@@ -33,9 +44,13 @@ def _get_request_tenant(request: "web.Request") -> str | None:
         request: Incoming aiohttp web.Request.
 
     Returns:
-        Tenant slug string, or ``None`` if neither the session nor the
-        application registry can provide one.
+        Tenant slug string, or ``None`` if neither the host context, the
+        session nor the application registry can provide one.
     """
+    declared = request.get("tenant_context")
+    if declared:
+        return str(declared)
+
     session = getattr(request, "session", None)
     if session is not None:
         userinfo = session.get("session", {})

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/api/handlers.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/api/handlers.py
@@ -256,11 +256,18 @@ class FormAPIHandler:
     def _get_tenant(self, request: web.Request) -> str:
         """Extract the effective tenant for this request.
 
-        Returns the first program slug from the navigator-auth session (as set
-        by :meth:`_get_programs`). When no programs are present — anonymous
-        requests, sessions without program scope, or test setups without
-        navigator-auth — falls back to the registry's configured
-        ``default_tenant`` so write paths don't crash on
+        Prefers ``request["tenant_context"]`` — a tenant the HOST
+        APPLICATION resolved, authorized and declared for this request
+        (see ``_utils._get_request_tenant``'s step 0 for the full
+        rationale: authorization cannot be this library's job, and the
+        session's ``programs[0]`` is an arbitrarily ordered default, not
+        a statement of which programme the request is about).
+
+        Otherwise returns the first program slug from the navigator-auth
+        session (as set by :meth:`_get_programs`). When no programs are
+        present — anonymous requests, sessions without program scope, or
+        test setups without navigator-auth — falls back to the registry's
+        configured ``default_tenant`` so write paths don't crash on
         ``require_tenant=True``.
 
         Args:
@@ -270,6 +277,9 @@ class FormAPIHandler:
         Returns:
             A tenant slug string — never ``None``.
         """
+        declared = request.get("tenant_context")
+        if declared:
+            return str(declared)
         programs = self._get_programs(request)
         if programs:
             return programs[0]

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/question_bank.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/question_bank.py
@@ -92,9 +92,12 @@ CREATE TABLE IF NOT EXISTS {table} (
 );
 """
 
+# `$2::text::jsonb`: the param is JSON TEXT (json.dumps). See
+# PostgresFormStorage._upsert_sql for why a bare `::jsonb` double-encodes
+# on a host pool that registers a json/jsonb codec.
 _INSERT_SQL = """
 INSERT INTO {table} (question_id, definition_json, tenant)
-VALUES ($1, $2::jsonb, $3)
+VALUES ($1, $2::text::jsonb, $3)
 ON CONFLICT (question_id, tenant) DO NOTHING
 """
 

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/rbac.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/rbac.py
@@ -212,9 +212,12 @@ class RBACContext(BaseModel):
 # SQL constants
 # ---------------------------------------------------------------------------
 
+# `$2::text::jsonb`: the param is JSON TEXT (json.dumps). See
+# PostgresFormStorage._upsert_sql for why a bare `::jsonb` double-encodes
+# on a host pool that registers a json/jsonb codec.
 _INSERT_POLICY_SQL = """
 INSERT INTO fieldsync.auth_policies (name, policy, tenant, priority, enforcing)
-VALUES ($1, $2::jsonb, $3, $4, $5)
+VALUES ($1, $2::text::jsonb, $3, $4, $5)
 ON CONFLICT (name) DO UPDATE
     SET policy    = EXCLUDED.policy,
         tenant    = EXCLUDED.tenant,

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/registry.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/registry.py
@@ -312,6 +312,58 @@ class FormRegistry:
     # Public API — write paths
     # ------------------------------------------------------------------
 
+    async def _next_free_slug(
+        self, base: str, tenant: str, form_uid: uuid.UUID
+    ) -> str:
+        """Return ``base``, or the first free ``base-N`` in ``tenant``.
+
+        A slug is TAKEN when it maps to a DIFFERENT ``form_uid`` — in the
+        in-memory index, or (when a storage backend is configured) in the
+        persisted table, probed via ``load_by_slug``. The storage probe is
+        what makes this hold on a cold cache: the in-memory slug index
+        starts empty every boot, and a memory-only check would let the
+        collision fall through to the database's per-tenant unique
+        constraint as a raw error.
+
+        Args:
+            base: The requested slug.
+            tenant: The resolved tenant scope.
+            form_uid: The registering form's identity — its OWN existing
+                row/registration never counts as a collision.
+
+        Returns:
+            ``base`` when free, else ``base-2``, ``base-3``, ...
+
+        Raises:
+            FormAlreadyExistsError: When no free slug is found within a
+                pathological number of attempts.
+        """
+        candidate = base
+        for suffix in range(2, 202):
+            owner = self._slug_index.get(self._make_slug_key(tenant, candidate))
+            taken = owner is not None and owner != form_uid
+            if not taken and self._storage is not None:
+                try:
+                    persisted = await self._storage.load_by_slug(candidate, tenant)
+                except Exception:  # noqa: BLE001 — probe only; register's
+                    # own persist path will surface real storage faults
+                    persisted = None
+                # isinstance guard: a stub/mock storage returns truthy
+                # non-FormSchema objects whose `.form_uid` is not a UUID —
+                # those must never read as a collision (they would suffix
+                # forever). A real backend returns FormSchema | None.
+                persisted_uid = getattr(persisted, "form_uid", None)
+                taken = (
+                    isinstance(persisted_uid, uuid.UUID)
+                    and persisted_uid != form_uid
+                )
+            if not taken:
+                return candidate
+            candidate = f"{base}-{suffix}"
+        raise FormAlreadyExistsError(
+            f"No free slug found for {base!r} in tenant {tenant!r}"
+        )
+
     async def register(
         self,
         form: FormSchema,
@@ -363,6 +415,16 @@ class FormRegistry:
                 this form_uid's own prior registration. Subclasses
                 ``ValueError`` so existing ``except ValueError`` call sites
                 keep working.
+
+                EXCEPTION (2026-08-12): a BRAND-NEW form (a ``form_uid``
+                this registry has never seen) registering with
+                ``persist=True`` does not raise — its slug is numerically
+                suffixed to the first free one instead
+                (``bug-report-form`` → ``bug-report-form-2``), probing
+                BOTH the in-memory index and the storage backend, and
+                ``form.form_id`` is updated in place so the caller returns
+                the real slug. Create-from-template mints canonical slugs
+                on purpose; only RENAMES of existing forms keep the error.
         """
         # Determine whether resolution would fall all the way to default_tenant
         # because no explicit information was provided.
@@ -390,6 +452,32 @@ class FormRegistry:
                 form.form_id,
                 resolved,
             )
+
+        # Create-from-template friendliness (2026-08-12): a BRAND-NEW form
+        # (this registry has never seen its form_uid) whose slug is already
+        # owned by ANOTHER form in the tenant gets a numeric suffix
+        # (`bug-report-form-2`) instead of an error. The quick-start
+        # templates deterministically re-mint canonical slugs, and every
+        # click is meant to create an INDEPENDENT form — erroring made the
+        # feature unusable, and the historical alternative (piling creates
+        # up as fake "versions" of one form_id) predates form_uid identity
+        # and corrupts version lineage. Renames of EXISTING forms keep
+        # raising FormAlreadyExistsError below: silently renaming an
+        # explicit user choice would be surprising. Gated on ``persist``
+        # so pure in-memory registration (hydration) never probes storage.
+        if persist and self._uid_to_slug.get(form.form_uid) is None:
+            free_slug = await self._next_free_slug(
+                form.form_id, resolved, form.form_uid
+            )
+            if free_slug != form.form_id:
+                self.logger.info(
+                    "FormRegistry.register: slug %r already taken in tenant "
+                    "%r — creating as %r",
+                    form.form_id,
+                    resolved,
+                    free_slug,
+                )
+                form.form_id = free_slug
 
         slug_key = self._make_slug_key(resolved, form.form_id)
 

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/registry.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/registry.py
@@ -858,19 +858,30 @@ class FormRegistry:
     async def get(self, form_uid: uuid.UUID, *, tenant: str | None = None) -> FormSchema | None:
         """Get a form schema by ``form_uid`` (primary key) within a tenant.
 
+        Read-through (2026-08-13): on a cache miss, when a storage backend
+        is attached, the form is loaded from storage and admitted into the
+        cache — see :meth:`_read_through`. The in-memory index alone made
+        every uid-gated handler (delete/update/validate/render/clone) 404
+        on any persisted form the boot-time hydration did not cover, and a
+        restart was required before a form created by another process (or
+        seeded directly) became visible at all.
+
         Args:
             form_uid: The form's immutable ``form_uid`` (UUID). NOT
                 ``form_id`` — use :meth:`get_by_slug` for slug-based lookups.
             tenant: Tenant scope.  ``None`` resolves to ``default_tenant``.
 
         Returns:
-            FormSchema if found under the resolved tenant, ``None`` otherwise.
-            A form registered under ``"epson"`` is invisible to
-            ``get(form_uid, tenant="pokemon")``.
+            FormSchema if found under the resolved tenant (cache first,
+            then storage), ``None`` otherwise. A form registered under
+            ``"epson"`` is invisible to ``get(form_uid, tenant="pokemon")``.
         """
         resolved = self._resolve_tenant(tenant)
         async with self._lock:
-            return self._forms.get(resolved, {}).get(form_uid)
+            cached = self._forms.get(resolved, {}).get(form_uid)
+        if cached is not None:
+            return cached
+        return await self._read_through(resolved, form_uid=form_uid)
 
     async def get_by_slug(
         self, form_id: str, *, tenant: str | None = None
@@ -878,23 +889,97 @@ class FormRegistry:
         """Get a form schema by its slug (``form_id``) within a tenant.
 
         Resolves ``form_id`` → ``tenant_form_slug`` → ``form_uid`` via
-        ``_slug_index``, then looks up the primary index (FEAT-389).
+        ``_slug_index``, then looks up the primary index (FEAT-389). On a
+        cache miss, falls through to storage (:meth:`_read_through`) —
+        same rationale as :meth:`get`.
 
         Args:
             form_id: The form's human-readable slug.
             tenant: Tenant scope.  ``None`` resolves to ``default_tenant``.
 
         Returns:
-            FormSchema if a form with this slug is registered under the
-            resolved tenant, ``None`` otherwise.
+            FormSchema if a form with this slug exists under the resolved
+            tenant (cache first, then storage), ``None`` otherwise.
         """
         resolved = self._resolve_tenant(tenant)
         slug_key = self._make_slug_key(resolved, form_id)
         async with self._lock:
             form_uid = self._slug_index.get(slug_key)
-            if form_uid is None:
-                return None
-            return self._forms.get(resolved, {}).get(form_uid)
+            cached = (
+                self._forms.get(resolved, {}).get(form_uid)
+                if form_uid is not None
+                else None
+            )
+        if cached is not None:
+            return cached
+        return await self._read_through(resolved, form_id=form_id)
+
+    async def _read_through(
+        self,
+        resolved: str,
+        *,
+        form_uid: uuid.UUID | None = None,
+        form_id: str | None = None,
+    ) -> FormSchema | None:
+        """Load a cache-missed form from storage and admit it to the cache.
+
+        Fail-soft by design: a lookup must degrade to ``None`` (the
+        pre-read-through answer), never raise — storage faults are logged
+        and swallowed HERE because every caller of :meth:`get` /
+        :meth:`get_by_slug` already treats ``None`` as "not found".
+
+        Admission reuses :meth:`register` with ``persist=False`` (never a
+        re-save, never the new-form slug-suffix probe — that path is gated
+        on ``persist=True``) and ``overwrite=False`` (a racing admission of
+        the same uid wins harmlessly). The one register() failure mode a
+        STORAGE row can trigger is a slug already claimed by a DIFFERENT
+        cached form_uid (``FormAlreadyExistsError``): the loaded form is
+        then served UNCACHED with a warning — refusing the lookup because
+        the cache is inconsistent would turn a bookkeeping conflict into a
+        user-facing 404.
+
+        Args:
+            resolved: The already-resolved tenant (never ``None``).
+            form_uid: Lookup by immutable uid — exactly one of
+                ``form_uid``/``form_id`` is provided by the two callers.
+            form_id: Lookup by mutable slug.
+
+        Returns:
+            The loaded FormSchema, or ``None`` (no storage attached, no
+            such row, or a storage fault — logged).
+        """
+        if self._storage is None:
+            return None
+        try:
+            if form_uid is not None:
+                loaded = await self._storage.load(form_uid, tenant=resolved)
+            else:
+                loaded = await self._storage.load_by_slug(form_id, resolved)
+        except Exception as exc:  # noqa: BLE001 — lookups degrade, never raise
+            self.logger.warning(
+                "FormRegistry read-through: storage load failed "
+                "(tenant=%r form_uid=%r form_id=%r): %s",
+                resolved,
+                form_uid,
+                form_id,
+                exc,
+            )
+            return None
+        if loaded is None:
+            return None
+        try:
+            await self.register(
+                loaded, tenant=resolved, overwrite=False, persist=False
+            )
+        except FormAlreadyExistsError as exc:
+            self.logger.warning(
+                "FormRegistry read-through: slug %r conflicts with a cached "
+                "form under tenant=%r — serving the storage row uncached: %s",
+                loaded.form_id,
+                resolved,
+                exc,
+            )
+        return loaded
 
     async def list_forms(self, *, tenant: str | None = None) -> list[FormSchema]:
         """List all registered form schemas for a specific tenant.

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/storage.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/storage.py
@@ -172,9 +172,18 @@ class PostgresFormStorage(FormStorage):
 
     def _upsert_sql(self, tenant: str | None) -> str:
         qt = self._qualified(tenant)
+        # `$n::text::jsonb`, NOT `$n::jsonb`: the params are JSON TEXT
+        # (model_dump_json()). On a plain pool both casts behave the same,
+        # but a HOST-provided pool may register a json/jsonb type codec
+        # (encoder=json.dumps) — and a `::jsonb`-typed parameter is then
+        # re-encoded by that codec, storing a double-encoded jsonb STRING
+        # instead of an object (`jsonb_typeof = 'string'`, every
+        # `->>'key'` read returns NULL). Typing the parameter as TEXT
+        # keeps any codec out of the way; the explicit cast then parses
+        # the JSON server-side, identically under both pool regimes.
         return f"""
         INSERT INTO {qt} (form_uid, form_id, version, schema_json, style_json, tenant, created_by)
-        VALUES ($1, $2, $3, $4::jsonb, $5::jsonb, $6, $7)
+        VALUES ($1, $2, $3, $4::text::jsonb, $5::text::jsonb, $6, $7)
         ON CONFLICT (form_uid, version)
         DO UPDATE SET
             form_id = EXCLUDED.form_id,

--- a/packages/parrot-formdesigner/tests/test_create_slug_suffix.py
+++ b/packages/parrot-formdesigner/tests/test_create_slug_suffix.py
@@ -1,0 +1,132 @@
+"""Create-from-template: colliding slugs suffix numerically, renames still raise.
+
+The 2026-08-12 live failure: the quick-start templates deterministically
+mint canonical slugs (``bug-report-form``), so the SECOND create from the
+same template collided with the per-tenant unique constraint — and with a
+cold registry cache (hydration gap) the friendly in-memory guard never
+fired, so the collision surfaced as a raw database error swallowed into a
+fake "Form created" success.
+
+The fix, proven here BY EFFECT against a real Postgres:
+
+- A brand-new form whose slug is taken gets ``-2``/``-3``/... — probing
+  STORAGE, so a cold cache cannot hide the collision (every test below
+  uses a FRESH registry against pre-persisted rows, exactly the cold
+  boot).
+- Re-registering/updating the SAME form_uid never suffixes.
+- Renaming an EXISTING form onto another form's slug still raises
+  ``FormAlreadyExistsError`` — silently renaming an explicit user choice
+  would be worse than the error.
+
+Requires a disposable Postgres::
+
+    SCRATCH_DSN="postgresql://postgres:postgres@localhost:15931/postgres" \\
+        pytest tests/test_create_slug_suffix.py -v
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from parrot_formdesigner.core.schema import FormSchema
+from parrot_formdesigner.services.registry import (
+    FormAlreadyExistsError,
+    FormRegistry,
+)
+from parrot_formdesigner.services.storage import PostgresFormStorage
+
+_SCRATCH_DSN = os.getenv("SCRATCH_DSN")
+
+pytestmark = [
+    pytest.mark.skipif(
+        not _SCRATCH_DSN,
+        reason="SCRATCH_DSN not set (scratch Postgres required)",
+    ),
+]
+
+SCHEMA = "pfd_slug_suffix_test"
+TENANT = "flexroc_suffix_test"
+
+
+@pytest.fixture()
+async def storage() -> AsyncIterator[PostgresFormStorage]:
+    import asyncpg
+
+    pool = await asyncpg.create_pool(dsn=_SCRATCH_DSN, min_size=1, max_size=2)
+    async with pool.acquire() as conn:
+        await conn.execute(f'CREATE SCHEMA IF NOT EXISTS "{SCHEMA}"')
+        await conn.execute(f'CREATE SCHEMA IF NOT EXISTS "{TENANT}"')
+    built = PostgresFormStorage(pool=pool, schema=SCHEMA)
+    await built.initialize(tenant=TENANT)
+    try:
+        yield built
+    finally:
+        async with pool.acquire() as conn:
+            await conn.execute(f'DROP SCHEMA IF EXISTS "{SCHEMA}" CASCADE')
+            await conn.execute(f'DROP SCHEMA IF EXISTS "{TENANT}" CASCADE')
+        await pool.close()
+
+
+def _fresh_registry(storage: PostgresFormStorage) -> FormRegistry:
+    """A COLD registry (empty slug index) — the post-boot reality under
+    the hydration gap; the storage probe is what must catch collisions."""
+    registry = FormRegistry(require_tenant=False, default_tenant=TENANT)
+    registry.set_storage(storage)
+    return registry
+
+
+def _template_form(slug: str = "bug-report-form") -> FormSchema:
+    return FormSchema(
+        form_id=slug, title="Bug Report Form", sections=[], tenant=TENANT
+    )
+
+
+async def test_second_create_from_template_suffixes(
+    storage: PostgresFormStorage,
+) -> None:
+    first = _template_form()
+    await _fresh_registry(storage).register(first, persist=True)
+    assert first.form_id == "bug-report-form"
+
+    # Fresh registry = cold cache: only the storage probe can see `first`.
+    second = _template_form()
+    await _fresh_registry(storage).register(second, persist=True)
+    assert second.form_id == "bug-report-form-2"
+
+    third = _template_form()
+    await _fresh_registry(storage).register(third, persist=True)
+    assert third.form_id == "bug-report-form-3"
+
+    # All three persisted as independent identities.
+    listed = await storage.list_forms(tenant=TENANT)
+    slugs = sorted(entry["form_id"] for entry in listed)
+    assert slugs == ["bug-report-form", "bug-report-form-2", "bug-report-form-3"]
+
+
+async def test_updating_the_same_form_never_suffixes(
+    storage: PostgresFormStorage,
+) -> None:
+    form = _template_form(slug="visit-recap")
+    registry = _fresh_registry(storage)
+    await registry.register(form, persist=True)
+    # Same uid, same slug, new save — an UPDATE, not a new identity.
+    await registry.register(form, persist=True)
+    assert form.form_id == "visit-recap"
+
+
+async def test_rename_onto_a_taken_slug_still_raises(
+    storage: PostgresFormStorage,
+) -> None:
+    registry = _fresh_registry(storage)
+    owner = _template_form(slug="owner-form")
+    victim = _template_form(slug="victim-form")
+    await registry.register(owner, persist=True)
+    await registry.register(victim, persist=True)
+
+    victim.form_id = "owner-form"  # explicit rename onto a taken slug
+    with pytest.raises(FormAlreadyExistsError):
+        await registry.register(victim, persist=True)

--- a/packages/parrot-formdesigner/tests/test_jsonb_object_storage.py
+++ b/packages/parrot-formdesigner/tests/test_jsonb_object_storage.py
@@ -1,0 +1,138 @@
+"""schema_json must be stored as a jsonb OBJECT under BOTH pool regimes.
+
+The 2026-07-30 defect, pinned at the layer that can see it: ``save()``
+passes JSON TEXT as a ``::jsonb``-typed parameter, and a HOST-provided
+pool that registers a json/jsonb type codec (encoder=json.dumps —
+navigator's shared pool does) re-encodes that text, storing a
+double-encoded jsonb STRING. Every Python reader compensates
+(``json.loads`` if ``str``), so round-trip tests stay green — what breaks
+is SQL: ``->>'title'`` returns NULL and ``jsonb_typeof`` says
+``'string'``. These tests therefore assert the STORED SHAPE directly,
+once per pool regime, so a regression on either side cannot hide behind
+the compensating readers.
+
+Requires a disposable Postgres::
+
+    SCRATCH_DSN="postgresql://postgres:postgres@localhost:15931/postgres" \\
+        pytest tests/test_jsonb_object_storage.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from parrot_formdesigner.core.schema import FormSchema
+from parrot_formdesigner.services.storage import PostgresFormStorage
+
+_SCRATCH_DSN = os.getenv("SCRATCH_DSN")
+
+pytestmark = [
+    pytest.mark.skipif(
+        not _SCRATCH_DSN,
+        reason="SCRATCH_DSN not set (scratch Postgres required)",
+    ),
+]
+
+SCHEMA = "pfd_jsonb_shape_test"
+
+
+async def _codec_init(conn: Any) -> None:
+    """Mirror navigator's shared-pool json/jsonb codec registration."""
+    for name in ("json", "jsonb"):
+        await conn.set_type_codec(
+            name, encoder=json.dumps, decoder=json.loads, schema="pg_catalog"
+        )
+
+
+@pytest.fixture(params=["plain", "codec"])
+async def pool(request: pytest.FixtureRequest) -> AsyncIterator[Any]:
+    """One run per pool regime: parrot's own plain pool, and a pool with
+    the json/jsonb codec a host application may register."""
+    import asyncpg
+
+    kwargs: dict[str, Any] = {"dsn": _SCRATCH_DSN, "min_size": 1, "max_size": 2}
+    if request.param == "codec":
+        kwargs["init"] = _codec_init
+    created = await asyncpg.create_pool(**kwargs)
+    async with created.acquire() as conn:
+        await conn.execute(f'CREATE SCHEMA IF NOT EXISTS "{SCHEMA}"')
+    try:
+        yield created
+    finally:
+        async with created.acquire() as conn:
+            await conn.execute(f'DROP SCHEMA IF EXISTS "{SCHEMA}" CASCADE')
+        await created.close()
+
+
+async def test_save_stores_a_jsonb_object_never_a_string(pool: Any) -> None:
+    storage = PostgresFormStorage(pool=pool, schema=SCHEMA)
+    await storage.initialize()
+
+    form = FormSchema(
+        form_id="shape-proof",
+        title="Shape Proof",
+        sections=[],
+        tenant=None,
+    )
+    await storage.save(form)
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            f'SELECT jsonb_typeof(schema_json) AS kind, '
+            f"schema_json->>'title' AS title "
+            f'FROM "{SCHEMA}".form_schemas WHERE form_uid = $1',
+            form.form_uid,
+        )
+    assert row is not None
+    assert row["kind"] == "object", (
+        "schema_json stored as a jsonb STRING — the double-encoding "
+        "defect is back for this pool regime"
+    )
+    # The SQL-level read the double-encoding used to break silently.
+    assert row["title"] == "Shape Proof"
+
+
+async def test_loader_still_reads_both_shapes(
+    pool: Any, request: pytest.FixtureRequest
+) -> None:
+    """The compensating reader keeps accepting legacy string rows —
+    fixing the writer must not strand data written before the fix.
+
+    Codec-pool regime ONLY, because that is the only regime where legacy
+    string rows exist: they were written by codec pools re-encoding the
+    old ``::jsonb`` parameter, and those installations read through the
+    same codec pool (which decodes one level, leaving the reader's
+    ``json.loads``-if-str to unwrap the second). A plain pool never
+    produced string rows — the old cast stored objects correctly there —
+    so the plain+legacy combination exists in no deployment.
+    """
+    if "plain" in request.node.callspec.id:
+        pytest.skip("legacy string rows only ever existed under codec pools")
+    storage = PostgresFormStorage(pool=pool, schema=SCHEMA)
+    await storage.initialize()
+
+    form = FormSchema(
+        form_id="legacy-string-row",
+        title="Legacy Row",
+        sections=[],
+        tenant=None,
+    )
+    # Simulate a pre-fix row: a jsonb STRING containing the JSON text.
+    async with pool.acquire() as conn:
+        await conn.execute(
+            f'INSERT INTO "{SCHEMA}".form_schemas '
+            f"(form_uid, form_id, version, schema_json, tenant) "
+            f"VALUES ($1, $2, '1.0', to_jsonb($3::text), NULL)",
+            form.form_uid,
+            form.form_id,
+            form.model_dump_json(),
+        )
+
+    loaded = await storage.load(form.form_uid)
+    assert loaded is not None
+    assert loaded.form_id == "legacy-string-row"

--- a/packages/parrot-formdesigner/tests/test_registry_read_through.py
+++ b/packages/parrot-formdesigner/tests/test_registry_read_through.py
@@ -1,0 +1,168 @@
+"""Registry read-through: a cache miss falls through to storage (2026-08-13).
+
+The live failure this closes: ``FormRegistry.get``/``get_by_slug`` were pure
+in-memory lookups, and boot-time hydration does not cover per-tenant-schema
+forms — so after any restart, every uid-gated handler (DELETE/PUT/validate/
+render/clone) answered 404 for a form that demonstrably existed in storage
+(observed on a day-old ``flexroc`` form; the row was intact, only the cache
+was cold). Creating a form masked the gap until the next restart, because
+the create path registers in memory as a side effect.
+
+Proven BY EFFECT against a real Postgres, mirroring
+``test_create_slug_suffix.py``'s cold-boot discipline: every test uses a
+FRESH registry against pre-persisted rows.
+
+Requires a disposable Postgres::
+
+    SCRATCH_DSN="postgresql://postgres:postgres@localhost:15931/postgres" \\
+        pytest tests/test_registry_read_through.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import AsyncIterator
+
+import pytest
+
+from parrot_formdesigner.core.schema import FormSchema
+from parrot_formdesigner.services.registry import FormRegistry
+from parrot_formdesigner.services.storage import PostgresFormStorage
+
+_SCRATCH_DSN = os.getenv("SCRATCH_DSN")
+
+pytestmark = [
+    pytest.mark.skipif(
+        not _SCRATCH_DSN,
+        reason="SCRATCH_DSN not set (scratch Postgres required)",
+    ),
+]
+
+SCHEMA = "pfd_read_through_test"
+TENANT = "flexroc_rt_test"
+
+
+@pytest.fixture()
+async def storage() -> AsyncIterator[PostgresFormStorage]:
+    import asyncpg
+
+    pool = await asyncpg.create_pool(dsn=_SCRATCH_DSN, min_size=1, max_size=2)
+    async with pool.acquire() as conn:
+        await conn.execute(f'CREATE SCHEMA IF NOT EXISTS "{SCHEMA}"')
+        await conn.execute(f'CREATE SCHEMA IF NOT EXISTS "{TENANT}"')
+    built = PostgresFormStorage(pool=pool, schema=SCHEMA)
+    await built.initialize(tenant=TENANT)
+    try:
+        yield built
+    finally:
+        async with pool.acquire() as conn:
+            await conn.execute(f'DROP SCHEMA IF EXISTS "{SCHEMA}" CASCADE')
+            await conn.execute(f'DROP SCHEMA IF EXISTS "{TENANT}" CASCADE')
+        await pool.close()
+
+
+def _fresh_registry(storage: PostgresFormStorage | None) -> FormRegistry:
+    """A COLD registry (empty cache) — the post-restart reality."""
+    registry = FormRegistry(require_tenant=False, default_tenant=TENANT)
+    if storage is not None:
+        registry.set_storage(storage)
+    return registry
+
+
+def _form(slug: str) -> FormSchema:
+    return FormSchema(form_id=slug, title=slug, sections=[], tenant=TENANT)
+
+
+async def _persist(storage: PostgresFormStorage, slug: str) -> FormSchema:
+    """Persist through one registry, so the row is exactly what a real
+    create writes — then every test reads it through a DIFFERENT, cold one."""
+    form = _form(slug)
+    await _fresh_registry(storage).register(form, persist=True)
+    return form
+
+
+async def test_cold_get_reads_through_and_caches(
+    storage: PostgresFormStorage,
+) -> None:
+    persisted = await _persist(storage, "contact-form")
+
+    cold = _fresh_registry(storage)
+    loaded = await cold.get(persisted.form_uid, tenant=TENANT)
+    assert loaded is not None
+    assert loaded.form_id == "contact-form"
+
+    # Admitted into the cache: a second lookup is served in-memory —
+    # proven by detaching storage and asking again.
+    cold.set_storage(None)
+    cached = await cold.get(persisted.form_uid, tenant=TENANT)
+    assert cached is not None
+    assert cached.form_uid == persisted.form_uid
+
+
+async def test_cold_get_by_slug_reads_through(
+    storage: PostgresFormStorage,
+) -> None:
+    persisted = await _persist(storage, "visit-recap")
+
+    cold = _fresh_registry(storage)
+    loaded = await cold.get_by_slug("visit-recap", tenant=TENANT)
+    assert loaded is not None
+    assert loaded.form_uid == persisted.form_uid
+
+
+async def test_read_through_respects_tenant_isolation(
+    storage: PostgresFormStorage,
+) -> None:
+    """A form persisted under TENANT must NOT resolve under another tenant
+    — read-through widens the SOURCE, never the isolation contract."""
+    persisted = await _persist(storage, "isolated-form")
+
+    cold = _fresh_registry(storage)
+    assert await cold.get(persisted.form_uid, tenant="some_other_tenant") is None
+
+
+async def test_miss_everywhere_is_none(storage: PostgresFormStorage) -> None:
+    cold = _fresh_registry(storage)
+    assert await cold.get(uuid.uuid4(), tenant=TENANT) is None
+    assert await cold.get_by_slug("never-created", tenant=TENANT) is None
+
+
+async def test_no_storage_stays_cache_only() -> None:
+    """Without a backend the pre-read-through behaviour survives
+    byte-identical: pure in-memory answer, no error."""
+    cold = _fresh_registry(None)
+    assert await cold.get(uuid.uuid4(), tenant=TENANT) is None
+
+
+async def test_storage_fault_degrades_to_none() -> None:
+    """A lookup NEVER raises on a storage fault — callers already treat
+    None as not-found; a flaky pool must not turn reads into 500s."""
+
+    class _ExplodingStorage:
+        async def load(self, *a, **kw):  # noqa: ANN001, ANN003
+            raise RuntimeError("pool is down")
+
+        async def load_by_slug(self, *a, **kw):  # noqa: ANN001, ANN003
+            raise RuntimeError("pool is down")
+
+    registry = FormRegistry(require_tenant=False, default_tenant=TENANT)
+    registry.set_storage(_ExplodingStorage())
+    assert await registry.get(uuid.uuid4(), tenant=TENANT) is None
+    assert await registry.get_by_slug("whatever", tenant=TENANT) is None
+
+
+async def test_unregister_after_read_through(
+    storage: PostgresFormStorage,
+) -> None:
+    """The DELETE flow's registry half on a cold cache: get() admits the
+    form, unregister() then finds it — the exact gate that 404'd live."""
+    persisted = await _persist(storage, "deletable-form")
+
+    cold = _fresh_registry(storage)
+    assert await cold.get(persisted.form_uid, tenant=TENANT) is not None
+    await cold.unregister(persisted.form_uid, tenant=TENANT)
+    # Gone from the cache; storage row untouched by unregister (the
+    # handler deletes storage separately).
+    cold.set_storage(None)
+    assert await cold.get(persisted.form_uid, tenant=TENANT) is None

--- a/packages/parrot-formdesigner/tests/test_tenant_context_resolution.py
+++ b/packages/parrot-formdesigner/tests/test_tenant_context_resolution.py
@@ -1,0 +1,55 @@
+"""The host-declared ``request["tenant_context"]`` wins tenant resolution.
+
+Rationale (mirrors ``_utils._get_request_tenant`` step 0): the session's
+``programs[0]`` is an arbitrarily ordered DEFAULT — a caller with eleven
+programmes is a member of all eleven — so it can never state which
+programme a request is about. The host application authorizes a claim
+(something this library cannot do: it knows nothing about the host's
+entitlement model) and declares the result on the request. When it does,
+that declaration must win; when it does not, behaviour is byte-identical
+to before this key existed.
+"""
+
+from unittest.mock import Mock
+
+from aiohttp.test_utils import make_mocked_request
+
+from parrot_formdesigner.api._utils import _get_request_tenant
+
+
+def _request_with(tenant_context=None, session_programs=None, default_tenant=None):
+    app = {}
+    if default_tenant is not None:
+        registry = Mock()
+        registry.default_tenant = default_tenant
+        app["form_registry"] = registry
+    request = make_mocked_request("GET", "/api/v1/forms", app=app)
+    if tenant_context is not None:
+        request["tenant_context"] = tenant_context
+    if session_programs is not None:
+        request.session = {"session": {"programs": session_programs}}
+    return request
+
+
+def test_host_declared_context_wins_over_session_programs():
+    request = _request_with(
+        tenant_context="flexroc", session_programs=["walmart", "flexroc"]
+    )
+    assert _get_request_tenant(request) == "flexroc"
+
+
+def test_without_context_session_programs_zero_still_wins():
+    """No key set -> the pre-existing behaviour, byte-identical."""
+    request = _request_with(session_programs=["walmart", "flexroc"])
+    assert _get_request_tenant(request) == "walmart"
+
+
+def test_without_context_or_session_registry_default_survives():
+    request = _request_with(default_tenant="navigator")
+    assert _get_request_tenant(request) == "navigator"
+
+
+def test_empty_context_is_ignored_never_returned():
+    """A falsy declaration ('' or None) must not shadow the fallbacks."""
+    request = _request_with(tenant_context="", default_tenant="navigator")
+    assert _get_request_tenant(request) == "navigator"


### PR DESCRIPTION
Release cut of `dev` → `main`, carrying PR #1146 (merged to dev today): **parrot-formdesigner 0.8.21** — host-declared `tenant_context` resolution, the `::text::jsonb` double-encoding fix, numeric slug suffix on create, and the registry storage read-through. FieldSync's per-programme migration (Trocdigital/fieldsync#222) depends on this version being on PyPI.

Two additions on top of dev:

1. **`skip-existing: true` on the PyPI publish step.** Every release builds all 12 packages, but PyPI rejects re-uploads of an existing version — so one unchanged sibling fails the whole deploy. This is not hypothetical: the **0.25.34 and 0.25.32 releases both failed exactly there** (all 12 build jobs green, `deploy` red). With the flag, unchanged packages are skipped and only bumped ones publish — which also makes selective releases (like this formdesigner-only one) possible.

2. **Core bumped 0.25.34 → 0.25.35** purely to keep the tag==core-version release-naming convention — there are no core code changes in this cut. If you'd rather not republish an unchanged core, drop that commit's version bump and pick whatever tag name you prefer; the formdesigner payload is unaffected either way.

After merge: create the GitHub Release (tag `0.25.35` from `main`) and the workflow publishes. We can create the release ourselves once this is approved — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)