### PR TITLE
FEAT-392: Obsidian vault integration (toolkit, loader, graph bridge)

### DIFF
--- a/examples/knowledge_wiki/obsidian_wiki_agent.py
+++ b/examples/knowledge_wiki/obsidian_wiki_agent.py
@@ -1,0 +1,179 @@
+"""Obsidian vault → LLM Wiki end-to-end example (FEAT-392, Module 9).
+
+Demonstrates the three-phase Obsidian ingestion pipeline against a real
+vault directory:
+
+1. **Phase 1 — raw ingest (no LLM)**: ``ObsidianVaultLoader`` parses the
+   vault (wikilinks, embeds, frontmatter, tags, canvas files) and stores
+   one PageIndex node per note.
+2. **Phase 1b — graph bridge (no LLM)**: ``ObsidianGraphBridge`` imports
+   the hand-curated ``[[wikilink]]`` graph into GraphIndex as
+   pre-curated REFERENCES/CONTAINS edges plus tag CONCEPT nodes.
+3. **Phase 2 — entity extraction (LLM, opt-in)**:
+   ``WikiIngestOrchestrator.extract_entities`` runs LLM entity/concept
+   extraction over the ingested pages (``--extract-entities``, needs a
+   configured Google GenAI key).
+
+Usage::
+
+    python obsidian_wiki_agent.py /path/to/vault             # phases 1 + 1b
+    python obsidian_wiki_agent.py /path/to/vault --query ml  # + BM25 query
+    python obsidian_wiki_agent.py /path/to/vault --extract-entities
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import wiki  # noqa: E402  (sibling module with the toolkit builders)
+
+from parrot.loaders.obsidian import (  # noqa: E402
+    ObsidianGraphBridge,
+    ObsidianVaultLoader,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger("obsidian_wiki_agent")
+
+STORE_DIR = Path(__file__).parent / "store" / "obsidian"
+TREE_NAME = "obsidian-vault"
+HEAVY_MODEL = "gemini-2.5-flash"
+LIGHT_MODEL = "gemini-2.5-flash-lite"
+
+
+def _header(title: str) -> None:
+    print(f"\n{'=' * 70}\n{title}\n{'=' * 70}")
+
+
+async def run(
+    vault_path: Path,
+    query: str | None,
+    extract_entities: bool,
+    granularity: str,
+) -> int:
+    from parrot.knowledge.pageindex import PageIndexLLMAdapter
+    from parrot.knowledge.wiki.bookkeeper import WikiBookkeeper
+    from parrot.knowledge.wiki.ingest import WikiIngestOrchestrator
+    from parrot.knowledge.wiki.models import WikiConfig
+    from parrot.knowledge.wiki.sources import SourceCollectionManager
+
+    STORE_DIR.mkdir(parents=True, exist_ok=True)
+
+    if extract_entities:
+        from parrot.clients.google.client import GoogleGenAIClient
+
+        client_ctx = GoogleGenAIClient()
+    else:
+
+        class _NullClient:
+            """Placeholder client — Phase 1/1b never call the LLM."""
+
+        client_ctx = None
+
+    # ------------------------------------------------------------------ #
+    # Phase 1 — raw vault ingest into PageIndex (no LLM required)
+    # ------------------------------------------------------------------ #
+    _header("Phase 1 — raw vault ingest (no LLM)")
+    if client_ctx is None:
+        adapter = PageIndexLLMAdapter(client=_NullClient(), model=HEAVY_MODEL)
+    else:
+        await client_ctx.__aenter__()
+        adapter = PageIndexLLMAdapter(client=client_ctx, model=HEAVY_MODEL)
+    try:
+        pi = wiki.build_pageindex_toolkit(adapter=adapter, storage_dir=STORE_DIR)
+        if TREE_NAME in await pi.list_trees():
+            await pi.delete_tree(TREE_NAME)
+
+        sources = SourceCollectionManager(STORE_DIR / "sources", backend="json")
+        loader = ObsidianVaultLoader(vault_path)
+        report = await loader.ingest(pi, TREE_NAME, sources)
+        print(
+            f"notes={report.notes_processed} canvas={report.canvas_processed} "
+            f"nodes={report.nodes_created} errors={len(report.errors)} "
+            f"({report.duration_ms:.0f} ms)"
+        )
+        for error in report.errors[:5]:
+            print(f"  ! {error}")
+
+        # ---------------------------------------------------------------- #
+        # Phase 1b — wikilink graph → GraphIndex (no LLM required)
+        # ---------------------------------------------------------------- #
+        _header("Phase 1b — graph bridge: [[wikilinks]] → GraphIndex")
+        notes, canvases = await loader.discover()
+        bridge = ObsidianGraphBridge(
+            notes,
+            canvases,
+            await loader.vault.build_index(),
+            vault_name=loader.vault.vault_name,
+        )
+        nodes, edges = bridge.build_graph()
+        gi = await wiki.build_graphindex_toolkit(nodes, edges)
+        print(f"graph nodes={len(nodes)} edges={len(edges)}")
+        central = await gi.find_central_nodes(top_k=5)
+        print("most central vault notes:")
+        for row in central if isinstance(central, list) else []:
+            print(f"  - {row}")
+
+        # ---------------------------------------------------------------- #
+        # Query the wiki (BM25 — still no LLM)
+        # ---------------------------------------------------------------- #
+        if query:
+            _header(f"Query — BM25 over the vault wiki: {query!r}")
+            hits = await pi.search(
+                TREE_NAME, query, top_k=5, use_bm25=True, use_llm_walk=False
+            )
+            for hit in hits or []:
+                print(f"  - {hit}")
+
+        # ---------------------------------------------------------------- #
+        # Phase 2 — LLM entity extraction (opt-in)
+        # ---------------------------------------------------------------- #
+        if extract_entities:
+            _header(f"Phase 2 — entity extraction (granularity={granularity})")
+            orchestrator = WikiIngestOrchestrator(
+                pi, gi, sources, WikiBookkeeper()
+            )
+            config = WikiConfig(wiki_name=TREE_NAME, storage_dir=STORE_DIR)
+            entity_report = await orchestrator.extract_entities(
+                TREE_NAME, config, granularity=granularity
+            )
+            print(
+                f"entities={entity_report.pages_created} "
+                f"graph_nodes={entity_report.graph_nodes_created} "
+                f"status={entity_report.status}"
+            )
+    finally:
+        if client_ctx is not None:
+            await client_ctx.__aexit__(None, None, None)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("vault", type=Path, help="Obsidian vault directory")
+    parser.add_argument("--query", default=None, help="BM25 query to run")
+    parser.add_argument(
+        "--extract-entities",
+        action="store_true",
+        help="Run Phase 2 LLM entity extraction (needs Google GenAI key)",
+    )
+    parser.add_argument(
+        "--granularity",
+        default="standard",
+        choices=["minimal", "standard", "fine", "custom"],
+    )
+    args = parser.parse_args()
+    if not args.vault.is_dir():
+        parser.error(f"not a directory: {args.vault}")
+    return asyncio.run(
+        run(args.vault, args.query, args.extract_entities, args.granularity)
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/ai-parrot-tools/src/parrot_tools/__init__.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/__init__.py
@@ -52,6 +52,7 @@ TOOL_REGISTRY: dict[str, str] = {
     "calculator": "parrot_tools.calculator.tool.CalculatorTool",
     "file_manager": "parrot.tools.filemanager.FileManagerTool",
     "file_manager_toolkit": "parrot.tools.filemanager.FileManagerToolkit",
+    "obsidian": "parrot.tools.obsidian.ObsidianToolkit",
     "shell": "parrot_tools.shell_tool.tool.ShellTool",
     "system_health": "parrot_tools.system_health.tool.SystemHealthTool",
     # --- Toolkits (Batch 2 — toolkit-based tools) ---

--- a/packages/ai-parrot/pyproject.toml
+++ b/packages/ai-parrot/pyproject.toml
@@ -51,6 +51,9 @@ dependencies = [
     "pydantic==2.12.5",
     "PyYAML>=6.0.2",
     "python-frontmatter>=1.1.0",
+    # Obsidian-flavored markdown parsing (wikilinks/embeds/tags) for the
+    # shared vault interface (parrot.interfaces.obsidian) — FEAT-392.
+    "marko>=2.0",
     "xmltodict>=0.14.2",
     "tiktoken>=0.9.0",
     "psutil>=5.9",

--- a/packages/ai-parrot/src/parrot/interfaces/obsidian/__init__.py
+++ b/packages/ai-parrot/src/parrot/interfaces/obsidian/__init__.py
@@ -1,0 +1,82 @@
+"""Shared Obsidian vault interface (FEAT-392 + shared-interface work).
+
+One vault-access + parsing core reused by:
+
+* ``parrot.tools.obsidian.ObsidianToolkit`` — agent-facing tools
+* ``parrot.loaders.obsidian`` — PageIndex/GraphIndex vault ingestion
+* ``parrot.knowledge.wiki.vault_scan`` — wikitoolkit vault build mode
+
+Two backends implement :class:`ObsidianVaultInterface`:
+:class:`LocalVaultBackend` (direct filesystem, primary) and
+:class:`RestVaultBackend` (Obsidian Local REST API plugin, optional).
+"""
+from typing import Any, Literal
+
+from .abstract import ObsidianVaultInterface, VaultAccessError
+from .index import VaultIndex
+from .local import LocalVaultBackend
+from .models import (
+    CANVAS_SUFFIX,
+    DEFAULT_SKIP_PATTERNS,
+    NOTE_SUFFIX,
+    ExtractionGranularity,
+    ObsidianCanvas,
+    ObsidianCanvasCard,
+    ObsidianLink,
+    ObsidianNote,
+    VaultFileInfo,
+    VaultIngestConfig,
+    VaultIngestReport,
+    VaultSearchHit,
+)
+from .parser import ObsidianNoteParser, parse_canvas
+from .rest import RestVaultBackend
+
+__all__ = (
+    "CANVAS_SUFFIX",
+    "DEFAULT_SKIP_PATTERNS",
+    "NOTE_SUFFIX",
+    "ExtractionGranularity",
+    "LocalVaultBackend",
+    "ObsidianCanvas",
+    "ObsidianCanvasCard",
+    "ObsidianLink",
+    "ObsidianNote",
+    "ObsidianNoteParser",
+    "ObsidianVaultInterface",
+    "RestVaultBackend",
+    "VaultAccessError",
+    "VaultFileInfo",
+    "VaultIndex",
+    "VaultIngestConfig",
+    "VaultIngestReport",
+    "VaultSearchHit",
+    "create_vault_backend",
+    "parse_canvas",
+)
+
+
+def create_vault_backend(
+    backend: Literal["local", "rest"] = "local", **kwargs: Any
+) -> ObsidianVaultInterface:
+    """Factory for vault backends.
+
+    Args:
+        backend: ``"local"`` (filesystem, requires ``vault_path``) or
+            ``"rest"`` (Local REST API plugin, accepts ``base_url``,
+            ``api_key``, ``verify_ssl``, ``timeout``).
+        **kwargs: Forwarded to the backend constructor.
+
+    Returns:
+        A configured, unopened backend instance.
+
+    Raises:
+        ValueError: For an unknown backend name.
+    """
+    if backend == "local":
+        return LocalVaultBackend(**kwargs)
+    if backend == "rest":
+        return RestVaultBackend(**kwargs)
+    raise ValueError(
+        f"Unknown Obsidian backend {backend!r} — expected 'local' or 'rest'"
+    )

--- a/packages/ai-parrot/src/parrot/interfaces/obsidian/__init__.py
+++ b/packages/ai-parrot/src/parrot/interfaces/obsidian/__init__.py
@@ -29,6 +29,14 @@ from .models import (
     VaultIngestReport,
     VaultSearchHit,
 )
+from .okf import (
+    OKF_KEY,
+    apply_okf,
+    normalize_relates_target,
+    project_okf_block,
+    read_okf,
+    validate_okf,
+)
 from .parser import ObsidianNoteParser, parse_canvas
 from .rest import RestVaultBackend
 
@@ -36,6 +44,7 @@ __all__ = (
     "CANVAS_SUFFIX",
     "DEFAULT_SKIP_PATTERNS",
     "NOTE_SUFFIX",
+    "OKF_KEY",
     "ExtractionGranularity",
     "LocalVaultBackend",
     "ObsidianCanvas",
@@ -51,8 +60,13 @@ __all__ = (
     "VaultIngestConfig",
     "VaultIngestReport",
     "VaultSearchHit",
+    "apply_okf",
     "create_vault_backend",
+    "normalize_relates_target",
     "parse_canvas",
+    "project_okf_block",
+    "read_okf",
+    "validate_okf",
 )
 
 

--- a/packages/ai-parrot/src/parrot/interfaces/obsidian/abstract.py
+++ b/packages/ai-parrot/src/parrot/interfaces/obsidian/abstract.py
@@ -1,0 +1,213 @@
+"""Backend-agnostic async access to an Obsidian vault.
+
+``ObsidianVaultInterface`` defines the primitive operations every backend
+must provide (list/read/write/delete/stat/search) and layers the shared
+conveniences on top: parsed-note access (:meth:`get_note`), async iteration
+(:meth:`iter_notes`) and a cached :class:`VaultIndex`
+(:meth:`build_index`).
+
+Backends:
+    * :class:`parrot.interfaces.obsidian.local.LocalVaultBackend` — direct
+      filesystem access to a vault directory (primary).
+    * :class:`parrot.interfaces.obsidian.rest.RestVaultBackend` — the
+      Obsidian *Local REST API* community plugin over aiohttp (optional,
+      requires a running Obsidian instance).
+"""
+import asyncio
+import logging
+from abc import ABC, abstractmethod
+from typing import AsyncIterator, Optional
+
+from .index import VaultIndex
+from .models import (
+    CANVAS_SUFFIX,
+    DEFAULT_SKIP_PATTERNS,
+    NOTE_SUFFIX,
+    ObsidianCanvas,
+    ObsidianNote,
+    VaultFileInfo,
+    VaultSearchHit,
+)
+from .parser import ObsidianNoteParser, parse_canvas
+
+
+class VaultAccessError(RuntimeError):
+    """Raised for vault access failures (missing note, backend errors)."""
+
+
+class ObsidianVaultInterface(ABC):
+    """Abstract async interface over an Obsidian vault."""
+
+    def __init__(self, vault_name: Optional[str] = None) -> None:
+        self.vault_name: str = vault_name or "vault"
+        self.logger = logging.getLogger(
+            f"{type(self).__module__}.{type(self).__name__}"
+        )
+        self.parser = ObsidianNoteParser()
+        self.skip_patterns: frozenset[str] = DEFAULT_SKIP_PATTERNS
+        self._index: Optional[VaultIndex] = None
+        self._index_lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle
+    # ------------------------------------------------------------------ #
+    async def open(self) -> None:
+        """Acquire backend resources (sessions, handles). Default: no-op."""
+
+    async def close(self) -> None:
+        """Release backend resources. Default: drops the cached index."""
+        self._index = None
+
+    # ------------------------------------------------------------------ #
+    # Abstract primitives
+    # ------------------------------------------------------------------ #
+    @abstractmethod
+    async def list_files(
+        self,
+        folder: Optional[str] = None,
+        recursive: bool = True,
+        suffixes: Optional[frozenset[str]] = None,
+    ) -> list[VaultFileInfo]:
+        """List vault files.
+
+        Args:
+            folder: Vault-relative folder to list; None for the vault root.
+            recursive: Descend into subfolders.
+            suffixes: Restrict to these suffixes (e.g. ``{".md"}``); None
+                lists notes and canvas files.
+
+        Returns:
+            File descriptors, skip patterns already applied.
+        """
+
+    @abstractmethod
+    async def read_note(self, path: str) -> str:
+        """Read a note's raw text (frontmatter included).
+
+        Args:
+            path: Vault-relative path (``.md`` optional).
+
+        Returns:
+            Full file text.
+
+        Raises:
+            FileNotFoundError: If the note does not exist.
+        """
+
+    @abstractmethod
+    async def write_note(
+        self, path: str, content: str, *, overwrite: bool = True
+    ) -> VaultFileInfo:
+        """Create or replace a note.
+
+        Args:
+            path: Vault-relative path (``.md`` appended when missing).
+            content: Full new file text.
+            overwrite: When False, refuse to replace an existing note.
+
+        Returns:
+            Descriptor of the written file.
+
+        Raises:
+            FileExistsError: If the note exists and ``overwrite`` is False.
+        """
+
+    @abstractmethod
+    async def delete_note(self, path: str) -> bool:
+        """Delete a note. Returns True when a file was removed."""
+
+    @abstractmethod
+    async def note_exists(self, path: str) -> bool:
+        """Whether a note exists at the vault-relative path."""
+
+    @abstractmethod
+    async def stat(self, path: str) -> VaultFileInfo:
+        """File descriptor for one vault path.
+
+        Raises:
+            FileNotFoundError: If the path does not exist.
+        """
+
+    @abstractmethod
+    async def search(self, query: str, limit: int = 20) -> list[VaultSearchHit]:
+        """Backend-native text search over the vault.
+
+        Args:
+            query: Search terms.
+            limit: Maximum hits.
+
+        Returns:
+            Hits sorted by descending score.
+        """
+
+    # ------------------------------------------------------------------ #
+    # Shared conveniences
+    # ------------------------------------------------------------------ #
+    def normalize_note_path(self, path: str) -> str:
+        """Normalize a user-supplied path to a POSIX ``.md`` path."""
+        clean = path.strip().replace("\\", "/").lstrip("/")
+        if not clean.lower().endswith((NOTE_SUFFIX, CANVAS_SUFFIX)):
+            clean = f"{clean}{NOTE_SUFFIX}"
+        return clean
+
+    async def get_note(self, path: str) -> ObsidianNote:
+        """Read and parse one note into an :class:`ObsidianNote`."""
+        rel = self.normalize_note_path(path)
+        raw = await self.read_note(rel)
+        return await asyncio.to_thread(self.parser.parse, raw, rel)
+
+    async def get_canvas(self, path: str) -> ObsidianCanvas:
+        """Read and parse one ``.canvas`` file."""
+        raw = await self.read_note(path)
+        return parse_canvas(raw, path)
+
+    async def iter_notes(
+        self, folder: Optional[str] = None
+    ) -> AsyncIterator[ObsidianNote]:
+        """Iterate parsed notes, skipping unreadable files with a warning."""
+        for info in await self.list_files(
+            folder=folder, suffixes=frozenset({NOTE_SUFFIX})
+        ):
+            try:
+                yield await self.get_note(info.path)
+            except (FileNotFoundError, UnicodeDecodeError, ValueError) as exc:
+                self.logger.warning("Skipping %s: %s", info.path, exc)
+
+    async def load_notes(
+        self, folder: Optional[str] = None, concurrency: int = 8
+    ) -> list[ObsidianNote]:
+        """Read and parse all notes concurrently (Semaphore-bounded)."""
+        infos = await self.list_files(
+            folder=folder, suffixes=frozenset({NOTE_SUFFIX})
+        )
+        semaphore = asyncio.Semaphore(concurrency)
+
+        async def _one(info: VaultFileInfo) -> Optional[ObsidianNote]:
+            async with semaphore:
+                try:
+                    return await self.get_note(info.path)
+                except (FileNotFoundError, UnicodeDecodeError, ValueError) as exc:
+                    self.logger.warning("Skipping %s: %s", info.path, exc)
+                    return None
+
+        notes = await asyncio.gather(*(_one(info) for info in infos))
+        return [note for note in notes if note is not None]
+
+    async def build_index(self, force: bool = False) -> VaultIndex:
+        """Build (or return the cached) :class:`VaultIndex`.
+
+        Args:
+            force: Rebuild even when a cached index exists.
+
+        Returns:
+            The vault-wide link/tag/alias index.
+        """
+        async with self._index_lock:
+            if self._index is None or force:
+                notes = await self.load_notes()
+                self._index = await asyncio.to_thread(VaultIndex.build, notes)
+            return self._index
+
+    def invalidate_index(self) -> None:
+        """Drop the cached index (call after any note mutation)."""
+        self._index = None

--- a/packages/ai-parrot/src/parrot/interfaces/obsidian/index.py
+++ b/packages/ai-parrot/src/parrot/interfaces/obsidian/index.py
@@ -1,0 +1,152 @@
+"""In-memory vault index: wikilink resolution, backlinks, tags, aliases.
+
+One resolution engine shared by every Obsidian consumer (toolkit search,
+FEAT-392 graph bridge, wikitoolkit vault scan) so a ``[[wikilink]]`` always
+resolves to the same note everywhere.
+
+Resolution replicates Obsidian's semantics (FEAT-392 §7 gotcha):
+an exact vault-relative path wins, then a basename match (shortest path on
+duplicates — Obsidian's tiebreak), then an alias match.
+"""
+import logging
+import posixpath
+from collections import defaultdict
+from pathlib import Path
+from typing import Optional
+
+from .models import ObsidianLink, ObsidianNote
+
+logger = logging.getLogger(__name__)
+
+
+def _norm(path: str | Path) -> str:
+    """Normalize a vault path to POSIX form without the .md suffix."""
+    text = Path(path).as_posix()
+    if text.lower().endswith(".md"):
+        text = text[: -len(".md")]
+    return text
+
+
+class VaultIndex:
+    """Immutable index over a parsed vault snapshot.
+
+    Build with :meth:`build`; rebuild after any note mutation (the toolkit
+    invalidates its cached index after write/delete/move operations).
+    """
+
+    def __init__(self) -> None:
+        self._notes: dict[str, ObsidianNote] = {}          # norm path -> note
+        self._by_basename: dict[str, list[str]] = defaultdict(list)
+        self._by_alias: dict[str, str] = {}
+        self._by_tag: dict[str, set[str]] = defaultdict(set)
+        self._outlinks: dict[str, list[ObsidianLink]] = defaultdict(list)
+        self._backlinks: dict[str, set[str]] = defaultdict(set)
+        self._unresolved: list[tuple[str, str]] = []
+
+    @classmethod
+    def build(cls, notes: list[ObsidianNote]) -> "VaultIndex":
+        """Build the index from parsed notes.
+
+        Args:
+            notes: All parsed markdown notes of the vault.
+
+        Returns:
+            A fully populated :class:`VaultIndex` (links resolved, backlink
+            map computed, unresolved links recorded).
+        """
+        index = cls()
+        for note in notes:
+            key = _norm(note.path)
+            index._notes[key] = note
+            index._by_basename[posixpath.basename(key).lower()].append(key)
+            for alias in note.aliases:
+                index._by_alias.setdefault(alias.lower(), key)
+            for tag in note.tags:
+                index._by_tag[tag.lower()].add(key)
+
+        for key, note in index._notes.items():
+            index._outlinks[key] = list(note.links)
+            for link in note.links:
+                resolved = index.resolve(link.target, from_path=key)
+                if resolved is None:
+                    index._unresolved.append((key, link.target))
+                else:
+                    index._backlinks[resolved].add(key)
+        return index
+
+    def resolve(
+        self, target: str, from_path: Optional[str] = None
+    ) -> Optional[str]:
+        """Resolve a wikilink target to a normalized vault path.
+
+        Args:
+            target: Raw wikilink target (``note``, ``folder/note``, alias).
+            from_path: Path of the linking note (reserved for future
+                relative-resolution rules; Obsidian's default "shortest path
+                when ambiguous" does not depend on it).
+
+        Returns:
+            Normalized vault-relative path (no ``.md``), or ``None`` when
+            the target does not resolve to any note.
+        """
+        wanted = _norm(target.strip())
+        if not wanted:
+            return None
+        # 1. Exact vault-relative path.
+        if wanted in self._notes:
+            return wanted
+        exact_ci = wanted.lower()
+        for key in self._notes:
+            if key.lower() == exact_ci:
+                return key
+        # 2. Basename match; shortest path wins on duplicates.
+        candidates = self._by_basename.get(posixpath.basename(exact_ci), [])
+        if candidates:
+            return min(candidates, key=lambda p: (len(p.split("/")), p))
+        # 3. Alias match.
+        return self._by_alias.get(exact_ci)
+
+    def note(self, path: str | Path) -> Optional[ObsidianNote]:
+        """Return the parsed note at a vault path, or None."""
+        return self._notes.get(_norm(path))
+
+    def paths(self) -> list[str]:
+        """All indexed note paths (normalized, sorted)."""
+        return sorted(self._notes)
+
+    def backlinks(self, path: str | Path) -> list[str]:
+        """Notes whose wikilinks resolve to this note (sorted paths)."""
+        return sorted(self._backlinks.get(_norm(path), set()))
+
+    def outlinks(self, path: str | Path) -> list[ObsidianLink]:
+        """This note's outgoing wikilinks/embeds (resolved or not)."""
+        return list(self._outlinks.get(_norm(path), []))
+
+    def notes_by_tag(self, tag: str) -> list[str]:
+        """Notes carrying a tag; nested tags match by prefix (``a`` ⊇ ``a/b``)."""
+        wanted = tag.lstrip("#").lower()
+        found: set[str] = set()
+        for candidate, paths in self._by_tag.items():
+            if candidate == wanted or candidate.startswith(f"{wanted}/"):
+                found.update(paths)
+        return sorted(found)
+
+    def tags(self) -> dict[str, int]:
+        """Tag -> note count over the whole vault."""
+        return {tag: len(paths) for tag, paths in sorted(self._by_tag.items())}
+
+    def aliases(self) -> dict[str, str]:
+        """Alias (lowercased) -> normalized note path."""
+        return dict(self._by_alias)
+
+    def orphans(self) -> list[str]:
+        """Notes with no resolved incoming and no outgoing links."""
+        return sorted(
+            key
+            for key in self._notes
+            if not self._backlinks.get(key) and not self._outlinks.get(key)
+        )
+
+    def unresolved(self) -> list[tuple[str, str]]:
+        """(from_path, raw_target) pairs for broken wikilinks."""
+        return list(self._unresolved)

--- a/packages/ai-parrot/src/parrot/interfaces/obsidian/local.py
+++ b/packages/ai-parrot/src/parrot/interfaces/obsidian/local.py
@@ -1,0 +1,212 @@
+"""Direct-filesystem Obsidian vault backend.
+
+All blocking file I/O runs in ``asyncio.to_thread``. Every user-supplied
+path passes the :meth:`LocalVaultBackend._resolve` sandbox guard — the
+resolved path must stay under the vault root (same discipline as
+``FileManagerToolkit``'s sandboxed local manager).
+"""
+import asyncio
+import os
+from pathlib import Path
+from typing import Optional
+
+from .abstract import ObsidianVaultInterface
+from .models import (
+    CANVAS_SUFFIX,
+    NOTE_SUFFIX,
+    VaultFileInfo,
+    VaultSearchHit,
+)
+
+
+class LocalVaultBackend(ObsidianVaultInterface):
+    """Filesystem access to an Obsidian vault directory."""
+
+    def __init__(
+        self,
+        vault_path: str | Path,
+        vault_name: Optional[str] = None,
+    ) -> None:
+        """Initialize the backend.
+
+        Args:
+            vault_path: Directory of the vault (must exist).
+            vault_name: Logical vault name; defaults to the directory name.
+
+        Raises:
+            ValueError: If ``vault_path`` is not an existing directory.
+        """
+        root = Path(vault_path).expanduser().resolve()
+        if not root.is_dir():
+            raise ValueError(f"Vault path is not a directory: {vault_path}")
+        super().__init__(vault_name=vault_name or root.name)
+        self.vault_path = root
+
+    # ------------------------------------------------------------------ #
+    # Path safety
+    # ------------------------------------------------------------------ #
+    def _resolve(self, path: str) -> Path:
+        """Resolve a vault-relative path, rejecting escapes from the root.
+
+        Raises:
+            ValueError: If the resolved path leaves the vault directory.
+        """
+        candidate = (self.vault_path / path.lstrip("/")).resolve()
+        if (
+            candidate != self.vault_path
+            and self.vault_path not in candidate.parents
+        ):
+            raise ValueError(f"Path escapes the vault root: {path}")
+        return candidate
+
+    def _relative(self, full: Path) -> str:
+        return full.relative_to(self.vault_path).as_posix()
+
+    def _skipped(self, full: Path) -> bool:
+        parts = full.relative_to(self.vault_path).parts
+        return any(part in self.skip_patterns for part in parts)
+
+    def _info(self, full: Path, stat: Optional[os.stat_result] = None) -> VaultFileInfo:
+        stat = stat or full.stat()
+        suffix = full.suffix.lower()
+        return VaultFileInfo(
+            path=self._relative(full),
+            name=full.name,
+            size=stat.st_size,
+            mtime=stat.st_mtime,
+            is_note=suffix == NOTE_SUFFIX,
+            is_canvas=suffix == CANVAS_SUFFIX,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Primitives
+    # ------------------------------------------------------------------ #
+    async def list_files(
+        self,
+        folder: Optional[str] = None,
+        recursive: bool = True,
+        suffixes: Optional[frozenset[str]] = None,
+    ) -> list[VaultFileInfo]:
+        base = self._resolve(folder) if folder else self.vault_path
+        wanted = suffixes or frozenset({NOTE_SUFFIX, CANVAS_SUFFIX})
+
+        def _scan() -> list[VaultFileInfo]:
+            if not base.is_dir():
+                raise FileNotFoundError(f"Folder not found: {folder}")
+            pattern = "**/*" if recursive else "*"
+            found = [
+                self._info(item)
+                for item in sorted(base.glob(pattern))
+                if item.is_file()
+                and item.suffix.lower() in wanted
+                and not self._skipped(item)
+            ]
+            return found
+
+        return await asyncio.to_thread(_scan)
+
+    async def read_note(self, path: str) -> str:
+        full = self._resolve(self.normalize_note_path(path))
+
+        def _read() -> str:
+            if not full.is_file():
+                raise FileNotFoundError(f"Note not found: {path}")
+            return full.read_text(encoding="utf-8")
+
+        return await asyncio.to_thread(_read)
+
+    async def write_note(
+        self, path: str, content: str, *, overwrite: bool = True
+    ) -> VaultFileInfo:
+        full = self._resolve(self.normalize_note_path(path))
+
+        def _write() -> VaultFileInfo:
+            if full.exists() and not overwrite:
+                raise FileExistsError(f"Note already exists: {path}")
+            full.parent.mkdir(parents=True, exist_ok=True)
+            full.write_text(content, encoding="utf-8")
+            return self._info(full)
+
+        info = await asyncio.to_thread(_write)
+        self.invalidate_index()
+        return info
+
+    async def delete_note(self, path: str) -> bool:
+        full = self._resolve(self.normalize_note_path(path))
+
+        def _delete() -> bool:
+            if not full.is_file():
+                return False
+            full.unlink()
+            return True
+
+        removed = await asyncio.to_thread(_delete)
+        if removed:
+            self.invalidate_index()
+        return removed
+
+    async def note_exists(self, path: str) -> bool:
+        full = self._resolve(self.normalize_note_path(path))
+        return await asyncio.to_thread(full.is_file)
+
+    async def stat(self, path: str) -> VaultFileInfo:
+        full = self._resolve(self.normalize_note_path(path))
+
+        def _stat() -> VaultFileInfo:
+            if not full.is_file():
+                raise FileNotFoundError(f"Note not found: {path}")
+            return self._info(full)
+
+        return await asyncio.to_thread(_stat)
+
+    async def search(self, query: str, limit: int = 20) -> list[VaultSearchHit]:
+        """Keyword scan over titles, aliases, tags and bodies.
+
+        Deliberately simple (linear scan, Semaphore-bounded reads): the
+        FTS5-backed wikitoolkit vault plane is the scalable search path.
+        """
+        terms = [term for term in query.lower().split() if term]
+        if not terms:
+            return []
+        index = await self.build_index()
+        semaphore = asyncio.Semaphore(16)
+        hits: list[VaultSearchHit] = []
+
+        async def _score(path: str) -> None:
+            note = index.note(path)
+            if note is None:
+                return
+            async with semaphore:
+                haystacks = {
+                    "title": note.title.lower(),
+                    "tag": " ".join(note.tags).lower(),
+                    "alias": " ".join(note.aliases).lower(),
+                    "body": note.content.lower(),
+                }
+                score = 0.0
+                matched: list[str] = []
+                snippet: Optional[str] = None
+                weights = {"title": 4.0, "tag": 3.0, "alias": 3.0, "body": 1.0}
+                for field, text in haystacks.items():
+                    field_hits = sum(text.count(term) for term in terms)
+                    if field_hits:
+                        matched.append(field)
+                        score += weights[field] * field_hits
+                        if field == "body" and snippet is None:
+                            pos = min(
+                                (text.find(t) for t in terms if t in text),
+                                default=0,
+                            )
+                            start = max(0, pos - 60)
+                            snippet = note.content[start:pos + 120].strip()
+                if score > 0:
+                    hits.append(
+                        VaultSearchHit(
+                            path=path, score=score,
+                            snippet=snippet, matches=matched,
+                        )
+                    )
+
+        await asyncio.gather(*(_score(path) for path in index.paths()))
+        hits.sort(key=lambda hit: (-hit.score, hit.path))
+        return hits[:limit]

--- a/packages/ai-parrot/src/parrot/interfaces/obsidian/models.py
+++ b/packages/ai-parrot/src/parrot/interfaces/obsidian/models.py
@@ -1,0 +1,143 @@
+"""Pydantic data models for the shared Obsidian vault interface.
+
+These models are the single source of truth for Obsidian structures across
+the framework: the ``ObsidianToolkit`` (parrot.tools.obsidian), the vault
+loader/graph bridge (parrot.loaders.obsidian, FEAT-392) and the wikitoolkit
+vault scanner (parrot.knowledge.wiki.vault_scan) all consume them.
+
+The core note/canvas models follow the approved FEAT-392 spec
+(``sdd/specs/llmwiki-obsidian-plugin.spec.md`` §2) verbatim; the
+``VaultFileInfo``/``VaultSearchHit`` models belong to the backend access
+layer added by the shared-interface work.
+"""
+from enum import Enum
+from pathlib import Path
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ExtractionGranularity(str, Enum):
+    """Granularity for Phase-2 LLM entity extraction (FEAT-392)."""
+
+    MINIMAL = "minimal"
+    STANDARD = "standard"
+    FINE = "fine"
+    CUSTOM = "custom"
+
+
+class ObsidianLink(BaseModel):
+    """A single ``[[wikilink]]`` or ``![[embed]]`` reference."""
+
+    target: str = Field(..., description="Target note name or path")
+    alias: Optional[str] = Field(default=None, description="Display text |alias")
+    is_embed: bool = Field(default=False, description="True if ![[embed]]")
+    heading: Optional[str] = Field(default=None, description="#heading fragment")
+
+
+class ObsidianNote(BaseModel):
+    """Parsed representation of a single Obsidian markdown note."""
+
+    path: Path = Field(..., description="Relative path within the vault")
+    title: str = Field(..., description="Note title (filename stem or frontmatter)")
+    content: str = Field(..., description="Raw markdown body (frontmatter stripped)")
+    frontmatter: dict = Field(default_factory=dict, description="YAML frontmatter")
+    links: list[ObsidianLink] = Field(default_factory=list)
+    tags: set[str] = Field(default_factory=set, description="Inline and frontmatter #tags")
+    aliases: list[str] = Field(default_factory=list, description="From frontmatter")
+    dataview_queries: list[str] = Field(default_factory=list, description="Raw DQL")
+
+
+class ObsidianCanvasCard(BaseModel):
+    """A single card in a ``.canvas`` file."""
+
+    card_id: str
+    card_type: str = Field(description="'text' | 'file' | 'link' | 'group'")
+    file_path: Optional[str] = None
+    text: Optional[str] = None
+    url: Optional[str] = None
+
+
+class ObsidianCanvas(BaseModel):
+    """Parsed representation of a ``.canvas`` file."""
+
+    path: Path
+    title: str
+    cards: list[ObsidianCanvasCard] = Field(default_factory=list)
+    connections: list[tuple[str, str]] = Field(
+        default_factory=list, description="(from_card_id, to_card_id) pairs"
+    )
+
+
+class VaultIngestConfig(BaseModel):
+    """Configuration for an Obsidian vault ingest operation (FEAT-392)."""
+
+    vault_path: Path
+    tree_name: str
+    wiki_config: Any = None
+    skip_patterns: list[str] = Field(
+        default_factory=lambda: [".obsidian", ".trash", ".git"],
+        description="Directory names to skip during vault discovery",
+    )
+    embed_depth_limit: int = Field(default=3, description="Max transclusion depth")
+    concurrency: int = Field(default=8, ge=1, le=32, description="Async batch size")
+    granularity: ExtractionGranularity = Field(
+        default=ExtractionGranularity.STANDARD,
+        description="Entity extraction granularity (Phase 2 only)",
+    )
+
+
+class VaultIngestReport(BaseModel):
+    """Result of a vault ingest operation (FEAT-392)."""
+
+    vault_path: str
+    tree_name: str
+    phase: str = Field(
+        description="'raw_ingest' | 'graph_bridge' | 'entity_extraction'"
+    )
+    notes_processed: int = 0
+    canvas_processed: int = 0
+    nodes_created: int = 0
+    edges_created: int = 0
+    files_added: int = 0
+    files_updated: int = 0
+    files_deleted: int = 0
+    files_skipped: int = 0
+    errors: list[str] = Field(default_factory=list)
+    duration_ms: float = 0.0
+
+
+class VaultFileInfo(BaseModel):
+    """Lightweight file descriptor returned by vault backends."""
+
+    path: str = Field(..., description="Vault-relative POSIX path")
+    name: str = Field(..., description="File name including extension")
+    size: Optional[int] = Field(default=None, description="Size in bytes when known")
+    mtime: Optional[float] = Field(
+        default=None, description="POSIX mtime when known (REST backend may omit)"
+    )
+    is_note: bool = Field(default=False, description="True for .md files")
+    is_canvas: bool = Field(default=False, description="True for .canvas files")
+
+
+class VaultSearchHit(BaseModel):
+    """One search result from a vault backend's search primitive."""
+
+    path: str = Field(..., description="Vault-relative POSIX path of the note")
+    score: float = Field(default=0.0, description="Backend-specific relevance score")
+    snippet: Optional[str] = Field(
+        default=None, description="Matching context excerpt when available"
+    )
+    matches: list[str] = Field(
+        default_factory=list, description="Which fields matched (title/tag/alias/body)"
+    )
+
+
+#: Directory names never traversed by vault backends.
+DEFAULT_SKIP_PATTERNS: frozenset[str] = frozenset({".obsidian", ".trash", ".git"})
+
+#: Suffix of Obsidian markdown notes.
+NOTE_SUFFIX = ".md"
+
+#: Suffix of Obsidian canvas files.
+CANVAS_SUFFIX = ".canvas"

--- a/packages/ai-parrot/src/parrot/interfaces/obsidian/okf.py
+++ b/packages/ai-parrot/src/parrot/interfaces/obsidian/okf.py
@@ -1,0 +1,285 @@
+"""OKF (Open Knowledge Format) metadata inside Obsidian note frontmatter.
+
+Design (Phase D of the Obsidian integration): Obsidian owns the top-level
+frontmatter namespace (``tags``, ``aliases``, ``cssclasses``, user keys) —
+those keys round-trip untouched. OKF owns exactly ONE top-level key,
+``okf``, whose subtree mirrors :class:`ConceptFrontmatter` field order and
+is always regenerated wholesale by the single sanctioned writer
+(:func:`apply_okf`), reusing the serialization discipline of
+``parrot.knowledge.okf.frontmatter`` (fixed field order, sorted tags,
+``sort_keys=False``, optional ``source`` omitted when None).
+
+Determinism scope: byte-determinism is guaranteed for the ``okf:`` subtree
+given the same node dict — whole-file determinism is impossible because
+the user owns the native keys around it. Hand-edits to the ``okf`` block
+are invalid and are overwritten on the next projection;
+:func:`validate_okf` surfaces such drift first.
+
+``relates_to`` targets may be written Obsidian-style (``[[note]]``) —
+they are resolved through the shared :class:`VaultIndex` and normalized
+to stable note ids (vault-relative path without ``.md``, matching the
+FEAT-392 node-ID convention).
+"""
+import re
+from typing import Any, Optional
+
+import frontmatter as fm
+import yaml
+from pydantic import ValidationError
+
+from parrot.knowledge.okf.frontmatter import (
+    ConceptFrontmatter,
+    _to_yaml_dict,
+)
+from parrot.knowledge.okf.ontology import (
+    ConceptType,
+    RelatesTo,
+    RelationType,
+    SourceProvenance,
+)
+
+from .index import VaultIndex
+from .models import ObsidianNote
+
+#: The single top-level frontmatter key owned by OKF.
+OKF_KEY = "okf"
+
+_WIKILINK_TARGET = re.compile(r"^\[\[([^\[\]\|#]+)(?:#[^\[\]\|]*)?(?:\|[^\[\]]*)?\]\]$")
+
+
+def _build_model(node: dict, tree_name: str) -> ConceptFrontmatter:
+    """Build a ConceptFrontmatter from a node dict (same rules as the
+    sanctioned ``project_frontmatter`` writer)."""
+    return ConceptFrontmatter(
+        type=ConceptType(node.get("type", ConceptType.SECTION.value)),
+        title=node.get("title", ""),
+        id=node["concept_id"],
+        node_id=str(node.get("node_id", "")),
+        resource=node.get(
+            "resource", f"pageindex://{tree_name}/{node['concept_id']}"
+        ),
+        tags=sorted(node.get("categories", []) or node.get("tags", [])),
+        timestamp=str(node.get("timestamp", "")),
+        summary=node.get("summary", "") or "",
+        relates_to=[RelatesTo(**r) for r in (node.get("relates_to") or [])],
+        source=(
+            SourceProvenance(**node["source"]) if node.get("source") else None
+        ),
+    )
+
+
+def project_okf_block(node: dict, tree_name: str) -> str:
+    """Deterministic YAML for the ``okf:`` subtree.
+
+    Args:
+        node: Node dict with at least ``concept_id`` and ``title``
+            (same shape ``project_frontmatter`` accepts).
+        tree_name: Tree/vault name used for the default resource URI.
+
+    Returns:
+        A YAML string of the form ``okf:\\n  type: ...`` — byte-identical
+        for identical inputs (single-writer determinism guarantee, scoped
+        to this subtree).
+    """
+    payload = {OKF_KEY: _to_yaml_dict(_build_model(node, tree_name))}
+    return yaml.dump(
+        payload,
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=True,
+    )
+
+
+def read_okf(note: ObsidianNote) -> Optional[ConceptFrontmatter]:
+    """Extract and validate a note's ``okf`` frontmatter block.
+
+    Args:
+        note: A parsed Obsidian note.
+
+    Returns:
+        The validated :class:`ConceptFrontmatter`, or ``None`` when the
+        note carries no ``okf`` key.
+
+    Raises:
+        ValueError: If the ``okf`` block exists but is malformed.
+    """
+    block = note.frontmatter.get(OKF_KEY)
+    if block is None:
+        return None
+    if not isinstance(block, dict):
+        raise ValueError(
+            f"okf frontmatter in {note.path} must be a mapping, "
+            f"got {type(block).__name__}"
+        )
+    try:
+        return ConceptFrontmatter(
+            type=ConceptType(block.get("type", ConceptType.SECTION.value)),
+            title=block.get("title", note.title),
+            id=str(block.get("id", "")),
+            node_id=str(block.get("node_id", "")),
+            resource=str(block.get("resource", "")),
+            tags=list(block.get("tags") or []),
+            timestamp=str(block.get("timestamp", "")),
+            summary=block.get("summary", "") or "",
+            relates_to=[
+                RelatesTo(
+                    concept=r["concept"], rel=r.get("rel", "references")
+                )
+                for r in (block.get("relates_to") or [])
+                if isinstance(r, dict) and "concept" in r
+            ],
+            source=(
+                SourceProvenance(**block["source"])
+                if block.get("source")
+                else None
+            ),
+        )
+    except (ValidationError, ValueError, KeyError, TypeError) as exc:
+        raise ValueError(f"Malformed okf frontmatter in {note.path}: {exc}") from exc
+
+
+def apply_okf(
+    raw_text: str,
+    node: dict,
+    tree_name: str,
+    mirror_tags: bool = False,
+) -> str:
+    """Return the full new note text with the ``okf`` block (re)projected.
+
+    Native frontmatter keys are preserved (values re-serialized, original
+    key order kept); the ``okf`` mapping is regenerated wholesale and
+    always emitted last; the markdown body is untouched.
+
+    Args:
+        raw_text: Current full note text (frontmatter included).
+        node: OKF node dict (``concept_id``, ``title``, ``type``,
+            ``summary``, ``tags``/``categories``, ``relates_to``, ...).
+        tree_name: Tree/vault name for the default resource URI.
+        mirror_tags: When True, OKF tags are additionally merged into the
+            native ``tags:`` list as ``okf/<tag>`` so Obsidian tag search
+            sees them.
+
+    Returns:
+        The complete new file text.
+    """
+    try:
+        post = fm.loads(raw_text)
+        native = dict(post.metadata)
+        body = post.content
+    except (yaml.YAMLError, ValueError):
+        native = {}
+        body = raw_text
+    native.pop(OKF_KEY, None)
+
+    model = _build_model(node, tree_name)
+    if mirror_tags and model.tags:
+        mirrored = [f"okf/{tag}" for tag in sorted(model.tags)]
+        existing = native.get("tags")
+        if isinstance(existing, str):
+            existing = [part.strip() for part in existing.split(",") if part.strip()]
+        elif not isinstance(existing, list):
+            existing = []
+        keep = [tag for tag in existing if not str(tag).startswith("okf/")]
+        native["tags"] = keep + mirrored
+
+    sections: list[str] = []
+    if native:
+        sections.append(
+            yaml.dump(
+                native,
+                default_flow_style=False,
+                sort_keys=False,
+                allow_unicode=True,
+            )
+        )
+    sections.append(project_okf_block(node, tree_name))
+    frontmatter_block = "".join(sections)
+    return f"---\n{frontmatter_block}---\n{body if body.startswith(chr(10)) else chr(10) + body}"
+
+
+def normalize_relates_target(
+    target: str, index: Optional[VaultIndex] = None
+) -> Optional[str]:
+    """Normalize a relates_to target, resolving ``[[wikilink]]`` syntax.
+
+    Args:
+        target: A concept id, note path, or ``[[wikilink]]`` string.
+        index: Optional vault index for wikilink/path resolution.
+
+    Returns:
+        The stable note id (vault-relative path, no ``.md``) when the
+        target resolves; the verbatim target when no index is given; or
+        ``None`` when an index is given and the target does not resolve.
+    """
+    match = _WIKILINK_TARGET.match(target.strip())
+    raw = match.group(1).strip() if match else target.strip()
+    if index is None:
+        return raw
+    return index.resolve(raw)
+
+
+def validate_okf(
+    note: ObsidianNote, index: Optional[VaultIndex] = None
+) -> list[str]:
+    """Lint a note's ``okf`` frontmatter block.
+
+    Args:
+        note: Parsed Obsidian note.
+        index: Optional vault index — when given, ``relates_to`` targets
+            are checked for resolvability.
+
+    Returns:
+        Human-readable findings; empty when the block is absent or valid.
+    """
+    findings: list[str] = []
+    block = note.frontmatter.get(OKF_KEY)
+    if block is None:
+        return findings
+    if not isinstance(block, dict):
+        return [f"{note.path}: okf block is not a mapping"]
+
+    raw_type = block.get("type")
+    if raw_type is not None:
+        try:
+            ConceptType(raw_type)
+        except ValueError:
+            findings.append(
+                f"{note.path}: unknown okf type {raw_type!r} "
+                f"(open vocabulary maps to 'Other' on import)"
+            )
+    if not block.get("id"):
+        findings.append(f"{note.path}: okf block is missing 'id'")
+    if not block.get("summary"):
+        findings.append(f"{note.path}: okf block is missing 'summary'")
+
+    for row in block.get("relates_to") or []:
+        if not isinstance(row, dict) or "concept" not in row:
+            findings.append(
+                f"{note.path}: relates_to entry {row!r} needs a 'concept'"
+            )
+            continue
+        rel = row.get("rel", "references")
+        try:
+            RelationType(rel)
+        except ValueError:
+            findings.append(
+                f"{note.path}: unknown relates_to rel {rel!r}"
+            )
+        if index is not None:
+            resolved = normalize_relates_target(str(row["concept"]), index)
+            if resolved is None:
+                findings.append(
+                    f"{note.path}: relates_to target {row['concept']!r} "
+                    f"does not resolve to any note"
+                )
+    return findings
+
+
+__all__ = [
+    "OKF_KEY",
+    "apply_okf",
+    "normalize_relates_target",
+    "project_okf_block",
+    "read_okf",
+    "validate_okf",
+]

--- a/packages/ai-parrot/src/parrot/interfaces/obsidian/parser.py
+++ b/packages/ai-parrot/src/parrot/interfaces/obsidian/parser.py
@@ -1,0 +1,254 @@
+"""Obsidian-flavored markdown parsing into :class:`ObsidianNote` models.
+
+Implements FEAT-392 Module 1 (relocated to the shared interface package so
+the toolkit, the vault loader and the wikitoolkit vault scanner all parse
+notes identically): ``python-frontmatter`` for YAML frontmatter extraction
+and ``marko`` with a custom inline element for ``[[wikilinks]]`` /
+``![[embeds]]``. Inline ``#tags`` are collected from raw-text nodes only
+(code blocks and link targets never produce tags), callout blocks are
+preserved verbatim in the note body, and dataview queries are captured as
+raw text.
+
+Parsing is pure and synchronous — no I/O happens here.
+"""
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any, Optional
+
+import frontmatter as fm
+import yaml
+from marko import Markdown
+from marko.block import FencedCode
+from marko.helpers import MarkoExtension
+from marko.inline import CodeSpan, InlineElement
+
+from .models import (
+    ObsidianCanvas,
+    ObsidianCanvasCard,
+    ObsidianLink,
+    ObsidianNote,
+)
+
+logger = logging.getLogger(__name__)
+
+# Obsidian tag: at least one letter, may contain digits, '_', '-', and '/'
+# for nested tags. Must be preceded by start-of-text or whitespace so URL
+# fragments ("…/#anchor") and headings ("# Title") never match.
+_TAG_RE = re.compile(r"(?:(?<=\s)|^)#([\w/-]*[A-Za-z][\w/-]*)")
+
+# ``dataview`` fenced blocks are matched by info-string; inline `= …` DQL is
+# out of scope (stored raw only when fenced), per the FEAT-392 non-goals.
+_DATAVIEW_LANGS = frozenset({"dataview", "dataviewjs"})
+
+
+class WikiLinkElement(InlineElement):
+    """marko inline element for ``[[target#heading|alias]]`` / ``![[embed]]``."""
+
+    pattern = re.compile(
+        r"(!?)\[\[([^\[\]\|#\n]+)(?:#([^\[\]\|\n]+))?(?:\|([^\[\]\n]+))?\]\]"
+    )
+    parse_children = False
+    priority = 6  # above standard links so [[...]] wins over [ ... ] parsing
+
+    def __init__(self, match: re.Match) -> None:
+        self.is_embed: bool = match.group(1) == "!"
+        self.target: str = match.group(2).strip()
+        self.heading: Optional[str] = (
+            match.group(3).strip() if match.group(3) else None
+        )
+        self.alias: Optional[str] = (
+            match.group(4).strip() if match.group(4) else None
+        )
+
+
+#: marko extension registering the wikilink inline element.
+ObsidianExtension = MarkoExtension(elements=[WikiLinkElement])
+
+
+def _coerce_str_list(value: Any) -> list[str]:
+    """Normalize a frontmatter scalar/list into a list of strings."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    if isinstance(value, (list, tuple, set)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return [str(value)]
+
+
+class ObsidianNoteParser:
+    """Parse raw Obsidian markdown text into :class:`ObsidianNote` models.
+
+    The parser is stateless and reusable; one instance can parse any number
+    of notes (a single ``marko.Markdown`` instance is reused).
+    """
+
+    def __init__(self) -> None:
+        self._markdown = Markdown(extensions=[ObsidianExtension])
+
+    def parse(self, raw: str, rel_path: str | Path) -> ObsidianNote:
+        """Parse one note.
+
+        Args:
+            raw: Full file text including any YAML frontmatter block.
+            rel_path: Vault-relative path of the note (used for the title
+                fallback and stored on the model).
+
+        Returns:
+            The parsed :class:`ObsidianNote`. Invalid YAML frontmatter is
+            tolerated: the whole text becomes the body and frontmatter is
+            empty (per the FEAT-392 robustness requirement).
+        """
+        rel_path = Path(rel_path)
+        metadata: dict[str, Any] = {}
+        body = raw
+        try:
+            post = fm.loads(raw)
+            metadata = dict(post.metadata)
+            body = post.content
+        except (yaml.YAMLError, ValueError) as exc:
+            logger.warning(
+                "Invalid frontmatter in %s — treating full text as body: %s",
+                rel_path, exc,
+            )
+
+        links: list[ObsidianLink] = []
+        tags: set[str] = set()
+        dataview_queries: list[str] = []
+        try:
+            document = self._markdown.parse(body)
+            self._walk(document, links, tags, dataview_queries)
+        except Exception as exc:  # noqa: BLE001 — parser must never fail a note
+            logger.warning(
+                "marko failed on %s (%s) — falling back to regex link scan",
+                rel_path, exc,
+            )
+            links = self._fallback_links(body)
+            tags = {m.group(1) for m in _TAG_RE.finditer(body)}
+
+        # Frontmatter tags: `tags: [a, b]`, `tags: a, b` or singular `tag:`.
+        for key in ("tags", "tag"):
+            for tag in _coerce_str_list(metadata.get(key)):
+                tags.add(tag.lstrip("#"))
+
+        aliases = _coerce_str_list(
+            metadata.get("aliases", metadata.get("alias"))
+        )
+        title = str(metadata.get("title") or rel_path.stem)
+
+        return ObsidianNote(
+            path=rel_path,
+            title=title,
+            content=body,
+            frontmatter=metadata,
+            links=links,
+            tags=tags,
+            aliases=aliases,
+            dataview_queries=dataview_queries,
+        )
+
+    def _walk(
+        self,
+        element: Any,
+        links: list[ObsidianLink],
+        tags: set[str],
+        dataview_queries: list[str],
+    ) -> None:
+        """Depth-first AST walk collecting links, tags and dataview blocks."""
+        if isinstance(element, WikiLinkElement):
+            links.append(
+                ObsidianLink(
+                    target=element.target,
+                    alias=element.alias,
+                    is_embed=element.is_embed,
+                    heading=element.heading,
+                )
+            )
+            return
+        if isinstance(element, FencedCode):
+            if (element.lang or "").lower() in _DATAVIEW_LANGS:
+                query = self._raw_text(element).strip()
+                if query:
+                    dataview_queries.append(query)
+            return  # never harvest tags/links from code
+        if isinstance(element, CodeSpan):
+            return
+        children = getattr(element, "children", None)
+        if isinstance(children, str):
+            for match in _TAG_RE.finditer(children):
+                tags.add(match.group(1))
+            return
+        if children:
+            for child in children:
+                self._walk(child, links, tags, dataview_queries)
+
+    def _raw_text(self, element: Any) -> str:
+        """Concatenate all raw text under an AST element."""
+        children = getattr(element, "children", None)
+        if isinstance(children, str):
+            return children
+        if not children:
+            return ""
+        return "".join(self._raw_text(child) for child in children)
+
+    @staticmethod
+    def _fallback_links(body: str) -> list[ObsidianLink]:
+        """Regex-only link extraction used if marko raises unexpectedly."""
+        found: list[ObsidianLink] = []
+        for match in WikiLinkElement.pattern.finditer(body):
+            found.append(
+                ObsidianLink(
+                    target=match.group(2).strip(),
+                    alias=match.group(4).strip() if match.group(4) else None,
+                    is_embed=match.group(1) == "!",
+                    heading=match.group(3).strip() if match.group(3) else None,
+                )
+            )
+        return found
+
+
+def parse_canvas(raw_json: str, rel_path: str | Path) -> ObsidianCanvas:
+    """Parse an Obsidian ``.canvas`` JSON file.
+
+    Args:
+        raw_json: The canvas file content (JSON Canvas format).
+        rel_path: Vault-relative path of the canvas file.
+
+    Returns:
+        The parsed :class:`ObsidianCanvas` with cards and connections.
+
+    Raises:
+        ValueError: If the file is not valid JSON or not an object.
+    """
+    rel_path = Path(rel_path)
+    try:
+        data = json.loads(raw_json)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid canvas JSON in {rel_path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"Canvas file {rel_path} is not a JSON object")
+
+    cards = [
+        ObsidianCanvasCard(
+            card_id=str(node.get("id", "")),
+            card_type=str(node.get("type", "text")),
+            file_path=node.get("file"),
+            text=node.get("text"),
+            url=node.get("url"),
+        )
+        for node in data.get("nodes", [])
+        if isinstance(node, dict)
+    ]
+    connections = [
+        (str(edge.get("fromNode", "")), str(edge.get("toNode", "")))
+        for edge in data.get("edges", [])
+        if isinstance(edge, dict)
+    ]
+    return ObsidianCanvas(
+        path=rel_path,
+        title=rel_path.stem,
+        cards=cards,
+        connections=connections,
+    )

--- a/packages/ai-parrot/src/parrot/interfaces/obsidian/rest.py
+++ b/packages/ai-parrot/src/parrot/interfaces/obsidian/rest.py
@@ -1,0 +1,234 @@
+"""Obsidian *Local REST API* community-plugin backend (aiohttp).
+
+Talks to a running Obsidian instance with the `Local REST API
+<https://github.com/coddingtonbear/obsidian-local-rest-api>`_ plugin
+enabled. Route mapping:
+
+* ``GET /vault/`` and ``GET /vault/{folder}/`` — directory listings
+* ``GET/PUT/DELETE /vault/{path}`` — note read/write/delete
+* ``POST /search/simple/?query=…`` — plugin-side simple search
+
+The plugin serves HTTPS with a self-signed certificate on
+``https://127.0.0.1:27124`` by default, hence ``verify_ssl=False`` as the
+default for this localhost-only integration. Listings carry no
+size/mtime, so :meth:`stat` degrades to existence + name (``mtime=None``).
+"""
+import asyncio
+from typing import Any, Optional
+
+import aiohttp
+
+from .abstract import ObsidianVaultInterface, VaultAccessError
+from .models import (
+    CANVAS_SUFFIX,
+    NOTE_SUFFIX,
+    VaultFileInfo,
+    VaultSearchHit,
+)
+
+
+class RestVaultBackend(ObsidianVaultInterface):
+    """Vault access through the Obsidian Local REST API plugin."""
+
+    def __init__(
+        self,
+        base_url: str = "https://127.0.0.1:27124",
+        api_key: str = "",
+        vault_name: Optional[str] = None,
+        verify_ssl: bool = False,
+        timeout: float = 30.0,
+    ) -> None:
+        """Initialize the backend.
+
+        Args:
+            base_url: Root URL of the Local REST API plugin.
+            api_key: Bearer token configured in the plugin settings.
+            vault_name: Logical vault name for node IDs and reports.
+            verify_ssl: Verify the plugin's TLS certificate (it ships
+                self-signed, so this defaults to False; localhost only).
+            timeout: Total request timeout in seconds.
+        """
+        super().__init__(vault_name=vault_name)
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.verify_ssl = verify_ssl
+        self.timeout = aiohttp.ClientTimeout(total=timeout)
+        self._session: Optional[aiohttp.ClientSession] = None
+
+    async def open(self) -> None:
+        """Create the aiohttp session."""
+        if self._session is None or self._session.closed:
+            connector = aiohttp.TCPConnector(ssl=self.verify_ssl or False)
+            self._session = aiohttp.ClientSession(
+                connector=connector,
+                timeout=self.timeout,
+                headers={"Authorization": f"Bearer {self.api_key}"},
+            )
+
+    async def close(self) -> None:
+        """Close the aiohttp session and drop the cached index."""
+        if self._session is not None and not self._session.closed:
+            await self._session.close()
+        self._session = None
+        await super().close()
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        expect_json: bool = False,
+        **kwargs: Any,
+    ) -> Any:
+        """Perform one API request, mapping HTTP errors to exceptions."""
+        await self.open()
+        assert self._session is not None
+        url = f"{self.base_url}{path}"
+        try:
+            async with self._session.request(method, url, **kwargs) as response:
+                if response.status == 404:
+                    raise FileNotFoundError(f"Not found in vault: {path}")
+                if response.status >= 400:
+                    detail = (await response.text())[:200]
+                    raise VaultAccessError(
+                        f"Local REST API {method} {path} -> "
+                        f"{response.status}: {detail}"
+                    )
+                if expect_json:
+                    return await response.json(content_type=None)
+                return await response.text()
+        except aiohttp.ClientError as exc:
+            raise VaultAccessError(
+                f"Cannot reach Obsidian Local REST API at {self.base_url}: {exc}"
+            ) from exc
+
+    # ------------------------------------------------------------------ #
+    # Primitives
+    # ------------------------------------------------------------------ #
+    async def list_files(
+        self,
+        folder: Optional[str] = None,
+        recursive: bool = True,
+        suffixes: Optional[frozenset[str]] = None,
+    ) -> list[VaultFileInfo]:
+        wanted = suffixes or frozenset({NOTE_SUFFIX, CANVAS_SUFFIX})
+        found: list[VaultFileInfo] = []
+
+        async def _walk(prefix: str) -> None:
+            route = f"/vault/{prefix}" if prefix else "/vault/"
+            if prefix and not route.endswith("/"):
+                route += "/"
+            payload = await self._request("GET", route, expect_json=True)
+            entries = payload.get("files", []) if isinstance(payload, dict) else []
+            subfolders: list[str] = []
+            for entry in entries:
+                name = str(entry)
+                rel = f"{prefix}{name}"
+                if name.endswith("/"):
+                    if name.rstrip("/") not in self.skip_patterns:
+                        subfolders.append(rel)
+                    continue
+                suffix = "." + name.rsplit(".", 1)[-1].lower() if "." in name else ""
+                if suffix in wanted:
+                    found.append(
+                        VaultFileInfo(
+                            path=rel,
+                            name=name,
+                            size=None,
+                            mtime=None,
+                            is_note=suffix == NOTE_SUFFIX,
+                            is_canvas=suffix == CANVAS_SUFFIX,
+                        )
+                    )
+            if recursive:
+                for sub in subfolders:
+                    await _walk(sub)
+
+        start = ""
+        if folder:
+            start = folder.strip("/") + "/"
+        await _walk(start)
+        found.sort(key=lambda info: info.path)
+        return found
+
+    async def read_note(self, path: str) -> str:
+        rel = self.normalize_note_path(path)
+        return await self._request("GET", f"/vault/{rel}")
+
+    async def write_note(
+        self, path: str, content: str, *, overwrite: bool = True
+    ) -> VaultFileInfo:
+        rel = self.normalize_note_path(path)
+        if not overwrite and await self.note_exists(rel):
+            raise FileExistsError(f"Note already exists: {path}")
+        await self._request(
+            "PUT",
+            f"/vault/{rel}",
+            data=content.encode("utf-8"),
+            headers={"Content-Type": "text/markdown"},
+        )
+        self.invalidate_index()
+        return VaultFileInfo(
+            path=rel,
+            name=rel.rsplit("/", 1)[-1],
+            size=len(content.encode("utf-8")),
+            mtime=None,
+            is_note=rel.endswith(NOTE_SUFFIX),
+            is_canvas=rel.endswith(CANVAS_SUFFIX),
+        )
+
+    async def delete_note(self, path: str) -> bool:
+        rel = self.normalize_note_path(path)
+        try:
+            await self._request("DELETE", f"/vault/{rel}")
+        except FileNotFoundError:
+            return False
+        self.invalidate_index()
+        return True
+
+    async def note_exists(self, path: str) -> bool:
+        try:
+            await self.stat(path)
+            return True
+        except FileNotFoundError:
+            return False
+
+    async def stat(self, path: str) -> VaultFileInfo:
+        rel = self.normalize_note_path(path)
+        # The plugin has no metadata route for arbitrary files; a HEAD-style
+        # GET both proves existence and yields the size. mtime is unknown.
+        content = await self._request("GET", f"/vault/{rel}")
+        return VaultFileInfo(
+            path=rel,
+            name=rel.rsplit("/", 1)[-1],
+            size=len(str(content).encode("utf-8")),
+            mtime=None,
+            is_note=rel.endswith(NOTE_SUFFIX),
+            is_canvas=rel.endswith(CANVAS_SUFFIX),
+        )
+
+    async def search(self, query: str, limit: int = 20) -> list[VaultSearchHit]:
+        payload = await self._request(
+            "POST",
+            "/search/simple/",
+            params={"query": query, "contextLength": 120},
+            expect_json=True,
+        )
+        hits: list[VaultSearchHit] = []
+        if isinstance(payload, list):
+            for row in payload[:limit]:
+                if not isinstance(row, dict):
+                    continue
+                matches = row.get("matches") or []
+                snippet = None
+                if matches and isinstance(matches[0], dict):
+                    snippet = matches[0].get("context")
+                hits.append(
+                    VaultSearchHit(
+                        path=str(row.get("filename", "")),
+                        score=float(row.get("score", 0.0)),
+                        snippet=snippet,
+                        matches=["body"] if matches else [],
+                    )
+                )
+        return hits

--- a/packages/ai-parrot/src/parrot/knowledge/graphindex/schema.py
+++ b/packages/ai-parrot/src/parrot/knowledge/graphindex/schema.py
@@ -193,6 +193,10 @@ class UniversalEdge(BaseModel):
             agent or human (``Provenance.ASSERTED``). Assertion-level
             confidence lives in ``AssertionMeta.confidence`` — it does
             NOT interact with the similarity ``confidence`` field.
+        domain_tags: Arbitrary key-value metadata from the extractor
+            (e.g. ``{"embed": true}`` for Obsidian transclusion edges —
+            FEAT-392 expresses domain semantics on existing edge kinds
+            through tags instead of new enum members).
     """
 
     source_id: str
@@ -201,6 +205,7 @@ class UniversalEdge(BaseModel):
     provenance: Provenance = Provenance.EXTRACTED
     confidence: Optional[float] = None
     assertion: Optional[AssertionMeta] = None
+    domain_tags: dict = Field(default_factory=dict)
 
     @model_validator(mode="after")
     def _validate_confidence_with_provenance(self) -> "UniversalEdge":

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/cli.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/cli.py
@@ -736,6 +736,16 @@ def mcp() -> None:
     show_default=True,
     help="Comma list of page categories included in graph.html.",
 )
+@click.option(
+    "--vault/--no-vault",
+    "vault_mode",
+    default=None,
+    help=(
+        "Treat the path as an Obsidian vault (notes/wikilinks/tags scan) "
+        "instead of a source repository. Default: auto-detect via the "
+        ".obsidian/ directory."
+    ),
+)
 def build(
     path_: str | None,
     name: str | None,
@@ -746,6 +756,7 @@ def build(
     no_export: bool,
     no_graph: bool,
     graph_kinds: str,
+    vault_mode: bool | None,
 ) -> None:
     """Generate (or refresh) the KB graph from the current repository.
 
@@ -771,16 +782,33 @@ def build(
         if backend:
             config.backend = backend  # type: ignore[assignment]
 
-        if not quiet:
-            click.echo(f"Scanning {root} ...")
-        scan = scan_repository(
-            root,
-            suffixes=config.include_suffixes or None,
-            exclude_dirs=config.exclude_dirs,
-            body_max_chars=config.body_max_chars,
-            max_file_bytes=config.max_file_kb * 1024,
-            use_git=not no_git,
+        from parrot.knowledge.wiki.vault_scan import (
+            is_obsidian_vault,
+            scan_vault,
         )
+
+        vault_stats = None
+        if vault_mode is None:
+            vault_mode = is_obsidian_vault(root)
+        if vault_mode:
+            if not quiet:
+                click.echo(f"Scanning Obsidian vault {root} ...")
+            scan, vault_stats = scan_vault(
+                root,
+                body_max_chars=config.body_max_chars,
+                max_file_bytes=config.max_file_kb * 1024,
+            )
+        else:
+            if not quiet:
+                click.echo(f"Scanning {root} ...")
+            scan = scan_repository(
+                root,
+                suffixes=config.include_suffixes or None,
+                exclude_dirs=config.exclude_dirs,
+                body_max_chars=config.body_max_chars,
+                max_file_bytes=config.max_file_kb * 1024,
+                use_git=not no_git,
+            )
 
         output_dir = config.storage_path(root)
 
@@ -847,6 +875,13 @@ def build(
             f"{counts['removed']} removed; "
             f"{stats.get('pages', 0)} pages, {stats.get('edges', 0)} edges."
         )
+        if vault_stats is not None:
+            click.echo(
+                f"Vault: {vault_stats.notes} notes, {vault_stats.tags} tags, "
+                f"{vault_stats.wikilink_edges} wikilink edges, "
+                f"{vault_stats.embed_edges} embed edges, "
+                f"{len(vault_stats.unresolved_links)} unresolved links."
+            )
         okf = counts.get("okf")
         if okf and not quiet:
             click.echo(f"OKF bundle: {okf['files_written']} files exported.")

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/ingest.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/ingest.py
@@ -436,6 +436,167 @@ class WikiIngestOrchestrator:
             status="ok",
         )
 
+    async def extract_entities(
+        self,
+        tree_name: str,
+        wiki_config: WikiConfig,
+        granularity: Any = "standard",
+        custom_instructions: Optional[str] = None,
+    ) -> IngestReport:
+        """Phase 2 (FEAT-392): LLM entity/concept extraction from pages.
+
+        Iterates over the content-bearing nodes of an already-ingested
+        PageIndex tree, asks the PageIndex LLM adapter for the entities
+        and concepts each page mentions, creates one sub-node per
+        extracted item, and mirrors each as a CONCEPT node in GraphIndex
+        (when a graph toolkit is configured).
+
+        Args:
+            tree_name: PageIndex tree to extract from (must exist).
+            wiki_config: Wiki configuration (used for logging context).
+            granularity: ``ExtractionGranularity`` or its string value —
+                ``minimal`` (up to 3 key concepts per page), ``standard``
+                (up to 8 entities + concepts), ``fine`` (exhaustive), or
+                ``custom`` (drive with ``custom_instructions``).
+            custom_instructions: Extraction directive used when
+                ``granularity="custom"``.
+
+        Returns:
+            An :class:`IngestReport` — ``pages_created`` counts entity
+            sub-nodes, ``graph_nodes_created`` counts GraphIndex mirrors.
+        """
+        from parrot.interfaces.obsidian.models import ExtractionGranularity
+
+        t0 = time.monotonic()
+        source_id = f"entity-extraction::{tree_name}"
+        if not isinstance(granularity, ExtractionGranularity):
+            granularity = ExtractionGranularity(str(granularity))
+
+        adapter = getattr(self._pi, "_light_adapter", None) or getattr(
+            self._pi, "_adapter", None
+        )
+        if adapter is None:
+            return self._error_report(
+                source_id, tree_name, t0,
+                "PageIndexToolkit has no LLM adapter for entity extraction",
+            )
+        try:
+            tree = await self._pi.get_tree(tree_name)
+        except KeyError as exc:
+            return self._error_report(source_id, tree_name, t0, str(exc))
+
+        directives = {
+            ExtractionGranularity.MINIMAL: (
+                "Extract at most 3 KEY concepts central to the text."
+            ),
+            ExtractionGranularity.STANDARD: (
+                "Extract up to 8 salient entities (people, projects, "
+                "systems, places) and concepts."
+            ),
+            ExtractionGranularity.FINE: (
+                "Extract ALL distinct entities and concepts mentioned, "
+                "however minor."
+            ),
+            ExtractionGranularity.CUSTOM: custom_instructions
+            or "Extract the entities and concepts from the text.",
+        }
+        directive = directives[granularity]
+
+        # Collect content-bearing nodes, skipping prior extraction output.
+        targets: list[dict[str, Any]] = []
+
+        def _walk(data: Any) -> None:
+            if isinstance(data, dict):
+                metadata = data.get("metadata") or {}
+                if data.get("node_id") and not metadata.get("extracted_from"):
+                    targets.append(data)
+                for key in data:
+                    if "nodes" in key:
+                        _walk(data[key])
+            elif isinstance(data, list):
+                for item in data:
+                    _walk(item)
+
+        _walk(tree.get("structure", tree))
+
+        loader = None
+        content_store = getattr(self._pi, "_content_store", None)
+        if content_store is not None:
+            loader = content_store.loader_for(tree_name)
+
+        entities_created = 0
+        graph_created = 0
+        errors: list[str] = []
+        for node in targets:
+            node_id = node.get("node_id") or ""
+            body = self._load_body(
+                loader, node.get("concept_id") or node_id, node_id
+            )
+            if not body or len(body.strip()) < 20:
+                continue
+            prompt = (
+                f"{directive}\n\n"
+                "Return ONLY a JSON array; each item: "
+                '{"name": str, "kind": "entity"|"concept", "summary": str '
+                "(one sentence)}.\n\nTEXT:\n" + body[:6000]
+            )
+            try:
+                items = await adapter.ask_json(prompt)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"{node_id}: {exc}")
+                continue
+            if not isinstance(items, list):
+                continue
+            for item in items:
+                if not isinstance(item, dict) or not item.get("name"):
+                    continue
+                name = str(item["name"]).strip()
+                kind = str(item.get("kind", "concept")).lower()
+                kind = kind if kind in ("entity", "concept") else "concept"
+                summary = str(item.get("summary", "")).strip()
+                try:
+                    await self._pi.add_node(
+                        tree_name,
+                        title=name,
+                        summary=summary,
+                        parent_node_id=node_id,
+                        categories=[kind],
+                        metadata={
+                            "extracted_from": node_id,
+                            "granularity": granularity.value,
+                        },
+                    )
+                    entities_created += 1
+                except Exception as exc:  # noqa: BLE001
+                    errors.append(f"{node_id}/{name}: {exc}")
+                    continue
+                if self._gi is not None:
+                    try:
+                        created = await self._gi.create_concept(
+                            title=name,
+                            summary=summary or name,
+                            source_uri=f"pageindex://{tree_name}/{node_id}",
+                            categories=[kind],
+                        )
+                        if isinstance(created, dict) and not created.get("error"):
+                            graph_created += 1
+                    except Exception as exc:  # noqa: BLE001
+                        errors.append(f"graph {name}: {exc}")
+
+        self.logger.info(
+            "extract_entities(%s, granularity=%s): %d entities, %d graph nodes",
+            tree_name, granularity.value, entities_created, graph_created,
+        )
+        return IngestReport(
+            source_id=source_id,
+            source_uri=tree_name,
+            pages_created=entities_created,
+            graph_nodes_created=graph_created,
+            duration_ms=(time.monotonic() - t0) * 1000,
+            status="ok" if not errors else "partial",
+            error="; ".join(errors[:5]) if errors else None,
+        )
+
     async def _record_discard(
         self,
         source_path_obj: Path,

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/mcp_server.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/mcp_server.py
@@ -106,12 +106,42 @@ def create_wiki_mcp_server(root: Path) -> StdioMCPServer:
             storage, wiki_name=config.wiki_name, backend=config.backend
         )
     tools = create_wiki_tools(store, root=root, config=config)
+
+    # Obsidian vault exposure: when the project has a vault (explicit
+    # `vault_dir` in wiki.json, or the root itself is a vault), register
+    # the full ObsidianToolkit plus the wiki-side vault_ingest tool.
+    # Everything — including resolution, whose vault_scan import pulls in
+    # parrot.interfaces (another stdout-printing navconfig chain) — runs
+    # under the same stdout-redirect discipline as the parrot.mcp.* import
+    # above. Destructive obsidian_* tools carry
+    # routing_meta["requires_confirmation"], which MCPToolAdapter turns
+    # into a required `confirm` argument (soft HITL guard over stdio).
+    description = "Codebase knowledge graph — query, explore, and remember"
+    vault_tools = []
+    with contextlib.redirect_stdout(sys.stderr):
+        from parrot.knowledge.wiki.project import resolve_vault_dir
+
+        vault = resolve_vault_dir(root, config)
+        if vault is not None:
+            from parrot.knowledge.wiki.tools import VaultIngestTool
+            from parrot.tools.obsidian import ObsidianToolkit
+
+            toolkit = ObsidianToolkit(vault_path=vault)
+            vault_tools = list(toolkit.get_tools_sync())
+            vault_tools.append(VaultIngestTool(store, root=root, config=config))
+            description += (
+                f" — plus Obsidian vault management for {vault.name!r}"
+            )
+    _ensure_stderr_logging()
+
     server = StdioMCPServer(LocalServerConfig(
         name="wikitoolkit",
         version="1.0.0",
-        description="Codebase knowledge graph — query, explore, and remember",
+        description=description,
     ))
     server.register_tools(tools)
+    if vault_tools:
+        server.register_tools(vault_tools)
     return server
 
 

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/project.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/project.py
@@ -13,6 +13,7 @@ PreToolUse hook can import them with minimal startup cost.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import time
 from collections.abc import Iterator
@@ -38,6 +39,8 @@ LOCK_FILENAME = "wiki.lock"
 
 #: Poll interval while waiting for a contended lock.
 _LOCK_POLL_SECONDS = 0.05
+
+logger = logging.getLogger(__name__)
 
 
 @contextmanager
@@ -171,6 +174,14 @@ class WikiProjectConfig(BaseModel):
         default="text_en",
         description="ArangoSearch text analyzer for FTS",
     )
+    vault_dir: Optional[str] = Field(
+        default=None,
+        description=(
+            "Obsidian vault directory served by the wiki MCP server; "
+            "absolute, or relative to the project root. When omitted, the "
+            "project root itself is used if it is a vault (.obsidian/)."
+        ),
+    )
 
     def graph_path(self, root: Path) -> Path:
         """Directory of the project's GraphIndex plane (``.parrot/graph``)."""
@@ -229,6 +240,52 @@ def resolve_arango_params(config: WikiProjectConfig) -> dict[str, Any]:
         "password": os.environ.get(f"{prefix}_PASSWORD", ""),
         "database": config.arango_database or f"wiki_{config.wiki_name}",
     }
+
+
+def resolve_vault_dir(
+    root: Path,
+    config: WikiProjectConfig,
+    override: Optional[str | Path] = None,
+) -> Optional[Path]:
+    """Resolve the Obsidian vault directory for a wiki project.
+
+    Precedence: explicit ``override`` > ``config.vault_dir`` (resolved
+    against ``root`` when relative) > ``root`` itself when it is a vault
+    (contains an ``.obsidian/`` directory).
+
+    Args:
+        root: Project root directory.
+        config: Project configuration.
+        override: Optional per-call vault path (e.g. a tool argument).
+
+    Returns:
+        The resolved, existing vault directory, or ``None`` when no vault
+        is configured/detected (a configured-but-missing directory is
+        logged and treated as absent).
+    """
+    from parrot.knowledge.wiki.vault_scan import is_obsidian_vault
+
+    candidate: Optional[Path] = None
+    if override:
+        candidate = Path(override).expanduser()
+        if not candidate.is_absolute():
+            candidate = root / candidate
+    elif config.vault_dir:
+        candidate = Path(config.vault_dir).expanduser()
+        if not candidate.is_absolute():
+            candidate = root / candidate
+    elif is_obsidian_vault(root):
+        candidate = root
+
+    if candidate is None:
+        return None
+    candidate = candidate.resolve()
+    if not candidate.is_dir():
+        logger.warning(
+            "Configured Obsidian vault directory does not exist: %s", candidate
+        )
+        return None
+    return candidate
 
 
 def config_path(root: Path) -> Path:

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/repo_scan.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/repo_scan.py
@@ -86,6 +86,9 @@ DEFAULT_EXCLUDE_DIRS: frozenset[str] = frozenset({
     ".venv", "venv", "node_modules", ".tox", "build", "dist", ".eggs",
     ".idea", ".vscode", ".mypy_cache", ".pytest_cache", ".ruff_cache",
     ".parrot", ".claude", ".worktrees", ".graphindex",
+    # Obsidian vault internals — never descend into these when a repo
+    # embeds a vault (the vault build mode has its own scanner).
+    ".obsidian", ".trash",
 })
 
 #: File basenames always skipped (lockfiles and similar noise).

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/toolkit.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/toolkit.py
@@ -193,6 +193,114 @@ class LLMWikiToolkit(AbstractToolkit):
         )
         return report.model_dump()
 
+    async def ingest_obsidian_vault(
+        self,
+        wiki_name: str,
+        vault_path: str,
+        incremental: bool = False,
+        extract_entities: bool = False,
+        granularity: str = "standard",
+    ) -> dict[str, Any]:
+        """Ingest an Obsidian vault into the wiki (FEAT-392).
+
+        Phase 1 stores one PageIndex node per note (no LLM), Phase 1b
+        imports the vault's ``[[wikilink]]`` graph into GraphIndex as
+        pre-curated edges, and Phase 2 (opt-in) runs LLM entity/concept
+        extraction over the ingested pages.
+
+        Args:
+            wiki_name: Name of the target wiki (tree name = wiki name).
+            vault_path: Absolute path of the Obsidian vault directory.
+            incremental: Only re-ingest added/changed files and prune
+                deleted ones (uses the source manifest for staleness).
+            extract_entities: Also run Phase-2 LLM entity extraction.
+            granularity: Entity extraction granularity — ``minimal``,
+                ``standard``, ``fine`` or ``custom``.
+
+        Returns:
+            Dict with the phase reports: ``raw_ingest``, ``graph_bridge``
+            (nodes/edges imported) and optionally ``entity_extraction``.
+        """
+        from parrot.loaders.obsidian import (
+            ObsidianGraphBridge,
+            ObsidianVaultLoader,
+        )
+
+        self.logger.info(
+            "Ingesting Obsidian vault into wiki '%s': %s", wiki_name, vault_path
+        )
+        effective_config = self._config_for(wiki_name)
+        loader = ObsidianVaultLoader(vault_path)
+        if incremental:
+            raw_report = await loader.incremental_update(
+                self._pi, wiki_name, self._sources
+            )
+        else:
+            raw_report = await loader.ingest(self._pi, wiki_name, self._sources)
+
+        # Phase 1b — wikilink graph import (best-effort, no LLM).
+        graph_summary: dict[str, Any] = {
+            "nodes_imported": 0, "edges_imported": 0, "errors": []
+        }
+        if self._gi is not None:
+            notes, canvases = await loader.discover()
+            bridge = ObsidianGraphBridge(
+                notes,
+                canvases,
+                await loader.vault.build_index(),
+                vault_name=loader.vault.vault_name,
+            )
+            nodes, edges = bridge.build_graph()
+            id_map: dict[str, str] = {}
+            for node in nodes:
+                try:
+                    created = await self._gi.create_node(
+                        kind=node.kind.value,
+                        title=node.title,
+                        summary=node.summary,
+                        source_uri=node.source_uri,
+                        domain_tags=node.domain_tags or None,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    graph_summary["errors"].append(f"{node.node_id}: {exc}")
+                    continue
+                if isinstance(created, dict) and created.get("node_id"):
+                    id_map[node.node_id] = created["node_id"]
+                    graph_summary["nodes_imported"] += 1
+                else:
+                    graph_summary["errors"].append(
+                        f"{node.node_id}: {created!r}"
+                    )
+            for edge in edges:
+                source_id = id_map.get(edge.source_id)
+                target_id = id_map.get(edge.target_id)
+                if not source_id or not target_id:
+                    continue
+                try:
+                    linked = await self._gi.link_nodes(
+                        source_id, target_id, edge.kind.value
+                    )
+                    if isinstance(linked, dict) and not linked.get("error"):
+                        graph_summary["edges_imported"] += 1
+                except Exception as exc:  # noqa: BLE001
+                    graph_summary["errors"].append(
+                        f"{edge.source_id}->{edge.target_id}: {exc}"
+                    )
+            graph_summary["errors"] = graph_summary["errors"][:10]
+
+        result: dict[str, Any] = {
+            "raw_ingest": raw_report.model_dump(),
+            "graph_bridge": graph_summary,
+        }
+
+        # Phase 2 — opt-in LLM entity extraction.
+        if extract_entities:
+            entity_report = await self._ingest_orch.extract_entities(
+                wiki_name, effective_config, granularity=granularity
+            )
+            result["entity_extraction"] = entity_report.model_dump()
+        return result
+
     async def query(
         self,
         wiki_name: str,

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/tools.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/tools.py
@@ -6,6 +6,7 @@ a `StdioMCPServer` (core) and appear as first-class MCP tools at
 tool-selection time — equal standing with Grep/Read instead of competing
 via a Bash-invoked CLI.
 """
+import asyncio
 import hashlib
 from datetime import UTC, datetime
 from pathlib import Path
@@ -43,6 +44,20 @@ class WikiRememberInput(BaseModel):
 class WikiNoteInput(BaseModel):
     page_id: str = Field(..., description="Page to append note to")
     text: str = Field(..., description="Note text")
+
+
+class VaultIngestInput(BaseModel):
+    vault_path: str | None = Field(
+        default=None,
+        description=(
+            "Obsidian vault directory (absolute or project-relative). "
+            "Omit to use the project's configured/auto-detected vault."
+        ),
+    )
+    force: bool = Field(
+        default=False,
+        description="Re-ingest every note, ignoring staleness tracking.",
+    )
 
 
 class WikiStatusInput(BaseModel):
@@ -268,6 +283,117 @@ class WikiStatusTool(AbstractTool):
     async def _execute(self) -> ToolResult:
         stats = await self._store.stats()
         return ToolResult(result=stats)
+
+
+class VaultIngestTool(AbstractTool):
+    """(Re)build the wiki retrieval plane from an Obsidian vault."""
+
+    name = "vault_ingest"
+    description = (
+        "Ingest (or refresh) an Obsidian vault into the wiki knowledge "
+        "base: one page per note, wikilink/embed/tag edges, FTS-searchable "
+        "via wiki_query. Incremental — unchanged notes are skipped unless "
+        "force=true. No LLM calls."
+    )
+    args_schema = VaultIngestInput
+
+    def __init__(
+        self,
+        store: BaseWikiStore,
+        root: Path,
+        config: WikiProjectConfig,
+    ):
+        super().__init__(name=self.name, description=self.description)
+        self._store = store
+        self._root = root
+        self._config = config
+
+    async def _execute(
+        self,
+        vault_path: str | None = None,
+        force: bool = False,
+        **kwargs,
+    ) -> ToolResult:
+        # Lazy imports: cli pulls click + scanners; keep the MCP server's
+        # module import light and stdout-clean.
+        from parrot.knowledge.wiki.cli import (
+            _ingest_files,
+            _open_sources,
+            _prune_removed,
+        )
+        from parrot.knowledge.wiki.project import (
+            resolve_vault_dir,
+            wiki_write_lock,
+        )
+        from parrot.knowledge.wiki.vault_scan import scan_vault
+
+        vault = resolve_vault_dir(self._root, self._config, override=vault_path)
+        if vault is None:
+            return ToolResult(
+                success=False,
+                status="error",
+                result=None,
+                error=(
+                    "No Obsidian vault found: pass vault_path, set "
+                    "'vault_dir' in .parrot/wiki.json, or run inside a "
+                    "vault (.obsidian/ directory)."
+                ),
+            )
+
+        storage = self._config.storage_path(self._root)
+        with wiki_write_lock(storage) as acquired:
+            if not acquired:
+                return ToolResult(
+                    success=False,
+                    status="error",
+                    result=None,
+                    error=(
+                        "Another wiki writer (build/upsert) is in progress "
+                        "— retry once it finishes."
+                    ),
+                )
+            scan, stats = await asyncio.to_thread(
+                scan_vault,
+                vault,
+                self._config.body_max_chars,
+                self._config.max_file_kb * 1024,
+            )
+            sources = _open_sources(self._root, self._config, store=self._store)
+            counts = await _ingest_files(
+                self._store, sources, vault, scan, force=force
+            )
+            await self._store.upsert_pages(scan.dir_records)
+            await self._store.add_edges(scan.dir_edges)
+            removed = await _prune_removed(self._store, sources, vault, scan)
+            store_stats = await self._store.stats()
+
+        try:
+            WikiBookkeeper().log_operation(
+                storage,
+                "VAULT_INGEST",
+                f"vault: {vault}, notes: {stats.notes}, tags: {stats.tags}, "
+                f"ingested: {counts.get('written', 0)}, removed: {removed}, "
+                f"by: agent:mcp",
+            )
+        except OSError as exc:
+            self.logger.warning(
+                "Failed to log VAULT_INGEST to wiki audit trail: %s", exc
+            )
+
+        return ToolResult(result={
+            "vault": str(vault),
+            "notes": stats.notes,
+            "tags": stats.tags,
+            "wikilink_edges": stats.wikilink_edges,
+            "embed_edges": stats.embed_edges,
+            "unresolved_links": len(stats.unresolved_links),
+            "ingested": counts.get("written", 0),
+            "unchanged": counts.get("unchanged", 0),
+            "removed": removed,
+            "skipped": len(scan.skipped),
+            "pages_total": store_stats.get("pages", 0),
+            "edges_total": store_stats.get("edges", 0),
+        })
 
 
 def create_wiki_tools(

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/vault_scan.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/vault_scan.py
@@ -1,0 +1,230 @@
+"""Obsidian vault scanning for the wikitoolkit build pipeline (Phase E).
+
+Turns an Obsidian vault directory into a ready-to-use LLM Wiki knowledge
+base with **zero LLM calls and zero embeddings**: pages land in the
+existing SQLite retrieval plane (FTS5 keyword search), the hand-curated
+``[[wikilink]]`` graph lands in the ``edges`` table (backlinks come free
+from directional edge queries), and ``#tags`` become first-class tag
+pages.
+
+The scanner mirrors :mod:`parrot.knowledge.wiki.repo_scan`'s conventions
+exactly — same :class:`RepoScan` result shape, same ``file:<relpath>``
+concept ids, same ``contains`` directory pages — so the whole build
+pipeline (incremental staleness, pruning, OKF export, graph.html) works
+unchanged; ``wikitoolkit build`` auto-detects vaults and routes here.
+
+Edge relations produced (open-string ``rel`` column):
+
+* resolved ``[[wikilink]]`` → ``references``
+* resolved ``![[embed]]`` → ``embeds``
+* note → tag page → ``tagged``
+* folder containment → ``contains`` (via ``build_dir_pages``)
+
+Unresolved wikilinks are dropped from the edge list (same discipline as
+``build_import_edges``) but counted in the scan's ``skipped`` telemetry
+via the returned :class:`VaultScanStats`.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+
+from parrot.interfaces.obsidian.index import VaultIndex
+from parrot.interfaces.obsidian.models import ObsidianNote
+from parrot.interfaces.obsidian.parser import ObsidianNoteParser
+
+from .repo_scan import (
+    DEFAULT_BODY_MAX_CHARS,
+    DEFAULT_MAX_FILE_BYTES,
+    FileSlice,
+    RepoScan,
+    build_dir_pages,
+    file_concept_id,
+)
+from .store import WikiPageRecord, estimate_tokens
+
+logger = logging.getLogger(__name__)
+
+#: Directories never scanned inside a vault.
+VAULT_EXCLUDE_DIRS: frozenset[str] = frozenset(
+    {".obsidian", ".trash", ".git", ".hg", ".svn"}
+)
+
+
+def is_obsidian_vault(root: Path) -> bool:
+    """Whether a directory is an Obsidian vault (has an ``.obsidian/`` dir).
+
+    Args:
+        root: Directory to test.
+
+    Returns:
+        True when ``root/.obsidian`` exists as a directory.
+    """
+    return (Path(root) / ".obsidian").is_dir()
+
+
+def tag_concept_id(tag: str) -> str:
+    """Stable concept id for a tag page."""
+    return f"tag:{tag}"
+
+
+@dataclass
+class VaultScanStats:
+    """Vault-specific telemetry for the build summary line."""
+
+    notes: int = 0
+    tags: int = 0
+    wikilink_edges: int = 0
+    embed_edges: int = 0
+    unresolved_links: list[tuple[str, str]] = field(default_factory=list)
+
+
+def _note_summary(note: ObsidianNote) -> str:
+    """Summary for a note page: frontmatter summary > first body line."""
+    for key in ("summary", "description"):
+        value = note.frontmatter.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    for line in note.content.splitlines():
+        text = line.strip().lstrip("#").strip()
+        if text:
+            return text[:300]
+    return note.title
+
+
+def _note_body(note: ObsidianNote, body_max_chars: int) -> str:
+    """Page body: deterministic header block + the note's markdown.
+
+    Tags and aliases are rendered into the header so FTS5 finds notes by
+    tag or alias without any schema change.
+    """
+    header: list[str] = [f"# {note.title}"]
+    if note.tags:
+        header.append(f"Tags: {' '.join(sorted(f'#{t}' for t in note.tags))}")
+    if note.aliases:
+        header.append(f"Aliases: {', '.join(note.aliases)}")
+    body = "\n".join(header) + "\n\n" + note.content
+    return body[:body_max_chars]
+
+
+def scan_vault(
+    root: Path,
+    body_max_chars: int = DEFAULT_BODY_MAX_CHARS,
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
+) -> tuple[RepoScan, VaultScanStats]:
+    """Scan an Obsidian vault into wiki page records and edges.
+
+    Args:
+        root: Vault root directory.
+        body_max_chars: Cap on stored page body length.
+        max_file_bytes: Skip notes larger than this.
+
+    Returns:
+        ``(scan, stats)`` — a :class:`RepoScan` shaped exactly like
+        ``scan_repository``'s result (so the build pipeline consumes it
+        unchanged) plus vault-specific :class:`VaultScanStats`.
+    """
+    root = Path(root).resolve()
+    parser = ObsidianNoteParser()
+    scan = RepoScan(root=root)
+    stats = VaultScanStats()
+    notes: list[ObsidianNote] = []
+
+    for path in sorted(root.rglob("*.md")):
+        rel = path.relative_to(root).as_posix()
+        parts = PurePosixPath(rel).parts
+        if any(part in VAULT_EXCLUDE_DIRS for part in parts):
+            continue
+        try:
+            if path.stat().st_size > max_file_bytes:
+                scan.skipped.append(rel)
+                continue
+            raw = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            logger.warning("Skipping %s: %s", rel, exc)
+            scan.skipped.append(rel)
+            continue
+        notes.append(parser.parse(raw, rel))
+
+    index = VaultIndex.build(notes)
+
+    # --- Note pages -----------------------------------------------------
+    for note in notes:
+        rel = note.path.as_posix()
+        body = _note_body(note, body_max_chars)
+        record = WikiPageRecord(
+            concept_id=file_concept_id(rel),
+            title=note.title,
+            category="document",
+            summary=_note_summary(note),
+            body=body,
+            token_count=estimate_tokens(body),
+        )
+        scan.files.append(FileSlice(rel_path=rel, record=record))
+        stats.notes += 1
+
+    # --- Wikilink / embed edges ----------------------------------------
+    seen_edges: set[tuple[str, str, str]] = set()
+    for note in notes:
+        rel = note.path.as_posix()
+        norm = rel[:-3] if rel.lower().endswith(".md") else rel
+        source_cid = file_concept_id(rel)
+        for link in note.links:
+            resolved = index.resolve(link.target, from_path=norm)
+            if resolved is None:
+                stats.unresolved_links.append((rel, link.target))
+                continue
+            target_cid = file_concept_id(f"{resolved}.md")
+            relation = "embeds" if link.is_embed else "references"
+            edge = (source_cid, target_cid, relation)
+            if edge not in seen_edges and source_cid != target_cid:
+                seen_edges.add(edge)
+                scan.import_edges.append(edge)
+                if link.is_embed:
+                    stats.embed_edges += 1
+                else:
+                    stats.wikilink_edges += 1
+
+    # --- Directory pages (same convention as repo scans) ----------------
+    scan.dir_records, scan.dir_edges = build_dir_pages(scan.files)
+
+    # --- Tag pages + tagged edges ---------------------------------------
+    for tag, count in index.tags().items():
+        note_paths = index.notes_by_tag(tag)
+        lines = [f"- [file:{p}.md]" for p in note_paths]
+        body = (
+            f"# Tag #{tag}\n\n{count} tagged note(s):\n\n" + "\n".join(lines)
+        )
+        scan.dir_records.append(
+            WikiPageRecord(
+                concept_id=tag_concept_id(tag),
+                title=f"#{tag}",
+                category="tag",
+                summary=f"Obsidian tag #{tag} ({count} notes)",
+                body=body,
+                token_count=estimate_tokens(body),
+            )
+        )
+        for note_path in note_paths:
+            scan.dir_edges.append(
+                (file_concept_id(f"{note_path}.md"), tag_concept_id(tag), "tagged")
+            )
+        stats.tags += 1
+
+    logger.info(
+        "Scanned vault %s: %d notes, %d tags, %d wikilink edges, "
+        "%d embed edges, %d unresolved links, %d skipped",
+        root, stats.notes, stats.tags, stats.wikilink_edges,
+        stats.embed_edges, len(stats.unresolved_links), len(scan.skipped),
+    )
+    return scan, stats
+
+
+__all__ = [
+    "VAULT_EXCLUDE_DIRS",
+    "VaultScanStats",
+    "is_obsidian_vault",
+    "scan_vault",
+    "tag_concept_id",
+]

--- a/packages/ai-parrot/src/parrot/loaders/obsidian/__init__.py
+++ b/packages/ai-parrot/src/parrot/loaders/obsidian/__init__.py
@@ -1,0 +1,39 @@
+"""Obsidian vault ingestion into PageIndex / GraphIndex (FEAT-392).
+
+The parsing core (models, parser, discovery/VaultIndex) lives in the
+shared interface package ``parrot.interfaces.obsidian`` — re-exported
+here so the FEAT-392 import surface keeps working:
+
+    from parrot.loaders.obsidian import ObsidianVaultLoader, ObsidianNote
+"""
+from parrot.interfaces.obsidian import (
+    ExtractionGranularity,
+    ObsidianCanvas,
+    ObsidianCanvasCard,
+    ObsidianLink,
+    ObsidianNote,
+    ObsidianNoteParser,
+    VaultIndex,
+    VaultIngestConfig,
+    VaultIngestReport,
+    parse_canvas,
+)
+
+from .graph_bridge import ObsidianGraphBridge
+from .loader import ObsidianLoader, ObsidianVaultLoader
+
+__all__ = (
+    "ExtractionGranularity",
+    "ObsidianCanvas",
+    "ObsidianCanvasCard",
+    "ObsidianGraphBridge",
+    "ObsidianLink",
+    "ObsidianLoader",
+    "ObsidianNote",
+    "ObsidianNoteParser",
+    "ObsidianVaultLoader",
+    "VaultIndex",
+    "VaultIngestConfig",
+    "VaultIngestReport",
+    "parse_canvas",
+)

--- a/packages/ai-parrot/src/parrot/loaders/obsidian/graph_bridge.py
+++ b/packages/ai-parrot/src/parrot/loaders/obsidian/graph_bridge.py
@@ -1,0 +1,232 @@
+"""ObsidianGraphBridge — vault link graph → GraphIndex nodes/edges.
+
+FEAT-392 Module 5. Pure transformation: takes parsed notes/canvases plus
+the shared :class:`VaultIndex` (so link resolution is identical to the
+toolkit and the wiki scanner) and emits ``UniversalNode``/``UniversalEdge``
+lists ready for GraphIndex import.
+
+Mapping (spec §5 — existing enum members only, Obsidian semantics carried
+in ``domain_tags``):
+
+* note → ``NodeKind.DOCUMENT``
+* ``[[wikilink]]`` → ``EdgeKind.REFERENCES``
+* ``![[embed]]`` → ``EdgeKind.REFERENCES`` + ``domain_tags={"embed": true}``
+* ``#tag`` → ``NodeKind.CONCEPT`` + ``domain_tags={"obsidian_type": "tag"}``
+* folder → ``NodeKind.DOCUMENT`` + ``{"obsidian_type": "folder"}`` and
+  ``EdgeKind.CONTAINS`` edges for the hierarchy
+* canvas → ``NodeKind.DOCUMENT`` + ``{"obsidian_type": "canvas"}``
+* broken wikilink → placeholder node ``{"status": "unresolved"}``
+"""
+import logging
+from pathlib import PurePosixPath
+
+from parrot.interfaces.obsidian import (
+    ObsidianCanvas,
+    ObsidianNote,
+    VaultIndex,
+)
+from parrot.knowledge.graphindex.schema import (
+    EdgeKind,
+    NodeKind,
+    UniversalEdge,
+    UniversalNode,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ObsidianGraphBridge:
+    """Convert an Obsidian vault's structure into GraphIndex form."""
+
+    def __init__(
+        self,
+        notes: list[ObsidianNote],
+        canvases: list[ObsidianCanvas],
+        index: VaultIndex,
+        vault_name: str = "vault",
+    ) -> None:
+        """Initialize the bridge.
+
+        Args:
+            notes: All parsed markdown notes.
+            canvases: All parsed ``.canvas`` files.
+            index: Shared vault index (single source of link resolution).
+            vault_name: Vault name used in the deterministic node IDs.
+        """
+        self.notes = notes
+        self.canvases = canvases
+        self.index = index
+        self.vault_name = vault_name
+        self.logger = logger
+
+    # ------------------------------------------------------------------ #
+    # Node-ID convention (spec §7)
+    # ------------------------------------------------------------------ #
+    def note_id(self, path: str) -> str:
+        """``obsidian::<vault>::<path-without-.md>``."""
+        return f"obsidian::{self.vault_name}::{path}"
+
+    def tag_id(self, tag: str) -> str:
+        return f"obsidian::{self.vault_name}::tag::{tag}"
+
+    def folder_id(self, folder: str) -> str:
+        return f"obsidian::{self.vault_name}::folder::{folder}"
+
+    def canvas_id(self, path: str) -> str:
+        stem = path[:-len(".canvas")] if path.endswith(".canvas") else path
+        return f"obsidian::{self.vault_name}::canvas::{stem}"
+
+    def _uri(self, rel_path: str) -> str:
+        return f"obsidian://{self.vault_name}/{rel_path}"
+
+    # ------------------------------------------------------------------ #
+    # Build
+    # ------------------------------------------------------------------ #
+    def build_graph(self) -> tuple[list[UniversalNode], list[UniversalEdge]]:
+        """Convert vault structure into GraphIndex-compatible nodes/edges.
+
+        Returns:
+            ``(nodes, edges)`` — deduplicated, deterministic IDs, ready
+            for GraphIndex import.
+        """
+        nodes: dict[str, UniversalNode] = {}
+        edges: dict[tuple[str, str, str], UniversalEdge] = {}
+
+        def add_node(node: UniversalNode) -> None:
+            nodes.setdefault(node.node_id, node)
+
+        def add_edge(
+            source_id: str,
+            target_id: str,
+            kind: EdgeKind,
+            domain_note: dict | None = None,
+        ) -> None:
+            key = (source_id, target_id, kind.value)
+            if key not in edges:
+                edges[key] = UniversalEdge(
+                    source_id=source_id,
+                    target_id=target_id,
+                    kind=kind,
+                    domain_tags=domain_note or {},
+                )
+
+        # --- Notes -----------------------------------------------------
+        for note in self.notes:
+            rel = note.path.as_posix()
+            norm = rel[:-3] if rel.lower().endswith(".md") else rel
+            domain_tags: dict = {"obsidian_type": "note"}
+            if note.aliases:
+                domain_tags["aliases"] = list(note.aliases)
+            add_node(
+                UniversalNode(
+                    node_id=self.note_id(norm),
+                    kind=NodeKind.DOCUMENT,
+                    title=note.title,
+                    source_uri=self._uri(rel),
+                    summary=None,
+                    domain_tags=domain_tags,
+                )
+            )
+
+        # --- Folder hierarchy → CONTAINS -------------------------------
+        for note in self.notes:
+            norm = note.path.as_posix()
+            norm = norm[:-3] if norm.lower().endswith(".md") else norm
+            parts = PurePosixPath(norm).parts
+            parent_id: str | None = None
+            prefix = ""
+            for folder in parts[:-1]:
+                prefix = f"{prefix}/{folder}" if prefix else folder
+                fid = self.folder_id(prefix)
+                add_node(
+                    UniversalNode(
+                        node_id=fid,
+                        kind=NodeKind.DOCUMENT,
+                        title=folder,
+                        source_uri=self._uri(prefix),
+                        domain_tags={"obsidian_type": "folder"},
+                    )
+                )
+                if parent_id:
+                    add_edge(parent_id, fid, EdgeKind.CONTAINS)
+                parent_id = fid
+            if parent_id:
+                add_edge(parent_id, self.note_id(norm), EdgeKind.CONTAINS)
+
+        # --- Wikilinks and embeds → REFERENCES --------------------------
+        for note in self.notes:
+            norm = note.path.as_posix()
+            norm = norm[:-3] if norm.lower().endswith(".md") else norm
+            source_id = self.note_id(norm)
+            for link in note.links:
+                resolved = self.index.resolve(link.target, from_path=norm)
+                if resolved is None:
+                    # Placeholder node for a broken link (spec §5).
+                    target_id = self.note_id(link.target)
+                    add_node(
+                        UniversalNode(
+                            node_id=target_id,
+                            kind=NodeKind.DOCUMENT,
+                            title=link.target,
+                            source_uri=self._uri(link.target),
+                            domain_tags={
+                                "obsidian_type": "note",
+                                "status": "unresolved",
+                            },
+                        )
+                    )
+                else:
+                    target_id = self.note_id(resolved)
+                add_edge(
+                    source_id,
+                    target_id,
+                    EdgeKind.REFERENCES,
+                    domain_note={"embed": True} if link.is_embed else None,
+                )
+
+        # --- Tags → CONCEPT + REFERENCES --------------------------------
+        for note in self.notes:
+            norm = note.path.as_posix()
+            norm = norm[:-3] if norm.lower().endswith(".md") else norm
+            for tag in sorted(note.tags):
+                tid = self.tag_id(tag)
+                add_node(
+                    UniversalNode(
+                        node_id=tid,
+                        kind=NodeKind.CONCEPT,
+                        title=f"#{tag}",
+                        source_uri=self._uri(f"tag/{tag}"),
+                        domain_tags={"obsidian_type": "tag"},
+                    )
+                )
+                add_edge(
+                    self.note_id(norm),
+                    tid,
+                    EdgeKind.REFERENCES,
+                    domain_note={"obsidian_type": "tag_link"},
+                )
+
+        # --- Canvas files ------------------------------------------------
+        for canvas in self.canvases:
+            rel = canvas.path.as_posix()
+            cid = self.canvas_id(rel)
+            add_node(
+                UniversalNode(
+                    node_id=cid,
+                    kind=NodeKind.DOCUMENT,
+                    title=canvas.title,
+                    source_uri=self._uri(rel),
+                    domain_tags={"obsidian_type": "canvas"},
+                )
+            )
+            for card in canvas.cards:
+                if card.card_type == "file" and card.file_path:
+                    resolved = self.index.resolve(card.file_path)
+                    if resolved is not None:
+                        add_edge(cid, self.note_id(resolved), EdgeKind.REFERENCES)
+
+        self.logger.debug(
+            "ObsidianGraphBridge: %d nodes, %d edges from %d notes / %d canvases",
+            len(nodes), len(edges), len(self.notes), len(self.canvases),
+        )
+        return list(nodes.values()), list(edges.values())

--- a/packages/ai-parrot/src/parrot/loaders/obsidian/graph_bridge.py
+++ b/packages/ai-parrot/src/parrot/loaders/obsidian/graph_bridge.py
@@ -35,6 +35,32 @@ from parrot.knowledge.graphindex.schema import (
 logger = logging.getLogger(__name__)
 
 
+def _okf_mappings() -> tuple[dict, dict]:
+    """Lazy OKF ontology → graph enum mappings (import kept local)."""
+    from parrot.knowledge.okf.ontology import ConceptType
+
+    type_map = {
+        ConceptType.CONCEPT_NODE: NodeKind.CONCEPT,
+        ConceptType.SYMBOL: NodeKind.SYMBOL,
+        ConceptType.RATIONALE: NodeKind.RATIONALE,
+        ConceptType.SKILL: NodeKind.SKILL,
+        ConceptType.DOCUMENT_NODE: NodeKind.DOCUMENT,
+        ConceptType.SECTION: NodeKind.SECTION,
+    }
+    rel_map = {
+        "references": EdgeKind.REFERENCES,
+        "defines": EdgeKind.DEFINES,
+        "mentions": EdgeKind.MENTIONS,
+        "explains": EdgeKind.EXPLAINS,
+        "contains": EdgeKind.CONTAINS,
+        "extends": EdgeKind.EXTENDS,
+    }
+    return type_map, rel_map
+
+
+_OKF_TYPE_TO_NODEKIND, _OKF_REL_TO_EDGEKIND = _okf_mappings()
+
+
 class ObsidianGraphBridge:
     """Convert an Obsidian vault's structure into GraphIndex form."""
 
@@ -79,6 +105,16 @@ class ObsidianGraphBridge:
     def _uri(self, rel_path: str) -> str:
         return f"obsidian://{self.vault_name}/{rel_path}"
 
+    def _read_okf(self, note: ObsidianNote):
+        """Read the note's OKF block, tolerating malformed blocks."""
+        from parrot.interfaces.obsidian.okf import read_okf
+
+        try:
+            return read_okf(note)
+        except ValueError as exc:
+            self.logger.warning("%s", exc)
+            return None
+
     # ------------------------------------------------------------------ #
     # Build
     # ------------------------------------------------------------------ #
@@ -111,19 +147,29 @@ class ObsidianGraphBridge:
                 )
 
         # --- Notes -----------------------------------------------------
+        okf_edges: list[tuple[str, str, str]] = []  # (source, target, rel)
         for note in self.notes:
             rel = note.path.as_posix()
             norm = rel[:-3] if rel.lower().endswith(".md") else rel
             domain_tags: dict = {"obsidian_type": "note"}
             if note.aliases:
                 domain_tags["aliases"] = list(note.aliases)
+            kind = NodeKind.DOCUMENT
+            summary = None
+            okf = self._read_okf(note)
+            if okf is not None:
+                kind = _OKF_TYPE_TO_NODEKIND.get(okf.type, NodeKind.DOCUMENT)
+                summary = okf.summary or None
+                domain_tags["okf_type"] = okf.type.value
+                for relates in okf.relates_to:
+                    okf_edges.append((norm, relates.concept, relates.rel.value))
             add_node(
                 UniversalNode(
                     node_id=self.note_id(norm),
-                    kind=NodeKind.DOCUMENT,
+                    kind=kind,
                     title=note.title,
                     source_uri=self._uri(rel),
-                    summary=None,
+                    summary=summary,
                     domain_tags=domain_tags,
                 )
             )
@@ -204,6 +250,27 @@ class ObsidianGraphBridge:
                     tid,
                     EdgeKind.REFERENCES,
                     domain_note={"obsidian_type": "tag_link"},
+                )
+
+        # --- OKF relates_to → typed edges (Phase D) ----------------------
+        for source_norm, target, rel in okf_edges:
+            resolved = self.index.resolve(target, from_path=source_norm)
+            if resolved is None:
+                self.logger.warning(
+                    "OKF relates_to target %r in %s does not resolve — skipped",
+                    target, source_norm,
+                )
+                continue
+            kind = _OKF_REL_TO_EDGEKIND.get(rel)
+            if kind is not None:
+                add_edge(self.note_id(source_norm), self.note_id(resolved), kind)
+            else:
+                # No matching EdgeKind — carry the OKF relation in tags.
+                add_edge(
+                    self.note_id(source_norm),
+                    self.note_id(resolved),
+                    EdgeKind.REFERENCES,
+                    domain_note={"okf_rel": rel},
                 )
 
         # --- Canvas files ------------------------------------------------

--- a/packages/ai-parrot/src/parrot/loaders/obsidian/loader.py
+++ b/packages/ai-parrot/src/parrot/loaders/obsidian/loader.py
@@ -1,0 +1,463 @@
+"""ObsidianVaultLoader — Phase-1 raw vault ingest into PageIndex (FEAT-392).
+
+Two entry points:
+
+* :class:`ObsidianVaultLoader` — the FEAT-392 orchestration class:
+  ``discover()`` parses the vault through the shared interface,
+  ``ingest()`` stores one PageIndex node per note (no LLM required) and
+  registers every file in :class:`SourceCollectionManager`;
+  ``incremental_update()`` re-ingests only changed files and prunes
+  deleted ones (local backend only — staleness is hash+mtime based).
+* :class:`ObsidianLoader` — a thin :class:`AbstractLoader` adapter that
+  yields one :class:`Document` per note with canonical metadata, so a
+  vault can also feed the generic RAG loader pipeline.
+"""
+import asyncio
+import logging
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from parrot.interfaces.obsidian import (
+    CANVAS_SUFFIX,
+    NOTE_SUFFIX,
+    LocalVaultBackend,
+    ObsidianCanvas,
+    ObsidianNote,
+    ObsidianVaultInterface,
+    VaultIndex,
+    VaultIngestConfig,
+    VaultIngestReport,
+)
+from parrot.loaders.abstract import AbstractLoader
+from parrot.stores.models import Document
+
+logger = logging.getLogger(__name__)
+
+
+def _norm_path(rel: str) -> str:
+    return rel[: -len(NOTE_SUFFIX)] if rel.lower().endswith(NOTE_SUFFIX) else rel
+
+
+class ObsidianVaultLoader:
+    """Parse and ingest Obsidian vault directories into PageIndex."""
+
+    def __init__(self, vault: ObsidianVaultInterface | str | Path) -> None:
+        """Initialize the loader.
+
+        Args:
+            vault: A prebuilt vault backend, or a vault directory path
+                (auto-wrapped in :class:`LocalVaultBackend`).
+        """
+        if isinstance(vault, (str, Path)):
+            vault = LocalVaultBackend(vault)
+        self.vault = vault
+        self.logger = logger
+
+    # ------------------------------------------------------------------ #
+    # Discovery
+    # ------------------------------------------------------------------ #
+    async def discover(
+        self,
+    ) -> tuple[list[ObsidianNote], list[ObsidianCanvas]]:
+        """Scan the vault and parse all notes and canvas files.
+
+        Returns:
+            ``(notes, canvases)`` — unreadable files are skipped with a
+            logged warning (never raises for individual files).
+        """
+        notes = await self.vault.load_notes()
+        canvases: list[ObsidianCanvas] = []
+        for info in await self.vault.list_files(
+            suffixes=frozenset({CANVAS_SUFFIX})
+        ):
+            try:
+                canvases.append(await self.vault.get_canvas(info.path))
+            except (ValueError, FileNotFoundError, UnicodeDecodeError) as exc:
+                self.logger.warning("Skipping canvas %s: %s", info.path, exc)
+        return notes, canvases
+
+    # ------------------------------------------------------------------ #
+    # Embed-cycle detection (spec §7 gotcha)
+    # ------------------------------------------------------------------ #
+    def _detect_embed_cycles(
+        self, notes: list[ObsidianNote], index: VaultIndex, depth_limit: int
+    ) -> list[str]:
+        """Detect circular ``![[embeds]]`` beyond the depth limit.
+
+        Returns:
+            Warning strings (also logged) — ingestion is never aborted.
+        """
+        embed_graph: dict[str, list[str]] = {}
+        for note in notes:
+            norm = _norm_path(note.path.as_posix())
+            targets = []
+            for link in note.links:
+                if link.is_embed:
+                    resolved = index.resolve(link.target, from_path=norm)
+                    if resolved is not None:
+                        targets.append(resolved)
+            if targets:
+                embed_graph[norm] = targets
+
+        warnings: list[str] = []
+
+        def _walk(start: str, node: str, depth: int, seen: set[str]) -> None:
+            if depth > depth_limit:
+                message = (
+                    f"Embed depth limit ({depth_limit}) exceeded from "
+                    f"'{start}' — stopping recursion"
+                )
+                if message not in warnings:
+                    warnings.append(message)
+                return
+            for target in embed_graph.get(node, []):
+                if target in seen:
+                    message = (
+                        f"Circular embed detected: '{target}' re-embedded "
+                        f"along the chain starting at '{start}'"
+                    )
+                    if message not in warnings:
+                        warnings.append(message)
+                    continue
+                _walk(start, target, depth + 1, seen | {target})
+
+        for start in embed_graph:
+            _walk(start, start, 1, {start})
+        for message in warnings:
+            self.logger.warning("%s", message)
+        return warnings
+
+    # ------------------------------------------------------------------ #
+    # Phase 1: full ingest
+    # ------------------------------------------------------------------ #
+    async def ingest(
+        self,
+        pageindex_toolkit: Any,
+        tree_name: str,
+        source_manager: Any,
+        config: Optional[VaultIngestConfig] = None,
+    ) -> VaultIngestReport:
+        """Full vault ingest into PageIndex (no LLM).
+
+        One PageIndex node per note (aliases/tags/dataview queries in the
+        node metadata); every source file registered with the
+        :class:`SourceCollectionManager` for staleness tracking.
+
+        Args:
+            pageindex_toolkit: ``PageIndexToolkit`` storage target.
+            tree_name: PageIndex tree to ingest into (created if missing).
+            source_manager: ``SourceCollectionManager`` for the wiki.
+            config: Optional ingest configuration (concurrency, skip
+                patterns, embed depth limit).
+
+        Returns:
+            A :class:`VaultIngestReport` for phase ``"raw_ingest"``.
+        """
+        started = time.monotonic()
+        config = config or VaultIngestConfig(
+            vault_path=getattr(self.vault, "vault_path", Path(".")),
+            tree_name=tree_name,
+        )
+        report = VaultIngestReport(
+            vault_path=str(config.vault_path),
+            tree_name=tree_name,
+            phase="raw_ingest",
+        )
+
+        notes, canvases = await self.discover()
+        index = await self.vault.build_index()
+        report.errors.extend(
+            self._detect_embed_cycles(notes, index, config.embed_depth_limit)
+        )
+
+        try:
+            await pageindex_toolkit.get_tree(tree_name)
+        except (KeyError, FileNotFoundError, ValueError):
+            await pageindex_toolkit.create_tree(
+                tree_name, doc_name=self.vault.vault_name
+            )
+
+        semaphore = asyncio.Semaphore(config.concurrency)
+
+        async def _ingest_note(note: ObsidianNote) -> None:
+            async with semaphore:
+                rel = note.path.as_posix()
+                try:
+                    result = await pageindex_toolkit.add_node(
+                        tree_name,
+                        title=note.title,
+                        body=note.content,
+                        summary=None,
+                        categories=sorted(note.tags) or None,
+                        metadata=self._node_metadata(note),
+                    )
+                    node_id = result.get("node_id")
+                    self._register_source(
+                        source_manager, rel, [node_id] if node_id else []
+                    )
+                    report.notes_processed += 1
+                    report.nodes_created += 1
+                    report.files_added += 1
+                except Exception as exc:  # noqa: BLE001 — collect, don't abort
+                    self.logger.error("Failed to ingest %s: %s", rel, exc)
+                    report.errors.append(f"{rel}: {exc}")
+                    report.files_skipped += 1
+
+        await asyncio.gather(*(_ingest_note(note) for note in notes))
+
+        for canvas in canvases:
+            rel = canvas.path.as_posix()
+            try:
+                card_titles = [
+                    card.text or card.file_path or card.url or card.card_id
+                    for card in canvas.cards
+                ]
+                result = await pageindex_toolkit.add_node(
+                    tree_name,
+                    title=canvas.title,
+                    body="\n".join(f"- {title}" for title in card_titles),
+                    metadata={"obsidian_type": "canvas", "obsidian_path": rel},
+                )
+                node_id = result.get("node_id")
+                self._register_source(
+                    source_manager, rel, [node_id] if node_id else []
+                )
+                report.canvas_processed += 1
+                report.nodes_created += 1
+                report.files_added += 1
+            except Exception as exc:  # noqa: BLE001
+                self.logger.error("Failed to ingest canvas %s: %s", rel, exc)
+                report.errors.append(f"{rel}: {exc}")
+                report.files_skipped += 1
+
+        report.duration_ms = (time.monotonic() - started) * 1000.0
+        return report
+
+    # ------------------------------------------------------------------ #
+    # Incremental update
+    # ------------------------------------------------------------------ #
+    async def incremental_update(
+        self,
+        pageindex_toolkit: Any,
+        tree_name: str,
+        source_manager: Any,
+        config: Optional[VaultIngestConfig] = None,
+    ) -> VaultIngestReport:
+        """Detect changed/new/deleted files and update PageIndex.
+
+        Local backend only: staleness detection needs real filesystem
+        paths (SHA-1 + mtime via ``SourceCollectionManager``).
+
+        Args:
+            pageindex_toolkit: ``PageIndexToolkit`` storage target.
+            tree_name: PageIndex tree to update.
+            source_manager: ``SourceCollectionManager`` with the previous
+                ingest's manifest.
+            config: Optional ingest configuration.
+
+        Returns:
+            A :class:`VaultIngestReport` with added/updated/deleted counts.
+
+        Raises:
+            NotImplementedError: For non-filesystem backends (REST).
+        """
+        if not isinstance(self.vault, LocalVaultBackend):
+            raise NotImplementedError(
+                "incremental_update requires the local filesystem backend — "
+                "SourceCollectionManager staleness tracking is path-based"
+            )
+        started = time.monotonic()
+        vault_root: Path = self.vault.vault_path
+        config = config or VaultIngestConfig(
+            vault_path=vault_root, tree_name=tree_name
+        )
+        report = VaultIngestReport(
+            vault_path=str(vault_root),
+            tree_name=tree_name,
+            phase="raw_ingest",
+        )
+
+        infos = await self.vault.list_files()
+        current = {info.path for info in infos}
+
+        # --- Deletions: manifest entries whose file vanished ------------
+        for entry in list(source_manager.list_sources()):
+            uri = getattr(entry, "source_uri", "") or ""
+            try:
+                rel = Path(uri).resolve().relative_to(vault_root).as_posix()
+            except ValueError:
+                continue  # not under this vault
+            if rel in current:
+                continue
+            for node_id in getattr(entry, "pages_generated", None) or []:
+                try:
+                    await pageindex_toolkit.delete_node(tree_name, node_id)
+                except Exception as exc:  # noqa: BLE001
+                    report.errors.append(f"delete {node_id}: {exc}")
+            source_manager.remove_source(entry.source_id)
+            report.files_deleted += 1
+
+        # --- Additions / modifications ----------------------------------
+        semaphore = asyncio.Semaphore(config.concurrency)
+
+        async def _sync_file(rel: str) -> None:
+            async with semaphore:
+                full = vault_root / rel
+                source_id = source_manager.find_by_uri(str(full))
+                is_new = source_id is None
+                if not is_new and not source_manager.is_stale(source_id):
+                    return
+                # Stale: drop the previous nodes, then re-ingest.
+                if not is_new:
+                    entry = source_manager.get_source(source_id)
+                    for node_id in getattr(entry, "pages_generated", None) or []:
+                        try:
+                            await pageindex_toolkit.delete_node(
+                                tree_name, node_id
+                            )
+                        except Exception as exc:  # noqa: BLE001
+                            report.errors.append(f"delete {node_id}: {exc}")
+                try:
+                    if rel.lower().endswith(NOTE_SUFFIX):
+                        note = await self.vault.get_note(rel)
+                        result = await pageindex_toolkit.add_node(
+                            tree_name,
+                            title=note.title,
+                            body=note.content,
+                            categories=sorted(note.tags) or None,
+                            metadata=self._node_metadata(note),
+                        )
+                        report.notes_processed += 1
+                    else:
+                        canvas = await self.vault.get_canvas(rel)
+                        result = await pageindex_toolkit.add_node(
+                            tree_name,
+                            title=canvas.title,
+                            body="",
+                            metadata={
+                                "obsidian_type": "canvas",
+                                "obsidian_path": rel,
+                            },
+                        )
+                        report.canvas_processed += 1
+                    node_id = result.get("node_id")
+                    self._register_source(
+                        source_manager, rel, [node_id] if node_id else []
+                    )
+                    report.nodes_created += 1
+                    if is_new:
+                        report.files_added += 1
+                    else:
+                        report.files_updated += 1
+                except (UnicodeDecodeError, ValueError) as exc:
+                    self.logger.warning("Skipping %s: %s", rel, exc)
+                    report.files_skipped += 1
+                except Exception as exc:  # noqa: BLE001
+                    self.logger.error("Failed to sync %s: %s", rel, exc)
+                    report.errors.append(f"{rel}: {exc}")
+                    report.files_skipped += 1
+
+        await asyncio.gather(*(_sync_file(info.path) for info in infos))
+        report.duration_ms = (time.monotonic() - started) * 1000.0
+        return report
+
+    # ------------------------------------------------------------------ #
+    # Helpers
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _node_metadata(note: ObsidianNote) -> dict[str, Any]:
+        """PageIndex node metadata for a note (spec §5 conventions)."""
+        metadata: dict[str, Any] = {
+            "obsidian_type": "note",
+            "obsidian_path": note.path.as_posix(),
+        }
+        if note.aliases:
+            metadata["aliases"] = list(note.aliases)
+        if note.dataview_queries:
+            metadata["dataview_queries"] = list(note.dataview_queries)
+        if note.frontmatter:
+            # Keep only JSON-safe scalars to avoid store surprises.
+            metadata["frontmatter_keys"] = sorted(
+                str(key) for key in note.frontmatter
+            )
+        return metadata
+
+    def _register_source(
+        self, source_manager: Any, rel: str, node_ids: list[str]
+    ) -> None:
+        """Register a vault file in the source manifest (best-effort)."""
+        vault_root = getattr(self.vault, "vault_path", None)
+        if source_manager is None or vault_root is None:
+            return
+        try:
+            entry = source_manager.add_source(Path(vault_root) / rel)
+            source_manager.mark_ingested(entry.source_id, node_ids)
+        except Exception as exc:  # noqa: BLE001 — manifest is advisory
+            self.logger.warning("Source registration failed for %s: %s", rel, exc)
+
+
+class ObsidianLoader(AbstractLoader):
+    """AbstractLoader adapter: one :class:`Document` per Obsidian note.
+
+    Enables the generic loader pipeline (chunking, vector stores) over a
+    vault. Obsidian-specific extras (tags, aliases, links, dataview
+    queries) go top-level in the metadata — the canonical
+    ``document_meta`` sub-dict stays closed per the metadata contract.
+    """
+
+    extensions: list[str] = [".md"]
+
+    def __init__(self, source: Any = None, **kwargs: Any) -> None:
+        kwargs.setdefault("doctype", "markdown")
+        kwargs.setdefault("category", "obsidian-note")
+        super().__init__(source, **kwargs)
+        self._vault_cache: dict[Path, LocalVaultBackend] = {}
+
+    def _vault_for(self, path: Path) -> LocalVaultBackend:
+        """Find (or wrap) the vault containing ``path``."""
+        candidate = path if path.is_dir() else path.parent
+        for parent in [candidate, *candidate.parents]:
+            if (parent / ".obsidian").is_dir():
+                candidate = parent
+                break
+        vault = self._vault_cache.get(candidate)
+        if vault is None:
+            vault = LocalVaultBackend(candidate)
+            self._vault_cache[candidate] = vault
+        return vault
+
+    async def _load(self, source: Any, **kwargs: Any) -> list[Document]:
+        """Load one note file (or every note of a vault directory).
+
+        Args:
+            source: Path to a ``.md`` note or a vault directory.
+
+        Returns:
+            One :class:`Document` per note.
+        """
+        path = Path(source).expanduser().resolve()
+        vault = self._vault_for(path)
+        if path.is_dir():
+            notes = await vault.load_notes()
+        else:
+            rel = path.relative_to(vault.vault_path).as_posix()
+            notes = [await vault.get_note(rel)]
+        documents: list[Document] = []
+        for note in notes:
+            metadata = self.create_metadata(
+                path=vault.vault_path / note.path,
+                doctype="markdown",
+                source_type="obsidian",
+                title=note.title,
+                obsidian_vault=vault.vault_name,
+                obsidian_path=note.path.as_posix(),
+                tags=sorted(note.tags),
+                aliases=list(note.aliases),
+                links=[link.target for link in note.links],
+                dataview_queries=list(note.dataview_queries),
+            )
+            documents.append(
+                self.create_document(content=note.content, path=path, metadata=metadata)
+            )
+        return documents

--- a/packages/ai-parrot/src/parrot/mcp/adapter.py
+++ b/packages/ai-parrot/src/parrot/mcp/adapter.py
@@ -6,11 +6,23 @@ from parrot.tools.abstract import AbstractTool, ToolResult
 
 
 class MCPToolAdapter:
-    """Adapts AI-Parrot AbstractTool to MCP tool format."""
+    """Adapts AI-Parrot AbstractTool to MCP tool format.
+
+    Tools marked ``routing_meta["requires_confirmation"]`` (e.g. the
+    destructive members of a toolkit's ``confirming_tools``) get an MCP-side
+    guard: a required ``confirm`` boolean is injected into their input
+    schema and the call is rejected unless ``confirm=true`` is passed —
+    the stdio transport has no interactive HITL channel, so the explicit
+    argument is the confirmation record.
+    """
 
     def __init__(self, tool: AbstractTool):
         self.tool = tool
         self.logger = logging.getLogger(f"MCPToolAdapter.{tool.name}")
+
+    def _requires_confirmation(self) -> bool:
+        meta = getattr(self.tool, "routing_meta", None) or {}
+        return bool(meta.get("requires_confirmation"))
 
     def to_mcp_tool_definition(self) -> dict[str, Any]:
         """Convert AbstractTool to MCP tool definition."""
@@ -24,6 +36,20 @@ class MCPToolAdapter:
                 self.logger.warning("Could not extract schema for %s: %s", self.tool.name, e)
                 input_schema = {"type": "object", "properties": {}}
 
+        if self._requires_confirmation():
+            input_schema.setdefault("type", "object")
+            input_schema.setdefault("properties", {})["confirm"] = {
+                "type": "boolean",
+                "description": (
+                    "This operation is destructive. Set true ONLY after the "
+                    "user has explicitly approved it; the call is rejected "
+                    "otherwise."
+                ),
+            }
+            required = input_schema.setdefault("required", [])
+            if "confirm" not in required:
+                required.append("confirm")
+
         return {
             "name": self.tool.name or "unknown_tool",
             "description": self.tool.description or f"Tool: {self.tool.name}",
@@ -32,6 +58,22 @@ class MCPToolAdapter:
 
     async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
         """Execute the AI-Parrot tool and convert result to MCP format."""
+        # The guard argument never reaches the tool itself.
+        confirm = arguments.pop("confirm", None)
+        if self._requires_confirmation() and confirm is not True:
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": (
+                            f"Error: '{self.tool.name}' is a destructive "
+                            "operation and was not confirmed. Ask the user "
+                            "for approval, then re-invoke with confirm=true."
+                        ),
+                    }
+                ],
+                "isError": True,
+            }
         try:
             # Execute the tool
             result = await self.tool._execute(**arguments)

--- a/packages/ai-parrot/src/parrot/tools/__init__.py
+++ b/packages/ai-parrot/src/parrot/tools/__init__.py
@@ -234,6 +234,7 @@ __all__ = (
     "FileManagerTool",
     "FileManagerFactory",
     "FileManagerToolkit",
+    "ObsidianToolkit",
     "MCPToolManagerMixin",
     "ToJsonTool",
     "AgentTool",
@@ -261,6 +262,7 @@ _LAZY_CORE_TOOLS = {
     "FileManagerTool": ".filemanager",
     "FileManagerFactory": ".filemanager",
     "FileManagerToolkit": ".filemanager",
+    "ObsidianToolkit": ".obsidian",
     "DatasetManager": ".dataset_manager",
     "InteractiveToolkit": ".interactive_toolkit",
     # Infographic section descriptor contract (FEAT-326)

--- a/packages/ai-parrot/src/parrot/tools/obsidian.py
+++ b/packages/ai-parrot/src/parrot/tools/obsidian.py
@@ -1,0 +1,543 @@
+"""ObsidianToolkit — agent tools for managing an Obsidian vault.
+
+Built on the shared vault interface (``parrot.interfaces.obsidian``):
+the same parsing, wikilink-resolution and backlink engine used by the
+FEAT-392 vault loader and the wikitoolkit vault scanner. Supports both
+vault backends — direct filesystem (``backend="local"``) and the Obsidian
+Local REST API community plugin (``backend="rest"``).
+
+Follows the one-tool-per-operation design (see ``FileManagerToolkit``):
+every public async method becomes an LLM-callable tool named
+``obsidian_<method>``; destructive operations are declared in
+``confirming_tools`` for human-in-the-loop confirmation.
+"""
+from pathlib import Path
+from typing import Any, Dict, Literal, Optional, Set
+
+from parrot.interfaces.obsidian import (
+    ObsidianNote,
+    ObsidianVaultInterface,
+    create_vault_backend,
+)
+
+from .toolkit import AbstractToolkit
+
+#: Maps allowed_operations keys → method names used in exclude_tools filtering.
+_OP_TO_METHOD: Dict[str, str] = {
+    "read": "read_note",
+    "bulk_read": "read_notes",
+    "list": "list_notes",
+    "search": "search_notes",
+    "search_tag": "search_by_tag",
+    "search_backlinks": "search_with_backlinks",
+    "backlinks": "get_backlinks",
+    "outlinks": "get_outgoing_links",
+    "metadata": "get_note_metadata",
+    "catalog": "catalog_notes",
+    "create": "create_note",
+    "update": "update_note",
+    "append": "append_note",
+    "delete": "delete_note",
+    "move": "move_note",
+}
+_ALL_OPS: frozenset = frozenset(_OP_TO_METHOD)
+
+#: Operations that mutate the vault (invalidate the cached VaultIndex).
+_MUTATING_METHODS: frozenset = frozenset(
+    {"create_note", "update_note", "append_note", "delete_note", "move_note"}
+)
+
+
+def _note_payload(note: ObsidianNote, include_content: bool = True) -> Dict[str, Any]:
+    """JSON-safe dict projection of a parsed note."""
+    payload: Dict[str, Any] = {
+        "path": note.path.as_posix(),
+        "title": note.title,
+        "frontmatter": note.frontmatter,
+        "tags": sorted(note.tags),
+        "aliases": note.aliases,
+        "links": [link.model_dump() for link in note.links],
+        "dataview_queries": note.dataview_queries,
+    }
+    if include_content:
+        payload["content"] = note.content
+    return payload
+
+
+class ObsidianToolkit(AbstractToolkit):
+    """Toolkit for AI agents to manage an Obsidian vault.
+
+    Tool names (with ``tool_prefix="obsidian"``):
+      - ``obsidian_read_note``            — read one note (parsed + content)
+      - ``obsidian_read_notes``           — bulk-read several notes
+      - ``obsidian_list_notes``           — list notes with file info
+      - ``obsidian_search_notes``         — keyword search over the vault
+      - ``obsidian_search_by_tag``        — notes carrying a tag
+      - ``obsidian_search_with_backlinks``— search + link neighborhood
+      - ``obsidian_get_backlinks``        — notes linking to a note
+      - ``obsidian_get_outgoing_links``   — a note's resolved outlinks
+      - ``obsidian_get_note_metadata``    — frontmatter + stat, no body
+      - ``obsidian_catalog_notes``        — vault catalog and health report
+      - ``obsidian_create_note``          — create a note (confirming)
+      - ``obsidian_update_note``          — replace note body (confirming)
+      - ``obsidian_append_note``          — append to a note (confirming)
+      - ``obsidian_delete_note``          — delete a note (confirming)
+      - ``obsidian_move_note``            — move/rename a note (confirming)
+
+    Example::
+
+        toolkit = ObsidianToolkit(vault_path="~/vaults/notes")
+        tools = toolkit.get_tools()
+        result = await toolkit.search_notes(query="retrieval")
+    """
+
+    #: Namespace prefix applied to every auto-generated tool name.
+    tool_prefix: Optional[str] = "obsidian"
+
+    #: FEAT-391 lifecycle: open the backend + build the index lazily.
+    auto_open: bool = True
+
+    #: Destructive operations requiring human-in-the-loop confirmation.
+    confirming_tools: frozenset = frozenset(
+        {"create_note", "update_note", "append_note", "delete_note", "move_note"}
+    )
+
+    def __init__(
+        self,
+        vault_path: Optional[str | Path] = None,
+        backend: Literal["local", "rest"] = "local",
+        vault: Optional[ObsidianVaultInterface] = None,
+        allowed_operations: Optional[Set[str]] = None,
+        **backend_kwargs: Any,
+    ) -> None:
+        """Initialize the Obsidian toolkit.
+
+        Args:
+            vault_path: Vault directory (local backend). Ignored when a
+                prebuilt ``vault`` is injected.
+            backend: ``"local"`` (filesystem) or ``"rest"`` (Local REST API
+                plugin; pass ``base_url``/``api_key`` via backend_kwargs).
+            vault: Optional prebuilt backend instance (overrides
+                ``vault_path``/``backend``).
+            allowed_operations: Restrict which operations become tools.
+                Subset of ``{"read", "bulk_read", "list", "search",
+                "search_tag", "search_backlinks", "backlinks", "outlinks",
+                "metadata", "catalog", "create", "update", "append",
+                "delete", "move"}``. ``None`` exposes all.
+            **backend_kwargs: Forwarded to the backend constructor.
+
+        Raises:
+            ValueError: For unknown operations or a missing vault source.
+        """
+        if allowed_operations is not None:
+            unknown = set(allowed_operations) - _ALL_OPS
+            if unknown:
+                raise ValueError(
+                    f"ObsidianToolkit: unknown operation(s): {sorted(unknown)!r}. "
+                    f"Valid operations are: {sorted(_ALL_OPS)}"
+                )
+            # Compute exclude_tools BEFORE super().__init__ so that
+            # _generate_tools() sees the instance-level override.
+            self.exclude_tools = tuple(
+                method
+                for op, method in _OP_TO_METHOD.items()
+                if op not in allowed_operations
+            )
+
+        super().__init__()
+
+        if vault is not None:
+            self.vault = vault
+        else:
+            if backend == "local":
+                if vault_path is None:
+                    raise ValueError(
+                        "ObsidianToolkit: vault_path is required for the "
+                        "local backend"
+                    )
+                backend_kwargs.setdefault("vault_path", vault_path)
+            self.vault = create_vault_backend(backend=backend, **backend_kwargs)
+        self.allowed_operations: Set[str] = (
+            set(allowed_operations) if allowed_operations is not None else set(_ALL_OPS)
+        )
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle (FEAT-391)
+    # ------------------------------------------------------------------ #
+    async def _open(self) -> None:
+        """Open the vault backend and warm the link index."""
+        await self.vault.open()
+        await self.vault.build_index()
+
+    async def _close(self) -> None:
+        """Close the vault backend."""
+        await self.vault.close()
+        await super()._close()
+
+    async def _post_execute(self, tool_name: str, result: Any, /, **kwargs: Any) -> Any:
+        """Invalidate the cached VaultIndex after mutating operations."""
+        method = tool_name
+        prefix = f"{self.tool_prefix}{self.prefix_separator}"
+        if method.startswith(prefix):
+            method = method[len(prefix):]
+        if method in _MUTATING_METHODS:
+            self.vault.invalidate_index()
+        return result
+
+    # ------------------------------------------------------------------ #
+    # Read tools
+    # ------------------------------------------------------------------ #
+    async def read_note(self, path: str, include_content: bool = True) -> Dict[str, Any]:
+        """Read one Obsidian note: content plus parsed structure.
+
+        Args:
+            path: Vault-relative note path (``.md`` optional).
+            include_content: Include the full markdown body (default True).
+
+        Returns:
+            Dict with path, title, content, frontmatter, tags, aliases,
+            links and dataview_queries.
+
+        Raises:
+            FileNotFoundError: If the note does not exist.
+        """
+        note = await self.vault.get_note(path)
+        return _note_payload(note, include_content=include_content)
+
+    async def read_notes(
+        self, paths: list[str], include_content: bool = True
+    ) -> Dict[str, Any]:
+        """Bulk-read several notes in one call.
+
+        Args:
+            paths: Vault-relative note paths (max 50 per call).
+            include_content: Include full markdown bodies (default True).
+
+        Returns:
+            Dict with ``notes`` (successfully read, parsed payloads) and
+            ``errors`` (path -> error message for failed reads).
+        """
+        capped = paths[:50]
+        notes: list[Dict[str, Any]] = []
+        errors: Dict[str, str] = {}
+        for path in capped:
+            try:
+                note = await self.vault.get_note(path)
+                notes.append(_note_payload(note, include_content=include_content))
+            except (FileNotFoundError, UnicodeDecodeError, ValueError) as exc:
+                errors[path] = str(exc)
+        return {
+            "notes": notes,
+            "errors": errors,
+            "truncated": len(paths) > len(capped),
+        }
+
+    async def list_notes(
+        self, folder: Optional[str] = None, recursive: bool = True
+    ) -> Dict[str, Any]:
+        """List markdown notes in the vault (or one folder).
+
+        Args:
+            folder: Vault-relative folder; None for the whole vault.
+            recursive: Descend into subfolders (default True).
+
+        Returns:
+            Dict with ``notes`` (path/name/size/mtime descriptors) and
+            ``count``.
+        """
+        infos = await self.vault.list_files(
+            folder=folder, recursive=recursive, suffixes=frozenset({".md"})
+        )
+        return {
+            "notes": [info.model_dump() for info in infos],
+            "count": len(infos),
+        }
+
+    async def get_note_metadata(self, path: str) -> Dict[str, Any]:
+        """Read a note's frontmatter and file info without its body.
+
+        Args:
+            path: Vault-relative note path.
+
+        Returns:
+            Dict with path, title, frontmatter, tags, aliases and file
+            stat info (size, mtime when available).
+
+        Raises:
+            FileNotFoundError: If the note does not exist.
+        """
+        note = await self.vault.get_note(path)
+        stat = await self.vault.stat(path)
+        payload = _note_payload(note, include_content=False)
+        payload["file"] = stat.model_dump()
+        return payload
+
+    # ------------------------------------------------------------------ #
+    # Search tools
+    # ------------------------------------------------------------------ #
+    async def search_notes(self, query: str, limit: int = 20) -> Dict[str, Any]:
+        """Search notes by keywords over titles, tags, aliases and bodies.
+
+        Args:
+            query: Search terms (space-separated keywords).
+            limit: Maximum results (default 20).
+
+        Returns:
+            Dict with ``hits`` (path, score, snippet, matched fields) and
+            ``count``.
+        """
+        hits = await self.vault.search(query, limit=limit)
+        return {"hits": [hit.model_dump() for hit in hits], "count": len(hits)}
+
+    async def search_by_tag(self, tag: str, limit: int = 50) -> Dict[str, Any]:
+        """Find notes carrying a tag (inline ``#tag`` or frontmatter).
+
+        Nested tags match by prefix: searching ``project`` also returns
+        notes tagged ``project/status``.
+
+        Args:
+            tag: Tag name with or without the leading ``#``.
+            limit: Maximum results (default 50).
+
+        Returns:
+            Dict with ``paths`` of matching notes and ``count``.
+        """
+        index = await self.vault.build_index()
+        paths = index.notes_by_tag(tag)[:limit]
+        return {"tag": tag.lstrip("#"), "paths": paths, "count": len(paths)}
+
+    async def search_with_backlinks(
+        self, query: str, limit: int = 10, expand: int = 5
+    ) -> Dict[str, Any]:
+        """Search notes, expanding each hit with its link neighborhood.
+
+        For every search hit, includes up to ``expand`` backlinks (notes
+        pointing at the hit) and ``expand`` outgoing links — the
+        hand-curated context Obsidian users build via wikilinks.
+
+        Args:
+            query: Search terms.
+            limit: Maximum primary hits (default 10).
+            expand: Maximum backlinks/outlinks listed per hit (default 5).
+
+        Returns:
+            Dict with ``hits``; each hit carries path, score, snippet,
+            ``backlinks`` and ``outlinks``.
+        """
+        hits = await self.vault.search(query, limit=limit)
+        index = await self.vault.build_index()
+        enriched = []
+        for hit in hits:
+            outlinks = []
+            for link in index.outlinks(hit.path)[:expand]:
+                resolved = index.resolve(link.target, from_path=hit.path)
+                outlinks.append(
+                    {
+                        "target": link.target,
+                        "resolved_path": resolved,
+                        "is_embed": link.is_embed,
+                    }
+                )
+            enriched.append(
+                {
+                    **hit.model_dump(),
+                    "backlinks": index.backlinks(hit.path)[:expand],
+                    "outlinks": outlinks,
+                }
+            )
+        return {"hits": enriched, "count": len(enriched)}
+
+    async def get_backlinks(self, path: str) -> Dict[str, Any]:
+        """List notes whose wikilinks resolve to this note.
+
+        Args:
+            path: Vault-relative note path.
+
+        Returns:
+            Dict with ``backlinks`` (note paths) and ``count``.
+        """
+        index = await self.vault.build_index()
+        backlinks = index.backlinks(path)
+        return {"path": path, "backlinks": backlinks, "count": len(backlinks)}
+
+    async def get_outgoing_links(self, path: str) -> Dict[str, Any]:
+        """List a note's outgoing wikilinks/embeds with resolution status.
+
+        Args:
+            path: Vault-relative note path.
+
+        Returns:
+            Dict with ``links`` (target, alias, heading, is_embed,
+            resolved_path or null) and ``unresolved`` targets.
+        """
+        index = await self.vault.build_index()
+        links = []
+        unresolved = []
+        for link in index.outlinks(path):
+            resolved = index.resolve(link.target, from_path=path)
+            links.append({**link.model_dump(), "resolved_path": resolved})
+            if resolved is None:
+                unresolved.append(link.target)
+        return {"path": path, "links": links, "unresolved": unresolved}
+
+    async def catalog_notes(self, folder: Optional[str] = None) -> Dict[str, Any]:
+        """Catalog the vault: folders, tags, orphans, broken links, aliases.
+
+        Args:
+            folder: Restrict the folder statistics to one subtree; the
+                link/tag analysis always covers the whole vault.
+
+        Returns:
+            Dict with ``note_count``, ``notes_per_folder``, ``tags`` (tag ->
+            count), ``orphans``, ``broken_links`` (from_path -> target) and
+            ``aliases`` (alias -> path).
+        """
+        index = await self.vault.build_index()
+        infos = await self.vault.list_files(
+            folder=folder, suffixes=frozenset({".md"})
+        )
+        per_folder: Dict[str, int] = {}
+        for info in infos:
+            parent = info.path.rsplit("/", 1)[0] if "/" in info.path else "."
+            per_folder[parent] = per_folder.get(parent, 0) + 1
+        return {
+            "note_count": len(infos),
+            "notes_per_folder": dict(sorted(per_folder.items())),
+            "tags": index.tags(),
+            "orphans": index.orphans(),
+            "broken_links": [
+                {"from": src, "target": target} for src, target in index.unresolved()
+            ],
+            "aliases": index.aliases(),
+        }
+
+    # ------------------------------------------------------------------ #
+    # Write tools (confirming)
+    # ------------------------------------------------------------------ #
+    async def create_note(
+        self,
+        path: str,
+        content: str,
+        frontmatter: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Create a new note (fails if it already exists).
+
+        Args:
+            path: Vault-relative path for the new note.
+            content: Markdown body.
+            frontmatter: Optional YAML frontmatter mapping (tags, aliases,
+                custom keys) rendered ahead of the body.
+
+        Returns:
+            Descriptor of the created file.
+
+        Raises:
+            FileExistsError: If a note already exists at ``path``.
+        """
+        text = content
+        if frontmatter:
+            import yaml
+
+            block = yaml.safe_dump(
+                frontmatter, default_flow_style=False, sort_keys=False,
+                allow_unicode=True,
+            )
+            text = f"---\n{block}---\n\n{content}"
+        info = await self.vault.write_note(path, text, overwrite=False)
+        return {"created": True, "file": info.model_dump()}
+
+    async def update_note(
+        self, path: str, content: str, preserve_frontmatter: bool = True
+    ) -> Dict[str, Any]:
+        """Replace a note's markdown body.
+
+        Args:
+            path: Vault-relative note path (must exist).
+            content: New markdown body.
+            preserve_frontmatter: Keep the existing YAML frontmatter block
+                (default True); False replaces the whole file with
+                ``content``.
+
+        Returns:
+            Descriptor of the updated file.
+
+        Raises:
+            FileNotFoundError: If the note does not exist.
+        """
+        raw = await self.vault.read_note(path)  # raises if missing
+        text = content
+        if preserve_frontmatter:
+            import frontmatter as fm
+
+            try:
+                post = fm.loads(raw)
+                if post.metadata:
+                    post.content = content
+                    text = fm.dumps(post)
+            except Exception:  # noqa: BLE001 — fall back to raw replacement
+                text = content
+        info = await self.vault.write_note(path, text, overwrite=True)
+        return {"updated": True, "file": info.model_dump()}
+
+    async def append_note(self, path: str, content: str) -> Dict[str, Any]:
+        """Append markdown to the end of an existing note.
+
+        Args:
+            path: Vault-relative note path (must exist).
+            content: Markdown to append.
+
+        Returns:
+            Descriptor of the updated file.
+
+        Raises:
+            FileNotFoundError: If the note does not exist.
+        """
+        raw = await self.vault.read_note(path)
+        joined = raw.rstrip("\n") + "\n\n" + content.lstrip("\n")
+        info = await self.vault.write_note(path, joined, overwrite=True)
+        return {"appended": True, "file": info.model_dump()}
+
+    async def delete_note(self, path: str) -> Dict[str, Any]:
+        """Delete a note from the vault.
+
+        Args:
+            path: Vault-relative note path.
+
+        Returns:
+            Dict with ``deleted`` (bool) and the affected ``backlinks``
+            that now point at a missing note.
+        """
+        index = await self.vault.build_index()
+        norm = path[:-3] if path.lower().endswith(".md") else path
+        affected = index.backlinks(norm)
+        deleted = await self.vault.delete_note(path)
+        return {"deleted": deleted, "path": path, "affected_backlinks": affected}
+
+    async def move_note(self, source: str, destination: str) -> Dict[str, Any]:
+        """Move or rename a note within the vault.
+
+        Args:
+            source: Current vault-relative path.
+            destination: New vault-relative path.
+
+        Returns:
+            Dict with the new file descriptor and ``affected_backlinks`` —
+            notes whose ``[[wikilinks]]`` referenced the old path/name and
+            may now be broken (links are NOT rewritten automatically).
+
+        Raises:
+            FileNotFoundError: If the source note does not exist.
+            FileExistsError: If a note already exists at the destination.
+        """
+        raw = await self.vault.read_note(source)
+        index = await self.vault.build_index()
+        norm = source[:-3] if source.lower().endswith(".md") else source
+        affected = index.backlinks(norm)
+        info = await self.vault.write_note(destination, raw, overwrite=False)
+        await self.vault.delete_note(source)
+        return {
+            "moved": True,
+            "from": source,
+            "file": info.model_dump(),
+            "affected_backlinks": affected,
+        }

--- a/packages/ai-parrot/src/parrot/tools/obsidian.py
+++ b/packages/ai-parrot/src/parrot/tools/obsidian.py
@@ -39,12 +39,23 @@ _OP_TO_METHOD: Dict[str, str] = {
     "append": "append_note",
     "delete": "delete_note",
     "move": "move_note",
+    "okf_read": "get_okf_metadata",
+    "okf_validate": "validate_okf_frontmatter",
+    "classify": "classify_note",
+    "okf_apply": "apply_okf_frontmatter",
 }
 _ALL_OPS: frozenset = frozenset(_OP_TO_METHOD)
 
 #: Operations that mutate the vault (invalidate the cached VaultIndex).
 _MUTATING_METHODS: frozenset = frozenset(
-    {"create_note", "update_note", "append_note", "delete_note", "move_note"}
+    {
+        "create_note",
+        "update_note",
+        "append_note",
+        "delete_note",
+        "move_note",
+        "apply_okf_frontmatter",
+    }
 )
 
 
@@ -83,6 +94,10 @@ class ObsidianToolkit(AbstractToolkit):
       - ``obsidian_append_note``          — append to a note (confirming)
       - ``obsidian_delete_note``          — delete a note (confirming)
       - ``obsidian_move_note``            — move/rename a note (confirming)
+      - ``obsidian_get_okf_metadata``     — read a note's OKF block
+      - ``obsidian_validate_okf_frontmatter`` — lint OKF metadata
+      - ``obsidian_classify_note``        — suggest OKF ConceptTypes
+      - ``obsidian_apply_okf_frontmatter``— write OKF block (confirming)
 
     Example::
 
@@ -99,7 +114,14 @@ class ObsidianToolkit(AbstractToolkit):
 
     #: Destructive operations requiring human-in-the-loop confirmation.
     confirming_tools: frozenset = frozenset(
-        {"create_note", "update_note", "append_note", "delete_note", "move_note"}
+        {
+            "create_note",
+            "update_note",
+            "append_note",
+            "delete_note",
+            "move_note",
+            "apply_okf_frontmatter",
+        }
     )
 
     def __init__(
@@ -540,4 +562,230 @@ class ObsidianToolkit(AbstractToolkit):
             "from": source,
             "file": info.model_dump(),
             "affected_backlinks": affected,
+        }
+
+    # ------------------------------------------------------------------ #
+    # OKF (Open Knowledge Format) tools — Phase D
+    # ------------------------------------------------------------------ #
+    async def get_okf_metadata(self, path: str) -> Dict[str, Any]:
+        """Read a note's OKF metadata (the ``okf:`` frontmatter block).
+
+        Args:
+            path: Vault-relative note path.
+
+        Returns:
+            Dict with ``okf`` (the parsed block, or null when absent) and
+            ``has_okf``.
+
+        Raises:
+            FileNotFoundError: If the note does not exist.
+            ValueError: If the okf block exists but is malformed.
+        """
+        from parrot.interfaces.obsidian.okf import read_okf
+
+        note = await self.vault.get_note(path)
+        block = read_okf(note)
+        return {
+            "path": note.path.as_posix(),
+            "has_okf": block is not None,
+            "okf": block.model_dump(mode="json") if block else None,
+        }
+
+    async def validate_okf_frontmatter(
+        self, path: Optional[str] = None, folder: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Lint OKF frontmatter for one note or the whole vault.
+
+        Checks type/relation values against the OKF controlled
+        vocabulary and verifies that ``relates_to`` targets resolve to
+        real notes.
+
+        Args:
+            path: Lint one note; when omitted the whole vault (or the
+                given ``folder``) is linted.
+            folder: Restrict the vault-wide lint to one folder.
+
+        Returns:
+            Dict with ``findings`` (list of human-readable strings),
+            ``notes_checked`` and ``notes_with_okf``.
+        """
+        from parrot.interfaces.obsidian.okf import validate_okf
+
+        index = await self.vault.build_index()
+        if path is not None:
+            notes = [await self.vault.get_note(path)]
+        else:
+            notes = await self.vault.load_notes(folder=folder)
+        findings: list[str] = []
+        with_okf = 0
+        for note in notes:
+            if note.frontmatter.get("okf") is not None:
+                with_okf += 1
+            findings.extend(validate_okf(note, index))
+        return {
+            "findings": findings,
+            "notes_checked": len(notes),
+            "notes_with_okf": with_okf,
+        }
+
+    async def classify_note(self, path: str) -> Dict[str, Any]:
+        """Suggest OKF ConceptType classifications for a note.
+
+        Deterministic heuristic over the note's frontmatter, tags and
+        title against the OKF controlled vocabulary — no LLM inside the
+        tool (the agent applies its own reasoning on top and can persist
+        a choice via ``apply_okf_frontmatter``).
+
+        Args:
+            path: Vault-relative note path.
+
+        Returns:
+            Dict with ranked ``candidates`` (type + rationale) and the
+            note's ``tags``/``title`` evidence.
+        """
+        from parrot.knowledge.okf.ontology import ConceptType
+
+        note = await self.vault.get_note(path)
+        candidates: list[Dict[str, str]] = []
+
+        def suggest(concept_type: ConceptType, rationale: str) -> None:
+            if all(c["type"] != concept_type.value for c in candidates):
+                candidates.append(
+                    {"type": concept_type.value, "rationale": rationale}
+                )
+
+        # 1. Explicit frontmatter type wins.
+        raw_type = note.frontmatter.get("type")
+        if isinstance(raw_type, str):
+            try:
+                explicit = ConceptType(raw_type.strip().title())
+                suggest(explicit, f"frontmatter type: {raw_type!r}")
+            except ValueError:
+                pass
+        # 2. Tag / title keyword evidence.
+        evidence = {tag.lower().split("/")[0] for tag in note.tags}
+        evidence.update(note.title.lower().split())
+        keyword_map = {
+            "policy": ConceptType.POLICY,
+            "control": ConceptType.CONTROL,
+            "safeguard": ConceptType.SAFEGUARD,
+            "evidence": ConceptType.EVIDENCE,
+            "playbook": ConceptType.PLAYBOOK,
+            "procedure": ConceptType.PROCEDURE,
+            "howto": ConceptType.PROCEDURE,
+            "standard": ConceptType.STANDARD,
+            "framework": ConceptType.FRAMEWORK,
+            "regulation": ConceptType.REGULATION,
+            "guideline": ConceptType.GUIDELINE,
+            "concept": ConceptType.CONCEPT_NODE,
+            "skill": ConceptType.SKILL,
+            "rationale": ConceptType.RATIONALE,
+            "decision": ConceptType.RATIONALE,
+        }
+        for keyword, concept_type in keyword_map.items():
+            if keyword in evidence:
+                suggest(concept_type, f"keyword {keyword!r} in tags/title")
+        # 3. Structural fallbacks.
+        if note.links and len(note.content) < 400:
+            suggest(
+                ConceptType.CONCEPT_NODE,
+                "short, link-dense note (hub/concept shape)",
+            )
+        suggest(ConceptType.DOCUMENT_NODE, "fallback: ordinary document")
+        return {
+            "path": note.path.as_posix(),
+            "title": note.title,
+            "tags": sorted(note.tags),
+            "candidates": candidates,
+        }
+
+    async def apply_okf_frontmatter(
+        self,
+        path: str,
+        okf: Dict[str, Any],
+        mirror_tags: bool = False,
+    ) -> Dict[str, Any]:
+        """Write/replace a note's ``okf:`` frontmatter block.
+
+        Native frontmatter keys are preserved; the ``okf`` subtree is
+        regenerated wholesale (single-writer rule — hand edits to it are
+        overwritten). The note body is untouched.
+
+        Args:
+            path: Vault-relative note path (must exist).
+            okf: OKF fields — ``type`` (ConceptType value), ``summary``,
+                ``tags``, ``relates_to`` (list of ``{concept, rel}``;
+                ``[[wikilink]]`` targets are normalized), optional
+                ``title``/``id``/``source``. ``id`` and ``resource``
+                default to the note's stable vault id.
+            mirror_tags: Also mirror OKF tags into native ``tags:`` as
+                ``okf/<tag>`` so Obsidian search sees them.
+
+        Returns:
+            Dict with the written file info and the applied okf block.
+
+        Raises:
+            FileNotFoundError: If the note does not exist.
+            ValueError: For unknown ConceptType/RelationType values or
+                unresolvable relates_to targets.
+        """
+        from parrot.interfaces.obsidian.okf import (
+            apply_okf,
+            normalize_relates_target,
+            read_okf,
+        )
+        from parrot.knowledge.okf.ontology import ConceptType, RelationType
+
+        raw = await self.vault.read_note(path)
+        note = await self.vault.get_note(path)
+        index = await self.vault.build_index()
+        norm = note.path.as_posix()
+        norm = norm[:-3] if norm.lower().endswith(".md") else norm
+
+        raw_type = str(okf.get("type", ConceptType.DOCUMENT_NODE.value))
+        try:
+            concept_type = ConceptType(raw_type)
+        except ValueError as exc:
+            valid = sorted(item.value for item in ConceptType)
+            raise ValueError(
+                f"Unknown OKF type {raw_type!r}. Valid types: {valid}"
+            ) from exc
+
+        relates_to: list[Dict[str, str]] = []
+        for row in okf.get("relates_to") or []:
+            target = str(row.get("concept", "")).strip()
+            rel = str(row.get("rel", "references"))
+            try:
+                RelationType(rel)
+            except ValueError as exc:
+                valid = sorted(item.value for item in RelationType)
+                raise ValueError(
+                    f"Unknown relates_to rel {rel!r}. Valid: {valid}"
+                ) from exc
+            resolved = normalize_relates_target(target, index)
+            if resolved is None:
+                raise ValueError(
+                    f"relates_to target {target!r} does not resolve to any note"
+                )
+            relates_to.append({"concept": resolved, "rel": rel})
+
+        node = {
+            "type": concept_type.value,
+            "title": okf.get("title", note.title),
+            "concept_id": okf.get("id", norm),
+            "node_id": okf.get("node_id", ""),
+            "resource": f"obsidian://{self.vault.vault_name}/{norm}",
+            "categories": list(okf.get("tags") or []),
+            "timestamp": okf.get("timestamp", ""),
+            "summary": okf.get("summary", ""),
+            "relates_to": relates_to,
+            "source": okf.get("source"),
+        }
+        new_text = apply_okf(raw, node, self.vault.vault_name, mirror_tags=mirror_tags)
+        info = await self.vault.write_note(path, new_text, overwrite=True)
+        written = read_okf(await self.vault.get_note(path))
+        return {
+            "applied": True,
+            "file": info.model_dump(),
+            "okf": written.model_dump(mode="json") if written else None,
         }

--- a/packages/ai-parrot/tests/interfaces/obsidian/conftest.py
+++ b/packages/ai-parrot/tests/interfaces/obsidian/conftest.py
@@ -1,0 +1,106 @@
+"""Shared fixture vault for all Obsidian test suites (FEAT-392 §4)."""
+import json
+from pathlib import Path
+
+import pytest
+
+DAILY_NOTE = """---
+title: Daily 2026-07-30
+tags: [daily, journal]
+---
+Worked on [[projects/ai-parrot|the parrot]] and reviewed
+[[machine-learning#Basics]] before lunch. See also [[orphanless-target]].
+"""
+
+PROJECT_NOTE = """---
+aliases: [parrot, AI Parrot]
+tags: project
+---
+# AI-Parrot
+
+Framework notes with an embed ![[diagram.png]] and a link to
+[[machine-learning]]. Inline #project/status tag here.
+
+```dataview
+LIST FROM #project
+```
+"""
+
+CONCEPT_NOTE = """---
+title: Machine Learning
+---
+# Machine Learning
+
+Tagged #concepts/ml and #ml.
+
+> [!note] Callout
+> Callouts must be preserved verbatim.
+
+```python
+# not-a-tag inside code
+x = 1
+```
+
+Linked from daily notes; links back to [[daily/2026-07-30]].
+"""
+
+ORPHAN_NOTE = """Just a lonely note with no links and no tags.
+"""
+
+BROKEN_LINK_NOTE = """This note points at [[nonexistent-target]] boldly.
+"""
+
+DUPLICATE_A = """Duplicate basename one. Links [[machine-learning]].
+"""
+
+DUPLICATE_B = """Duplicate basename two (deeper).
+"""
+
+CANVAS = {
+    "nodes": [
+        {"id": "abc", "type": "file", "file": "projects/ai-parrot.md"},
+        {"id": "def", "type": "text", "text": "Some canvas text"},
+    ],
+    "edges": [{"fromNode": "abc", "toNode": "def"}],
+}
+
+
+@pytest.fixture
+def fixture_vault(tmp_path: Path) -> Path:
+    """Create a small representative Obsidian vault under tmp_path."""
+    vault = tmp_path / "vault"
+    (vault / ".obsidian").mkdir(parents=True)
+    (vault / ".obsidian" / "app.json").write_text("{}", encoding="utf-8")
+    (vault / ".trash").mkdir()
+    (vault / ".trash" / "old.md").write_text("trashed", encoding="utf-8")
+
+    (vault / "daily").mkdir()
+    (vault / "daily" / "2026-07-30.md").write_text(DAILY_NOTE, encoding="utf-8")
+    (vault / "projects").mkdir()
+    (vault / "projects" / "ai-parrot.md").write_text(PROJECT_NOTE, encoding="utf-8")
+    (vault / "concepts").mkdir()
+    (vault / "concepts" / "machine-learning.md").write_text(
+        CONCEPT_NOTE, encoding="utf-8"
+    )
+    (vault / "orphan.md").write_text(ORPHAN_NOTE, encoding="utf-8")
+    (vault / "broken-link-note.md").write_text(BROKEN_LINK_NOTE, encoding="utf-8")
+
+    # Duplicate basenames in two folders — shortest path must win.
+    (vault / "notes.md").write_text(DUPLICATE_A, encoding="utf-8")
+    (vault / "deep" / "nested").mkdir(parents=True)
+    (vault / "deep" / "nested" / "notes.md").write_text(
+        DUPLICATE_B, encoding="utf-8"
+    )
+
+    (vault / "assets").mkdir()
+    (vault / "assets" / "diagram.png").write_bytes(b"\x89PNG\r\n\x1a\n000")
+
+    (vault / "canvas").mkdir()
+    (vault / "canvas" / "overview.canvas").write_text(
+        json.dumps(CANVAS), encoding="utf-8"
+    )
+
+    # Non-UTF-8 "note" — must be skipped with a warning, never crash.
+    (vault / "non-utf8.md").write_bytes(b"\xff\xfe invalid \xff")
+
+    return vault

--- a/packages/ai-parrot/tests/interfaces/obsidian/test_local_backend.py
+++ b/packages/ai-parrot/tests/interfaces/obsidian/test_local_backend.py
@@ -1,0 +1,120 @@
+"""Tests for LocalVaultBackend: I/O, sandbox, skip patterns, search."""
+import pytest
+
+from parrot.interfaces.obsidian.local import LocalVaultBackend
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def backend(fixture_vault) -> LocalVaultBackend:
+    return LocalVaultBackend(fixture_vault)
+
+
+class TestListFiles:
+    async def test_lists_notes_and_canvas(self, backend):
+        infos = await backend.list_files()
+        paths = {info.path for info in infos}
+        assert "daily/2026-07-30.md" in paths
+        assert "canvas/overview.canvas" in paths
+
+    async def test_skip_patterns(self, backend):
+        infos = await backend.list_files()
+        assert all(not info.path.startswith(".obsidian") for info in infos)
+        assert all(not info.path.startswith(".trash") for info in infos)
+
+    async def test_suffix_filter(self, backend):
+        infos = await backend.list_files(suffixes=frozenset({".canvas"}))
+        assert [info.path for info in infos] == ["canvas/overview.canvas"]
+
+    async def test_folder_scope(self, backend):
+        infos = await backend.list_files(folder="daily")
+        assert [info.path for info in infos] == ["daily/2026-07-30.md"]
+
+    async def test_missing_folder_raises(self, backend):
+        with pytest.raises(FileNotFoundError):
+            await backend.list_files(folder="does-not-exist")
+
+
+class TestReadWrite:
+    async def test_read_note(self, backend):
+        text = await backend.read_note("orphan.md")
+        assert "lonely" in text
+
+    async def test_read_without_suffix(self, backend):
+        text = await backend.read_note("orphan")
+        assert "lonely" in text
+
+    async def test_read_missing_raises(self, backend):
+        with pytest.raises(FileNotFoundError):
+            await backend.read_note("missing-note")
+
+    async def test_write_and_stat(self, backend):
+        info = await backend.write_note("new/deep/note", "# New\n")
+        assert info.path == "new/deep/note.md"
+        stat = await backend.stat("new/deep/note.md")
+        assert stat.size == len("# New\n")
+        assert stat.mtime is not None
+
+    async def test_write_no_overwrite(self, backend):
+        with pytest.raises(FileExistsError):
+            await backend.write_note("orphan", "clobber", overwrite=False)
+
+    async def test_delete(self, backend):
+        assert await backend.delete_note("orphan") is True
+        assert await backend.note_exists("orphan") is False
+        assert await backend.delete_note("orphan") is False
+
+    async def test_non_utf8_read_raises(self, backend):
+        with pytest.raises(UnicodeDecodeError):
+            await backend.read_note("non-utf8.md")
+
+
+class TestSandbox:
+    async def test_escape_rejected(self, backend):
+        with pytest.raises(ValueError):
+            await backend.read_note("../outside.md")
+
+    async def test_absolute_confined(self, backend, fixture_vault):
+        # Leading slashes are stripped, so this resolves inside the vault.
+        text = await backend.read_note("/orphan.md")
+        assert "lonely" in text
+
+
+class TestGetNoteAndIndex:
+    async def test_get_note_parsed(self, backend):
+        note = await backend.get_note("projects/ai-parrot")
+        assert note.aliases == ["parrot", "AI Parrot"]
+        assert "project" in note.tags
+        assert any(link.is_embed for link in note.links)
+
+    async def test_load_notes_skips_bad_files(self, backend):
+        notes = await backend.load_notes()
+        paths = {note.path.as_posix() for note in notes}
+        assert "non-utf8.md" not in paths
+        assert "daily/2026-07-30.md" in paths
+
+    async def test_index_backlinks(self, backend):
+        index = await backend.build_index()
+        assert "daily/2026-07-30" in index.backlinks("projects/ai-parrot")
+
+    async def test_index_cache_invalidated_on_write(self, backend):
+        index_one = await backend.build_index()
+        await backend.write_note("brand-new", "Links [[orphan]].")
+        index_two = await backend.build_index()
+        assert index_two is not index_one
+        assert index_two.note("brand-new") is not None
+
+
+class TestSearch:
+    async def test_search_title_and_body(self, backend):
+        hits = await backend.search("machine learning")
+        assert hits
+        assert hits[0].path == "concepts/machine-learning"
+
+    async def test_search_by_alias(self, backend):
+        hits = await backend.search("parrot")
+        assert any(hit.path == "projects/ai-parrot" for hit in hits)
+
+    async def test_empty_query(self, backend):
+        assert await backend.search("   ") == []

--- a/packages/ai-parrot/tests/interfaces/obsidian/test_okf_frontmatter.py
+++ b/packages/ai-parrot/tests/interfaces/obsidian/test_okf_frontmatter.py
@@ -1,0 +1,153 @@
+"""Tests for OKF metadata in Obsidian frontmatter (Phase D)."""
+import pytest
+
+from parrot.interfaces.obsidian.index import VaultIndex
+from parrot.interfaces.obsidian.okf import (
+    apply_okf,
+    normalize_relates_target,
+    project_okf_block,
+    read_okf,
+    validate_okf,
+)
+from parrot.interfaces.obsidian.parser import ObsidianNoteParser
+
+NODE = {
+    "type": "Concept",
+    "title": "Machine Learning",
+    "concept_id": "concepts/machine-learning",
+    "node_id": "",
+    "summary": "A field of AI.",
+    "categories": ["ml", "ai"],
+    "relates_to": [{"concept": "daily/today", "rel": "references"}],
+}
+
+NATIVE_NOTE = """---
+title: My Note
+tags: [personal]
+custom_key: kept
+---
+
+Body stays exactly as it was.
+"""
+
+
+@pytest.fixture(scope="module")
+def parser() -> ObsidianNoteParser:
+    return ObsidianNoteParser()
+
+
+class TestProjection:
+    def test_okf_block_deterministic(self):
+        one = project_okf_block(NODE, "vault")
+        two = project_okf_block(dict(NODE), "vault")
+        assert one == two
+        assert one.startswith("okf:\n")
+
+    def test_field_order_and_sorted_tags(self):
+        block = project_okf_block(NODE, "vault")
+        type_pos = block.find("type:")
+        title_pos = block.find("title:")
+        summary_pos = block.find("summary:")
+        assert type_pos < title_pos < summary_pos
+        assert block.find("- ai") < block.find("- ml")
+
+    def test_source_omitted_when_none(self):
+        block = project_okf_block(NODE, "vault")
+        assert "\n  source:" not in block
+
+
+class TestApplyOkf:
+    def test_native_keys_preserved(self, parser):
+        text = apply_okf(NATIVE_NOTE, NODE, "vault")
+        note = parser.parse(text, "a.md")
+        assert note.frontmatter["title"] == "My Note"
+        assert note.frontmatter["custom_key"] == "kept"
+        assert "personal" in note.tags
+        assert "Body stays exactly as it was." in note.content
+
+    def test_okf_block_written_and_readable(self, parser):
+        text = apply_okf(NATIVE_NOTE, NODE, "vault")
+        note = parser.parse(text, "a.md")
+        block = read_okf(note)
+        assert block is not None
+        assert block.type.value == "Concept"
+        assert block.id == "concepts/machine-learning"
+        assert block.relates_to[0].concept == "daily/today"
+
+    def test_reapply_replaces_wholesale(self, parser):
+        text = apply_okf(NATIVE_NOTE, NODE, "vault")
+        changed = {**NODE, "summary": "Updated summary."}
+        text2 = apply_okf(text, changed, "vault")
+        note = parser.parse(text2, "a.md")
+        block = read_okf(note)
+        assert block.summary == "Updated summary."
+        assert text2.count("okf:") == 1
+
+    def test_apply_okf_idempotent(self):
+        text = apply_okf(NATIVE_NOTE, NODE, "vault")
+        assert apply_okf(text, NODE, "vault") == text
+
+    def test_mirror_tags(self, parser):
+        text = apply_okf(NATIVE_NOTE, NODE, "vault", mirror_tags=True)
+        note = parser.parse(text, "a.md")
+        assert "okf/ml" in note.tags
+        assert "personal" in note.tags
+
+    def test_body_without_frontmatter(self, parser):
+        text = apply_okf("Just a body.", NODE, "vault")
+        note = parser.parse(text, "a.md")
+        assert read_okf(note) is not None
+        assert "Just a body." in note.content
+
+
+class TestReadValidate:
+    def test_read_absent_returns_none(self, parser):
+        note = parser.parse("No okf here.", "a.md")
+        assert read_okf(note) is None
+
+    def test_read_malformed_raises(self, parser):
+        note = parser.parse("---\nokf: not-a-mapping\n---\nBody", "a.md")
+        with pytest.raises(ValueError, match="must be a mapping"):
+            read_okf(note)
+
+    def test_validate_unknown_type(self, parser):
+        raw = "---\nokf:\n  type: Nonsense\n  id: x\n  summary: s\n---\nBody"
+        note = parser.parse(raw, "a.md")
+        findings = validate_okf(note)
+        assert any("unknown okf type" in finding for finding in findings)
+
+    def test_validate_missing_id_and_summary(self, parser):
+        raw = "---\nokf:\n  type: Concept\n---\nBody"
+        note = parser.parse(raw, "a.md")
+        findings = validate_okf(note)
+        assert any("missing 'id'" in finding for finding in findings)
+        assert any("missing 'summary'" in finding for finding in findings)
+
+    def test_validate_relates_resolution(self, parser):
+        target_note = parser.parse("Target.", "real-note.md")
+        raw = (
+            "---\nokf:\n  type: Concept\n  id: x\n  summary: s\n"
+            "  relates_to:\n"
+            "  - concept: '[[real-note]]'\n    rel: references\n"
+            "  - concept: missing-note\n    rel: references\n"
+            "  - concept: real-note\n    rel: bogus-rel\n---\nBody"
+        )
+        note = parser.parse(raw, "a.md")
+        index = VaultIndex.build([target_note, note])
+        findings = validate_okf(note, index)
+        assert any("'missing-note'" in finding for finding in findings)
+        assert any("bogus-rel" in finding for finding in findings)
+        assert not any("'[[real-note]]'" in finding for finding in findings)
+
+
+class TestNormalizeTarget:
+    def test_wikilink_syntax(self):
+        parser = ObsidianNoteParser()
+        index = VaultIndex.build([parser.parse("x", "folder/target.md")])
+        assert normalize_relates_target("[[target]]", index) == "folder/target"
+        assert normalize_relates_target("[[target|alias]]", index) == "folder/target"
+        assert normalize_relates_target("missing", index) is None
+
+    def test_without_index_verbatim(self):
+        assert normalize_relates_target("[[target]]") == "target"
+        assert normalize_relates_target("plain-id") == "plain-id"

--- a/packages/ai-parrot/tests/interfaces/obsidian/test_parser.py
+++ b/packages/ai-parrot/tests/interfaces/obsidian/test_parser.py
@@ -1,0 +1,157 @@
+"""Unit tests for ObsidianNoteParser and parse_canvas (FEAT-392 Module 1)."""
+import json
+
+import pytest
+
+from parrot.interfaces.obsidian.parser import ObsidianNoteParser, parse_canvas
+
+
+@pytest.fixture(scope="module")
+def parser() -> ObsidianNoteParser:
+    return ObsidianNoteParser()
+
+
+class TestParseWikilink:
+    def test_basic(self, parser):
+        note = parser.parse("See [[target]].", "a.md")
+        assert len(note.links) == 1
+        link = note.links[0]
+        assert link.target == "target"
+        assert link.alias is None
+        assert link.heading is None
+        assert link.is_embed is False
+
+    def test_alias(self, parser):
+        note = parser.parse("See [[target|display text]].", "a.md")
+        assert note.links[0].target == "target"
+        assert note.links[0].alias == "display text"
+
+    def test_heading(self, parser):
+        note = parser.parse("See [[target#Some Heading]].", "a.md")
+        assert note.links[0].target == "target"
+        assert note.links[0].heading == "Some Heading"
+
+    def test_heading_and_alias(self, parser):
+        note = parser.parse("See [[target#head|shown]].", "a.md")
+        link = note.links[0]
+        assert (link.target, link.heading, link.alias) == ("target", "head", "shown")
+
+    def test_path_qualified(self, parser):
+        note = parser.parse("See [[folder/note]].", "a.md")
+        assert note.links[0].target == "folder/note"
+
+    def test_multiple_links(self, parser):
+        note = parser.parse("[[one]] then [[two|2]] and ![[three]]", "a.md")
+        assert [link.target for link in note.links] == ["one", "two", "three"]
+
+
+class TestParseEmbed:
+    def test_note_embed(self, parser):
+        note = parser.parse("Body ![[note]] end.", "a.md")
+        assert note.links[0].is_embed is True
+        assert note.links[0].target == "note"
+
+    def test_image_embed(self, parser):
+        note = parser.parse("![[image.png]]", "a.md")
+        assert note.links[0].is_embed is True
+        assert note.links[0].target == "image.png"
+
+    def test_embed_with_heading(self, parser):
+        note = parser.parse("![[note#section]]", "a.md")
+        assert note.links[0].is_embed is True
+        assert note.links[0].heading == "section"
+
+
+class TestParseFrontmatter:
+    def test_frontmatter_extracted(self, parser):
+        raw = "---\ntitle: My Note\ntags: [a, b]\naliases: [x]\n---\nBody.\n"
+        note = parser.parse(raw, "a.md")
+        assert note.title == "My Note"
+        assert note.frontmatter["title"] == "My Note"
+        assert note.tags == {"a", "b"}
+        assert note.aliases == ["x"]
+        assert note.content.strip() == "Body."
+
+    def test_tags_as_string(self, parser):
+        raw = "---\ntags: one, two\n---\nBody\n"
+        note = parser.parse(raw, "a.md")
+        assert note.tags == {"one", "two"}
+
+    def test_invalid_yaml_treated_as_body(self, parser):
+        raw = "---\n: bad: [unclosed\n---\nBody text.\n"
+        note = parser.parse(raw, "a.md")
+        assert note.frontmatter == {}
+        assert "Body text." in note.content
+
+    def test_title_falls_back_to_stem(self, parser):
+        note = parser.parse("No frontmatter here.", "folder/some-note.md")
+        assert note.title == "some-note"
+
+
+class TestParseTags:
+    def test_inline_tag(self, parser):
+        note = parser.parse("Hello #tag world", "a.md")
+        assert "tag" in note.tags
+
+    def test_nested_tag(self, parser):
+        note = parser.parse("Hello #nested/tag world", "a.md")
+        assert "nested/tag" in note.tags
+
+    def test_heading_is_not_tag(self, parser):
+        note = parser.parse("# Heading\n\nBody #real one", "a.md")
+        assert note.tags == {"real"}
+
+    def test_code_block_tags_ignored(self, parser):
+        raw = "```python\n# not-a-tag\nx = '#alsonot'\n```\n\n#yes\n"
+        note = parser.parse(raw, "a.md")
+        assert note.tags == {"yes"}
+
+    def test_pure_number_not_tag(self, parser):
+        note = parser.parse("Issue #123 but #v2 counts", "a.md")
+        assert "123" not in note.tags
+        assert "v2" in note.tags
+
+
+class TestParseCallouts:
+    def test_callout_preserved(self, parser):
+        raw = "> [!note] Title\n> Callout body.\n"
+        note = parser.parse(raw, "a.md")
+        assert "[!note] Title" in note.content
+        assert "Callout body." in note.content
+
+
+class TestParseDataview:
+    def test_dataview_block_captured(self, parser):
+        raw = "Before\n\n```dataview\nLIST FROM #tag\n```\n\nAfter\n"
+        note = parser.parse(raw, "a.md")
+        assert note.dataview_queries == ["LIST FROM #tag"]
+
+    def test_dataview_not_tag_source(self, parser):
+        raw = "```dataview\nLIST FROM #hidden\n```\n"
+        note = parser.parse(raw, "a.md")
+        assert "hidden" not in note.tags
+
+    def test_dataviewjs_captured(self, parser):
+        raw = "```dataviewjs\ndv.list()\n```\n"
+        note = parser.parse(raw, "a.md")
+        assert note.dataview_queries == ["dv.list()"]
+
+
+class TestParseCanvas:
+    def test_parse_canvas(self):
+        payload = {
+            "nodes": [
+                {"id": "a", "type": "file", "file": "x.md"},
+                {"id": "b", "type": "text", "text": "hello"},
+            ],
+            "edges": [{"fromNode": "a", "toNode": "b"}],
+        }
+        canvas = parse_canvas(json.dumps(payload), "canvas/overview.canvas")
+        assert canvas.title == "overview"
+        assert len(canvas.cards) == 2
+        assert canvas.cards[0].file_path == "x.md"
+        assert canvas.connections == [("a", "b")]
+
+    def test_invalid_json_raises(self):
+        with pytest.raises(ValueError):
+            parse_canvas("{not json", "c.canvas")

--- a/packages/ai-parrot/tests/interfaces/obsidian/test_rest_backend.py
+++ b/packages/ai-parrot/tests/interfaces/obsidian/test_rest_backend.py
@@ -1,0 +1,145 @@
+"""Tests for RestVaultBackend against a mock Local REST API server."""
+import pytest
+from aiohttp import web
+
+from parrot.interfaces.obsidian.abstract import VaultAccessError
+from parrot.interfaces.obsidian.rest import RestVaultBackend
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_app(store: dict[str, str]) -> web.Application:
+    """Minimal emulation of the Obsidian Local REST API plugin routes."""
+
+    async def list_root(request: web.Request) -> web.Response:
+        return _listing(store, prefix="")
+
+    async def vault_entry(request: web.Request) -> web.Response:
+        tail = request.match_info["tail"]
+        if tail.endswith("/") or tail == "":
+            return _listing(store, prefix=tail)
+        if request.method == "GET":
+            if tail not in store:
+                return web.Response(status=404)
+            return web.Response(text=store[tail])
+        if request.method == "PUT":
+            store[tail] = (await request.read()).decode("utf-8")
+            return web.Response(status=204)
+        if request.method == "DELETE":
+            if tail not in store:
+                return web.Response(status=404)
+            del store[tail]
+            return web.Response(status=204)
+        return web.Response(status=405)
+
+    def _listing(files: dict[str, str], prefix: str) -> web.Response:
+        names: set[str] = set()
+        for path in files:
+            if not path.startswith(prefix):
+                continue
+            rest = path[len(prefix):]
+            if "/" in rest:
+                names.add(rest.split("/", 1)[0] + "/")
+            else:
+                names.add(rest)
+        if not names and prefix:
+            return web.json_response({"errorCode": 404}, status=404)
+        return web.json_response({"files": sorted(names)})
+
+    async def search_simple(request: web.Request) -> web.Response:
+        query = request.query.get("query", "").lower()
+        rows = []
+        for path, text in store.items():
+            if query and query in text.lower():
+                rows.append(
+                    {
+                        "filename": path,
+                        "score": float(text.lower().count(query)),
+                        "matches": [{"context": text[:60]}],
+                    }
+                )
+        return web.json_response(rows)
+
+    app = web.Application()
+    app.router.add_get("/vault/", list_root)
+    app.router.add_post("/search/simple/", search_simple)
+    app.router.add_route("*", "/vault/{tail:.*}", vault_entry)
+    return app
+
+
+@pytest.fixture
+def store() -> dict[str, str]:
+    return {
+        "orphan.md": "Just a lonely note.",
+        "daily/today.md": "Links to [[orphan]] twice: [[orphan]].",
+        "concepts/ml.md": "---\ntags: [ml]\n---\nMachine learning body.",
+        ".obsidian/app.json": "{}",
+    }
+
+
+@pytest.fixture
+async def backend(store):
+    runner = web.AppRunner(_make_app(store))
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    host, port = runner.addresses[0][:2]
+    vault = RestVaultBackend(
+        base_url=f"http://{host}:{port}", api_key="secret", verify_ssl=False
+    )
+    yield vault
+    await vault.close()
+    await runner.cleanup()
+
+
+class TestRestBackend:
+    async def test_list_files_recursive(self, backend):
+        infos = await backend.list_files()
+        paths = [info.path for info in infos]
+        assert "daily/today.md" in paths
+        assert "concepts/ml.md" in paths
+        assert all(not path.startswith(".obsidian") for path in paths)
+
+    async def test_read_note(self, backend):
+        assert "lonely" in await backend.read_note("orphan")
+
+    async def test_read_missing_raises(self, backend):
+        with pytest.raises(FileNotFoundError):
+            await backend.read_note("nope")
+
+    async def test_write_and_exists(self, backend, store):
+        await backend.write_note("new-note", "# Hello")
+        assert store["new-note.md"] == "# Hello"
+        assert await backend.note_exists("new-note") is True
+
+    async def test_write_no_overwrite(self, backend):
+        with pytest.raises(FileExistsError):
+            await backend.write_note("orphan", "x", overwrite=False)
+
+    async def test_delete(self, backend, store):
+        assert await backend.delete_note("orphan") is True
+        assert "orphan.md" not in store
+        assert await backend.delete_note("orphan") is False
+
+    async def test_stat_degrades_gracefully(self, backend):
+        info = await backend.stat("orphan")
+        assert info.mtime is None
+        assert info.size == len("Just a lonely note.")
+
+    async def test_search(self, backend):
+        hits = await backend.search("machine")
+        assert hits and hits[0].path == "concepts/ml.md"
+
+    async def test_get_note_parses(self, backend):
+        note = await backend.get_note("concepts/ml")
+        assert "ml" in note.tags
+
+    async def test_index_over_rest(self, backend):
+        index = await backend.build_index()
+        assert index.backlinks("orphan") == ["daily/today"]
+
+    async def test_unreachable_server(self):
+        vault = RestVaultBackend(base_url="http://127.0.0.1:1", timeout=0.5)
+        with pytest.raises(VaultAccessError):
+            await vault.read_note("x")
+        await vault.close()

--- a/packages/ai-parrot/tests/interfaces/obsidian/test_vault_index.py
+++ b/packages/ai-parrot/tests/interfaces/obsidian/test_vault_index.py
@@ -1,0 +1,91 @@
+"""Unit tests for VaultIndex resolution, backlinks, orphans (FEAT-392)."""
+from parrot.interfaces.obsidian.index import VaultIndex
+from parrot.interfaces.obsidian.parser import ObsidianNoteParser
+
+
+def _build_index() -> VaultIndex:
+    parser = ObsidianNoteParser()
+    notes = [
+        parser.parse(
+            "---\naliases: [ML, ml-notes]\n---\nBody #ml", "concepts/machine-learning.md"
+        ),
+        parser.parse("Links to [[machine-learning]] and [[ML]].", "daily/today.md"),
+        parser.parse("Path link [[concepts/machine-learning]].", "projects/proj.md"),
+        parser.parse("Broken [[nowhere-to-be-found]].", "broken.md"),
+        parser.parse("Nothing here.", "orphan.md"),
+        parser.parse("Root duplicate.", "notes.md"),
+        parser.parse("Deep duplicate.", "deep/nested/notes.md"),
+        parser.parse("Ambiguous [[notes]] link.", "ambig.md"),
+    ]
+    return VaultIndex.build(notes)
+
+
+class TestResolve:
+    def test_resolve_by_name(self):
+        index = _build_index()
+        assert index.resolve("machine-learning") == "concepts/machine-learning"
+
+    def test_resolve_by_path(self):
+        index = _build_index()
+        assert (
+            index.resolve("concepts/machine-learning")
+            == "concepts/machine-learning"
+        )
+
+    def test_resolve_by_alias(self):
+        index = _build_index()
+        assert index.resolve("ML") == "concepts/machine-learning"
+        assert index.resolve("ml-notes") == "concepts/machine-learning"
+
+    def test_resolve_with_md_suffix(self):
+        index = _build_index()
+        assert index.resolve("machine-learning.md") == "concepts/machine-learning"
+
+    def test_shortest_path_wins_on_duplicates(self):
+        index = _build_index()
+        assert index.resolve("notes") == "notes"
+
+    def test_unresolvable_returns_none(self):
+        index = _build_index()
+        assert index.resolve("nowhere-to-be-found") is None
+        assert index.resolve("") is None
+
+
+class TestBacklinks:
+    def test_backlinks(self):
+        index = _build_index()
+        backlinks = index.backlinks("concepts/machine-learning")
+        assert backlinks == ["daily/today", "projects/proj"]
+
+    def test_outlinks(self):
+        index = _build_index()
+        targets = [link.target for link in index.outlinks("daily/today")]
+        assert targets == ["machine-learning", "ML"]
+
+    def test_unresolved_recorded(self):
+        index = _build_index()
+        assert ("broken", "nowhere-to-be-found") in index.unresolved()
+
+
+class TestTagsAndOrphans:
+    def test_notes_by_tag(self):
+        index = _build_index()
+        assert index.notes_by_tag("ml") == ["concepts/machine-learning"]
+        assert index.notes_by_tag("#ml") == ["concepts/machine-learning"]
+
+    def test_nested_tag_prefix_match(self):
+        parser = ObsidianNoteParser()
+        index = VaultIndex.build(
+            [parser.parse("Tagged #project/status here.", "a.md")]
+        )
+        assert index.notes_by_tag("project") == ["a"]
+        assert index.notes_by_tag("project/status") == ["a"]
+
+    def test_orphans(self):
+        index = _build_index()
+        assert "orphan" in index.orphans()
+        assert "daily/today" not in index.orphans()
+
+    def test_tag_counts(self):
+        index = _build_index()
+        assert index.tags().get("ml") == 1

--- a/packages/ai-parrot/tests/knowledge/wiki/test_mcp_server_vault.py
+++ b/packages/ai-parrot/tests/knowledge/wiki/test_mcp_server_vault.py
@@ -1,0 +1,153 @@
+"""Tests: Obsidian vault exposure through the wikitoolkit MCP server."""
+import asyncio
+import json
+import sys
+
+import pytest
+
+from parrot.knowledge.wiki.mcp_server import create_wiki_mcp_server
+from parrot.knowledge.wiki.project import (
+    WikiProjectConfig,
+    save_project_config,
+)
+from tests.interfaces.obsidian.conftest import fixture_vault  # noqa: F401
+from tests.knowledge.wiki.test_mcp_server import _seed_wiki, _subprocess_env
+
+BASE_TOOLS = {
+    "wiki_query", "wiki_page", "wiki_related",
+    "wiki_remember", "wiki_note", "wiki_status",
+}
+
+
+class TestVaultRegistration:
+    def test_no_vault_keeps_base_tool_set(self, tmp_path):
+        save_project_config(tmp_path, WikiProjectConfig(wiki_name="plain"))
+        server = create_wiki_mcp_server(tmp_path)
+        assert set(server.tools) == BASE_TOOLS
+
+    def test_vault_root_autodetected(self, fixture_vault):
+        save_project_config(fixture_vault, WikiProjectConfig(wiki_name="v"))
+        server = create_wiki_mcp_server(fixture_vault)
+        names = set(server.tools)
+        assert BASE_TOOLS <= names
+        assert "vault_ingest" in names
+        assert "obsidian_read_note" in names
+        assert "obsidian_search_with_backlinks" in names
+        assert "obsidian_delete_note" in names
+        assert "vault" in server.config.description
+
+    def test_vault_dir_config_registers_sibling_vault(self, tmp_path, fixture_vault):
+        save_project_config(
+            tmp_path,
+            WikiProjectConfig(wiki_name="v", vault_dir=str(fixture_vault)),
+        )
+        server = create_wiki_mcp_server(tmp_path)
+        assert "obsidian_catalog_notes" in server.tools
+        assert "vault_ingest" in server.tools
+
+    def test_confirming_tools_require_confirm_over_mcp(self, fixture_vault):
+        save_project_config(fixture_vault, WikiProjectConfig(wiki_name="v"))
+        server = create_wiki_mcp_server(fixture_vault)
+        destructive = server.tools["obsidian_delete_note"]
+        schema = destructive.to_mcp_tool_definition()["inputSchema"]
+        assert "confirm" in schema["required"]
+        readonly = server.tools["obsidian_read_note"]
+        schema = readonly.to_mcp_tool_definition()["inputSchema"]
+        assert "confirm" not in schema.get("required", [])
+        # vault_ingest is a wiki-plane write, not a vault mutation — no gate.
+        ingest = server.tools["vault_ingest"]
+        schema = ingest.to_mcp_tool_definition()["inputSchema"]
+        assert "confirm" not in schema.get("required", [])
+
+    @pytest.mark.asyncio
+    async def test_end_to_end_ingest_then_query(self, fixture_vault):
+        save_project_config(fixture_vault, WikiProjectConfig(wiki_name="v"))
+        server = create_wiki_mcp_server(fixture_vault)
+
+        ingest = await server.tools["vault_ingest"].execute({})
+        assert ingest["isError"] is False
+
+        query = await server.tools["wiki_query"].execute(
+            {"question": "machine learning"}
+        )
+        assert query["isError"] is False
+        assert "machine-learning" in query["content"][0]["text"]
+
+        # Unconfirmed destructive call is rejected; note untouched.
+        denied = await server.tools["obsidian_delete_note"].execute(
+            {"path": "orphan"}
+        )
+        assert denied["isError"] is True
+        read = await server.tools["obsidian_read_note"].execute(
+            {"path": "orphan"}
+        )
+        assert read["isError"] is False
+
+        # Confirmed call goes through.
+        allowed = await server.tools["obsidian_delete_note"].execute(
+            {"path": "orphan", "confirm": True}
+        )
+        assert allowed["isError"] is False
+
+
+class TestVaultStdioIntegration:
+    """Subprocess stdio run with a vault project — guards stdout purity
+    (the obsidian import chain prints navconfig diagnostics that must
+    never reach the JSON-RPC channel)."""
+
+    @pytest.mark.asyncio
+    async def test_vault_tools_over_stdio(self, fixture_vault):
+        await _seed_wiki(fixture_vault)  # .git + config + built plane
+
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable, "-m", "parrot.knowledge.wiki.mcp_server",
+            cwd=str(fixture_vault),
+            env=_subprocess_env(),
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            async def send(request: dict) -> dict:
+                proc.stdin.write((json.dumps(request) + "\n").encode())
+                await proc.stdin.drain()
+                line = await asyncio.wait_for(proc.stdout.readline(), timeout=30)
+                assert line, "no response — server exited early"
+                return json.loads(line)
+
+            resp = await send({
+                "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}
+            })
+            assert resp["result"]["serverInfo"]["name"] == "wikitoolkit"
+
+            resp = await send({
+                "jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}
+            })
+            tools = {t["name"]: t for t in resp["result"]["tools"]}
+            assert BASE_TOOLS <= set(tools)
+            assert "vault_ingest" in tools
+            assert "obsidian_read_note" in tools
+            delete_schema = tools["obsidian_delete_note"]["inputSchema"]
+            assert "confirm" in delete_schema["required"]
+
+            resp = await send({
+                "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+                "params": {"name": "vault_ingest", "arguments": {}},
+            })
+            assert resp["result"]["isError"] is False
+
+            resp = await send({
+                "jsonrpc": "2.0", "id": 4, "method": "tools/call",
+                "params": {
+                    "name": "obsidian_delete_note",
+                    "arguments": {"path": "orphan"},
+                },
+            })
+            assert resp["result"]["isError"] is True
+        finally:
+            proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=5)
+            except TimeoutError:
+                proc.kill()
+                await proc.wait()

--- a/packages/ai-parrot/tests/knowledge/wiki/test_vault_ingest_tool.py
+++ b/packages/ai-parrot/tests/knowledge/wiki/test_vault_ingest_tool.py
@@ -1,0 +1,124 @@
+"""Tests for VaultIngestTool and vault_dir resolution (Obsidian over MCP)."""
+import pytest
+
+from parrot.knowledge.wiki.project import (
+    WikiProjectConfig,
+    resolve_vault_dir,
+    wiki_write_lock,
+)
+from parrot.knowledge.wiki.store import create_wiki_store
+from parrot.knowledge.wiki.tools import VaultIngestTool
+from tests.interfaces.obsidian.conftest import fixture_vault  # noqa: F401
+
+
+class TestResolveVaultDir:
+    def test_override_wins(self, tmp_path, fixture_vault):
+        config = WikiProjectConfig(vault_dir="somewhere-else")
+        assert (
+            resolve_vault_dir(tmp_path, config, override=fixture_vault)
+            == fixture_vault.resolve()
+        )
+
+    def test_config_relative(self, tmp_path, fixture_vault):
+        config = WikiProjectConfig(vault_dir="vault")
+        assert resolve_vault_dir(tmp_path, config) == fixture_vault.resolve()
+
+    def test_config_absolute(self, tmp_path, fixture_vault):
+        config = WikiProjectConfig(vault_dir=str(fixture_vault))
+        assert resolve_vault_dir(tmp_path, config) == fixture_vault.resolve()
+
+    def test_root_autodetect(self, fixture_vault):
+        config = WikiProjectConfig()
+        assert resolve_vault_dir(fixture_vault, config) == fixture_vault.resolve()
+
+    def test_no_vault_returns_none(self, tmp_path):
+        assert resolve_vault_dir(tmp_path, WikiProjectConfig()) is None
+
+    def test_missing_configured_dir_returns_none(self, tmp_path):
+        config = WikiProjectConfig(vault_dir="does-not-exist")
+        assert resolve_vault_dir(tmp_path, config) is None
+
+
+@pytest.fixture
+def project(tmp_path, fixture_vault):
+    """A wiki project (root=tmp_path) configured to serve fixture_vault."""
+    config = WikiProjectConfig(wiki_name="vaultwiki", vault_dir=str(fixture_vault))
+    storage = config.storage_path(tmp_path)
+    storage.mkdir(parents=True, exist_ok=True)
+    store = create_wiki_store(storage, wiki_name="vaultwiki")
+    return tmp_path, config, store
+
+
+class TestVaultIngestTool:
+    @pytest.mark.asyncio
+    async def test_ingest_happy_path(self, project):
+        root, config, store = project
+        tool = VaultIngestTool(store, root=root, config=config)
+        result = await tool._execute()
+        assert result.success, result.error
+        payload = result.result
+        assert payload["notes"] == 7
+        assert payload["ingested"] == 7
+        assert payload["wikilink_edges"] >= 3
+        assert payload["pages_total"] > 7  # notes + dirs + tags
+
+        # Pages are queryable in the plane, backlinks traversable.
+        hits = await store.search_fts("machine learning", limit=5)
+        assert any("machine-learning" in h["concept_id"] for h in hits)
+        incoming = await store.neighbors(
+            "file:concepts/machine-learning.md", direction="in"
+        )
+        assert any(
+            row["concept_id"] == "file:daily/2026-07-30.md" for row in incoming
+        )
+
+    @pytest.mark.asyncio
+    async def test_second_run_incremental(self, project):
+        root, config, store = project
+        tool = VaultIngestTool(store, root=root, config=config)
+        await tool._execute()
+        second = await tool._execute()
+        assert second.success
+        assert second.result["ingested"] == 0
+        assert second.result["unchanged"] == 7
+
+    @pytest.mark.asyncio
+    async def test_force_reingests(self, project):
+        root, config, store = project
+        tool = VaultIngestTool(store, root=root, config=config)
+        await tool._execute()
+        forced = await tool._execute(force=True)
+        assert forced.success
+        assert forced.result["ingested"] == 7
+
+    @pytest.mark.asyncio
+    async def test_vault_path_override(self, tmp_path, fixture_vault):
+        config = WikiProjectConfig(wiki_name="w")  # no vault_dir
+        storage = config.storage_path(tmp_path)
+        storage.mkdir(parents=True, exist_ok=True)
+        store = create_wiki_store(storage, wiki_name="w")
+        tool = VaultIngestTool(store, root=tmp_path, config=config)
+        result = await tool._execute(vault_path=str(fixture_vault))
+        assert result.success
+        assert result.result["notes"] == 7
+
+    @pytest.mark.asyncio
+    async def test_no_vault_errors(self, tmp_path):
+        config = WikiProjectConfig(wiki_name="w")
+        storage = config.storage_path(tmp_path)
+        storage.mkdir(parents=True, exist_ok=True)
+        store = create_wiki_store(storage, wiki_name="w")
+        tool = VaultIngestTool(store, root=tmp_path, config=config)
+        result = await tool._execute()
+        assert result.success is False
+        assert "No Obsidian vault" in result.error
+
+    @pytest.mark.asyncio
+    async def test_lock_contention_refused(self, project):
+        root, config, store = project
+        tool = VaultIngestTool(store, root=root, config=config)
+        with wiki_write_lock(config.storage_path(root)) as held:
+            assert held
+            result = await tool._execute()
+        assert result.success is False
+        assert "writer" in result.error

--- a/packages/ai-parrot/tests/knowledge/wiki/test_vault_scan.py
+++ b/packages/ai-parrot/tests/knowledge/wiki/test_vault_scan.py
@@ -1,0 +1,143 @@
+"""Tests for the wikitoolkit Obsidian vault build mode (Phase E)."""
+import pytest
+
+from parrot.knowledge.wiki.vault_scan import (
+    is_obsidian_vault,
+    scan_vault,
+    tag_concept_id,
+)
+from tests.interfaces.obsidian.conftest import fixture_vault  # noqa: F401
+
+
+@pytest.fixture
+def scanned(fixture_vault):
+    return scan_vault(fixture_vault)
+
+
+class TestDetection:
+    def test_detects_vault(self, fixture_vault):
+        assert is_obsidian_vault(fixture_vault) is True
+
+    def test_plain_dir_not_vault(self, tmp_path):
+        assert is_obsidian_vault(tmp_path) is False
+
+
+class TestScanPages:
+    def test_note_pages(self, scanned):
+        scan, stats = scanned
+        assert stats.notes == 7
+        by_id = {fs.record.concept_id: fs.record for fs in scan.files}
+        record = by_id["file:projects/ai-parrot.md"]
+        assert record.category == "document"
+        assert record.title == "ai-parrot"
+        # Tags + aliases rendered into the body so FTS finds them.
+        assert "#project" in record.body
+        assert "Aliases: parrot, AI Parrot" in record.body
+        assert record.token_count > 0
+
+    def test_summary_from_first_line(self, scanned):
+        scan, _ = scanned
+        by_id = {fs.record.concept_id: fs.record for fs in scan.files}
+        assert by_id["file:orphan.md"].summary.startswith("Just a lonely note")
+
+    def test_vault_internals_skipped(self, scanned):
+        scan, _ = scanned
+        ids = {fs.record.concept_id for fs in scan.files}
+        assert not any(".obsidian" in cid or ".trash" in cid for cid in ids)
+
+    def test_non_utf8_skipped(self, scanned):
+        scan, _ = scanned
+        assert "non-utf8.md" in scan.skipped
+
+    def test_tag_pages(self, scanned):
+        scan, stats = scanned
+        tag_records = {
+            record.concept_id: record
+            for record in scan.dir_records
+            if record.category == "tag"
+        }
+        assert tag_concept_id("daily") in tag_records
+        daily = tag_records[tag_concept_id("daily")]
+        assert daily.title == "#daily"
+        assert "file:daily/2026-07-30.md" in daily.body
+        assert stats.tags == len(tag_records)
+
+
+class TestScanEdges:
+    def test_wikilink_reference_edges(self, scanned):
+        scan, _ = scanned
+        assert (
+            "file:daily/2026-07-30.md",
+            "file:projects/ai-parrot.md",
+            "references",
+        ) in scan.import_edges
+
+    def test_embed_edges(self, scanned):
+        scan, stats = scanned
+        embeds = [edge for edge in scan.import_edges if edge[2] == "embeds"]
+        assert stats.embed_edges == len(embeds)
+
+    def test_unresolved_dropped_but_counted(self, scanned):
+        scan, stats = scanned
+        targets = {edge[1] for edge in scan.import_edges}
+        assert not any("nonexistent-target" in target for target in targets)
+        assert ("broken-link-note.md", "nonexistent-target") in stats.unresolved_links
+
+    def test_tagged_edges(self, scanned):
+        scan, _ = scanned
+        assert (
+            "file:projects/ai-parrot.md",
+            tag_concept_id("project"),
+            "tagged",
+        ) in scan.dir_edges
+
+    def test_directory_contains_edges(self, scanned):
+        scan, _ = scanned
+        assert (
+            "dir:daily",
+            "file:daily/2026-07-30.md",
+            "contains",
+        ) in scan.dir_edges
+
+
+class TestStorePlane:
+    @pytest.mark.asyncio
+    async def test_fts_and_backlinks_through_sqlite(
+        self, fixture_vault, tmp_path
+    ):
+        """End-to-end: scan → SQLiteWikiStore → FTS hit + backlink query."""
+        from parrot.knowledge.wiki.store import create_wiki_store
+
+        scan, _ = scan_vault(fixture_vault)
+        store = create_wiki_store(tmp_path / "wiki", wiki_name="vault")
+        await store.upsert_pages([fs.record for fs in scan.files])
+        await store.upsert_pages(scan.dir_records)
+        await store.add_edges(scan.import_edges)
+        await store.add_edges(scan.dir_edges)
+
+        # FTS search finds notes by tag text rendered into the body.
+        hits = await store.search_fts("machine learning", limit=5)
+        assert any("machine-learning" in hit["concept_id"] for hit in hits)
+
+        # Backlinks: incoming 'references' edges to the ML note.
+        neighbors = await store.neighbors(
+            "file:concepts/machine-learning.md", direction="in"
+        )
+        sources = {row["concept_id"] for row in neighbors}
+        assert "file:daily/2026-07-30.md" in sources
+
+        # Tag page reachable via the 'tagged' relation.
+        tagged = await store.neighbors(
+            tag_concept_id("project"), rel="tagged", direction="in"
+        )
+        assert any(
+            row["concept_id"] == "file:projects/ai-parrot.md" for row in tagged
+        )
+
+
+class TestRepoScanExclusions:
+    def test_repo_scan_never_descends_into_vault_internals(self):
+        from parrot.knowledge.wiki.repo_scan import DEFAULT_EXCLUDE_DIRS
+
+        assert ".obsidian" in DEFAULT_EXCLUDE_DIRS
+        assert ".trash" in DEFAULT_EXCLUDE_DIRS

--- a/packages/ai-parrot/tests/loaders/obsidian/conftest.py
+++ b/packages/ai-parrot/tests/loaders/obsidian/conftest.py
@@ -1,0 +1,84 @@
+"""Fixtures for the Obsidian loader tests (FEAT-392)."""
+from typing import Any, Optional
+
+import pytest
+
+from tests.interfaces.obsidian.conftest import fixture_vault  # noqa: F401
+
+
+class StubPageIndex:
+    """Minimal PageIndexToolkit stand-in recording every mutation."""
+
+    def __init__(self) -> None:
+        self.trees: dict[str, dict[str, Any]] = {}
+        self.deleted: list[str] = []
+        self._counter = 0
+
+    async def get_tree(self, tree_name: str) -> dict[str, Any]:
+        if tree_name not in self.trees:
+            raise KeyError(tree_name)
+        return self.trees[tree_name]
+
+    async def create_tree(
+        self, tree_name: str, doc_name: Optional[str] = None
+    ) -> dict[str, Any]:
+        self.trees[tree_name] = {"tree_name": tree_name, "nodes": []}
+        return {"tree_name": tree_name}
+
+    async def add_node(
+        self,
+        tree_name: str,
+        title: str,
+        body: str = "",
+        parent_node_id: Optional[str] = None,
+        summary: Optional[str] = None,
+        categories: Optional[list[str]] = None,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        self._counter += 1
+        node_id = f"node-{self._counter}"
+        self.trees.setdefault(
+            tree_name, {"tree_name": tree_name, "nodes": []}
+        )["nodes"].append(
+            {
+                "node_id": node_id,
+                "title": title,
+                "body": body,
+                "categories": categories or [],
+                "metadata": metadata or {},
+            }
+        )
+        return {
+            "tree_name": tree_name,
+            "node_id": node_id,
+            "parent_node_id": parent_node_id,
+        }
+
+    async def delete_node(self, tree_name: str, node_id: str) -> dict[str, Any]:
+        self.deleted.append(node_id)
+        tree = self.trees.get(tree_name) or {"nodes": []}
+        tree["nodes"] = [
+            node for node in tree["nodes"] if node["node_id"] != node_id
+        ]
+        return {"deleted": True}
+
+    def node_titles(self, tree_name: str) -> list[str]:
+        return [node["title"] for node in self.trees[tree_name]["nodes"]]
+
+    def node_by_title(self, tree_name: str, title: str) -> dict[str, Any]:
+        for node in self.trees[tree_name]["nodes"]:
+            if node["title"] == title:
+                return node
+        raise KeyError(title)
+
+
+@pytest.fixture
+def stub_pageindex() -> StubPageIndex:
+    return StubPageIndex()
+
+
+@pytest.fixture
+def source_manager(tmp_path):
+    from parrot.knowledge.wiki.sources import SourceCollectionManager
+
+    return SourceCollectionManager(tmp_path / "sources", backend="json")

--- a/packages/ai-parrot/tests/loaders/obsidian/test_graph_bridge.py
+++ b/packages/ai-parrot/tests/loaders/obsidian/test_graph_bridge.py
@@ -1,0 +1,121 @@
+"""Tests for ObsidianGraphBridge (FEAT-392 Module 5)."""
+import pytest
+
+from parrot.interfaces.obsidian import LocalVaultBackend
+from parrot.knowledge.graphindex.schema import EdgeKind, NodeKind
+from parrot.loaders.obsidian import ObsidianGraphBridge, ObsidianVaultLoader
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+async def graph(fixture_vault):
+    vault = LocalVaultBackend(fixture_vault, vault_name="testvault")
+    loader = ObsidianVaultLoader(vault)
+    notes, canvases = await loader.discover()
+    bridge = ObsidianGraphBridge(
+        notes, canvases, await vault.build_index(), vault_name="testvault"
+    )
+    return bridge.build_graph()
+
+
+class TestGraphNodes:
+    async def test_document_nodes_for_notes(self, graph):
+        nodes, _ = graph
+        by_id = {node.node_id: node for node in nodes}
+        note_node = by_id["obsidian::testvault::projects/ai-parrot"]
+        assert note_node.kind == NodeKind.DOCUMENT
+        assert note_node.domain_tags["obsidian_type"] == "note"
+        assert note_node.source_uri == "obsidian://testvault/projects/ai-parrot.md"
+
+    async def test_aliases_in_domain_tags(self, graph):
+        nodes, _ = graph
+        by_id = {node.node_id: node for node in nodes}
+        note_node = by_id["obsidian::testvault::projects/ai-parrot"]
+        assert note_node.domain_tags["aliases"] == ["parrot", "AI Parrot"]
+
+    async def test_tag_nodes_are_concepts(self, graph):
+        nodes, _ = graph
+        tag_node = next(
+            node for node in nodes
+            if node.node_id == "obsidian::testvault::tag::daily"
+        )
+        assert tag_node.kind == NodeKind.CONCEPT
+        assert tag_node.domain_tags["obsidian_type"] == "tag"
+
+    async def test_folder_nodes(self, graph):
+        nodes, _ = graph
+        folder = next(
+            node for node in nodes
+            if node.node_id == "obsidian::testvault::folder::daily"
+        )
+        assert folder.kind == NodeKind.DOCUMENT
+        assert folder.domain_tags["obsidian_type"] == "folder"
+
+    async def test_canvas_nodes(self, graph):
+        nodes, _ = graph
+        canvas = next(
+            node for node in nodes
+            if node.node_id == "obsidian::testvault::canvas::canvas/overview"
+        )
+        assert canvas.kind == NodeKind.DOCUMENT
+        assert canvas.domain_tags["obsidian_type"] == "canvas"
+
+    async def test_broken_link_placeholder(self, graph):
+        nodes, _ = graph
+        placeholder = next(
+            node for node in nodes
+            if node.domain_tags.get("status") == "unresolved"
+        )
+        assert placeholder.title == "nonexistent-target"
+
+
+class TestGraphEdges:
+    async def test_wikilink_references(self, graph):
+        _, edges = graph
+        assert any(
+            edge.source_id == "obsidian::testvault::daily/2026-07-30"
+            and edge.target_id == "obsidian::testvault::projects/ai-parrot"
+            and edge.kind == EdgeKind.REFERENCES
+            for edge in edges
+        )
+
+    async def test_embed_edges_tagged(self, graph):
+        _, edges = graph
+        embed = next(
+            edge for edge in edges
+            if edge.source_id == "obsidian::testvault::projects/ai-parrot"
+            and edge.domain_tags.get("embed")
+        )
+        assert embed.kind == EdgeKind.REFERENCES
+
+    async def test_tag_link_edges(self, graph):
+        _, edges = graph
+        assert any(
+            edge.target_id == "obsidian::testvault::tag::project"
+            and edge.domain_tags.get("obsidian_type") == "tag_link"
+            for edge in edges
+        )
+
+    async def test_folder_contains_edges(self, graph):
+        _, edges = graph
+        assert any(
+            edge.source_id == "obsidian::testvault::folder::daily"
+            and edge.target_id == "obsidian::testvault::daily/2026-07-30"
+            and edge.kind == EdgeKind.CONTAINS
+            for edge in edges
+        )
+
+    async def test_canvas_card_references(self, graph):
+        _, edges = graph
+        assert any(
+            edge.source_id == "obsidian::testvault::canvas::canvas/overview"
+            and edge.target_id == "obsidian::testvault::projects/ai-parrot"
+            and edge.kind == EdgeKind.REFERENCES
+            for edge in edges
+        )
+
+    async def test_edges_deduplicated(self, graph):
+        _, edges = graph
+        keys = [(e.source_id, e.target_id, e.kind.value) for e in edges]
+        assert len(keys) == len(set(keys))

--- a/packages/ai-parrot/tests/loaders/obsidian/test_loader.py
+++ b/packages/ai-parrot/tests/loaders/obsidian/test_loader.py
@@ -1,0 +1,127 @@
+"""Tests for ObsidianVaultLoader ingest / incremental update (FEAT-392)."""
+import pytest
+
+from parrot.loaders.obsidian import ObsidianLoader, ObsidianVaultLoader
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestDiscover:
+    async def test_discover_vault(self, fixture_vault):
+        loader = ObsidianVaultLoader(fixture_vault)
+        notes, canvases = await loader.discover()
+        note_paths = {note.path.as_posix() for note in notes}
+        assert "daily/2026-07-30.md" in note_paths
+        assert "non-utf8.md" not in note_paths          # skipped, not fatal
+        assert ".trash/old.md" not in note_paths        # skip patterns
+        assert [canvas.path.as_posix() for canvas in canvases] == [
+            "canvas/overview.canvas"
+        ]
+
+
+class TestFullIngest:
+    async def test_full_ingest(self, fixture_vault, stub_pageindex, source_manager):
+        loader = ObsidianVaultLoader(fixture_vault)
+        report = await loader.ingest(stub_pageindex, "wiki", source_manager)
+        assert report.phase == "raw_ingest"
+        assert report.notes_processed == 7
+        assert report.canvas_processed == 1
+        assert report.nodes_created == 8
+        titles = stub_pageindex.node_titles("wiki")
+        assert "Daily 2026-07-30" in titles     # frontmatter title
+        assert "overview" in titles             # canvas node
+        # Tags become categories; obsidian extras land in node metadata.
+        node = stub_pageindex.node_by_title("wiki", "ai-parrot")
+        assert "project" in node["categories"]
+        assert node["metadata"]["aliases"] == ["parrot", "AI Parrot"]
+        assert node["metadata"]["obsidian_path"] == "projects/ai-parrot.md"
+
+    async def test_dataview_queries_in_metadata(
+        self, fixture_vault, stub_pageindex, source_manager
+    ):
+        loader = ObsidianVaultLoader(fixture_vault)
+        await loader.ingest(stub_pageindex, "wiki", source_manager)
+        node = stub_pageindex.node_by_title("wiki", "ai-parrot")
+        assert node["metadata"]["dataview_queries"] == ["LIST FROM #project"]
+
+    async def test_sources_registered(
+        self, fixture_vault, stub_pageindex, source_manager
+    ):
+        loader = ObsidianVaultLoader(fixture_vault)
+        await loader.ingest(stub_pageindex, "wiki", source_manager)
+        uris = {entry.source_uri for entry in source_manager.list_sources()}
+        assert any(uri.endswith("orphan.md") for uri in uris)
+
+    async def test_circular_embeds_detected(
+        self, fixture_vault, stub_pageindex, source_manager
+    ):
+        (fixture_vault / "cycle-a.md").write_text("![[cycle-b]]", encoding="utf-8")
+        (fixture_vault / "cycle-b.md").write_text("![[cycle-a]]", encoding="utf-8")
+        loader = ObsidianVaultLoader(fixture_vault)
+        report = await loader.ingest(stub_pageindex, "wiki", source_manager)
+        assert any("Circular embed" in error for error in report.errors)
+
+
+class TestIncrementalUpdate:
+    async def test_incremental_add_update_delete(
+        self, fixture_vault, stub_pageindex, source_manager
+    ):
+        loader = ObsidianVaultLoader(fixture_vault)
+        first = await loader.ingest(stub_pageindex, "wiki", source_manager)
+        assert first.files_added == 8
+
+        # Add a new note, modify one, delete one.
+        (fixture_vault / "fresh.md").write_text("Brand new.", encoding="utf-8")
+        (fixture_vault / "orphan.md").write_text(
+            "Changed content entirely.", encoding="utf-8"
+        )
+        (fixture_vault / "broken-link-note.md").unlink()
+        loader.vault.invalidate_index()
+
+        second = await loader.incremental_update(
+            stub_pageindex, "wiki", source_manager
+        )
+        assert second.files_added == 1
+        assert second.files_updated >= 1
+        assert second.files_deleted == 1
+        assert stub_pageindex.deleted  # old node ids removed
+        titles = stub_pageindex.node_titles("wiki")
+        assert "fresh" in titles
+        assert "broken-link-note" not in titles
+
+    async def test_incremental_noop_when_unchanged(
+        self, fixture_vault, stub_pageindex, source_manager
+    ):
+        loader = ObsidianVaultLoader(fixture_vault)
+        await loader.ingest(stub_pageindex, "wiki", source_manager)
+        report = await loader.incremental_update(
+            stub_pageindex, "wiki", source_manager
+        )
+        assert report.files_added == 0
+        assert report.files_updated == 0
+        assert report.files_deleted == 0
+
+    async def test_incremental_requires_local_backend(self, fixture_vault):
+        from parrot.interfaces.obsidian import RestVaultBackend
+
+        loader = ObsidianVaultLoader(RestVaultBackend())
+        with pytest.raises(NotImplementedError):
+            await loader.incremental_update(None, "wiki", None)
+
+
+class TestAbstractLoaderAdapter:
+    async def test_load_single_note(self, fixture_vault):
+        loader = ObsidianLoader()
+        documents = await loader._load(fixture_vault / "projects" / "ai-parrot.md")
+        assert len(documents) == 1
+        document = documents[0]
+        assert "New body" not in document.page_content
+        assert document.metadata["obsidian_vault"] == "vault"
+        assert document.metadata["obsidian_path"] == "projects/ai-parrot.md"
+        assert "project" in document.metadata["tags"]
+        assert document.metadata["document_meta"]["title"] == "ai-parrot"
+
+    async def test_load_whole_vault(self, fixture_vault):
+        loader = ObsidianLoader()
+        documents = await loader._load(fixture_vault)
+        assert len(documents) == 7

--- a/packages/ai-parrot/tests/loaders/obsidian/test_pipeline.py
+++ b/packages/ai-parrot/tests/loaders/obsidian/test_pipeline.py
@@ -1,0 +1,140 @@
+"""Integration tests: vault → PageIndex + GraphIndex, entity extraction."""
+from typing import Any, Optional
+
+import pytest
+
+from parrot.interfaces.obsidian import LocalVaultBackend
+from parrot.loaders.obsidian import ObsidianGraphBridge, ObsidianVaultLoader
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestVaultToWikiPipeline:
+    async def test_vault_to_wiki_pipeline(
+        self, fixture_vault, stub_pageindex, source_manager
+    ):
+        """Phase 1 + Phase 1b: fixture vault → PageIndex + graph structures."""
+        vault = LocalVaultBackend(fixture_vault, vault_name="pipeline")
+        loader = ObsidianVaultLoader(vault)
+
+        report = await loader.ingest(stub_pageindex, "wiki", source_manager)
+        assert report.nodes_created == 8
+        assert not [
+            error for error in report.errors if "Circular" not in error
+        ]
+
+        notes, canvases = await loader.discover()
+        bridge = ObsidianGraphBridge(
+            notes, canvases, await vault.build_index(), vault_name="pipeline"
+        )
+        nodes, edges = bridge.build_graph()
+        kinds = {node.kind.value for node in nodes}
+        assert {"document", "concept"} <= kinds
+        assert len(edges) > len(notes)  # links + tags + containment
+
+    async def test_incremental_pipeline(
+        self, fixture_vault, stub_pageindex, source_manager
+    ):
+        loader = ObsidianVaultLoader(fixture_vault)
+        await loader.ingest(stub_pageindex, "wiki", source_manager)
+        (fixture_vault / "late-arrival.md").write_text(
+            "Points to [[orphan]].", encoding="utf-8"
+        )
+        loader.vault.invalidate_index()
+        report = await loader.incremental_update(
+            stub_pageindex, "wiki", source_manager
+        )
+        assert report.files_added == 1
+        assert "late-arrival" in stub_pageindex.node_titles("wiki")
+
+
+class _StubAdapter:
+    """LLM adapter stub returning canned entity JSON."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def ask_json(self, prompt: str, **kwargs: Any) -> Any:
+        self.calls.append(prompt)
+        return [
+            {"name": "AI-Parrot", "kind": "entity", "summary": "The framework."},
+            {"name": "Machine Learning", "kind": "concept", "summary": "A field."},
+        ]
+
+
+class _StubContentStore:
+    def __init__(self, bodies: dict[str, str]) -> None:
+        self._bodies = bodies
+
+    def loader_for(self, tree_name: str):
+        return lambda key: self._bodies.get(key, "")
+
+
+class _StubGraph:
+    def __init__(self) -> None:
+        self.concepts: list[str] = []
+
+    async def create_concept(
+        self,
+        title: str,
+        summary: str,
+        source_uri: Optional[str] = None,
+        categories: Optional[list] = None,
+    ) -> dict:
+        self.concepts.append(title)
+        return {"node_id": f"g-{len(self.concepts)}", "status": "created"}
+
+
+class TestExtractEntities:
+    async def test_extract_entities(self, stub_pageindex, source_manager):
+        from parrot.knowledge.wiki.bookkeeper import WikiBookkeeper
+        from parrot.knowledge.wiki.ingest import WikiIngestOrchestrator
+        from parrot.knowledge.wiki.models import WikiConfig
+
+        await stub_pageindex.create_tree("wiki")
+        result = await stub_pageindex.add_node(
+            "wiki", title="Page", body="A page about AI-Parrot and ML."
+        )
+        page_id = result["node_id"]
+        stub_pageindex._adapter = _StubAdapter()
+        stub_pageindex._light_adapter = None
+        stub_pageindex._content_store = _StubContentStore(
+            {page_id: "A long enough body describing AI-Parrot and ML."}
+        )
+        graph = _StubGraph()
+
+        orchestrator = WikiIngestOrchestrator(
+            stub_pageindex,
+            graph,
+            source_manager,
+            WikiBookkeeper(),
+        )
+        config = WikiConfig(wiki_name="wiki", storage_dir="/tmp/unused")
+        report = await orchestrator.extract_entities(
+            "wiki", config, granularity="standard"
+        )
+        assert report.status == "ok"
+        assert report.pages_created == 2
+        assert report.graph_nodes_created == 2
+        assert graph.concepts == ["AI-Parrot", "Machine Learning"]
+        titles = stub_pageindex.node_titles("wiki")
+        assert "AI-Parrot" in titles
+        # Sub-nodes are marked so re-extraction skips them.
+        entity = stub_pageindex.node_by_title("wiki", "AI-Parrot")
+        assert entity["metadata"]["extracted_from"] == page_id
+        assert entity["metadata"]["granularity"] == "standard"
+
+    async def test_extract_entities_missing_tree(
+        self, stub_pageindex, source_manager
+    ):
+        from parrot.knowledge.wiki.bookkeeper import WikiBookkeeper
+        from parrot.knowledge.wiki.ingest import WikiIngestOrchestrator
+        from parrot.knowledge.wiki.models import WikiConfig
+
+        stub_pageindex._adapter = _StubAdapter()
+        orchestrator = WikiIngestOrchestrator(
+            stub_pageindex, None, source_manager, WikiBookkeeper()
+        )
+        config = WikiConfig(wiki_name="wiki", storage_dir="/tmp/unused")
+        report = await orchestrator.extract_entities("missing", config)
+        assert report.status == "error"

--- a/packages/ai-parrot/tests/mcp/test_adapter_confirm.py
+++ b/packages/ai-parrot/tests/mcp/test_adapter_confirm.py
@@ -1,0 +1,66 @@
+"""MCPToolAdapter confirm-gate tests (Obsidian-over-MCP guarded writes)."""
+import pytest
+
+from parrot.mcp.adapter import MCPToolAdapter
+from parrot.tools.abstract import AbstractTool, ToolResult
+
+pytestmark = pytest.mark.asyncio
+
+
+class _EchoTool(AbstractTool):
+    name = "echo_tool"
+    description = "Echo the payload."
+
+    def __init__(self, requires_confirmation: bool = False):
+        super().__init__(name=self.name, description=self.description)
+        if requires_confirmation:
+            self.routing_meta = {"requires_confirmation": True}
+        self.calls: list[dict] = []
+
+    async def _execute(self, **kwargs) -> ToolResult:
+        self.calls.append(kwargs)
+        return ToolResult(result={"echo": kwargs})
+
+
+class TestConfirmGate:
+    def test_schema_gains_required_confirm(self):
+        adapter = MCPToolAdapter(_EchoTool(requires_confirmation=True))
+        definition = adapter.to_mcp_tool_definition()
+        schema = definition["inputSchema"]
+        assert schema["properties"]["confirm"]["type"] == "boolean"
+        assert "confirm" in schema["required"]
+
+    def test_plain_tool_schema_unchanged(self):
+        adapter = MCPToolAdapter(_EchoTool())
+        schema = adapter.to_mcp_tool_definition()["inputSchema"]
+        assert "confirm" not in schema.get("properties", {})
+        assert "confirm" not in schema.get("required", [])
+
+    async def test_unconfirmed_call_rejected(self):
+        tool = _EchoTool(requires_confirmation=True)
+        adapter = MCPToolAdapter(tool)
+        response = await adapter.execute({"payload": "x"})
+        assert response["isError"] is True
+        assert "confirm=true" in response["content"][0]["text"]
+        assert tool.calls == []  # never executed
+
+    async def test_confirm_false_rejected(self):
+        tool = _EchoTool(requires_confirmation=True)
+        adapter = MCPToolAdapter(tool)
+        response = await adapter.execute({"payload": "x", "confirm": False})
+        assert response["isError"] is True
+        assert tool.calls == []
+
+    async def test_confirmed_call_executes_without_confirm_kwarg(self):
+        tool = _EchoTool(requires_confirmation=True)
+        adapter = MCPToolAdapter(tool)
+        response = await adapter.execute({"payload": "x", "confirm": True})
+        assert response["isError"] is False
+        assert tool.calls == [{"payload": "x"}]  # confirm stripped
+
+    async def test_plain_tool_confirm_arg_stripped(self):
+        tool = _EchoTool()
+        adapter = MCPToolAdapter(tool)
+        response = await adapter.execute({"payload": "x", "confirm": True})
+        assert response["isError"] is False
+        assert tool.calls == [{"payload": "x"}]

--- a/packages/ai-parrot/tests/tools/test_obsidian_okf_tools.py
+++ b/packages/ai-parrot/tests/tools/test_obsidian_okf_tools.py
@@ -1,0 +1,140 @@
+"""Tests for the ObsidianToolkit OKF tools and the graph-bridge OKF hook."""
+import pytest
+
+from parrot.tools.obsidian import ObsidianToolkit
+from tests.interfaces.obsidian.conftest import fixture_vault  # noqa: F401
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def toolkit(fixture_vault) -> ObsidianToolkit:
+    return ObsidianToolkit(vault_path=fixture_vault)
+
+
+class TestOkfTools:
+    async def test_okf_tools_registered(self, toolkit):
+        names = toolkit.list_tool_names()
+        assert "obsidian_get_okf_metadata" in names
+        assert "obsidian_validate_okf_frontmatter" in names
+        assert "obsidian_classify_note" in names
+        assert "obsidian_apply_okf_frontmatter" in names
+        confirming = {
+            tool.name
+            for tool in toolkit.get_tools_sync()
+            if (tool.routing_meta or {}).get("requires_confirmation")
+        }
+        assert "obsidian_apply_okf_frontmatter" in confirming
+
+    async def test_get_okf_metadata_absent(self, toolkit):
+        result = await toolkit.get_okf_metadata("orphan")
+        assert result["has_okf"] is False
+        assert result["okf"] is None
+
+    async def test_apply_and_read_okf(self, toolkit):
+        applied = await toolkit.apply_okf_frontmatter(
+            "concepts/machine-learning",
+            {
+                "type": "Concept",
+                "summary": "A field of AI.",
+                "tags": ["ml"],
+                "relates_to": [
+                    {"concept": "[[daily/2026-07-30]]", "rel": "mentions"}
+                ],
+            },
+        )
+        assert applied["applied"] is True
+        assert applied["okf"]["type"] == "Concept"
+        # Wikilink target normalized to the stable note id.
+        assert applied["okf"]["relates_to"][0]["concept"] == "daily/2026-07-30"
+
+        result = await toolkit.get_okf_metadata("concepts/machine-learning")
+        assert result["has_okf"] is True
+        assert result["okf"]["id"] == "concepts/machine-learning"
+        # Native frontmatter must survive.
+        note = await toolkit.read_note("concepts/machine-learning")
+        assert note["frontmatter"]["title"] == "Machine Learning"
+
+    async def test_apply_rejects_unknown_type(self, toolkit):
+        with pytest.raises(ValueError, match="Unknown OKF type"):
+            await toolkit.apply_okf_frontmatter(
+                "orphan", {"type": "Nonsense", "summary": "x"}
+            )
+
+    async def test_apply_rejects_broken_target(self, toolkit):
+        with pytest.raises(ValueError, match="does not resolve"):
+            await toolkit.apply_okf_frontmatter(
+                "orphan",
+                {
+                    "type": "Concept",
+                    "summary": "x",
+                    "relates_to": [{"concept": "[[nowhere]]", "rel": "references"}],
+                },
+            )
+
+    async def test_validate_vault(self, toolkit):
+        await toolkit.apply_okf_frontmatter(
+            "orphan", {"type": "Concept", "summary": "Fine."}
+        )
+        result = await toolkit.validate_okf_frontmatter()
+        assert result["notes_with_okf"] == 1
+        assert result["findings"] == []
+
+    async def test_classify_note(self, toolkit):
+        await toolkit.create_note(
+            "policies/security-policy",
+            "Rules.",
+            frontmatter={"tags": ["policy"]},
+        )
+        result = await toolkit.classify_note("policies/security-policy")
+        types = [candidate["type"] for candidate in result["candidates"]]
+        assert types[0] == "Policy"
+        assert "Document" in types  # fallback always present
+
+
+class TestGraphBridgeOkfHook:
+    async def test_okf_note_upgrades_kind_and_edges(self, toolkit, fixture_vault):
+        from parrot.knowledge.graphindex.schema import EdgeKind, NodeKind
+        from parrot.loaders.obsidian import (
+            ObsidianGraphBridge,
+            ObsidianVaultLoader,
+        )
+
+        await toolkit.apply_okf_frontmatter(
+            "concepts/machine-learning",
+            {
+                "type": "Concept",
+                "summary": "A field of AI.",
+                "relates_to": [
+                    {"concept": "[[daily/2026-07-30]]", "rel": "explains"},
+                    {"concept": "[[orphan]]", "rel": "maps_to"},
+                ],
+            },
+        )
+        loader = ObsidianVaultLoader(toolkit.vault)
+        notes, canvases = await loader.discover()
+        bridge = ObsidianGraphBridge(
+            notes, canvases, await toolkit.vault.build_index(), vault_name="v"
+        )
+        nodes, edges = bridge.build_graph()
+
+        ml = next(
+            node for node in nodes
+            if node.node_id == "obsidian::v::concepts/machine-learning"
+        )
+        assert ml.kind == NodeKind.CONCEPT
+        assert ml.summary == "A field of AI."
+        assert ml.domain_tags["okf_type"] == "Concept"
+
+        assert any(
+            edge.kind == EdgeKind.EXPLAINS
+            and edge.source_id == "obsidian::v::concepts/machine-learning"
+            and edge.target_id == "obsidian::v::daily/2026-07-30"
+            for edge in edges
+        )
+        # 'maps_to' has no EdgeKind — carried as REFERENCES + okf_rel tag.
+        assert any(
+            edge.domain_tags.get("okf_rel") == "maps_to"
+            and edge.target_id == "obsidian::v::orphan"
+            for edge in edges
+        )

--- a/packages/ai-parrot/tests/tools/test_obsidian_toolkit.py
+++ b/packages/ai-parrot/tests/tools/test_obsidian_toolkit.py
@@ -2,8 +2,7 @@
 import pytest
 
 from parrot.tools.obsidian import _ALL_OPS, ObsidianToolkit
-
-pytest_plugins = ("tests.interfaces.obsidian.conftest",)
+from tests.interfaces.obsidian.conftest import fixture_vault  # noqa: F401
 
 pytestmark = pytest.mark.asyncio
 

--- a/packages/ai-parrot/tests/tools/test_obsidian_toolkit.py
+++ b/packages/ai-parrot/tests/tools/test_obsidian_toolkit.py
@@ -1,0 +1,193 @@
+"""Tests for ObsidianToolkit (Phase B of the Obsidian integration)."""
+import pytest
+
+from parrot.tools.obsidian import _ALL_OPS, ObsidianToolkit
+
+pytest_plugins = ("tests.interfaces.obsidian.conftest",)
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def toolkit(fixture_vault) -> ObsidianToolkit:
+    return ObsidianToolkit(vault_path=fixture_vault)
+
+
+class TestToolGeneration:
+    def test_all_tools_generated_with_prefix(self, toolkit):
+        names = toolkit.list_tool_names()
+        assert "obsidian_read_note" in names
+        assert "obsidian_search_with_backlinks" in names
+        assert "obsidian_catalog_notes" in names
+        assert len(names) == len(_ALL_OPS)
+
+    def test_tools_have_descriptions_and_schemas(self, toolkit):
+        for tool in toolkit.get_tools_sync():
+            assert tool.description, f"{tool.name} has no description"
+            schema = tool.get_schema()
+            assert schema["parameters"]["type"] == "object"
+
+    def test_confirming_tools_marked(self, toolkit):
+        confirming = {
+            tool.name
+            for tool in toolkit.get_tools_sync()
+            if (tool.routing_meta or {}).get("requires_confirmation")
+        }
+        assert confirming == {
+            "obsidian_create_note",
+            "obsidian_update_note",
+            "obsidian_append_note",
+            "obsidian_delete_note",
+            "obsidian_move_note",
+        }
+
+    def test_allowed_operations_filter(self, fixture_vault):
+        limited = ObsidianToolkit(
+            vault_path=fixture_vault,
+            allowed_operations={"read", "search", "backlinks"},
+        )
+        names = limited.list_tool_names()
+        assert sorted(names) == [
+            "obsidian_get_backlinks",
+            "obsidian_read_note",
+            "obsidian_search_notes",
+        ]
+
+    def test_unknown_operation_rejected(self, fixture_vault):
+        with pytest.raises(ValueError, match="unknown operation"):
+            ObsidianToolkit(vault_path=fixture_vault, allowed_operations={"nope"})
+
+    def test_missing_vault_path_rejected(self):
+        with pytest.raises(ValueError, match="vault_path is required"):
+            ObsidianToolkit()
+
+
+class TestReadTools:
+    async def test_read_note(self, toolkit):
+        result = await toolkit.read_note("projects/ai-parrot")
+        assert result["title"] == "ai-parrot"
+        assert "project" in result["tags"]
+        assert result["aliases"] == ["parrot", "AI Parrot"]
+        assert any(link["is_embed"] for link in result["links"])
+        assert "content" in result
+
+    async def test_read_note_without_content(self, toolkit):
+        result = await toolkit.read_note("orphan", include_content=False)
+        assert "content" not in result
+
+    async def test_read_notes_bulk(self, toolkit):
+        result = await toolkit.read_notes(["orphan", "missing", "non-utf8"])
+        assert len(result["notes"]) == 1
+        assert set(result["errors"]) == {"missing", "non-utf8"}
+
+    async def test_list_notes(self, toolkit):
+        result = await toolkit.list_notes(folder="daily")
+        assert result["count"] == 1
+        assert result["notes"][0]["path"] == "daily/2026-07-30.md"
+
+    async def test_get_note_metadata(self, toolkit):
+        result = await toolkit.get_note_metadata("concepts/machine-learning")
+        assert result["title"] == "Machine Learning"
+        assert result["file"]["size"] is not None
+        assert "content" not in result
+
+
+class TestSearchTools:
+    async def test_search_notes(self, toolkit):
+        result = await toolkit.search_notes(query="machine learning")
+        assert result["count"] >= 1
+        assert result["hits"][0]["path"] == "concepts/machine-learning"
+
+    async def test_search_by_tag(self, toolkit):
+        result = await toolkit.search_by_tag("project")
+        assert "projects/ai-parrot" in result["paths"]
+
+    async def test_search_with_backlinks(self, toolkit):
+        result = await toolkit.search_with_backlinks(query="machine learning")
+        hit = result["hits"][0]
+        assert "daily/2026-07-30" in hit["backlinks"]
+        assert any(
+            link["resolved_path"] == "daily/2026-07-30"
+            for link in hit["outlinks"]
+        )
+
+    async def test_get_backlinks(self, toolkit):
+        result = await toolkit.get_backlinks("projects/ai-parrot")
+        assert "daily/2026-07-30" in result["backlinks"]
+
+    async def test_get_outgoing_links(self, toolkit):
+        result = await toolkit.get_outgoing_links("broken-link-note")
+        assert result["unresolved"] == ["nonexistent-target"]
+
+    async def test_catalog_notes(self, toolkit):
+        result = await toolkit.catalog_notes()
+        assert result["note_count"] >= 6
+        assert result["tags"].get("daily") == 1
+        assert "orphan" in result["orphans"]
+        assert any(
+            row["target"] == "nonexistent-target"
+            for row in result["broken_links"]
+        )
+        assert result["aliases"]["parrot"] == "projects/ai-parrot"
+
+
+class TestWriteTools:
+    async def test_create_note_with_frontmatter(self, toolkit):
+        result = await toolkit.create_note(
+            "inbox/new-idea",
+            "Fresh thought.",
+            frontmatter={"tags": ["inbox"], "title": "New Idea"},
+        )
+        assert result["created"] is True
+        note = await toolkit.read_note("inbox/new-idea")
+        assert note["title"] == "New Idea"
+        assert "inbox" in note["tags"]
+
+    async def test_create_existing_fails(self, toolkit):
+        with pytest.raises(FileExistsError):
+            await toolkit.create_note("orphan", "clobber")
+
+    async def test_update_preserves_frontmatter(self, toolkit):
+        await toolkit.update_note("projects/ai-parrot", "New body only.")
+        note = await toolkit.read_note("projects/ai-parrot")
+        assert note["aliases"] == ["parrot", "AI Parrot"]
+        assert "New body only." in note["content"]
+
+    async def test_append_note(self, toolkit):
+        await toolkit.append_note("orphan", "Appended line.")
+        note = await toolkit.read_note("orphan")
+        assert note["content"].endswith("Appended line.")
+
+    async def test_delete_reports_affected_backlinks(self, toolkit):
+        result = await toolkit.delete_note("projects/ai-parrot.md")
+        assert result["deleted"] is True
+        assert "daily/2026-07-30" in result["affected_backlinks"]
+
+    async def test_move_note(self, toolkit):
+        result = await toolkit.move_note(
+            "concepts/machine-learning.md", "archive/ml.md"
+        )
+        assert result["moved"] is True
+        assert "daily/2026-07-30" in result["affected_backlinks"]
+        note = await toolkit.read_note("archive/ml")
+        assert note["title"] == "Machine Learning"
+        assert not await toolkit.vault.note_exists("concepts/machine-learning")
+
+    async def test_index_refreshes_after_write(self, toolkit):
+        await toolkit.create_note("linker", "Points at [[orphan]].")
+        result = await toolkit.get_backlinks("orphan")
+        assert "linker" in result["backlinks"]
+
+
+class TestLifecycle:
+    async def test_execute_via_tool_wrapper(self, toolkit):
+        tool = toolkit.get_tool("obsidian_read_note")
+        result = await tool.execute(path="orphan")
+        assert result.status == "success"
+        assert result.result["title"] == "orphan"
+
+    async def test_close_releases_backend(self, toolkit):
+        await toolkit._ensure_open()
+        assert toolkit._opened is True
+        await toolkit._close()
+        assert toolkit._opened is False

--- a/packages/ai-parrot/tests/tools/test_obsidian_toolkit.py
+++ b/packages/ai-parrot/tests/tools/test_obsidian_toolkit.py
@@ -38,6 +38,7 @@ class TestToolGeneration:
             "obsidian_append_note",
             "obsidian_delete_note",
             "obsidian_move_note",
+            "obsidian_apply_okf_frontmatter",
         }
 
     def test_allowed_operations_filter(self, fixture_vault):


### PR DESCRIPTION
## Summary

Implements the complete Obsidian vault integration pipeline (FEAT-392) with three major components:

1. **ObsidianToolkit** — LLM-callable tools for vault management (read/write/search/OKF metadata)
2. **ObsidianVaultLoader + ObsidianGraphBridge** — Phase 1 raw ingest into PageIndex/GraphIndex with hand-curated wikilink graph
3. **Shared vault interface** — Unified parsing and backend abstraction (local filesystem + REST API plugin) reused across toolkit, loader, and wikitoolkit

## Key Changes

### New Packages & Modules

- **`parrot.interfaces.obsidian`** — Shared vault interface (backend-agnostic)
  - `models.py` — Pydantic data models (ObsidianNote, ObsidianLink, ObsidianCanvas)
  - `parser.py` — Obsidian-flavored markdown parsing (wikilinks, embeds, tags, dataview queries)
  - `abstract.py` — Backend interface with cached VaultIndex
  - `local.py` — Direct filesystem backend (primary)
  - `rest.py` — Obsidian Local REST API plugin backend (optional)
  - `index.py` — Wikilink resolution engine (exact path → basename → alias matching)
  - `okf.py` — OKF metadata in frontmatter (read/validate/apply/project)

- **`parrot.tools.obsidian`** — ObsidianToolkit (Phase B)
  - 24 LLM-callable tools (read/write/search/metadata/OKF operations)
  - Destructive operations marked for human-in-the-loop confirmation
  - Supports both local and REST backends
  - Lazy vault initialization and cached index invalidation on mutations

- **`parrot.loaders.obsidian`** — Vault ingestion pipeline (Phase 1 + 1b)
  - `loader.py` — ObsidianVaultLoader (discover/ingest/incremental_update)
  - `graph_bridge.py` — ObsidianGraphBridge (vault structure → GraphIndex nodes/edges)
  - Embed cycle detection and unresolved wikilink tracking
  - OKF frontmatter hook for concept classification

- **`parrot.knowledge.wiki.vault_scan`** — Wikitoolkit vault build mode (Phase E)
  - Zero-LLM vault scanning (notes → pages, wikilinks → edges, tags → concepts)
  - Mirrors `repo_scan` conventions for incremental staleness and pruning
  - Integrated into `wikitoolkit build` pipeline

### Modified Modules

- **`parrot.knowledge.wiki.ingest`** — Added `extract_entities()` method (Phase 2 LLM entity extraction)
- **`parrot.knowledge.wiki.tools`** — Added `VaultIngestTool` for MCP-exposed vault ingestion
- **`parrot.knowledge.wiki.toolkit`** — Added `ingest_obsidian_vault()` orchestration method
- **`parrot.knowledge.wiki.mcp_server`** — Auto-detect and register vault tools
- **`parrot.knowledge.wiki.project`** — Added `resolve_vault_dir()` for vault path resolution
- **`parrot.knowledge.wiki.cli`** — Added `--vault/--no-vault` mode flag
- **`parrot.mcp.adapter`** — Enhanced to support confirmation-gated tools
- **`parrot.tools.__init__`** — Exported ObsidianToolkit
- **`parrot.knowledge.graphindex.schema`** — Added `domain_tags` field to UniversalEdge
- **`pyproject.toml`** — Added `marko` dependency for markdown parsing

### Test Coverage

- **`tests/interfaces/obsidian/`** — Parser, backends, index, OKF validation, vault fixtures
- **`tests/loaders/obsidian/`** — Loader ingest, graph bridge, incremental updates

https://claude.ai/code/session_015zs7cQRKbnahyWwKgb53LW