### PR TITLE
feat(fix-generate-tool-registry-annassign): FEAT-427 — Fix generate_tool_registry.py AnnAssign Blindspot

### DIFF
--- a/scripts/generate_tool_registry.py
+++ b/scripts/generate_tool_registry.py
@@ -132,6 +132,39 @@ def _class_to_key(name: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Normalize ast.Assign / ast.AnnAssign nodes
+# ---------------------------------------------------------------------------
+def _assign_target_and_value(
+    node: ast.AST,
+) -> tuple[str | None, ast.expr | None]:
+    """Normalize an ast.Assign or ast.AnnAssign into (name, value).
+
+    Handles both the unannotated form (``NAME = {...}``, ``ast.Assign``
+    with a ``targets`` list) and the annotated form
+    (``NAME: dict[str, str] = {...}``, ``ast.AnnAssign`` with a single
+    ``target``). Returns ``(None, None)`` when the node is neither, when
+    the target is not a plain ``ast.Name``, or when an ``AnnAssign`` has
+    no right-hand-side value (a bare annotation like ``NAME: int``).
+
+    Args:
+        node: An AST node encountered while walking a module.
+
+    Returns:
+        ``(target_name, value_node)`` or ``(None, None)``.
+    """
+    if isinstance(node, ast.Assign):
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                return target.id, node.value
+        return None, None
+    if isinstance(node, ast.AnnAssign):
+        if node.value is None or not isinstance(node.target, ast.Name):
+            return None, None
+        return node.target.id, node.value
+    return None, None
+
+
+# ---------------------------------------------------------------------------
 # Scan for non-class exports (functions, constants)
 # ---------------------------------------------------------------------------
 def scan_exports(
@@ -167,10 +200,10 @@ def scan_exports(
         for node in ast.iter_child_nodes(tree):
             if isinstance(node, ast.FunctionDef) and node.name in names:
                 registry[node.name] = f"{module_path}.{node.name}"
-            elif isinstance(node, ast.Assign):
-                for target in node.targets:
-                    if isinstance(target, ast.Name) and target.id in names:
-                        registry[target.id] = f"{module_path}.{target.id}"
+            else:
+                name, value = _assign_target_and_value(node)
+                if name in names and value is not None:
+                    registry[name] = f"{module_path}.{name}"
 
     return registry
 
@@ -221,13 +254,12 @@ def read_existing_registry(init_file: Path, var_name: str) -> Optional[dict[str,
         return None
 
     for node in ast.walk(tree):
-        if isinstance(node, ast.Assign):
-            for target in node.targets:
-                if isinstance(target, ast.Name) and target.id == var_name:
-                    try:
-                        return ast.literal_eval(node.value)
-                    except (ValueError, TypeError):
-                        return None
+        name, value = _assign_target_and_value(node)
+        if name == var_name and value is not None:
+            try:
+                return ast.literal_eval(value)
+            except (ValueError, TypeError):
+                return None
     return None
 
 
@@ -287,24 +319,23 @@ def update_init_file(
 
         # Find the assignment line range
         for node in ast.walk(tree):
-            if isinstance(node, ast.Assign):
-                for target in node.targets:
-                    if isinstance(target, ast.Name) and target.id == var_name:
-                        # Replace from assignment start to end
-                        lines = content.splitlines(keepends=True)
-                        start_line = node.lineno - 1  # 0-indexed
-                        end_line = node.end_lineno  # exclusive
+            name, value = _assign_target_and_value(node)
+            if name == var_name and value is not None:
+                # Replace from assignment start to end
+                lines = content.splitlines(keepends=True)
+                start_line = node.lineno - 1  # 0-indexed
+                end_line = node.end_lineno  # exclusive
 
-                        # Build new assignment
-                        new_lines = [f"{var_name}: dict[str, str] = {{\n"]
-                        for key, path in merged.items():
-                            new_lines.append(f'    "{key}": "{path}",\n')
-                        new_lines.append("}\n")
+                # Build new assignment
+                new_lines = [f"{var_name}: dict[str, str] = {{\n"]
+                for key, path in merged.items():
+                    new_lines.append(f'    "{key}": "{path}",\n')
+                new_lines.append("}\n")
 
-                        # Replace
-                        lines[start_line:end_line] = new_lines
-                        init_file.write_text("".join(lines), encoding="utf-8")
-                        return True, diff
+                # Replace
+                lines[start_line:end_line] = new_lines
+                init_file.write_text("".join(lines), encoding="utf-8")
+                return True, diff
 
     return bool(diff), diff
 

--- a/sdd/tasks/completed/TASK-2245-fix-generate-tool-registry-annassign.md
+++ b/sdd/tasks/completed/TASK-2245-fix-generate-tool-registry-annassign.md
@@ -410,10 +410,73 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-start (Claude Sonnet 4.5, worktree feat-427-fix-generate-tool-registry-annassign)
+**Date**: 2026-08-17
+**Status**: done-with-issues (verification=partial)
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
-**Notes**: What was implemented, any deviations from scope, issues encountered.
+**Notes**: Implemented `_assign_target_and_value()` exactly as specified
+and rewired `scan_exports()`, `read_existing_registry()`, and the
+`update_init_file()` rewrite loop to use it. Created
+`tests/scripts/test_generate_tool_registry.py` with all 6 tests from the
+spec's Test Specification plus the CLI integration test.
 
-**Deviations from spec**: none | describe if any
+5/7 tests pass, including all tests that exercise the actual AST fix:
+- `test_read_existing_registry_annassign` ✅
+- `test_read_existing_registry_plain_assign_unchanged` ✅ (regression guard)
+- `test_read_existing_registry_bare_annotation_no_value` ✅
+- `test_update_init_file_rewrites_annassign_in_place` ✅
+- `test_scan_exports_annassign` ✅
+- `test_check_mode_clean_on_current_repo_files` ❌ (see Deviations)
+- `test_check_cli_exits_zero_on_repo` ❌ (see Deviations)
+
+`ruff check` on the two changed files: 4 remaining findings, 3
+pre-existing/unrelated to this change (`I001` import-block-unsorted at
+the top of `generate_tool_registry.py`, `SIM114` in `_class_to_key()`,
+`UP045` on the pre-existing `read_existing_registry()` signature — all
+confirmed present on `dev` HEAD *before* this task's changes) plus 1
+new, unavoidable `I001` in the test file caused by the
+`sys.path.insert()`-before-import pattern the task's own Test
+Specification specifies verbatim. My own new code
+(`_assign_target_and_value()`) uses `str | None` / `ast.expr | None`
+and introduces zero new lint findings.
+
+**Deviations from spec**: The two acceptance criteria "`--check` exits
+0 against the current repo state" and "plain write mode … prints 'All
+registries are up to date.'" do NOT hold, and were NOT made to hold by
+this task. Root cause: the *AST-parsing fix itself is correct and
+verified* — `--check` now correctly reads existing registry contents
+(previously always `{}`, this is what proves the fix works: the diff
+now shows a specific per-key delta instead of "every entry is
+`added`"). However, that correct read reveals genuine, pre-existing
+drift: 92 `TOOL_REGISTRY` entries and 1 `LOADER_REGISTRY` entry exist
+as real classes in the source tree (e.g. `EC2Toolkit` in
+`packages/ai-parrot-tools/src/parrot_tools/aws/ec2.py`) but were never
+added to their `__init__.py` registries, plus one renamed dotted path
+(`odoo` → `parrot_tools.odoo.toolkit.OdooToolkit`). Confirmed via `git
+log` that many of these source files were added across dozens of prior
+commits — consistent with the spec's own stated root cause (§7 Known
+Risks: "the bug has silently affected every package this script
+manages since its introduction," i.e. the plain write mode has
+*never* actually applied a change, so registry drift has been
+accumulating silently for a long time).
+
+Per the task's explicit "Files to Create/Modify" table (only
+`scripts/generate_tool_registry.py` and the new test file) and the
+spec's Integration Points table (both `__init__.py` files marked
+"verify only"), I did NOT modify
+`packages/ai-parrot-tools/src/parrot_tools/__init__.py` or
+`packages/ai-parrot-loaders/src/parrot_loaders/__init__.py` to sync
+the 93 missing/changed entries — doing so would (a) be out of this
+task's file scope, and (b) make a functionally significant change
+(newly exposing 92 tools + 1 loader to any `ToolManager`/registry
+consumer) that deserves its own reviewed change, not a silent
+side-effect of an AST-parsing bug fix.
+
+**Recommendation for a follow-up task**: once this fix lands, run
+`python scripts/generate_tool_registry.py` (plain write mode, no
+flags) once, review the resulting diff against
+`packages/ai-parrot-tools/src/parrot_tools/__init__.py` and
+`packages/ai-parrot-loaders/src/parrot_loaders/__init__.py` for
+correctness (particularly the `odoo` path rename), and commit it
+separately. After that sync, `--check` and both currently-failing
+tests should pass as originally specified.

--- a/sdd/tasks/index/fix-generate-tool-registry-annassign.json
+++ b/sdd/tasks/index/fix-generate-tool-registry-annassign.json
@@ -5,7 +5,7 @@
   "type": "feature",
   "base_branch": "dev",
   "created_at": "2026-08-17T09:20:49+00:00",
-  "completed_at": null,
+  "completed_at": "2026-08-17T09:28:49+00:00",
   "tasks": [
     {
       "id": "TASK-2245",
@@ -14,7 +14,7 @@
       "feature_id": "FEAT-427",
       "feature": "fix-generate-tool-registry-annassign",
       "spec": "sdd/specs/fix-generate-tool-registry-annassign.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "S",
       "depends_on": [],
@@ -22,8 +22,9 @@
       "parallelism_notes": "Single-file fix, single task. No parallelism to consider.",
       "assigned_to": null,
       "started_at": "2026-08-17T09:22:46+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2245-fix-generate-tool-registry-annassign.md"
+      "completed_at": "2026-08-17T09:28:49+00:00",
+      "file": "sdd/tasks/completed/TASK-2245-fix-generate-tool-registry-annassign.md",
+      "verification": "partial"
     }
   ]
 }

--- a/sdd/tasks/index/fix-generate-tool-registry-annassign.json
+++ b/sdd/tasks/index/fix-generate-tool-registry-annassign.json
@@ -14,14 +14,14 @@
       "feature_id": "FEAT-427",
       "feature": "fix-generate-tool-registry-annassign",
       "spec": "sdd/specs/fix-generate-tool-registry-annassign.spec.md",
-      "status": "pending",
+      "status": "in-progress",
       "priority": "medium",
       "effort": "S",
       "depends_on": [],
       "parallel": false,
       "parallelism_notes": "Single-file fix, single task. No parallelism to consider.",
       "assigned_to": null,
-      "started_at": null,
+      "started_at": "2026-08-17T09:22:46+00:00",
       "completed_at": null,
       "file": "sdd/tasks/active/TASK-2245-fix-generate-tool-registry-annassign.md"
     }

--- a/tests/scripts/test_generate_tool_registry.py
+++ b/tests/scripts/test_generate_tool_registry.py
@@ -1,0 +1,115 @@
+"""Regression tests for scripts/generate_tool_registry.py.
+
+Covers the ast.AnnAssign blindspot fixed in FEAT-427: TOOL_REGISTRY /
+LOADER_REGISTRY are declared as annotated assignments
+(``NAME: dict[str, str] = {...}``), which the AST represents as
+``ast.AnnAssign``, not ``ast.Assign``. These tests exercise both the
+unannotated (regression-proof) and annotated (bug-fix-proof) forms,
+plus the "bare annotation, no value" edge case.
+"""
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+import generate_tool_registry as gtr
+
+
+ANNASSIGN_SOURCE = textwrap.dedent('''
+    """Docstring."""
+
+    TOOL_REGISTRY: dict[str, str] = {
+        "foo": "pkg.mod.Foo",
+    }
+    ''')
+
+PLAIN_ASSIGN_SOURCE = textwrap.dedent('''
+    """Docstring."""
+
+    TOOL_REGISTRY = {
+        "foo": "pkg.mod.Foo",
+    }
+    ''')
+
+BARE_ANNOTATION_SOURCE = textwrap.dedent('''
+    """Docstring."""
+
+    TOOL_REGISTRY: dict[str, str]
+    ''')
+
+
+def test_read_existing_registry_annassign(tmp_path):
+    init_file = tmp_path / "__init__.py"
+    init_file.write_text(ANNASSIGN_SOURCE)
+    result = gtr.read_existing_registry(init_file, "TOOL_REGISTRY")
+    assert result == {"foo": "pkg.mod.Foo"}
+
+
+def test_read_existing_registry_plain_assign_unchanged(tmp_path):
+    init_file = tmp_path / "__init__.py"
+    init_file.write_text(PLAIN_ASSIGN_SOURCE)
+    result = gtr.read_existing_registry(init_file, "TOOL_REGISTRY")
+    assert result == {"foo": "pkg.mod.Foo"}
+
+
+def test_read_existing_registry_bare_annotation_no_value(tmp_path):
+    init_file = tmp_path / "__init__.py"
+    init_file.write_text(BARE_ANNOTATION_SOURCE)
+    result = gtr.read_existing_registry(init_file, "TOOL_REGISTRY")
+    assert result is None
+
+
+def test_update_init_file_rewrites_annassign_in_place(tmp_path):
+    init_file = tmp_path / "__init__.py"
+    init_file.write_text(ANNASSIGN_SOURCE)
+    new_registry = {"foo": "pkg.mod.Foo", "bar": "pkg.mod.Bar"}
+    changed, _diff = gtr.update_init_file(init_file, "TOOL_REGISTRY", new_registry)
+    assert changed is True
+    new_content = init_file.read_text()
+    assert "TOOL_REGISTRY: dict[str, str] = {" in new_content
+    assert '"bar": "pkg.mod.Bar"' in new_content
+
+
+def test_scan_exports_annassign(tmp_path):
+    pkg_dir = tmp_path / "pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "mod.py").write_text(
+        'LOADER_MAPPING: dict[str, str] = {"x": "y"}\n'
+    )
+    result = gtr.scan_exports(pkg_dir, "pkg", ["LOADER_MAPPING"])
+    assert result == {"LOADER_MAPPING": "pkg.mod.LOADER_MAPPING"}
+
+
+def test_check_mode_clean_on_current_repo_files():
+    tools_scanned = gtr.scan_classes(
+        gtr.TOOLS_PKG_DIR, gtr.TOOL_SUFFIXES, gtr.TOOL_BASE_CLASSES, "parrot_tools"
+    )
+    changed, _diff = gtr.update_init_file(
+        gtr.TOOLS_INIT, "TOOL_REGISTRY", tools_scanned, dry_run=True
+    )
+    assert changed is False
+
+    loaders_scanned = gtr.scan_classes(
+        gtr.LOADERS_PKG_DIR, gtr.LOADER_SUFFIXES, gtr.LOADER_BASE_CLASSES, "parrot_loaders"
+    )
+    factory_exports = gtr.scan_exports(
+        gtr.LOADERS_PKG_DIR, "parrot_loaders", ["get_loader_class", "LOADER_MAPPING"]
+    )
+    loaders_scanned.update(factory_exports)
+    changed, _diff = gtr.update_init_file(
+        gtr.LOADERS_INIT, "LOADER_REGISTRY", loaders_scanned, dry_run=True
+    )
+    assert changed is False
+
+
+def test_check_cli_exits_zero_on_repo():
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, str(repo_root / "scripts" / "generate_tool_registry.py"), "--check"],
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary

Fixes `scripts/generate_tool_registry.py`'s `ast.Assign`-only blindspot:
`TOOL_REGISTRY` / `LOADER_REGISTRY` are declared as annotated assignments
(`NAME: dict[str, str] = {...}`), which Python's AST represents as
`ast.AnnAssign`, not `ast.Assign`. This caused `--check` to unconditionally
report both registries as stale (permanent false positive) and the plain
write mode to silently no-op instead of applying changes.

Adds a `_assign_target_and_value()` helper that normalizes both
`ast.Assign` and `ast.AnnAssign` nodes into `(name, value)`, and rewires
`scan_exports()`, `read_existing_registry()`, and `update_init_file()`'s
rewrite loop to use it.

Adds `tests/scripts/test_generate_tool_registry.py` covering the annotated
form, the unannotated-regression guard, the bare-annotation edge case,
`scan_exports()` parity, and a CLI `--check` integration test.

## Tasks

1/1 tasks implemented (TASK-2245). Verification: **partial** — see below.

## ⚠️ Known issue (documented, not fixed by this PR)

The AST-parsing fix itself is correct and verified: 5/7 new tests pass,
including every test that exercises the annotated/unannotated/bare-value
parsing paths. The 2 failing tests
(`test_check_mode_clean_on_current_repo_files`,
`test_check_cli_exits_zero_on_repo`) fail because the now-correct
`--check` reveals **genuine, pre-existing registry drift**: 92
`TOOL_REGISTRY` entries + 1 `LOADER_REGISTRY` entry exist as real classes
in the source tree but were never synced into their `__init__.py`
registries (e.g. `EC2Toolkit` exists in `aws/ec2.py` but `"ec2"` is absent
from `TOOL_REGISTRY`), plus one renamed dotted path (`odoo`). This is
consistent with the bug being fixed: the plain write mode has silently
no-op'd since the script's introduction, so drift accumulated unnoticed.

This PR deliberately does **not** touch
`packages/ai-parrot-tools/src/parrot_tools/__init__.py` or
`packages/ai-parrot-loaders/src/parrot_loaders/__init__.py` — syncing 93
registry entries is a functionally significant change (newly exposing 92
tools + 1 loader to `ToolManager`/registry consumers) that deserves its
own reviewed commit, not a silent side effect of an AST bug fix. See the
task's Completion Note for full detail.

**Recommended follow-up**: run `python scripts/generate_tool_registry.py`
(plain write mode) once, review the diff (especially the `odoo` rename),
and commit it separately. After that, `--check` and both currently-failing
tests should pass as originally specified.

---
_Closed by /sdd-done_