### PR TITLE
NAV-9522 fix(formdesigner): org graph reads auth.organizations.organization — no "name" column exists

### DIFF
--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/org_graph.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/org_graph.py
@@ -104,7 +104,7 @@ class OrgGraph(BaseModel):
 # ---------------------------------------------------------------------------
 
 _SQL_GET_ORG = """
-SELECT org_id, name
+SELECT org_id, organization AS name
 FROM auth.organizations
 WHERE org_id = $1
 """

--- a/packages/parrot-formdesigner/tests/unit/real_db_shapes.py
+++ b/packages/parrot-formdesigner/tests/unit/real_db_shapes.py
@@ -1,0 +1,68 @@
+"""Real column shapes for tables the fake pools emulate.
+
+A test double that accepts any column hides schema bugs. FEAT-302
+shipped ``SELECT org_id, name FROM auth.organizations`` while the real
+table has no ``name`` column, so every call failed in production with
+``asyncpg.exceptions.UndefinedColumnError`` — and the fakes stayed
+green. The fakes now validate the SELECT list of any query that reads
+``auth.organizations`` against the real shape and raise like Postgres.
+
+The column set below is the verified shape of ``auth.organizations``
+in every environment (navigator_dev checked 2026-08-16).
+"""
+
+from __future__ import annotations
+
+import re
+
+REAL_AUTH_ORGANIZATIONS_COLUMNS = frozenset({
+    "org_id",
+    "oid",
+    "organization",
+    "description",
+    "attributes",
+    "org_slug",
+    "is_active",
+    "created_at",
+    "updated_at",
+    "created_by",
+})
+
+_FROM_ORGANIZATIONS_RE = re.compile(
+    r"\bFROM\s+auth\.organizations\b", re.IGNORECASE
+)
+_SELECT_LIST_RE = re.compile(
+    r"\bSELECT\s+(?:DISTINCT\s+)?(.*?)\s+FROM\b", re.IGNORECASE | re.DOTALL
+)
+
+
+class FakeUndefinedColumnError(Exception):
+    """Stands in for ``asyncpg.exceptions.UndefinedColumnError``."""
+
+
+def assert_real_columns(sql: str) -> None:
+    """Raise like Postgres when a query selects a column that does not exist.
+
+    Only queries whose FROM target is ``auth.organizations`` are checked
+    (single-table queries; the service has no joins against it).
+
+    Args:
+        sql: The SQL text the fake connection received.
+
+    Raises:
+        FakeUndefinedColumnError: A selected base column is not a real
+            column of ``auth.organizations``.
+    """
+    if not _FROM_ORGANIZATIONS_RE.search(sql):
+        return
+    match = _SELECT_LIST_RE.search(sql)
+    if match is None:
+        return
+    for expr in match.group(1).split(","):
+        base = re.split(r"\s+AS\s+", expr.strip(), maxsplit=1, flags=re.IGNORECASE)[0]
+        base = base.strip()
+        if base == "*" or "(" in base:
+            continue
+        column = base.split(".")[-1].strip().strip('"')
+        if column not in REAL_AUTH_ORGANIZATIONS_COLUMNS:
+            raise FakeUndefinedColumnError(f'column "{column}" does not exist')

--- a/packages/parrot-formdesigner/tests/unit/test_feat302_review_fixes.py
+++ b/packages/parrot-formdesigner/tests/unit/test_feat302_review_fixes.py
@@ -19,6 +19,8 @@ import pytest
 from parrot_formdesigner.services.org_graph import OrgGraphService
 from parrot_formdesigner.services.project_service import ProjectService
 
+from tests.unit.real_db_shapes import assert_real_columns
+
 
 # ---------------------------------------------------------------------------
 # Fake asyncpg pool that records every (sql, args) call
@@ -36,6 +38,7 @@ def _make_pool(rows_by_marker: dict[str, list[dict]] | None = None) -> tuple[Mag
         return r
 
     async def _fetch(sql: str, *args: Any) -> list:
+        assert_real_columns(sql)
         calls.append((sql, args))
         for marker, rows in rows_by_marker.items():
             if marker in sql:
@@ -43,6 +46,7 @@ def _make_pool(rows_by_marker: dict[str, list[dict]] | None = None) -> tuple[Mag
         return []
 
     async def _fetchrow(sql: str, *args: Any) -> Any:
+        assert_real_columns(sql)
         calls.append((sql, args))
         for marker, rows in rows_by_marker.items():
             if marker in sql:

--- a/packages/parrot-formdesigner/tests/unit/test_org_graph_service.py
+++ b/packages/parrot-formdesigner/tests/unit/test_org_graph_service.py
@@ -19,6 +19,12 @@ import pytest
 
 from parrot_formdesigner.services.org_graph import OrgGraph, OrgGraphService, OrgNode
 
+from tests.unit.real_db_shapes import (
+    REAL_AUTH_ORGANIZATIONS_COLUMNS,
+    FakeUndefinedColumnError,
+    assert_real_columns,
+)
+
 
 # ---------------------------------------------------------------------------
 # Fake pool helpers
@@ -27,6 +33,9 @@ from parrot_formdesigner.services.org_graph import OrgGraph, OrgGraphService, Or
 
 def _make_conn(fetchrow_results: dict | None = None, fetch_results: dict | None = None) -> MagicMock:
     """Build a fake asyncpg-style connection.
+
+    Queries against ``auth.organizations`` are validated against the REAL
+    column shape (see ``real_db_shapes``); a bad column raises like Postgres.
 
     Args:
         fetchrow_results: Mapping of SQL → row dict (or None for not found).
@@ -37,6 +46,7 @@ def _make_conn(fetchrow_results: dict | None = None, fetch_results: dict | None 
     fetch_results = fetch_results or {}
 
     async def _fetchrow(sql: str, *args: Any) -> MagicMock | None:
+        assert_real_columns(sql)
         # Match on sql prefix
         for key, val in fetchrow_results.items():
             if key in sql:
@@ -49,6 +59,7 @@ def _make_conn(fetchrow_results: dict | None = None, fetch_results: dict | None 
         return None
 
     async def _fetch(sql: str, *args: Any) -> list[MagicMock]:
+        assert_real_columns(sql)
         for key, val in fetch_results.items():
             if key in sql:
                 rows = []
@@ -242,6 +253,49 @@ class TestOrgGraphServiceGetGraph:
         # Each graph has its own organization child
         assert g1.root.children[0].node_id == "1"
         assert g2.root.children[0].node_id == "2"
+
+
+# ---------------------------------------------------------------------------
+# Regression — auth.organizations has NO "name" column
+# ---------------------------------------------------------------------------
+
+
+class TestSqlMatchesRealOrganizationsShape:
+    """FEAT-302 shipped ``SELECT org_id, name FROM auth.organizations``.
+
+    The real table has ``organization``, not ``name`` — the first statement
+    of get_graph raised UndefinedColumnError in every environment and the
+    endpoint returned a 500. The SQL must alias: ``organization AS name``.
+    """
+
+    def test_sql_get_org_selects_only_real_columns(self) -> None:
+        from parrot_formdesigner.services.org_graph import _SQL_GET_ORG
+
+        # Raises FakeUndefinedColumnError if the SELECT list names a
+        # column the real table does not have (e.g. bare ``name``).
+        assert_real_columns(_SQL_GET_ORG)
+
+    def test_real_shape_has_no_name_column(self) -> None:
+        assert "name" not in REAL_AUTH_ORGANIZATIONS_COLUMNS
+        assert "organization" in REAL_AUTH_ORGANIZATIONS_COLUMNS
+
+    def test_validator_rejects_bare_name_column(self) -> None:
+        """Positive control: the validator can still go RED."""
+        with pytest.raises(FakeUndefinedColumnError, match='column "name"'):
+            assert_real_columns(
+                "SELECT org_id, name FROM auth.organizations WHERE org_id = $1"
+            )
+
+    @pytest.mark.asyncio
+    async def test_get_graph_works_against_real_shape(self) -> None:
+        """The alias keeps ``org_row['name']`` access working downstream."""
+        conn = _make_conn(
+            fetchrow_results={"auth.organizations": {"name": "Acme Corp"}},
+            fetch_results={"auth.clients": []},
+        )
+        svc = OrgGraphService(_make_pool(conn))
+        graph = await svc.get_graph(7, tenant="acme", depth=2)
+        assert graph.root.children[0].metadata["name"] == "Acme Corp"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Jira: [NAV-9522](https://trocglobal.atlassian.net/browse/NAV-9522)

## Problem

`GET /api/v1/org/graph` on the FieldSync API returns 500 with a valid token — five of five attempts on dev (control endpoint 200 in the same run). The endpoint never worked against a real database.

## Cause

`packages/parrot-formdesigner/src/parrot_formdesigner/services/org_graph.py` — the first query of `get_graph` runs `SELECT org_id, name FROM auth.organizations`, and `auth.organizations` has no column called `name` in any environment (the real column is `organization`; full column set verified on `navigator_dev` and `navigator_staging`). asyncpg raises `UndefinedColumnError`; the API handler converts it into a generic 500.

Exception captured by executing the shipped code read-only against `navigator_dev`:

```
asyncpg.exceptions.UndefinedColumnError: column "name" does not exist
  (org_graph.py, org_row = await conn.fetchrow(_SQL_GET_ORG, org_id))
```

## Fix

```sql
SELECT org_id, organization AS name FROM auth.organizations WHERE org_id = $1
```

The alias keeps every downstream `org_row["name"]` access unchanged. This is the only SQL in the package touching `auth.organizations` (16 references checked untruncated: 1 SQL, 1 docstring, 14 test-fixture keys).

## Tests

The existing fakes returned a `name` column that production does not have — exactly the double that hides this bug. Added `tests/unit/real_db_shapes.py` with the verified real column set and a validator that raises `column "name" does not exist` for any query selecting a nonexistent column from `auth.organizations`, wired into both fake pools, plus a `TestSqlMatchesRealOrganizationsShape` class (4 tests, with a positive control that the validator can still go RED).

- Fixed code: `tests/unit/test_org_graph_service.py` → 28 passed.
- Mutation check: with the SQL reverted to `SELECT org_id, name`, **18 failed**; restored → green.
- Pre-existing environmental failure, unrelated: `TestShadowGateWired` needs the `ai-parrot` package installed and fails identically on pristine `origin/main` in the same environment.

Independent adversarial review (blind, non-authored model): no findings.

No DB migrations. Consumer note: fieldsync pins `parrot-formdesigner>=0.8.21`, so the fix flows into fieldsync on the next package release + deploy, with no fieldsync code change.

cc @jelitox @phenobarbital — review requested (cross-fork PR, cannot assign reviewers).

CI note: the failing checks (Test ai-parrot 3.11, ai-parrot-loaders, ai-parrot-tools, Lint & Registry) fail identically on `main` today — pre-existing monorepo state, not introduced by this PR; the touched package's own tests pass 28/28.
