### PR TITLE
fix(quickeda): FEAT-424 — escape DataFrame values in HTML output (XSS)

### DIFF
--- a/packages/ai-parrot-tools/src/parrot_tools/dftohtml.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/dftohtml.py
@@ -31,8 +31,8 @@ class DfToHtmlArgs(BaseModel):
         description="Whether to include the DataFrame index in the HTML"
     )
     escape: bool = Field(
-        default=False,
-        description="Whether to escape HTML characters in the data"
+        default=True,
+        description="Whether to escape HTML characters in the data (disable only for pre-sanitized content)"
     )
     max_rows: Optional[int] = Field(
         default=None,
@@ -172,7 +172,7 @@ class DfToHtmlTool(AbstractTool):
         table_id: Optional[str] = None,
         css_classes: str = "dataframe table table-striped table-hover",
         include_index: bool = True,
-        escape: bool = False,
+        escape: bool = True,
         max_rows: Optional[int] = None,
         max_cols: Optional[int] = None,
         table_attributes: Optional[str] = None,

--- a/packages/ai-parrot-tools/src/parrot_tools/dftohtml.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/dftohtml.py
@@ -3,6 +3,7 @@ DataFrame to HTML Tool - Convert pandas DataFrames to styled HTML tables.
 """
 from typing import Any, Dict, Optional
 from pathlib import Path
+from html import escape as html_escape
 import pandas as pd
 from pydantic import BaseModel, Field
 from .abstract import AbstractTool
@@ -210,17 +211,37 @@ class DfToHtmlTool(AbstractTool):
 
         # Convert DataFrame to HTML using pandas styler for better control
         try:
+            # NOTE: Styler.to_html() has no `escape` kwarg of its own —
+            # escaping must be applied via `.format(escape="html")` /
+            # `.format_index(escape="html", axis=...)` before rendering,
+            # otherwise cell values, column headers, AND row index labels
+            # (all attacker-controlled, e.g. CSV headers) pass through
+            # unescaped (XSS). `.format()` only covers cell values, so both
+            # axes need their own `.format_index()` call. The axis *names*
+            # (`df.index.name` / `df.columns.name`, rendered as the
+            # `index_name` header cell) are a further gap: neither
+            # `.format()` nor `.format_index()` touches them, so they are
+            # escaped directly on `df_to_convert` (already a copy) before
+            # the styler is built.
+            if escape:
+                if df_to_convert.index.name is not None:
+                    df_to_convert.index.name = html_escape(str(df_to_convert.index.name))
+                if df_to_convert.columns.name is not None:
+                    df_to_convert.columns.name = html_escape(str(df_to_convert.columns.name))
+
             # Use pandas styler for more advanced styling options
             styler = df_to_convert.style
 
             # Set table attributes
             styler = styler.set_table_attributes(table_attrs)
 
-            # NOTE: Styler.to_html() has no `escape` kwarg of its own —
-            # escaping must be applied via `.format(escape="html")` before
-            # rendering, otherwise cell values pass through unescaped (XSS).
             if escape:
-                styler = styler.format(escape="html")
+                styler = (
+                    styler
+                    .format(escape="html")
+                    .format_index(escape="html", axis=0)
+                    .format_index(escape="html", axis=1)
+                )
 
             # Convert to HTML
             table_html = styler.to_html(

--- a/packages/ai-parrot-tools/src/parrot_tools/dftohtml.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/dftohtml.py
@@ -216,9 +216,14 @@ class DfToHtmlTool(AbstractTool):
             # Set table attributes
             styler = styler.set_table_attributes(table_attrs)
 
+            # NOTE: Styler.to_html() has no `escape` kwarg of its own —
+            # escaping must be applied via `.format(escape="html")` before
+            # rendering, otherwise cell values pass through unescaped (XSS).
+            if escape:
+                styler = styler.format(escape="html")
+
             # Convert to HTML
             table_html = styler.to_html(
-                escape=escape,
                 table_uuid=table_id
             )
 

--- a/packages/ai-parrot-tools/src/parrot_tools/quickeda.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/quickeda.py
@@ -264,15 +264,34 @@ class QuickEdaTool(AbstractTool):
     def _df_to_html_with_style(self, df_input: pd.DataFrame, title: str = "") -> str:
         """Convert DataFrame to HTML with styling.
 
-        Cell values and column headers are HTML-escaped, and any caption
-        `title` is escaped before being set, to prevent XSS when rendering
-        user-supplied DataFrames (column names and cell values are both
-        attacker-controlled, e.g. via an uploaded CSV).
+        Cell values, column headers, AND the row index are HTML-escaped
+        (`.format()` only covers cell values — index labels on either axis
+        require a separate `.format_index()` call), and any caption `title`
+        is escaped before being set, to prevent XSS when rendering
+        user-supplied DataFrames. Row index labels are just as
+        attacker-controlled as cell values or column names here: several
+        callers (e.g. `_generate_categorical_section`'s `value_counts()`
+        result, `_generate_descriptive_stats_section`'s transposed
+        `describe()`) put user data directly into the index.
+
+        The axis *names* (`df.index.name` / `df.columns.name`, rendered by
+        the Styler as the `index_name` header cell) are a separate gap:
+        neither `.format()` nor `.format_index()` touches them, so they are
+        escaped manually on a copy before styling — this is exactly the
+        path `value_counts().to_frame()` hits, since the resulting index
+        inherits the (attacker-controlled) source column's name.
         """
+        df_input = df_input.copy()
+        if df_input.index.name is not None:
+            df_input.index.name = escape(str(df_input.index.name))
+        if df_input.columns.name is not None:
+            df_input.columns.name = escape(str(df_input.columns.name))
+
         styler = (
             df_input.style
             .set_table_attributes('class="dataframe"')
             .format(escape="html")
+            .format_index(escape="html", axis=0)
             .format_index(escape="html", axis=1)
         )
         if title:

--- a/packages/ai-parrot-tools/src/parrot_tools/quickeda.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/quickeda.py
@@ -264,16 +264,19 @@ class QuickEdaTool(AbstractTool):
     def _df_to_html_with_style(self, df_input: pd.DataFrame, title: str = "") -> str:
         """Convert DataFrame to HTML with styling.
 
-        Cell values are HTML-escaped to prevent XSS when rendering
-        user-supplied DataFrames.
+        Cell values and column headers are HTML-escaped, and any caption
+        `title` is escaped before being set, to prevent XSS when rendering
+        user-supplied DataFrames (column names and cell values are both
+        attacker-controlled, e.g. via an uploaded CSV).
         """
         styler = (
             df_input.style
             .set_table_attributes('class="dataframe"')
             .format(escape="html")
+            .format_index(escape="html", axis=1)
         )
         if title:
-            styler = styler.set_caption(title)
+            styler = styler.set_caption(escape(title))
         return styler.to_html()
 
     def _generate_basic_info_section(self, df: pd.DataFrame) -> str:

--- a/packages/ai-parrot-tools/src/parrot_tools/quickeda.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/quickeda.py
@@ -262,8 +262,16 @@ class QuickEdaTool(AbstractTool):
         return img_base64
 
     def _df_to_html_with_style(self, df_input: pd.DataFrame, title: str = "") -> str:
-        """Convert DataFrame to HTML with styling."""
-        styler = df_input.style.set_table_attributes('class="dataframe"')
+        """Convert DataFrame to HTML with styling.
+
+        Cell values are HTML-escaped to prevent XSS when rendering
+        user-supplied DataFrames.
+        """
+        styler = (
+            df_input.style
+            .set_table_attributes('class="dataframe"')
+            .format(escape="html")
+        )
         if title:
             styler = styler.set_caption(title)
         return styler.to_html()

--- a/packages/ai-parrot-tools/tests/test_quickeda_xss.py
+++ b/packages/ai-parrot-tools/tests/test_quickeda_xss.py
@@ -71,8 +71,57 @@ class TestDfToHtmlEscaping:
     def test_title_does_not_inject(self, tool):
         df = pd.DataFrame({"col": ["safe"]})
         html = tool._df_to_html_with_style(df, title="<script>bad</script>")
-        # set_caption may or may not escape; verify no raw <script> tag
         assert "<script>bad</script>" not in html
+        assert "&lt;script&gt;bad&lt;/script&gt;" in html
+
+    def test_row_index_label_escaped(self, tool):
+        """Row index labels are attacker-controlled too (e.g. value_counts()
+        results, transposed describe()) — `.format()` alone does not cover
+        them, only `.format_index(axis=0)` does."""
+        df = pd.DataFrame(
+            {"Count": [1]},
+            index=pd.Index(["<script>alert(1)</script>"]),
+        )
+        html = tool._df_to_html_with_style(df)
+        assert "<script>alert(1)</script>" not in html
+        assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+
+    def test_index_name_escaped(self, tool):
+        """`df.index.name` is rendered as a separate `index_name` header
+        cell that neither `.format()` nor `.format_index()` touches — it
+        must be escaped independently. This is exactly the shape produced
+        by `value_counts().to_frame()`, which inherits the source column's
+        (attacker-controlled) name as the index name."""
+        df = pd.DataFrame({"Count": [1]})
+        df.index.name = "<script>alert(1)</script>"
+        html = tool._df_to_html_with_style(df)
+        assert "<script>alert(1)</script>" not in html
+        assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+
+    def test_columns_name_escaped(self, tool):
+        """`df.columns.name` has the same gap as `df.index.name`."""
+        df = pd.DataFrame({"col": [1]})
+        df.columns.name = "<script>alert(1)</script>"
+        html = tool._df_to_html_with_style(df)
+        assert "<script>alert(1)</script>" not in html
+        assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+
+    @pytest.mark.asyncio
+    async def test_execute_categorical_section_value_counts_escaped(self, tool):
+        """End-to-end regression: a malicious column name AND a malicious
+        categorical value must both come out escaped in the full report,
+        via the real `_generate_categorical_section` -> `value_counts()`
+        -> `_df_to_html_with_style()` path (not just the private helper in
+        isolation)."""
+        malicious_col = "<script>alert(1)</script>"
+        malicious_val = "<img src=x onerror=alert(2)>"
+        df = pd.DataFrame({malicious_col: [malicious_val, malicious_val, "safe"]})
+        result = await tool._execute(dataframe=df)
+        html = result["html"]
+        assert malicious_col not in html
+        assert malicious_val not in html
+        assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+        assert "&lt;img src=x onerror=alert(2)&gt;" in html
 
 
 class TestDfToHtmlDefaultEscape:
@@ -87,8 +136,25 @@ class TestDfToHtmlDefaultEscape:
         assert "&lt;script&gt;" in result["html"]
 
     @pytest.mark.asyncio
+    async def test_column_header_escaped_by_default(self):
+        """Column names are just as attacker-controlled as cell values
+        (e.g. CSV headers) — the default `escape=True` must cover them."""
+        tool = DfToHtmlTool()
+        df = pd.DataFrame({"<script>alert(1)</script>": ["safe"]})
+        result = await tool._execute(dataframe=df)
+        assert "<script>alert(1)</script>" not in result["html"]
+        assert "&lt;script&gt;alert(1)&lt;/script&gt;" in result["html"]
+
+    @pytest.mark.asyncio
     async def test_escape_false_passes_through(self):
         tool = DfToHtmlTool()
         df = pd.DataFrame({"col": ["<b>bold</b>"]})
+        result = await tool._execute(dataframe=df, escape=False)
+        assert "<b>bold</b>" in result["html"]
+
+    @pytest.mark.asyncio
+    async def test_escape_false_column_header_passes_through(self):
+        tool = DfToHtmlTool()
+        df = pd.DataFrame({"<b>bold</b>": ["safe"]})
         result = await tool._execute(dataframe=df, escape=False)
         assert "<b>bold</b>" in result["html"]

--- a/packages/ai-parrot-tools/tests/test_quickeda_xss.py
+++ b/packages/ai-parrot-tools/tests/test_quickeda_xss.py
@@ -1,0 +1,94 @@
+"""XSS regression tests for QuickEdaTool and DfToHtmlTool HTML output.
+
+Prevents regression of GitHub Issue #1159:
+  security(quickeda): unescaped DataFrame values in _df_to_html_with_style()
+"""
+import pandas as pd
+import pytest
+from parrot_tools.dftohtml import DfToHtmlTool
+from parrot_tools.quickeda import QuickEdaTool
+
+# ── XSS payloads ──────────────────────────────────────────────
+
+PAYLOADS = [
+    "<script>alert(1)</script>",
+    "<img src=x onerror=alert(1)>",
+    '"><svg/onload=alert(1)>',
+    "</td><td><script>alert(1)</script>",
+]
+
+ESCAPED_MARKERS = [
+    "&lt;script&gt;",
+    "&lt;img",
+    "&lt;svg",
+    "&lt;/td&gt;",
+]
+
+
+@pytest.fixture
+def tool():
+    return QuickEdaTool()
+
+
+@pytest.fixture
+def xss_df():
+    return pd.DataFrame({"category": PAYLOADS, "value": range(len(PAYLOADS))})
+
+
+class TestDfToHtmlEscaping:
+    """Verify _df_to_html_with_style() HTML-escapes cell values."""
+
+    def test_script_tag_escaped(self, tool):
+        df = pd.DataFrame({"col": ["<script>alert(1)</script>"]})
+        html = tool._df_to_html_with_style(df)
+        assert "<script>" not in html
+        assert "&lt;script&gt;" in html
+
+    def test_img_onerror_escaped(self, tool):
+        df = pd.DataFrame({"col": ["<img src=x onerror=alert(1)>"]})
+        html = tool._df_to_html_with_style(df)
+        assert "<img " not in html
+        assert "&lt;img" in html
+
+    def test_all_payloads_escaped(self, tool, xss_df):
+        html = tool._df_to_html_with_style(xss_df)
+        for payload, marker in zip(PAYLOADS, ESCAPED_MARKERS):
+            assert payload not in html, f"Raw payload found: {payload}"
+            assert marker in html, f"Escaped marker missing: {marker}"
+
+    def test_legitimate_data_preserved(self, tool):
+        df = pd.DataFrame({"name": ["Alice", "Bob"], "score": [95, 87]})
+        html = tool._df_to_html_with_style(df)
+        assert "Alice" in html
+        assert "Bob" in html
+
+    def test_column_name_with_html_escaped(self, tool):
+        df = pd.DataFrame({"<b>name</b>": ["Alice"]})
+        html = tool._df_to_html_with_style(df)
+        assert "<b>name</b>" not in html
+        assert "&lt;b&gt;" in html
+
+    def test_title_does_not_inject(self, tool):
+        df = pd.DataFrame({"col": ["safe"]})
+        html = tool._df_to_html_with_style(df, title="<script>bad</script>")
+        # set_caption may or may not escape; verify no raw <script> tag
+        assert "<script>bad</script>" not in html
+
+
+class TestDfToHtmlDefaultEscape:
+    """Verify DfToHtmlTool defaults to escape=True after TASK-2224."""
+
+    @pytest.mark.asyncio
+    async def test_default_escapes(self):
+        tool = DfToHtmlTool()
+        df = pd.DataFrame({"col": ["<script>alert(1)</script>"]})
+        result = await tool._execute(dataframe=df)
+        assert "<script>" not in result["html"]
+        assert "&lt;script&gt;" in result["html"]
+
+    @pytest.mark.asyncio
+    async def test_escape_false_passes_through(self):
+        tool = DfToHtmlTool()
+        df = pd.DataFrame({"col": ["<b>bold</b>"]})
+        result = await tool._execute(dataframe=df, escape=False)
+        assert "<b>bold</b>" in result["html"]

--- a/sdd/tasks/completed/TASK-2224-escape-styler-html-output.md
+++ b/sdd/tasks/completed/TASK-2224-escape-styler-html-output.md
@@ -171,6 +171,46 @@ task):
   headers), added `.format_index(escape="html", axis=1)` to the chain
   and `html.escape(title)` before `set_caption()`.
 
+**Critical follow-up (post code-review, before push)**: the dispatched
+`code-reviewer` agent built end-to-end repros against the patched code
+and found the fix above was still materially incomplete — confirmed by
+an independent Codex cross-check with pandas-source citations. Two more
+gaps, closed in the same files:
+
+- **Row index (axis=0) never escaped.** `.format_index(..., axis=1)`
+  only covers column headers; the row *index* needs its own
+  `.format_index(escape="html", axis=0)` call. Real attacker-reachable
+  paths in `quickeda.py`: `_generate_missing_values_section`'s
+  `to_frame()`, `_generate_descriptive_stats_section`'s transposed
+  `describe()`, and — the exact payload class this fix targets —
+  `_generate_categorical_section`'s `value_counts().to_frame()`, whose
+  index holds the actual category *values* from user data. `dftohtml.py`
+  had no `.format_index()` at all for either axis, so `escape=True`
+  (the new default) did not protect column headers or the index either.
+  Added `.format_index(escape="html", axis=0)` (and confirmed axis=1
+  was already/now present) in both files.
+- **Axis *names* (`df.index.name` / `df.columns.name`) are a third,
+  separate gap** — pandas' Styler renders them as a distinct
+  `class="index_name"` header cell that neither `.format()` nor
+  `.format_index()` touches at all (verified against pandas 2.2.3
+  directly: a `.format_index(escape="html")`-wrapped Styler still
+  renders a raw `<script>` tag from `index.name`). This is exactly what
+  `value_counts().to_frame()` produces: the resulting index inherits the
+  source column's (attacker-controlled) name. Fixed by escaping
+  `index.name` / `columns.name` in place on a DataFrame copy, in both
+  `quickeda.py` and `dftohtml.py` (`dftohtml.py`'s escaping is gated on
+  `escape=True`, preserving the `escape=False` pre-sanitized-content
+  opt-out).
+
+Re-verified end-to-end after this follow-up: a malicious column name
+(`<script>alert(1)</script>`) fed through the real
+`QuickEdaTool._execute()` → `_generate_categorical_section` →
+`value_counts()` path, and a malicious categorical value
+(`<img src=x onerror=alert(2)>`), both now come out escaped in the full
+report HTML — this exact case was the reviewer's failing repro before
+the fix. Also added 6 end-to-end regression tests to TASK-2225's test
+file covering all three gaps (see that task's completion note).
+
 Sweep of `parrot_tools/` for other unescaped `to_html()` call sites (item 3
 in Scope):
 - `edareport.py:226` — `ProfileReport.to_html()` (ydata-profiling's own

--- a/sdd/tasks/completed/TASK-2224-escape-styler-html-output.md
+++ b/sdd/tasks/completed/TASK-2224-escape-styler-html-output.md
@@ -2,10 +2,10 @@
 
 **Feature**: quickeda-html-escape-xss (FEAT-424)
 **Spec**: n/a — bug fix from [GitHub Issue #1159](https://github.com/phenobarbital/ai-parrot/issues/1159)
-**Status**: [ ] pending
+**Status**: [x] done
 **Priority**: critical
 **Depends-on**: none
-**Assigned-to**: unassigned
+**Assigned-to**: sdd-worker
 
 ## Context
 
@@ -141,4 +141,22 @@ When complete, the agent must:
 3. Add a brief completion note below
 
 ### Completion Note
-(Agent fills this in when done)
+
+Applied `.format(escape="html")` to the Styler chain in
+`_df_to_html_with_style()` (`quickeda.py`), and flipped `DfToHtmlArgs.escape`
+default (and the corresponding `_execute()` parameter default) to `True` in
+`dftohtml.py`, matching the "After" snippets in this task exactly. Verified
+manually with the payload from the task's Verification section — `<img`
+does not survive, `&lt;img` does.
+
+Sweep of `parrot_tools/` for other unescaped `to_html()` call sites (item 3
+in Scope):
+- `edareport.py:226` — `ProfileReport.to_html()` (ydata-profiling's own
+  renderer, not raw pandas). Out of scope for this fix; left un-annotated
+  in code since `edareport.py` is not listed in this task's Files to
+  Create/Modify (Cardinal Rule: file fidelity) — documented here instead.
+- `correlationanalysis.py:388` — `correlation_df.to_html(classes=...,
+  table_id=...)` with no `escape=` kwarg, so it uses pandas'
+  `DataFrame.to_html()` default of `escape=True` already. Not a
+  vulnerability; no change needed.
+- No other `.style...to_html()` or `DataFrame.to_html()` call sites found.

--- a/sdd/tasks/completed/TASK-2224-escape-styler-html-output.md
+++ b/sdd/tasks/completed/TASK-2224-escape-styler-html-output.md
@@ -149,6 +149,28 @@ default (and the corresponding `_execute()` parameter default) to `True` in
 manually with the payload from the task's Verification section — `<img`
 does not survive, `&lt;img` does.
 
+Two follow-up corrections beyond the literal Before/After snippets, made
+after writing TASK-2225's regression tests surfaced they were needed to
+close the actual XSS vector and to satisfy that task's given test
+scaffold (both changes stayed inside files already authorized for this
+task):
+
+- **`dftohtml.py`**: `Styler.to_html()` has no `escape` kwarg in pandas
+  2.2 (it silently absorbs it into `**kwargs` and does nothing) — passing
+  `escape=escape` there, as the original code did, never actually escaped
+  anything regardless of the flag's value. Fixed by applying
+  `.format(escape="html")` to the styler conditionally on `escape` before
+  calling `.to_html()` (mirroring the `quickeda.py` fix), and dropped the
+  no-op `escape=` kwarg from the `.to_html()` call. Confirmed manually:
+  default now escapes `<script>`, `escape=False` still passes through
+  raw HTML for pre-sanitized content.
+- **`quickeda.py`**: `.format(escape="html")` only escapes *cell* values,
+  not column headers (`.format_index(..., axis=1)` needed) or the
+  `set_caption()` title (Styler never escapes captions). Since column
+  names are just as attacker-controlled as cell values (e.g. CSV
+  headers), added `.format_index(escape="html", axis=1)` to the chain
+  and `html.escape(title)` before `set_caption()`.
+
 Sweep of `parrot_tools/` for other unescaped `to_html()` call sites (item 3
 in Scope):
 - `edareport.py:226` — `ProfileReport.to_html()` (ydata-profiling's own

--- a/sdd/tasks/completed/TASK-2225-quickeda-xss-regression-test.md
+++ b/sdd/tasks/completed/TASK-2225-quickeda-xss-regression-test.md
@@ -2,10 +2,10 @@
 
 **Feature**: quickeda-html-escape-xss (FEAT-424)
 **Spec**: n/a — bug fix from [GitHub Issue #1159](https://github.com/phenobarbital/ai-parrot/issues/1159)
-**Status**: [ ] pending
+**Status**: [x] done
 **Priority**: critical
 **Depends-on**: TASK-2224
-**Assigned-to**: unassigned
+**Assigned-to**: sdd-worker
 
 ## Context
 
@@ -175,4 +175,24 @@ When complete, the agent must:
 3. Add a brief completion note below
 
 ### Completion Note
-(Agent fills this in when done)
+
+Created `packages/ai-parrot-tools/tests/test_quickeda_xss.py` exactly per
+the test scaffold in this task (`TestDfToHtmlEscaping` +
+`TestDfToHtmlDefaultEscape`, 8 tests total). All 8 pass against the
+TASK-2224 fix.
+
+Writing/running these tests against the literal TASK-2224 fix surfaced
+two gaps that made 3 of the given tests fail (`test_column_name_with_
+html_escaped`, `test_title_does_not_inject`, and — for `DfToHtmlTool` —
+`test_default_escapes`): `.format(escape="html")` alone does not escape
+column headers or `set_caption()` text, and `Styler.to_html()` has no
+functional `escape` kwarg in pandas 2.2 (dftohtml.py's original
+`escape=escape` argument to it was a silent no-op). Both were fixed as a
+TASK-2224 follow-up (see that task's amended Completion Note) since the
+files were already in TASK-2224's scope; this task's commit only adds
+the new test file. Verified the negative control manually: reverting the
+`quickeda.py` escaping calls makes 5 of these 8 tests fail (confirmed,
+then restored) — satisfying the "tests fail if the fix is removed"
+acceptance criterion.
+
+`ruff check` on the new test file: clean.

--- a/sdd/tasks/completed/TASK-2225-quickeda-xss-regression-test.md
+++ b/sdd/tasks/completed/TASK-2225-quickeda-xss-regression-test.md
@@ -196,3 +196,30 @@ then restored) — satisfying the "tests fail if the fix is removed"
 acceptance criterion.
 
 `ruff check` on the new test file: clean.
+
+**Critical follow-up (post code-review, before push)**: a dispatched
+`code-reviewer` agent (cross-checked independently by Codex) found the
+initial 8-test suite above did not exercise two further, real
+attacker-reachable escaping gaps in the TASK-2224 fix (row index labels
+on axis=0, and the separate `df.index.name`/`df.columns.name` "axis
+name" gap that neither `.format()` nor `.format_index()` covers — see
+TASK-2224's amended completion note for the full technical detail).
+Added 6 more tests, bringing the file to 14 tests total:
+
+- `test_row_index_label_escaped` — index labels via `pd.Index(...)`.
+- `test_index_name_escaped` / `test_columns_name_escaped` — the
+  axis-name gap directly.
+- `test_execute_categorical_section_value_counts_escaped` — end-to-end
+  through the *real* `QuickEdaTool._execute()` →
+  `_generate_categorical_section` → `value_counts()` path (the
+  reviewer's point that testing the private helper in isolation missed
+  this), with both a malicious column name and a malicious categorical
+  value.
+- `test_column_header_escaped_by_default` /
+  `test_escape_false_column_header_passes_through` — `DfToHtmlTool`
+  column-header coverage for both the new default and the opt-out.
+
+Also strengthened `test_title_does_not_inject` (reviewer nitpick) to
+assert the escaped marker is present, not just that the raw tag is
+absent. All 14 tests pass against the fully-patched code; `ruff check`
+still clean.

--- a/sdd/tasks/index/quickeda-html-escape-xss.json
+++ b/sdd/tasks/index/quickeda-html-escape-xss.json
@@ -14,11 +14,12 @@
       "feature": "quickeda-html-escape-xss",
       "slug": "escape-styler-html-output",
       "title": "Escape DataFrame cell values in _df_to_html_with_style()",
-      "status": "pending",
+      "status": "in-progress",
       "priority": "critical",
       "depends_on": [],
       "assigned_to": null,
-      "file": "sdd/tasks/active/TASK-2224-escape-styler-html-output.md"
+      "file": "sdd/tasks/active/TASK-2224-escape-styler-html-output.md",
+      "started_at": "2026-08-16T22:50:03+00:00"
     },
     {
       "id": "TASK-2225",
@@ -26,11 +27,14 @@
       "feature": "quickeda-html-escape-xss",
       "slug": "quickeda-xss-regression-test",
       "title": "Add XSS regression tests for QuickEdaTool HTML output",
-      "status": "pending",
+      "status": "in-progress",
       "priority": "critical",
-      "depends_on": ["TASK-2224"],
+      "depends_on": [
+        "TASK-2224"
+      ],
       "assigned_to": null,
-      "file": "sdd/tasks/active/TASK-2225-quickeda-xss-regression-test.md"
+      "file": "sdd/tasks/active/TASK-2225-quickeda-xss-regression-test.md",
+      "started_at": "2026-08-16T22:50:03+00:00"
     }
   ]
 }

--- a/sdd/tasks/index/quickeda-html-escape-xss.json
+++ b/sdd/tasks/index/quickeda-html-escape-xss.json
@@ -5,7 +5,7 @@
   "type": "hotfix",
   "base_branch": "dev",
   "created_at": "2026-08-17T00:00:00+00:00",
-  "completed_at": null,
+  "completed_at": "2026-08-16T22:57:00+00:00",
   "github_issue": "https://github.com/phenobarbital/ai-parrot/issues/1159",
   "tasks": [
     {
@@ -28,14 +28,15 @@
       "feature": "quickeda-html-escape-xss",
       "slug": "quickeda-xss-regression-test",
       "title": "Add XSS regression tests for QuickEdaTool HTML output",
-      "status": "in-progress",
+      "status": "done",
       "priority": "critical",
       "depends_on": [
         "TASK-2224"
       ],
       "assigned_to": null,
-      "file": "sdd/tasks/active/TASK-2225-quickeda-xss-regression-test.md",
-      "started_at": "2026-08-16T22:50:03+00:00"
+      "file": "sdd/tasks/completed/TASK-2225-quickeda-xss-regression-test.md",
+      "started_at": "2026-08-16T22:50:03+00:00",
+      "completed_at": "2026-08-16T22:57:00+00:00"
     }
   ]
 }

--- a/sdd/tasks/index/quickeda-html-escape-xss.json
+++ b/sdd/tasks/index/quickeda-html-escape-xss.json
@@ -2,7 +2,7 @@
   "feature": "quickeda-html-escape-xss",
   "feature_id": "FEAT-424",
   "spec": null,
-  "type": "hotfix",
+  "type": "feature",
   "base_branch": "dev",
   "created_at": "2026-08-17T00:00:00+00:00",
   "completed_at": "2026-08-16T22:57:00+00:00",
@@ -20,7 +20,8 @@
       "assigned_to": null,
       "file": "sdd/tasks/completed/TASK-2224-escape-styler-html-output.md",
       "started_at": "2026-08-16T22:50:03+00:00",
-      "completed_at": "2026-08-16T22:52:12+00:00"
+      "completed_at": "2026-08-16T22:52:12+00:00",
+      "verification": "verified"
     },
     {
       "id": "TASK-2225",
@@ -36,7 +37,8 @@
       "assigned_to": null,
       "file": "sdd/tasks/completed/TASK-2225-quickeda-xss-regression-test.md",
       "started_at": "2026-08-16T22:50:03+00:00",
-      "completed_at": "2026-08-16T22:57:00+00:00"
+      "completed_at": "2026-08-16T22:57:00+00:00",
+      "verification": "verified"
     }
   ]
 }

--- a/sdd/tasks/index/quickeda-html-escape-xss.json
+++ b/sdd/tasks/index/quickeda-html-escape-xss.json
@@ -14,12 +14,13 @@
       "feature": "quickeda-html-escape-xss",
       "slug": "escape-styler-html-output",
       "title": "Escape DataFrame cell values in _df_to_html_with_style()",
-      "status": "in-progress",
+      "status": "done",
       "priority": "critical",
       "depends_on": [],
       "assigned_to": null,
-      "file": "sdd/tasks/active/TASK-2224-escape-styler-html-output.md",
-      "started_at": "2026-08-16T22:50:03+00:00"
+      "file": "sdd/tasks/completed/TASK-2224-escape-styler-html-output.md",
+      "started_at": "2026-08-16T22:50:03+00:00",
+      "completed_at": "2026-08-16T22:52:12+00:00"
     },
     {
       "id": "TASK-2225",


### PR DESCRIPTION
## Summary

Fixes #1159 — `_df_to_html_with_style()` renders untrusted DataFrame cell values as raw HTML (XSS).

## Changes

### `quickeda.py`
- Added `.format(escape="html")` to the Styler chain in `_df_to_html_with_style()`
- Manually escape row-index labels (`value_counts()`, transposed `describe()`)
- Manually escape `index.name` / `columns.name` axis names (pandas Styler has no escaping hook for these)

### `dftohtml.py`
- Changed `escape` parameter default from `False` → `True` (safe-by-default)

### `test_quickeda_xss.py` (new)
- 14 regression tests covering `<script>`, `<img onerror>`, `<svg/onload>`, `</td>` breakout payloads in cells, column names, row indices, and DfToHtmlTool defaults

## Tasks

| Task | Status |
|------|--------|
| TASK-2224 — Escape DataFrame cell values | ✅ verified |
| TASK-2225 — XSS regression tests | ✅ verified |

2/2 tasks verified and closed.

---
_Closed by /sdd-done_