### PR TITLE
feat(agent-cli-daemon): FEAT-422 — Agent CLI Daemon

### DIFF
--- a/docs/agentd.md
+++ b/docs/agentd.md
@@ -1,0 +1,318 @@
+# Agent CLI Daemon (agentd)
+
+> **Feature**: FEAT-422 — Agent CLI Daemon
+> **Spec**: [sdd/specs/agent-cli-daemon.spec.md](../sdd/specs/agent-cli-daemon.spec.md)
+> **Package**: `ai-parrot-integrations[agentd]` (`parrot.integrations.agentd`)
+
+`agentd` runs **one AI-Parrot agent** as a long-lived, foreground *Nix
+service (systemd/supervisord-managed), and lets you converse with it from
+a terminal, from a one-shot script, or from an external LLM (Claude Code
+and friends) over MCP — all while its internal machinery
+(`AgentSchedulerManager` jobs, method invocation) keeps working exactly as
+it does under the full aiohttp server.
+
+It sits between two existing options:
+
+- The full **aiohttp server** — multi-agent, HTTP API, always running.
+- The **in-process `parrot agent` REPL** — single agent, but dies with
+  the terminal, no client/server split.
+
+`agentd` is the middle ground: **1 daemon = 1 agent**, reachable over a
+Unix domain socket, with thin clients (console, one-shot, MCP) attaching
+and detaching independently of the daemon's own lifetime.
+
+---
+
+## Quickstart
+
+```bash
+# 1. Run an agent daemon in the foreground, straight from a Python path
+#    (class, instance, or sync/async factory) — no YAML needed for a
+#    quick spin:
+parrot serve my_package.agents:MyAgent --name my-agent
+
+# 2. In another terminal, attach the interactive Rich console:
+parrot attach my-agent
+
+# 3. Or fire a one-shot, pipe-friendly question:
+parrot ask my-agent "What's the status of order 4821?"
+
+# 4. Pretty-print daemon status:
+parrot status my-agent
+```
+
+`parrot attach`/`parrot ask`/`parrot status` all accept either the
+service **name** (resolved to the default socket path) or an explicit
+**socket path**.
+
+---
+
+## YAML configuration
+
+For anything beyond a quick spin — and required for `parrot
+install-service` — describe the daemon in a YAML file
+(`AgentServiceConfig`, Pydantic v2):
+
+```yaml
+name: my-agent                    # required — becomes the socket/unit/log identity
+agent:
+  target: "my_package.agents:MyAgent"   # required — "module.path:attr"
+  kwargs:                         # optional — passed to the class/factory
+    verbose: true
+socket: null                      # optional — default: $XDG_RUNTIME_DIR/parrot/<name>.sock
+scheduler:
+  enabled: true                   # default: true
+  dsn: null                       # optional Postgres DSN for schedule persistence
+  redis: false                    # default: false — attach a Redis jobstore
+exposed_methods: []               # default: [] — allowlist for agent.invoke / MCP invoke_method
+log_level: "INFO"                 # default: "INFO"
+max_line_bytes: 10485760           # default: 10 MB — NDJSON line-size limit
+shutdown_grace: 30.0               # default: 30.0 — seconds to wait for graceful shutdown
+```
+
+```bash
+parrot serve my-agent.yaml
+```
+
+### Field reference
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `name` | `str` | — (required) | Non-empty, no path separators (`/`, `\`) — becomes the socket filename and systemd unit name. |
+| `agent.target` | `str` | — (required) | `"module.path:attr"` — resolved as a class (instantiated), an already-constructed instance (used as-is), or a sync/async factory callable (called, awaited if it returns a coroutine). |
+| `agent.kwargs` | `dict` | `{}` | Passed to the class/factory when `target` isn't already an instance. |
+| `socket` | `Path \| null` | `null` | Explicit UDS path. `null` → `$XDG_RUNTIME_DIR/parrot/<name>.sock`, falling back to `/tmp/parrot-<uid>/<name>.sock`. |
+| `scheduler.enabled` | `bool` | `true` | `false` skips the headless scheduler bootstrap entirely. |
+| `scheduler.dsn` | `str \| null` | `null` | Postgres DSN. `null` → no DB-backed schedule persistence (decorator schedules still work, in-memory). |
+| `scheduler.redis` | `bool` | `false` | Attach a Redis-backed jobstore alongside the always-present in-memory one. |
+| `exposed_methods` | `list[str]` | `[]` | Allowlist for `agent.invoke` (RPC) and a **hard requirement** for the MCP `invoke_method` tool to even be registered — empty means `invoke_method` is never exposed over MCP. |
+| `log_level` | `str` | `"INFO"` | Standard `logging` level name. |
+| `max_line_bytes` | `int` | `10 * 1024 * 1024` | NDJSON line-size limit for the UDS server. |
+| `shutdown_grace` | `float` | `30.0` | Seconds `SIGTERM`/`SIGINT` handling waits for scheduler shutdown before forcing ahead. |
+
+CLI overrides on `parrot serve`: `--name`, `--socket`, `--dsn`,
+`--redis`/`--no-redis`, `--log-level` — applied on top of either the YAML
+file or a direct `module:attr` target (`--name` is required in that
+latter case, since there's no YAML to source it from).
+
+---
+
+## Deploying as a service
+
+### systemd (user, default)
+
+```bash
+parrot install-service my-agent.yaml
+```
+
+Writes `~/.config/systemd/user/parrot-my-agent.service` and prints the
+follow-up commands:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now parrot-my-agent
+```
+
+Generated unit:
+
+```ini
+[Unit]
+Description=AI-Parrot Agent Daemon: my-agent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=notify
+ExecStart=/path/to/venv/bin/parrot serve /path/to/my-agent.yaml
+Restart=on-failure
+Environment=PYTHONUNBUFFERED=1
+
+[Install]
+WantedBy=default.target
+```
+
+- `Type=notify`: the daemon sends a hand-rolled `sd_notify("READY=1")`
+  datagram once its socket is bound and ready — no `sdnotify` PyPI
+  dependency. When `NOTIFY_SOCKET` is absent (e.g. under supervisord, or
+  a plain terminal run), this is a silent no-op — the daemon behaves
+  exactly like `Type=simple`.
+- `ExecStart` is resolved from `sys.executable`'s own bin directory, so
+  it always points at the venv the unit was generated from.
+- `journalctl --user -u parrot-my-agent -f` follows the logs (plain,
+  timestamp-free format — journald already timestamps every line).
+
+### systemd (system-wide)
+
+```bash
+parrot install-service my-agent.yaml --system
+```
+
+**Prints the unit to stdout only** — `agentd` never writes to `/etc` and
+never escalates privileges. To install it system-wide:
+
+```bash
+# copy the printed unit yourself, as root:
+sudo tee /etc/systemd/system/parrot-my-agent.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now parrot-my-agent
+```
+
+### supervisord
+
+`agentd` never double-forks or writes a pidfile (spec decision: foreground
++ orchestrator-managed, not self-daemonizing), so a plain supervisord
+program block works as-is — `Type=notify`'s `sd_notify` call is simply a
+no-op here (no `NOTIFY_SOCKET`):
+
+```ini
+[program:parrot-my-agent]
+command=/path/to/venv/bin/parrot serve /path/to/my-agent.yaml
+autostart=true
+autorestart=true
+stdout_logfile=/var/log/parrot/my-agent.log
+environment=PYTHONUNBUFFERED="1"
+```
+
+---
+
+## Scheduler modes
+
+`AgentSchedulerManager` boots **headless** — no aiohttp import anywhere in
+the daemon's process path — via `start_headless(dsn=..., use_redis=...)`.
+Decorator-registered schedules (`@schedule(...)` on your agent's methods)
+always work; DB-backed dynamic schedules (`schedules.add/pause/resume/
+remove`) need a DSN.
+
+| `scheduler.dsn` | `scheduler.redis` | Jobstores | Decorator schedules | `schedules.add/pause/resume/remove` |
+|---|---|---|---|---|
+| `null` | `false` | in-memory only | ✅ | proxy errors (no DB to persist to, but calls don't crash the daemon) |
+| set | `false` | in-memory + Postgres-backed | ✅ | ✅ |
+| set | `true` | in-memory + Postgres + Redis | ✅ | ✅ |
+
+`schedules.list` always works regardless of DSN — it degrades gracefully
+to a JobStore-only view (decorator schedules) when no DB is configured.
+
+If `ai-parrot-server` (which owns `AgentSchedulerManager`) isn't
+installed at all, the daemon logs a warning and runs without a
+scheduler — `schedules.*` RPCs then return application error `1003`
+(`SCHEDULER_UNAVAILABLE`) instead of crashing.
+
+### Decorator example
+
+```python
+from parrot.scheduler.manager import ScheduleType, schedule
+
+class MyAgent(Agent):
+    @schedule(ScheduleType.INTERVAL, seconds=3600)
+    async def hourly_digest(self) -> None:
+        await self.ask("Summarize today's activity so far.")
+```
+
+Once the daemon starts, `register_bot_schedules(agent)` finds every
+`@schedule`-decorated method and registers it with APScheduler
+automatically — no extra configuration needed. Subscribed clients
+(`events.subscribe`) receive `event.job_executed`/`event.job_error`
+notifications as jobs run.
+
+---
+
+## Attaching a console / one-shot / MCP client
+
+```bash
+# Full interactive console (reuses the existing AgentREPL — same UX as
+# `parrot agent`, plus daemon-only slash commands):
+parrot attach my-agent
+
+# Inside the console:
+#   /status      — daemon.status pretty-printed
+#   /schedules   — list|add|pause|resume|remove
+#   /invoke <method> [json-kwargs]  — call an allowlisted agent method
+#   (queued job-event lines, e.g. "⏱ job auto_my-agent_hourly_digest
+#    ejecutado ✓", are flushed between turns, never mid-stream)
+
+# One-shot, pipe-friendly (Markdown on a TTY, plain text otherwise):
+parrot ask my-agent "..." | tee output.txt
+echo $?   # 0 on success, 1 on error
+```
+
+---
+
+## MCP registration (external LLMs)
+
+`parrot mcp-serve <name|socket>` runs an MCP **stdio** proxy: an MCP
+client (Claude Code, another agent framework) talks JSON-RPC over
+stdin/stdout, and every tool call is proxied to the daemon over its UDS
+socket. All logging goes to stderr — stdout is reserved for the MCP
+channel.
+
+```bash
+claude mcp add my-agent -- parrot mcp-serve my-agent
+```
+
+Exposed tools:
+
+| Tool | Always available? | Notes |
+|---|---|---|
+| `ask_agent(prompt)` | ✅ | Non-streaming `chat.send`. One MCP process = one daemon connection = one conversation session, so consecutive calls in the same MCP session share history. |
+| `agent_info()` | ✅ | Name, class, LLM, tool count, uptime, `exposed_methods`. |
+| `list_schedules()` | ✅ | Same payload as `schedules.list` (degrades gracefully without a DSN). |
+| `daemon_status()` | ✅ | Same payload as `daemon.status`. |
+| `invoke_method(method, kwargs)` | ⚠️ **only when `exposed_methods` is non-empty** | Client-side allowlist check as defense in depth, on top of the daemon's own enforcement. If your config has `exposed_methods: []`, this tool is never even registered — external LLMs cannot discover or call it. |
+
+**Gating warning**: `invoke_method` is powerful — it lets an external LLM
+call arbitrary allowlisted methods on your live agent. Only populate
+`exposed_methods` with methods you have deliberately reviewed for MCP
+exposure.
+
+---
+
+## Protocol appendix
+
+Wire format: **JSON-RPC 2.0** framed as **NDJSON** (one `\n`-terminated
+UTF-8 JSON object per line) over a Unix domain socket at
+`$XDG_RUNTIME_DIR/parrot/<name>.sock` (fallback `/tmp/parrot-<uid>/
+<name>.sock`), directory `0700`, socket file `0600`. One UDS connection =
+one conversation session.
+
+### Method table
+
+| Method | Params | Returns |
+|---|---|---|
+| `chat.send` | `{prompt, stream: bool, metadata?}` | Full `{output, metadata}` response, or `{stream_id}` ack when `stream=true` |
+| `agent.info` | — | `{name, class, llm, tools_count, uptime_s, exposed_methods}` |
+| `tools.list` | — | `{tools: [...]}` |
+| `agent.invoke` | `{method, args?, kwargs?}` | Serialized result of a public agent method (underscore-prefixed methods always rejected; `exposed_methods` acts as an allowlist when non-empty) |
+| `schedules.list` | — | Jobs: id, trigger, next_run_time, `source` (`db`/`auto`) |
+| `schedules.add` | schedule fields | ack (`AgentSchedule`) |
+| `schedules.pause` / `schedules.resume` / `schedules.remove` | `{schedule_id}` | ack |
+| `events.subscribe` / `events.unsubscribe` | — | `{subscribed: bool}` |
+| `daemon.status` | — | `{pid, uptime_s, version, scheduler: {available, running, jobs}, active_connections}` |
+| `daemon.shutdown` | — | ack, then graceful shutdown |
+
+Streaming (`chat.send` with `stream=true`): the ack `{stream_id}` is
+followed by `chat.delta {stream_id, text}` ×N, then exactly one terminal
+`chat.complete {stream_id, response, usage}` or `chat.error {stream_id,
+error}`. Subscribed clients also receive `event.job_executed`,
+`event.job_error`, `event.shutdown`.
+
+### Error codes
+
+| Code | Meaning |
+|---|---|
+| `-32700` | Parse error (malformed JSON) |
+| `-32600` | Invalid request |
+| `-32601` | Method not found |
+| `-32602` | Invalid params |
+| `-32603` | Internal error (any uncaught handler exception — message only, full traceback logged daemon-side) |
+| `1001` | `AGENT_BUSY` |
+| `1002` | `UNKNOWN_AGENT_METHOD` — unknown/private/non-allowlisted `agent.invoke` method |
+| `1003` | `SCHEDULER_UNAVAILABLE` — `ai-parrot-server` not installed, or `scheduler.enabled: false` |
+| `1004` | `SCHEDULE_NOT_FOUND` |
+
+---
+
+## Related
+
+- Spec: [`sdd/specs/agent-cli-daemon.spec.md`](../sdd/specs/agent-cli-daemon.spec.md)
+- Console engine reused as-is: `parrot.cli.repl.AgentREPL` (see `parrot agent`)
+- MCP server base reused as-is: `parrot.mcp.local_server.StdioMCPServer`

--- a/packages/ai-parrot-integrations/pyproject.toml
+++ b/packages/ai-parrot-integrations/pyproject.toml
@@ -31,6 +31,12 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# FEAT-422 — Agent CLI Daemon. Marker extra: rich/prompt_toolkit/click/
+# pydantic/pyyaml all come from ai-parrot core already; this extra exists
+# so the core CLI's missing-module error can name a concrete `pip install`
+# target. Scheduler support is via the separate optional `ai-parrot-server`
+# install (lazily imported, degrades with a warning when absent).
+agentd = []
 slack = [
     "slack-sdk>=3.27",
     "slack-bolt>=1.18",

--- a/packages/ai-parrot-integrations/src/parrot/integrations/agentd/__init__.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/agentd/__init__.py
@@ -1,0 +1,55 @@
+"""Agent CLI Daemon (agentd) — per-agent *Nix service subsystem.
+
+Implements the JSON-RPC 2.0 / NDJSON daemon described in
+``sdd/specs/agent-cli-daemon.spec.md``: a per-agent headless daemon
+(``AgentDaemon``), its Unix-domain-socket server (``JsonRpcUnixServer``), a
+thin async client (``AgentDaemonClient``), and the console/MCP proxies that
+consume it.
+
+This package is added incrementally, task by task, per FEAT-422. Only the
+wire-protocol layer (``protocol.py``) exists so far.
+"""
+
+from .protocol import (
+    AGENT_BUSY,
+    INTERNAL_ERROR,
+    INVALID_PARAMS,
+    INVALID_REQUEST,
+    JSONRPC_VERSION,
+    METHOD_NOT_FOUND,
+    PARSE_ERROR,
+    SCHEDULE_NOT_FOUND,
+    SCHEDULER_UNAVAILABLE,
+    UNKNOWN_AGENT_METHOD,
+    MalformedMessageError,
+    OversizedLineError,
+    ProtocolError,
+    RpcError,
+    RpcNotification,
+    RpcRequest,
+    RpcResponse,
+    read_message,
+    write_message,
+)
+
+__all__ = [
+    "AGENT_BUSY",
+    "INTERNAL_ERROR",
+    "INVALID_PARAMS",
+    "INVALID_REQUEST",
+    "JSONRPC_VERSION",
+    "METHOD_NOT_FOUND",
+    "PARSE_ERROR",
+    "SCHEDULER_UNAVAILABLE",
+    "SCHEDULE_NOT_FOUND",
+    "UNKNOWN_AGENT_METHOD",
+    "MalformedMessageError",
+    "OversizedLineError",
+    "ProtocolError",
+    "RpcError",
+    "RpcNotification",
+    "RpcRequest",
+    "RpcResponse",
+    "read_message",
+    "write_message",
+]

--- a/packages/ai-parrot-integrations/src/parrot/integrations/agentd/cli.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/agentd/cli.py
@@ -1,0 +1,403 @@
+"""Click commands for the Agent CLI Daemon (agentd) — Module 9.
+
+Lazily registered into the existing core ``parrot`` `LazyGroup` (see
+``packages/ai-parrot/src/parrot/cli/__init__.py``) under the keys
+``serve``, ``attach``, ``ask``, ``status``, ``install-service``,
+``mcp-serve``. Function names MUST match those keys (with ``-`` -> ``_``)
+since ``LazyGroup.get_command()`` resolves them via
+``getattr(mod, cmd_name.replace("-", "_"))``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+
+import click
+from parrot.cli.renderer import ResponseRenderer
+from parrot.cli.repl import AgentREPL, REPLConfig
+from rich.console import Console
+from rich.markdown import Markdown
+
+from .client import AgentDaemonClient, DaemonNotRunning, RpcRemoteError, resolve_socket
+from .config import AgentServiceConfig
+from .mcp_server import run_mcp_proxy
+from .proxy import DaemonAgentProxy, register_daemon_commands
+from .service import AgentDaemon
+
+console = Console()
+
+__all__ = [
+    "ask",
+    "attach",
+    "install_service",
+    "mcp_serve",
+    "serve",
+    "status",
+]
+
+
+# --------------------------------------------------------------------------
+# serve
+# --------------------------------------------------------------------------
+
+
+@click.command("serve")
+@click.argument("config_or_target")
+@click.option(
+    "--name", default=None, help="Service name (required for a module:attr target)."
+)
+@click.option(
+    "--socket", "socket_path", default=None, type=click.Path(), help="Explicit UDS socket path."
+)
+@click.option("--dsn", default=None, help="Postgres DSN for schedule persistence.")
+@click.option(
+    "--redis/--no-redis",
+    "use_redis",
+    default=None,
+    help="Attach a Redis-backed jobstore.",
+)
+@click.option("--log-level", default=None, help="Logging level (e.g. INFO, DEBUG).")
+def serve(
+    config_or_target: str,
+    name: str | None,
+    socket_path: str | None,
+    dsn: str | None,
+    use_redis: bool | None,
+    log_level: str | None,
+) -> None:
+    """Run a per-agent daemon in the foreground.
+
+    CONFIG_OR_TARGET is either a path to a YAML config file (``.yaml``/
+    ``.yml``) or a Python ``module:attr`` target (class, instance, or
+    sync/async factory).
+    """
+    try:
+        cfg = _build_serve_config(config_or_target, name, socket_path, dsn, use_redis, log_level)
+    except click.ClickException:
+        raise
+    except Exception as exc:
+        click.echo(f"Error building agentd config: {exc}", err=True)
+        raise SystemExit(1) from exc
+
+    try:
+        asyncio.run(AgentDaemon(cfg).run())
+    except KeyboardInterrupt:
+        pass
+
+
+def _build_serve_config(
+    config_or_target: str,
+    name: str | None,
+    socket_path: str | None,
+    dsn: str | None,
+    use_redis: bool | None,
+    log_level: str | None,
+) -> AgentServiceConfig:
+    """Build an `AgentServiceConfig` from CLI args (YAML file or target)."""
+    path = Path(config_or_target)
+    if path.is_file() and path.suffix.lower() in (".yaml", ".yml"):
+        cfg = AgentServiceConfig.from_yaml(path)
+        if name:
+            cfg = cfg.model_copy(update={"name": name})
+    else:
+        if not name:
+            raise click.UsageError(
+                "--name is required when serving directly from a module:attr target."
+            )
+        cfg = AgentServiceConfig.from_target(config_or_target, name=name)
+
+    overrides: dict[str, Any] = {}
+    if socket_path:
+        overrides["socket"] = Path(socket_path)
+    if log_level:
+        overrides["log_level"] = log_level
+    if overrides:
+        cfg = cfg.model_copy(update=overrides)
+
+    scheduler_overrides: dict[str, Any] = {}
+    if dsn is not None:
+        scheduler_overrides["dsn"] = dsn
+    if use_redis is not None:
+        scheduler_overrides["redis"] = use_redis
+    if scheduler_overrides:
+        cfg = cfg.model_copy(
+            update={"scheduler": cfg.scheduler.model_copy(update=scheduler_overrides)}
+        )
+
+    return cfg
+
+
+# --------------------------------------------------------------------------
+# attach
+# --------------------------------------------------------------------------
+
+
+@click.command("attach")
+@click.argument("name_or_socket")
+@click.option(
+    "--no-stream",
+    is_flag=True,
+    default=False,
+    help="Disable streaming; wait for the full response before rendering.",
+)
+def attach(name_or_socket: str, no_stream: bool) -> None:
+    """Attach the interactive Rich console to a running agentd daemon."""
+    try:
+        asyncio.run(_run_attach(name_or_socket, no_stream))
+    except SystemExit:
+        raise
+    except KeyboardInterrupt:
+        console.print("\n[dim]Interrupted.[/dim]")
+
+
+async def _run_attach(name_or_socket: str, no_stream: bool) -> None:
+    """Async implementation of the `attach` command."""
+    renderer = ResponseRenderer()
+    proxy = DaemonAgentProxy(name_or_socket)
+
+    try:
+        bot = await proxy.load(name_or_socket)
+    except DaemonNotRunning as exc:
+        console.print(f"[bold red]Cannot attach:[/bold red] {exc}")
+        console.print(
+            "[dim]Check 'systemctl --user status parrot-<name>' or start it "
+            "with 'parrot serve <config.yaml|module:attr>'.[/dim]"
+        )
+        raise SystemExit(1) from exc
+
+    display_name = bot.name
+    try:
+        agents = await proxy.list_agents()
+        if agents:
+            display_name = agents[0].get("name", display_name)
+            bot.name = display_name
+    except RpcRemoteError:
+        pass  # Cosmetic only -- keep going with the fallback name.
+
+    config = REPLConfig(agent_name=display_name, streaming=not no_stream)
+    repl = AgentREPL(bot=bot, config=config, renderer=renderer)
+    register_daemon_commands(repl, proxy)
+    _wrap_with_event_drain(repl, proxy)
+
+    console.print(
+        f"\n[bold green]Attached to daemon:[/bold green] [bold]{display_name}[/bold]"
+    )
+    console.print(
+        "[dim]Type your message to chat.  Use /help for slash commands "
+        "(including /status, /schedules, /invoke).  Ctrl+D or /quit to "
+        "exit.[/dim]\n"
+    )
+
+    try:
+        await repl.run()
+    except SystemExit:
+        raise
+    except Exception as exc:
+        console.print(f"[bold red]REPL error:[/bold red] {exc}")
+        raise SystemExit(1) from exc
+    finally:
+        await proxy.close()
+
+
+def _wrap_with_event_drain(repl: AgentREPL, proxy: DaemonAgentProxy) -> None:
+    """Flush queued job-event lines after each turn, never mid-stream.
+
+    `AgentREPL.run()`'s loop is a monolithic method with no exposed
+    post-turn hook, and modifying `parrot.cli.repl` is out of scope for
+    this feature. Instead, this wraps `repl.send`/`repl.send_stream` at
+    the INSTANCE level (shadowing the class methods `run()` calls) so
+    queued events print right after a turn completes and before the next
+    prompt is shown -- the same seam the spec calls for, achieved without
+    touching core.
+    """
+    original_send = repl.send
+    original_send_stream = repl.send_stream
+
+    async def _send_with_drain(query: str):
+        result = await original_send(query)
+        _print_drained_events(proxy)
+        return result
+
+    async def _send_stream_with_drain(query: str) -> None:
+        await original_send_stream(query)
+        _print_drained_events(proxy)
+
+    repl.send = _send_with_drain
+    repl.send_stream = _send_stream_with_drain
+
+
+def _print_drained_events(proxy: DaemonAgentProxy) -> None:
+    """Print every queued job-event line, then clear the queue."""
+    for line in proxy.drain_events():
+        console.print(f"[dim]{line}[/dim]")
+
+
+# --------------------------------------------------------------------------
+# ask
+# --------------------------------------------------------------------------
+
+
+@click.command("ask")
+@click.argument("name_or_socket")
+@click.argument("question")
+def ask(name_or_socket: str, question: str) -> None:
+    """One-shot, pipe-friendly question to a running agentd daemon.
+
+    Renders Markdown when stdout is a TTY, plain text otherwise (no ANSI
+    in pipes/CI). Exits 0 on success, 1 on error.
+    """
+    asyncio.run(_run_ask(name_or_socket, question))
+
+
+async def _run_ask(name_or_socket: str, question: str) -> None:
+    """Async implementation of the `ask` command."""
+    socket_path = resolve_socket(name_or_socket)
+    try:
+        client = await AgentDaemonClient.connect(socket_path)
+    except DaemonNotRunning as exc:
+        click.echo(str(exc), err=True)
+        raise SystemExit(1) from exc
+
+    try:
+        try:
+            result = await client.call(
+                "chat.send", prompt=question, stream=False, metadata={}
+            )
+        except RpcRemoteError as exc:
+            click.echo(f"Error: {exc}", err=True)
+            raise SystemExit(1) from exc
+    finally:
+        await client.close()
+
+    output = result.get("output", "")
+    if sys.stdout.isatty():
+        console.print(Markdown(output))
+    else:
+        click.echo(output)
+
+
+# --------------------------------------------------------------------------
+# status
+# --------------------------------------------------------------------------
+
+
+@click.command("status")
+@click.argument("name_or_socket")
+def status(name_or_socket: str) -> None:
+    """Pretty-print a running agentd daemon's status."""
+    asyncio.run(_run_status(name_or_socket))
+
+
+async def _run_status(name_or_socket: str) -> None:
+    """Async implementation of the `status` command."""
+    socket_path = resolve_socket(name_or_socket)
+    try:
+        client = await AgentDaemonClient.connect(socket_path)
+    except DaemonNotRunning as exc:
+        click.echo(str(exc), err=True)
+        raise SystemExit(1) from exc
+
+    try:
+        result = await client.call("daemon.status")
+    finally:
+        await client.close()
+
+    scheduler = result.get("scheduler", {})
+    ResponseRenderer().render_info(
+        [
+            ("PID", str(result.get("pid"))),
+            ("Uptime (s)", f"{result.get('uptime_s', 0):.1f}"),
+            ("Version", str(result.get("version"))),
+            ("Scheduler available", str(scheduler.get("available"))),
+            ("Scheduler running", str(scheduler.get("running"))),
+            ("Scheduled jobs", str(scheduler.get("jobs"))),
+            ("Active connections", str(result.get("active_connections"))),
+        ]
+    )
+
+
+# --------------------------------------------------------------------------
+# install-service
+# --------------------------------------------------------------------------
+
+
+@click.command("install-service")
+@click.argument("config_path", type=click.Path(exists=True, dir_okay=False))
+@click.option(
+    "--system",
+    "system_mode",
+    is_flag=True,
+    default=False,
+    help="Print a system-wide unit instead of writing a user unit (never writes to /etc, never sudo).",
+)
+def install_service(config_path: str, system_mode: bool) -> None:
+    """Generate a systemd unit file for an agentd daemon."""
+    cfg_path = Path(config_path).resolve()
+    try:
+        cfg = AgentServiceConfig.from_yaml(cfg_path)
+    except Exception as exc:
+        click.echo(f"Error reading config: {exc}", err=True)
+        raise SystemExit(1) from exc
+
+    unit_text = _render_unit(cfg.name, cfg_path)
+
+    if system_mode:
+        click.echo(unit_text)
+        click.echo(
+            "\n# --system prints ONLY -- this command never writes to /etc "
+            "or escalates privileges. To install system-wide, save the unit "
+            f"above as /etc/systemd/system/parrot-{cfg.name}.service as root, "
+            "then run:\n"
+            "#   sudo systemctl daemon-reload\n"
+            f"#   sudo systemctl enable --now parrot-{cfg.name}",
+            err=True,
+        )
+        return
+
+    unit_dir = Path.home() / ".config" / "systemd" / "user"
+    unit_dir.mkdir(parents=True, exist_ok=True)
+    unit_path = unit_dir / f"parrot-{cfg.name}.service"
+    unit_path.write_text(unit_text, encoding="utf-8")
+
+    click.echo(f"Wrote {unit_path}")
+    click.echo("Next steps:")
+    click.echo("  systemctl --user daemon-reload")
+    click.echo(f"  systemctl --user enable --now parrot-{cfg.name}")
+
+
+def _render_unit(name: str, config_path: Path) -> str:
+    """Render the systemd unit file content for one agentd service."""
+    parrot_bin = Path(sys.executable).parent / "parrot"
+    return (
+        "[Unit]\n"
+        f"Description=AI-Parrot Agent Daemon: {name}\n"
+        "After=network-online.target\n"
+        "Wants=network-online.target\n"
+        "\n"
+        "[Service]\n"
+        "Type=notify\n"
+        f"ExecStart={parrot_bin} serve {config_path}\n"
+        "Restart=on-failure\n"
+        "Environment=PYTHONUNBUFFERED=1\n"
+        "\n"
+        "[Install]\n"
+        "WantedBy=default.target\n"
+    )
+
+
+# --------------------------------------------------------------------------
+# mcp-serve
+# --------------------------------------------------------------------------
+
+
+@click.command("mcp-serve")
+@click.argument("name_or_socket")
+def mcp_serve(name_or_socket: str) -> None:
+    """Run an MCP stdio proxy exposing an agentd daemon to external LLMs."""
+    try:
+        asyncio.run(run_mcp_proxy(name_or_socket))
+    except KeyboardInterrupt:
+        pass

--- a/packages/ai-parrot-integrations/src/parrot/integrations/agentd/client.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/agentd/client.py
@@ -1,0 +1,353 @@
+"""Async Unix-domain-socket JSON-RPC client for the Agent CLI Daemon.
+
+Implements Module 6 of ``sdd/specs/agent-cli-daemon.spec.md``: the single
+shared client consumed by the Rich console (``proxy.py``, TASK-2214), the
+one-shot ``parrot ask`` command, and the MCP stdio proxy
+(``mcp_server.py``, TASK-2215). A background reader task demultiplexes
+incoming NDJSON lines: RPC responses are matched to pending futures by
+``id``; streaming ``chat.*`` notifications are routed by ``stream_id`` to
+per-stream queues; ``event.*`` notifications are delivered to an optional
+callback.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import itertools
+import logging
+from collections.abc import AsyncIterator, Callable
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+from .config import default_socket_path
+from .protocol import (
+    DEFAULT_MAX_LINE_BYTES,
+    METHOD_CHAT_COMPLETE,
+    METHOD_CHAT_DELTA,
+    METHOD_CHAT_ERROR,
+    METHOD_CHAT_SEND,
+    METHOD_EVENTS_SUBSCRIBE,
+    MalformedMessageError,
+    OversizedLineError,
+    ProtocolError,
+    RpcNotification,
+    RpcRequest,
+    RpcResponse,
+    read_message,
+    write_message,
+)
+
+__all__ = [
+    "AgentDaemonClient",
+    "ConnectionClosed",
+    "DaemonNotRunning",
+    "RpcRemoteError",
+    "StreamEvent",
+    "resolve_socket",
+]
+
+#: Bounded queue size for per-stream notification delivery -- backpressure:
+#: a slow stream consumer blocks further daemon writes on this connection
+#: rather than growing client memory without bound.
+_STREAM_QUEUE_MAXSIZE = 1024
+
+
+def resolve_socket(name_or_path: str) -> Path:
+    """Resolve a daemon identifier into a concrete socket path.
+
+    Args:
+        name_or_path: Either an existing filesystem path to a socket, or a
+            bare service name (resolved via `default_socket_path()`).
+
+    Returns:
+        The concrete socket path (existence/liveness is NOT re-checked
+        here — `AgentDaemonClient.connect()` handles that).
+    """
+    candidate = Path(name_or_path)
+    if candidate.exists():
+        return candidate
+    return default_socket_path(name_or_path)
+
+
+class DaemonNotRunning(Exception):
+    """Raised when `connect()` exhausts its retries with no live daemon."""
+
+
+class ConnectionClosed(Exception):
+    """Raised against pending calls/streams when the connection is closed."""
+
+
+class RpcRemoteError(Exception):
+    """Raised when a `call()` receives a JSON-RPC error response.
+
+    Attributes:
+        code: The JSON-RPC (or agentd application-range) error code.
+        message: The error message.
+    """
+
+    def __init__(self, code: int, message: str) -> None:
+        super().__init__(f"[{code}] {message}")
+        self.code = code
+        self.message = message
+
+
+class StreamEvent(BaseModel):
+    """One event yielded by `AgentDaemonClient.stream()`.
+
+    Attributes:
+        kind: `"delta"`, `"complete"`, or `"error"`.
+        text: Incremental text (only set when `kind == "delta"`).
+        response: Final response (only set when `kind == "complete"`).
+        usage: Usage metadata (only set when `kind == "complete"`).
+        error: Error message (only set when `kind == "error"`).
+    """
+
+    kind: Literal["delta", "complete", "error"]
+    text: str | None = None
+    response: Any | None = None
+    usage: dict[str, Any] | None = None
+    error: str | None = None
+
+
+class AgentDaemonClient:
+    """Async JSON-RPC 2.0 / NDJSON client over a Unix domain socket.
+
+    Attributes:
+        on_event: Optional callback invoked with `(method, params)` for
+            every `event.*` notification received (scheduler/daemon
+            fan-out events — distinct from `chat.*` stream notifications).
+    """
+
+    def __init__(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        *,
+        max_line_bytes: int = DEFAULT_MAX_LINE_BYTES,
+        on_event: Callable[[str, dict[str, Any]], Any] | None = None,
+    ) -> None:
+        self._reader = reader
+        self._writer = writer
+        self._max_line_bytes = max_line_bytes
+        self.on_event = on_event
+        self.logger = logging.getLogger(__name__)
+
+        self._id_counter = itertools.count(1)
+        self._pending: dict[int, asyncio.Future] = {}
+        self._streams: dict[str, asyncio.Queue] = {}
+        self._closed = False
+        self._reader_task = asyncio.ensure_future(self._read_loop())
+
+    @classmethod
+    async def connect(
+        cls,
+        socket_path: Path,
+        *,
+        retries: int = 3,
+        backoff: float = 0.5,
+        on_event: Callable[[str, dict[str, Any]], Any] | None = None,
+    ) -> AgentDaemonClient:
+        """Connect to a daemon's UDS socket, retrying with a fixed backoff.
+
+        Args:
+            socket_path: Path to the daemon's Unix domain socket.
+            retries: Number of connection attempts before giving up.
+            backoff: Seconds to sleep between attempts (survives a
+                `systemctl restart` window).
+            on_event: Optional `event.*` notification callback.
+
+        Returns:
+            A connected `AgentDaemonClient`.
+
+        Raises:
+            DaemonNotRunning: If all `retries` attempts fail, with an
+                actionable message.
+        """
+        last_exc: Exception | None = None
+        for attempt in range(1, retries + 1):
+            try:
+                reader, writer = await asyncio.open_unix_connection(
+                    path=str(socket_path)
+                )
+                return cls(reader, writer, on_event=on_event)
+            except OSError as exc:
+                last_exc = exc
+                if attempt < retries:
+                    await asyncio.sleep(backoff)
+
+        raise DaemonNotRunning(
+            f"No daemon listening on {socket_path} after {retries} attempt(s). "
+            "Start it with 'parrot serve <config.yaml|module:attr>', or check "
+            f"'systemctl --user status parrot-<name>' ({last_exc})."
+        )
+
+    async def call(self, method: str, **params: Any) -> Any:
+        """Issue a request and await its response.
+
+        Args:
+            method: RPC method name.
+            **params: Method parameters.
+
+        Returns:
+            The response `result`.
+
+        Raises:
+            RpcRemoteError: If the daemon returns an error response.
+            ConnectionClosed: If the connection closes before a response
+                arrives.
+        """
+        request_id = next(self._id_counter)
+        future: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._pending[request_id] = future
+        try:
+            write_message(
+                self._writer,
+                RpcRequest(id=request_id, method=method, params=params),
+            )
+            await self._writer.drain()
+            response: RpcResponse = await future
+        finally:
+            self._pending.pop(request_id, None)
+
+        if response.error is not None:
+            raise RpcRemoteError(response.error.code, response.error.message)
+        return response.result
+
+    async def stream(self, prompt: str, **metadata: Any) -> AsyncIterator[StreamEvent]:
+        """Issue a streaming `chat.send` and yield events as they arrive.
+
+        Args:
+            prompt: The prompt to send.
+            **metadata: Extra `chat.send` metadata, passed through as-is.
+
+        Yields:
+            Zero or more `kind="delta"` events, followed by exactly one
+            terminal `kind="complete"` or `kind="error"` event.
+        """
+        ack = await self.call(
+            METHOD_CHAT_SEND, prompt=prompt, stream=True, metadata=metadata
+        )
+        stream_id = ack["stream_id"]
+        queue: asyncio.Queue = asyncio.Queue(maxsize=_STREAM_QUEUE_MAXSIZE)
+        self._streams[stream_id] = queue
+
+        try:
+            while True:
+                item = await queue.get()
+                if isinstance(item, BaseException):
+                    raise item
+                yield item
+                if item.kind in ("complete", "error"):
+                    break
+        finally:
+            self._streams.pop(stream_id, None)
+
+    async def subscribe_events(
+        self, callback: Callable[[str, dict[str, Any]], Any]
+    ) -> None:
+        """Subscribe to daemon/scheduler events and register the callback.
+
+        Args:
+            callback: Invoked with `(method, params)` for every `event.*`
+                notification received from this point on.
+        """
+        self.on_event = callback
+        await self.call(METHOD_EVENTS_SUBSCRIBE)
+
+    async def close(self) -> None:
+        """Close the connection: cancel the reader, fail pending calls/streams."""
+        if self._closed:
+            return
+        self._closed = True
+
+        self._reader_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await self._reader_task
+
+        self._fail_all(ConnectionClosed("Connection closed"))
+
+        with contextlib.suppress(Exception):
+            self._writer.close()
+        with contextlib.suppress(Exception):
+            await self._writer.wait_closed()
+
+    def _fail_all(self, exc: Exception) -> None:
+        """Fail every pending call and stream with `exc` (idempotent)."""
+        for future in list(self._pending.values()):
+            if not future.done():
+                future.set_exception(exc)
+        self._pending.clear()
+
+        for queue in list(self._streams.values()):
+            with contextlib.suppress(asyncio.QueueFull):
+                queue.put_nowait(exc)
+        self._streams.clear()
+
+    async def _read_loop(self) -> None:
+        """Background task: demux incoming lines to pending futures/streams.
+
+        Must never die silently -- on EOF, protocol error, or unexpected
+        exception, every pending call/stream is failed with
+        `ConnectionClosed` so callers never hang.
+        """
+        try:
+            while True:
+                try:
+                    message = await read_message(
+                        self._reader, max_line_bytes=self._max_line_bytes
+                    )
+                except (MalformedMessageError, OversizedLineError, ProtocolError) as exc:
+                    self.logger.warning("Protocol error from daemon: %s", exc)
+                    break
+
+                if message is None:
+                    break  # Clean EOF.
+
+                if isinstance(message, RpcResponse):
+                    future = self._pending.get(message.id)
+                    if future is not None and not future.done():
+                        future.set_result(message)
+                elif isinstance(message, RpcNotification):
+                    self._dispatch_notification(message)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger.exception("agentd client reader loop crashed")
+
+        self._fail_all(ConnectionClosed("Connection closed by daemon"))
+
+    def _dispatch_notification(self, note: RpcNotification) -> None:
+        """Route one notification to its stream queue or the event callback."""
+        if note.method in (METHOD_CHAT_DELTA, METHOD_CHAT_COMPLETE, METHOD_CHAT_ERROR):
+            stream_id = note.params.get("stream_id")
+            queue = self._streams.get(stream_id)
+            if queue is None:
+                self.logger.debug(
+                    "Notification for unknown stream_id=%r: %s",
+                    stream_id,
+                    note.method,
+                )
+                return
+            with contextlib.suppress(asyncio.QueueFull):
+                queue.put_nowait(self._to_stream_event(note))
+        elif note.method.startswith("event."):
+            if self.on_event is not None:
+                self.on_event(note.method, note.params)
+        else:
+            self.logger.debug("Unhandled notification method: %s", note.method)
+
+    @staticmethod
+    def _to_stream_event(note: RpcNotification) -> StreamEvent:
+        """Convert a `chat.*` notification into a typed `StreamEvent`."""
+        if note.method == METHOD_CHAT_DELTA:
+            return StreamEvent(kind="delta", text=note.params.get("text"))
+        if note.method == METHOD_CHAT_COMPLETE:
+            return StreamEvent(
+                kind="complete",
+                response=note.params.get("response"),
+                usage=note.params.get("usage"),
+            )
+        return StreamEvent(kind="error", error=note.params.get("error"))

--- a/packages/ai-parrot-integrations/src/parrot/integrations/agentd/client.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/agentd/client.py
@@ -16,6 +16,7 @@ import asyncio
 import contextlib
 import itertools
 import logging
+import uuid
 from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 from typing import Any, Literal
@@ -240,12 +241,31 @@ class AgentDaemonClient:
             Zero or more `kind="delta"` events, followed by exactly one
             terminal `kind="complete"` or `kind="error"` event.
         """
-        ack = await self.call(
-            METHOD_CHAT_SEND, prompt=prompt, stream=True, metadata=metadata
-        )
-        stream_id = ack["stream_id"]
+        # The stream_id is generated CLIENT-side and the queue registered
+        # BEFORE the request is even sent (rather than waiting for the
+        # daemon's ack to hand one back). `_read_loop()` is a single task
+        # processing the wire strictly in order, but it does not yield
+        # back to this coroutine between processing the ack and the very
+        # next buffered line -- for a fast/local daemon, `chat.delta`
+        # notifications can already be queued up behind the ack by the
+        # time it resumes. Registering the queue first closes that race:
+        # any notification for this stream_id always finds its queue.
+        stream_id = uuid.uuid4().hex
         queue: asyncio.Queue = asyncio.Queue(maxsize=_STREAM_QUEUE_MAXSIZE)
         self._streams[stream_id] = queue
+
+        try:
+            ack = await self.call(
+                METHOD_CHAT_SEND,
+                prompt=prompt,
+                stream=True,
+                stream_id=stream_id,
+                metadata=metadata,
+            )
+            assert ack.get("stream_id", stream_id) == stream_id
+        except Exception:
+            self._streams.pop(stream_id, None)
+            raise
 
         try:
             while True:

--- a/packages/ai-parrot-integrations/src/parrot/integrations/agentd/client.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/agentd/client.py
@@ -184,12 +184,24 @@ class AgentDaemonClient:
             f"'systemctl --user status parrot-<name>' ({last_exc})."
         )
 
-    async def call(self, method: str, **params: Any) -> Any:
+    async def call(
+        self,
+        method: str,
+        *,
+        params: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> Any:
         """Issue a request and await its response.
 
         Args:
             method: RPC method name.
-            **params: Method parameters.
+            params: Explicit params mapping. Merged with `**kwargs` (kwargs
+                win on key collision) -- use this when a param key would
+                otherwise collide with this method's own `method`/`params`
+                argument names (e.g. `agent.invoke`'s own `"method"` param:
+                `call("agent.invoke", params={"method": "some_method"})`).
+            **kwargs: Method parameters, for the common case where no
+                param name collides with `call()`'s own signature.
 
         Returns:
             The response `result`.
@@ -199,13 +211,14 @@ class AgentDaemonClient:
             ConnectionClosed: If the connection closes before a response
                 arrives.
         """
+        merged_params = {**(params or {}), **kwargs}
         request_id = next(self._id_counter)
         future: asyncio.Future = asyncio.get_event_loop().create_future()
         self._pending[request_id] = future
         try:
             write_message(
                 self._writer,
-                RpcRequest(id=request_id, method=method, params=params),
+                RpcRequest(id=request_id, method=method, params=merged_params),
             )
             await self._writer.drain()
             response: RpcResponse = await future

--- a/packages/ai-parrot-integrations/src/parrot/integrations/agentd/config.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/agentd/config.py
@@ -77,8 +77,9 @@ class AgentServiceConfig(BaseModel):
         exposed_methods: Allowlist of agent method names exposed via the
             `agent.invoke` RPC method; when non-empty it is also a hard
             requirement for the MCP `invoke_method` tool to be registered
-            at all. Empty means all public async methods are exposed over
-            RPC (still subject to the underscore-prefix rejection).
+            at all. Empty means every public method (sync or async; the
+            handler awaits the result when it is awaitable) is exposed
+            over RPC, still subject to the underscore-prefix rejection.
         log_level: Logging level name (e.g. `"INFO"`, `"DEBUG"`).
         max_line_bytes: NDJSON line-size limit for the UDS server.
         shutdown_grace: Seconds to wait for graceful shutdown before the

--- a/packages/ai-parrot-integrations/src/parrot/integrations/agentd/config.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/agentd/config.py
@@ -1,0 +1,244 @@
+"""Agent Service configuration — YAML config + agent target resolution.
+
+Implements the daemon-side configuration surface described in
+``sdd/specs/agent-cli-daemon.spec.md`` §2 ("Data Models") and Module 2:
+Pydantic v2 models for ``AgentServiceConfig`` (loadable from YAML or built
+directly from a Python-path target for CLI use), the default Unix-domain-
+socket path computation, and ``resolve_agent()`` — turning a
+``module:attr`` target into a live, configured agent instance.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field, field_validator
+
+__all__ = [
+    "AgentServiceConfig",
+    "AgentTargetConfig",
+    "AgentTargetError",
+    "SchedulerConfig",
+    "default_socket_path",
+    "resolve_agent",
+]
+
+#: Default NDJSON line-size limit (bytes) for the UDS server (spec §2).
+_DEFAULT_MAX_LINE_BYTES = 10 * 1024 * 1024  # 10 MB
+
+#: Characters not allowed in a service `name` (it becomes a filename).
+_NAME_INVALID_CHARS = frozenset("/\\")
+
+
+class SchedulerConfig(BaseModel):
+    """Headless scheduler bootstrap options for the daemon.
+
+    Attributes:
+        enabled: Whether to boot `AgentSchedulerManager` at all.
+        dsn: Postgres DSN for schedule persistence. `None` means no
+            Postgres pool is created (decorator-registered schedules only).
+        redis: Whether to attach a Redis-backed jobstore.
+    """
+
+    enabled: bool = True
+    dsn: str | None = None
+    redis: bool = False
+
+
+class AgentTargetConfig(BaseModel):
+    """Identifies the agent to load via a Python path.
+
+    Attributes:
+        target: `"module.path:attr"` — a class, an already-constructed
+            instance, or a sync/async factory callable.
+        kwargs: Keyword arguments passed when `target` resolves to a class
+            or a factory callable.
+    """
+
+    target: str
+    kwargs: dict[str, Any] = Field(default_factory=dict)
+
+
+class AgentServiceConfig(BaseModel):
+    """Full configuration for one `AgentDaemon` instance.
+
+    Attributes:
+        name: Service name — becomes the socket filename, unit name, and
+            log identity. Must be non-empty and contain no path separators.
+        agent: The agent target to load.
+        socket: Explicit UDS path. `None` means `default_socket_path(name)`
+            is used at daemon start time.
+        scheduler: Headless scheduler bootstrap options.
+        exposed_methods: Allowlist of agent method names exposed via the
+            `agent.invoke` RPC method; when non-empty it is also a hard
+            requirement for the MCP `invoke_method` tool to be registered
+            at all. Empty means all public async methods are exposed over
+            RPC (still subject to the underscore-prefix rejection).
+        log_level: Logging level name (e.g. `"INFO"`, `"DEBUG"`).
+        max_line_bytes: NDJSON line-size limit for the UDS server.
+        shutdown_grace: Seconds to wait for graceful shutdown before the
+            daemon forces an exit.
+    """
+
+    name: str
+    agent: AgentTargetConfig
+    socket: Path | None = None
+    scheduler: SchedulerConfig = Field(default_factory=SchedulerConfig)
+    exposed_methods: list[str] = Field(default_factory=list)
+    log_level: str = "INFO"
+    max_line_bytes: int = _DEFAULT_MAX_LINE_BYTES
+    shutdown_grace: float = 30.0
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, value: str) -> str:
+        """Reject empty names or names containing path separators."""
+        if not value or any(ch in _NAME_INVALID_CHARS for ch in value):
+            raise ValueError(
+                f"Invalid service name {value!r}: must be non-empty and "
+                "contain no path separators (it becomes a filename)."
+            )
+        return value
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> AgentServiceConfig:
+        """Load an `AgentServiceConfig` from a YAML file.
+
+        Args:
+            path: Path to the YAML config file.
+
+        Returns:
+            The parsed and validated config.
+        """
+        raw = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+        return cls.model_validate(raw)
+
+    @classmethod
+    def from_target(
+        cls, target: str, name: str, **overrides: Any
+    ) -> AgentServiceConfig:
+        """Build a config directly from a `module:attr` target (no YAML).
+
+        Args:
+            target: `"module.path:attr"` agent target.
+            name: Service name.
+            **overrides: Any other `AgentServiceConfig` fields to override
+                (e.g. `socket=...`, `log_level=...`).
+
+        Returns:
+            The constructed config.
+        """
+        return cls(name=name, agent=AgentTargetConfig(target=target), **overrides)
+
+
+def default_socket_path(name: str) -> Path:
+    """Compute the default Unix-domain-socket path for a service name.
+
+    Uses `$XDG_RUNTIME_DIR/parrot/<name>.sock`, falling back to
+    `/tmp/parrot-<uid>/<name>.sock` when `XDG_RUNTIME_DIR` is unset.
+
+    Args:
+        name: Service name.
+
+    Returns:
+        The socket path. The parent directory is NOT created by this
+        function — callers are responsible for `mkdir(mode=0o700)`.
+    """
+    xdg_runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
+    if xdg_runtime_dir:
+        base = Path(xdg_runtime_dir) / "parrot"
+    else:
+        base = Path(f"/tmp/parrot-{os.getuid()}")
+    return base / f"{name}.sock"
+
+
+class AgentTargetError(Exception):
+    """Raised when an `AgentTargetConfig.target` cannot be resolved."""
+
+
+def _split_target(target: str) -> tuple[str, str]:
+    """Split a `"module.path:attr"` target into its two components.
+
+    Raises:
+        AgentTargetError: If `target` is not of the form `"module:attr"`.
+    """
+    if ":" not in target:
+        raise AgentTargetError(
+            f"Invalid agent target {target!r}: expected 'module.path:attr'"
+        )
+    module_path, _, attr_path = target.partition(":")
+    if not module_path or not attr_path:
+        raise AgentTargetError(
+            f"Invalid agent target {target!r}: expected 'module.path:attr'"
+        )
+    return module_path, attr_path
+
+
+async def resolve_agent(cfg: AgentTargetConfig) -> Any:
+    """Resolve an `AgentTargetConfig` into a live, configured agent instance.
+
+    `cfg.target` is imported as `module.path:attr`:
+
+    - A class → instantiated with `cfg.kwargs`.
+    - A callable (factory) → called with `cfg.kwargs`; the result is
+      awaited when it is a coroutine (async factory support).
+    - Anything else (an already-constructed instance) → used as-is.
+
+    If the resolved object exposes an async `configure()` method, it is
+    awaited before returning (mirrors `AbstractBot.configure()`).
+
+    Args:
+        cfg: The target configuration to resolve.
+
+    Returns:
+        The resolved (and configured, if applicable) agent instance.
+
+    Raises:
+        AgentTargetError: If the module/attribute cannot be found, or
+            resolution otherwise fails.
+    """
+    module_path, attr_path = _split_target(cfg.target)
+
+    try:
+        module = importlib.import_module(module_path)
+    except ImportError as exc:
+        raise AgentTargetError(
+            f"Cannot import module {module_path!r} from target "
+            f"{cfg.target!r}: {exc}"
+        ) from exc
+
+    attr: Any = module
+    for part in attr_path.split("."):
+        try:
+            attr = getattr(attr, part)
+        except AttributeError as exc:
+            raise AgentTargetError(
+                f"Attribute {attr_path!r} not found on module "
+                f"{module_path!r} (target {cfg.target!r}): {exc}"
+            ) from exc
+
+    try:
+        if inspect.isclass(attr):
+            instance = attr(**cfg.kwargs)
+        elif callable(attr):
+            result = attr(**cfg.kwargs)
+            instance = await result if inspect.isawaitable(result) else result
+        else:
+            instance = attr
+    except AgentTargetError:
+        raise
+    except Exception as exc:
+        raise AgentTargetError(
+            f"Failed to resolve agent target {cfg.target!r}: {exc}"
+        ) from exc
+
+    configure = getattr(instance, "configure", None)
+    if configure is not None and inspect.iscoroutinefunction(configure):
+        await configure()
+
+    return instance

--- a/packages/ai-parrot-integrations/src/parrot/integrations/agentd/mcp_server.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/agentd/mcp_server.py
@@ -1,0 +1,214 @@
+"""MCP stdio proxy — expose an agentd daemon to external LLMs.
+
+Implements Module 8 of ``sdd/specs/agent-cli-daemon.spec.md``. An MCP
+client (Claude Code, another LLM) launches ``parrot mcp-serve <name>``
+(CLI wiring is TASK-2216) as a stdio server; internally it is a thin
+proxy: MCP tool call -> ``AgentDaemonClient`` -> daemon. Built on the
+CORE ``StdioMCPServer`` (the integrations-local ``mcp/`` package only
+holds OAuth helpers, NOT a stdio server).
+
+All logging goes to stderr -- stdout is the MCP JSON-RPC channel, per
+``LocalMCPServerBase``'s convention.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from parrot.mcp.local_server import StdioMCPServer
+from parrot.mcp.server_base import LocalServerConfig
+from parrot.tools.abstract import AbstractTool, AbstractToolArgsSchema
+from pydantic import Field
+
+from .client import AgentDaemonClient, DaemonNotRunning, resolve_socket
+
+__all__ = [
+    "AgentInfoTool",
+    "AskAgentTool",
+    "DaemonStatusTool",
+    "InvokeMethodTool",
+    "ListSchedulesTool",
+    "build_proxy_tools",
+    "run_mcp_proxy",
+]
+
+
+class _AgentDaemonTool(AbstractTool):
+    """Base class for MCP tools proxying calls to an `AgentDaemonClient`.
+
+    Attributes:
+        _client: The connected `AgentDaemonClient` shared by every tool in
+            this MCP session (one process = one daemon connection = one
+            conversation session).
+    """
+
+    def __init__(self, client: AgentDaemonClient, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._client = client
+
+
+class _AskAgentArgs(AbstractToolArgsSchema):
+    """Input schema for `ask_agent`."""
+
+    prompt: str = Field(..., description="The question or instruction to send to the agent.")
+
+
+class AskAgentTool(_AgentDaemonTool):
+    """Ask the daemon's agent a question and get its response.
+
+    One MCP process is one daemon connection, i.e. one conversation
+    session (spec §2) -- consecutive `ask_agent` calls in the same MCP
+    session share conversation history on the daemon side.
+    """
+
+    name = "ask_agent"
+    args_schema = _AskAgentArgs
+
+    async def _execute(self, prompt: str, **kwargs: Any) -> str:
+        result = await self._client.call(
+            "chat.send", prompt=prompt, stream=False, metadata={}
+        )
+        return result.get("output", "")
+
+
+class AgentInfoTool(_AgentDaemonTool):
+    """Get information about the daemon's agent: name, class, LLM, tool count, uptime."""
+
+    name = "agent_info"
+    args_schema = AbstractToolArgsSchema
+
+    async def _execute(self, **kwargs: Any) -> str:
+        result = await self._client.call("agent.info")
+        return json.dumps(result, indent=2, default=str)
+
+
+class ListSchedulesTool(_AgentDaemonTool):
+    """List the daemon's scheduled jobs (decorator-based and DB-backed)."""
+
+    name = "list_schedules"
+    args_schema = AbstractToolArgsSchema
+
+    async def _execute(self, **kwargs: Any) -> str:
+        result = await self._client.call("schedules.list")
+        return json.dumps(result, indent=2, default=str)
+
+
+class DaemonStatusTool(_AgentDaemonTool):
+    """Get the daemon's operational status: pid, uptime, scheduler, connections."""
+
+    name = "daemon_status"
+    args_schema = AbstractToolArgsSchema
+
+    async def _execute(self, **kwargs: Any) -> str:
+        result = await self._client.call("daemon.status")
+        return json.dumps(result, indent=2, default=str)
+
+
+class _InvokeMethodArgs(AbstractToolArgsSchema):
+    """Input schema for `invoke_method`."""
+
+    method: str = Field(..., description="Name of the allowlisted agent method to invoke.")
+    kwargs: dict[str, Any] = Field(
+        default_factory=dict, description="Keyword arguments for the method."
+    )
+
+
+class InvokeMethodTool(_AgentDaemonTool):
+    """Invoke a specific allowlisted method on the daemon's agent directly.
+
+    Only registered when the daemon's `exposed_methods` allowlist is
+    non-empty (spec §7 hard requirement) -- this tool is powerful and
+    gated accordingly. Validates the method name against that same
+    allowlist client-side too, as defense in depth (the daemon enforces
+    it regardless).
+
+    Attributes:
+        _exposed_methods: The daemon's `exposed_methods` allowlist.
+    """
+
+    name = "invoke_method"
+    args_schema = _InvokeMethodArgs
+
+    def __init__(
+        self, client: AgentDaemonClient, exposed_methods: list[str], **kwargs: Any
+    ) -> None:
+        super().__init__(client, **kwargs)
+        self._exposed_methods = list(exposed_methods)
+
+    async def _execute(
+        self, method: str, kwargs: dict[str, Any] | None = None, **_: Any
+    ) -> str:
+        if method not in self._exposed_methods:
+            raise ValueError(
+                f"Method {method!r} is not in the allowlist "
+                f"({self._exposed_methods}). Ask the daemon operator to add "
+                "it to `exposed_methods` if this invocation is expected."
+            )
+        result = await self._client.call(
+            "agent.invoke", params={"method": method, "kwargs": kwargs or {}}
+        )
+        if isinstance(result, str):
+            return result
+        return json.dumps(result, indent=2, default=str)
+
+
+def build_proxy_tools(
+    client: AgentDaemonClient, exposed_methods: list[str] | None = None
+) -> list[AbstractTool]:
+    """Build the full agentd MCP tool set for a connected client.
+
+    Args:
+        client: A connected `AgentDaemonClient`.
+        exposed_methods: The daemon's `exposed_methods` allowlist (from
+            `agent.info`). `InvokeMethodTool` is included ONLY when this
+            is non-empty (spec §7 hard requirement).
+
+    Returns:
+        The tool instances to register on an MCP server.
+    """
+    tools: list[AbstractTool] = [
+        AskAgentTool(client),
+        AgentInfoTool(client),
+        ListSchedulesTool(client),
+        DaemonStatusTool(client),
+    ]
+    if exposed_methods:
+        tools.append(InvokeMethodTool(client, exposed_methods))
+    return tools
+
+
+async def run_mcp_proxy(name_or_socket: str) -> None:
+    """Connect to a daemon and serve its tools over MCP stdio.
+
+    Args:
+        name_or_socket: Service name or explicit socket path (resolved
+            via `resolve_socket()`).
+
+    On daemon disconnect (or if it was never reachable), prints an
+    actionable message to stderr and exits non-zero -- never to stdout,
+    which is reserved for the MCP JSON-RPC channel.
+    """
+    socket_path = resolve_socket(name_or_socket)
+    try:
+        client = await AgentDaemonClient.connect(socket_path)
+    except DaemonNotRunning as exc:
+        print(f"agentd MCP proxy: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        info = await client.call("agent.info")
+        exposed_methods = info.get("exposed_methods") or []
+
+        agent_name = info.get("name", name_or_socket)
+        config = LocalServerConfig(
+            name=f"agentd-{agent_name}",
+            description=f"MCP proxy for agentd daemon '{agent_name}'",
+        )
+        server = StdioMCPServer(config)
+        server.register_tools(build_proxy_tools(client, exposed_methods))
+
+        await server.start()
+    finally:
+        await client.close()

--- a/packages/ai-parrot-integrations/src/parrot/integrations/agentd/protocol.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/agentd/protocol.py
@@ -1,0 +1,332 @@
+"""JSON-RPC 2.0 / NDJSON wire protocol for the Agent CLI Daemon (agentd).
+
+This module implements the foundation of the daemon wire format described in
+``sdd/specs/agent-cli-daemon.spec.md`` §2 ("Wire Protocol"). It provides:
+
+- Pydantic v2 models for JSON-RPC 2.0 requests, responses, errors, and
+  notifications.
+- Error-code constants (both the JSON-RPC standard range and the
+  application-specific range used by agentd).
+- Method-name constants for the full RPC surface exposed by the daemon.
+- An NDJSON framing codec (``read_message`` / ``write_message``) built on top
+  of ``asyncio.StreamReader`` / ``asyncio.StreamWriter``, with a configurable
+  maximum line size to avoid unbounded buffering.
+
+No I/O beyond stream helpers lives here; socket accept/dispatch logic is
+implemented in ``server.py`` (TASK-2211) and the client in ``client.py``
+(TASK-2213).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+__all__ = [
+    "AGENT_BUSY",
+    "DEFAULT_MAX_LINE_BYTES",
+    "INTERNAL_ERROR",
+    "INVALID_PARAMS",
+    "INVALID_REQUEST",
+    "JSONRPC_VERSION",
+    "METHOD_AGENT_INFO",
+    "METHOD_AGENT_INVOKE",
+    "METHOD_CHAT_COMPLETE",
+    "METHOD_CHAT_DELTA",
+    "METHOD_CHAT_ERROR",
+    "METHOD_CHAT_SEND",
+    "METHOD_DAEMON_SHUTDOWN",
+    "METHOD_DAEMON_STATUS",
+    "METHOD_EVENTS_SUBSCRIBE",
+    "METHOD_EVENTS_UNSUBSCRIBE",
+    "METHOD_EVENT_JOB_ERROR",
+    "METHOD_EVENT_JOB_EXECUTED",
+    "METHOD_EVENT_SHUTDOWN",
+    "METHOD_NOT_FOUND",
+    "METHOD_SCHEDULES_ADD",
+    "METHOD_SCHEDULES_LIST",
+    "METHOD_SCHEDULES_PAUSE",
+    "METHOD_SCHEDULES_REMOVE",
+    "METHOD_SCHEDULES_RESUME",
+    "METHOD_TOOLS_LIST",
+    "PARSE_ERROR",
+    "SCHEDULER_UNAVAILABLE",
+    "SCHEDULE_NOT_FOUND",
+    "UNKNOWN_AGENT_METHOD",
+    "MalformedMessageError",
+    "OversizedLineError",
+    "ProtocolError",
+    "RpcError",
+    "RpcNotification",
+    "RpcRequest",
+    "RpcResponse",
+    "read_message",
+    "write_message",
+]
+
+JSONRPC_VERSION: Literal["2.0"] = "2.0"
+
+# --------------------------------------------------------------------------
+# Error codes
+# --------------------------------------------------------------------------
+
+# JSON-RPC 2.0 standard error codes.
+PARSE_ERROR = -32700
+INVALID_REQUEST = -32600
+METHOD_NOT_FOUND = -32601
+INVALID_PARAMS = -32602
+INTERNAL_ERROR = -32603
+
+# Application-specific error codes (spec §2 "Wire Protocol").
+AGENT_BUSY = 1001
+UNKNOWN_AGENT_METHOD = 1002
+SCHEDULER_UNAVAILABLE = 1003
+SCHEDULE_NOT_FOUND = 1004
+
+# --------------------------------------------------------------------------
+# Method-name constants (spec §2 "Wire Protocol" table)
+# --------------------------------------------------------------------------
+
+METHOD_CHAT_SEND = "chat.send"
+METHOD_CHAT_DELTA = "chat.delta"
+METHOD_CHAT_COMPLETE = "chat.complete"
+METHOD_CHAT_ERROR = "chat.error"
+METHOD_AGENT_INFO = "agent.info"
+METHOD_AGENT_INVOKE = "agent.invoke"
+METHOD_TOOLS_LIST = "tools.list"
+METHOD_SCHEDULES_LIST = "schedules.list"
+METHOD_SCHEDULES_ADD = "schedules.add"
+METHOD_SCHEDULES_PAUSE = "schedules.pause"
+METHOD_SCHEDULES_RESUME = "schedules.resume"
+METHOD_SCHEDULES_REMOVE = "schedules.remove"
+METHOD_EVENTS_SUBSCRIBE = "events.subscribe"
+METHOD_EVENTS_UNSUBSCRIBE = "events.unsubscribe"
+METHOD_EVENT_JOB_EXECUTED = "event.job_executed"
+METHOD_EVENT_JOB_ERROR = "event.job_error"
+METHOD_EVENT_SHUTDOWN = "event.shutdown"
+METHOD_DAEMON_STATUS = "daemon.status"
+METHOD_DAEMON_SHUTDOWN = "daemon.shutdown"
+
+
+# --------------------------------------------------------------------------
+# Pydantic v2 models
+# --------------------------------------------------------------------------
+
+
+class RpcError(BaseModel):
+    """JSON-RPC 2.0 error object.
+
+    Attributes:
+        code: Numeric error code (JSON-RPC standard or agentd application
+            range — see the module-level constants).
+        message: Short, human-readable error description.
+        data: Optional additional error context (never a traceback — those
+            are logged daemon-side only, per spec §2 "Error Handling").
+    """
+
+    code: int
+    message: str
+    data: Any | None = None
+
+
+class RpcRequest(BaseModel):
+    """JSON-RPC 2.0 request object.
+
+    Attributes:
+        jsonrpc: Always ``"2.0"``.
+        id: Request identifier, echoed back in the matching ``RpcResponse``.
+        method: RPC method name (see ``METHOD_*`` constants).
+        params: Method parameters, as a mapping.
+    """
+
+    jsonrpc: Literal["2.0"] = JSONRPC_VERSION
+    id: int | str
+    method: str
+    params: dict[str, Any] = Field(default_factory=dict)
+
+
+class RpcResponse(BaseModel):
+    """JSON-RPC 2.0 response object.
+
+    Exactly one of ``result`` / ``error`` is expected to be set, mirroring
+    the JSON-RPC 2.0 spec (enforced by callers, not validated here to keep
+    the model permissive for partial/streaming construction).
+
+    Attributes:
+        jsonrpc: Always ``"2.0"``.
+        id: Echoes the originating request's ``id``.
+        result: The method's return value, when successful.
+        error: An ``RpcError``, when the call failed.
+    """
+
+    jsonrpc: Literal["2.0"] = JSONRPC_VERSION
+    id: int | str | None
+    result: Any | None = None
+    error: RpcError | None = None
+
+
+class RpcNotification(BaseModel):
+    """JSON-RPC 2.0 notification object (no ``id`` — no reply expected).
+
+    Used for server-initiated messages: streaming ``chat.delta``/
+    ``chat.complete``/``chat.error``, and fan-out scheduler/daemon events
+    (``event.job_executed``, ``event.job_error``, ``event.shutdown``).
+
+    Attributes:
+        jsonrpc: Always ``"2.0"``.
+        method: Notification method name.
+        params: Notification payload, as a mapping.
+    """
+
+    jsonrpc: Literal["2.0"] = JSONRPC_VERSION
+    method: str
+    params: dict[str, Any] = Field(default_factory=dict)
+
+
+# --------------------------------------------------------------------------
+# NDJSON framing
+# --------------------------------------------------------------------------
+
+#: Default maximum size (in bytes) of a single NDJSON line, before decoding.
+DEFAULT_MAX_LINE_BYTES = 10 * 1024 * 1024  # 10 MB
+
+
+class ProtocolError(Exception):
+    """Base class for all agentd wire-protocol errors."""
+
+
+class OversizedLineError(ProtocolError):
+    """Raised when an incoming NDJSON line exceeds the configured limit."""
+
+
+class MalformedMessageError(ProtocolError):
+    """Raised when an incoming line is not valid JSON or not a known shape.
+
+    Attributes:
+        rpc_id: The JSON-RPC ``id`` recovered from the malformed payload, if
+            any could be salvaged (best-effort), else ``None``.
+    """
+
+    def __init__(self, message: str, *, rpc_id: int | str | None = None) -> None:
+        super().__init__(message)
+        self.rpc_id = rpc_id
+
+
+AnyRpcMessage = RpcRequest | RpcResponse | RpcNotification
+
+
+def _parse_message(raw: dict[str, Any]) -> AnyRpcMessage:
+    """Classify and validate a decoded JSON object into an RPC model.
+
+    Args:
+        raw: The decoded JSON object (a mapping).
+
+    Returns:
+        The matching ``RpcRequest``, ``RpcResponse``, or ``RpcNotification``.
+
+    Raises:
+        MalformedMessageError: If ``raw`` does not match any known shape.
+    """
+    has_id = "id" in raw
+    is_response = "result" in raw or "error" in raw
+
+    try:
+        if is_response:
+            return RpcResponse.model_validate(raw)
+        if has_id:
+            return RpcRequest.model_validate(raw)
+        return RpcNotification.model_validate(raw)
+    except Exception as exc:
+        raise MalformedMessageError(
+            f"Malformed JSON-RPC message: {exc}",
+            rpc_id=raw.get("id") if isinstance(raw, dict) else None,
+        ) from exc
+
+
+async def read_message(
+    reader: asyncio.StreamReader,
+    *,
+    max_line_bytes: int = DEFAULT_MAX_LINE_BYTES,
+) -> AnyRpcMessage | None:
+    """Read one NDJSON-framed JSON-RPC message from ``reader``.
+
+    Handles both split frames (a single message arriving across multiple
+    reads) and coalesced frames (multiple ``\\n``-terminated messages
+    delivered in one underlying read) transparently — both are standard
+    ``asyncio.StreamReader`` behaviours, since ``readuntil`` buffers until it
+    finds the separator regardless of how many underlying reads that takes.
+
+    Args:
+        reader: The stream to read a single line from.
+        max_line_bytes: Maximum allowed size (bytes) of one line, enforced
+            BEFORE JSON parsing to avoid unbounded buffering on hostile or
+            broken input.
+
+    Returns:
+        The parsed message, or ``None`` on a clean EOF with no data pending.
+
+    Raises:
+        OversizedLineError: If the line exceeds ``max_line_bytes``.
+        MalformedMessageError: If the line is not valid JSON, or not a
+            recognizable JSON-RPC shape.
+    """
+    try:
+        line = await reader.readuntil(b"\n")
+    except asyncio.IncompleteReadError as exc:
+        # EOF reached; any partial (unterminated) data left is a truncated
+        # message unless it's an empty tail.
+        if not exc.partial:
+            return None
+        line = exc.partial
+        if len(line) > max_line_bytes:
+            raise OversizedLineError(
+                f"Line of {len(line)} bytes exceeds limit of {max_line_bytes} bytes"
+            ) from exc
+        raise MalformedMessageError(
+            "Truncated message at EOF (missing trailing newline)"
+        ) from exc
+    except asyncio.LimitOverrunError as exc:
+        # StreamReader's own internal buffer limit was hit before the
+        # separator was found — definitely oversized.
+        raise OversizedLineError(
+            f"Line exceeds StreamReader buffer limit ({exc})"
+        ) from exc
+
+    if len(line) > max_line_bytes:
+        raise OversizedLineError(
+            f"Line of {len(line)} bytes exceeds limit of {max_line_bytes} bytes"
+        )
+
+    stripped = line.rstrip(b"\n")
+    if not stripped:
+        # Blank line (e.g. trailing newline at EOF) — treat as no message.
+        return None
+
+    try:
+        raw = json.loads(stripped)
+    except json.JSONDecodeError as exc:
+        raise MalformedMessageError(f"Invalid JSON: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise MalformedMessageError(
+            f"Expected a JSON object, got {type(raw).__name__}"
+        )
+
+    return _parse_message(raw)
+
+
+def write_message(writer: asyncio.StreamWriter, model: AnyRpcMessage) -> None:
+    """Serialize ``model`` and write it as one NDJSON line to ``writer``.
+
+    Args:
+        writer: The stream to write the encoded line to. Callers are
+            responsible for calling ``await writer.drain()`` afterwards to
+            respect backpressure.
+        model: The ``RpcRequest`` / ``RpcResponse`` / ``RpcNotification`` to
+            encode.
+    """
+    payload = model.model_dump_json(exclude_none=False)
+    writer.write(payload.encode("utf-8") + b"\n")

--- a/packages/ai-parrot-integrations/src/parrot/integrations/agentd/proxy.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/agentd/proxy.py
@@ -1,0 +1,407 @@
+"""DaemonAgentProxy + daemon slash commands for AgentREPL.
+
+Implements Module 7 of ``sdd/specs/agent-cli-daemon.spec.md``. The Rich
+console is the EXISTING ``parrot.cli.repl.AgentREPL`` — this module
+supplies a third loader strategy (daemon over UDS), mirroring
+``parrot.cli.loaders.ServerAgentProxy``/``_ServerBotProxy`` EXACTLY so
+``AgentREPL`` sees an interchangeable loader, plus daemon-only slash
+commands (``/status``, ``/schedules``, ``/invoke``) and a queued
+job-event display drained between conversation turns.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import deque
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any
+
+from .client import AgentDaemonClient, RpcRemoteError, resolve_socket
+from .protocol import (
+    METHOD_EVENT_JOB_ERROR,
+    METHOD_EVENT_JOB_EXECUTED,
+    METHOD_EVENT_SHUTDOWN,
+)
+
+if TYPE_CHECKING:
+    from parrot.cli.repl import AgentREPL
+
+__all__ = [
+    "DaemonAgentProxy",
+    "register_daemon_commands",
+]
+
+#: Bounded queue length for job-event lines awaiting `drain_events()`.
+_EVENT_QUEUE_MAXLEN = 512
+
+
+class _DaemonResponse:
+    """Lightweight wrapper for `chat.send` (non-stream) RPC results.
+
+    Mirrors `parrot.cli.loaders._ServerResponse`'s shape.
+
+    Attributes:
+        output: The response text output.
+        response: Alias for `output` (mirrors `_ServerResponse`).
+        tool_calls: Empty list (not surfaced by agentd v1).
+        usage: `None` (not surfaced by agentd v1).
+    """
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self.output: str = data.get("output") or ""
+        self.response: str | None = data.get("output")
+        self.tool_calls: list[Any] = []
+        self.usage: Any = None
+        self._data = data
+
+    def __repr__(self) -> str:
+        return f"_DaemonResponse(output={self.output!r})"
+
+
+class _DaemonBotProxy:
+    """Thin UDS proxy satisfying the same duck type as `_ServerBotProxy`.
+
+    Only implements the subset `AgentREPL` uses: `ask()`, `ask_stream()`,
+    `get_available_tools()`, `get_tools_count()`, `has_tools()`,
+    `configure()` — signatures mirror `_ServerBotProxy` exactly so the two
+    loader strategies are interchangeable.
+
+    Attributes:
+        name: Agent name.
+        _client: The shared `AgentDaemonClient`.
+        _tools: Cached list of tool names (populated once via
+            `_ensure_tools()`).
+    """
+
+    def __init__(self, name: str, client: AgentDaemonClient) -> None:
+        self.name = name
+        self._client = client
+        self._tools: list[str] = []
+        self._tools_fetched = False
+        self.logger = logging.getLogger(__name__)
+
+    async def configure(self, app: Any = None) -> None:
+        """No-op -- the daemon's agent is already configured server-side."""
+
+    async def ask(
+        self,
+        question: str,
+        session_id: str | None = None,
+        user_id: str | None = None,
+        output_mode: Any = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Proxy a one-shot `ask()` call to the daemon via `chat.send`.
+
+        Args:
+            question: The user's question.
+            session_id: Unused -- the daemon assigns one session per
+                connection (spec §2); kept for signature parity.
+            user_id: Unused; kept for signature parity.
+            output_mode: Unused; kept for signature parity.
+            **kwargs: Passed through as `chat.send` metadata.
+
+        Returns:
+            A `_DaemonResponse` with an `.output` attribute.
+        """
+        result = await self._client.call(
+            "chat.send", prompt=question, stream=False, metadata=kwargs
+        )
+        return _DaemonResponse(result)
+
+    async def ask_stream(
+        self,
+        question: str,
+        session_id: str | None = None,
+        user_id: str | None = None,
+        output_mode: Any = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[str]:
+        """Proxy a streaming `ask_stream()` call via `chat.send(stream=true)`.
+
+        Args:
+            question: The user's question.
+            session_id: Unused; kept for signature parity.
+            user_id: Unused; kept for signature parity.
+            output_mode: Unused; kept for signature parity.
+            **kwargs: Passed through as `chat.send` metadata.
+
+        Yields:
+            Text chunks (`chat.delta` payloads). Terminates on
+            `chat.complete` or `chat.error` (an error is logged, not
+            raised, to match `_ServerBotProxy.ask_stream`'s never-raises
+            contract).
+        """
+        async for event in self._client.stream(question, **kwargs):
+            if event.kind == "delta":
+                yield event.text or ""
+            elif event.kind == "error":
+                self.logger.warning("agentd stream error: %s", event.error)
+                return
+            # "complete" -> nothing to yield; the loop ends naturally.
+
+    async def _ensure_tools(self) -> None:
+        """Fetch and cache the tool list once, via `tools.list`."""
+        if self._tools_fetched:
+            return
+        result = await self._client.call("tools.list")
+        self._tools = list(result.get("tools", []))
+        self._tools_fetched = True
+
+    def get_available_tools(self) -> list[str]:
+        """Return the cached list of tool names."""
+        return self._tools
+
+    def get_tools_count(self) -> int:
+        """Return the cached tool count."""
+        return len(self._tools)
+
+    def has_tools(self) -> bool:
+        """Return whether any tools are cached."""
+        return bool(self._tools)
+
+
+def _format_event(method: str, params: dict[str, Any]) -> str:
+    """Format one `event.*` notification into a human-readable console line."""
+    job_id = params.get("job_id", "?")
+    if method == METHOD_EVENT_JOB_EXECUTED:
+        return f"⏱ job {job_id} ejecutado ✓"
+    if method == METHOD_EVENT_JOB_ERROR:
+        error = params.get("error", "")
+        return f"⏱ job {job_id} error ✗ ({error})"
+    if method == METHOD_EVENT_SHUTDOWN:
+        return "⏹ daemon shutting down"
+    return f"⏱ event {method}: {params}"
+
+
+class DaemonAgentProxy:
+    """Loader strategy: proxy agent interactions to a running agentd daemon.
+
+    Mirrors `ServerAgentProxy`'s shape (`load`/`list_agents`/`close`) but
+    talks JSON-RPC over a Unix domain socket instead of HTTP.
+
+    Attributes:
+        name_or_socket: Service name or explicit socket path (resolved via
+            `resolve_socket()`).
+    """
+
+    def __init__(self, name_or_socket: str) -> None:
+        self.name_or_socket = name_or_socket
+        self._client: AgentDaemonClient | None = None
+        self._events: deque[str] = deque(maxlen=_EVENT_QUEUE_MAXLEN)
+        self.logger = logging.getLogger(__name__)
+
+    async def load(self, name: str) -> _DaemonBotProxy:
+        """Connect to the daemon and return a proxy bot for `name`.
+
+        Args:
+            name: Agent name (used only for display -- the daemon serves
+                exactly one agent, per spec §1 "1 daemon = 1 agent").
+
+        Returns:
+            A `_DaemonBotProxy`, with its tool list already cached.
+        """
+        socket_path = resolve_socket(self.name_or_socket)
+        self._client = await AgentDaemonClient.connect(socket_path)
+        await self._client.subscribe_events(self._on_event)
+
+        proxy = _DaemonBotProxy(name, self._client)
+        await proxy._ensure_tools()
+        return proxy
+
+    async def list_agents(self) -> list[dict[str, Any]]:
+        """Return the single agent this daemon serves, via `agent.info`.
+
+        Returns:
+            A one-element list with the daemon's `agent.info` payload.
+
+        Raises:
+            RuntimeError: If called before `load()`.
+        """
+        if self._client is None:
+            raise RuntimeError("DaemonAgentProxy.load() must be called first")
+        info = await self._client.call("agent.info")
+        return [info]
+
+    async def close(self) -> None:
+        """Close the underlying daemon connection."""
+        if self._client is not None:
+            await self._client.close()
+            self._client = None
+
+    def _on_event(self, method: str, params: dict[str, Any]) -> None:
+        """Format and enqueue one `event.*` notification for later drain."""
+        self._events.append(_format_event(method, params))
+
+    def drain_events(self) -> list[str]:
+        """Return and clear all queued, formatted job-event lines.
+
+        Meant to be called between conversation turns only (never
+        mid-stream) -- the drain point is orchestrated by the `attach`
+        command wiring (TASK-2216).
+
+        Returns:
+            The queued lines, in arrival order. The queue is empty
+            afterwards.
+        """
+        lines = list(self._events)
+        self._events.clear()
+        return lines
+
+
+# --------------------------------------------------------------------------
+# Daemon-only slash commands
+# --------------------------------------------------------------------------
+
+
+async def _cmd_status(repl: AgentREPL, proxy: DaemonAgentProxy) -> None:
+    """Handle `/status` -- pretty-print `daemon.status`."""
+    if proxy._client is None:
+        repl.renderer.print("[red]Not connected to a daemon.[/red]")
+        return
+    try:
+        status = await proxy._client.call("daemon.status")
+    except RpcRemoteError as exc:
+        repl.renderer.render_error(exc)
+        return
+
+    scheduler = status.get("scheduler", {})
+    repl.renderer.render_info(
+        [
+            ("PID", str(status.get("pid"))),
+            ("Uptime (s)", f"{status.get('uptime_s', 0):.1f}"),
+            ("Version", str(status.get("version"))),
+            ("Scheduler available", str(scheduler.get("available"))),
+            ("Scheduler running", str(scheduler.get("running"))),
+            ("Scheduled jobs", str(scheduler.get("jobs"))),
+            ("Active connections", str(status.get("active_connections"))),
+        ]
+    )
+
+
+async def _cmd_schedules(repl: AgentREPL, proxy: DaemonAgentProxy, args: str) -> None:
+    """Handle `/schedules [list|add|pause|resume|remove ...]`."""
+    if proxy._client is None:
+        repl.renderer.print("[red]Not connected to a daemon.[/red]")
+        return
+
+    parts = args.split(maxsplit=1)
+    sub = parts[0].lower() if parts else "list"
+    rest = parts[1] if len(parts) > 1 else ""
+
+    try:
+        if sub == "list":
+            jobs = await proxy._client.call("schedules.list")
+            if not jobs:
+                repl.renderer.print("[dim]No schedules registered.[/dim]")
+                return
+            rows = [
+                [
+                    str(job.get("schedule_id", "")),
+                    str(job.get("agent_name", "")),
+                    str(job.get("source", "")),
+                    str(job.get("job", {}).get("next_run", "")),
+                ]
+                for job in jobs
+            ]
+            repl.renderer.render_table(
+                headers=["ID", "Agent", "Source", "Next Run"],
+                rows=rows,
+                title="Schedules",
+            )
+        elif sub == "pause":
+            result = await proxy._client.call("schedules.pause", schedule_id=rest.strip())
+            repl.renderer.print(f"[green]Paused:[/green] {result}")
+        elif sub == "resume":
+            result = await proxy._client.call("schedules.resume", schedule_id=rest.strip())
+            repl.renderer.print(f"[green]Resumed:[/green] {result}")
+        elif sub == "remove":
+            result = await proxy._client.call("schedules.remove", schedule_id=rest.strip())
+            repl.renderer.print(f"[green]Removed:[/green] {result}")
+        elif sub == "add":
+            try:
+                payload = json.loads(rest) if rest.strip() else {}
+            except json.JSONDecodeError as exc:
+                repl.renderer.print(f"[red]Invalid JSON for /schedules add: {exc}[/red]")
+                return
+            result = await proxy._client.call("schedules.add", **payload)
+            repl.renderer.print(f"[green]Added:[/green] {result}")
+        else:
+            repl.renderer.print(
+                f"[yellow]Unknown /schedules subcommand: {sub}[/yellow] "
+                "(use list|add|pause|resume|remove)"
+            )
+    except RpcRemoteError as exc:
+        repl.renderer.render_error(exc)
+
+
+async def _cmd_invoke(repl: AgentREPL, proxy: DaemonAgentProxy, args: str) -> None:
+    """Handle `/invoke <method> [json-kwargs]`."""
+    if proxy._client is None:
+        repl.renderer.print("[red]Not connected to a daemon.[/red]")
+        return
+
+    parts = args.split(maxsplit=1)
+    if not parts:
+        repl.renderer.print("[yellow]Usage: /invoke <method> [json-kwargs][/yellow]")
+        return
+
+    method = parts[0]
+    raw_kwargs = parts[1] if len(parts) > 1 else ""
+    kwargs: dict[str, Any] = {}
+    if raw_kwargs.strip():
+        try:
+            kwargs = json.loads(raw_kwargs)
+        except json.JSONDecodeError as exc:
+            repl.renderer.print(f"[red]Invalid JSON kwargs for /invoke: {exc}[/red]")
+            return
+        if not isinstance(kwargs, dict):
+            repl.renderer.print("[red]/invoke kwargs must be a JSON object.[/red]")
+            return
+
+    try:
+        result = await proxy._client.call(
+            "agent.invoke", params={"method": method, "kwargs": kwargs}
+        )
+    except RpcRemoteError as exc:
+        repl.renderer.render_error(exc)
+        return
+
+    repl.renderer.print(f"[cyan]{method}[/cyan] -> {result}")
+
+
+def register_daemon_commands(repl: AgentREPL, proxy: DaemonAgentProxy) -> None:
+    """Register `/status`, `/schedules`, `/invoke` onto an `AgentREPL`.
+
+    Args:
+        repl: The REPL instance to register commands on.
+        proxy: The `DaemonAgentProxy` backing this REPL session -- its
+            `AgentDaemonClient` is what the handlers call.
+    """
+    from parrot.cli.commands import SlashCommand
+
+    async def _status(repl: AgentREPL, args: str) -> None:
+        await _cmd_status(repl, proxy)
+
+    async def _schedules(repl: AgentREPL, args: str) -> None:
+        await _cmd_schedules(repl, proxy, args)
+
+    async def _invoke(repl: AgentREPL, args: str) -> None:
+        await _cmd_invoke(repl, proxy, args)
+
+    repl.register_command(SlashCommand("status", "Show daemon status.", _status))
+    repl.register_command(
+        SlashCommand(
+            "schedules",
+            "Manage schedules: /schedules [list|add|pause|resume|remove ...]",
+            _schedules,
+        )
+    )
+    repl.register_command(
+        SlashCommand(
+            "invoke",
+            "Invoke an agent method: /invoke <method> [json-kwargs]",
+            _invoke,
+        )
+    )

--- a/packages/ai-parrot-integrations/src/parrot/integrations/agentd/server.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/agentd/server.py
@@ -1,0 +1,335 @@
+"""Unix-domain-socket JSON-RPC server for the Agent CLI Daemon (agentd).
+
+Implements Module 4 of ``sdd/specs/agent-cli-daemon.spec.md``: the
+transport server sitting between the wire protocol (``protocol.py``,
+TASK-2208) and the daemon service (``service.py``, TASK-2212). Owns the
+socket lifecycle (including stale-socket detection), per-connection
+``Session`` state, method dispatch, streaming notification delivery, and
+event fan-out via ``EventBroker``.
+
+No RPC method implementations live here — those are supplied by the caller
+as a ``dispatch`` mapping (built by ``AgentDaemon`` in TASK-2212).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import uuid
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any
+
+from pydantic import ValidationError
+
+from .protocol import (
+    DEFAULT_MAX_LINE_BYTES,
+    INTERNAL_ERROR,
+    INVALID_PARAMS,
+    INVALID_REQUEST,
+    METHOD_NOT_FOUND,
+    PARSE_ERROR,
+    MalformedMessageError,
+    OversizedLineError,
+    RpcError,
+    RpcNotification,
+    RpcRequest,
+    RpcResponse,
+    read_message,
+    write_message,
+)
+
+__all__ = [
+    "DaemonAlreadyRunning",
+    "EventBroker",
+    "Handler",
+    "JsonRpcUnixServer",
+    "Session",
+]
+
+
+class DaemonAlreadyRunning(Exception):
+    """Raised when a live daemon is already listening on the socket path."""
+
+
+class Session:
+    """Per-connection state for one UDS client.
+
+    Attributes:
+        session_id: Unique identifier for this connection (its own
+            "conversation session", per spec §2).
+        writer: The connection's ``asyncio.StreamWriter``.
+        subscribed: Whether this session is subscribed to broadcast events
+            via ``EventBroker``.
+        stream_ids: Active `chat.send(stream=true)` stream identifiers for
+            this session.
+        tasks: In-flight handler tasks for this session (tracked so they
+            can be cancelled on disconnect).
+    """
+
+    def __init__(self, session_id: str, writer: asyncio.StreamWriter) -> None:
+        self.session_id = session_id
+        self.writer = writer
+        self.subscribed = False
+        self.stream_ids: set[str] = set()
+        self.tasks: set[asyncio.Task] = set()
+        self._lock = asyncio.Lock()
+
+    async def send(self, message: RpcResponse | RpcNotification) -> None:
+        """Serialize and write one message, serialized under this session's lock.
+
+        Args:
+            message: The response or notification to send.
+        """
+        async with self._lock:
+            write_message(self.writer, message)
+            await self.writer.drain()
+
+    async def notify(self, method: str, params: dict[str, Any]) -> None:
+        """Send a server-initiated notification (e.g. `chat.delta`).
+
+        Args:
+            method: Notification method name.
+            params: Notification payload.
+        """
+        await self.send(RpcNotification(method=method, params=params))
+
+
+#: Signature every dispatch table entry must implement.
+Handler = Callable[[Session, dict[str, Any]], Awaitable[Any]]
+
+
+class EventBroker:
+    """Subscribe/fan-out broadcaster for scheduler/daemon events.
+
+    Sessions opt in via `subscribe()` (typically from an `events.subscribe`
+    RPC handler) and receive every `publish()`ed notification until they
+    `unsubscribe()` or disconnect.
+    """
+
+    def __init__(self) -> None:
+        self._subscribers: set[Session] = set()
+        self.logger = logging.getLogger(__name__)
+
+    def subscribe(self, session: Session) -> None:
+        """Add `session` to the broadcast set."""
+        session.subscribed = True
+        self._subscribers.add(session)
+
+    def unsubscribe(self, session: Session) -> None:
+        """Remove `session` from the broadcast set (idempotent)."""
+        session.subscribed = False
+        self._subscribers.discard(session)
+
+    async def publish(self, method: str, params: dict[str, Any]) -> None:
+        """Fan out a notification to every subscribed session.
+
+        Dead/broken connections are dropped silently (best-effort
+        broadcast) rather than raising — one bad subscriber must not break
+        delivery to the rest.
+
+        Args:
+            method: Notification method name (e.g. `event.job_executed`).
+            params: Notification payload.
+        """
+        for session in list(self._subscribers):
+            try:
+                await session.notify(method, params)
+            except Exception:  # noqa: BLE001 - isolate broadcast failures
+                self.logger.debug(
+                    "Dropping dead subscriber %s", session.session_id
+                )
+                self._subscribers.discard(session)
+
+
+class JsonRpcUnixServer:
+    """JSON-RPC 2.0 / NDJSON server over a Unix domain socket.
+
+    Attributes:
+        socket_path: Path to the UDS socket file.
+        dispatch: Mapping of RPC method name to `Handler`. Mutable after
+            construction — callers may add/replace entries at any time
+            (the same `dict` object is retained, not copied).
+        max_line_bytes: NDJSON line-size limit passed to `read_message()`.
+        event_broker: Shared `EventBroker` for this server instance.
+    """
+
+    def __init__(
+        self,
+        socket_path: Path,
+        dispatch: dict[str, Handler],
+        *,
+        max_line_bytes: int = DEFAULT_MAX_LINE_BYTES,
+    ) -> None:
+        self.socket_path = Path(socket_path)
+        self.dispatch = dispatch
+        self.max_line_bytes = max_line_bytes
+        self.event_broker = EventBroker()
+        self.logger = logging.getLogger(__name__)
+        self._server: asyncio.Server | None = None
+        self._sessions: dict[str, Session] = {}
+
+    async def start(self) -> None:
+        """Bind and start accepting connections.
+
+        Raises:
+            DaemonAlreadyRunning: If a live daemon already owns
+                `socket_path`.
+        """
+        await self._prepare_socket_path()
+        self._server = await asyncio.start_unix_server(
+            self._handle_connection, path=str(self.socket_path)
+        )
+        os.chmod(self.socket_path, 0o600)
+        self.logger.info("agentd UDS server listening on %s", self.socket_path)
+
+    async def close(self) -> None:
+        """Stop accepting connections, close all sessions, unlink the socket."""
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+        for session in list(self._sessions.values()):
+            await self._disconnect(session)
+
+        if self.socket_path.exists():
+            with contextlib.suppress(OSError):
+                self.socket_path.unlink()
+
+    async def _prepare_socket_path(self) -> None:
+        """Create the parent dir (0700) and resolve any stale socket file.
+
+        Raises:
+            DaemonAlreadyRunning: If an existing socket at `socket_path` is
+                still accepting connections (a daemon is already running).
+        """
+        parent = self.socket_path.parent
+        parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        os.chmod(parent, 0o700)
+
+        if self.socket_path.exists():
+            if await self._socket_is_alive():
+                raise DaemonAlreadyRunning(
+                    f"A daemon is already listening on {self.socket_path}"
+                )
+            self.socket_path.unlink()
+
+    async def _socket_is_alive(self) -> bool:
+        """Try-connect to `socket_path` to tell a live socket from a dead one."""
+        try:
+            _, writer = await asyncio.open_unix_connection(
+                path=str(self.socket_path)
+            )
+        except OSError:
+            return False
+        writer.close()
+        with contextlib.suppress(OSError):
+            await writer.wait_closed()
+        return True
+
+    async def _handle_connection(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        """Per-connection accept-loop callback for `start_unix_server`."""
+        session = Session(session_id=str(uuid.uuid4()), writer=writer)
+        self._sessions[session.session_id] = session
+        self.logger.debug("Session %s connected", session.session_id)
+
+        try:
+            while True:
+                try:
+                    message = await read_message(
+                        reader, max_line_bytes=self.max_line_bytes
+                    )
+                except OversizedLineError as exc:
+                    with contextlib.suppress(Exception):
+                        await session.send(
+                            RpcResponse(
+                                id=None,
+                                error=RpcError(
+                                    code=INVALID_REQUEST, message=str(exc)
+                                ),
+                            )
+                        )
+                    break
+                except MalformedMessageError as exc:
+                    with contextlib.suppress(Exception):
+                        await session.send(
+                            RpcResponse(
+                                id=exc.rpc_id,
+                                error=RpcError(code=PARSE_ERROR, message=str(exc)),
+                            )
+                        )
+                    continue
+
+                if message is None:
+                    break  # Clean EOF.
+
+                if isinstance(message, RpcRequest):
+                    task = asyncio.create_task(self._run_handler(session, message))
+                    session.tasks.add(task)
+                    task.add_done_callback(session.tasks.discard)
+                else:
+                    self.logger.debug(
+                        "Ignoring unsupported inbound message type: %s",
+                        type(message).__name__,
+                    )
+        finally:
+            await self._disconnect(session)
+
+    async def _run_handler(self, session: Session, request: RpcRequest) -> None:
+        """Dispatch one request to its handler and send back the response.
+
+        Every failure mode is converted into a JSON-RPC error response —
+        the connection (and the server) stay alive regardless of handler
+        exceptions.
+        """
+        handler = self.dispatch.get(request.method)
+        if handler is None:
+            response = RpcResponse(
+                id=request.id,
+                error=RpcError(
+                    code=METHOD_NOT_FOUND,
+                    message=f"Unknown method: {request.method}",
+                ),
+            )
+        else:
+            try:
+                result = await handler(session, request.params)
+                response = RpcResponse(id=request.id, result=result)
+            except ValidationError as exc:
+                response = RpcResponse(
+                    id=request.id,
+                    error=RpcError(code=INVALID_PARAMS, message=str(exc)),
+                )
+            except Exception as exc:
+                self.logger.exception(
+                    "Handler for %r raised an exception", request.method
+                )
+                response = RpcResponse(
+                    id=request.id,
+                    error=RpcError(code=INTERNAL_ERROR, message=str(exc)),
+                )
+
+        with contextlib.suppress(Exception):
+            await session.send(response)
+
+    async def _disconnect(self, session: Session) -> None:
+        """Tear down a session: cancel tasks, unsubscribe, close the writer."""
+        for task in list(session.tasks):
+            task.cancel()
+        if session.tasks:
+            await asyncio.gather(*session.tasks, return_exceptions=True)
+
+        self.event_broker.unsubscribe(session)
+        self._sessions.pop(session.session_id, None)
+
+        with contextlib.suppress(Exception):
+            session.writer.close()
+        with contextlib.suppress(Exception):
+            await session.writer.wait_closed()
+
+        self.logger.debug("Session %s disconnected", session.session_id)

--- a/packages/ai-parrot-integrations/src/parrot/integrations/agentd/server.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/agentd/server.py
@@ -205,9 +205,17 @@ class JsonRpcUnixServer:
                 `socket_path`.
         """
         await self._prepare_socket_path()
-        self._server = await asyncio.start_unix_server(
-            self._handle_connection, path=str(self.socket_path)
-        )
+        # Defense in depth: even though the parent dir is already 0700
+        # (unreachable to other local users), narrow the process umask
+        # for the bind itself so the socket is never briefly created with
+        # looser permissions before the chmod() below lands.
+        previous_umask = os.umask(0o177)
+        try:
+            self._server = await asyncio.start_unix_server(
+                self._handle_connection, path=str(self.socket_path)
+            )
+        finally:
+            os.umask(previous_umask)
         os.chmod(self.socket_path, 0o600)
         self.logger.info("agentd UDS server listening on %s", self.socket_path)
 

--- a/packages/ai-parrot-integrations/src/parrot/integrations/agentd/server.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/agentd/server.py
@@ -46,12 +46,33 @@ __all__ = [
     "EventBroker",
     "Handler",
     "JsonRpcUnixServer",
+    "RpcHandlerError",
     "Session",
 ]
 
 
 class DaemonAlreadyRunning(Exception):
     """Raised when a live daemon is already listening on the socket path."""
+
+
+class RpcHandlerError(Exception):
+    """Raised by a dispatch handler to return a specific JSON-RPC error.
+
+    Use this instead of a bare exception when a handler needs to surface
+    one of the application-range error codes (spec §2 "Wire Protocol":
+    `AGENT_BUSY`, `UNKNOWN_AGENT_METHOD`, `SCHEDULER_UNAVAILABLE`,
+    `SCHEDULE_NOT_FOUND`) rather than the generic `INTERNAL_ERROR`
+    fallback every other exception gets.
+
+    Attributes:
+        code: The JSON-RPC (or agentd application-range) error code.
+        message: The error message.
+    """
+
+    def __init__(self, code: int, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
 
 
 class Session:
@@ -170,6 +191,11 @@ class JsonRpcUnixServer:
         self.logger = logging.getLogger(__name__)
         self._server: asyncio.Server | None = None
         self._sessions: dict[str, Session] = {}
+
+    @property
+    def active_connections(self) -> int:
+        """Number of currently connected sessions."""
+        return len(self._sessions)
 
     async def start(self) -> None:
         """Bind and start accepting connections.
@@ -300,6 +326,11 @@ class JsonRpcUnixServer:
             try:
                 result = await handler(session, request.params)
                 response = RpcResponse(id=request.id, result=result)
+            except RpcHandlerError as exc:
+                response = RpcResponse(
+                    id=request.id,
+                    error=RpcError(code=exc.code, message=exc.message),
+                )
             except ValidationError as exc:
                 response = RpcResponse(
                     id=request.id,

--- a/packages/ai-parrot-integrations/src/parrot/integrations/agentd/service.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/agentd/service.py
@@ -125,6 +125,15 @@ def _serialize_for_rpc(value: Any) -> Any:
 def _agent_response_to_rpc(response: Any) -> dict[str, Any]:
     """Convert an agent's `ask()` response into the minimal RPC shape.
 
+    Prefers the canonical text fields -- `.output`, falling back to
+    `.response` -- mirroring `ResponseRenderer.render()`'s own extraction
+    (`parrot.cli.renderer`) for a real `AIMessage`. A bare `str()` of an
+    `AIMessage` would otherwise dump every Pydantic field (input, output,
+    response, data, code, images, ...) into `output`, since `AIMessage`
+    has no custom `__str__`. Falls back to `str(response)` only when
+    neither attribute is present (e.g. a plain object with no `.output`/
+    `.response`, such as a bare string response).
+
     Args:
         response: Whatever `agent.ask()` returned.
 
@@ -139,7 +148,16 @@ def _agent_response_to_rpc(response: Any) -> dict[str, Any]:
     elif hasattr(response, "to_dict"):
         with contextlib.suppress(Exception):
             metadata = response.to_dict()
-    return {"output": str(response), "metadata": metadata}
+
+    output = getattr(response, "output", None)
+    if output is None:
+        output = getattr(response, "response", None)
+    if output is None:
+        output = str(response)
+    elif not isinstance(output, str):
+        output = str(output)
+
+    return {"output": output, "metadata": metadata}
 
 
 class SingleAgentManager:
@@ -209,6 +227,12 @@ class AgentDaemon:
         """
         self._configure_logging()
 
+        # Install signal handlers FIRST, before the socket is bound and
+        # advertised (sd_notify) -- a SIGTERM arriving in that window would
+        # otherwise hit Python's default disposition (immediate kill)
+        # instead of the graceful shutdown path.
+        await self._install_signal_handlers()
+
         self.agent = await resolve_agent(self.config.agent)
 
         await self._start_scheduler()
@@ -228,7 +252,6 @@ class AgentDaemon:
         )
         sd_notify("READY=1")
 
-        await self._install_signal_handlers()
         await self._shutdown_event.wait()
         await self._shutdown()
 
@@ -356,7 +379,15 @@ class AgentDaemon:
         }
 
     async def _handle_chat_send(self, session: Session, params: dict[str, Any]) -> Any:
-        """Handle `chat.send`: one-shot response, or ack + streamed deltas."""
+        """Handle `chat.send`: one-shot response, or ack + streamed deltas.
+
+        `stream_id` may be supplied by the caller (e.g. `AgentDaemonClient.
+        stream()` generates it up front and registers its queue before
+        even sending this request, to avoid a race where the daemon's
+        first `chat.delta` arrives before the client is listening for
+        it). Falls back to generating one server-side for callers that
+        don't supply it (e.g. a raw NDJSON client).
+        """
         prompt = params.get("prompt", "")
         stream = bool(params.get("stream", False))
         metadata = params.get("metadata") or {}
@@ -367,7 +398,7 @@ class AgentDaemon:
             )
             return _agent_response_to_rpc(response)
 
-        stream_id = uuid.uuid4().hex
+        stream_id = params.get("stream_id") or uuid.uuid4().hex
         session.stream_ids.add(stream_id)
         task = asyncio.create_task(
             self._run_stream(session, stream_id, prompt, metadata)
@@ -379,22 +410,52 @@ class AgentDaemon:
     async def _run_stream(
         self, session: Session, stream_id: str, prompt: str, metadata: dict[str, Any]
     ) -> None:
-        """Iterate `agent.ask_stream()`, emitting `chat.delta`/`chat.complete`."""
+        """Iterate `agent.ask_stream()`, emitting `chat.delta`/`chat.complete`.
+
+        `AbstractBot.ask_stream()`'s real contract yields text deltas
+        (`str`, or an object with `.text`/`.content`) followed by a
+        trailing `AIMessage`-shaped sentinel (identified by `.output`) --
+        mirrors the exact chunk-shape handling `AgentREPL.send_stream()`
+        already uses (`parrot.cli.repl`). The sentinel is NOT itself a
+        text delta -- treating it as one would `str()`-dump every
+        Pydantic field into the stream.
+        """
         accumulated: list[str] = []
+        final_response: Any = None
         try:
             async for chunk in self.agent.ask_stream(
                 prompt, session_id=session.session_id, **metadata
             ):
-                text = str(chunk)
+                if isinstance(chunk, str):
+                    text = chunk
+                elif hasattr(chunk, "text"):
+                    text = chunk.text
+                elif hasattr(chunk, "content"):
+                    text = chunk.content
+                elif hasattr(chunk, "output"):
+                    # Final AIMessage-like sentinel -- not a text delta.
+                    final_response = chunk
+                    break
+                else:
+                    text = str(chunk)
                 accumulated.append(text)
                 await session.notify(
                     METHOD_CHAT_DELTA, {"stream_id": stream_id, "text": text}
                 )
+
+            response_text = "".join(accumulated)
+            if final_response is not None:
+                output = getattr(final_response, "output", None)
+                if output is None:
+                    output = getattr(final_response, "response", None)
+                if output is not None:
+                    response_text = output if isinstance(output, str) else str(output)
+
             await session.notify(
                 METHOD_CHAT_COMPLETE,
                 {
                     "stream_id": stream_id,
-                    "response": "".join(accumulated),
+                    "response": response_text,
                     "usage": {},
                 },
             )

--- a/packages/ai-parrot-integrations/src/parrot/integrations/agentd/service.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/agentd/service.py
@@ -1,0 +1,556 @@
+"""AgentDaemon — lifecycle, RPC handlers, SingleAgentManager, sd_notify.
+
+Implements Module 5 of ``sdd/specs/agent-cli-daemon.spec.md``: the daemon
+itself. Binds one agent (``resolve_agent()``, TASK-2210) + an optional
+headless scheduler (``AgentSchedulerManager.start_headless()``,
+TASK-2209, lazily imported from ai-parrot-server) + the UDS server
+(``JsonRpcUnixServer``, TASK-2211) into one foreground process
+implementing the full RPC surface and the 6-step lifecycle of spec §2
+"Daemon lifecycle".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import inspect
+import logging
+import os
+import signal
+import socket
+import sys
+import time
+import uuid
+from typing import Any
+
+from .config import AgentServiceConfig, default_socket_path, resolve_agent
+from .protocol import (
+    METHOD_AGENT_INFO,
+    METHOD_AGENT_INVOKE,
+    METHOD_CHAT_COMPLETE,
+    METHOD_CHAT_DELTA,
+    METHOD_CHAT_ERROR,
+    METHOD_CHAT_SEND,
+    METHOD_DAEMON_SHUTDOWN,
+    METHOD_DAEMON_STATUS,
+    METHOD_EVENT_JOB_ERROR,
+    METHOD_EVENT_JOB_EXECUTED,
+    METHOD_EVENT_SHUTDOWN,
+    METHOD_EVENTS_SUBSCRIBE,
+    METHOD_EVENTS_UNSUBSCRIBE,
+    METHOD_SCHEDULES_ADD,
+    METHOD_SCHEDULES_LIST,
+    METHOD_SCHEDULES_PAUSE,
+    METHOD_SCHEDULES_REMOVE,
+    METHOD_SCHEDULES_RESUME,
+    METHOD_TOOLS_LIST,
+    SCHEDULE_NOT_FOUND,
+    SCHEDULER_UNAVAILABLE,
+    UNKNOWN_AGENT_METHOD,
+)
+from .server import Handler, JsonRpcUnixServer, RpcHandlerError, Session
+
+__all__ = [
+    "AgentDaemon",
+    "SingleAgentManager",
+    "sd_notify",
+]
+
+
+def sd_notify(state: str) -> None:
+    """Send a systemd `sd_notify` datagram, if `NOTIFY_SOCKET` is set.
+
+    Hand-rolled (no dependency on the `sdnotify` PyPI package, per spec
+    §7). No-op when `NOTIFY_SOCKET` is unset (e.g. `Type=simple` /
+    supervisord, or a plain terminal run).
+
+    Args:
+        state: The state string to send (e.g. `"READY=1"`, `"STOPPING=1"`).
+    """
+    address = os.environ.get("NOTIFY_SOCKET")
+    if not address:
+        return
+
+    if address.startswith("@"):
+        address = "\0" + address[1:]  # Linux abstract namespace socket.
+
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    try:
+        sock.connect(address)
+        sock.sendall(state.encode("utf-8"))
+    except OSError:
+        pass  # Best-effort notification; never fail the daemon over this.
+    finally:
+        sock.close()
+
+
+def _serialize_for_rpc(value: Any) -> Any:
+    """Best-effort JSON-serializable conversion for RPC results.
+
+    Mirrors `AgentSchedulerManager._format_result()`'s fallback chain
+    (`model_dump` -> `to_dict`/`dict` -> JSON-compatible -> `str`), but
+    keeps structured data (dict/list) intact instead of stringifying it,
+    since RPC results should stay structured whenever possible.
+
+    Args:
+        value: The value to convert.
+
+    Returns:
+        A JSON-serializable representation of `value`.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {k: _serialize_for_rpc(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_serialize_for_rpc(v) for v in value]
+    if hasattr(value, "model_dump"):
+        with contextlib.suppress(Exception):
+            return value.model_dump(mode="json")
+    if hasattr(value, "to_dict"):
+        with contextlib.suppress(Exception):
+            return value.to_dict()
+    if hasattr(value, "dict"):
+        with contextlib.suppress(Exception):
+            return value.dict()
+    try:
+        import json
+
+        json.dumps(value)
+        return value
+    except TypeError:
+        return str(value)
+
+
+def _agent_response_to_rpc(response: Any) -> dict[str, Any]:
+    """Convert an agent's `ask()` response into the minimal RPC shape.
+
+    Args:
+        response: Whatever `agent.ask()` returned.
+
+    Returns:
+        `{"output": str, "metadata": dict}` -- `metadata` is the response's
+        `model_dump()`/`to_dict()` when available, else empty.
+    """
+    metadata: dict[str, Any] = {}
+    if hasattr(response, "model_dump"):
+        with contextlib.suppress(Exception):
+            metadata = response.model_dump(mode="json")
+    elif hasattr(response, "to_dict"):
+        with contextlib.suppress(Exception):
+            metadata = response.to_dict()
+    return {"output": str(response), "metadata": metadata}
+
+
+class SingleAgentManager:
+    """Minimal `bot_manager` contract for `AgentSchedulerManager`.
+
+    Exposes exactly the surface `AgentSchedulerManager._execute_agent_job`
+    touches: `_bots` (dict), `registry.get_instance(name)`, and
+    `get_crew(name)` (always `None` -- agentd v1 is single-agent, no crew
+    support; multi-agent/crew orchestration is covered by the aiohttp
+    server, per spec §1 Non-Goals).
+    """
+
+    class _Registry:
+        """Minimal stand-in for `BotManager.registry`."""
+
+        def __init__(self, bots: dict[str, Any]) -> None:
+            self._bots = bots
+
+        async def get_instance(self, name: str) -> Any:
+            """Return the single registered agent by name.
+
+            Raises:
+                ValueError: If `name` does not match the registered agent.
+            """
+            agent = self._bots.get(name)
+            if agent is None:
+                raise ValueError(f"Agent {name!r} not found")
+            return agent
+
+    def __init__(self, agent: Any, name: str) -> None:
+        self._bots: dict[str, Any] = {name: agent}
+        self.registry = SingleAgentManager._Registry(self._bots)
+
+    def get_crew(self, name: str) -> None:
+        """Always return `None` -- no crew support in agentd v1."""
+        return
+
+
+class AgentDaemon:
+    """Foreground per-agent daemon (spec §2 "Daemon lifecycle").
+
+    Loads exactly one agent, optionally boots `AgentSchedulerManager`
+    headless (best-effort -- degrades with a warning if ai-parrot-server
+    is not installed), and serves JSON-RPC 2.0 over a Unix domain socket
+    until a shutdown signal (or `daemon.shutdown` RPC) is received.
+
+    Attributes:
+        config: The daemon's `AgentServiceConfig`.
+        agent: The resolved agent instance (set once `run()` starts).
+        server: The `JsonRpcUnixServer` instance (set once `run()` starts).
+    """
+
+    def __init__(self, config: AgentServiceConfig) -> None:
+        self.config = config
+        self.agent: Any = None
+        self.server: JsonRpcUnixServer | None = None
+        self._scheduler_manager: Any = None
+        self._shutdown_event = asyncio.Event()
+        self._start_time = time.monotonic()
+        self.logger = logging.getLogger(__name__)
+
+    async def run(self) -> None:
+        """Run the daemon's full lifecycle (spec §2, steps 1-6).
+
+        Returns once a graceful shutdown completes (SIGTERM/SIGINT or a
+        `daemon.shutdown` RPC).
+        """
+        self._configure_logging()
+
+        self.agent = await resolve_agent(self.config.agent)
+
+        await self._start_scheduler()
+
+        socket_path = self.config.socket or default_socket_path(self.config.name)
+        self.server = JsonRpcUnixServer(
+            socket_path, self._build_dispatch(), max_line_bytes=self.config.max_line_bytes
+        )
+        await self.server.start()
+
+        self._start_time = time.monotonic()
+        self.logger.info(
+            "agentd ready: socket=%s agent=%s scheduler=%s",
+            socket_path,
+            self.config.name,
+            "on" if self._scheduler_manager is not None else "off",
+        )
+        sd_notify("READY=1")
+
+        await self._install_signal_handlers()
+        await self._shutdown_event.wait()
+        await self._shutdown()
+
+    def _configure_logging(self) -> None:
+        """Configure stdout logging (journald-friendly -- no own timestamp)."""
+        logging.basicConfig(
+            level=self.config.log_level,
+            format="%(levelname)s %(name)s :: %(message)s",
+            stream=sys.stdout,
+        )
+
+    async def _install_signal_handlers(self) -> None:
+        """Register SIGTERM/SIGINT handlers that trigger graceful shutdown."""
+        loop = asyncio.get_event_loop()
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            with contextlib.suppress(NotImplementedError):
+                loop.add_signal_handler(sig, self._shutdown_event.set)
+
+    async def _start_scheduler(self) -> None:
+        """Best-effort headless scheduler bootstrap (spec §2, step 3).
+
+        Skipped entirely when `config.scheduler.enabled` is False. When
+        ai-parrot-server is not installed, logs a warning and continues
+        without a scheduler -- `schedules.*` RPCs then return
+        `SCHEDULER_UNAVAILABLE` (1003) instead of crashing the daemon.
+        """
+        if not self.config.scheduler.enabled:
+            self.logger.info("Scheduler disabled by config; skipping.")
+            return
+
+        try:
+            from apscheduler.events import EVENT_JOB_ERROR, EVENT_JOB_EXECUTED
+            from parrot.scheduler.manager import AgentSchedulerManager
+        except ImportError as exc:
+            self.logger.warning(
+                "ai-parrot-server (scheduler support) not installed; "
+                "running without a scheduler (%s)",
+                exc,
+            )
+            return
+
+        single_agent_manager = SingleAgentManager(self.agent, self.config.name)
+        manager = AgentSchedulerManager(bot_manager=single_agent_manager)
+        await manager.start_headless(
+            dsn=self.config.scheduler.dsn, use_redis=self.config.scheduler.redis
+        )
+        manager.register_bot_schedules(self.agent)
+        manager.scheduler.add_listener(self._on_job_executed, EVENT_JOB_EXECUTED)
+        manager.scheduler.add_listener(self._on_job_error, EVENT_JOB_ERROR)
+        self._scheduler_manager = manager
+
+    def _on_job_executed(self, event: Any) -> None:
+        """APScheduler listener (sync, per APScheduler's contract) -> fan-out."""
+        if self.server is None:
+            return
+        asyncio.create_task(
+            self.server.event_broker.publish(
+                METHOD_EVENT_JOB_EXECUTED,
+                {
+                    "job_id": event.job_id,
+                    "scheduled_run_time": str(getattr(event, "scheduled_run_time", "")),
+                },
+            )
+        )
+
+    def _on_job_error(self, event: Any) -> None:
+        """APScheduler listener (sync, per APScheduler's contract) -> fan-out."""
+        if self.server is None:
+            return
+        asyncio.create_task(
+            self.server.event_broker.publish(
+                METHOD_EVENT_JOB_ERROR,
+                {
+                    "job_id": event.job_id,
+                    "error": str(getattr(event, "exception", "")),
+                },
+            )
+        )
+
+    async def _shutdown(self) -> None:
+        """Graceful shutdown (spec §2, step 6), bounded by `shutdown_grace`."""
+        self.logger.info("agentd shutting down...")
+
+        if self.server is not None:
+            with contextlib.suppress(Exception):
+                await self.server.event_broker.publish(METHOD_EVENT_SHUTDOWN, {})
+
+        if self._scheduler_manager is not None:
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(
+                    self._scheduler_manager.stop_headless(wait=True),
+                    timeout=self.config.shutdown_grace,
+                )
+
+        cleanup = getattr(self.agent, "cleanup", None)
+        if callable(cleanup):
+            with contextlib.suppress(Exception):
+                result = cleanup()
+                if inspect.isawaitable(result):
+                    await result
+
+        if self.server is not None:
+            await self.server.close()
+
+        self.logger.info("agentd stopped.")
+
+    # -- RPC dispatch table -------------------------------------------------
+
+    def _build_dispatch(self) -> dict[str, Handler]:
+        """Build the method -> handler mapping passed to `JsonRpcUnixServer`."""
+        return {
+            METHOD_CHAT_SEND: self._handle_chat_send,
+            METHOD_AGENT_INFO: self._handle_agent_info,
+            METHOD_TOOLS_LIST: self._handle_tools_list,
+            METHOD_AGENT_INVOKE: self._handle_agent_invoke,
+            METHOD_SCHEDULES_LIST: self._handle_schedules_list,
+            METHOD_SCHEDULES_ADD: self._handle_schedules_add,
+            METHOD_SCHEDULES_PAUSE: self._handle_schedules_pause,
+            METHOD_SCHEDULES_RESUME: self._handle_schedules_resume,
+            METHOD_SCHEDULES_REMOVE: self._handle_schedules_remove,
+            METHOD_EVENTS_SUBSCRIBE: self._handle_events_subscribe,
+            METHOD_EVENTS_UNSUBSCRIBE: self._handle_events_unsubscribe,
+            METHOD_DAEMON_STATUS: self._handle_daemon_status,
+            METHOD_DAEMON_SHUTDOWN: self._handle_daemon_shutdown,
+        }
+
+    async def _handle_chat_send(self, session: Session, params: dict[str, Any]) -> Any:
+        """Handle `chat.send`: one-shot response, or ack + streamed deltas."""
+        prompt = params.get("prompt", "")
+        stream = bool(params.get("stream", False))
+        metadata = params.get("metadata") or {}
+
+        if not stream:
+            response = await self.agent.ask(
+                prompt, session_id=session.session_id, **metadata
+            )
+            return _agent_response_to_rpc(response)
+
+        stream_id = uuid.uuid4().hex
+        session.stream_ids.add(stream_id)
+        task = asyncio.create_task(
+            self._run_stream(session, stream_id, prompt, metadata)
+        )
+        session.tasks.add(task)
+        task.add_done_callback(session.tasks.discard)
+        return {"stream_id": stream_id}
+
+    async def _run_stream(
+        self, session: Session, stream_id: str, prompt: str, metadata: dict[str, Any]
+    ) -> None:
+        """Iterate `agent.ask_stream()`, emitting `chat.delta`/`chat.complete`."""
+        accumulated: list[str] = []
+        try:
+            async for chunk in self.agent.ask_stream(
+                prompt, session_id=session.session_id, **metadata
+            ):
+                text = str(chunk)
+                accumulated.append(text)
+                await session.notify(
+                    METHOD_CHAT_DELTA, {"stream_id": stream_id, "text": text}
+                )
+            await session.notify(
+                METHOD_CHAT_COMPLETE,
+                {
+                    "stream_id": stream_id,
+                    "response": "".join(accumulated),
+                    "usage": {},
+                },
+            )
+        except Exception as exc:
+            self.logger.exception(
+                "Streaming chat.send failed for stream_id=%s", stream_id
+            )
+            with contextlib.suppress(Exception):
+                await session.notify(
+                    METHOD_CHAT_ERROR, {"stream_id": stream_id, "error": str(exc)}
+                )
+        finally:
+            session.stream_ids.discard(stream_id)
+
+    async def _handle_agent_info(self, session: Session, params: dict[str, Any]) -> Any:
+        """Handle `agent.info`."""
+        get_tools_count = getattr(self.agent, "get_tools_count", None)
+        return {
+            "name": getattr(self.agent, "name", self.config.name),
+            "class": type(self.agent).__name__,
+            "llm": str(getattr(self.agent, "llm", None)),
+            "tools_count": get_tools_count() if callable(get_tools_count) else 0,
+            "uptime_s": time.monotonic() - self._start_time,
+        }
+
+    async def _handle_tools_list(self, session: Session, params: dict[str, Any]) -> Any:
+        """Handle `tools.list`."""
+        get_tools = getattr(self.agent, "get_available_tools", None)
+        tools = get_tools() if callable(get_tools) else []
+        return {"tools": list(tools)}
+
+    async def _handle_agent_invoke(self, session: Session, params: dict[str, Any]) -> Any:
+        """Handle `agent.invoke`.
+
+        Raises:
+            RpcHandlerError: `UNKNOWN_AGENT_METHOD` for underscore-prefixed
+                methods (always rejected), methods outside a non-empty
+                `exposed_methods` allowlist, or methods that don't exist.
+        """
+        method_name = params.get("method")
+        args = params.get("args") or []
+        kwargs = params.get("kwargs") or {}
+
+        if not method_name or method_name.startswith("_"):
+            raise RpcHandlerError(
+                UNKNOWN_AGENT_METHOD, f"Method not allowed: {method_name!r}"
+            )
+
+        if (
+            self.config.exposed_methods
+            and method_name not in self.config.exposed_methods
+        ):
+            raise RpcHandlerError(
+                UNKNOWN_AGENT_METHOD, f"Method not in allowlist: {method_name!r}"
+            )
+
+        method = getattr(self.agent, method_name, None)
+        if method is None or not callable(method):
+            raise RpcHandlerError(
+                UNKNOWN_AGENT_METHOD, f"Unknown agent method: {method_name!r}"
+            )
+
+        result = method(*args, **kwargs)
+        if inspect.isawaitable(result):
+            result = await result
+
+        return _serialize_for_rpc(result)
+
+    async def _require_scheduler(self) -> Any:
+        """Return the scheduler manager, or raise `SCHEDULER_UNAVAILABLE`."""
+        if self._scheduler_manager is None:
+            raise RpcHandlerError(
+                SCHEDULER_UNAVAILABLE,
+                "Scheduler is not available (ai-parrot-server not "
+                "installed, or scheduler.enabled=false in config).",
+            )
+        return self._scheduler_manager
+
+    async def _handle_schedules_list(self, session: Session, params: dict[str, Any]) -> Any:
+        """Handle `schedules.list`."""
+        manager = await self._require_scheduler()
+        return _serialize_for_rpc(await manager.list_jobs())
+
+    async def _handle_schedules_add(self, session: Session, params: dict[str, Any]) -> Any:
+        """Handle `schedules.add`."""
+        manager = await self._require_scheduler()
+        schedule = await manager.add_schedule(**params)
+        return _serialize_for_rpc(schedule)
+
+    async def _handle_schedules_pause(self, session: Session, params: dict[str, Any]) -> Any:
+        """Handle `schedules.pause`."""
+        manager = await self._require_scheduler()
+        try:
+            schedule = await manager.pause_schedule(params.get("schedule_id"))
+        except Exception as exc:
+            raise RpcHandlerError(SCHEDULE_NOT_FOUND, str(exc)) from exc
+        return _serialize_for_rpc(schedule)
+
+    async def _handle_schedules_resume(self, session: Session, params: dict[str, Any]) -> Any:
+        """Handle `schedules.resume` (re-enable + reschedule the job)."""
+        manager = await self._require_scheduler()
+        try:
+            schedule = await manager.update_schedule(
+                params.get("schedule_id"), {"enabled": True}
+            )
+        except Exception as exc:
+            raise RpcHandlerError(SCHEDULE_NOT_FOUND, str(exc)) from exc
+        return _serialize_for_rpc(schedule)
+
+    async def _handle_schedules_remove(self, session: Session, params: dict[str, Any]) -> Any:
+        """Handle `schedules.remove`."""
+        manager = await self._require_scheduler()
+        try:
+            await manager.delete_schedule(params.get("schedule_id"))
+        except Exception as exc:
+            raise RpcHandlerError(SCHEDULE_NOT_FOUND, str(exc)) from exc
+        return {"removed": True}
+
+    async def _handle_events_subscribe(self, session: Session, params: dict[str, Any]) -> Any:
+        """Handle `events.subscribe`."""
+        self.server.event_broker.subscribe(session)
+        return {"subscribed": True}
+
+    async def _handle_events_unsubscribe(self, session: Session, params: dict[str, Any]) -> Any:
+        """Handle `events.unsubscribe`."""
+        self.server.event_broker.unsubscribe(session)
+        return {"subscribed": False}
+
+    async def _handle_daemon_status(self, session: Session, params: dict[str, Any]) -> Any:
+        """Handle `daemon.status`."""
+        scheduler_info: dict[str, Any] = {
+            "available": self._scheduler_manager is not None
+        }
+        if self._scheduler_manager is not None:
+            scheduler_info["running"] = bool(self._scheduler_manager.scheduler.running)
+            scheduler_info["jobs"] = len(self._scheduler_manager.scheduler.get_jobs())
+
+        return {
+            "pid": os.getpid(),
+            "uptime_s": time.monotonic() - self._start_time,
+            "version": _integrations_version(),
+            "scheduler": scheduler_info,
+            "active_connections": self.server.active_connections if self.server else 0,
+        }
+
+    async def _handle_daemon_shutdown(self, session: Session, params: dict[str, Any]) -> Any:
+        """Handle `daemon.shutdown`: signal the main loop to shut down."""
+        self._shutdown_event.set()
+        return {"ok": True}
+
+
+def _integrations_version() -> str:
+    """Return the installed `ai-parrot-integrations` package version."""
+    try:
+        from importlib.metadata import version
+
+        return version("ai-parrot-integrations")
+    except Exception:  # noqa: BLE001 - version reporting must never crash the daemon
+        return "unknown"

--- a/packages/ai-parrot-integrations/src/parrot/integrations/agentd/service.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/agentd/service.py
@@ -410,7 +410,13 @@ class AgentDaemon:
             session.stream_ids.discard(stream_id)
 
     async def _handle_agent_info(self, session: Session, params: dict[str, Any]) -> Any:
-        """Handle `agent.info`."""
+        """Handle `agent.info`.
+
+        Includes `exposed_methods` (the daemon's `agent.invoke` allowlist)
+        so clients that only know a socket path/name -- e.g. the MCP stdio
+        proxy (TASK-2215) -- can decide whether to expose `invoke_method`
+        without needing the `AgentServiceConfig` object itself.
+        """
         get_tools_count = getattr(self.agent, "get_tools_count", None)
         return {
             "name": getattr(self.agent, "name", self.config.name),
@@ -418,6 +424,7 @@ class AgentDaemon:
             "llm": str(getattr(self.agent, "llm", None)),
             "tools_count": get_tools_count() if callable(get_tools_count) else 0,
             "uptime_s": time.monotonic() - self._start_time,
+            "exposed_methods": list(self.config.exposed_methods),
         }
 
     async def _handle_tools_list(self, session: Session, params: dict[str, Any]) -> Any:

--- a/packages/ai-parrot-integrations/tests/agentd/__init__.py
+++ b/packages/ai-parrot-integrations/tests/agentd/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Agent CLI Daemon (agentd) subsystem — FEAT-422."""

--- a/packages/ai-parrot-integrations/tests/agentd/conftest.py
+++ b/packages/ai-parrot-integrations/tests/agentd/conftest.py
@@ -1,0 +1,86 @@
+"""Shared fixtures for the agentd test suite (TASK-2217).
+
+`echo_daemon` and `agentd_yaml` (plus the `run_daemon`/`stop_daemon`/
+`wait_for_socket` helpers they're built on) are used by cross-module
+integration tests (`test_e2e.py`) that exercise the REAL `AgentDaemon` +
+`AgentDaemonClient` stack -- no scripted fakes, no external infra
+(`MemoryJobStore` only).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+
+import pytest
+from parrot.integrations.agentd.config import (
+    AgentServiceConfig,
+    AgentTargetConfig,
+    SchedulerConfig,
+)
+from parrot.integrations.agentd.service import AgentDaemon
+
+
+async def wait_for_socket(socket_path: Path, timeout: float = 5.0) -> None:
+    """Poll until `socket_path` exists (the daemon has bound its UDS).
+
+    Raises:
+        TimeoutError: If the socket does not appear within `timeout`.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if socket_path.exists():
+            return
+        await asyncio.sleep(0.01)
+    raise TimeoutError(f"Socket {socket_path} did not appear within {timeout}s")
+
+
+async def run_daemon(config: AgentServiceConfig) -> tuple[AgentDaemon, asyncio.Task]:
+    """Start an `AgentDaemon` in the background; wait until it is ready.
+
+    Returns:
+        `(daemon, run_task)` -- `run_task` is `daemon.run()` scheduled as
+        a background task.
+    """
+    daemon = AgentDaemon(config)
+    run_task = asyncio.ensure_future(daemon.run())
+    await wait_for_socket(config.socket)
+    return daemon, run_task
+
+
+async def stop_daemon(daemon: AgentDaemon, run_task: asyncio.Task) -> None:
+    """Trigger graceful shutdown and await the daemon's `run()` task."""
+    daemon._shutdown_event.set()
+    await asyncio.wait_for(run_task, timeout=5)
+
+
+@pytest.fixture
+async def echo_daemon(tmp_path):
+    """`AgentDaemon` running `EchoAgent` on a tmp socket; yields `(daemon, socket_path)`."""
+    socket_path = tmp_path / "echo.sock"
+    config = AgentServiceConfig(
+        name="echo-daemon",
+        agent=AgentTargetConfig(
+            target="tests.agentd.fakes:EchoAgent", kwargs={"name": "echo"}
+        ),
+        socket=socket_path,
+        scheduler=SchedulerConfig(enabled=False),
+    )
+    daemon, run_task = await run_daemon(config)
+
+    yield daemon, socket_path
+
+    await stop_daemon(daemon, run_task)
+
+
+@pytest.fixture
+def agentd_yaml(tmp_path) -> Path:
+    """Minimal valid agent YAML pointing at `tests.agentd.fakes:EchoAgent`."""
+    yaml_path = tmp_path / "agentd.yaml"
+    yaml_path.write_text(
+        "name: yaml-echo\n"
+        'agent:\n  target: "tests.agentd.fakes:EchoAgent"\n'
+        "scheduler:\n  enabled: false\n"
+    )
+    return yaml_path

--- a/packages/ai-parrot-integrations/tests/agentd/fakes.py
+++ b/packages/ai-parrot-integrations/tests/agentd/fakes.py
@@ -1,0 +1,85 @@
+"""Shared test fakes for the agentd test suite (FEAT-422).
+
+`EchoAgent` is a minimal, dependency-free, duck-typed agent — it does NOT
+subclass `AbstractBot` (that would require LLM client configuration) but
+exposes the same interface surface `DaemonAgentProxy`/`_DaemonBotProxy` and
+the MCP proxy expect: `ask`, `ask_stream`, `configure`,
+`get_available_tools`, `get_tools_count`, `has_tools`.
+
+Also exposed here: sync/async factory functions and a pre-built instance,
+used to exercise every branch of `resolve_agent()`'s target-resolution
+matrix (class / instance / sync factory / async factory).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+
+class EchoAgentResponse:
+    """Minimal AIMessage-like response object."""
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+    def __str__(self) -> str:  # pragma: no cover - convenience only
+        return self.content
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, EchoAgentResponse) and other.content == self.content
+
+
+class EchoAgent:
+    """Duck-typed fake agent: echoes back whatever it is asked.
+
+    Attributes:
+        name: Agent name, included in echoed responses.
+        configured: Set True after `configure()` has been awaited.
+    """
+
+    def __init__(self, name: str = "echo", **kwargs: Any) -> None:
+        self.name = name
+        self.configured = False
+        self.kwargs = kwargs
+
+    async def configure(self, app: Any = None) -> None:
+        """Mark the agent as configured (mirrors `AbstractBot.configure`)."""
+        self.configured = True
+
+    async def ask(self, question: str, **kwargs: Any) -> EchoAgentResponse:
+        """Echo the question back as the response."""
+        return EchoAgentResponse(f"echo: {question}")
+
+    async def ask_stream(
+        self, question: str, **kwargs: Any
+    ) -> AsyncIterator[str]:
+        """Yield the echoed response one token at a time."""
+        for token in f"echo: {question}".split():
+            yield token
+
+    def get_available_tools(self) -> list[str]:
+        """Return the (empty) tool list."""
+        return []
+
+    def get_tools_count(self) -> int:
+        """Return the tool count (always 0)."""
+        return 0
+
+    def has_tools(self) -> bool:
+        """Return whether this agent has tools (always False)."""
+        return False
+
+
+def make_echo_agent(name: str = "echo", **kwargs: Any) -> EchoAgent:
+    """Sync factory returning a new `EchoAgent` (not yet configured)."""
+    return EchoAgent(name=name, **kwargs)
+
+
+async def make_echo_agent_async(name: str = "echo", **kwargs: Any) -> EchoAgent:
+    """Async factory returning a new `EchoAgent` (not yet configured)."""
+    return EchoAgent(name=name, **kwargs)
+
+
+#: Pre-built instance target, for the "already an instance" resolution case.
+echo_instance = EchoAgent(name="singleton-instance")

--- a/packages/ai-parrot-integrations/tests/agentd/test_cli.py
+++ b/packages/ai-parrot-integrations/tests/agentd/test_cli.py
@@ -1,0 +1,226 @@
+"""Tests for parrot.integrations.agentd.cli (TASK-2216).
+
+CliRunner-based: `serve` arg parsing (yaml vs target), `ask` exit codes +
+non-TTY plain output, `install-service` unit-file generation, and the
+core `LazyGroup` missing-module error message.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import click
+import pytest
+from click.testing import CliRunner
+from parrot.integrations.agentd import cli as agentd_cli
+from parrot.integrations.agentd.client import DaemonNotRunning
+
+
+class _FakeDaemon:
+    """Stand-in for AgentDaemon -- records the config it was built with."""
+
+    last_config = None
+
+    def __init__(self, config) -> None:
+        _FakeDaemon.last_config = config
+
+    async def run(self) -> None:
+        return None
+
+
+class _FakeAskClient:
+    def __init__(self, result=None, error=None) -> None:
+        self._result = result
+        self._error = error
+        self.closed = False
+
+    async def call(self, method, **kwargs):
+        if self._error is not None:
+            raise self._error
+        return self._result
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class TestServe:
+    def test_yaml_arg(self, tmp_path, monkeypatch):
+        yaml_path = tmp_path / "cfg.yaml"
+        yaml_path.write_text(
+            'name: my-agent\nagent:\n  target: "tests.agentd.fakes:EchoAgent"\n'
+        )
+        monkeypatch.setattr(agentd_cli, "AgentDaemon", _FakeDaemon)
+
+        runner = CliRunner()
+        result = runner.invoke(agentd_cli.serve, [str(yaml_path)])
+
+        assert result.exit_code == 0, result.output
+        assert _FakeDaemon.last_config.name == "my-agent"
+        assert _FakeDaemon.last_config.agent.target == "tests.agentd.fakes:EchoAgent"
+
+    def test_target_arg(self, monkeypatch):
+        monkeypatch.setattr(agentd_cli, "AgentDaemon", _FakeDaemon)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            agentd_cli.serve, ["tests.agentd.fakes:EchoAgent", "--name", "cli-agent"]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert _FakeDaemon.last_config.name == "cli-agent"
+        assert _FakeDaemon.last_config.agent.target == "tests.agentd.fakes:EchoAgent"
+
+    def test_target_arg_without_name_errors(self):
+        runner = CliRunner()
+        result = runner.invoke(agentd_cli.serve, ["tests.agentd.fakes:EchoAgent"])
+
+        assert result.exit_code != 0
+
+    def test_overrides_applied(self, tmp_path, monkeypatch):
+        yaml_path = tmp_path / "cfg.yaml"
+        yaml_path.write_text(
+            'name: my-agent\nagent:\n  target: "tests.agentd.fakes:EchoAgent"\n'
+        )
+        monkeypatch.setattr(agentd_cli, "AgentDaemon", _FakeDaemon)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            agentd_cli.serve,
+            [
+                str(yaml_path),
+                "--socket",
+                str(tmp_path / "custom.sock"),
+                "--dsn",
+                "postgres://x",
+                "--redis",
+                "--log-level",
+                "DEBUG",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        cfg = _FakeDaemon.last_config
+        assert cfg.socket == tmp_path / "custom.sock"
+        assert cfg.log_level == "DEBUG"
+        assert cfg.scheduler.dsn == "postgres://x"
+        assert cfg.scheduler.redis is True
+
+
+class TestAsk:
+    def test_exit_codes_success(self, monkeypatch, tmp_path):
+        fake_client = _FakeAskClient(result={"output": "hi there"})
+
+        async def _fake_connect(socket_path, **kwargs):
+            return fake_client
+
+        monkeypatch.setattr(
+            agentd_cli.AgentDaemonClient, "connect", staticmethod(_fake_connect)
+        )
+        monkeypatch.setattr(agentd_cli, "resolve_socket", lambda name: tmp_path / "fake.sock")
+
+        runner = CliRunner()
+        result = runner.invoke(agentd_cli.ask, ["myagent", "hello?"])
+
+        assert result.exit_code == 0
+        assert "hi there" in result.output
+        assert fake_client.closed is True
+
+    def test_exit_codes_daemon_not_running(self, monkeypatch, tmp_path):
+        async def _fake_connect(socket_path, **kwargs):
+            raise DaemonNotRunning("no daemon listening")
+
+        monkeypatch.setattr(
+            agentd_cli.AgentDaemonClient, "connect", staticmethod(_fake_connect)
+        )
+        monkeypatch.setattr(agentd_cli, "resolve_socket", lambda name: tmp_path / "fake.sock")
+
+        runner = CliRunner()
+        result = runner.invoke(agentd_cli.ask, ["myagent", "hello?"])
+
+        assert result.exit_code == 1
+
+    def test_non_tty_plain(self, monkeypatch, tmp_path):
+        """CliRunner's captured stdout is never a TTY -- output must be
+        plain text with no ANSI escape codes."""
+        fake_client = _FakeAskClient(result={"output": "plain output"})
+
+        async def _fake_connect(socket_path, **kwargs):
+            return fake_client
+
+        monkeypatch.setattr(
+            agentd_cli.AgentDaemonClient, "connect", staticmethod(_fake_connect)
+        )
+        monkeypatch.setattr(agentd_cli, "resolve_socket", lambda name: tmp_path / "fake.sock")
+
+        runner = CliRunner()
+        result = runner.invoke(agentd_cli.ask, ["myagent", "hello?"])
+
+        assert result.exit_code == 0
+        assert "\x1b[" not in result.output
+        assert result.output.strip() == "plain output"
+
+
+class TestInstallService:
+    def test_unit_content(self, tmp_path, monkeypatch):
+        cfg_path = tmp_path / "cfg.yaml"
+        cfg_path.write_text(
+            'name: my-agent\nagent:\n  target: "tests.agentd.fakes:EchoAgent"\n'
+        )
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+        runner = CliRunner()
+        result = runner.invoke(agentd_cli.install_service, [str(cfg_path)])
+
+        assert result.exit_code == 0, result.output
+        unit_path = fake_home / ".config" / "systemd" / "user" / "parrot-my-agent.service"
+        assert unit_path.exists()
+
+        content = unit_path.read_text()
+        assert "Type=notify" in content
+        assert "Restart=on-failure" in content
+        assert "Environment=PYTHONUNBUFFERED=1" in content
+        assert "WantedBy=default.target" in content
+        assert "After=network-online.target" in content
+        assert str(cfg_path) in content
+        assert "sudo" not in content
+
+    def test_system_prints_only(self, tmp_path, monkeypatch):
+        cfg_path = tmp_path / "cfg.yaml"
+        cfg_path.write_text(
+            'name: my-agent\nagent:\n  target: "tests.agentd.fakes:EchoAgent"\n'
+        )
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+        runner = CliRunner()
+        result = runner.invoke(agentd_cli.install_service, [str(cfg_path), "--system"])
+
+        assert result.exit_code == 0, result.output
+        assert "Type=notify" in result.stdout
+        assert "sudo" not in result.stdout
+        assert not (fake_home / ".config").exists()
+
+
+class TestCoreRegistration:
+    def test_missing_module_message(self, monkeypatch):
+        from parrot.cli import cli as core_cli
+
+        def _raise_import_error(name, *args, **kwargs):
+            raise ImportError(f"No module named {name!r}")
+
+        monkeypatch.setattr(importlib, "import_module", _raise_import_error)
+
+        with pytest.raises(click.ClickException) as excinfo:
+            core_cli.get_command(None, "serve")
+
+        assert "ai-parrot-integrations[agentd]" in str(excinfo.value)
+
+    def test_lazy_keys_registered(self):
+        from parrot.cli import cli as core_cli
+
+        for key in ("serve", "attach", "ask", "status", "install-service", "mcp-serve"):
+            assert core_cli._lazy_commands.get(key) == "parrot.integrations.agentd.cli"

--- a/packages/ai-parrot-integrations/tests/agentd/test_client.py
+++ b/packages/ai-parrot-integrations/tests/agentd/test_client.py
@@ -1,0 +1,235 @@
+"""Unit tests for parrot.integrations.agentd.client (TASK-2213).
+
+Uses a scripted raw asyncio UDS server replaying canned NDJSON exchanges --
+deliberately NOT `JsonRpcUnixServer` (TASK-2211), so this task stays
+parallel-safe against it and exercises only the client's own framing,
+demux, retry, and error-mapping logic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+
+import pytest
+from parrot.integrations.agentd.client import (
+    AgentDaemonClient,
+    ConnectionClosed,
+    DaemonNotRunning,
+    RpcRemoteError,
+)
+
+
+class _Harness:
+    """Scripted-server test harness.
+
+    Attributes:
+        socket_path: The UDS path the fake server is listening on.
+        script: Maps an incoming request's `method` to a callable
+            `(request_dict) -> list[dict] | None` producing raw NDJSON
+            payloads to write back, in order (empty/None -> no reply).
+        connections: Every accepted connection's `StreamWriter`, in
+            acceptance order -- lets tests push notifications directly.
+    """
+
+    def __init__(self, socket_path):
+        self.socket_path = socket_path
+        self.script: dict = {}
+        self.connections: list[asyncio.StreamWriter] = []
+
+
+@pytest.fixture
+async def scripted_server(tmp_path):
+    socket_path = tmp_path / "scripted.sock"
+    harness = _Harness(socket_path)
+
+    async def _handle(reader, writer):
+        harness.connections.append(writer)
+        try:
+            while True:
+                line = await reader.readline()
+                if not line:
+                    break
+                request = json.loads(line.decode("utf-8"))
+                handler = harness.script.get(request.get("method"))
+                if handler is None:
+                    continue
+                for out in handler(request) or []:
+                    writer.write((json.dumps(out) + "\n").encode("utf-8"))
+                await writer.drain()
+        except (asyncio.IncompleteReadError, ConnectionResetError):
+            pass
+        finally:
+            with contextlib.suppress(Exception):
+                writer.close()
+
+    server = await asyncio.start_unix_server(_handle, path=str(socket_path))
+
+    yield harness
+
+    server.close()
+    await server.wait_closed()
+
+
+def _write_notification(writer, method, stream_id, **params):
+    payload = {
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": {"stream_id": stream_id, **params},
+    }
+    writer.write((json.dumps(payload) + "\n").encode("utf-8"))
+
+
+class TestClient:
+    async def test_call_roundtrip(self, scripted_server):
+        def ping_handler(request):
+            return [
+                {"jsonrpc": "2.0", "id": request["id"], "result": {"pong": True}}
+            ]
+
+        scripted_server.script["ping"] = ping_handler
+
+        client = await AgentDaemonClient.connect(scripted_server.socket_path)
+        try:
+            result = await client.call("ping", x=1)
+        finally:
+            await client.close()
+
+        assert result == {"pong": True}
+
+    async def test_error_mapping(self, scripted_server):
+        def bad_handler(request):
+            return [
+                {
+                    "jsonrpc": "2.0",
+                    "id": request["id"],
+                    "error": {"code": -32601, "message": "nope"},
+                }
+            ]
+
+        scripted_server.script["bad"] = bad_handler
+
+        client = await AgentDaemonClient.connect(scripted_server.socket_path)
+        try:
+            with pytest.raises(RpcRemoteError) as excinfo:
+                await client.call("bad")
+        finally:
+            await client.close()
+
+        assert excinfo.value.code == -32601
+        assert excinfo.value.message == "nope"
+
+    async def test_stream_demux_interleaved(self, scripted_server):
+        counter = {"n": 0}
+
+        def chat_send_handler(request):
+            counter["n"] += 1
+            stream_id = f"s{counter['n']}"
+            return [
+                {
+                    "jsonrpc": "2.0",
+                    "id": request["id"],
+                    "result": {"stream_id": stream_id},
+                }
+            ]
+
+        scripted_server.script["chat.send"] = chat_send_handler
+
+        client = await AgentDaemonClient.connect(scripted_server.socket_path)
+        try:
+            agen1 = client.stream("prompt-1")
+            agen2 = client.stream("prompt-2")
+
+            # Drive both chat.send round-trips (ack); each __anext__() then
+            # blocks on its own queue.get() until we push notifications.
+            next1 = asyncio.ensure_future(agen1.__anext__())
+            next2 = asyncio.ensure_future(agen2.__anext__())
+            await asyncio.sleep(0.05)
+
+            writer = scripted_server.connections[0]
+            _write_notification(writer, "chat.delta", "s1", text="hello-1")
+            _write_notification(writer, "chat.delta", "s2", text="hello-2")
+            _write_notification(writer, "chat.delta", "s1", text="-more-1")
+            _write_notification(
+                writer, "chat.complete", "s2", response="done-2", usage={}
+            )
+            _write_notification(
+                writer, "chat.complete", "s1", response="done-1", usage={}
+            )
+            await writer.drain()
+
+            event1a = await next1
+            event2a = await next2
+            assert event1a.kind == "delta" and event1a.text == "hello-1"
+            assert event2a.kind == "delta" and event2a.text == "hello-2"
+
+            event1b = await agen1.__anext__()
+            assert event1b.kind == "delta" and event1b.text == "-more-1"
+
+            event1c = await agen1.__anext__()
+            assert event1c.kind == "complete" and event1c.response == "done-1"
+
+            event2b = await agen2.__anext__()
+            assert event2b.kind == "complete" and event2b.response == "done-2"
+
+            with pytest.raises(StopAsyncIteration):
+                await agen1.__anext__()
+            with pytest.raises(StopAsyncIteration):
+                await agen2.__anext__()
+        finally:
+            await client.close()
+
+    async def test_retry_then_daemon_not_running(self, tmp_path):
+        socket_path = tmp_path / "nobody-here.sock"
+
+        with pytest.raises(DaemonNotRunning) as excinfo:
+            await AgentDaemonClient.connect(socket_path, retries=2, backoff=0.01)
+
+        assert str(socket_path) in str(excinfo.value)
+
+    async def test_close_with_pending(self, scripted_server):
+        scripted_server.script["stall"] = lambda request: []  # never responds
+
+        client = await AgentDaemonClient.connect(scripted_server.socket_path)
+        call_task = asyncio.ensure_future(client.call("stall"))
+        await asyncio.sleep(0.05)
+
+        await client.close()
+
+        with pytest.raises(ConnectionClosed):
+            await call_task
+
+    async def test_event_callback_receives_events(self, scripted_server):
+        received = []
+
+        def subscribe_handler(request):
+            return [
+                {"jsonrpc": "2.0", "id": request["id"], "result": {"ok": True}}
+            ]
+
+        scripted_server.script["events.subscribe"] = subscribe_handler
+
+        client = await AgentDaemonClient.connect(scripted_server.socket_path)
+        try:
+            await client.subscribe_events(lambda method, params: received.append((method, params)))
+
+            writer = scripted_server.connections[0]
+            writer.write(
+                (
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "method": "event.job_executed",
+                            "params": {"job_id": "j1"},
+                        }
+                    )
+                    + "\n"
+                ).encode("utf-8")
+            )
+            await writer.drain()
+            await asyncio.sleep(0.05)
+        finally:
+            await client.close()
+
+        assert received == [("event.job_executed", {"job_id": "j1"})]

--- a/packages/ai-parrot-integrations/tests/agentd/test_client.py
+++ b/packages/ai-parrot-integrations/tests/agentd/test_client.py
@@ -121,11 +121,14 @@ class TestClient:
         assert excinfo.value.message == "nope"
 
     async def test_stream_demux_interleaved(self, scripted_server):
-        counter = {"n": 0}
+        received_stream_ids: list[str] = []
 
         def chat_send_handler(request):
-            counter["n"] += 1
-            stream_id = f"s{counter['n']}"
+            # `stream()` now generates the stream_id client-side and
+            # registers its queue before sending -- the daemon (real or
+            # scripted) must echo it back rather than assigning its own.
+            stream_id = request["params"]["stream_id"]
+            received_stream_ids.append(stream_id)
             return [
                 {
                     "jsonrpc": "2.0",
@@ -147,15 +150,18 @@ class TestClient:
             next2 = asyncio.ensure_future(agen2.__anext__())
             await asyncio.sleep(0.05)
 
+            assert len(received_stream_ids) == 2
+            s1, s2 = received_stream_ids
+
             writer = scripted_server.connections[0]
-            _write_notification(writer, "chat.delta", "s1", text="hello-1")
-            _write_notification(writer, "chat.delta", "s2", text="hello-2")
-            _write_notification(writer, "chat.delta", "s1", text="-more-1")
+            _write_notification(writer, "chat.delta", s1, text="hello-1")
+            _write_notification(writer, "chat.delta", s2, text="hello-2")
+            _write_notification(writer, "chat.delta", s1, text="-more-1")
             _write_notification(
-                writer, "chat.complete", "s2", response="done-2", usage={}
+                writer, "chat.complete", s2, response="done-2", usage={}
             )
             _write_notification(
-                writer, "chat.complete", "s1", response="done-1", usage={}
+                writer, "chat.complete", s1, response="done-1", usage={}
             )
             await writer.drain()
 

--- a/packages/ai-parrot-integrations/tests/agentd/test_config.py
+++ b/packages/ai-parrot-integrations/tests/agentd/test_config.py
@@ -1,0 +1,165 @@
+"""Unit tests for parrot.integrations.agentd.config (TASK-2210)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from parrot.integrations.agentd.config import (
+    AgentServiceConfig,
+    AgentTargetConfig,
+    AgentTargetError,
+    SchedulerConfig,
+    default_socket_path,
+    resolve_agent,
+)
+
+
+class TestConfig:
+    def test_yaml_roundtrip(self, tmp_path):
+        yaml_path = tmp_path / "agentd.yaml"
+        yaml_path.write_text(
+            """
+name: my-agent
+agent:
+  target: "tests.agentd.fakes:EchoAgent"
+  kwargs:
+    name: "yaml-echo"
+scheduler:
+  enabled: true
+  dsn: "postgres://user:pass@localhost/db"
+  redis: true
+exposed_methods:
+  - "some_method"
+log_level: "DEBUG"
+max_line_bytes: 1024
+shutdown_grace: 5.0
+""".strip()
+        )
+
+        cfg = AgentServiceConfig.from_yaml(yaml_path)
+
+        assert cfg.name == "my-agent"
+        assert cfg.agent.target == "tests.agentd.fakes:EchoAgent"
+        assert cfg.agent.kwargs == {"name": "yaml-echo"}
+        assert cfg.scheduler.enabled is True
+        assert cfg.scheduler.dsn == "postgres://user:pass@localhost/db"
+        assert cfg.scheduler.redis is True
+        assert cfg.exposed_methods == ["some_method"]
+        assert cfg.log_level == "DEBUG"
+        assert cfg.max_line_bytes == 1024
+        assert cfg.shutdown_grace == 5.0
+
+    def test_defaults(self, tmp_path):
+        yaml_path = tmp_path / "minimal.yaml"
+        yaml_path.write_text(
+            'name: minimal\nagent:\n  target: "tests.agentd.fakes:EchoAgent"\n'
+        )
+
+        cfg = AgentServiceConfig.from_yaml(yaml_path)
+
+        assert cfg.socket is None
+        assert cfg.scheduler == SchedulerConfig()
+        assert cfg.exposed_methods == []
+        assert cfg.log_level == "INFO"
+        assert cfg.max_line_bytes == 10 * 1024 * 1024
+        assert cfg.shutdown_grace == 30.0
+
+    def test_from_target_builds_config_without_yaml(self):
+        cfg = AgentServiceConfig.from_target(
+            "tests.agentd.fakes:EchoAgent", name="cli-agent", log_level="WARNING"
+        )
+
+        assert cfg.name == "cli-agent"
+        assert cfg.agent.target == "tests.agentd.fakes:EchoAgent"
+        assert cfg.log_level == "WARNING"
+
+    def test_bad_name_rejected(self):
+        with pytest.raises(ValueError):
+            AgentServiceConfig(
+                name="bad/name",
+                agent=AgentTargetConfig(target="tests.agentd.fakes:EchoAgent"),
+            )
+
+    def test_empty_name_rejected(self):
+        with pytest.raises(ValueError):
+            AgentServiceConfig(
+                name="",
+                agent=AgentTargetConfig(target="tests.agentd.fakes:EchoAgent"),
+            )
+
+
+class TestDefaultSocketPath:
+    def test_uses_xdg_runtime_dir_when_set(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+
+        path = default_socket_path("my-agent")
+
+        assert path == tmp_path / "parrot" / "my-agent.sock"
+
+    def test_falls_back_to_tmp_when_unset(self, monkeypatch):
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+
+        path = default_socket_path("my-agent")
+
+        assert str(path) == f"/tmp/parrot-{os.getuid()}/my-agent.sock"
+
+
+class TestResolveAgent:
+    async def test_class_target(self):
+        cfg = AgentTargetConfig(
+            target="tests.agentd.fakes:EchoAgent", kwargs={"name": "class-target"}
+        )
+
+        agent = await resolve_agent(cfg)
+
+        assert agent.name == "class-target"
+        assert agent.configured is True
+
+    async def test_instance_target(self):
+        cfg = AgentTargetConfig(target="tests.agentd.fakes:echo_instance")
+
+        agent = await resolve_agent(cfg)
+
+        assert agent.name == "singleton-instance"
+        assert agent.configured is True
+
+    async def test_sync_factory_target(self):
+        cfg = AgentTargetConfig(
+            target="tests.agentd.fakes:make_echo_agent",
+            kwargs={"name": "sync-factory"},
+        )
+
+        agent = await resolve_agent(cfg)
+
+        assert agent.name == "sync-factory"
+        assert agent.configured is True
+
+    async def test_async_factory_target(self):
+        cfg = AgentTargetConfig(
+            target="tests.agentd.fakes:make_echo_agent_async",
+            kwargs={"name": "async-factory"},
+        )
+
+        agent = await resolve_agent(cfg)
+
+        assert agent.name == "async-factory"
+        assert agent.configured is True
+
+    async def test_missing_module_raises(self):
+        cfg = AgentTargetConfig(target="tests.agentd.does_not_exist:EchoAgent")
+
+        with pytest.raises(AgentTargetError):
+            await resolve_agent(cfg)
+
+    async def test_missing_attr_raises(self):
+        cfg = AgentTargetConfig(target="tests.agentd.fakes:DoesNotExist")
+
+        with pytest.raises(AgentTargetError):
+            await resolve_agent(cfg)
+
+    async def test_bad_target_shape_raises(self):
+        cfg = AgentTargetConfig(target="no-colon-in-target")
+
+        with pytest.raises(AgentTargetError):
+            await resolve_agent(cfg)

--- a/packages/ai-parrot-integrations/tests/agentd/test_e2e.py
+++ b/packages/ai-parrot-integrations/tests/agentd/test_e2e.py
@@ -1,0 +1,386 @@
+"""End-to-end integration tests for the Agent CLI Daemon (TASK-2217).
+
+Exercises the REAL stack -- daemon + client + proxy/MCP + CLI together --
+with `EchoAgent`, tmp Unix domain sockets, and no Postgres/Redis
+(`MemoryJobStore` only). Closes spec §5's acceptance criteria; see the
+Completion Note for the criterion -> test mapping.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+from parrot.integrations.agentd import cli as agentd_cli
+from parrot.integrations.agentd.client import AgentDaemonClient
+from parrot.integrations.agentd.config import (
+    AgentServiceConfig,
+    AgentTargetConfig,
+    SchedulerConfig,
+)
+from parrot.integrations.agentd.mcp_server import build_proxy_tools
+from parrot.mcp.local_server import StdioMCPServer
+from parrot.mcp.server_base import LocalServerConfig
+
+from tests.agentd.fakes import EchoAgent
+
+from .conftest import run_daemon, stop_daemon
+
+
+def _integrations_pythonpath_env() -> dict[str, str]:
+    """Build a subprocess env with `packages/ai-parrot-integrations` on
+    `PYTHONPATH`, so a spawned `parrot` process (not launched through
+    pytest) can still resolve `tests.agentd.fakes:EchoAgent` targets.
+    """
+    integrations_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    existing_path = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        f"{integrations_root}{os.pathsep}{existing_path}"
+        if existing_path
+        else str(integrations_root)
+    )
+    return env
+
+
+class _TrackingEchoAgent(EchoAgent):
+    """EchoAgent subclass recording per-`session_id` conversation history.
+
+    Module-level so it can be resolved via
+    `"tests.agentd.test_e2e:_TrackingEchoAgent"`. Used to assert that
+    concurrent daemon connections (spec §2: one UDS connection = one
+    conversation session) stay isolated from each other.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.session_history: dict[str, list[str]] = {}
+
+    async def ask(self, question: str, session_id: str | None = None, **kwargs):
+        self.session_history.setdefault(session_id or "default", []).append(question)
+        return await super().ask(question, session_id=session_id, **kwargs)
+
+
+class _IntervalEchoAgent(EchoAgent):
+    """EchoAgent subclass with a decorated schedule -- module-level so it
+    can be resolved via `"tests.agentd.test_e2e:_IntervalEchoAgent"`.
+
+    Decorating requires `parrot.scheduler.manager` (ai-parrot-server) to
+    be importable; when it's absent, `tick` simply lacks
+    `_schedule_config` and the one test using this class skips itself.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.tick_count = 0
+
+
+with contextlib.suppress(ImportError):
+    from parrot.scheduler.manager import ScheduleType, schedule
+
+    async def _tick(self) -> None:
+        """Increment `tick_count` -- fires every second once scheduled."""
+        self.tick_count += 1
+
+    _IntervalEchoAgent.tick = schedule(ScheduleType.INTERVAL, seconds=1)(_tick)
+
+
+class TestEndToEnd:
+    async def test_chat_send_and_stream_end_to_end(self, echo_daemon):
+        """AC: `chat.send` roundtrip; stream deltas -> complete."""
+        _daemon, socket_path = echo_daemon
+
+        client = await AgentDaemonClient.connect(socket_path)
+        try:
+            result = await client.call(
+                "chat.send", prompt="hello", stream=False, metadata={}
+            )
+            assert result["output"] == "echo: hello"
+
+            deltas: list[str] = []
+            async for event in client.stream("hi there"):
+                if event.kind == "delta":
+                    deltas.append(event.text or "")
+                elif event.kind == "complete":
+                    assert event.response == "".join(deltas)
+        finally:
+            await client.close()
+
+        assert deltas == ["echo:", "hi", "there"]
+
+    async def test_two_clients_isolated_sessions(self, tmp_path):
+        """AC: concurrent connections don't share history."""
+        config = AgentServiceConfig(
+            name="tracking-echo",
+            agent=AgentTargetConfig(
+                target="tests.agentd.test_e2e:_TrackingEchoAgent"
+            ),
+            socket=tmp_path / "tracking.sock",
+            scheduler=SchedulerConfig(enabled=False),
+        )
+        daemon, run_task = await run_daemon(config)
+        try:
+            client1 = await AgentDaemonClient.connect(config.socket)
+            client2 = await AgentDaemonClient.connect(config.socket)
+            try:
+                await client1.call(
+                    "chat.send", prompt="from client 1", stream=False, metadata={}
+                )
+                await client2.call(
+                    "chat.send", prompt="from client 2", stream=False, metadata={}
+                )
+            finally:
+                await client1.close()
+                await client2.close()
+
+            history = daemon.agent.session_history
+            assert len(history) == 2
+            values = list(history.values())
+            assert ["from client 1"] in values
+            assert ["from client 2"] in values
+        finally:
+            await stop_daemon(daemon, run_task)
+
+    async def test_scheduler_interval_job_fires_and_event_emitted(self, tmp_path):
+        """AC: real APScheduler MemoryJobStore path; subscribed client gets the event."""
+        if not hasattr(_IntervalEchoAgent, "tick") or not hasattr(
+            _IntervalEchoAgent.tick, "_schedule_config"
+        ):
+            import pytest
+
+            pytest.skip("ai-parrot-server (scheduler support) not installed")
+
+        config = AgentServiceConfig(
+            name="interval-echo",
+            agent=AgentTargetConfig(
+                target="tests.agentd.test_e2e:_IntervalEchoAgent"
+            ),
+            socket=tmp_path / "interval.sock",
+            scheduler=SchedulerConfig(enabled=True, dsn=None, redis=False),
+        )
+
+        daemon, run_task = await run_daemon(config)
+        try:
+            event_received = asyncio.Event()
+
+            def _on_event(method: str, params: dict) -> None:
+                if method == "event.job_executed":
+                    event_received.set()
+
+            client = await AgentDaemonClient.connect(config.socket)
+            try:
+                await client.subscribe_events(_on_event)
+                await asyncio.wait_for(event_received.wait(), timeout=5)
+            finally:
+                await client.close()
+        finally:
+            await stop_daemon(daemon, run_task)
+
+        assert daemon.agent.tick_count >= 1
+
+    async def test_mcp_stdio_ask_agent(self, echo_daemon):
+        """AC: MCP handshake over stdio-handler calls + `ask_agent` against a real daemon."""
+        _daemon, socket_path = echo_daemon
+
+        client = await AgentDaemonClient.connect(socket_path)
+        try:
+            info = await client.call("agent.info")
+            tools = build_proxy_tools(client, info.get("exposed_methods") or [])
+
+            server = StdioMCPServer(LocalServerConfig(name="agentd-echo"))
+            server.register_tools(tools)
+
+            init_result = await server.handle_initialize({})
+            assert "protocolVersion" in init_result
+
+            listing = await server.handle_tools_list({})
+            names = {t["name"] for t in listing["tools"]}
+            assert "ask_agent" in names
+
+            call_result = await server.handle_tools_call(
+                {"name": "ask_agent", "arguments": {"prompt": "hello via mcp"}}
+            )
+            assert call_result["isError"] is False
+            assert call_result["content"][0]["text"] == "echo: hello via mcp"
+        finally:
+            await client.close()
+
+    async def test_graceful_shutdown_sigterm(self, tmp_path):
+        """AC: SIGTERM -> event.shutdown, socket removed, exit 0 (real subprocess)."""
+        socket_path = tmp_path / "sigterm.sock"
+        yaml_path = tmp_path / "agentd.yaml"
+        yaml_path.write_text(
+            "name: sigterm-echo\n"
+            'agent:\n  target: "tests.agentd.fakes:EchoAgent"\n'
+            "scheduler:\n  enabled: false\n"
+            f"socket: {socket_path}\n"
+            "shutdown_grace: 5.0\n"
+        )
+
+        parrot_bin = Path(sys.executable).parent / "parrot"
+        env = _integrations_pythonpath_env()
+
+        proc = await asyncio.create_subprocess_exec(
+            str(parrot_bin),
+            "serve",
+            str(yaml_path),
+            env=env,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            deadline = time.monotonic() + 20.0
+            while time.monotonic() < deadline and not socket_path.exists():
+                if proc.returncode is not None:
+                    stdout, stderr = await proc.communicate()
+                    raise AssertionError(
+                        "daemon subprocess exited early "
+                        f"(code={proc.returncode}): stdout={stdout!r} stderr={stderr!r}"
+                    )
+                await asyncio.sleep(0.05)
+            assert socket_path.exists(), "daemon subprocess did not create its socket in time"
+
+            proc.send_signal(signal.SIGTERM)
+            returncode = await asyncio.wait_for(proc.wait(), timeout=10.0)
+
+            assert returncode == 0
+            assert not socket_path.exists()
+        finally:
+            if proc.returncode is None:
+                proc.kill()
+                await proc.wait()
+
+
+class TestCliE2E:
+    def test_ask_oneshot_exit_codes(self, tmp_path):
+        """AC: `parrot ask` exits 0 on success and 1 when no daemon is listening.
+
+        Runs the daemon in a REAL subprocess (not a background thread) --
+        `AgentDaemon._install_signal_handlers()` uses
+        `loop.add_signal_handler()`, which only works in the main thread
+        of the main interpreter, so it cannot run inside a thread-hosted
+        event loop. `CliRunner.invoke()` also calls `asyncio.run()` in the
+        pytest process's main thread, so the two would conflict on the
+        same thread anyway. A subprocess sidesteps both problems.
+        """
+        socket_path = tmp_path / "cli_echo.sock"
+        yaml_path = tmp_path / "cli_echo.yaml"
+        yaml_path.write_text(
+            "name: cli-echo\n"
+            'agent:\n  target: "tests.agentd.fakes:EchoAgent"\n'
+            "scheduler:\n  enabled: false\n"
+            f"socket: {socket_path}\n"
+        )
+
+        parrot_bin = Path(sys.executable).parent / "parrot"
+        env = _integrations_pythonpath_env()
+
+        proc = subprocess.Popen(
+            [str(parrot_bin), "serve", str(yaml_path)],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            deadline = time.monotonic() + 20.0
+            while time.monotonic() < deadline and not socket_path.exists():
+                if proc.poll() is not None:
+                    stdout, stderr = proc.communicate()
+                    raise AssertionError(
+                        "daemon subprocess exited early "
+                        f"(code={proc.returncode}): stdout={stdout!r} stderr={stderr!r}"
+                    )
+                time.sleep(0.05)
+            assert socket_path.exists(), "daemon subprocess did not create its socket in time"
+
+            runner = CliRunner()
+            ok_result = runner.invoke(agentd_cli.ask, [str(socket_path), "hello cli"])
+            assert ok_result.exit_code == 0, ok_result.output
+            assert "echo: hello cli" in ok_result.output
+        finally:
+            proc.send_signal(signal.SIGTERM)
+            try:
+                proc.wait(timeout=10.0)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+
+        # No daemon listening on this (never-created) path -> exit 1.
+        missing_result = CliRunner().invoke(
+            agentd_cli.ask, [str(tmp_path / "does-not-exist.sock"), "hi"]
+        )
+        assert missing_result.exit_code == 1
+
+
+_NO_AIOHTTP_SCRIPT = """
+import sys
+sys.modules["parrot.scheduler.manager"] = None
+
+import asyncio
+from pathlib import Path
+
+from parrot.integrations.agentd.config import (
+    AgentServiceConfig,
+    AgentTargetConfig,
+    SchedulerConfig,
+)
+from parrot.integrations.agentd.service import AgentDaemon
+
+
+async def main() -> None:
+    socket_path = Path(sys.argv[1])
+    cfg = AgentServiceConfig(
+        name="isolated",
+        agent=AgentTargetConfig(target="tests.agentd.fakes:EchoAgent"),
+        socket=socket_path,
+        scheduler=SchedulerConfig(enabled=True),
+    )
+    daemon = AgentDaemon(cfg)
+    run_task = asyncio.ensure_future(daemon.run())
+    while not socket_path.exists():
+        await asyncio.sleep(0.01)
+
+    print("AIOHTTP_ABSENT" if "aiohttp" not in sys.modules else "AIOHTTP_PRESENT")
+
+    daemon._shutdown_event.set()
+    await run_task
+
+
+asyncio.run(main())
+"""
+
+
+def test_no_aiohttp_without_server_pkg(tmp_path):
+    """AC (spec §5 #1): with the scheduler import blocked, boot a real
+    daemon in a subprocess and assert aiohttp was never imported.
+
+    Runs in a FRESH subprocess specifically because this pytest process
+    already has aiohttp loaded (the `pytest-aiohttp` plugin imports it
+    unconditionally at startup, unrelated to anything agentd does) --
+    a subprocess is the only way to make this assertion meaningful.
+    """
+    socket_path = tmp_path / "isolated.sock"
+    script_path = tmp_path / "check_no_aiohttp.py"
+    script_path.write_text(_NO_AIOHTTP_SCRIPT)
+
+    env = _integrations_pythonpath_env()
+
+    result = subprocess.run(
+        [sys.executable, str(script_path), str(socket_path)],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        env=env,
+        check=False,
+    )
+
+    assert "AIOHTTP_ABSENT" in result.stdout, (
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )

--- a/packages/ai-parrot-integrations/tests/agentd/test_mcp_proxy.py
+++ b/packages/ai-parrot-integrations/tests/agentd/test_mcp_proxy.py
@@ -1,0 +1,191 @@
+"""Unit tests for parrot.integrations.agentd.mcp_server (TASK-2215).
+
+Tool registration matrix, `handle_tools_call` for `ask_agent`, and a stdio
+smoke test driving `StdioMCPServer` handlers directly (no subprocess) --
+against a scripted raw UDS server (same harness pattern as TASK-2213's
+`test_client.py`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+
+import pytest
+from parrot.integrations.agentd.client import AgentDaemonClient
+from parrot.integrations.agentd.mcp_server import build_proxy_tools
+from parrot.mcp.local_server import StdioMCPServer
+from parrot.mcp.server_base import LocalServerConfig
+
+
+class _Harness:
+    def __init__(self, socket_path):
+        self.socket_path = socket_path
+        self.script: dict = {}
+        self.connections: list[asyncio.StreamWriter] = []
+
+
+@pytest.fixture
+async def scripted_server(tmp_path):
+    socket_path = tmp_path / "mcp_scripted.sock"
+    harness = _Harness(socket_path)
+
+    async def _handle(reader, writer):
+        harness.connections.append(writer)
+        try:
+            while True:
+                line = await reader.readline()
+                if not line:
+                    break
+                request = json.loads(line.decode("utf-8"))
+                handler = harness.script.get(request.get("method"))
+                if handler is None:
+                    continue
+                for out in handler(request) or []:
+                    writer.write((json.dumps(out) + "\n").encode("utf-8"))
+                await writer.drain()
+        except (asyncio.IncompleteReadError, ConnectionResetError):
+            pass
+        finally:
+            with contextlib.suppress(Exception):
+                writer.close()
+
+    server = await asyncio.start_unix_server(_handle, path=str(socket_path))
+
+    yield harness
+
+    server.close()
+    await server.wait_closed()
+
+
+def _reply(result):
+    def _handler(request):
+        return [{"jsonrpc": "2.0", "id": request["id"], "result": result}]
+
+    return _handler
+
+
+class TestToolMatrix:
+    async def test_invoke_absent_without_allowlist(self, scripted_server):
+        scripted_server.script["agent.info"] = _reply(
+            {"name": "echo", "exposed_methods": []}
+        )
+
+        client = await AgentDaemonClient.connect(scripted_server.socket_path)
+        try:
+            info = await client.call("agent.info")
+            tools = build_proxy_tools(client, info.get("exposed_methods") or [])
+
+            names = {tool.name for tool in tools}
+            assert names == {"ask_agent", "agent_info", "list_schedules", "daemon_status"}
+            assert "invoke_method" not in names
+
+            server = StdioMCPServer(LocalServerConfig())
+            server.register_tools(tools)
+            listing = await server.handle_tools_list({})
+            listed_names = {t["name"] for t in listing["tools"]}
+            assert listed_names == names
+        finally:
+            await client.close()
+
+    async def test_invoke_present_with_allowlist(self, scripted_server):
+        scripted_server.script["agent.info"] = _reply(
+            {"name": "echo", "exposed_methods": ["safe_method"]}
+        )
+
+        def invoke_handler(request):
+            method = request["params"]["method"]
+            if method == "safe_method":
+                return [
+                    {"jsonrpc": "2.0", "id": request["id"], "result": {"ok": True}}
+                ]
+            return [
+                {
+                    "jsonrpc": "2.0",
+                    "id": request["id"],
+                    "error": {"code": 1002, "message": f"Unknown method: {method}"},
+                }
+            ]
+
+        scripted_server.script["agent.invoke"] = invoke_handler
+
+        client = await AgentDaemonClient.connect(scripted_server.socket_path)
+        try:
+            info = await client.call("agent.info")
+            tools = build_proxy_tools(client, info.get("exposed_methods") or [])
+            names = {tool.name for tool in tools}
+            assert "invoke_method" in names
+
+            server = StdioMCPServer(LocalServerConfig())
+            server.register_tools(tools)
+
+            ok_response = await server.handle_tools_call(
+                {"name": "invoke_method", "arguments": {"method": "safe_method", "kwargs": {}}}
+            )
+            assert ok_response["isError"] is False
+
+            denied_response = await server.handle_tools_call(
+                {
+                    "name": "invoke_method",
+                    "arguments": {"method": "not_allowed", "kwargs": {}},
+                }
+            )
+            assert denied_response["isError"] is True
+            assert "not in the allowlist" in denied_response["content"][0]["text"]
+        finally:
+            await client.close()
+
+
+class TestAskAgent:
+    async def test_tools_call_ask_agent(self, scripted_server):
+        scripted_server.script["agent.info"] = _reply(
+            {"name": "echo", "exposed_methods": []}
+        )
+        scripted_server.script["chat.send"] = _reply(
+            {"output": "hi there", "metadata": {}}
+        )
+
+        client = await AgentDaemonClient.connect(scripted_server.socket_path)
+        try:
+            info = await client.call("agent.info")
+            tools = build_proxy_tools(client, info.get("exposed_methods") or [])
+
+            server = StdioMCPServer(LocalServerConfig())
+            server.register_tools(tools)
+
+            response = await server.handle_tools_call(
+                {"name": "ask_agent", "arguments": {"prompt": "hello"}}
+            )
+
+            assert response["isError"] is False
+            assert response["content"][0]["text"] == "hi there"
+        finally:
+            await client.close()
+
+    async def test_stderr_only_logging(self, scripted_server, capsys):
+        scripted_server.script["agent.info"] = _reply(
+            {"name": "echo", "exposed_methods": []}
+        )
+        scripted_server.script["chat.send"] = _reply(
+            {"output": "hi there", "metadata": {}}
+        )
+
+        client = await AgentDaemonClient.connect(scripted_server.socket_path)
+        try:
+            info = await client.call("agent.info")
+            tools = build_proxy_tools(client, info.get("exposed_methods") or [])
+
+            server = StdioMCPServer(LocalServerConfig())
+            server.register_tools(tools)
+
+            await server.handle_initialize({})
+            await server.handle_tools_list({})
+            await server.handle_tools_call(
+                {"name": "ask_agent", "arguments": {"prompt": "hello"}}
+            )
+        finally:
+            await client.close()
+
+        captured = capsys.readouterr()
+        assert captured.out == ""

--- a/packages/ai-parrot-integrations/tests/agentd/test_protocol.py
+++ b/packages/ai-parrot-integrations/tests/agentd/test_protocol.py
@@ -1,0 +1,155 @@
+"""Unit tests for parrot.integrations.agentd.protocol (TASK-2208)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from parrot.integrations.agentd.protocol import (
+    DEFAULT_MAX_LINE_BYTES,
+    MalformedMessageError,
+    OversizedLineError,
+    RpcError,
+    RpcNotification,
+    RpcRequest,
+    RpcResponse,
+    read_message,
+    write_message,
+)
+
+
+class _FakeWriter:
+    """Minimal stand-in for asyncio.StreamWriter — collects written bytes."""
+
+    def __init__(self) -> None:
+        self.buffer = bytearray()
+
+    def write(self, data: bytes) -> None:
+        self.buffer.extend(data)
+
+
+class TestModels:
+    def test_request_roundtrip(self):
+        req = RpcRequest(id=1, method="chat.send", params={"prompt": "hi"})
+        dumped = req.model_dump_json()
+        restored = RpcRequest.model_validate_json(dumped)
+        assert restored == req
+        assert restored.jsonrpc == "2.0"
+        assert restored.method == "chat.send"
+        assert restored.params == {"prompt": "hi"}
+
+    def test_response_error_shape(self):
+        err = RpcError(code=-32601, message="Method not found")
+        resp = RpcResponse(id=1, error=err)
+        assert resp.result is None
+        assert resp.error is not None
+        assert resp.error.code == -32601
+
+        dumped = resp.model_dump_json()
+        restored = RpcResponse.model_validate_json(dumped)
+        assert restored.error.code == -32601
+        assert restored.error.message == "Method not found"
+
+    def test_notification_has_no_id(self):
+        note = RpcNotification(method="chat.delta", params={"stream_id": "s1", "text": "hi"})
+        dumped = note.model_dump(mode="json")
+        assert "id" not in dumped
+        assert dumped["method"] == "chat.delta"
+
+
+class TestFraming:
+    @pytest.mark.asyncio
+    async def test_split_frame(self):
+        """A single message delivered across two feed_data() calls."""
+        reader = asyncio.StreamReader()
+        payload = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "agent.info", "params": {}})
+        raw = (payload + "\n").encode("utf-8")
+        mid = len(raw) // 2
+        reader.feed_data(raw[:mid])
+        reader.feed_data(raw[mid:])
+        reader.feed_eof()
+
+        msg = await read_message(reader)
+        assert isinstance(msg, RpcRequest)
+        assert msg.method == "agent.info"
+        assert msg.id == 1
+
+    @pytest.mark.asyncio
+    async def test_coalesced_frames(self):
+        """Two messages delivered in a single feed_data() call."""
+        reader = asyncio.StreamReader()
+        m1 = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "agent.info", "params": {}})
+        m2 = json.dumps({"jsonrpc": "2.0", "method": "event.shutdown", "params": {}})
+        reader.feed_data((m1 + "\n" + m2 + "\n").encode("utf-8"))
+        reader.feed_eof()
+
+        first = await read_message(reader)
+        second = await read_message(reader)
+
+        assert isinstance(first, RpcRequest)
+        assert first.method == "agent.info"
+        assert isinstance(second, RpcNotification)
+        assert second.method == "event.shutdown"
+
+    @pytest.mark.asyncio
+    async def test_oversized_line_rejected(self):
+        reader = asyncio.StreamReader(limit=64)
+        huge_params = {"blob": "x" * 1024}
+        payload = json.dumps(
+            {"jsonrpc": "2.0", "id": 1, "method": "chat.send", "params": huge_params}
+        )
+        reader.feed_data((payload + "\n").encode("utf-8"))
+        reader.feed_eof()
+
+        with pytest.raises(OversizedLineError):
+            await read_message(reader, max_line_bytes=32)
+
+    @pytest.mark.asyncio
+    async def test_oversized_line_default_limit_not_triggered_by_small_payload(self):
+        reader = asyncio.StreamReader()
+        payload = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "agent.info", "params": {}})
+        reader.feed_data((payload + "\n").encode("utf-8"))
+        reader.feed_eof()
+
+        msg = await read_message(reader, max_line_bytes=DEFAULT_MAX_LINE_BYTES)
+        assert isinstance(msg, RpcRequest)
+
+    @pytest.mark.asyncio
+    async def test_malformed_json(self):
+        reader = asyncio.StreamReader()
+        reader.feed_data(b"{not valid json\n")
+        reader.feed_eof()
+
+        with pytest.raises(MalformedMessageError):
+            await read_message(reader)
+
+    @pytest.mark.asyncio
+    async def test_malformed_shape_neither_request_nor_notification(self):
+        """Valid JSON object, but not a recognizable JSON-RPC shape."""
+        reader = asyncio.StreamReader()
+        reader.feed_data(b'{"foo": "bar"}\n')
+        reader.feed_eof()
+
+        # No "id", no "result"/"error" -> parsed as a notification lacking
+        # "method" -> pydantic validation error -> MalformedMessageError.
+        with pytest.raises(MalformedMessageError):
+            await read_message(reader)
+
+    @pytest.mark.asyncio
+    async def test_clean_eof_returns_none(self):
+        reader = asyncio.StreamReader()
+        reader.feed_eof()
+        assert await read_message(reader) is None
+
+    def test_write_message_produces_ndjson_line(self):
+        writer = _FakeWriter()
+        req = RpcRequest(id=1, method="agent.info", params={})
+        write_message(writer, req)
+
+        raw = bytes(writer.buffer)
+        assert raw.endswith(b"\n")
+        assert raw.count(b"\n") == 1
+        decoded = json.loads(raw.decode("utf-8"))
+        assert decoded["method"] == "agent.info"
+        assert decoded["id"] == 1

--- a/packages/ai-parrot-integrations/tests/agentd/test_proxy.py
+++ b/packages/ai-parrot-integrations/tests/agentd/test_proxy.py
@@ -117,10 +117,20 @@ def _write_notification(writer, method, stream_id, **params):
 
 class TestProxy:
     async def test_ask_and_stream(self, scripted_server):
+        received_stream_ids: list[str] = []
+
         def chat_send_handler(request):
             if request["params"].get("stream"):
+                # `stream()` now generates the stream_id client-side and
+                # registers its queue before sending -- echo it back.
+                stream_id = request["params"]["stream_id"]
+                received_stream_ids.append(stream_id)
                 return [
-                    {"jsonrpc": "2.0", "id": request["id"], "result": {"stream_id": "s1"}}
+                    {
+                        "jsonrpc": "2.0",
+                        "id": request["id"],
+                        "result": {"stream_id": stream_id},
+                    }
                 ]
             return [
                 {
@@ -146,8 +156,12 @@ class TestProxy:
             agen = bot.ask_stream("hi")
             first = asyncio.ensure_future(agen.__anext__())
             await asyncio.sleep(0.05)
-            _write_notification(writer, "chat.delta", "s1", text="chunk1")
-            _write_notification(writer, "chat.complete", "s1", response="chunk1", usage={})
+            assert len(received_stream_ids) == 1
+            stream_id = received_stream_ids[0]
+            _write_notification(writer, "chat.delta", stream_id, text="chunk1")
+            _write_notification(
+                writer, "chat.complete", stream_id, response="chunk1", usage={}
+            )
             await writer.drain()
 
             chunk = await first

--- a/packages/ai-parrot-integrations/tests/agentd/test_proxy.py
+++ b/packages/ai-parrot-integrations/tests/agentd/test_proxy.py
@@ -1,0 +1,327 @@
+"""Unit tests for parrot.integrations.agentd.proxy (TASK-2214).
+
+Interface-parity check against `_ServerBotProxy`; behaviour tests against
+a scripted raw UDS server (same pattern as TASK-2213's `test_client.py`);
+slash-command handlers exercised against a stubbed REPL/client (no real
+socket needed for those).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import inspect
+import json
+
+import pytest
+from parrot.cli.loaders import _ServerBotProxy
+from parrot.integrations.agentd.client import RpcRemoteError
+from parrot.integrations.agentd.proxy import (
+    DaemonAgentProxy,
+    _cmd_invoke,
+    _cmd_schedules,
+    _cmd_status,
+    _DaemonBotProxy,
+)
+
+
+def test_duck_type_parity_with_server_bot_proxy():
+    checklist = [
+        "configure",
+        "ask",
+        "ask_stream",
+        "get_available_tools",
+        "get_tools_count",
+        "has_tools",
+    ]
+    for attr_name in checklist:
+        assert hasattr(_DaemonBotProxy, attr_name), f"_DaemonBotProxy missing {attr_name!r}"
+
+        server_attr = getattr(_ServerBotProxy, attr_name)
+        daemon_attr = getattr(_DaemonBotProxy, attr_name)
+
+        assert inspect.iscoroutinefunction(server_attr) == inspect.iscoroutinefunction(
+            daemon_attr
+        ), f"{attr_name}: coroutine-ness mismatch"
+        assert inspect.isasyncgenfunction(server_attr) == inspect.isasyncgenfunction(
+            daemon_attr
+        ), f"{attr_name}: async-generator-ness mismatch"
+
+        server_params = list(inspect.signature(server_attr).parameters)
+        daemon_params = list(inspect.signature(daemon_attr).parameters)
+        assert server_params == daemon_params, (
+            f"{attr_name}: {server_params} != {daemon_params}"
+        )
+
+
+# --------------------------------------------------------------------------
+# Scripted-server harness (mirrors TASK-2213's test_client.py)
+# --------------------------------------------------------------------------
+
+
+class _Harness:
+    def __init__(self, socket_path):
+        self.socket_path = socket_path
+        self.script: dict = {}
+        self.connections: list[asyncio.StreamWriter] = []
+
+
+@pytest.fixture
+async def scripted_server(tmp_path):
+    socket_path = tmp_path / "proxy_scripted.sock"
+    harness = _Harness(socket_path)
+
+    async def _handle(reader, writer):
+        harness.connections.append(writer)
+        try:
+            while True:
+                line = await reader.readline()
+                if not line:
+                    break
+                request = json.loads(line.decode("utf-8"))
+                handler = harness.script.get(request.get("method"))
+                if handler is None:
+                    continue
+                for out in handler(request) or []:
+                    writer.write((json.dumps(out) + "\n").encode("utf-8"))
+                await writer.drain()
+        except (asyncio.IncompleteReadError, ConnectionResetError):
+            pass
+        finally:
+            with contextlib.suppress(Exception):
+                writer.close()
+
+    server = await asyncio.start_unix_server(_handle, path=str(socket_path))
+
+    yield harness
+
+    server.close()
+    await server.wait_closed()
+
+
+def _ack(method_key="result"):
+    def _handler(request):
+        return [{"jsonrpc": "2.0", "id": request["id"], method_key: {"subscribed": True}}]
+
+    return _handler
+
+
+def _write_notification(writer, method, stream_id, **params):
+    payload = {
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": {"stream_id": stream_id, **params},
+    }
+    writer.write((json.dumps(payload) + "\n").encode("utf-8"))
+
+
+class TestProxy:
+    async def test_ask_and_stream(self, scripted_server):
+        def chat_send_handler(request):
+            if request["params"].get("stream"):
+                return [
+                    {"jsonrpc": "2.0", "id": request["id"], "result": {"stream_id": "s1"}}
+                ]
+            return [
+                {
+                    "jsonrpc": "2.0",
+                    "id": request["id"],
+                    "result": {"output": "hi back", "metadata": {}},
+                }
+            ]
+
+        scripted_server.script["chat.send"] = chat_send_handler
+        scripted_server.script["tools.list"] = lambda request: [
+            {"jsonrpc": "2.0", "id": request["id"], "result": {"tools": ["t1", "t2"]}}
+        ]
+        scripted_server.script["events.subscribe"] = _ack()
+
+        proxy = DaemonAgentProxy(str(scripted_server.socket_path))
+        bot = await proxy.load("echo")
+        try:
+            response = await bot.ask("hello")
+            assert response.output == "hi back"
+
+            writer = scripted_server.connections[0]
+            agen = bot.ask_stream("hi")
+            first = asyncio.ensure_future(agen.__anext__())
+            await asyncio.sleep(0.05)
+            _write_notification(writer, "chat.delta", "s1", text="chunk1")
+            _write_notification(writer, "chat.complete", "s1", response="chunk1", usage={})
+            await writer.drain()
+
+            chunk = await first
+            assert chunk == "chunk1"
+            with pytest.raises(StopAsyncIteration):
+                await agen.__anext__()
+        finally:
+            await proxy.close()
+
+    async def test_tools_cached(self, scripted_server):
+        call_count = {"n": 0}
+
+        def tools_handler(request):
+            call_count["n"] += 1
+            return [
+                {"jsonrpc": "2.0", "id": request["id"], "result": {"tools": ["a", "b", "c"]}}
+            ]
+
+        scripted_server.script["tools.list"] = tools_handler
+        scripted_server.script["events.subscribe"] = _ack()
+
+        proxy = DaemonAgentProxy(str(scripted_server.socket_path))
+        try:
+            bot = await proxy.load("echo")
+
+            assert bot.get_available_tools() == ["a", "b", "c"]
+            assert bot.get_tools_count() == 3
+            assert bot.has_tools() is True
+            assert call_count["n"] == 1
+        finally:
+            await proxy.close()
+
+    async def test_event_queue_and_drain(self, scripted_server):
+        scripted_server.script["tools.list"] = lambda request: [
+            {"jsonrpc": "2.0", "id": request["id"], "result": {"tools": []}}
+        ]
+        scripted_server.script["events.subscribe"] = _ack()
+
+        proxy = DaemonAgentProxy(str(scripted_server.socket_path))
+        try:
+            await proxy.load("echo")
+
+            assert proxy.drain_events() == []
+
+            writer = scripted_server.connections[0]
+            writer.write(
+                (
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "method": "event.job_executed",
+                            "params": {"job_id": "auto_echo_tick"},
+                        }
+                    )
+                    + "\n"
+                ).encode("utf-8")
+            )
+            await writer.drain()
+            await asyncio.sleep(0.05)
+
+            lines = proxy.drain_events()
+            assert lines == ["⏱ job auto_echo_tick ejecutado ✓"]
+            assert proxy.drain_events() == []
+        finally:
+            await proxy.close()
+
+
+# --------------------------------------------------------------------------
+# Slash commands -- stubbed repl/client (no real socket needed)
+# --------------------------------------------------------------------------
+
+
+class _FakeRenderer:
+    def __init__(self) -> None:
+        self.printed: list[str] = []
+        self.tables: list[dict] = []
+        self.infos: list[list[tuple[str, str]]] = []
+        self.errors: list[Exception] = []
+
+    def print(self, *args, **kwargs) -> None:
+        self.printed.append(" ".join(str(a) for a in args))
+
+    def render_table(self, headers, rows, title=None) -> None:
+        self.tables.append({"headers": headers, "rows": rows, "title": title})
+
+    def render_info(self, lines) -> None:
+        self.infos.append(lines)
+
+    def render_error(self, error) -> None:
+        self.errors.append(error)
+
+
+class _FakeRepl:
+    def __init__(self) -> None:
+        self.renderer = _FakeRenderer()
+
+
+class _FakeClient:
+    def __init__(self, responses: dict) -> None:
+        self._responses = responses
+        self.calls: list[tuple[str, dict]] = []
+
+    async def call(self, method: str, *, params: dict | None = None, **kwargs):
+        merged = {**(params or {}), **kwargs}
+        self.calls.append((method, merged))
+        result = self._responses.get(method)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+class TestSlashCommands:
+    async def test_status_command(self):
+        fake_client = _FakeClient(
+            {
+                "daemon.status": {
+                    "pid": 123,
+                    "uptime_s": 42.5,
+                    "version": "0.1.0",
+                    "scheduler": {"available": True, "running": True, "jobs": 2},
+                    "active_connections": 1,
+                }
+            }
+        )
+        proxy = DaemonAgentProxy("dummy")
+        proxy._client = fake_client
+        repl = _FakeRepl()
+
+        await _cmd_status(repl, proxy)
+
+        assert repl.renderer.infos
+        info = dict(repl.renderer.infos[0])
+        assert info["PID"] == "123"
+        assert info["Scheduler available"] == "True"
+
+    async def test_status_error_rendered(self):
+        proxy = DaemonAgentProxy("dummy")
+        proxy._client = _FakeClient({"daemon.status": RpcRemoteError(-32603, "boom")})
+        repl = _FakeRepl()
+
+        await _cmd_status(repl, proxy)
+
+        assert len(repl.renderer.errors) == 1
+
+    async def test_invoke_bad_json_friendly(self):
+        proxy = DaemonAgentProxy("dummy")
+        proxy._client = _FakeClient({})
+        repl = _FakeRepl()
+
+        await _cmd_invoke(repl, proxy, "some_method {not valid json")
+
+        assert repl.renderer.printed
+        assert "Invalid JSON" in repl.renderer.printed[-1]
+        assert proxy._client.calls == []
+
+    async def test_invoke_success(self):
+        proxy = DaemonAgentProxy("dummy")
+        proxy._client = _FakeClient({"agent.invoke": 42})
+        repl = _FakeRepl()
+
+        await _cmd_invoke(repl, proxy, 'get_tools_count {}')
+
+        assert proxy._client.calls == [
+            ("agent.invoke", {"method": "get_tools_count", "kwargs": {}})
+        ]
+        assert "42" in repl.renderer.printed[-1]
+
+    async def test_schedules_add_bad_json_friendly(self):
+        proxy = DaemonAgentProxy("dummy")
+        proxy._client = _FakeClient({})
+        repl = _FakeRepl()
+
+        await _cmd_schedules(repl, proxy, "add {not valid json")
+
+        assert repl.renderer.printed
+        assert "Invalid JSON" in repl.renderer.printed[-1]
+        assert proxy._client.calls == []

--- a/packages/ai-parrot-integrations/tests/agentd/test_server.py
+++ b/packages/ai-parrot-integrations/tests/agentd/test_server.py
@@ -1,0 +1,184 @@
+"""Unit tests for parrot.integrations.agentd.server (TASK-2211).
+
+Uses real temporary Unix domain sockets with a toy dispatch table — no
+agent, no client module (TASK-2213 is out of scope here); test clients
+talk raw NDJSON over `asyncio.open_unix_connection`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+import stat
+
+import pytest
+from parrot.integrations.agentd.protocol import (
+    INTERNAL_ERROR,
+    METHOD_NOT_FOUND,
+)
+from parrot.integrations.agentd.server import (
+    DaemonAlreadyRunning,
+    JsonRpcUnixServer,
+)
+
+
+async def _send_request(writer: asyncio.StreamWriter, *, id_, method, params=None) -> None:
+    payload = {
+        "jsonrpc": "2.0",
+        "id": id_,
+        "method": method,
+        "params": params or {},
+    }
+    writer.write((json.dumps(payload) + "\n").encode("utf-8"))
+    await writer.drain()
+
+
+async def _recv_line(reader: asyncio.StreamReader) -> dict:
+    line = await asyncio.wait_for(reader.readuntil(b"\n"), timeout=5)
+    return json.loads(line.decode("utf-8"))
+
+
+async def _ping_handler(session, params):
+    return {"pong": True, "echo": params}
+
+
+async def _boom_handler(session, params):
+    raise RuntimeError("boom")
+
+
+@pytest.fixture
+async def server(tmp_path):
+    socket_path = tmp_path / "agentd.sock"
+    srv = JsonRpcUnixServer(
+        socket_path,
+        dispatch={"ping": _ping_handler, "boom": _boom_handler},
+    )
+    await srv.start()
+    yield srv
+    await srv.close()
+
+
+class TestServer:
+    async def test_roundtrip(self, server):
+        reader, writer = await asyncio.open_unix_connection(
+            path=str(server.socket_path)
+        )
+        try:
+            await _send_request(writer, id_=1, method="ping", params={"x": 1})
+            response = await _recv_line(reader)
+        finally:
+            writer.close()
+
+        assert response["id"] == 1
+        assert response["result"] == {"pong": True, "echo": {"x": 1}}
+        assert response.get("error") is None
+
+    async def test_unknown_method_32601(self, server):
+        reader, writer = await asyncio.open_unix_connection(
+            path=str(server.socket_path)
+        )
+        try:
+            await _send_request(writer, id_=2, method="does.not.exist")
+            response = await _recv_line(reader)
+        finally:
+            writer.close()
+
+        assert response["id"] == 2
+        assert response["error"]["code"] == METHOD_NOT_FOUND
+
+    async def test_handler_exception_isolated(self, server):
+        reader, writer = await asyncio.open_unix_connection(
+            path=str(server.socket_path)
+        )
+        try:
+            await _send_request(writer, id_=3, method="boom")
+            error_response = await _recv_line(reader)
+
+            # Server (and this same connection) must still be alive.
+            await _send_request(writer, id_=4, method="ping")
+            ok_response = await _recv_line(reader)
+        finally:
+            writer.close()
+
+        assert error_response["id"] == 3
+        assert error_response["error"]["code"] == INTERNAL_ERROR
+        assert "boom" in error_response["error"]["message"]
+
+        assert ok_response["id"] == 4
+        assert ok_response["result"]["pong"] is True
+
+    async def test_stale_socket_reboot(self, tmp_path):
+        socket_path = tmp_path / "stale.sock"
+
+        # Simulate a dead socket: bind a raw socket and close it without
+        # unlinking the path, leaving the file present but unconnectable.
+        raw = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        raw.bind(str(socket_path))
+        raw.close()
+        assert socket_path.exists()
+
+        srv = JsonRpcUnixServer(socket_path, dispatch={})
+        await srv.start()
+        try:
+            assert socket_path.exists()
+        finally:
+            await srv.close()
+
+    async def test_live_socket_refuses(self, server):
+        second = JsonRpcUnixServer(server.socket_path, dispatch={})
+
+        with pytest.raises(DaemonAlreadyRunning):
+            await second.start()
+
+    async def test_permissions(self, server):
+        parent_mode = stat.S_IMODE(server.socket_path.parent.stat().st_mode)
+        socket_mode = stat.S_IMODE(server.socket_path.stat().st_mode)
+
+        assert parent_mode == 0o700
+        assert socket_mode == 0o600
+
+    async def test_event_broker_fanout(self, tmp_path):
+        socket_path = tmp_path / "broker.sock"
+        dispatch: dict = {}
+        srv = JsonRpcUnixServer(socket_path, dispatch=dispatch)
+
+        async def _subscribe(session, params):
+            srv.event_broker.subscribe(session)
+            return {"subscribed": True}
+
+        dispatch["events.subscribe"] = _subscribe
+
+        await srv.start()
+        try:
+            reader1, writer1 = await asyncio.open_unix_connection(
+                path=str(socket_path)
+            )
+            reader2, writer2 = await asyncio.open_unix_connection(
+                path=str(socket_path)
+            )
+
+            await _send_request(writer1, id_=1, method="events.subscribe")
+            await _recv_line(reader1)  # ack
+            await _send_request(writer2, id_=1, method="events.subscribe")
+            await _recv_line(reader2)  # ack
+
+            await srv.event_broker.publish("event.job_executed", {"job_id": "j1"})
+
+            note1 = await _recv_line(reader1)
+            note2 = await _recv_line(reader2)
+            assert note1["method"] == "event.job_executed"
+            assert note2["method"] == "event.job_executed"
+
+            # Disconnect subscriber 1; give the server's read loop a tick to
+            # process the EOF and unsubscribe it via _disconnect().
+            writer1.close()
+            await asyncio.sleep(0.05)
+
+            await srv.event_broker.publish("event.job_executed", {"job_id": "j2"})
+            note2_again = await _recv_line(reader2)
+            assert note2_again["params"]["job_id"] == "j2"
+
+            writer2.close()
+        finally:
+            await srv.close()

--- a/packages/ai-parrot-integrations/tests/agentd/test_service.py
+++ b/packages/ai-parrot-integrations/tests/agentd/test_service.py
@@ -103,6 +103,44 @@ with contextlib.suppress(ImportError):
     _ScheduledEchoAgent.tick = schedule(ScheduleType.INTERVAL, seconds=1)(_tick)
 
 
+class _FakeAIMessage:
+    """Minimal AIMessage-like object (mirrors the real `AIMessage`'s
+    `.output`/`.response` fields, and its lack of a custom `__str__`) --
+    used to prove agentd extracts clean text rather than a full-object
+    dump. `EchoAgentResponse` (the default fake) has a clean `__str__`
+    that masks this class of bug; this one deliberately does not.
+    """
+
+    def __init__(self, output: str, response: str | None = None) -> None:
+        self.output = output
+        self.response = response if response is not None else output
+
+    def __str__(self) -> str:
+        # Reproduces AIMessage's default Pydantic __str__ (a full field
+        # dump) -- a regression back to `str(response)` would show up as
+        # this text leaking into the RPC `output`.
+        return f"input=... output={self.output!r} response={self.response!r} data=None"
+
+
+class _RealisticBot(EchoAgent):
+    """Agent whose `ask()`/`ask_stream()` mirror `AbstractBot`'s REAL
+    contract: `ask()` returns an `AIMessage`-like object (not a bare
+    string-friendly wrapper like `EchoAgentResponse`), and `ask_stream()`
+    yields text deltas followed by a trailing `AIMessage`-like sentinel --
+    exactly the shape that exposed two response-handling bugs in code
+    review (both masked by `EchoAgent`'s clean `__str__`/sentinel-free
+    streaming).
+    """
+
+    async def ask(self, question: str, **kwargs):
+        return _FakeAIMessage(output=f"real: {question}")
+
+    async def ask_stream(self, question: str, **kwargs):
+        for token in f"real: {question}".split():
+            yield token
+        yield _FakeAIMessage(output=f"real: {question}")
+
+
 @pytest.fixture
 async def echo_daemon(tmp_path):
     """AgentDaemon running EchoAgent on a tmp socket; yields (daemon, socket_path)."""
@@ -214,6 +252,75 @@ class TestDaemonRpc:
         assert status["pid"] == os.getpid()
         assert status["scheduler"]["available"] is False
         assert status["active_connections"] >= 1
+
+
+class TestRealisticResponseShapes:
+    """Regression coverage (code review) for two response-shape bugs that
+    `EchoAgent`'s clean `__str__`/sentinel-free streaming masked:
+    `chat.send` stringifying a whole `AIMessage`-like object instead of
+    extracting `.output`/`.response`, and `chat.stream` sending the
+    trailing `AIMessage`-like sentinel as if it were a text delta.
+    """
+
+    async def test_chat_send_extracts_output_not_full_dump(self, tmp_path):
+        socket_path = tmp_path / "realistic.sock"
+        config = AgentServiceConfig(
+            name="realistic-daemon",
+            agent=AgentTargetConfig(target="tests.agentd.test_service:_RealisticBot"),
+            socket=socket_path,
+            scheduler=SchedulerConfig(enabled=False),
+        )
+        daemon, run_task = await _run_daemon(config)
+        try:
+            reader, writer = await asyncio.open_unix_connection(path=str(socket_path))
+            try:
+                response = await _call(reader, writer, "chat.send", prompt="hello")
+            finally:
+                writer.close()
+        finally:
+            await _stop_daemon(daemon, run_task)
+
+        assert response.get("error") is None
+        assert response["result"]["output"] == "real: hello"
+        # Must NOT be the full-object str() dump (would contain "input=").
+        assert "input=" not in response["result"]["output"]
+
+    async def test_chat_stream_final_sentinel_not_sent_as_delta(self, tmp_path):
+        socket_path = tmp_path / "realistic_stream.sock"
+        config = AgentServiceConfig(
+            name="realistic-stream-daemon",
+            agent=AgentTargetConfig(target="tests.agentd.test_service:_RealisticBot"),
+            socket=socket_path,
+            scheduler=SchedulerConfig(enabled=False),
+        )
+        daemon, run_task = await _run_daemon(config)
+        try:
+            reader, writer = await asyncio.open_unix_connection(path=str(socket_path))
+            try:
+                ack = await _call(
+                    reader, writer, "chat.send", prompt="hi there", stream=True
+                )
+                stream_id = ack["result"]["stream_id"]
+
+                deltas = []
+                while True:
+                    note = await _recv(reader)
+                    assert note["params"]["stream_id"] == stream_id
+                    if note["method"] == "chat.delta":
+                        deltas.append(note["params"]["text"])
+                    elif note["method"] == "chat.complete":
+                        assert note["params"]["response"] == "real: hi there"
+                        break
+                    else:
+                        pytest.fail(f"Unexpected notification: {note['method']}")
+            finally:
+                writer.close()
+        finally:
+            await _stop_daemon(daemon, run_task)
+
+        # The trailing AIMessage-like sentinel must never appear as a delta.
+        assert deltas == ["real:", "hi", "there"]
+        assert not any("input=" in d for d in deltas)
 
 
 class TestDegradation:

--- a/packages/ai-parrot-integrations/tests/agentd/test_service.py
+++ b/packages/ai-parrot-integrations/tests/agentd/test_service.py
@@ -1,0 +1,350 @@
+"""Daemon-level tests for AgentDaemon (TASK-2212).
+
+Uses `EchoAgent` (from `tests.agentd.fakes`, TASK-2210) over a real tmp
+Unix domain socket. Talks raw NDJSON via `asyncio.open_unix_connection`
+(client library, TASK-2213, is out of scope here per the task).
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import contextlib
+import inspect
+import json
+import os
+import signal
+import socket
+import sys
+import time
+from pathlib import Path
+
+import parrot.integrations.agentd.client as _client_mod
+import parrot.integrations.agentd.config as _config_mod
+import parrot.integrations.agentd.protocol as _protocol_mod
+import parrot.integrations.agentd.server as _server_mod
+import parrot.integrations.agentd.service as _service_mod
+import pytest
+from parrot.integrations.agentd.config import (
+    AgentServiceConfig,
+    AgentTargetConfig,
+    SchedulerConfig,
+)
+from parrot.integrations.agentd.protocol import (
+    SCHEDULER_UNAVAILABLE,
+    UNKNOWN_AGENT_METHOD,
+)
+from parrot.integrations.agentd.service import AgentDaemon, sd_notify
+
+from tests.agentd.fakes import EchoAgent
+
+
+async def _wait_for_socket(socket_path: Path, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if socket_path.exists():
+            return
+        await asyncio.sleep(0.01)
+    raise TimeoutError(f"Socket {socket_path} did not appear within {timeout}s")
+
+
+async def _send(writer: asyncio.StreamWriter, payload: dict) -> None:
+    writer.write((json.dumps(payload) + "\n").encode("utf-8"))
+    await writer.drain()
+
+
+async def _recv(reader: asyncio.StreamReader) -> dict:
+    line = await asyncio.wait_for(reader.readuntil(b"\n"), timeout=5)
+    return json.loads(line.decode("utf-8"))
+
+
+async def _call(reader, writer, rpc_method, *, id_=1, **params) -> dict:
+    await _send(
+        writer, {"jsonrpc": "2.0", "id": id_, "method": rpc_method, "params": params}
+    )
+    return await _recv(reader)
+
+
+async def _run_daemon(config: AgentServiceConfig):
+    """Start an AgentDaemon in the background; returns (daemon, run_task)."""
+    daemon = AgentDaemon(config)
+    run_task = asyncio.ensure_future(daemon.run())
+    await _wait_for_socket(config.socket)
+    return daemon, run_task
+
+
+async def _stop_daemon(daemon: AgentDaemon, run_task: asyncio.Task) -> None:
+    daemon._shutdown_event.set()
+    await asyncio.wait_for(run_task, timeout=5)
+
+
+class _ScheduledEchoAgent(EchoAgent):
+    """EchoAgent subclass with a decorated schedule -- module-level so it
+    can be resolved via `"tests.agentd.test_service:_ScheduledEchoAgent"`.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.tick_count = 0
+
+
+# Decorating requires `parrot.scheduler.manager` (ai-parrot-server) to be
+# importable -- only TestSchedulerIntegration exercises this class, and
+# that suite is skipped (not a collection-time failure) if the package is
+# absent, since `_ScheduledEchoAgent.tick` then simply lacks
+# `_schedule_config`.
+with contextlib.suppress(ImportError):
+    from parrot.scheduler.manager import ScheduleType, schedule
+
+    async def _tick(self) -> None:
+        """Increment `tick_count` -- fires every second once scheduled."""
+        self.tick_count += 1
+
+    _ScheduledEchoAgent.tick = schedule(ScheduleType.INTERVAL, seconds=1)(_tick)
+
+
+@pytest.fixture
+async def echo_daemon(tmp_path):
+    """AgentDaemon running EchoAgent on a tmp socket; yields (daemon, socket_path)."""
+    socket_path = tmp_path / "echo.sock"
+    config = AgentServiceConfig(
+        name="echo-daemon",
+        agent=AgentTargetConfig(target="tests.agentd.fakes:EchoAgent", kwargs={"name": "echo"}),
+        socket=socket_path,
+        scheduler=SchedulerConfig(enabled=False),
+    )
+    daemon, run_task = await _run_daemon(config)
+
+    yield daemon, socket_path
+
+    await _stop_daemon(daemon, run_task)
+
+
+class TestDaemonRpc:
+    async def test_chat_send(self, echo_daemon):
+        _daemon, socket_path = echo_daemon
+        reader, writer = await asyncio.open_unix_connection(path=str(socket_path))
+        try:
+            response = await _call(reader, writer, "chat.send", prompt="hello")
+        finally:
+            writer.close()
+
+        assert response.get("error") is None
+        assert response["result"]["output"] == "echo: hello"
+
+    async def test_chat_stream(self, echo_daemon):
+        _daemon, socket_path = echo_daemon
+        reader, writer = await asyncio.open_unix_connection(path=str(socket_path))
+        try:
+            ack = await _call(reader, writer, "chat.send", prompt="hi there", stream=True)
+            stream_id = ack["result"]["stream_id"]
+
+            deltas = []
+            while True:
+                note = await _recv(reader)
+                assert note["params"]["stream_id"] == stream_id
+                if note["method"] == "chat.delta":
+                    deltas.append(note["params"]["text"])
+                elif note["method"] == "chat.complete":
+                    assert note["params"]["response"] == "".join(deltas)
+                    break
+                else:
+                    pytest.fail(f"Unexpected notification: {note['method']}")
+        finally:
+            writer.close()
+
+        assert deltas == ["echo:", "hi", "there"]
+
+    async def test_invoke_rejects_private_and_unknown(self, echo_daemon):
+        _daemon, socket_path = echo_daemon
+        reader, writer = await asyncio.open_unix_connection(path=str(socket_path))
+        try:
+            private_resp = await _call(reader, writer, "agent.invoke", method="_secret")
+            unknown_resp = await _call(
+                reader, writer, "agent.invoke", id_=2, method="does_not_exist"
+            )
+            ok_resp = await _call(
+                reader, writer, "agent.invoke", id_=3, method="get_tools_count"
+            )
+        finally:
+            writer.close()
+
+        assert private_resp["error"]["code"] == UNKNOWN_AGENT_METHOD
+        assert unknown_resp["error"]["code"] == UNKNOWN_AGENT_METHOD
+        assert ok_resp.get("error") is None
+        assert ok_resp["result"] == 0
+
+    async def test_invoke_allowlist_restricts_when_configured(self, tmp_path):
+        socket_path = tmp_path / "allowlist.sock"
+        config = AgentServiceConfig(
+            name="allow-daemon",
+            agent=AgentTargetConfig(target="tests.agentd.fakes:EchoAgent"),
+            socket=socket_path,
+            scheduler=SchedulerConfig(enabled=False),
+            exposed_methods=["get_tools_count"],
+        )
+        daemon, run_task = await _run_daemon(config)
+        try:
+            reader, writer = await asyncio.open_unix_connection(path=str(socket_path))
+            try:
+                denied = await _call(
+                    reader, writer, "agent.invoke", method="get_available_tools"
+                )
+                allowed = await _call(
+                    reader, writer, "agent.invoke", id_=2, method="get_tools_count"
+                )
+            finally:
+                writer.close()
+        finally:
+            await _stop_daemon(daemon, run_task)
+
+        assert denied["error"]["code"] == UNKNOWN_AGENT_METHOD
+        assert allowed.get("error") is None
+        assert allowed["result"] == 0
+
+    async def test_status(self, echo_daemon):
+        _daemon, socket_path = echo_daemon
+        reader, writer = await asyncio.open_unix_connection(path=str(socket_path))
+        try:
+            response = await _call(reader, writer, "daemon.status")
+        finally:
+            writer.close()
+
+        status = response["result"]
+        assert status["pid"] == os.getpid()
+        assert status["scheduler"]["available"] is False
+        assert status["active_connections"] >= 1
+
+
+class TestDegradation:
+    async def test_without_scheduler_package(self, tmp_path, monkeypatch):
+        monkeypatch.setitem(sys.modules, "parrot.scheduler.manager", None)
+
+        socket_path = tmp_path / "noscheduler.sock"
+        config = AgentServiceConfig(
+            name="no-sched-daemon",
+            agent=AgentTargetConfig(target="tests.agentd.fakes:EchoAgent"),
+            socket=socket_path,
+            scheduler=SchedulerConfig(enabled=True),
+        )
+        daemon, run_task = await _run_daemon(config)
+        try:
+            reader, writer = await asyncio.open_unix_connection(path=str(socket_path))
+            try:
+                response = await _call(reader, writer, "schedules.list")
+            finally:
+                writer.close()
+        finally:
+            await _stop_daemon(daemon, run_task)
+
+        assert response["error"]["code"] == SCHEDULER_UNAVAILABLE
+
+    async def test_sigterm_graceful(self, tmp_path):
+        socket_path = tmp_path / "sigterm.sock"
+        config = AgentServiceConfig(
+            name="sigterm-daemon",
+            agent=AgentTargetConfig(target="tests.agentd.fakes:EchoAgent"),
+            socket=socket_path,
+            scheduler=SchedulerConfig(enabled=False),
+            shutdown_grace=5.0,
+        )
+        daemon = AgentDaemon(config)
+        run_task = asyncio.ensure_future(daemon.run())
+        await _wait_for_socket(socket_path)
+
+        os.kill(os.getpid(), signal.SIGTERM)
+
+        await asyncio.wait_for(run_task, timeout=5)
+
+        assert not socket_path.exists()
+
+
+class TestSchedulerIntegration:
+    async def test_interval_job_fires_and_event(self, tmp_path):
+        if not hasattr(_ScheduledEchoAgent, "tick") or not hasattr(
+            _ScheduledEchoAgent.tick, "_schedule_config"
+        ):
+            pytest.skip("ai-parrot-server (scheduler support) not installed")
+
+        socket_path = tmp_path / "scheduler.sock"
+        config = AgentServiceConfig(
+            name="sched-daemon",
+            agent=AgentTargetConfig(
+                target="tests.agentd.test_service:_ScheduledEchoAgent"
+            ),
+            socket=socket_path,
+            scheduler=SchedulerConfig(enabled=True, dsn=None, redis=False),
+        )
+        daemon, run_task = await _run_daemon(config)
+        try:
+            reader, writer = await asyncio.open_unix_connection(path=str(socket_path))
+            try:
+                sub_resp = await _call(reader, writer, "events.subscribe")
+                assert sub_resp.get("error") is None
+
+                note = await asyncio.wait_for(_recv(reader), timeout=5)
+                assert note["method"] == "event.job_executed"
+            finally:
+                writer.close()
+        finally:
+            await _stop_daemon(daemon, run_task)
+
+        assert daemon.agent.tick_count >= 1
+
+
+class TestSdNotify:
+    def test_sends_datagram_when_notify_socket_set(self, tmp_path, monkeypatch):
+        notify_path = tmp_path / "notify.sock"
+        recv_sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+        recv_sock.bind(str(notify_path))
+        recv_sock.settimeout(2)
+        monkeypatch.setenv("NOTIFY_SOCKET", str(notify_path))
+        try:
+            sd_notify("READY=1")
+            data, _ = recv_sock.recvfrom(1024)
+            assert data == b"READY=1"
+        finally:
+            recv_sock.close()
+
+    def test_noop_when_notify_socket_unset(self, monkeypatch):
+        monkeypatch.delenv("NOTIFY_SOCKET", raising=False)
+        sd_notify("READY=1")  # must not raise
+
+
+def _module_imports_aiohttp(module) -> bool:
+    """Static check: does `module`'s own source import aiohttp?
+
+    Note: a runtime `"aiohttp" not in sys.modules` check is not meaningful
+    in this suite -- the installed `pytest-aiohttp` plugin imports aiohttp
+    unconditionally at pytest startup, well before any agentd code runs,
+    regardless of what this daemon does. This AST-based check instead
+    verifies the actual intent of spec §5's acceptance criterion: agentd's
+    own modules never import aiohttp themselves.
+    """
+    tree = ast.parse(inspect.getsource(module))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import) and any(
+            alias.name.split(".")[0] == "aiohttp" for alias in node.names
+        ):
+            return True
+        if (
+            isinstance(node, ast.ImportFrom)
+            and node.module
+            and node.module.split(".")[0] == "aiohttp"
+        ):
+            return True
+    return False
+
+
+class TestNoAiohttp:
+    def test_agentd_modules_never_import_aiohttp(self):
+        for module in (
+            _protocol_mod,
+            _config_mod,
+            _server_mod,
+            _client_mod,
+            _service_mod,
+        ):
+            assert not _module_imports_aiohttp(module), (
+                f"{module.__name__} must not import aiohttp"
+            )

--- a/packages/ai-parrot-server/src/parrot/scheduler/manager.py
+++ b/packages/ai-parrot-server/src/parrot/scheduler/manager.py
@@ -299,6 +299,10 @@ class AgentSchedulerManager:
         self.app: Optional[web.Application] = None
         self.db: Optional[AsyncDB] = None
         self._pool: Optional[AsyncDB] = None  # Database connection pool
+        # True only when start_headless() created self._pool itself (via a
+        # `dsn`) — used by stop_headless() to decide whether it owns the
+        # pool's lifecycle and should close it.
+        self._owns_pool: bool = False
         self._job_context: Dict[str, Dict[str, Any]] = {}
         self._pending_success_tasks: Set[asyncio.Task] = set()
         self.registered_name = kwargs.get(
@@ -306,17 +310,13 @@ class AgentSchedulerManager:
         )
         self.scheduler: Optional[AsyncIOScheduler] = None
 
-        # Configure APScheduler with AsyncIO
-        jobstores = {
-            'default': MemoryJobStore(),
-            "redis": RedisJobStore(
-                db=6,
-                jobs_key="apscheduler.jobs",
-                run_times_key="apscheduler.run_times",
-                host=CACHE_HOST,
-                port=CACHE_PORT,
-            ),
-        }
+        # Configure APScheduler with AsyncIO.
+        # NOTE: RedisJobStore is intentionally NOT constructed here anymore
+        # (it used to be built unconditionally, which could attempt a Redis
+        # connection even when Redis is never used). Jobstore selection now
+        # happens at start time via `_build_jobstores()`/`start_headless()`;
+        # `self.scheduler` still exists after `__init__` with the always-on
+        # 'default' MemoryJobStore, per existing code that touches it.
         executors = {
             'default': AsyncIOExecutor()
         }
@@ -327,7 +327,7 @@ class AgentSchedulerManager:
         }
 
         self.scheduler = AsyncIOScheduler(
-            jobstores=jobstores,
+            jobstores=self._build_jobstores(use_redis=False),
             executors=executors,
             job_defaults=job_defaults,
             timezone='UTC'
@@ -1460,6 +1460,106 @@ class AgentSchedulerManager:
             AgentSchedule.Meta.connection = conn
             await schedule.delete()
 
+    def _build_jobstores(self, use_redis: bool = False) -> Dict[str, Any]:
+        """Build the APScheduler jobstore mapping.
+
+        Args:
+            use_redis: When True, also include a Redis-backed jobstore under
+                the ``'redis'`` alias (used by schedules whose
+                ``scheduler_type`` is ``'redis'``). The ``'default'``
+                ``MemoryJobStore`` is always present.
+
+        Returns:
+            A jobstore mapping suitable for ``AsyncIOScheduler(jobstores=...)``.
+        """
+        jobstores: Dict[str, Any] = {'default': MemoryJobStore()}
+        if use_redis:
+            jobstores['redis'] = self._make_redis_jobstore()
+        return jobstores
+
+    def _make_redis_jobstore(self) -> RedisJobStore:
+        """Construct a `RedisJobStore` using the shared cache configuration."""
+        return RedisJobStore(
+            db=6,
+            jobs_key="apscheduler.jobs",
+            run_times_key="apscheduler.run_times",
+            host=CACHE_HOST,
+            port=CACHE_PORT,
+        )
+
+    def _ensure_redis_jobstore(self) -> None:
+        """Attach a ``'redis'`` jobstore to the running scheduler if absent.
+
+        Idempotent: safe to call more than once (e.g. if `start_headless()`
+        is invoked again) — APScheduler raises `ValueError` when the alias
+        is already registered, which is swallowed here.
+        """
+        try:
+            self.scheduler.add_jobstore(self._make_redis_jobstore(), alias='redis')
+        except ValueError:
+            # Alias already registered — nothing to do.
+            pass
+
+    async def start_headless(
+        self, *, dsn: Optional[str] = None, use_redis: bool = False
+    ) -> None:
+        """Boot the scheduler without an aiohttp application.
+
+        Only requires a running asyncio event loop. Builds/attaches the
+        Redis jobstore only when requested, creates a Postgres connection
+        pool only when a `dsn` is given (and none is already set), wires
+        the APScheduler event listeners, starts the scheduler, and loads
+        persisted schedules from the database only when a pool exists.
+
+        Args:
+            dsn: Postgres DSN to build a connection pool from. When
+                `None` (and no pool is already assigned via `self._pool`),
+                the scheduler runs with decorator-registered schedules only.
+            use_redis: When True, attach a Redis-backed jobstore under the
+                `'redis'` alias. Defaults to `False` (MemoryJobStore only).
+        """
+        if use_redis:
+            self._ensure_redis_jobstore()
+
+        if dsn is not None and self._pool is None:
+            self._pool = AsyncDB("pg", dsn=dsn)
+            await self._pool.connection()
+            self._owns_pool = True
+
+        self.define_listeners()
+
+        if not self.scheduler.running:
+            self.scheduler.start()
+
+        if self._pool is not None:
+            await self.load_schedules_from_db()
+
+        self.logger.notice("Agent Scheduler started (headless)")
+
+    async def stop_headless(self, *, wait: bool = True) -> None:
+        """Stop a scheduler previously started via `start_headless()`.
+
+        Tolerant of partial initialization: safe to call even if
+        `start_headless()` was never called, or failed partway through.
+        Only closes the connection pool when `start_headless()` created it
+        itself (via `dsn`) — a pool injected from elsewhere (e.g. the
+        aiohttp `on_startup()` path) is left for its owner to close.
+
+        Args:
+            wait: Passed through to `AsyncIOScheduler.shutdown(wait=...)`.
+        """
+        if self.scheduler is not None and self.scheduler.running:
+            with contextlib.suppress(Exception):
+                self.scheduler.shutdown(wait=wait)
+
+        if self._owns_pool and self._pool is not None:
+            with contextlib.suppress(Exception):
+                await self._pool.close()
+            self._pool = None
+            self._owns_pool = False
+
+        self.logger.notice("Agent Scheduler stopped (headless)")
+
     def setup(self, app: web.Application) -> web.Application:
         """
         Setup scheduler with aiohttp application.
@@ -1512,11 +1612,14 @@ class AgentSchedulerManager:
             )
             self._pool = app['agentdb']
 
-        # Load schedules from database
-        await self.load_schedules_from_db()
-
-        # Start scheduler
-        self.scheduler.start()
+        # Delegate the transport-free bootstrap steps (jobstore(s), event
+        # listeners, scheduler start, schedule loading) to start_headless().
+        # `self._pool` is already assigned above (owned by aiohttp's
+        # PostgresPool via `conn`) so start_headless()'s own dsn-based pool
+        # creation is skipped, while schedules are still loaded from it.
+        # `use_redis=True` preserves the previous behaviour of always having
+        # a Redis jobstore available under aiohttp.
+        await self.start_headless(use_redis=True)
 
         self.logger.notice(
             "Agent Scheduler started successfully"
@@ -1550,8 +1653,11 @@ class AgentSchedulerManager:
         """Cleanup on app shutdown."""
         self.logger.info("Shutting down Agent Scheduler...")
 
-        if self.scheduler.running:
-            self.scheduler.shutdown(wait=True)
+        # Delegate to stop_headless(): since on_startup() never sets
+        # `_owns_pool` (the pool is owned by aiohttp's PostgresPool, not by
+        # us), stop_headless() will shut the scheduler down but leave pool
+        # teardown to its owner — identical to the previous behaviour.
+        await self.stop_headless(wait=True)
 
         self.logger.notice("Agent Scheduler shut down")
 

--- a/packages/ai-parrot-server/src/parrot/scheduler/manager.py
+++ b/packages/ai-parrot-server/src/parrot/scheduler/manager.py
@@ -1501,15 +1501,20 @@ class AgentSchedulerManager:
             pass
 
     async def start_headless(
-        self, *, dsn: Optional[str] = None, use_redis: bool = False
+        self,
+        *,
+        dsn: Optional[str] = None,
+        use_redis: bool = False,
+        register_listeners: bool = True,
     ) -> None:
         """Boot the scheduler without an aiohttp application.
 
         Only requires a running asyncio event loop. Builds/attaches the
         Redis jobstore only when requested, creates a Postgres connection
-        pool only when a `dsn` is given (and none is already set), wires
-        the APScheduler event listeners, starts the scheduler, and loads
-        persisted schedules from the database only when a pool exists.
+        pool only when a `dsn` is given (and none is already set),
+        optionally wires the APScheduler event listeners, starts the
+        scheduler, and loads persisted schedules from the database only
+        when a pool exists.
 
         Args:
             dsn: Postgres DSN to build a connection pool from. When
@@ -1517,6 +1522,14 @@ class AgentSchedulerManager:
                 the scheduler runs with decorator-registered schedules only.
             use_redis: When True, attach a Redis-backed jobstore under the
                 `'redis'` alias. Defaults to `False` (MemoryJobStore only).
+            register_listeners: When True (default), call
+                `define_listeners()`. `on_startup()` passes `False` to stay
+                strictly behaviour-preserving for the aiohttp path, where
+                these listeners were never wired before FEAT-422 (this
+                param exists so the standalone headless-daemon path — the
+                only caller that needs `job_success`/`job_status`/etc.
+                actually firing — can still opt in without changing
+                aiohttp's existing runtime behaviour).
         """
         if use_redis:
             self._ensure_redis_jobstore()
@@ -1526,7 +1539,8 @@ class AgentSchedulerManager:
             await self._pool.connection()
             self._owns_pool = True
 
-        self.define_listeners()
+        if register_listeners:
+            self.define_listeners()
 
         if not self.scheduler.running:
             self.scheduler.start()
@@ -1612,14 +1626,20 @@ class AgentSchedulerManager:
             )
             self._pool = app['agentdb']
 
-        # Delegate the transport-free bootstrap steps (jobstore(s), event
-        # listeners, scheduler start, schedule loading) to start_headless().
-        # `self._pool` is already assigned above (owned by aiohttp's
-        # PostgresPool via `conn`) so start_headless()'s own dsn-based pool
-        # creation is skipped, while schedules are still loaded from it.
-        # `use_redis=True` preserves the previous behaviour of always having
-        # a Redis jobstore available under aiohttp.
-        await self.start_headless(use_redis=True)
+        # Delegate the transport-free bootstrap steps (jobstore(s),
+        # scheduler start, schedule loading) to start_headless(). `self.
+        # _pool` is already assigned above (owned by aiohttp's PostgresPool
+        # via `conn`) so start_headless()'s own dsn-based pool creation is
+        # skipped, while schedules are still loaded from it. `use_redis=
+        # True` preserves the previous behaviour of always having a Redis
+        # jobstore available under aiohttp. `register_listeners=False`
+        # keeps this strictly behaviour-preserving: `define_listeners()`
+        # was never called anywhere on this path before FEAT-422 (dead
+        # code), so wiring it now would be a silent, undocumented change
+        # to production aiohttp deployments (job_success/job_status
+        # callbacks, notifications, DB updates firing for the first time)
+        # — out of scope for this feature.
+        await self.start_headless(use_redis=True, register_listeners=False)
 
         self.logger.notice(
             "Agent Scheduler started successfully"

--- a/packages/ai-parrot-server/tests/scheduler/__init__.py
+++ b/packages/ai-parrot-server/tests/scheduler/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for parrot.scheduler (AgentSchedulerManager)."""

--- a/packages/ai-parrot-server/tests/scheduler/test_headless.py
+++ b/packages/ai-parrot-server/tests/scheduler/test_headless.py
@@ -1,0 +1,143 @@
+"""Unit tests for AgentSchedulerManager headless bootstrap (TASK-2209).
+
+Covers `start_headless()` / `stop_headless()` (no aiohttp, no real Redis or
+Postgres — everything is mocked) and the `on_startup()`/`on_shutdown()`
+delegation that preserves the existing aiohttp behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from parrot.scheduler.manager import AgentSchedulerManager
+
+pytestmark = pytest.mark.requires_apscheduler
+
+
+@pytest.fixture
+async def manager():
+    mgr = AgentSchedulerManager()
+    yield mgr
+    # Best-effort cleanup so the AsyncIOScheduler doesn't leak across tests.
+    # Async fixture: teardown still runs on the test's own event loop
+    # (unlike a plain-sync fixture, whose teardown would run after the
+    # loop closes and blow up on AsyncIOScheduler's call_soon_threadsafe).
+    await mgr.stop_headless(wait=False)
+
+
+class TestStartHeadless:
+    async def test_no_dsn_no_redis_memory_jobstore(self, manager):
+        with patch.object(
+            manager, "load_schedules_from_db", new=AsyncMock()
+        ) as mock_load:
+            await manager.start_headless()
+
+        assert manager.scheduler.running is True
+        assert "default" in manager.scheduler._jobstores
+        assert "redis" not in manager.scheduler._jobstores
+        assert manager._pool is None
+        mock_load.assert_not_awaited()
+
+    async def test_redis_not_constructed_when_disabled(self, manager):
+        with patch(
+            "parrot.scheduler.manager.RedisJobStore"
+        ) as mock_redis_cls, patch.object(
+            manager, "load_schedules_from_db", new=AsyncMock()
+        ):
+            await manager.start_headless(use_redis=False)
+
+        mock_redis_cls.assert_not_called()
+
+    async def test_redis_jobstore_attached_when_enabled(self, manager):
+        with patch.object(manager, "load_schedules_from_db", new=AsyncMock()):
+            await manager.start_headless(use_redis=True)
+
+        assert "redis" in manager.scheduler._jobstores
+
+    async def test_dsn_creates_pool_and_loads_db(self, manager):
+        fake_pool = AsyncMock()
+        with patch(
+            "parrot.scheduler.manager.AsyncDB", return_value=fake_pool
+        ) as mock_asyncdb, patch.object(
+            manager, "load_schedules_from_db", new=AsyncMock()
+        ) as mock_load:
+            await manager.start_headless(dsn="postgres://fake")
+
+        mock_asyncdb.assert_called_once_with("pg", dsn="postgres://fake")
+        fake_pool.connection.assert_awaited_once()
+        assert manager._pool is fake_pool
+        assert manager._owns_pool is True
+        mock_load.assert_awaited_once()
+
+    async def test_stop_headless_partial_init(self, manager):
+        # start_headless() was never called -- must not raise.
+        await manager.stop_headless()
+        assert manager._pool is None
+
+    async def test_stop_headless_closes_owned_pool(self, manager):
+        fake_pool = AsyncMock()
+        with patch(
+            "parrot.scheduler.manager.AsyncDB", return_value=fake_pool
+        ), patch.object(manager, "load_schedules_from_db", new=AsyncMock()):
+            await manager.start_headless(dsn="postgres://fake")
+
+        await manager.stop_headless()
+        # AsyncIOScheduler.shutdown() dispatches the actual state change via
+        # call_soon_threadsafe -- give the loop one tick to process it.
+        await asyncio.sleep(0)
+
+        fake_pool.close.assert_awaited_once()
+        assert manager._pool is None
+        assert manager._owns_pool is False
+        assert manager.scheduler.running is False
+
+
+class TestAiohttpDelegation:
+    async def test_on_startup_delegates(self, manager):
+        fake_conn = MagicMock(name="agentdb-pool")
+        fake_app = {"bot_manager": None}
+
+        with patch.object(
+            manager, "start_headless", new=AsyncMock()
+        ) as mock_start:
+            await manager.on_startup(fake_app, fake_conn)
+
+        assert manager._pool is fake_conn
+        mock_start.assert_awaited_once_with(use_redis=True)
+
+    async def test_on_shutdown_preserves_injected_pool(self, manager):
+        """A pool injected via on_startup()/conn is NOT owned -- on_shutdown
+        must not attempt to close it (zero behaviour change vs. before the
+        refactor, where on_shutdown never touched the pool at all)."""
+        fake_conn = MagicMock(name="agentdb-pool")
+        manager._pool = fake_conn
+        manager._owns_pool = False
+
+        with patch.object(manager, "load_schedules_from_db", new=AsyncMock()):
+            await manager.start_headless(use_redis=False)
+
+        await manager.on_shutdown({}, fake_conn)
+        # AsyncIOScheduler.shutdown() dispatches the actual state change via
+        # call_soon_threadsafe -- give the loop one tick to process it.
+        await asyncio.sleep(0)
+
+        fake_conn.close.assert_not_called()
+        assert manager._pool is fake_conn
+        assert manager.scheduler.running is False
+
+    async def test_register_bot_schedules_after_headless_start(self, manager):
+        """register_bot_schedules() should keep working after a headless
+        start (no aiohttp involved) -- exercised with a fake bot exposing no
+        decorated methods, so we only assert it runs without error and
+        returns zero registrations."""
+        with patch.object(manager, "load_schedules_from_db", new=AsyncMock()):
+            await manager.start_headless()
+
+        class _FakeBot:
+            pass
+
+        count = manager.register_bot_schedules(_FakeBot())
+        assert count == 0

--- a/packages/ai-parrot-server/tests/scheduler/test_headless.py
+++ b/packages/ai-parrot-server/tests/scheduler/test_headless.py
@@ -11,7 +11,6 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 from parrot.scheduler.manager import AgentSchedulerManager
 
 pytestmark = pytest.mark.requires_apscheduler
@@ -56,6 +55,32 @@ class TestStartHeadless:
             await manager.start_headless(use_redis=True)
 
         assert "redis" in manager.scheduler._jobstores
+
+    async def test_register_listeners_default_true(self, manager):
+        """FEAT-422: the standalone headless-daemon path (no explicit
+        `register_listeners=`) must still get `define_listeners()` wired,
+        per TASK-2209's original requirement."""
+        with patch.object(
+            manager, "define_listeners", new=MagicMock()
+        ) as mock_define, patch.object(
+            manager, "load_schedules_from_db", new=AsyncMock()
+        ):
+            await manager.start_headless()
+
+        mock_define.assert_called_once()
+
+    async def test_register_listeners_false_skips_define_listeners(self, manager):
+        """`register_listeners=False` (used by `on_startup()`) must NOT
+        wire the APScheduler event listeners -- they were never called on
+        the aiohttp path before FEAT-422, and this keeps it that way."""
+        with patch.object(
+            manager, "define_listeners", new=MagicMock()
+        ) as mock_define, patch.object(
+            manager, "load_schedules_from_db", new=AsyncMock()
+        ):
+            await manager.start_headless(register_listeners=False)
+
+        mock_define.assert_not_called()
 
     async def test_dsn_creates_pool_and_loads_db(self, manager):
         fake_pool = AsyncMock()
@@ -106,7 +131,24 @@ class TestAiohttpDelegation:
             await manager.on_startup(fake_app, fake_conn)
 
         assert manager._pool is fake_conn
-        mock_start.assert_awaited_once_with(use_redis=True)
+        mock_start.assert_awaited_once_with(use_redis=True, register_listeners=False)
+
+    async def test_on_startup_never_wires_listeners_end_to_end(self, manager):
+        """Not mocking `start_headless()` this time: the real aiohttp path,
+        end to end, must never call `define_listeners()` -- FEAT-422
+        regression coverage (code review) for a behaviour-change risk
+        found in `start_headless()`'s new `register_listeners` param."""
+        fake_conn = MagicMock(name="agentdb-pool")
+        fake_app = {"bot_manager": None}
+
+        with patch.object(
+            manager, "define_listeners", new=MagicMock()
+        ) as mock_define, patch.object(
+            manager, "load_schedules_from_db", new=AsyncMock()
+        ):
+            await manager.on_startup(fake_app, fake_conn)
+
+        mock_define.assert_not_called()
 
     async def test_on_shutdown_preserves_injected_pool(self, manager):
         """A pool injected via on_startup()/conn is NOT owned -- on_shutdown

--- a/packages/ai-parrot/src/parrot/cli/__init__.py
+++ b/packages/ai-parrot/src/parrot/cli/__init__.py
@@ -27,6 +27,11 @@ class LazyGroup(click.Group):
         """
         super().__init__(*args, **kwargs)
         self._lazy_commands: dict[str, str] = {}
+        # Optional per-command install hint shown when a lazy module fails
+        # to import (e.g. an optional extra wasn't installed). Generic --
+        # any lazy command may register one; falls back to a generic
+        # message naming the failing module path when absent (FEAT-422).
+        self._lazy_extras: dict[str, str] = {}
 
     def list_commands(self, ctx):
         """Return sorted list of registered subcommand names.
@@ -52,7 +57,17 @@ class LazyGroup(click.Group):
         if cmd_name not in self._lazy_commands:
             return None
         module_path = self._lazy_commands[cmd_name]
-        mod = importlib.import_module(module_path)
+        try:
+            mod = importlib.import_module(module_path)
+        except ImportError as exc:
+            hint = self._lazy_extras.get(cmd_name)
+            message = (
+                f"'parrot {cmd_name}' requires {hint}"
+                if hint
+                else f"'parrot {cmd_name}' is unavailable: could not import "
+                f"{module_path!r} ({exc})"
+            )
+            raise click.ClickException(message) from exc
         attr_name = cmd_name.replace("-", "_")
         return getattr(mod, attr_name, None) or getattr(mod, cmd_name, None)
 
@@ -76,6 +91,23 @@ cli._lazy_commands = {
     "claude": "parrot.knowledge.wiki.claude_code.cli",
     "generate-keys": "parrot.cli.generate_keys",
     "devloop": "parrot.cli.devloop",
+    # FEAT-422 — Agent CLI Daemon (agentd), ships in ai-parrot-integrations.
+    "serve": "parrot.integrations.agentd.cli",
+    "attach": "parrot.integrations.agentd.cli",
+    "ask": "parrot.integrations.agentd.cli",
+    "status": "parrot.integrations.agentd.cli",
+    "install-service": "parrot.integrations.agentd.cli",
+    "mcp-serve": "parrot.integrations.agentd.cli",
+}
+
+_AGENTD_INSTALL_HINT = "ai-parrot-integrations[agentd]: pip install ai-parrot-integrations[agentd]"
+cli._lazy_extras = {
+    "serve": _AGENTD_INSTALL_HINT,
+    "attach": _AGENTD_INSTALL_HINT,
+    "ask": _AGENTD_INSTALL_HINT,
+    "status": _AGENTD_INSTALL_HINT,
+    "install-service": _AGENTD_INSTALL_HINT,
+    "mcp-serve": _AGENTD_INSTALL_HINT,
 }
 
 if __name__ == "__main__":

--- a/sdd/tasks/completed/TASK-2208-agentd-protocol.md
+++ b/sdd/tasks/completed/TASK-2208-agentd-protocol.md
@@ -131,10 +131,16 @@ class TestFraming:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**:
-**Date**:
-**Notes**:
+**Completed by**: sdd-worker (Claude Sonnet 5)
+**Date**: 2026-08-16
+**Notes**: Implemented `protocol.py` with `RpcRequest`/`RpcResponse`/`RpcError`/
+`RpcNotification` Pydantic v2 models, JSON-RPC + application error-code
+constants, the full method-name constant set from spec §2, and an NDJSON
+codec (`read_message`/`write_message`) built on `asyncio.StreamReader.
+readuntil`/`StreamWriter.write`. Oversize protection checks length both via
+`StreamReader(limit=...)` (`LimitOverrunError`) and an explicit
+`max_line_bytes` check after `readuntil` returns. 11 unit tests cover model
+roundtrips, split/coalesced/oversized/malformed frames, and clean EOF — all
+passing. `ruff check` clean.
 
 **Deviations from spec**: none

--- a/sdd/tasks/completed/TASK-2209-scheduler-headless.md
+++ b/sdd/tasks/completed/TASK-2209-scheduler-headless.md
@@ -158,10 +158,53 @@ class TestAiohttpDelegation:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (Claude Sonnet 5)
+**Date**: 2026-08-16
+**Notes**: Moved jobstore construction out of `__init__` into
+`_build_jobstores(use_redis)`/`_make_redis_jobstore()`/`_ensure_redis_jobstore()`;
+`__init__` now builds the scheduler with `MemoryJobStore` only (no eager
+`RedisJobStore`). Added `start_headless(dsn=None, use_redis=False)` (attach
+Redis jobstore if requested, create an AsyncDB pool only when `dsn` given
+and no pool already set, `define_listeners()`, start scheduler if not
+running, `load_schedules_from_db()` only when a pool exists) and
+`stop_headless(wait=True)` (scheduler shutdown, tolerant of partial init;
+closes the pool only if `start_headless()` created it itself, tracked via
+`self._owns_pool`). `on_startup`/`on_shutdown` signatures are unchanged and
+now delegate to `start_headless(use_redis=True)`/`stop_headless(wait=True)`
+respectively — `on_startup` still assigns `self._pool = conn` first (from
+aiohttp's `PostgresPool`), so `start_headless()` skips its own pool
+creation but still loads schedules from the pool already in place;
+`on_shutdown` never sets `_owns_pool`, so the injected aiohttp pool is left
+untouched, exactly as before the refactor. Bonus (spec-mandated) side
+effect: `define_listeners()` — previously never called anywhere in the
+codebase — is now wired in via `start_headless()`, fixing a latent gap
+without altering any tested behaviour.
 
-**Completed by**:
-**Date**:
-**Notes**:
+9 new unit tests in `test_headless.py` cover: no-dsn/no-redis (MemoryJobStore
+only, no pool, no DB load), Redis jobstore not constructed when disabled,
+Redis jobstore attached when enabled, dsn creates+connects a pool and loads
+schedules, `stop_headless` tolerant of partial init, `stop_headless` closes
+an owned pool, `on_startup` delegates to `start_headless(use_redis=True)`,
+`on_shutdown` preserves an injected (non-owned) pool, and
+`register_bot_schedules()` still works after a headless start. All 9 pass.
 
-**Deviations from spec**: none
+Regression check: ran the pre-existing `test_schedules.py` and
+`test_scheduler_report_decorators.py` suites on both this branch and the
+unmodified main checkout — identical results on both (3 pre-existing
+failures in `test_schedules.py` unrelated to `__init__`/`on_startup`/
+`on_shutdown`; a pre-existing `parrot.scheduler` package-shadowing
+collection error in `test_scheduler_report_decorators.py`). Zero new
+failures attributable to this change.
+
+`ruff check` on `manager.py`: 3 new UP006/UP045 findings (`Dict`/`Optional`
+typing style) in the new code, consistent with the file's pre-existing
+convention (used throughout the other ~140 pre-existing findings in this
+large legacy file); no new BLE001 or other logic-smell categories.
+Modernizing the whole file's typing style is out of scope for this task.
+
+**Deviations from spec**: none. One implementation decision not fully
+spelled out by the spec: pool-ownership tracking (`_owns_pool`) was added
+so `stop_headless()` only closes a pool it created itself via `dsn` — this
+is what makes `on_shutdown()` "tolerant of partial init" while staying
+strictly behaviour-preserving for the aiohttp path (which owns its pool via
+`PostgresPool`/`self.db`, not via the scheduler manager).

--- a/sdd/tasks/completed/TASK-2210-agentd-config.md
+++ b/sdd/tasks/completed/TASK-2210-agentd-config.md
@@ -132,10 +132,28 @@ class TestResolveAgent:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (Claude Sonnet 5)
+**Date**: 2026-08-16
+**Notes**: Implemented `config.py` with `SchedulerConfig`, `AgentTargetConfig`,
+`AgentServiceConfig` (fields exactly per spec §2: name, agent, socket,
+scheduler, exposed_methods, log_level, max_line_bytes=10MB,
+shutdown_grace=30.0), `AgentServiceConfig.from_yaml()`/`.from_target()`,
+`default_socket_path()` (XDG_RUNTIME_DIR with `/tmp/parrot-<uid>/` fallback),
+and `resolve_agent()` covering class / instance / sync-factory /
+async-factory targets plus `AgentTargetError` for bad module/attr/shape.
+`resolve_agent()` awaits `configure()` only when it is an async function
+(`inspect.iscoroutinefunction`), matching `AbstractBot.configure(app=None)`.
+`name` validation rejects empty strings and path separators (`/`, `\`).
 
-**Completed by**:
-**Date**:
-**Notes**:
+Added `tests/agentd/fakes.py` with a dependency-free, duck-typed `EchoAgent`
+(ask/ask_stream/configure/get_available_tools/get_tools_count/has_tools) plus
+`make_echo_agent`/`make_echo_agent_async` factories and a module-level
+`echo_instance` — used to exercise every branch of the target-resolution
+matrix, and available for later agentd tasks per the spec's fixture note
+(`tests.agentd.fakes:EchoAgent`).
 
-**Deviations from spec**: none
+25 tests pass (14 new in `test_config.py`, 11 pre-existing in
+`test_protocol.py` unaffected). `ruff check` clean after auto-fix (quoted
+forward-ref return types, unused noqa directives, import ordering).
+
+**Deviations from spec**: none.

--- a/sdd/tasks/completed/TASK-2211-agentd-uds-server.md
+++ b/sdd/tasks/completed/TASK-2211-agentd-uds-server.md
@@ -140,10 +140,33 @@ class TestServer:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (Claude Sonnet 5)
+**Date**: 2026-08-16
+**Notes**: Implemented `server.py` with `Session` (session_id, writer,
+subscribed flag, stream_ids, in-flight tasks, per-session write lock via
+`send()`/`notify()`), `Handler` type alias, `EventBroker`
+(subscribe/unsubscribe/publish with dead-subscriber isolation), and
+`JsonRpcUnixServer` (`start()`/`close()`, boot sequence with `0700` parent
+dir + try-connect-then-unlink stale-socket handling +
+`DaemonAlreadyRunning`, `0600` socket chmod after bind, per-connection
+accept loop dispatching `RpcRequest`s as tracked `asyncio.Task`s so a slow
+handler never blocks other requests on the same connection, and
+disconnect handling that cancels in-flight tasks + unsubscribes + closes
+the writer). Every handler failure path (`ValidationError` → `INVALID_
+PARAMS`, unknown method → `METHOD_NOT_FOUND`, any other exception →
+`INTERNAL_ERROR` with full traceback logged) is converted to a JSON-RPC
+error response without killing the connection. Malformed/oversized
+inbound lines are also converted to error responses (`PARSE_ERROR`/
+`INVALID_REQUEST`) rather than propagating.
 
-**Completed by**:
-**Date**:
-**Notes**:
+7 unit tests in `test_server.py` cover: request/response roundtrip over a
+real tmp UDS, unknown-method → −32601, handler-exception isolation
+(connection survives), stale-socket detection+reboot (raw dead socket file
+unlinked and rebound), live-socket refusal (`DaemonAlreadyRunning`), socket/
+dir permission bits (`0600`/`0700`), and event-broker fan-out (two
+subscribers, one disconnects, publish continues to the survivor without
+raising). All 7 pass; full `agentd/` suite (32 tests across protocol,
+config, server) still green. `ruff check` clean after auto-fix (unused
+`noqa`, import ordering).
 
-**Deviations from spec**: none
+**Deviations from spec**: none.

--- a/sdd/tasks/completed/TASK-2212-agentd-daemon-service.md
+++ b/sdd/tasks/completed/TASK-2212-agentd-daemon-service.md
@@ -181,10 +181,61 @@ class TestSchedulerIntegration:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (Claude Sonnet 5)
+**Date**: 2026-08-16
+**Notes**: Implemented `service.py` with `SingleAgentManager` (`_bots`
+dict, `registry.get_instance()`, `get_crew()` → `None`), `AgentDaemon`
+(the full 6-step lifecycle: logging config, `resolve_agent()`, best-effort
+lazy scheduler bootstrap via `start_headless(dsn=cfg.scheduler.dsn,
+use_redis=cfg.scheduler.redis)` + `register_bot_schedules()`, dispatch
+table + `JsonRpcUnixServer` start, ready log line + `sd_notify("READY=1")`,
+SIGTERM/SIGINT → graceful shutdown bounded by `shutdown_grace`), the full
+RPC method table (`chat.send` non-stream/stream, `agent.info`,
+`tools.list`, `agent.invoke` with underscore-rejection + allowlist
+enforcement, `schedules.list/add/pause/resume/remove` proxying to
+`AgentSchedulerManager`, `events.subscribe/unsubscribe`, `daemon.status`,
+`daemon.shutdown`), scheduler event fan-out (`EVENT_JOB_EXECUTED`/
+`EVENT_JOB_ERROR` APScheduler listeners publishing through
+`server.event_broker`), and a hand-rolled `sd_notify()` (no `sdnotify`
+dependency).
 
-**Completed by**:
-**Date**:
-**Notes**:
+**Deviation from the task's file list (documented, not silent)**:
+`server.py` (TASK-2211) was additively modified — a new `RpcHandlerError`
+exception (checked in `_run_handler` BEFORE the generic `Exception`
+fallback) and a new `JsonRpcUnixServer.active_connections` property. This
+was necessary because TASK-2211, as built, collapsed every handler
+exception to the generic `INTERNAL_ERROR` (-32603), with no way for a
+handler to surface one of spec §2's application-range codes (1001–1004).
+Spec §2 "Error Handling" and this very task's acceptance criteria
+(`agent.invoke` on `_private` → error; `schedules.list` with no scheduler
+→ error 1003) require those specific codes, so this was a required,
+minimal (~20 lines), purely additive, non-breaking fix — all 7 pre-existing
+`test_server.py` tests still pass unchanged. `active_connections` avoids
+`service.py` reaching into `JsonRpcUnixServer`'s private `_sessions` dict
+for `daemon.status`.
 
-**Deviations from spec**: none
+Test coverage (`test_service.py`, `EchoAgent` from TASK-2210 fakes, real
+tmp UDS sockets): happy path (send, stream delta→complete, invoke
+allowlist + underscore rejection, status), scheduler-absent degradation
+(`sys.modules` patch → `schedules.list` returns 1003), SIGTERM graceful
+shutdown, a real APScheduler `MemoryJobStore` interval job firing +
+`event.job_executed` reaching a subscribed client, and `sd_notify()`
+send/no-op. 11 new tests; full `agentd/` suite (49 tests) green. `ruff
+check` clean after auto-fix.
+
+**Test-criterion substitution (documented)**: the acceptance criterion
+"assert `'aiohttp' not in sys.modules`" is not meaningful in this test
+process — the `pytest-aiohttp` plugin imports aiohttp unconditionally at
+pytest startup, before any agentd code runs, regardless of this feature.
+Replaced with an AST-based static check (`TestNoAiohttp`) verifying
+agentd's own modules (`protocol`/`config`/`server`/`client`/`service`)
+never contain an `import aiohttp`/`from aiohttp import` statement
+themselves — this is the criterion's actual intent and is robust to the
+test harness's own unrelated aiohttp import.
+
+**Design choice**: `schedules.resume` proxies to
+`AgentSchedulerManager.update_schedule(schedule_id, {"enabled": True})`
+(re-adds the job with a fresh trigger) since manager.py has no dedicated
+`resume_schedule`/`scheduler.resume_job` wrapper; `schedules.pause/remove`
+and this resume path catch generic exceptions from the manager and
+re-raise as `SCHEDULE_NOT_FOUND` (1004).

--- a/sdd/tasks/completed/TASK-2213-agentd-client.md
+++ b/sdd/tasks/completed/TASK-2213-agentd-client.md
@@ -140,10 +140,32 @@ class TestClient:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (Claude Sonnet 5)
+**Date**: 2026-08-16
+**Notes**: Implemented `client.py` with `resolve_socket()` (existing path
+passthrough, else `default_socket_path()` from TASK-2210),
+`AgentDaemonClient.connect()` (fixed-backoff retry, raises
+`DaemonNotRunning` with an actionable message after exhaustion), a
+background `_read_loop()` reader task demuxing responses by `id` (pending
+`asyncio.Future`s) and `chat.*` notifications by `stream_id` (bounded
+per-stream `asyncio.Queue`, maxsize=1024 for backpressure), `call()`
+(raises `RpcRemoteError(code, message)` on error responses),
+`stream()` (async generator yielding typed `StreamEvent` — Pydantic model
+per project convention — terminating on `complete`/`error`),
+`subscribe_events()`, and `close()` (cancels the reader, fails all pending
+calls/streams with `ConnectionClosed`). The reader loop never dies
+silently: EOF, protocol errors, and unexpected exceptions all funnel into
+`_fail_all(ConnectionClosed(...))` so no caller can hang.
 
-**Completed by**:
-**Date**:
-**Notes**:
+6 unit tests in `test_client.py` (5 from the spec + 1 extra for the event
+callback) use a scripted raw `asyncio.start_unix_server` fake — NOT
+`JsonRpcUnixServer` (TASK-2211), per the task's explicit parallel-safety
+instruction — covering: call roundtrip, error-code mapping, two
+interleaved streams demuxed correctly by `stream_id`, retry-then-
+`DaemonNotRunning`, `close()` failing a pending call with
+`ConnectionClosed` (no hang), and `event.*` notifications reaching the
+`on_event`/`subscribe_events()` callback. All 6 pass; full `agentd/` suite
+(38 tests) still green. `ruff check` clean after auto-fix (unused `noqa`,
+import ordering).
 
-**Deviations from spec**: none
+**Deviations from spec**: none.

--- a/sdd/tasks/completed/TASK-2214-agentd-console-proxy.md
+++ b/sdd/tasks/completed/TASK-2214-agentd-console-proxy.md
@@ -158,10 +158,47 @@ loaders.py/commands.py before coding; 4. index → in-progress; 5. implement;
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (Claude Sonnet 5)
+**Date**: 2026-08-16
+**Notes**: Implemented `proxy.py` with `_DaemonBotProxy` mirroring
+`_ServerBotProxy` EXACTLY (verified by a signature/coroutine-ness parity
+test against the real `_ServerBotProxy` class): `configure`, `ask`,
+`ask_stream` (async generator over `client.stream()`, terminating on
+`chat.complete`/`chat.error` without raising), `get_available_tools`/
+`get_tools_count`/`has_tools` backed by a `tools.list` fetch cached once
+via `_ensure_tools()`. `DaemonAgentProxy` mirrors `ServerAgentProxy`
+(`load`/`list_agents`/`close`); `load()` connects, subscribes to events,
+constructs the bot proxy, and pre-fetches its tool cache. Event queue: a
+bounded `deque` fed by the `subscribe_events()` callback, formatted via
+`_format_event()` (`"⏱ job <id> ejecutado ✓"` etc.), exposed only through
+`drain_events()` (never surfaced mid-turn — that's orchestrated by
+TASK-2216's attach wiring). `register_daemon_commands(repl, proxy)`
+registers `/status`, `/schedules [list|add|pause|resume|remove ...]`,
+`/invoke <method> [json-kwargs]` via `repl.register_command()`; bad JSON
+in `/schedules add`/`/invoke` renders a friendly `[red]...[/red]` message
+instead of raising.
 
-**Completed by**:
-**Date**:
-**Notes**:
+**Deviation from the task's file list (documented, not silent)**:
+`client.py` (TASK-2213) was additively modified — `AgentDaemonClient.
+call()` gained an optional keyword-only `params: dict | None = None`
+argument (merged with `**kwargs`, kwargs win on collision). This was
+required because `agent.invoke`'s own RPC params legitimately need a key
+literally named `"method"` (the target agent method to invoke), which
+collides with `call()`'s own `method: str` positional parameter — passing
+it via `**kwargs` is impossible regardless of caller. Fixed by allowing
+`call("agent.invoke", params={"method": ..., "kwargs": ...})` as an
+escape hatch. Purely additive/backward-compatible: every existing
+TASK-2213 call site (`call("ping", x=1)` etc.) is untouched and all 6
+pre-existing `test_client.py` tests still pass unchanged.
 
-**Deviations from spec**: none
+Test coverage (`test_proxy.py`): full signature/behavioural parity check
+against `_ServerBotProxy`; `ask`/`ask_stream` (interleaved delta→complete)
+and tool caching (asserting the `tools.list` RPC fires exactly once)
+against a scripted raw UDS server (same harness pattern as TASK-2213, per
+task instruction — not the real `JsonRpcUnixServer`); event queue/format/
+drain; slash-command handlers against a stubbed repl+client (status
+success/error, invoke success/bad-JSON, schedules-add bad-JSON). 9 new
+tests; full `agentd/` suite (58 tests) green. `ruff check` clean after
+auto-fix.
+
+**Deviations from spec**: none.

--- a/sdd/tasks/completed/TASK-2215-agentd-mcp-proxy.md
+++ b/sdd/tasks/completed/TASK-2215-agentd-mcp-proxy.md
@@ -153,10 +153,46 @@ AbstractTool + local_server.py first; 4. index → in-progress; 5. implement;
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (Claude Sonnet 5)
+**Date**: 2026-08-16
+**Notes**: Implemented `mcp_server.py` on top of the CORE `StdioMCPServer`/
+`MCPServerBase`/`AbstractTool` (not the integrations-local `mcp/` dir,
+which only holds OAuth): `AskAgentTool` (`chat.send` non-stream — one MCP
+process = one daemon connection = one conversation session, so history is
+shared across calls), `AgentInfoTool`, `ListSchedulesTool`,
+`DaemonStatusTool` (all JSON-encode their RPC result), and
+`InvokeMethodTool` (client-side allowlist check as defense in depth, on
+top of the daemon's own enforcement). `build_proxy_tools(client,
+exposed_methods)` registers `InvokeMethodTool` ONLY when
+`exposed_methods` is non-empty. `run_mcp_proxy(name_or_socket)` connects,
+fetches `agent.info`, builds the tool set, configures
+`LocalServerConfig`, registers on `StdioMCPServer`, and runs it — on
+`DaemonNotRunning`, prints to stderr and exits non-zero. All tool
+`_execute()` bodies use the framework's `MCPToolAdapter._execute(**arguments)`
+call contract directly (verified in `parrot.mcp.adapter`), returning plain
+strings (the adapter's documented "direct results" path) rather than
+`ToolResult` for simplicity.
 
-**Completed by**:
-**Date**:
-**Notes**:
+**Deviation from the task's file list (documented, not silent)**:
+`service.py` (TASK-2212) was additively modified — `_handle_agent_info`'s
+response now includes `"exposed_methods": list(self.config.exposed_methods)`.
+This task's own scope explicitly requires "fetch `agent.info`" to learn
+the daemon's `exposed_methods` allowlist (there is no other channel
+available to `run_mcp_proxy(name_or_socket: str)`, which only ever has a
+socket path/name — never the `AgentServiceConfig` object), but TASK-2212's
+`agent.info` handler did not surface that field. One-line, additive,
+non-breaking addition — all 58 pre-existing tests (through TASK-2214)
+still pass unchanged after the change.
 
-**Deviations from spec**: none
+Test coverage (`test_mcp_proxy.py`, scripted raw UDS server, same harness
+pattern as TASK-2213 per instruction): tool-registration matrix
+(`invoke_method` absent with an empty allowlist / present + validating
+method names with a non-empty one, exercised through
+`StdioMCPServer.handle_tools_list`/`handle_tools_call` directly — no
+subprocess), `ask_agent` end-to-end via `handle_tools_call`, and a stdio
+smoke test asserting zero stdout pollution (`capsys`) across
+`handle_initialize`/`handle_tools_list`/`handle_tools_call`. 4 new tests;
+full `agentd/` suite (62 tests) green. `ruff check` clean after auto-fix
+(import ordering).
+
+**Deviations from spec**: none.

--- a/sdd/tasks/completed/TASK-2216-agentd-cli-packaging.md
+++ b/sdd/tasks/completed/TASK-2216-agentd-cli-packaging.md
@@ -179,10 +179,61 @@ read agent_repl.py + cli/__init__.py current state; 4. index → in-progress;
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (Claude Sonnet 5)
+**Date**: 2026-08-16
+**Notes**: Implemented `cli.py` with all 6 Click commands: `serve`
+(YAML-vs-`module:attr` detection, `--name`/`--socket`/`--dsn`/`--redis`/
+`--no-redis`/`--log-level` overrides applied via `AgentServiceConfig.
+model_copy()`), `attach` (`DaemonAgentProxy` + existing `AgentREPL`/
+`REPLConfig`, `register_daemon_commands()`, friendly
+`systemctl --user status`/`parrot serve` hint on `DaemonNotRunning`),
+`ask` (one-shot, TTY-conditional Markdown vs plain `click.echo`, exit 0/1),
+`status` (pretty `daemon.status` via `ResponseRenderer.render_info`),
+`install_service` (systemd unit exactly per the task's field list —
+`After=network-online.target`, `Type=notify`, `Restart=on-failure`,
+`Environment=PYTHONUNBUFFERED=1`, `WantedBy=default.target`,
+`ExecStart` resolved from `sys.executable`'s bin dir; user mode writes
+`~/.config/systemd/user/parrot-<name>.service` + prints
+daemon-reload/enable-now follow-ups; `--system` ONLY prints to stdout,
+never writes `/etc`, never sudo), and `mcp_serve` (`asyncio.run(
+run_mcp_proxy(...))`).
 
-**Completed by**:
-**Date**:
-**Notes**:
+Core registration (`packages/ai-parrot/src/parrot/cli/__init__.py`): added
+lazy keys `serve`/`attach`/`ask`/`status`/`install-service`/`mcp-serve` →
+`parrot.integrations.agentd.cli` (verified NO key collisions against the
+existing dict first, confirming the Open-Question default: plain
+`parrot serve` etc., not `parrot agentd serve`). `LazyGroup` gained a
+generic `_lazy_extras: dict[str, str]` (any lazy command may register an
+install hint) and `get_command()` now wraps the `importlib.import_module()`
+call in try/except `ImportError`, raising `click.ClickException` with the
+hint when registered, else a generic "could not import `<module>`"
+message — never a raw traceback. Smallest-viable, fully generic change
+(not agentd-specific): all 49 pre-existing core CLI tests
+(`test_setup_wizard.py`, `test_click_wiring.py`) still pass unchanged.
 
-**Deviations from spec**: none
+Packaging: added `agentd = []` (marker extra) to
+`ai-parrot-integrations/pyproject.toml`.
+
+**Attach event-drain seam (documented choice, per task instruction)**:
+`AgentREPL.run()`'s loop is a monolithic method with no exposed post-turn
+hook, and modifying `parrot.cli.repl`/`parrot.cli.commands` in core is out
+of scope for this feature (confirmed in TASK-2214). `_wrap_with_event_
+drain()` instead shadows `repl.send`/`repl.send_stream` at the INSTANCE
+level (assigning new bound-like callables as instance attributes, which
+Python's attribute lookup prefers over the class methods `run()` calls) —
+queued job-event lines print right after a turn completes and before the
+next prompt, achieving the spec's "flush between turns only, never
+mid-stream" requirement without touching core.
+
+Test coverage (`test_cli.py`, CliRunner): `serve` YAML-arg/target-arg/
+missing-`--name`-error/override-application; `ask` success/`DaemonNotRunning`/
+non-TTY-plain-output (asserting no `\x1b[` ANSI codes — CliRunner's
+captured stdout is never a TTY, so this exercises the real plain-text
+path); `install-service` unit content (all required fields + no `sudo`)
+and `--system` stdout-only (`result.stdout` vs `result.stderr`, no file
+written); core `LazyGroup` missing-module message (monkeypatched
+`importlib.import_module`) and lazy-key registration. 11 new tests; full
+`agentd/` suite (73 tests) green. `ruff check` clean after auto-fix +
+2 manual `TRY203` (redundant except-reraise) simplifications.
+
+**Deviations from spec**: none.

--- a/sdd/tasks/completed/TASK-2217-agentd-e2e-docs.md
+++ b/sdd/tasks/completed/TASK-2217-agentd-e2e-docs.md
@@ -152,10 +152,68 @@ def test_no_aiohttp_without_server_pkg(tmp_path): ...  # subprocess-isolated
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (Claude Sonnet 5)
+**Date**: 2026-08-16
+**Notes**: Created `conftest.py` (promoted `echo_daemon`/`agentd_yaml`
+fixtures + `run_daemon`/`stop_daemon`/`wait_for_socket` helpers — kept
+`test_service.py`'s own local `echo_daemon` fixture untouched, since a
+test-module-local fixture shadows a conftest one of the same name with no
+conflict, and modifying `test_service.py` wasn't in this task's file list)
+and `test_e2e.py` with all 7 cross-module integration tests exercising the
+REAL stack (no scripted fakes): `chat.send`/stream roundtrip, two
+concurrent clients with isolated per-`session_id` history
+(`_TrackingEchoAgent`, module-level so it resolves via `importlib`), a
+real APScheduler `MemoryJobStore` interval job firing + `event.job_executed`
+reaching a subscribed `AgentDaemonClient` (`_IntervalEchoAgent`, same
+skip-if-`ai-parrot-server`-absent pattern as TASK-2212), a real subprocess
+SIGTERM graceful-shutdown test (`parrot serve` via `asyncio.create_subprocess_exec`,
+exit 0 + socket removed), `run_mcp_proxy`'s handler pieces driven directly
+against a real daemon, a CliRunner `parrot ask` end-to-end test (also via
+subprocess — see the design-fix note below), and a subprocess-isolated
+`sys.modules["parrot.scheduler.manager"] = None` test asserting `"aiohttp"
+not in sys.modules` for real (unlike TASK-2212's necessary AST substitute,
+a genuinely fresh subprocess makes this literal check meaningful again).
+Wrote `docs/agentd.md`: quickstart, full `AgentServiceConfig` field
+reference, systemd (user + `--system` print-only) + supervisord, a
+scheduler-modes matrix with a decorator example, MCP registration +
+`exposed_methods` gating warning, and a protocol appendix (method table +
+error codes) — skimmed `bot-cleanup-lifecycle.md` for tone/structure first.
 
-**Completed by**:
-**Date**:
-**Notes**:
+**Design fix found (documented, not a silent workaround)**: the original
+plan for `test_ask_oneshot_exit_codes` ran a live `AgentDaemon` in a
+background thread so a synchronous `CliRunner.invoke()` could exercise it
+without an `asyncio.run()`-inside-a-running-loop conflict. This hung
+every run: `AgentDaemon._install_signal_handlers()` calls
+`loop.add_signal_handler()`, which raises `RuntimeError: set_wakeup_fd
+only works in main thread of the main interpreter` when the daemon's loop
+lives on a non-main thread — that `RuntimeError` isn't a `NotImplementedError`,
+so it wasn't caught, crashing the daemon's `run()` task silently inside
+the thread right after the socket was already bound, leaving a dead
+listener the CLI's `ask` could connect to but never get a response from
+(the actual hang). Fixed by switching this test to a real subprocess (same
+technique as the SIGTERM test) instead of a thread — no daemon-code change
+was needed or made; this is a testing-approach fix, not a product bug (a
+real `parrot serve` process always runs in ITS OWN main thread).
 
-**Deviations from spec**: none
+**Spec §5 acceptance criteria → evidence mapping**:
+1. No aiohttp in daemon path → `test_no_aiohttp_without_server_pkg` (subprocess) + `TestNoAiohttp` (TASK-2212, AST-based).
+2. Headless scheduler (no DB/Redis) + DSN path exercised → `test_scheduler_interval_job_fires_and_event_emitted` (e2e) + `TestStartHeadless` (TASK-2209).
+3. Web-server scheduler behaviour unchanged → `packages/ai-parrot-server/tests/scheduler/` (9 tests, unmodified, still green).
+4. `parrot attach` reuses `AgentREPL` + daemon slash commands → `TestSlashCommands`/`TestProxy` (TASK-2214); interactive prompt loop itself intentionally NOT tested (out of scope, per this task's contract).
+5. `parrot ask` pipe-safe → `test_ask_oneshot_exit_codes` (e2e, real subprocess) + `TestAsk` (TASK-2216).
+6. MCP proxy tool gating → `test_mcp_stdio_ask_agent` (e2e) + `TestToolMatrix` (TASK-2215).
+7. Socket `0600`/dir `0700`, stale/already-running → `TestServer::test_permissions/test_stale_socket_reboot/test_live_socket_refuses` (TASK-2211).
+8. SIGTERM graceful, bounded by `shutdown_grace` → `test_graceful_shutdown_sigterm` (e2e, real subprocess) + `TestDegradation::test_sigterm_graceful` (TASK-2212, in-process).
+9. `install-service` valid unit, `Type=notify`/degrades → `TestInstallService` (TASK-2216) + `TestSdNotify` (TASK-2212).
+10. Core CLI degrades with actionable message → `TestCoreRegistration::test_missing_module_message` (TASK-2216).
+11. All unit + integration tests pass → 80/80 in `agentd/`, 9/9 in `ai-parrot-server/tests/scheduler/`.
+12. `docs/agentd.md` → this task.
+13. No breaking changes to existing public API → all pre-existing suites (core CLI, scheduler) verified green throughout the feature; every cross-task deviation was additive-only.
+
+Final sweep: full `agentd/` suite 80/80, `ai-parrot-server/tests/scheduler/`
+9/9, core CLI 49/49 (all run individually — a `tests.conftest` module-name
+collision when combining `ai-parrot` and `ai-parrot-server` test roots in
+ONE invocation is a pre-existing test-infra quirk, unrelated to this
+feature). `ruff check` clean across every agentd file.
+
+**Deviations from spec**: none.

--- a/sdd/tasks/index/agent-cli-daemon.json
+++ b/sdd/tasks/index/agent-cli-daemon.json
@@ -150,7 +150,7 @@
       "feature_id": "FEAT-422",
       "feature": "agent-cli-daemon",
       "spec": "sdd/specs/agent-cli-daemon.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "M",
       "depends_on": [
@@ -160,8 +160,8 @@
       "parallelism_notes": "Imports client.py; disjoint files from TASK-2214 but sequential in the single feature worktree.",
       "assigned_to": null,
       "started_at": "2026-08-16T17:35:04+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2215-agentd-mcp-proxy.md"
+      "completed_at": "2026-08-16T18:17:07+00:00",
+      "file": "sdd/tasks/completed/TASK-2215-agentd-mcp-proxy.md"
     },
     {
       "id": "TASK-2216",

--- a/sdd/tasks/index/agent-cli-daemon.json
+++ b/sdd/tasks/index/agent-cli-daemon.json
@@ -110,7 +110,7 @@
       "feature_id": "FEAT-422",
       "feature": "agent-cli-daemon",
       "spec": "sdd/specs/agent-cli-daemon.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -120,8 +120,8 @@
       "parallelism_notes": "Imports protocol.py (TASK-2208) and config.default_socket_path (TASK-2210); tests use a scripted fake server so it does NOT depend on TASK-2211/2212.",
       "assigned_to": null,
       "started_at": "2026-08-16T17:35:04+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2213-agentd-client.md"
+      "completed_at": "2026-08-16T17:58:07+00:00",
+      "file": "sdd/tasks/completed/TASK-2213-agentd-client.md"
     },
     {
       "id": "TASK-2214",

--- a/sdd/tasks/index/agent-cli-daemon.json
+++ b/sdd/tasks/index/agent-cli-daemon.json
@@ -32,7 +32,7 @@
       "feature_id": "FEAT-422",
       "feature": "agent-cli-daemon",
       "spec": "sdd/specs/agent-cli-daemon.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [],
@@ -40,8 +40,8 @@
       "parallelism_notes": "Only touches ai-parrot-server scheduler/manager.py — disjoint from all agentd package files.",
       "assigned_to": null,
       "started_at": "2026-08-16T17:35:04+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2209-scheduler-headless.md"
+      "completed_at": "2026-08-16T17:49:17+00:00",
+      "file": "sdd/tasks/completed/TASK-2209-scheduler-headless.md"
     },
     {
       "id": "TASK-2210",

--- a/sdd/tasks/index/agent-cli-daemon.json
+++ b/sdd/tasks/index/agent-cli-daemon.json
@@ -5,7 +5,7 @@
   "type": "feature",
   "base_branch": "dev",
   "created_at": "2026-08-16T19:19:45+02:00",
-  "completed_at": "2026-08-16T18:39:06+00:00",
+  "completed_at": "2026-08-16T19:28:12+00:00",
   "tasks": [
     {
       "id": "TASK-2208",
@@ -23,7 +23,8 @@
       "assigned_to": null,
       "started_at": "2026-08-16T17:35:04+00:00",
       "completed_at": "2026-08-16T17:38:45+00:00",
-      "file": "sdd/tasks/completed/TASK-2208-agentd-protocol.md"
+      "file": "sdd/tasks/completed/TASK-2208-agentd-protocol.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2209",
@@ -41,7 +42,8 @@
       "assigned_to": null,
       "started_at": "2026-08-16T17:35:04+00:00",
       "completed_at": "2026-08-16T17:49:17+00:00",
-      "file": "sdd/tasks/completed/TASK-2209-scheduler-headless.md"
+      "file": "sdd/tasks/completed/TASK-2209-scheduler-headless.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2210",
@@ -59,7 +61,8 @@
       "assigned_to": null,
       "started_at": "2026-08-16T17:35:04+00:00",
       "completed_at": "2026-08-16T17:52:09+00:00",
-      "file": "sdd/tasks/completed/TASK-2210-agentd-config.md"
+      "file": "sdd/tasks/completed/TASK-2210-agentd-config.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2211",
@@ -79,7 +82,8 @@
       "assigned_to": null,
       "started_at": "2026-08-16T17:35:04+00:00",
       "completed_at": "2026-08-16T17:54:57+00:00",
-      "file": "sdd/tasks/completed/TASK-2211-agentd-uds-server.md"
+      "file": "sdd/tasks/completed/TASK-2211-agentd-uds-server.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2212",
@@ -101,7 +105,8 @@
       "assigned_to": null,
       "started_at": "2026-08-16T17:35:04+00:00",
       "completed_at": "2026-08-16T18:06:42+00:00",
-      "file": "sdd/tasks/completed/TASK-2212-agentd-daemon-service.md"
+      "file": "sdd/tasks/completed/TASK-2212-agentd-daemon-service.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2213",
@@ -121,7 +126,8 @@
       "assigned_to": null,
       "started_at": "2026-08-16T17:35:04+00:00",
       "completed_at": "2026-08-16T17:58:07+00:00",
-      "file": "sdd/tasks/completed/TASK-2213-agentd-client.md"
+      "file": "sdd/tasks/completed/TASK-2213-agentd-client.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2214",
@@ -141,7 +147,8 @@
       "assigned_to": null,
       "started_at": "2026-08-16T17:35:04+00:00",
       "completed_at": "2026-08-16T18:13:29+00:00",
-      "file": "sdd/tasks/completed/TASK-2214-agentd-console-proxy.md"
+      "file": "sdd/tasks/completed/TASK-2214-agentd-console-proxy.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2215",
@@ -161,7 +168,8 @@
       "assigned_to": null,
       "started_at": "2026-08-16T17:35:04+00:00",
       "completed_at": "2026-08-16T18:17:07+00:00",
-      "file": "sdd/tasks/completed/TASK-2215-agentd-mcp-proxy.md"
+      "file": "sdd/tasks/completed/TASK-2215-agentd-mcp-proxy.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2216",
@@ -183,7 +191,8 @@
       "assigned_to": null,
       "started_at": "2026-08-16T17:35:04+00:00",
       "completed_at": "2026-08-16T18:23:07+00:00",
-      "file": "sdd/tasks/completed/TASK-2216-agentd-cli-packaging.md"
+      "file": "sdd/tasks/completed/TASK-2216-agentd-cli-packaging.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2217",
@@ -203,7 +212,8 @@
       "assigned_to": null,
       "started_at": "2026-08-16T17:35:04+00:00",
       "completed_at": "2026-08-16T18:39:06+00:00",
-      "file": "sdd/tasks/completed/TASK-2217-agentd-e2e-docs.md"
+      "file": "sdd/tasks/completed/TASK-2217-agentd-e2e-docs.md",
+      "verification": "verified"
     }
   ]
 }

--- a/sdd/tasks/index/agent-cli-daemon.json
+++ b/sdd/tasks/index/agent-cli-daemon.json
@@ -88,7 +88,7 @@
       "feature_id": "FEAT-422",
       "feature": "agent-cli-daemon",
       "spec": "sdd/specs/agent-cli-daemon.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "depends_on": [
@@ -100,8 +100,8 @@
       "parallelism_notes": "Integrates scheduler refactor, config and server — sequential by nature.",
       "assigned_to": null,
       "started_at": "2026-08-16T17:35:04+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2212-agentd-daemon-service.md"
+      "completed_at": "2026-08-16T18:06:42+00:00",
+      "file": "sdd/tasks/completed/TASK-2212-agentd-daemon-service.md"
     },
     {
       "id": "TASK-2213",

--- a/sdd/tasks/index/agent-cli-daemon.json
+++ b/sdd/tasks/index/agent-cli-daemon.json
@@ -170,7 +170,7 @@
       "feature_id": "FEAT-422",
       "feature": "agent-cli-daemon",
       "spec": "sdd/specs/agent-cli-daemon.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -182,8 +182,8 @@
       "parallelism_notes": "Touches shared core file parrot/cli/__init__.py and integrations pyproject — must be last implementation task.",
       "assigned_to": null,
       "started_at": "2026-08-16T17:35:04+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2216-agentd-cli-packaging.md"
+      "completed_at": "2026-08-16T18:23:07+00:00",
+      "file": "sdd/tasks/completed/TASK-2216-agentd-cli-packaging.md"
     },
     {
       "id": "TASK-2217",

--- a/sdd/tasks/index/agent-cli-daemon.json
+++ b/sdd/tasks/index/agent-cli-daemon.json
@@ -130,7 +130,7 @@
       "feature_id": "FEAT-422",
       "feature": "agent-cli-daemon",
       "spec": "sdd/specs/agent-cli-daemon.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "M",
       "depends_on": [
@@ -140,8 +140,8 @@
       "parallelism_notes": "Imports client.py; mirrors core parrot.cli loaders (read-only in core).",
       "assigned_to": null,
       "started_at": "2026-08-16T17:35:04+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2214-agentd-console-proxy.md"
+      "completed_at": "2026-08-16T18:13:29+00:00",
+      "file": "sdd/tasks/completed/TASK-2214-agentd-console-proxy.md"
     },
     {
       "id": "TASK-2215",

--- a/sdd/tasks/index/agent-cli-daemon.json
+++ b/sdd/tasks/index/agent-cli-daemon.json
@@ -68,7 +68,7 @@
       "feature_id": "FEAT-422",
       "feature": "agent-cli-daemon",
       "spec": "sdd/specs/agent-cli-daemon.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -78,8 +78,8 @@
       "parallelism_notes": "Imports protocol.py from TASK-2208.",
       "assigned_to": null,
       "started_at": "2026-08-16T17:35:04+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2211-agentd-uds-server.md"
+      "completed_at": "2026-08-16T17:54:57+00:00",
+      "file": "sdd/tasks/completed/TASK-2211-agentd-uds-server.md"
     },
     {
       "id": "TASK-2212",

--- a/sdd/tasks/index/agent-cli-daemon.json
+++ b/sdd/tasks/index/agent-cli-daemon.json
@@ -50,7 +50,7 @@
       "feature_id": "FEAT-422",
       "feature": "agent-cli-daemon",
       "spec": "sdd/specs/agent-cli-daemon.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "S",
       "depends_on": [],
@@ -58,8 +58,8 @@
       "parallelism_notes": "New file agentd/config.py + test fakes; no imports from other pending tasks.",
       "assigned_to": null,
       "started_at": "2026-08-16T17:35:04+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2210-agentd-config.md"
+      "completed_at": "2026-08-16T17:52:09+00:00",
+      "file": "sdd/tasks/completed/TASK-2210-agentd-config.md"
     },
     {
       "id": "TASK-2211",

--- a/sdd/tasks/index/agent-cli-daemon.json
+++ b/sdd/tasks/index/agent-cli-daemon.json
@@ -14,7 +14,7 @@
       "feature_id": "FEAT-422",
       "feature": "agent-cli-daemon",
       "spec": "sdd/specs/agent-cli-daemon.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [],
@@ -22,8 +22,8 @@
       "parallelism_notes": "New files only (agentd/protocol.py); shares no files or imports with TASK-2209/2210.",
       "assigned_to": null,
       "started_at": "2026-08-16T17:35:04+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2208-agentd-protocol.md"
+      "completed_at": "2026-08-16T17:38:45+00:00",
+      "file": "sdd/tasks/completed/TASK-2208-agentd-protocol.md"
     },
     {
       "id": "TASK-2209",

--- a/sdd/tasks/index/agent-cli-daemon.json
+++ b/sdd/tasks/index/agent-cli-daemon.json
@@ -5,7 +5,7 @@
   "type": "feature",
   "base_branch": "dev",
   "created_at": "2026-08-16T19:19:45+02:00",
-  "completed_at": null,
+  "completed_at": "2026-08-16T18:39:06+00:00",
   "tasks": [
     {
       "id": "TASK-2208",
@@ -192,7 +192,7 @@
       "feature_id": "FEAT-422",
       "feature": "agent-cli-daemon",
       "spec": "sdd/specs/agent-cli-daemon.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "M",
       "depends_on": [
@@ -202,8 +202,8 @@
       "parallelism_notes": "Tests the as-built full stack; closes spec §5 acceptance criteria.",
       "assigned_to": null,
       "started_at": "2026-08-16T17:35:04+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2217-agentd-e2e-docs.md"
+      "completed_at": "2026-08-16T18:39:06+00:00",
+      "file": "sdd/tasks/completed/TASK-2217-agentd-e2e-docs.md"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Implements FEAT-422 — Agent CLI Daemon (agentd): a per-agent *Nix service
with Rich console, JSON-RPC/UDS transport, and MCP stdio proxy, per
`sdd/specs/agent-cli-daemon.spec.md`.

New `parrot.integrations.agentd` package (ai-parrot-integrations):
- **Protocol** — JSON-RPC 2.0 / NDJSON framing (`protocol.py`)
- **Config** — `AgentServiceConfig` YAML + `module:attr` target resolution (`config.py`)
- **Server** — `JsonRpcUnixServer`: UDS server, sessions, dispatch, event broker (`server.py`)
- **Service** — `AgentDaemon`: lifecycle, RPC handlers, `SingleAgentManager`, `sd_notify` (`service.py`)
- **Client** — `AgentDaemonClient`: async UDS JSON-RPC client (`client.py`)
- **Proxy** — `DaemonAgentProxy` + daemon slash commands for the existing `AgentREPL` (`proxy.py`)
- **MCP** — stdio proxy exposing the daemon to external LLMs (`mcp_server.py`)
- **CLI** — `serve`/`attach`/`ask`/`status`/`install-service`/`mcp-serve`, lazily registered into core `parrot` (`cli.py`)

Also: `AgentSchedulerManager.start_headless()`/`stop_headless()` in
ai-parrot-server (headless APScheduler bootstrap, no aiohttp), a minimal
`ai-parrot[agentd]` packaging extra, and `docs/agentd.md`.

## Tasks

10/10 tasks verified (TASK-2208 – TASK-2217). See
`sdd/tasks/index/agent-cli-daemon.json` for the full per-task record.

## Testing

- 82 `agentd/` tests + 12 `ai-parrot-server` scheduler tests + 49 core CLI
  tests green.
- Adversarial code review completed: 5 critical + 2 important findings,
  all fixed with regression tests added (response-shape stringification
  bugs, a client-side stream-registration race, a SIGTERM handling race,
  and an aiohttp-scheduler behaviour-preservation fix). 3 minor
  suggestions noted below for the human reviewer.
- `ruff check` clean on every touched file.
- SIGTERM graceful-shutdown test stress-run 5/5 stable after the fix.

## Notes for reviewer

- `AgentSchedulerManager.start_headless()` gained a `register_listeners`
  param so the aiohttp path stays behaviour-preserving while the
  standalone daemon path gets `define_listeners()` wired (previously dead
  code) — worth a second look given it touches shared scheduler code.
- Minor open items (not blocking): `AgentDaemonClient.call()`'s `params`
  kwarg could theoretically collide with a same-named RPC field; core
  `LazyGroup`'s generic missing-module handler doesn't surface the
  underlying `ImportError` text; RPC/`RpcHandlerError` messages are
  returned verbatim to callers (fine today, worth a stricter allowlist in
  a future hardening pass if agent methods start raising exceptions with
  sensitive internal state).

---
_Closed by /sdd-done_