### PR TITLE
Add InfographicResponse → A2UI adapter (FEAT-273 Module 11)

### DIFF
--- a/packages/ai-parrot-visualizations/tests/outputs/a2ui_renderers/test_e2e_ssr_html.py
+++ b/packages/ai-parrot-visualizations/tests/outputs/a2ui_renderers/test_e2e_ssr_html.py
@@ -43,3 +43,42 @@ async def test_e2e_tool_envelope_to_html():
     assert "&lt;b&gt;Sales&lt;/b&gt;" in doc
     # Baked: no live bindings remain.
     assert "$bind" not in doc
+    # ...and the bound rows actually reach the document. Absence of "$bind" alone
+    # was never proof of that: before row materialisation the resolved rows sat in
+    # an inert property on a childless node and every table rendered empty.
+    assert "EU" in doc
+    assert ">5<" in doc
+
+
+async def test_e2e_bound_rows_render_as_escaped_cells():
+    """Every bound row reaches the document, in declared column order, escaped."""
+    envelope = CreateSurface(
+        surfaceId="report",
+        catalogId="https://parrot.dev/catalogs/v1",
+        components=[
+            Component(
+                id="blk-000",
+                component="DataTable",
+                properties={
+                    "columns": [{"name": "region"}, {"name": "total"}],
+                    "data": {"$bind": "/rows"},
+                },
+            )
+        ],
+        dataModel={
+            "rows": [
+                {"region": "EU", "total": 5},
+                {"region": "APAC", "total": 7},
+                {"region": "<script>alert(1)</script>", "total": None},
+            ]
+        },
+    )
+    doc = (await SSRHTMLRenderer().render(envelope)).content.decode()
+
+    # One cell per column per row.
+    assert doc.count('class="a2ui-text a2ui-cell"') == 6
+    for value in ("EU", "APAC", ">5<", ">7<"):
+        assert value in doc
+    # Cell data is data, never markup.
+    assert "<script>alert(1)</script>" not in doc
+    assert "&lt;script&gt;" in doc

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/adapters/__init__.py
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/adapters/__init__.py
@@ -1,0 +1,17 @@
+"""Deterministic adapters from legacy Parrot output models to A2UI envelopes.
+
+Each adapter is a **pure function**: same input → byte-identical ``CreateSurface``.
+No clocks, no uuids, no network, no LLM tokens — the D1a (tool-producer) lane of
+spec FEAT-273 §1/G2 applied to output models that predate the A2UI catalog.
+
+One-way import rule (spec G8): this subpackage imports only the a2ui core plus
+pure Pydantic model modules under ``parrot.models``. It MUST NEVER import
+``parrot.bots``, ``parrot.clients`` or ``parrot.tools.dataset_manager``.
+"""
+
+from parrot.outputs.a2ui.adapters.infographic import (
+    CHART_TYPE_MAP,
+    infographic_response_to_envelope,
+)
+
+__all__ = ["CHART_TYPE_MAP", "infographic_response_to_envelope"]

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/adapters/infographic.py
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/adapters/infographic.py
@@ -1,0 +1,489 @@
+"""``InfographicResponse`` → A2UI ``CreateSurface`` adapter (FEAT-273 Module 11 lane).
+
+Bridges the legacy structured infographic model (:mod:`parrot.models.infographic`,
+an ordered flat list of typed blocks) to the A2UI ``Infographic`` composite catalog
+component (a header plus ordered *sections* nesting other catalog components).
+
+The function is **pure and deterministic**: same input → byte-identical envelope.
+No clocks, no uuids, no network, no LLM tokens (spec G2/D1a).
+
+Sectioning policy
+-----------------
+``InfographicResponse.blocks`` is flat; the ``Infographic`` component is sectioned.
+Blocks are grouped with these rules, applied in order:
+
+* The **first** ``title`` block supplies the surface ``title``/``subtitle`` and does
+  not open a section.
+* Any **later** ``title`` block opens a new section (``heading`` = its title,
+  ``text`` = its subtitle).
+* A ``divider`` block closes the current section and opens an anonymous one.
+* ``accordion`` and ``tab_view`` blocks flatten: each item/pane becomes its own
+  sibling section (A2UI sections do not nest), with its nested blocks mapped as
+  that section's components.
+* Every other block maps to a nested catalog component appended to the current
+  section. A ``summary`` becomes the section's ``text`` when that slot is still
+  free, otherwise a ``Card``.
+
+Block → component mapping
+-------------------------
+=================  =====================================================
+Block              A2UI component
+=================  =====================================================
+``hero_card``      ``KPICard``
+``chart``          ``Chart`` (+ rows into the data model, bound by pointer)
+``table``          ``DataTable`` (+ rows into the data model)
+``timeline``       ``Timeline``
+``progress``       one ``KPICard`` per item
+``summary``        section ``text``, else ``Card``
+``bullet_list``    ``Card`` (items rendered into ``body``)
+``checklist``      ``Card`` (items rendered into ``body``)
+``callout``        ``Card`` (``badge`` carries the level)
+``quote``          ``Card`` (``footer`` carries the attribution)
+``image``          ``Card`` (``image`` + ``footer`` caption)
+=================  =====================================================
+
+Known lossy degradations (spec §8, OQ-C):
+
+* Chart types with no A2UI equivalent (``radar``, ``heatmap``, ``treemap``,
+  ``gauge``, ``funnel``, ``waterfall``, ``donut``) collapse to the nearest
+  supported type — see :data:`CHART_TYPE_MAP`.
+* Presentation-only fields (``layout``, ``color_by_sign``, per-series colors,
+  table ``style``, bullet ``columns``…) are dropped: A2UI carries data and
+  semantics, and the renderer owns presentation.
+* ``Card`` ``title`` is omitted for blocks with no title-like field. The lowering
+  in ``catalog/components/card.py`` skips absent properties, so this degrades to a
+  title-less card rather than an invented heading.
+
+One-way import rule (G8): this module imports only the a2ui core and the pure
+Pydantic ``parrot.models.infographic`` module — never agents, clients or
+DatasetManager.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from parrot.outputs.a2ui.builders import build_infographic
+from parrot.outputs.a2ui.models import CreateSurface
+
+__all__ = ["CHART_TYPE_MAP", "infographic_response_to_envelope"]
+
+
+#: ``ChartType`` (legacy, 12 members) → A2UI ``Chart`` ``type`` enum
+#: (``bar``/``line``/``area``/``scatter``/``pie``/``map``). Types with no direct
+#: equivalent collapse to their nearest supported neighbour — a documented,
+#: deterministic degradation, never a silent drop.
+CHART_TYPE_MAP: dict[str, str] = {
+    "bar": "bar",
+    "line": "line",
+    "area": "area",
+    "scatter": "scatter",
+    "pie": "pie",
+    "donut": "pie",
+    "radar": "line",
+    "funnel": "bar",
+    "waterfall": "bar",
+    "heatmap": "bar",
+    "treemap": "bar",
+    "gauge": "bar",
+}
+
+_CHART_FALLBACK = "bar"
+
+#: Maximum nesting depth followed when flattening ``accordion``/``tab_view``.
+#: Beyond it, nested blocks degrade to a ``Card`` instead of recursing.
+_MAX_NESTING_DEPTH = 4
+
+_X_COLUMN = "label"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    """Return a plain dict view of a Pydantic model or mapping (never mutates)."""
+    dumper = getattr(value, "model_dump", None)
+    if callable(dumper):
+        return dumper(mode="json")
+    if isinstance(value, dict):
+        return dict(value)
+    raise TypeError(
+        f"Expected an InfographicResponse, block model or mapping, got {type(value)!r}."
+    )
+
+
+def _clean(props: dict[str, Any]) -> dict[str, Any]:
+    """Drop ``None`` values so absent optionals never reach the wire."""
+    return {k: v for k, v in props.items() if v is not None}
+
+
+def _descriptor(component: str, properties: dict[str, Any]) -> dict[str, Any]:
+    """Build a nested composite child descriptor for the Infographic component."""
+    return {"component": component, "properties": _clean(properties)}
+
+
+def _unique(name: str, taken: dict[str, int]) -> str:
+    """Return ``name`` made unique against ``taken`` (deterministic suffixing)."""
+    count = taken.get(name, 0) + 1
+    taken[name] = count
+    return name if count == 1 else f"{name} ({count})"
+
+
+def _lines(items: list[Any], *, ordered: bool = False) -> str:
+    """Render list items as a deterministic text block for a ``Card`` body."""
+    out: list[str] = []
+    for index, item in enumerate(items, 1):
+        text = item if isinstance(item, str) else str(item)
+        out.append(f"{index}. {text}" if ordered else f"• {text}")
+    return "\n".join(out)
+
+
+class _SectionAccumulator:
+    """Collects sections while walking the flat block list.
+
+    Sections are only materialised once they hold content, so a leading
+    ``divider`` or a trailing boundary never emits an empty section.
+    """
+
+    def __init__(self) -> None:
+        self._sections: list[dict[str, Any]] = []
+        self._current: Optional[dict[str, Any]] = None
+
+    def open(self, *, heading: Optional[str] = None, text: Optional[str] = None) -> None:
+        """Close the current section and start a new one."""
+        self.close()
+        self._current = _clean({"heading": heading, "text": text})
+
+    def close(self) -> None:
+        """Flush the current section if it carries any content."""
+        if self._current and (
+            self._current.get("heading")
+            or self._current.get("text")
+            or self._current.get("components")
+        ):
+            self._sections.append(self._current)
+        self._current = None
+
+    def _ensure(self) -> dict[str, Any]:
+        if self._current is None:
+            self._current = {}
+        return self._current
+
+    def add(self, descriptor: dict[str, Any]) -> None:
+        """Append a nested component descriptor to the current section."""
+        section = self._ensure()
+        section.setdefault("components", []).append(descriptor)
+
+    def set_text(self, text: str) -> bool:
+        """Fill the section's free ``text`` slot. Returns False when taken."""
+        section = self._ensure()
+        if section.get("text"):
+            return False
+        section["text"] = text
+        return True
+
+    def result(self) -> list[dict[str, Any]]:
+        """Close the trailing section and return every collected section."""
+        self.close()
+        return self._sections
+
+
+class _Converter:
+    """Stateful walk over the block list, owning data-model key allocation."""
+
+    def __init__(self) -> None:
+        self.data_model: dict[str, dict[str, Any]] = {}
+        self._chart_index = 0
+        self._table_index = 0
+
+    # -- data model -----------------------------------------------------
+
+    def _bind_rows(self, bucket: str, key: str, rows: list[dict[str, Any]]) -> dict[str, str]:
+        self.data_model.setdefault(bucket, {})[key] = rows
+        return {"$bind": f"/{bucket}/{key}"}
+
+    # -- per-block mappings ---------------------------------------------
+
+    def _chart(self, block: dict[str, Any]) -> dict[str, Any]:
+        key = f"chart-{self._chart_index}"
+        self._chart_index += 1
+
+        labels = block.get("labels") or []
+        series = block.get("series") or []
+
+        # Reserve the x column name so a series called "label" is suffixed
+        # instead of overwriting the category column.
+        taken: dict[str, int] = {_X_COLUMN: 1}
+        y_names = [_unique(str(s.get("name") or "series"), taken) for s in series]
+
+        rows: list[dict[str, Any]] = []
+        for i, label in enumerate(labels):
+            row: dict[str, Any] = {_X_COLUMN: label}
+            for name, spec in zip(y_names, series):
+                values = spec.get("values") or []
+                row[name] = values[i] if i < len(values) else None
+            rows.append(row)
+
+        raw_type = str(block.get("chart_type") or "")
+        properties = {
+            "title": block.get("title"),
+            "type": CHART_TYPE_MAP.get(raw_type, _CHART_FALLBACK),
+            "x": _X_COLUMN,
+            "y": y_names,
+            "stacked": bool(block.get("stacked")),
+            "showLegend": block.get("show_legend") is not False,
+            "data": self._bind_rows("charts", key, rows),
+        }
+        return _descriptor("Chart", properties)
+
+    def _table(self, block: dict[str, Any]) -> dict[str, Any]:
+        key = f"table-{self._table_index}"
+        self._table_index += 1
+
+        taken: dict[str, int] = {}
+        names: list[str] = []
+        for column in block.get("columns") or []:
+            header = column if isinstance(column, str) else str(_as_dict(column).get("header") or "")
+            names.append(_unique(header or "column", taken))
+
+        rows: list[dict[str, Any]] = []
+        for raw_row in block.get("rows") or []:
+            cells = list(raw_row) if isinstance(raw_row, (list, tuple)) else [raw_row]
+            rows.append(
+                {name: (cells[i] if i < len(cells) else None) for i, name in enumerate(names)}
+            )
+
+        properties = {
+            "title": block.get("title") or block.get("caption"),
+            "columns": [{"name": name, "title": name} for name in names],
+            "totalRows": len(rows),
+            "data": self._bind_rows("tables", key, rows),
+        }
+        return _descriptor("DataTable", properties)
+
+    def _hero_card(self, block: dict[str, Any]) -> dict[str, Any]:
+        return _descriptor(
+            "KPICard",
+            {
+                "label": block.get("label") or "",
+                "value": block.get("value") or "",
+                "delta": block.get("trend_value"),
+                "trend": block.get("trend"),
+            },
+        )
+
+    def _timeline(self, block: dict[str, Any]) -> dict[str, Any]:
+        events = []
+        for raw in block.get("events") or []:
+            event = _as_dict(raw)
+            events.append(
+                _clean(
+                    {
+                        "timestamp": event.get("date"),
+                        "title": event.get("title") or "",
+                        "description": event.get("description"),
+                    }
+                )
+            )
+        return _descriptor("Timeline", {"title": block.get("title"), "events": events})
+
+    def _progress(self, block: dict[str, Any]) -> list[dict[str, Any]]:
+        descriptors = []
+        for raw in block.get("items") or []:
+            item = _as_dict(raw)
+            descriptors.append(
+                _descriptor(
+                    "KPICard",
+                    {"label": item.get("label") or "", "value": item.get("value")},
+                )
+            )
+        return descriptors
+
+    def _card_like(self, block: dict[str, Any], block_type: str) -> dict[str, Any]:
+        """Map the block types that share the generic ``Card`` shape."""
+        if block_type == "bullet_list":
+            return _descriptor(
+                "Card",
+                {
+                    "title": block.get("title"),
+                    "body": _lines(
+                        block.get("items") or [], ordered=bool(block.get("ordered"))
+                    ),
+                },
+            )
+        if block_type == "checklist":
+            lines = []
+            for raw in block.get("items") or []:
+                item = _as_dict(raw)
+                mark = "[x]" if item.get("checked") else "[ ]"
+                lines.append(f"{mark} {item.get('text') or ''}".rstrip())
+            return _descriptor(
+                "Card", {"title": block.get("title"), "body": "\n".join(lines)}
+            )
+        if block_type == "callout":
+            return _descriptor(
+                "Card",
+                {
+                    "title": block.get("title"),
+                    "body": block.get("content") or "",
+                    "badge": block.get("level"),
+                },
+            )
+        if block_type == "quote":
+            attribution = " — ".join(
+                part for part in (block.get("author"), block.get("source")) if part
+            )
+            return _descriptor(
+                "Card",
+                {"body": block.get("text") or "", "footer": attribution or None},
+            )
+        if block_type == "image":
+            return _descriptor(
+                "Card",
+                {
+                    "title": block.get("alt"),
+                    "image": block.get("url"),
+                    "footer": block.get("caption"),
+                },
+            )
+        # summary (title present or text slot taken) and any unknown block type
+        return _descriptor(
+            "Card",
+            {
+                "title": block.get("title"),
+                "body": block.get("content") or block.get("text") or "",
+            },
+        )
+
+    # -- walk ------------------------------------------------------------
+
+    def walk(
+        self,
+        blocks: list[Any],
+        sections: _SectionAccumulator,
+        *,
+        depth: int = 0,
+        seen_title: bool = False,
+    ) -> tuple[Optional[str], Optional[str], bool]:
+        """Map ``blocks`` into ``sections``.
+
+        Returns the surface ``(title, subtitle, seen_title)`` harvested from the
+        first ``title`` block encountered.
+        """
+        title: Optional[str] = None
+        subtitle: Optional[str] = None
+
+        for raw in blocks:
+            block = _as_dict(raw)
+            block_type = str(block.get("type") or "")
+
+            if block_type == "title":
+                if not seen_title:
+                    title = block.get("title")
+                    subtitle = block.get("subtitle")
+                    seen_title = True
+                else:
+                    sections.open(
+                        heading=block.get("title"), text=block.get("subtitle")
+                    )
+                continue
+
+            if block_type == "divider":
+                sections.open()
+                continue
+
+            if block_type in ("accordion", "tab_view") and depth < _MAX_NESTING_DEPTH:
+                self._flatten_container(block, block_type, sections, depth)
+                continue
+
+            if block_type == "summary" and not block.get("title"):
+                if sections.set_text(block.get("content") or ""):
+                    continue
+
+            if block_type == "chart":
+                sections.add(self._chart(block))
+            elif block_type == "table":
+                sections.add(self._table(block))
+            elif block_type == "hero_card":
+                sections.add(self._hero_card(block))
+            elif block_type == "timeline":
+                sections.add(self._timeline(block))
+            elif block_type == "progress":
+                for descriptor in self._progress(block):
+                    sections.add(descriptor)
+            else:
+                sections.add(self._card_like(block, block_type))
+
+        return title, subtitle, seen_title
+
+    def _flatten_container(
+        self,
+        block: dict[str, Any],
+        block_type: str,
+        sections: _SectionAccumulator,
+        depth: int,
+    ) -> None:
+        """Flatten an accordion/tab_view into sibling sections (sections never nest)."""
+        if block_type == "accordion":
+            entries = [
+                (_as_dict(item).get("title"), _as_dict(item).get("content_blocks") or [])
+                for item in block.get("items") or []
+            ]
+        else:
+            entries = [
+                (_as_dict(pane).get("label"), _as_dict(pane).get("blocks") or [])
+                for pane in block.get("tabs") or []
+            ]
+
+        group_title = block.get("title")
+        for index, (heading, nested) in enumerate(entries):
+            # The group title only labels the first sub-section, so the grouping
+            # survives flattening without repeating on every sibling.
+            if group_title and index == 0 and heading:
+                heading = f"{group_title} — {heading}"
+            elif group_title and index == 0:
+                heading = group_title
+            sections.open(heading=heading)
+            self.walk(nested, sections, depth=depth + 1, seen_title=True)
+
+
+def infographic_response_to_envelope(
+    response: Any,
+    *,
+    surface_id: str = "infographic",
+    title: Optional[str] = None,
+    theme: Optional[str] = None,
+) -> CreateSurface:
+    """Convert an ``InfographicResponse`` into a validated A2UI ``CreateSurface``.
+
+    Pure and deterministic — the same response always yields an identical envelope.
+
+    Args:
+        response: An :class:`~parrot.models.infographic.InfographicResponse`, or any
+            mapping with the same shape (``blocks``/``theme``/``template``).
+        surface_id: Surface id for the emitted envelope.
+        title: Explicit surface title. When omitted, the first ``title`` block's
+            title is used, falling back to the response ``template`` and finally
+            to ``"Infographic"``.
+        theme: Explicit theme hint. When omitted, ``response.theme`` is used.
+
+    Returns:
+        A catalog-validated ``CreateSurface`` carrying one ``Infographic`` component,
+        with chart and table rows resolved through data-model bindings.
+
+    Raises:
+        TypeError: If ``response`` is neither a model nor a mapping.
+        CatalogValidationError: If any mapped component is not in the catalog.
+    """
+    payload = _as_dict(response)
+    blocks = payload.get("blocks") or []
+
+    sections = _SectionAccumulator()
+    converter = _Converter()
+    block_title, subtitle, _ = converter.walk(blocks, sections)
+
+    return build_infographic(
+        title=title or block_title or payload.get("template") or "Infographic",
+        subtitle=subtitle,
+        sections=sections.result(),
+        theme=theme if theme is not None else payload.get("theme"),
+        surface_id=surface_id,
+        data_model=converter.data_model or None,
+    )

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/catalog/components/datatable.py
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/catalog/components/datatable.py
@@ -47,6 +47,42 @@ DATATABLE_INSTRUCTIONS = (
 )
 
 
+def _lower_row(row: Any, column_names: list[Any]) -> BasicNode:
+    """Lower one resolved row to a ``Row`` of ``Text`` cells (pure, deterministic).
+
+    Cells follow the DECLARED column order, so a table never renders its columns
+    in dict-insertion order. Mapping rows are read by column name; sequence rows
+    positionally; a scalar row degrades to a single cell.
+
+    Args:
+        row: One resolved row — a mapping keyed by column name, a sequence of
+            cell values, or a scalar.
+        column_names: Column ``name`` values in declared order.
+
+    Returns:
+        A ``Row`` node whose children are one ``Text`` cell per column.
+    """
+    if isinstance(row, dict):
+        # No declared columns is degenerate (the schema requires them); fall back
+        # to the row's own key order so data still reaches the surface.
+        keys = column_names or list(row)
+        values = [row.get(name) for name in keys]
+    elif isinstance(row, (list, tuple)):
+        count = len(column_names) or len(row)
+        values = [row[i] if i < len(row) else None for i in range(count)]
+    else:
+        values = [row]
+
+    return BasicNode(
+        component="Row",
+        properties={"role": "row"},
+        children=[
+            BasicNode(component="Text", properties={"role": "cell", "text": value})
+            for value in values
+        ],
+    )
+
+
 @register_component("DataTable")
 class DataTableComponent:
     """The ``DataTable`` catalog component (display-only, ``requires_actions=False``)."""
@@ -80,13 +116,29 @@ class DataTableComponent:
         )
 
         body_props: dict[str, Any] = {"role": "rows"}
-        if "data" in props:
-            body_props["data"] = props["data"]
         if "totalRows" in props:
             body_props["totalRows"] = props["totalRows"]
         if props.get("truncated"):
             body_props["truncated"] = True
-        children.append(BasicNode(component="Column", properties=body_props))
+
+        # Two-phase contract (spec §7):
+        #  * REQUEST-live — ``data`` is still a binding expression: pass it through
+        #    untouched for renderers that resolve it client-side.
+        #  * CONFIGURE-bake — the bake pass already replaced the binding with the
+        #    row list, so materialise one Row of Text cells per row. Without this
+        #    the rows stay in an inert property and every static renderer emits an
+        #    empty table (the SSR-HTML renderer only draws Text/Image leaves).
+        data = props.get("data")
+        row_nodes: list[BasicNode] = []
+        if isinstance(data, list):
+            column_names = [col.get("name") for col in (props.get("columns") or [])]
+            row_nodes = [_lower_row(row, column_names) for row in data]
+        elif "data" in props:
+            body_props["data"] = data
+
+        children.append(
+            BasicNode(component="Column", properties=body_props, children=row_nodes)
+        )
 
         return BasicNode(
             component="Card",

--- a/packages/ai-parrot/src/parrot/tools/infographic_toolkit.py
+++ b/packages/ai-parrot/src/parrot/tools/infographic_toolkit.py
@@ -502,8 +502,10 @@ class InfographicToolkit(AbstractToolkit):
 
         a2ui_envelope = None
         if self._emit_a2ui:
+            # Same response object the HTML renderer consumed, so both surfaces
+            # describe identical content.
             a2ui_envelope = self._build_a2ui_envelope(
-                coerced_blocks, template.name, validated_theme, artifact_id,
+                infographic_response, artifact_id,
             )
 
         return InfographicRenderResult(
@@ -603,12 +605,25 @@ class InfographicToolkit(AbstractToolkit):
 
         a2ui_envelope = None
         if self._emit_a2ui:
-            sections = [{"heading": title or template_name}]
-            if data:
-                sections[0]["text"] = str(list(data.keys()))
+            # The Jinja lane has no typed blocks — the template owns the layout.
+            # Model what IS known semantically: the heading, plus the payload keys
+            # the template was given. Anything richer would be fabricated.
+            synthetic_blocks: List[Dict[str, Any]] = [
+                {"type": "title", "title": title or template_name}
+            ]
+            if isinstance(data, dict) and data:
+                synthetic_blocks.append(
+                    {
+                        "type": "summary",
+                        "content": "Data: " + ", ".join(sorted(map(str, data))),
+                    }
+                )
             a2ui_envelope = self._build_a2ui_envelope(
-                [], template_name, theme, artifact_id, title=title,
-                extra_sections=sections,
+                InfographicResponse(
+                    template=template_name, theme=theme, blocks=synthetic_blocks
+                ),
+                artifact_id,
+                title=title,
             )
 
         return InfographicRenderResult(
@@ -827,32 +842,36 @@ class InfographicToolkit(AbstractToolkit):
 
     def _build_a2ui_envelope(
         self,
-        blocks: List[Dict[str, Any]],
-        template_name: str,
-        theme: Optional[str],
+        response: InfographicResponse,
         artifact_id: str,
         *,
         title: Optional[str] = None,
-        extra_sections: Optional[List[Dict[str, Any]]] = None,
     ) -> Optional[Dict[str, Any]]:
-        """Build a validated A2UI Infographic envelope from the render data."""
-        from parrot.outputs.a2ui.builders import build_infographic
+        """Build a validated A2UI Infographic envelope from an ``InfographicResponse``.
 
-        sections = extra_sections or []
-        if not sections:
-            for i, block in enumerate(blocks):
-                heading = block.get("title") or block.get("type") or f"Block {i + 1}"
-                sections.append({"heading": heading})
-        if not sections:
-            sections = [{"heading": template_name}]
+        Delegates the whole mapping to the deterministic adapter
+        (``parrot.outputs.a2ui.adapters``), which turns each typed block into a
+        real catalog component and routes chart/table rows through data-model
+        bindings. The toolkit only owns the surface id and the failure policy.
+
+        Args:
+            response: The same ``InfographicResponse`` handed to the HTML renderer,
+                so the envelope and the HTML always describe identical content.
+            artifact_id: Persisted artifact id, used to derive the surface id.
+            title: Optional explicit surface title, overriding the response's own.
+
+        Returns:
+            The serialised envelope, or ``None`` when the build fails — the A2UI
+            lane is additive (spec G7), so a failure degrades to an HTML-only
+            result instead of breaking the render.
+        """
+        from parrot.outputs.a2ui.adapters import infographic_response_to_envelope
 
         try:
-            envelope = build_infographic(
-                title=title or template_name,
-                sections=sections,
-                theme=theme,
+            envelope = infographic_response_to_envelope(
+                response,
                 surface_id=f"infographic-{artifact_id}",
-                data_model={"blocks": blocks} if blocks else None,
+                title=title,
             )
             return envelope.model_dump(mode="json")
         except Exception:

--- a/packages/ai-parrot/src/parrot/tools/infographic_toolkit.py
+++ b/packages/ai-parrot/src/parrot/tools/infographic_toolkit.py
@@ -752,6 +752,13 @@ class InfographicToolkit(AbstractToolkit):
             template_name, effective_marker, len(html),
         )
 
+        a2ui_envelope = None
+        if self._emit_a2ui:
+            a2ui_envelope = self._build_a2ui_envelope_from_layout(
+                descriptor, payload, artifact_id, title=title,
+                template_name=template_name,
+            )
+
         return InfographicRenderResult(
             artifact_id=artifact_id,
             html_url=html_url,
@@ -760,7 +767,7 @@ class InfographicToolkit(AbstractToolkit):
             theme=None,
             data_variables=[],
             enhanced=False,
-            a2ui_envelope=None,
+            a2ui_envelope=a2ui_envelope,
         )
 
     @staticmethod
@@ -877,6 +884,91 @@ class InfographicToolkit(AbstractToolkit):
         except Exception:
             self.logger.warning(
                 "A2UI envelope build failed for infographic %s; "
+                "falling back to HTML-only result.",
+                artifact_id,
+                exc_info=True,
+            )
+            return None
+
+    def _build_a2ui_envelope_from_layout(
+        self,
+        descriptor: Optional["SectionDescriptor"],
+        payload: Dict[str, Any],
+        artifact_id: str,
+        *,
+        title: Optional[str] = None,
+        template_name: str = "",
+    ) -> Optional[Dict[str, Any]]:
+        """Build an envelope for the data-splice lane (FEAT-326 + FEAT-420).
+
+        The spliced ``payload`` IS the data model: the template's client-side JS
+        reads it from the marker script tag, and a descriptor's declared
+        ``layout`` carries ``$bind`` pointers into exactly that document. So when
+        a layout is declared it is used VERBATIM against the payload — the same
+        contract ``RecipeRunner._assemble_envelope_or_raise`` honours for saved
+        recipes (this mirrors its component dispatch, but degrades instead of
+        raising, because the A2UI lane is additive here).
+
+        Without a declared layout there is no component structure to model — the
+        template owns the layout and the payload shape is arbitrary. That case
+        falls back to the same minimal surface ``render_template`` emits: the
+        heading plus the payload's top-level keys, never invented structure.
+
+        Args:
+            descriptor: Optional section descriptor; its ``layout`` is the only
+                declarative source of component structure for this lane.
+            payload: The spliced JSON payload, used as the envelope's data model.
+            artifact_id: Persisted artifact id, used to derive the surface id.
+            title: Optional explicit surface title.
+            template_name: Template name, used as the title fallback.
+
+        Returns:
+            The serialised envelope, or ``None`` when the build fails.
+        """
+        from parrot.outputs.a2ui.builders import build_infographic, build_surface
+
+        layout = getattr(descriptor, "layout", None)
+        surface_id = f"infographic-{artifact_id}"
+
+        try:
+            if layout is None:
+                blocks: List[Dict[str, Any]] = [
+                    {"type": "title", "title": title or template_name}
+                ]
+                if isinstance(payload, dict) and payload:
+                    blocks.append(
+                        {
+                            "type": "summary",
+                            "content": "Data: " + ", ".join(sorted(map(str, payload))),
+                        }
+                    )
+                return self._build_a2ui_envelope(
+                    InfographicResponse(template=template_name, blocks=blocks),
+                    artifact_id,
+                    title=title,
+                )
+
+            properties = dict(layout.properties or {})
+            if layout.component == "Infographic":
+                envelope = build_infographic(
+                    title=properties.get("title") or title or template_name,
+                    sections=properties.get("sections", []),
+                    subtitle=properties.get("subtitle"),
+                    theme=properties.get("theme"),
+                    surface_id=surface_id,
+                    data_model=payload or None,
+                )
+            else:
+                envelope = build_surface(
+                    layout.component,
+                    properties,
+                    surface_id=surface_id,
+                    data_model=payload or None,
+                )
+            return envelope.model_dump(mode="json")
+        except Exception:
+            self.logger.warning(
+                "A2UI envelope build failed for data-splice infographic %s; "
                 "falling back to HTML-only result.",
                 artifact_id,
                 exc_info=True,

--- a/packages/ai-parrot/tests/outputs/a2ui/adapters/test_import_rule.py
+++ b/packages/ai-parrot/tests/outputs/a2ui/adapters/test_import_rule.py
@@ -1,0 +1,67 @@
+"""G8 one-way import-rule guard for ``parrot.outputs.a2ui.adapters``.
+
+Mirrors ``tests/outputs/a2ui/recipes/test_import_rule.py``: the adapters
+subpackage bridges legacy output models to A2UI envelopes, so it is exactly the
+place where an agent/client import would sneak back into the a2ui core.
+"""
+
+from pathlib import Path
+
+_ADAPTERS_DIR = (
+    Path(__file__).resolve().parents[4]
+    / "src"
+    / "parrot"
+    / "outputs"
+    / "a2ui"
+    / "adapters"
+)
+
+_FORBIDDEN_IMPORTS = (
+    "parrot.tools.dataset_manager",
+    "parrot.bots",
+    "parrot.clients",
+)
+
+
+def _python_files():
+    assert _ADAPTERS_DIR.is_dir(), f"expected adapters subpackage at {_ADAPTERS_DIR}"
+    yield from _ADAPTERS_DIR.rglob("*.py")
+
+
+def test_adapters_subpackage_has_no_forbidden_imports():
+    offenders = []
+    for path in _python_files():
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), 1):
+            stripped = line.strip()
+            if not (stripped.startswith("import ") or stripped.startswith("from ")):
+                continue
+            for forbidden in _FORBIDDEN_IMPORTS:
+                if forbidden in stripped:
+                    offenders.append(f"{path}:{lineno}: {stripped}")
+    assert not offenders, (
+        "G8 one-way import-rule violation in parrot.outputs.a2ui.adapters:\n"
+        + "\n".join(offenders)
+    )
+
+
+def test_adapters_subpackage_importable_without_agents_or_clients():
+    # Fresh interpreter so module state from other tests cannot mask a violation.
+    import subprocess
+    import sys
+
+    src_dir = _ADAPTERS_DIR.parents[3]  # .../src
+    probe = (
+        "import sys\n"
+        f"sys.path.insert(0, {str(src_dir)!r})\n"
+        "from parrot.outputs.a2ui.adapters import infographic_response_to_envelope\n"
+        "assert infographic_response_to_envelope is not None\n"
+        "forbidden = ('parrot.tools.dataset_manager', 'parrot.bots', 'parrot.clients')\n"
+        "loaded = [m for m in sys.modules "
+        "if any(m == f or m.startswith(f + '.') for f in forbidden)]\n"
+        "assert not loaded, f'forbidden modules loaded: {loaded}'\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, timeout=60
+    )
+    assert result.returncode == 0, result.stderr

--- a/packages/ai-parrot/tests/outputs/a2ui/adapters/test_infographic_adapter.py
+++ b/packages/ai-parrot/tests/outputs/a2ui/adapters/test_infographic_adapter.py
@@ -1,0 +1,550 @@
+"""Tests for the ``InfographicResponse`` → A2UI ``CreateSurface`` adapter.
+
+Exercises the adapter against the REAL :class:`InfographicResponse` model (not
+hand-rolled dicts) so a drift in either contract fails here, plus the purity,
+sectioning and lossy-degradation rules the module documents.
+"""
+
+import json
+
+import pytest
+
+from parrot.models.infographic import InfographicResponse
+from parrot.outputs.a2ui.adapters import (
+    CHART_TYPE_MAP,
+    infographic_response_to_envelope,
+)
+from parrot.outputs.a2ui.catalog import (
+    ProducerOrigin,
+    get_component,
+    validate_envelope,
+)
+from parrot.outputs.a2ui.catalog import components as _all_components  # noqa: F401
+from parrot.outputs.a2ui.models import Component
+
+
+def _response(**overrides) -> InfographicResponse:
+    payload = {
+        "template": "quarterly",
+        "theme": "ocean",
+        "blocks": [
+            {"type": "title", "title": "Q1 Overview", "subtitle": "Financials"},
+            {"type": "summary", "content": "Revenue grew across every region."},
+            {"type": "hero_card", "label": "Revenue", "value": "$1.2M",
+             "trend": "up", "trend_value": "+8%"},
+            {
+                "type": "chart",
+                "chart_type": "bar",
+                "title": "Revenue by month",
+                "labels": ["Jan", "Feb"],
+                "series": [
+                    {"name": "2026", "values": [10, 20]},
+                    {"name": "2025", "values": [8, 15]},
+                ],
+            },
+        ],
+    }
+    payload.update(overrides)
+    return InfographicResponse(**payload)
+
+
+def _infographic_props(envelope) -> dict:
+    assert len(envelope.components) == 1
+    component = envelope.components[0]
+    assert component.component == "Infographic"
+    return component.properties
+
+
+def _sections(envelope) -> list:
+    return _infographic_props(envelope)["sections"]
+
+
+class TestSurfaceShape:
+    def test_emits_a_single_validated_infographic_component(self):
+        envelope = infographic_response_to_envelope(_response())
+        props = _infographic_props(envelope)
+        assert props["title"] == "Q1 Overview"
+        assert props["subtitle"] == "Financials"
+        assert props["theme"] == "ocean"
+        # build_infographic validates; re-assert explicitly for the allowlist.
+        validate_envelope(envelope, origin=ProducerOrigin.TOOL)
+
+    def test_first_title_block_does_not_become_a_section(self):
+        sections = _sections(infographic_response_to_envelope(_response()))
+        assert all(s.get("heading") != "Q1 Overview" for s in sections)
+
+    def test_title_falls_back_to_template_then_constant(self):
+        no_title = InfographicResponse(
+            template="quarterly", blocks=[{"type": "summary", "content": "x"}]
+        )
+        assert _infographic_props(
+            infographic_response_to_envelope(no_title)
+        )["title"] == "quarterly"
+
+        bare = InfographicResponse(blocks=[{"type": "summary", "content": "x"}])
+        assert _infographic_props(
+            infographic_response_to_envelope(bare)
+        )["title"] == "Infographic"
+
+    def test_explicit_title_and_theme_override_the_response(self):
+        envelope = infographic_response_to_envelope(
+            _response(), title="Override", theme="petrol"
+        )
+        props = _infographic_props(envelope)
+        assert props["title"] == "Override"
+        assert props["theme"] == "petrol"
+
+    def test_accepts_a_plain_mapping(self):
+        envelope = infographic_response_to_envelope(
+            {"blocks": [{"type": "hero_card", "label": "Users", "value": "42"}]}
+        )
+        assert _sections(envelope)[0]["components"][0]["component"] == "KPICard"
+
+    def test_rejects_unsupported_input(self):
+        with pytest.raises(TypeError):
+            infographic_response_to_envelope(["not", "a", "response"])
+
+
+class TestPurity:
+    def test_same_input_yields_byte_identical_envelopes(self):
+        first = infographic_response_to_envelope(_response())
+        second = infographic_response_to_envelope(_response())
+        assert json.dumps(first.model_dump(mode="json"), sort_keys=True) == json.dumps(
+            second.model_dump(mode="json"), sort_keys=True
+        )
+
+    def test_adapter_does_not_mutate_the_source_response(self):
+        response = _response()
+        before = response.model_dump(mode="json")
+        infographic_response_to_envelope(response)
+        assert response.model_dump(mode="json") == before
+
+
+class TestSectioning:
+    def test_later_title_block_opens_a_section(self):
+        envelope = infographic_response_to_envelope(
+            _response(
+                blocks=[
+                    {"type": "title", "title": "Doc"},
+                    {"type": "title", "title": "Part Two", "subtitle": "Detail"},
+                    {"type": "hero_card", "label": "A", "value": "1"},
+                ]
+            )
+        )
+        section = _sections(envelope)[0]
+        assert section["heading"] == "Part Two"
+        assert section["text"] == "Detail"
+        assert section["components"][0]["component"] == "KPICard"
+
+    def test_divider_opens_an_anonymous_section(self):
+        envelope = infographic_response_to_envelope(
+            _response(
+                blocks=[
+                    {"type": "hero_card", "label": "A", "value": "1"},
+                    {"type": "divider"},
+                    {"type": "hero_card", "label": "B", "value": "2"},
+                ]
+            )
+        )
+        sections = _sections(envelope)
+        assert len(sections) == 2
+        assert "heading" not in sections[1]
+        assert sections[1]["components"][0]["properties"]["label"] == "B"
+
+    def test_leading_divider_emits_no_empty_section(self):
+        envelope = infographic_response_to_envelope(
+            _response(
+                blocks=[
+                    {"type": "divider"},
+                    {"type": "hero_card", "label": "A", "value": "1"},
+                ]
+            )
+        )
+        assert len(_sections(envelope)) == 1
+
+    def test_untitled_summary_fills_section_text_then_becomes_a_card(self):
+        envelope = infographic_response_to_envelope(
+            _response(
+                blocks=[
+                    {"type": "summary", "content": "First"},
+                    {"type": "summary", "content": "Second"},
+                ]
+            )
+        )
+        section = _sections(envelope)[0]
+        assert section["text"] == "First"
+        card = section["components"][0]
+        assert card["component"] == "Card"
+        assert card["properties"]["body"] == "Second"
+
+    def test_titled_summary_always_becomes_a_card(self):
+        envelope = infographic_response_to_envelope(
+            _response(blocks=[{"type": "summary", "title": "Notes", "content": "Body"}])
+        )
+        section = _sections(envelope)[0]
+        assert "text" not in section
+        assert section["components"][0]["properties"]["title"] == "Notes"
+
+
+class TestChartMapping:
+    def test_rows_land_in_the_data_model_and_are_bound_by_pointer(self):
+        envelope = infographic_response_to_envelope(_response())
+        chart = _sections(envelope)[0]["components"][-1]
+        assert chart["component"] == "Chart"
+        assert chart["properties"]["data"] == {"$bind": "/charts/chart-0"}
+        assert chart["properties"]["x"] == "label"
+        assert chart["properties"]["y"] == ["2026", "2025"]
+        assert envelope.data_model["charts"]["chart-0"] == [
+            {"label": "Jan", "2026": 10, "2025": 8},
+            {"label": "Feb", "2026": 20, "2025": 15},
+        ]
+
+    @pytest.mark.parametrize(
+        "source,expected",
+        [("donut", "pie"), ("gauge", "bar"), ("radar", "line"), ("area", "area")],
+    )
+    def test_unsupported_chart_types_degrade_to_the_nearest_neighbour(
+        self, source, expected
+    ):
+        envelope = infographic_response_to_envelope(
+            _response(
+                blocks=[
+                    {
+                        "type": "chart",
+                        "chart_type": source,
+                        "labels": ["a"],
+                        "series": [{"name": "s", "values": [1]}],
+                    }
+                ]
+            )
+        )
+        assert _sections(envelope)[0]["components"][0]["properties"]["type"] == expected
+
+    def test_every_mapped_type_is_in_the_a2ui_chart_enum(self):
+        allowed = set(
+            get_component("Chart").definition.schema_["properties"]["type"]["enum"]
+        )
+        assert set(CHART_TYPE_MAP.values()) <= allowed
+
+    def test_series_named_label_does_not_collide_with_the_x_column(self):
+        envelope = infographic_response_to_envelope(
+            _response(
+                blocks=[
+                    {
+                        "type": "chart",
+                        "chart_type": "bar",
+                        "labels": ["Jan"],
+                        "series": [{"name": "label", "values": [7]}],
+                    }
+                ]
+            )
+        )
+        chart = _sections(envelope)[0]["components"][0]["properties"]
+        assert chart["y"] == ["label (2)"]
+        assert envelope.data_model["charts"]["chart-0"] == [
+            {"label": "Jan", "label (2)": 7}
+        ]
+
+    def test_short_series_pad_with_none(self):
+        envelope = infographic_response_to_envelope(
+            _response(
+                blocks=[
+                    {
+                        "type": "chart",
+                        "chart_type": "line",
+                        "labels": ["a", "b", "c"],
+                        "series": [{"name": "s", "values": [1]}],
+                    }
+                ]
+            )
+        )
+        rows = envelope.data_model["charts"]["chart-0"]
+        assert [row["s"] for row in rows] == [1, None, None]
+
+    def test_multiple_charts_get_distinct_data_model_keys(self):
+        chart = {
+            "type": "chart",
+            "chart_type": "bar",
+            "labels": ["a"],
+            "series": [{"name": "s", "values": [1]}],
+        }
+        envelope = infographic_response_to_envelope(_response(blocks=[chart, chart]))
+        assert sorted(envelope.data_model["charts"]) == ["chart-0", "chart-1"]
+
+
+class TestTableMapping:
+    def test_columns_and_rows_map_with_total_rows(self):
+        envelope = infographic_response_to_envelope(
+            _response(
+                blocks=[
+                    {
+                        "type": "table",
+                        "title": "Regions",
+                        "columns": ["Region", "Total"],
+                        "rows": [["North", 10], ["South", 20]],
+                    }
+                ]
+            )
+        )
+        table = _sections(envelope)[0]["components"][0]
+        assert table["component"] == "DataTable"
+        props = table["properties"]
+        assert props["columns"] == [
+            {"name": "Region", "title": "Region"},
+            {"name": "Total", "title": "Total"},
+        ]
+        assert props["totalRows"] == 2
+        assert props["data"] == {"$bind": "/tables/table-0"}
+        assert envelope.data_model["tables"]["table-0"] == [
+            {"Region": "North", "Total": 10},
+            {"Region": "South", "Total": 20},
+        ]
+
+    def test_columndef_objects_use_their_header(self):
+        envelope = infographic_response_to_envelope(
+            _response(
+                blocks=[
+                    {
+                        "type": "table",
+                        "columns": [{"header": "Region"}, {"header": "Total"}],
+                        "rows": [["North", 1]],
+                    }
+                ]
+            )
+        )
+        props = _sections(envelope)[0]["components"][0]["properties"]
+        assert [c["name"] for c in props["columns"]] == ["Region", "Total"]
+
+    def test_ragged_rows_pad_with_none(self):
+        envelope = infographic_response_to_envelope(
+            _response(
+                blocks=[
+                    {
+                        "type": "table",
+                        "columns": ["A", "B", "C"],
+                        "rows": [["only-a"]],
+                    }
+                ]
+            )
+        )
+        assert envelope.data_model["tables"]["table-0"] == [
+            {"A": "only-a", "B": None, "C": None}
+        ]
+
+
+class TestBlockMappings:
+    def test_hero_card_carries_trend_and_delta(self):
+        envelope = infographic_response_to_envelope(_response())
+        kpi = _sections(envelope)[0]["components"][0]
+        assert kpi["component"] == "KPICard"
+        assert kpi["properties"] == {
+            "label": "Revenue",
+            "value": "$1.2M",
+            "delta": "+8%",
+            "trend": "up",
+        }
+
+    def test_timeline_maps_date_to_timestamp(self):
+        envelope = infographic_response_to_envelope(
+            _response(
+                blocks=[
+                    {
+                        "type": "timeline",
+                        "title": "Roadmap",
+                        "events": [
+                            {"date": "2026-01", "title": "Kickoff", "description": "Go"}
+                        ],
+                    }
+                ]
+            )
+        )
+        props = _sections(envelope)[0]["components"][0]["properties"]
+        assert props["events"] == [
+            {"timestamp": "2026-01", "title": "Kickoff", "description": "Go"}
+        ]
+
+    def test_progress_expands_to_one_kpicard_per_item(self):
+        envelope = infographic_response_to_envelope(
+            _response(
+                blocks=[
+                    {
+                        "type": "progress",
+                        "items": [
+                            {"label": "Onboarding", "value": 80},
+                            {"label": "Migration", "value": 45},
+                        ],
+                    }
+                ]
+            )
+        )
+        components = _sections(envelope)[0]["components"]
+        assert [c["component"] for c in components] == ["KPICard", "KPICard"]
+        assert components[0]["properties"]["label"] == "Onboarding"
+
+    def test_bullet_list_ordered_and_unordered_bodies(self):
+        envelope = infographic_response_to_envelope(
+            _response(
+                blocks=[
+                    {"type": "bullet_list", "items": ["one", "two"]},
+                    {"type": "bullet_list", "items": ["one"], "ordered": True},
+                ]
+            )
+        )
+        components = _sections(envelope)[0]["components"]
+        assert components[0]["properties"]["body"] == "• one\n• two"
+        assert components[1]["properties"]["body"] == "1. one"
+
+    def test_checklist_marks_checked_items(self):
+        envelope = infographic_response_to_envelope(
+            _response(
+                blocks=[
+                    {
+                        "type": "checklist",
+                        "items": [
+                            {"text": "Done", "checked": True},
+                            {"text": "Pending"},
+                        ],
+                    }
+                ]
+            )
+        )
+        body = _sections(envelope)[0]["components"][0]["properties"]["body"]
+        assert body == "[x] Done\n[ ] Pending"
+
+    def test_callout_level_becomes_a_badge(self):
+        envelope = infographic_response_to_envelope(
+            _response(
+                blocks=[{"type": "callout", "level": "warning", "content": "Careful"}]
+            )
+        )
+        props = _sections(envelope)[0]["components"][0]["properties"]
+        assert props["badge"] == "warning"
+        assert props["body"] == "Careful"
+
+    def test_quote_attribution_lands_in_the_footer(self):
+        envelope = infographic_response_to_envelope(
+            _response(
+                blocks=[
+                    {"type": "quote", "text": "Ship it", "author": "Ana",
+                     "source": "Retro"}
+                ]
+            )
+        )
+        props = _sections(envelope)[0]["components"][0]["properties"]
+        assert props["body"] == "Ship it"
+        assert props["footer"] == "Ana — Retro"
+        assert "title" not in props
+
+    def test_image_maps_url_alt_and_caption(self):
+        envelope = infographic_response_to_envelope(
+            _response(
+                blocks=[
+                    {
+                        "type": "image",
+                        "url": "https://example.test/a.png",
+                        "alt": "Chart",
+                        "caption": "Fig 1",
+                    }
+                ]
+            )
+        )
+        props = _sections(envelope)[0]["components"][0]["properties"]
+        assert props == {
+            "title": "Chart",
+            "image": "https://example.test/a.png",
+            "footer": "Fig 1",
+        }
+
+
+class TestContainerFlattening:
+    def test_accordion_items_become_sibling_sections(self):
+        envelope = infographic_response_to_envelope(
+            _response(
+                blocks=[
+                    {
+                        "type": "accordion",
+                        "title": "Phases",
+                        "items": [
+                            {
+                                "title": "Phase 1",
+                                "content_blocks": [
+                                    {"type": "hero_card", "label": "A", "value": "1"}
+                                ],
+                            },
+                            {
+                                "title": "Phase 2",
+                                "content_blocks": [
+                                    {"type": "summary", "content": "Later"}
+                                ],
+                            },
+                        ],
+                    }
+                ]
+            )
+        )
+        sections = _sections(envelope)
+        assert [s["heading"] for s in sections] == ["Phases — Phase 1", "Phase 2"]
+        assert sections[0]["components"][0]["component"] == "KPICard"
+        assert sections[1]["text"] == "Later"
+
+    def test_tab_panes_become_sibling_sections(self):
+        envelope = infographic_response_to_envelope(
+            _response(
+                blocks=[
+                    {
+                        "type": "tab_view",
+                        "tabs": [
+                            {
+                                "id": "a",
+                                "label": "Overview",
+                                "blocks": [
+                                    {"type": "hero_card", "label": "A", "value": "1"}
+                                ],
+                            },
+                            {"id": "b", "label": "Detail", "blocks": []},
+                        ],
+                    }
+                ]
+            )
+        )
+        sections = _sections(envelope)
+        assert [s["heading"] for s in sections] == ["Overview", "Detail"]
+
+    def test_nested_title_block_inside_a_pane_does_not_hijack_the_surface_title(self):
+        envelope = infographic_response_to_envelope(
+            _response(
+                blocks=[
+                    {"type": "title", "title": "Real Title"},
+                    {
+                        "type": "tab_view",
+                        "tabs": [
+                            {
+                                "id": "a",
+                                "label": "Tab",
+                                "blocks": [{"type": "title", "title": "Nested"}],
+                            },
+                            {"id": "b", "label": "Other", "blocks": []},
+                        ],
+                    },
+                ]
+            )
+        )
+        assert _infographic_props(envelope)["title"] == "Real Title"
+
+
+class TestLowering:
+    def test_adapted_envelope_lowers_to_a_basic_tree(self):
+        envelope = infographic_response_to_envelope(_response())
+        component = envelope.components[0]
+        tree = get_component("Infographic").component_cls().lower(
+            Component(
+                id=component.id,
+                component=component.component,
+                properties=component.properties,
+            ),
+            envelope.data_model or {},
+        )
+        assert tree.component == "Card"
+        # Lowering is pure: the nested KPICard/Chart children resolved through
+        # their own registered lower() without raising.
+        assert tree.children

--- a/packages/ai-parrot/tests/outputs/a2ui/test_datatable_row_materialization.py
+++ b/packages/ai-parrot/tests/outputs/a2ui/test_datatable_row_materialization.py
@@ -1,0 +1,144 @@
+"""``DataTable`` row materialisation in the lowering (FEAT-273 Module 3/6).
+
+The bake pass replaces a row binding with the resolved row list, but the
+lowering used to leave that list in an inert ``data`` property on a childless
+``Column``. Static renderers only draw ``Text``/``Image`` leaves, so every
+baked table rendered empty. These tests pin both halves of the two-phase
+contract: a live binding is passed through untouched, resolved rows become
+``Row``/``Text`` nodes.
+"""
+
+import json
+
+import pytest
+
+from parrot.outputs.a2ui.catalog import components as _all_components  # noqa: F401
+from parrot.outputs.a2ui.catalog.components import datatable
+from parrot.outputs.a2ui.models import Component
+
+COLUMNS = [{"name": "region", "title": "Region"}, {"name": "total", "type": "number"}]
+
+
+def _component(**props) -> Component:
+    payload = {"title": "Sales", "columns": COLUMNS}
+    payload.update(props)
+    return Component(id="blk-001", component="DataTable", properties=payload)
+
+
+def _lower(component: Component):
+    return datatable.DataTableComponent().lower(component, {})
+
+
+def _rows_node(tree):
+    (node,) = [
+        child
+        for child in tree.children
+        if child.component == "Column" and child.properties.get("role") == "rows"
+    ]
+    return node
+
+
+def _cells(row_node) -> list:
+    return [child.properties.get("text") for child in row_node.children]
+
+
+class TestLiveBindingPassthrough:
+    def test_binding_is_preserved_and_no_rows_are_invented(self):
+        tree = _lower(_component(data={"$bind": "/tables/blk-001"}))
+        rows = _rows_node(tree)
+        assert rows.properties["data"] == {"$bind": "/tables/blk-001"}
+        assert rows.children == []
+
+    def test_absent_data_yields_no_data_property(self):
+        rows = _rows_node(_lower(_component()))
+        assert "data" not in rows.properties
+        assert rows.children == []
+
+
+class TestBakedRowsMaterialise:
+    def test_resolved_rows_become_row_and_text_nodes(self):
+        tree = _lower(
+            _component(data=[{"region": "North", "total": 10}, {"region": "South", "total": 20}])
+        )
+        rows = _rows_node(tree)
+        assert [child.component for child in rows.children] == ["Row", "Row"]
+        assert _cells(rows.children[0]) == ["North", 10]
+        assert _cells(rows.children[1]) == ["South", 20]
+        assert all(
+            cell.properties["role"] == "cell"
+            for row in rows.children
+            for cell in row.children
+        )
+
+    def test_materialised_rows_drop_the_inert_data_property(self):
+        # Keeping it would duplicate the whole row set inside the tree.
+        rows = _rows_node(_lower(_component(data=[{"region": "North", "total": 1}])))
+        assert "data" not in rows.properties
+
+    def test_cells_follow_declared_column_order_not_dict_order(self):
+        rows = _rows_node(_lower(_component(data=[{"total": 10, "region": "North"}])))
+        assert _cells(rows.children[0]) == ["North", 10]
+
+    def test_missing_keys_become_empty_cells(self):
+        rows = _rows_node(_lower(_component(data=[{"region": "North"}])))
+        assert _cells(rows.children[0]) == ["North", None]
+
+    def test_extra_keys_outside_the_declared_columns_are_ignored(self):
+        rows = _rows_node(
+            _lower(_component(data=[{"region": "N", "total": 1, "secret": "x"}]))
+        )
+        assert _cells(rows.children[0]) == ["N", 1]
+
+    def test_sequence_rows_map_positionally(self):
+        rows = _rows_node(_lower(_component(data=[["North", 10], ["South"]])))
+        assert _cells(rows.children[0]) == ["North", 10]
+        assert _cells(rows.children[1]) == ["South", None]
+
+    def test_scalar_row_degrades_to_a_single_cell(self):
+        rows = _rows_node(_lower(_component(data=["North"])))
+        assert _cells(rows.children[0]) == ["North"]
+
+    def test_empty_row_list_renders_no_rows(self):
+        rows = _rows_node(_lower(_component(data=[])))
+        assert rows.children == []
+        assert "data" not in rows.properties
+
+    def test_rows_without_declared_columns_fall_back_to_row_keys(self):
+        component = Component(
+            id="blk-001",
+            component="DataTable",
+            properties={"columns": [], "data": [{"a": 1, "b": 2}]},
+        )
+        rows = _rows_node(_lower(component))
+        assert _cells(rows.children[0]) == [1, 2]
+
+    def test_totalrows_and_truncated_survive_materialisation(self):
+        rows = _rows_node(
+            _lower(_component(data=[{"region": "N", "total": 1}], totalRows=42, truncated=True))
+        )
+        assert rows.properties["totalRows"] == 42
+        assert rows.properties["truncated"] is True
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            [{"region": "North", "total": 10}],
+            {"$bind": "/tables/blk-001"},
+        ],
+    )
+    def test_lowering_stays_pure(self, data):
+        component = _component(data=data)
+        one = json.dumps(_lower(component).model_dump(), sort_keys=True)
+        two = json.dumps(_lower(component).model_dump(), sort_keys=True)
+        assert one == two
+
+
+class TestHeaderIsUnaffected:
+    def test_header_still_uses_column_titles_then_names(self):
+        tree = _lower(_component(data=[{"region": "N", "total": 1}]))
+        (header,) = [
+            child
+            for child in tree.children
+            if child.component == "Row" and child.properties.get("role") == "header"
+        ]
+        assert [cell.properties["text"] for cell in header.children] == ["Region", "total"]

--- a/packages/ai-parrot/tests/tools/test_infographic_toolkit_a2ui_wiring.py
+++ b/packages/ai-parrot/tests/tools/test_infographic_toolkit_a2ui_wiring.py
@@ -132,6 +132,119 @@ class TestSurfaceMatchesTheRenderedResponse:
             r"_build_a2ui_envelope\(\s*infographic_response\b", source
         ), "render() must pass the InfographicResponse to _build_a2ui_envelope"
 
+class TestDataSpliceLane:
+    """``render_data_template`` used to hardcode ``a2ui_envelope=None``."""
+
+    def _descriptor(self, layout=None):
+        # LayoutSpec lives in recipes.models — infographic_sections only
+        # forward-references it (circular-import workaround, FEAT-420).
+        from parrot.outputs.a2ui.recipes.models import LayoutSpec
+        from parrot.tools.infographic_sections import SectionDescriptor
+
+        return SectionDescriptor(
+            template="dash",
+            mode="data-splice",
+            layout=LayoutSpec(**layout) if layout else None,
+        )
+
+    def test_declared_layout_is_used_verbatim_against_the_payload(self, toolkit):
+        # The spliced payload IS the data model, so the layout's $bind pointers
+        # resolve against it — the same contract RecipeRunner honours.
+        descriptor = self._descriptor(
+            {
+                "component": "Infographic",
+                "properties": {
+                    "title": "Budget Variance",
+                    "sections": [
+                        {
+                            "heading": "Detail",
+                            "components": [
+                                {
+                                    "component": "DataTable",
+                                    "properties": {
+                                        "columns": [{"name": "region"}],
+                                        "data": {"$bind": "/rows"},
+                                    },
+                                }
+                            ],
+                        }
+                    ],
+                },
+            }
+        )
+        envelope = toolkit._build_a2ui_envelope_from_layout(
+            descriptor, {"rows": [{"region": "North"}]}, "art-5", template_name="dash"
+        )
+        props = _infographic(envelope)
+        assert props["title"] == "Budget Variance"
+        table = props["sections"][0]["components"][0]
+        assert table["properties"]["data"] == {"$bind": "/rows"}
+        assert envelope["data_model"] == {"rows": [{"region": "North"}]}
+        assert envelope["surface_id"] == "infographic-art-5"
+
+    def test_non_infographic_layout_dispatches_to_build_surface(self, toolkit):
+        descriptor = self._descriptor(
+            {
+                "component": "DataTable",
+                "properties": {
+                    "columns": [{"name": "region"}],
+                    "data": {"$bind": "/rows"},
+                },
+            }
+        )
+        envelope = toolkit._build_a2ui_envelope_from_layout(
+            descriptor, {"rows": [{"region": "N"}]}, "art-6", template_name="dash"
+        )
+        assert envelope["components"][0]["component"] == "DataTable"
+        assert envelope["data_model"] == {"rows": [{"region": "N"}]}
+
+    def test_without_a_layout_it_falls_back_to_the_minimal_surface(self, toolkit):
+        envelope = toolkit._build_a2ui_envelope_from_layout(
+            None, {"beta": 1, "alpha": 2}, "art-7", title="Dash", template_name="dash"
+        )
+        props = _infographic(envelope)
+        assert props["title"] == "Dash"
+        # Keys sorted so the envelope stays deterministic.
+        assert props["sections"][0]["text"] == "Data: alpha, beta"
+
+    def test_descriptor_without_layout_uses_the_same_fallback(self, toolkit):
+        envelope = toolkit._build_a2ui_envelope_from_layout(
+            self._descriptor(), {"a": 1}, "art-8", template_name="dash"
+        )
+        assert _infographic(envelope)["title"] == "dash"
+
+    def test_empty_payload_yields_no_data_model(self, toolkit):
+        envelope = toolkit._build_a2ui_envelope_from_layout(
+            None, {}, "art-9", title="Empty", template_name="dash"
+        )
+        assert not envelope.get("data_model")
+
+    def test_invalid_layout_degrades_to_none(self, toolkit, caplog):
+        descriptor = self._descriptor(
+            {"component": "NotAnA2UIComponent", "properties": {}}
+        )
+        assert (
+            toolkit._build_a2ui_envelope_from_layout(
+                descriptor, {}, "art-10", template_name="dash"
+            )
+            is None
+        )
+        assert "falling back to HTML-only result" in caplog.text
+
+    def test_lane_is_wired_and_respects_the_flag(self, toolkit):
+        import inspect
+        import re
+
+        cls = _toolkit_or_skip()
+        source = inspect.getsource(cls.render_data_template)
+        assert re.search(r"if self\._emit_a2ui", source)
+        assert re.search(
+            r"_build_a2ui_envelope_from_layout\(", source
+        ), "render_data_template must build the envelope from the descriptor layout"
+        assert "a2ui_envelope=a2ui_envelope" in source
+
+
+class TestTemplateLane:
     def test_template_lane_models_only_what_it_knows(self, toolkit):
         # The Jinja lane has no typed blocks; it must still emit a valid,
         # title-bearing surface rather than fabricated structure.

--- a/packages/ai-parrot/tests/tools/test_infographic_toolkit_a2ui_wiring.py
+++ b/packages/ai-parrot/tests/tools/test_infographic_toolkit_a2ui_wiring.py
@@ -1,0 +1,150 @@
+"""``InfographicToolkit`` → A2UI adapter wiring (FEAT-273 Module 11).
+
+Verifies that ``emit_a2ui=True`` now produces envelopes carrying REAL catalog
+components (KPICard/Chart/DataTable…) rather than heading-only sections, and
+that the A2UI lane stays additive: a build failure degrades to an HTML-only
+result instead of breaking the render.
+
+The toolkit is a heavy module (namespace packages + Cython) that resolves
+inconsistently under the worktree pytest layout, so the import is deferred and
+skipped the same way ``test_toolkits_a2ui_migration.py`` does.
+"""
+
+import importlib
+
+import pytest
+
+from parrot.models.infographic import InfographicResponse
+
+
+def _toolkit_or_skip():
+    try:
+        module = importlib.import_module("parrot.tools.infographic_toolkit")
+    except Exception as exc:  # noqa: BLE001 - Cython/namespace worktree limitation
+        pytest.skip(f"cannot import parrot.tools.infographic_toolkit: {exc}")
+    return module.InfographicToolkit
+
+
+@pytest.fixture
+def toolkit():
+    """A toolkit instance built without running __init__ (no ArtifactStore needed).
+
+    ``_build_a2ui_envelope`` only touches ``self.logger``, so bypassing the
+    constructor keeps this a focused unit test of the wiring.
+    """
+    import logging
+
+    cls = _toolkit_or_skip()
+    instance = cls.__new__(cls)
+    instance.logger = logging.getLogger("test.infographic_toolkit")
+    return instance
+
+
+def _response() -> InfographicResponse:
+    return InfographicResponse(
+        template="quarterly",
+        theme="ocean",
+        blocks=[
+            {"type": "title", "title": "Q1 Overview", "subtitle": "Financials"},
+            {"type": "summary", "content": "Revenue grew."},
+            {"type": "hero_card", "label": "Revenue", "value": "$1.2M"},
+            {
+                "type": "chart",
+                "chart_type": "bar",
+                "labels": ["Jan"],
+                "series": [{"name": "2026", "values": [10]}],
+            },
+            {
+                "type": "table",
+                "columns": ["Region", "Total"],
+                "rows": [["North", 10]],
+            },
+        ],
+    )
+
+
+def _infographic(envelope: dict) -> dict:
+    components = envelope["components"]
+    assert len(components) == 1
+    assert components[0]["component"] == "Infographic"
+    return components[0]["properties"]
+
+
+class TestEnvelopeCarriesRealComponents:
+    def test_blocks_become_catalog_components(self, toolkit):
+        envelope = toolkit._build_a2ui_envelope(_response(), "art-1")
+        assert envelope is not None
+        section = _infographic(envelope)["sections"][0]
+        assert [c["component"] for c in section["components"]] == [
+            "KPICard",
+            "Chart",
+            "DataTable",
+        ]
+
+    def test_surface_carries_title_subtitle_and_theme(self, toolkit):
+        props = _infographic(toolkit._build_a2ui_envelope(_response(), "art-1"))
+        assert props["title"] == "Q1 Overview"
+        assert props["subtitle"] == "Financials"
+        assert props["theme"] == "ocean"
+
+    def test_surface_id_derives_from_the_artifact_id(self, toolkit):
+        envelope = toolkit._build_a2ui_envelope(_response(), "art-42")
+        assert envelope["surface_id"] == "infographic-art-42"
+
+    def test_chart_and_table_rows_reach_the_data_model(self, toolkit):
+        envelope = toolkit._build_a2ui_envelope(_response(), "art-1")
+        data_model = envelope["data_model"]
+        assert data_model["charts"]["chart-0"] == [{"label": "Jan", "2026": 10}]
+        assert data_model["tables"]["table-0"] == [{"Region": "North", "Total": 10}]
+
+    def test_explicit_title_overrides_the_response(self, toolkit):
+        envelope = toolkit._build_a2ui_envelope(_response(), "art-1", title="Custom")
+        assert _infographic(envelope)["title"] == "Custom"
+
+    def test_no_longer_dumps_raw_blocks_into_the_data_model(self, toolkit):
+        # The pre-adapter implementation shipped data_model={"blocks": [...]}
+        # with heading-only sections and zero components.
+        envelope = toolkit._build_a2ui_envelope(_response(), "art-1")
+        assert "blocks" not in (envelope.get("data_model") or {})
+
+
+class TestFailureIsAdditive:
+    def test_build_failure_degrades_to_none(self, toolkit, caplog):
+        # A block type the catalog cannot express as a known component would
+        # normally raise; feeding a non-response object exercises the same
+        # degradation path deterministically.
+        envelope = toolkit._build_a2ui_envelope(object(), "art-1")
+        assert envelope is None
+        assert "falling back to HTML-only result" in caplog.text
+
+
+class TestSurfaceMatchesTheRenderedResponse:
+    def test_same_response_object_feeds_both_lanes(self, toolkit):
+        # Guards the regression the wiring fixes: the envelope must be built
+        # from the InfographicResponse the HTML renderer consumed, so the two
+        # surfaces never diverge. Whitespace-tolerant so reformatting is safe.
+        import inspect
+        import re
+
+        cls = _toolkit_or_skip()
+        source = inspect.getsource(cls.render)
+        assert re.search(
+            r"_build_a2ui_envelope\(\s*infographic_response\b", source
+        ), "render() must pass the InfographicResponse to _build_a2ui_envelope"
+
+    def test_template_lane_models_only_what_it_knows(self, toolkit):
+        # The Jinja lane has no typed blocks; it must still emit a valid,
+        # title-bearing surface rather than fabricated structure.
+        envelope = toolkit._build_a2ui_envelope(
+            InfographicResponse(
+                template="report",
+                blocks=[
+                    {"type": "title", "title": "Report"},
+                    {"type": "summary", "content": "Data: alpha, beta"},
+                ],
+            ),
+            "art-9",
+        )
+        props = _infographic(envelope)
+        assert props["title"] == "Report"
+        assert props["sections"][0]["text"] == "Data: alpha, beta"


### PR DESCRIPTION
## Summary

Implements a pure, deterministic adapter that bridges the legacy `InfographicResponse` model (flat list of typed blocks) to A2UI `CreateSurface` envelopes with real catalog components (KPICard, Chart, DataTable, etc.). This completes the D1a (tool-producer) lane of FEAT-273 §1/G2 for infographic output.

## Key Changes

- **New adapter module** (`parrot/outputs/a2ui/adapters/infographic.py`):
  - `infographic_response_to_envelope()` pure function converts `InfographicResponse` → `CreateSurface`
  - Implements documented sectioning policy: first title becomes surface header, later titles open sections, dividers create anonymous sections
  - Maps 11 block types to catalog components (hero_card→KPICard, chart→Chart, table→DataTable, etc.)
  - Handles lossy degradations deterministically (unsupported chart types collapse to nearest neighbor per `CHART_TYPE_MAP`)
  - Materializes chart/table rows into the data model with pointer bindings (`$bind`)
  - Flattens accordion/tab_view nesting up to depth 4

- **Toolkit integration** (`parrot/tools/infographic_toolkit.py`):
  - Updated `_build_a2ui_envelope()` to use the new adapter instead of hand-rolled sections
  - Both `render()` and `render_template()` now produce envelopes with real components
  - Synthetic blocks for Jinja templates preserve semantic intent (title + data keys as summary)

- **DataTable row materialization** (`parrot/outputs/a2ui/catalog/components/datatable.py`):
  - New `_lower_row()` helper materializes resolved rows to `Row`/`Text` nodes
  - Respects declared column order (not dict insertion order)
  - Handles mapping rows (by name), sequence rows (positionally), and scalar rows
  - Pads ragged rows with `None`

- **Comprehensive test coverage**:
  - 550-line test suite (`test_infographic_adapter.py`) exercises real `InfographicResponse` models against documented rules
  - Purity tests verify byte-identical output and no source mutation
  - Sectioning, chart mapping, table mapping, and block-type-specific tests
  - Toolkit wiring tests (`test_infographic_toolkit_a2ui_wiring.py`) verify integration
  - DataTable row materialization tests (`test_datatable_row_materialization.py`) pin the two-phase contract
  - Import-rule guard (`test_import_rule.py`) enforces G8 one-way dependency

## Implementation Details

- **Purity**: No clocks, UUIDs, network, or LLM tokens; deterministic key allocation (chart-0, chart-1, etc.)
- **Sectioning**: `_SectionAccumulator` class manages lazy section materialization to avoid empty sections
- **Data model binding**: Chart/table rows stored under `/charts/<key>` and `/tables/<key>`, referenced via `{"$bind": "..."}` pointers
- **Deterministic uniqueness**: `_unique()` helper handles series/column name collisions with numeric suffixes
- **Graceful degradation**: Unknown block types and unsupported chart types map to sensible fallbacks (Card, bar chart)
- **No mutation**: All conversions work on dict copies; source `InfographicResponse` is never modified

## Spec Compliance

- **D1a (tool-producer)**: Pure function, no side effects
- **G8 (one-way imports)**: Adapters subpackage imports only a2ui core + pure Pydantic models
- **OQ-C (lossy degradation)**: Documented, deterministic, never silent drops

https://claude.ai/code/session_01LLcj2wY26jahPk6EkS52Qj