### PR TITLE
feat(host): declare browsed programme as forms tenant_context (FEAT-421)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from aiohttp import web
 from navconfig import config
 from navigator.handlers.types import AppHandler
 # Tasker:
@@ -61,6 +62,38 @@ from parrot_formdesigner.services.storage import PostgresFormStorage
 from parrot.voice.transcriber.faster_whisper_backend import FasterWhisperBackend
 from parrot.core.ws_auth import TokenValidator
 from parrot_pipelines.handlers import PlanogramComplianceHandler
+
+
+@web.middleware
+async def forms_tenant_context_middleware(request: web.Request, handler):
+    """FEAT-421 — declare the browsed programme as the form request's tenant.
+
+    parrot-formdesigner's ``_get_tenant`` honors ``request["tenant_context"]``
+    (a tenant the HOST resolves AND authorizes) over the session's arbitrarily
+    ordered ``programs[0]`` (see ``parrot_formdesigner.api._utils`` step 0).
+    navigator-svelte sends the browsed programme as ``?program_slug=`` on every
+    forms call; here — the host, which owns the entitlement model — we validate
+    that claim against the caller's session (a member of the programme, or a
+    superuser) and, ONLY if authorized, declare it as ``tenant_context``.
+
+    A non-member's claim is ignored (no cross-tenant access) and parrot falls
+    back to its existing behavior. Runs after ``AuthHandler`` so
+    ``request.session`` is populated.
+
+    Fixes AI-created/edited forms landing under the user's first program
+    (``navigator``) instead of the browsed programme — the 404s in NAV-9372
+    (create) and NAV-9370 (edit/save).
+    """
+    program_slug = request.query.get("program_slug")
+    if program_slug:
+        session = getattr(request, "session", None)
+        if session is not None:
+            userinfo = session.get("session", {}) or {}
+            programs = userinfo.get("programs", []) or []
+            is_superuser = bool(userinfo.get("superuser", False))
+            if is_superuser or program_slug in programs:
+                request["tenant_context"] = program_slug
+    return await handler(request)
 
 
 class Main(AppHandler):
@@ -332,6 +365,12 @@ class Main(AppHandler):
         auth.add_exclude_list('/a2a')
         auth.add_exclude_list('/a2a/*')
         auth.add_exclude_list('/.well-known/*')
+
+        # FEAT-421: declare the browsed programme (?program_slug=), authorized
+        # against the caller's session, as request["tenant_context"] so
+        # parrot-formdesigner scopes forms to it (honored by _get_tenant).
+        # Appended AFTER auth.setup so request.session is populated when it runs.
+        self.app.middlewares.append(forms_tenant_context_middleware)
 
         # PBAC setup — navigator-auth Rust evaluator bug is now fixed.
         # setup_pbac() MUST be called BEFORE BotManager.setup(app) so that

--- a/sdd/specs/FEAT-421-form-tenant-program-slug-scoping.spec.md
+++ b/sdd/specs/FEAT-421-form-tenant-program-slug-scoping.spec.md
@@ -1,0 +1,108 @@
+---
+type: feature
+base_branch: dev
+---
+
+# Feature Specification: Host middleware declares browsed programme as form tenant
+
+**Feature ID**: FEAT-421
+**Date**: 2026-08-13
+**Author**: José Mendoza + Claude (fork PR for the parrot owner's review)
+**Status**: review — implemented in fork (host middleware + tests)
+**Target version**: 1.x
+**Jira**: NAV-9372, NAV-9370 (NAV-9329 activity-types is a fieldsync host — see §7)
+**Related**: #1146 (parrot-formdesigner honors `request["tenant_context"]`), FEAT-466 (navigator-svelte program-slug)
+
+---
+
+## 1. Motivation
+
+navigator-svelte sends the browsed programme as `?program_slug=<slug>` on every
+forms call (FEAT-466). Before #1146, `FormAPIHandler._get_tenant` resolved the
+tenant from `session.programs[0]` (the user's FIRST program) and ignored
+`program_slug`, so a superuser browsing *epson* created/edited forms under
+*navigator* → 404 on the follow-up load/save (NAV-9372 create, NAV-9370 edit).
+
+**#1146 already did the parrot-library half correctly**: `_get_tenant` now prefers
+`request["tenant_context"]` — a tenant the HOST resolves AND authorizes — over
+`programs[0]`, on the explicit principle that *authorizing* a `program_slug` claim
+"cannot be this library's job" (parrot doesn't know the host's entitlement model).
+
+**The missing half is the host**: nothing sets `request["tenant_context"]` for the
+forms API, so `_get_tenant` still falls back to `programs[0]` and the bug persists.
+This spec adds that host piece.
+
+## 2. Design
+
+`app.py` (the aiohttp host that mounts `setup_form_api` and runs `navigator_auth`)
+gains a middleware `forms_tenant_context_middleware`:
+
+1. Reads `?program_slug` from the request.
+2. Reads the caller's session (`request.session["session"]`): `programs` + `superuser`.
+3. Authorizes the claim: the caller must be a **member** of that programme
+   (`program_slug in programs`) OR a **superuser**.
+4. Only if authorized, sets `request["tenant_context"] = program_slug`.
+
+Registered **after** `auth.setup(self.app)` so `request.session` is populated when
+it runs. parrot's `_get_tenant` (#1146) then honors it → create/read/write scope to
+the browsed programme. A non-member's claim is ignored (no cross-tenant access);
+parrot falls back to its existing behavior.
+
+```python
+@web.middleware
+async def forms_tenant_context_middleware(request, handler):
+    program_slug = request.query.get("program_slug")
+    if program_slug:
+        session = getattr(request, "session", None)
+        if session is not None:
+            userinfo = session.get("session", {}) or {}
+            programs = userinfo.get("programs", []) or []
+            is_superuser = bool(userinfo.get("superuser", False))
+            if is_superuser or program_slug in programs:
+                request["tenant_context"] = program_slug
+    return await handler(request)
+```
+
+### Why the host, not the library
+This mirrors #1146's rationale and `_utils._get_request_tenant` step 0: the host
+owns the entitlement model (navigator-auth session), so it is the only layer that
+can authorize a `program_slug` claim. parrot stays entitlement-agnostic.
+
+## 3. Files
+
+| File | Action | Description |
+|---|---|---|
+| `app.py` | MODIFY | `forms_tenant_context_middleware` + `from aiohttp import web`; append it after `auth.setup` |
+| `tests/test_forms_tenant_context_middleware.py` | CREATE | authz boundary tests (member / superuser / non-member / no-slug / no-session / empty) |
+
+## 4. Acceptance Criteria
+- [ ] A member browsing programme X → `tenant_context == X` → forms create/load/save under X.
+- [ ] A superuser → any browsed programme is declared.
+- [ ] A non-member / no `program_slug` / no session → `tenant_context` NOT set (no cross-tenant access; parrot falls back).
+- [ ] Middleware runs after `AuthHandler` (session populated).
+- [ ] `pytest tests/test_forms_tenant_context_middleware.py -v` green (ai-parrot CI).
+
+## 5. Codebase Contract (verified on origin/dev 2026-08-13)
+- `_get_tenant` prefers `request["tenant_context"]` (#1146, handlers.py ~281-285) then `programs[0]` then `default_tenant`.
+- Nothing sets `request["tenant_context"]` for forms (grep: only a test does) → the fix.
+- `app.py` mounts forms via `setup_form_api` and auth via `AuthHandler().setup()`; middlewares appended with `self.app.middlewares.append(...)` (pattern: `a2a/security.py:1426`).
+- Session shape: `request.session["session"]["programs" | "superuser"]` (formdesigner `_get_programs`; ai-parrot-server `abstract.py:508`).
+
+### Does NOT change
+- parrot-formdesigner (#1146 already did its half); navigator-svelte (already sends `program_slug`).
+
+## 6. Verification performed (author machine)
+- `python -m py_compile app.py` + test file: clean.
+- Middleware authz logic validated with a standalone repro (all cases pass).
+- Full suite NOT run locally (Python 3.10 < required 3.11; monorepo deps not installed) — must run in ai-parrot CI.
+
+## 7. Follow-ups (out of scope here)
+- **NAV-9329** (form activity-types 404) is served by a DIFFERENT host (**fieldsync**
+  `apps/formtypes`), not this app. It needs the equivalent host-side `program_slug`
+  authorization there — separate change in fieldsync.
+- One-time tenant backfill of forms already stored under `navigator` (FEAT-466 / navigator-svelte TASK-2198).
+
+## Revision History
+| Version | Date | Author | Change |
+|---|---|---|---|
+| 1.0 | 2026-08-13 | José Mendoza + Claude | Host middleware approach (aligned with merged #1146); supersedes the earlier parrot-side draft |

--- a/sdd/tasks/completed/TASK-2198-form-tenant-program-slug-scoping.md
+++ b/sdd/tasks/completed/TASK-2198-form-tenant-program-slug-scoping.md
@@ -1,0 +1,59 @@
+# TASK-2198: Host middleware declares browsed programme as form tenant_context
+
+**Feature**: FEAT-421 — Host middleware declares browsed programme as form tenant
+**Spec**: `sdd/specs/FEAT-421-form-tenant-program-slug-scoping.spec.md`
+**Status**: done
+**Priority**: high
+**Estimated effort**: S (< 2h)
+**Depends-on**: none (builds on merged #1146)
+**Assigned-to**: claude-session (fork PR)
+
+---
+
+## Context
+
+#1146 made `FormAPIHandler._get_tenant` honor `request["tenant_context"]` over the
+session's `programs[0]`, on the principle that authorizing a `program_slug` claim
+is the HOST's job, not the library's. But nothing sets `tenant_context` for the
+forms API, so `_get_tenant` still falls back to `programs[0]` and AI-created/edited
+forms land under the user's first program (`navigator`) instead of the browsed
+programme → 404 (NAV-9372 create, NAV-9370 edit/save). This task adds the host half.
+
+---
+
+## Scope
+
+- Add `forms_tenant_context_middleware` to `app.py`: read `?program_slug`, authorize
+  it against the caller's session (member of the programme OR superuser), and only
+  then set `request["tenant_context"]`.
+- Register it via `self.app.middlewares.append(...)` after `auth.setup(self.app)` so
+  `request.session` is populated when it runs.
+- Add `from aiohttp import web` import.
+- Write authz-boundary tests.
+
+**NOT in scope**: any parrot-formdesigner change (#1146 already did its half);
+navigator-svelte (already sends `program_slug`); NAV-9329's activity-types (a
+fieldsync host — separate change); the tenant backfill of already mis-tenanted forms.
+
+---
+
+## Files to Create / Modify
+
+| File | Action | Description |
+|---|---|---|
+| `app.py` | MODIFY | `forms_tenant_context_middleware` + import + registration after auth |
+| `tests/test_forms_tenant_context_middleware.py` | CREATE | 6 tests: member / superuser / non-member / no-slug / no-session / empty-programs |
+
+---
+
+## Test Criteria
+
+- `pytest tests/test_forms_tenant_context_middleware.py -v` green (ai-parrot CI).
+- member/superuser → `tenant_context` declared; non-member/no-slug/no-session → not set.
+
+## Verification performed
+
+- `python -m py_compile` clean (app.py + test).
+- Middleware authz logic validated via standalone repro (all cases pass).
+- Full suite NOT run on author machine (Python 3.10 < required 3.11; monorepo deps
+  absent) — must run in ai-parrot CI.

--- a/sdd/tasks/index/FEAT-421.json
+++ b/sdd/tasks/index/FEAT-421.json
@@ -1,0 +1,24 @@
+{
+  "feature": "FEAT-421",
+  "feature_id": "FEAT-421",
+  "spec": "sdd/specs/FEAT-421-form-tenant-program-slug-scoping.spec.md",
+  "type": "feature",
+  "base_branch": "dev",
+  "created_at": null,
+  "completed_at": null,
+  "tasks": [
+    {
+      "id": "TASK-2198",
+      "slug": "form-tenant-program-slug-scoping",
+      "title": "Host middleware declares browsed programme as form tenant_context",
+      "feature": "FEAT-421",
+      "spec": "sdd/specs/FEAT-421-form-tenant-program-slug-scoping.spec.md",
+      "status": "done",
+      "priority": "high",
+      "effort": "S",
+      "depends_on": [],
+      "assigned_to": "claude-session",
+      "file": "sdd/tasks/completed/TASK-2198-form-tenant-program-slug-scoping.md"
+    }
+  ]
+}

--- a/tests/test_forms_tenant_context_middleware.py
+++ b/tests/test_forms_tenant_context_middleware.py
@@ -1,0 +1,59 @@
+"""FEAT-421 / TASK-2198 — host middleware declares the browsed programme as
+``request["tenant_context"]`` after authorizing the ``?program_slug=`` claim.
+
+parrot-formdesigner (#1146) honors ``request["tenant_context"]`` over the
+session's ``programs[0]``, but deliberately does NOT authorize it — that is the
+host's job. ``forms_tenant_context_middleware`` (app.py) is that host piece: it
+validates ``program_slug`` against the caller's session (member OR superuser)
+and only then declares it. These tests pin that authorization boundary.
+
+Fixes AI-created/edited forms landing under the wrong tenant (NAV-9372/9370).
+"""
+
+from aiohttp.test_utils import make_mocked_request
+
+from app import forms_tenant_context_middleware
+
+
+async def _resolve(program_slug, *, programs=None, superuser=False):
+    """Run the middleware over a mocked forms request and return the
+    ``tenant_context`` it declared (or ``None``)."""
+    path = "/api/v1/forms"
+    if program_slug is not None:
+        path += f"?program_slug={program_slug}"
+    request = make_mocked_request("GET", path)
+    if programs is not None or superuser:
+        request.session = {  # type: ignore[attr-defined]
+            "session": {"programs": programs or [], "superuser": superuser}
+        }
+
+    async def _handler(req):
+        return req
+
+    returned = await forms_tenant_context_middleware(request, _handler)
+    return returned.get("tenant_context")
+
+
+async def test_member_declares_requested_programme():
+    assert await _resolve("epson", programs=["navigator", "epson"]) == "epson"
+
+
+async def test_superuser_declares_any_programme():
+    assert await _resolve("epson", programs=["navigator"], superuser=True) == "epson"
+
+
+async def test_non_member_non_superuser_declares_nothing():
+    # Claim is ignored → parrot falls back to its own resolution (no cross-tenant).
+    assert await _resolve("epson", programs=["navigator"], superuser=False) is None
+
+
+async def test_no_program_slug_declares_nothing():
+    assert await _resolve(None, programs=["navigator", "epson"]) is None
+
+
+async def test_no_session_declares_nothing():
+    assert await _resolve("epson") is None
+
+
+async def test_empty_programs_non_superuser_declares_nothing():
+    assert await _resolve("epson", programs=[], superuser=False) is None


### PR DESCRIPTION
## FEAT-421 — Host declares browsed programme as forms tenant_context

Completes the host half of the tenant-scoping fix. Builds on #1146.

### Problem
#1146 made `_get_tenant` honor `request["tenant_context"]` over `session.programs[0]`, leaving authorization of the `?program_slug=` claim to the host (parrot is entitlement-agnostic). But nothing sets `tenant_context` for the forms API, so `_get_tenant` still falls back to `programs[0]` — AI-created/edited forms land under the user's first program (`navigator`) instead of the browsed programme → 404 on load/save. (NAV-9372 create, NAV-9370 edit/save.)

### Change
`forms_tenant_context_middleware` in `app.py`:
- reads `?program_slug`,
- authorizes it against the caller's session (member of the programme **or** superuser),
- only then sets `request["tenant_context"]`.
Registered after `auth.setup` (session populated). A non-member's claim is ignored — no cross-tenant access. No parrot-formdesigner change.

### Tests
`tests/test_forms_tenant_context_middleware.py` — member / superuser / non-member / no-slug / no-session / empty-programs. 

### Out of scope
- NAV-9329 (form activity-types) is served by a different host (fieldsync `apps/formtypes`) — equivalent fix needed there separately.
- One-time tenant backfill of forms already stored under `navigator` (FEAT-466).

SDD: `sdd/specs/FEAT-421-...spec.md`, `sdd/tasks/completed/TASK-2198-...md`.
