### PR TITLE
fix(formdesigner): deterministic networkninja import identity + persist imported forms

### DIFF
--- a/packages/parrot-formdesigner/src/parrot_formdesigner/api/handlers.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/api/handlers.py
@@ -1750,8 +1750,14 @@ class FormAPIHandler:
         tenant = self._get_tenant(request)
         from ..tools.database_form import DatabaseFormTool
         db_tool = DatabaseFormTool(registry=self.registry, tenant=tenant)
+        # persist=True: an import that only ever reached the in-memory registry
+        # is invisible to every table-backed reader (the caller's very next
+        # request usually IS one), which surfaced as a 404 on a form the
+        # importer had just reported loading. Safe only because import identity
+        # is now deterministic — with the former uuid4 this path silently
+        # created db-form-X-Y-2, -3, -4, one duplicate per import.
         result = await db_tool.execute(
-            service=service, formid=formid, orgid=orgid, persist=False
+            service=service, formid=formid, orgid=orgid, persist=True
         )
 
         if not result.success:

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/tools/services/networkninja.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/tools/services/networkninja.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import uuid
 from typing import Any, Literal, cast
 
 from datetime import datetime, timezone
@@ -17,9 +18,73 @@ from pydantic import BaseModel, ConfigDict
 
 from ...core.constraints import ConditionOperator, DependencyRule, FieldCondition
 from ...core.options import FieldOption
-from ...core.schema import FormField, FormSchema, FormSection, FormType
+from ...core.schema import (
+    FormField,
+    FormSchema,
+    FormSection,
+    FormSubsection,
+    FormType,
+)
 from ...core.types import FieldType
 from .abstract import AbstractFormService
+
+# ---------------------------------------------------------------------------
+# Stable import identity
+# ---------------------------------------------------------------------------
+
+#: Namespace for every UUIDv5 minted by this importer. Derived (not a magic
+#: literal) so the value is reproducible from the URI alone.
+_IDENTITY_NAMESPACE = uuid.uuid5(
+    uuid.NAMESPACE_URL, "https://parrot-formdesigner/import/networkninja"
+)
+
+
+def stable_form_uid(formid: int | str, orgid: int | str) -> uuid.UUID:
+    """Derive the deterministic ``form_uid`` for a networkninja source form.
+
+    The importer must be idempotent: re-importing the same source form has to
+    yield the SAME ``form_uid``, or ``FormRegistry.register`` rejects it as a
+    new form claiming an already-owned slug (``db-form-<formid>-<orgid>``),
+    and every ``field_uid``-keyed answer, partial save, and resolved rule is
+    orphaned.
+
+    Args:
+        formid: Numeric form identifier at the source.
+        orgid: Organization ID that owns the form.
+
+    Returns:
+        A UUIDv5 that is a pure function of ``(formid, orgid)``.
+    """
+    return uuid.uuid5(_IDENTITY_NAMESPACE, f"networkninja:{orgid}:{formid}")
+
+
+def _apply_stable_identity(schema: FormSchema, form_uid: uuid.UUID) -> None:
+    """Rewrite the schema's auto-generated UUID4 identities to stable UUIDv5s.
+
+    ``FormSchema``/``FormSection``/``FormField`` all default their ``*_uid``
+    to ``uuid.uuid4()``, which makes an import non-reproducible. Every uid is
+    re-derived here from the form's own identity plus the element's stable
+    local id (``section_id`` / ``field_id`` — both already validated unique
+    by ``FormSchema``'s post-init validator, which ran when the schema was
+    constructed).
+
+    Mutates ``schema`` in place.
+
+    Args:
+        schema: The freshly built schema whose uids are still random.
+        form_uid: The deterministic form identity to derive children from.
+    """
+    schema.form_uid = form_uid
+    for section in schema.sections:
+        section.section_uid = uuid.uuid5(form_uid, f"section:{section.section_id}")
+        for item in section.fields:
+            if isinstance(item, FormSubsection):
+                item.subsection_uid = uuid.uuid5(
+                    form_uid, f"subsection:{item.subsection_id}"
+                )
+    for field in schema.iter_fields_recursive():
+        field.field_uid = uuid.uuid5(form_uid, f"field:{field.field_id}")
+
 
 # ---------------------------------------------------------------------------
 # SQL Query
@@ -397,13 +462,20 @@ class NetworkninjaFormService(AbstractFormService):
             if section is not None:
                 sections.append(section)
 
-        return FormSchema(
+        schema = FormSchema(
             form_id=form_id,
             title=form_name,
             description=description,
             sections=sections,
             form_type=form_type,
         )
+
+        # Identity must be a pure function of the source row, never uuid4 —
+        # see stable_form_uid() for why a random uid breaks re-import.
+        _apply_stable_identity(
+            schema, stable_form_uid(row["formid"], row["orgid"])
+        )
+        return schema
 
     @staticmethod
     def _normalize_question_blocks(

--- a/packages/parrot-formdesigner/tests/unit/test_networkninja_importer.py
+++ b/packages/parrot-formdesigner/tests/unit/test_networkninja_importer.py
@@ -10,6 +10,7 @@ from parrot_formdesigner.tools.services.networkninja import (
     ImportDiffEntry,
     ImportDiffReport,
     NetworkninjaFormService,
+    stable_form_uid,
 )
 
 
@@ -847,3 +848,91 @@ def test_malformed_metadata_options_do_not_crash():
     assert not fields["field_2493"].options
     # select column: the one valid option survived, the non-dict was dropped
     assert [o.value for o in fields["field_2500"].options] == ["6091"]
+
+
+# ---------------------------------------------------------------------------
+# Stable import identity — re-import must be idempotent
+# ---------------------------------------------------------------------------
+
+
+def test_form_uid_is_stable_across_imports(networkninja_formula_row):
+    """Two imports of the same source row yield the SAME form_uid.
+
+    Regression: FormSchema.form_uid defaulted to uuid4(), so every import
+    minted a new identity and re-registering hit FormRegistry's slug
+    uniqueness check (FormAlreadyExistsError) while form_id stayed constant.
+    """
+    svc = _svc()
+    first = svc.to_form_schema(networkninja_formula_row)
+    second = svc.to_form_schema(networkninja_formula_row)
+
+    assert first.form_id == second.form_id
+    assert first.form_uid == second.form_uid
+    assert first.form_uid == stable_form_uid(999, 1)
+
+
+def test_child_uids_are_stable_across_imports(networkninja_survey_row):
+    """section_uid / field_uid are derived, not random.
+
+    field_uid-keyed state (answers, partial saves, resolved rules) must
+    survive a re-import of the same source form.
+    """
+    svc = _svc()
+    first = svc.to_form_schema(networkninja_survey_row)
+    second = svc.to_form_schema(networkninja_survey_row)
+
+    assert [s.section_uid for s in first.sections] == [
+        s.section_uid for s in second.sections
+    ]
+    assert {f.field_id: f.field_uid for f in first.iter_all_fields()} == {
+        f.field_id: f.field_uid for f in second.iter_all_fields()
+    }
+
+
+def test_distinct_source_forms_get_distinct_uids(networkninja_formula_row):
+    """A different (formid, orgid) must never collide with another form."""
+    svc = _svc()
+    base = svc.to_form_schema(networkninja_formula_row)
+
+    other_form = {**networkninja_formula_row, "formid": 1000}
+    other_org = {**networkninja_formula_row, "orgid": 2}
+
+    uids = {
+        base.form_uid,
+        svc.to_form_schema(other_form).form_uid,
+        svc.to_form_schema(other_org).form_uid,
+    }
+    assert len(uids) == 3
+
+
+def test_all_uids_within_a_form_are_unique(networkninja_survey_row):
+    """Deriving uids must not introduce duplicates inside one form."""
+    svc = _svc()
+    schema = svc.to_form_schema(networkninja_survey_row)
+
+    uids = (
+        [schema.form_uid]
+        + [s.section_uid for s in schema.sections]
+        + [f.field_uid for f in schema.iter_all_fields()]
+    )
+    assert len(uids) == len(set(uids))
+
+
+@pytest.mark.asyncio
+async def test_reimport_reregisters_without_slug_conflict(networkninja_formula_row):
+    """The end-to-end symptom: re-registering a re-imported form must not raise.
+
+    Before the fix this raised FormAlreadyExistsError ("Slug 'db-form-999-1'
+    already in use by form_uid=..."), which DatabaseFormTool surfaced to the
+    API as HTTP 500 "Form load succeeded but form_uid missing".
+    """
+    from parrot_formdesigner.services.registry import FormRegistry
+
+    svc = _svc()
+    registry = FormRegistry(require_tenant=False, default_tenant="troc")
+
+    for _ in range(3):
+        schema = svc.to_form_schema(networkninja_formula_row)
+        await registry.register(schema, persist=False, tenant="troc")
+
+    assert await registry.list_form_ids(tenant="troc") == ["db-form-999-1"]


### PR DESCRIPTION
## Problem

Two defects made importing a networkninja form fail, the second hidden behind the first.

### 1. Import identity was non-deterministic → HTTP 500 on re-import

`NetworkninjaFormService._build_form_schema()` constructs
`FormSchema`/`FormSection`/`FormField` **without** passing `form_uid`/`section_uid`/
`field_uid`, so `core/schema.py`'s `default_factory=uuid.uuid4` mints a brand-new identity
on **every** import — while `form_id` (`db-form-<formid>-<orgid>`) and `field_id`
(`field_<col>`) are deterministic.

A re-import therefore looks like a new form claiming an already-owned slug:

- `FormRegistry.register` raises `FormAlreadyExistsError` (`registry.py:499`). The
  suffix-probe escape hatch does not apply — it is gated on `persist=True`
  (`registry.py:468`) and `api/handlers.py` hardcoded `persist=False`.
- `AbstractTool.execute` swallows the exception into
  `ToolResult(success=True, status="error")` with no `metadata["form"]`.
- `load_from_db` guards on `if not result.success`, which is `True`, so it falls through
  and answers `HTTP 500 {"error": "Form load succeeded but form_uid missing"}` — a message
  that points nowhere near the cause.

Reproduced before the fix:

```
POST 1: status=success
POST 2: FormAlreadyExistsError: Slug 'db-form-999-1' already in use by form_uid=UUID('a81ec63a-…')
        -> handler answers HTTP 500 "Form load succeeded but form_uid missing"
```

On the `persist=True` path it did **not** raise — it silently created `db-form-999-1-2`,
`-3`, `-4`: one duplicate form per import.

Regenerated `field_uid`s also orphan every `field_uid`-keyed answer, partial save, and
resolved rule (FEAT-393), even though `field_id` never changed.

### 2. Imported forms never reached storage → HTTP 404 right after a green import

`load_from_db` called the tool with `persist=False`, so an imported form existed only in
the in-memory registry. Every reader that goes to storage — including the importing
client's own immediate follow-up read — got a 404 for a form the importer had just
reported loading successfully.

## Fix

- **Identity is derived, not random.** `form_uid` is a UUIDv5 of
  `(source, orgid, formid)`; section/subsection/field uids are UUIDv5s of that `form_uid`
  plus their already-unique local id (`FormSchema`'s post-init validator guarantees
  `field_id`/`section_uid` uniqueness). Imports are idempotent, so a re-import updates the
  same form in place.
  Implemented as a post-construction pass (`_apply_stable_identity`) rather than threading
  `form_uid` through four mapper signatures: one testable place, and it avoids growing
  functions that already exceed the complexity budget.
- **`persist=True`** on the import call, so the row lands in `<tenant>.form_schemas` where
  those readers look. This is safe **only** because identity is now deterministic.

## Verification

```
form_uid stable across imports?   before: False        after: True
field_uid stable?                 before: False        after: True
3 sequential imports (HTTP path)  before: 500 from #2  after: 200, one form_uid
persist=True                      before: -2/-3/-4     after: one slug
```

- 5 new regression tests in `tests/unit/test_networkninja_importer.py` (golden vector,
  child-uid stability, distinct sources stay distinct, intra-form uniqueness, and the
  end-to-end "re-register a re-import without a slug conflict"). Three of them fail when
  the identity pass is disabled; the other two are uniqueness guards that also hold under
  uuid4.
- Package suite on top of this branch: **38 failed / 1853 passed / 20 skipped / 81
  errors**, against a `main` baseline of **38 failed / 1848 passed / 20 skipped / 81
  errors** — identical failures and errors, +5 passed (the new tests).
- `flake8` clean on the changed file; the two remaining `C901`s
  (`_collect_select_options`, `_map_question_to_field`) are pre-existing and untouched.

## Note for reviewers

`AbstractTool.execute` returning `success=True` alongside `status="error"` is a separate
contract bug that affects every caller of the tool layer, and `load_from_db` should read
`result.status` and propagate the real error message instead of the misleading one. Both
are deliberately left out of this PR.

FieldSync carries a temporary, self-disarming override of this same fix
(`fieldsync/forms_identity_hotfix.py`) so it can ship before this release lands; its
UUIDv5 namespace and key strings are byte-identical to the ones here, so a form imported
through the override keeps the same `form_uid` once the wheel is upgraded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)