### PR TITLE
fix(formdesigner): clone slug collision must consult storage, not just the cache

### DIFF
--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/registry.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/registry.py
@@ -312,6 +312,36 @@ class FormRegistry:
     # Public API — write paths
     # ------------------------------------------------------------------
 
+    async def _persisted_slug_owner(
+        self, form_id: str, tenant: str
+    ) -> uuid.UUID | None:
+        """Return the ``form_uid`` owning ``form_id`` in storage, if any.
+
+        Probe-only and fail-soft: a storage backend that raises reads as
+        "no owner" — the caller's own persist path will surface real
+        storage faults. The isinstance guard matters because a stub/mock
+        storage returns truthy non-FormSchema objects whose ``form_uid``
+        is not a UUID — those must never read as a collision.
+
+        Args:
+            form_id: The slug to probe.
+            tenant: The resolved tenant scope.
+
+        Returns:
+            The persisted owner's ``form_uid``, or ``None`` when the slug
+            is unclaimed in storage (or no storage is configured).
+        """
+        if self._storage is None:
+            return None
+        try:
+            persisted = await self._storage.load_by_slug(form_id, tenant)
+        except Exception:  # noqa: BLE001 — probe only, see docstring
+            return None
+        persisted_uid = getattr(persisted, "form_uid", None)
+        if isinstance(persisted_uid, uuid.UUID):
+            return persisted_uid
+        return None
+
     async def _next_free_slug(
         self, base: str, tenant: str, form_uid: uuid.UUID
     ) -> str:
@@ -342,21 +372,9 @@ class FormRegistry:
         for suffix in range(2, 202):
             owner = self._slug_index.get(self._make_slug_key(tenant, candidate))
             taken = owner is not None and owner != form_uid
-            if not taken and self._storage is not None:
-                try:
-                    persisted = await self._storage.load_by_slug(candidate, tenant)
-                except Exception:  # noqa: BLE001 — probe only; register's
-                    # own persist path will surface real storage faults
-                    persisted = None
-                # isinstance guard: a stub/mock storage returns truthy
-                # non-FormSchema objects whose `.form_uid` is not a UUID —
-                # those must never read as a collision (they would suffix
-                # forever). A real backend returns FormSchema | None.
-                persisted_uid = getattr(persisted, "form_uid", None)
-                taken = (
-                    isinstance(persisted_uid, uuid.UUID)
-                    and persisted_uid != form_uid
-                )
+            if not taken:
+                persisted_uid = await self._persisted_slug_owner(candidate, tenant)
+                taken = persisted_uid is not None and persisted_uid != form_uid
             if not taken:
                 return candidate
             candidate = f"{base}-{suffix}"
@@ -787,6 +805,14 @@ class FormRegistry:
         new_slug_key = self._make_slug_key(resolved, new_form_id)
         async with self._lock:
             slug_taken = new_slug_key in self._slug_index
+        if not slug_taken:
+            # The in-memory slug index starts empty on every boot; a slug
+            # that lives only in the persisted table must still 409 here,
+            # not fall through to register()'s free-slug renaming.
+            slug_taken = (
+                await self._persisted_slug_owner(new_form_id, resolved)
+                is not None
+            )
         if slug_taken:
             raise FormAlreadyExistsError(
                 f"Form '{new_form_id}' already exists"

--- a/packages/parrot-formdesigner/tests/unit/test_clone_form.py
+++ b/packages/parrot-formdesigner/tests/unit/test_clone_form.py
@@ -293,3 +293,63 @@ async def test_clone_source_still_present(
     assert source is not None
     assert source.form_id == "source-form"
     assert source.version == "2.3"
+
+
+# ---------------------------------------------------------------------------
+# Slug collision against STORAGE (cold cache) — regression for the silent
+# rename: a slug living only in the persisted table must 409, never become
+# an unrequested "<slug>-2".
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clone_slug_taken_in_storage_only_raises(
+    registry: FormRegistry, sample_form: FormSchema
+) -> None:
+    """A slug persisted in storage but absent from the in-memory index is
+    still a collision: clone_form raises FormAlreadyExistsError (HTTP 409
+    at the handler), instead of falling through to register()'s free-slug
+    renaming."""
+    from parrot_formdesigner.services.registry import FormAlreadyExistsError
+
+    persisted_owner = FormSchema(
+        form_id="taken-in-db",
+        title="Persisted Elsewhere",
+        sections=[],
+    )
+
+    class _ColdCacheStorage:
+        async def load(self, *a, **kw):  # noqa: ANN001, ANN003
+            return None
+
+        async def load_by_slug(self, form_id, tenant, *a, **kw):  # noqa: ANN001, ANN003
+            if form_id == "taken-in-db":
+                return persisted_owner
+            return None
+
+    registry.set_storage(_ColdCacheStorage())
+    with pytest.raises(FormAlreadyExistsError, match="already exists"):
+        await registry.clone_form(
+            sample_form.form_uid, "taken-in-db", persist=False
+        )
+
+
+@pytest.mark.asyncio
+async def test_clone_storage_probe_fault_is_fail_soft(
+    registry: FormRegistry, sample_form: FormSchema
+) -> None:
+    """A storage probe that raises must not turn a working clone into an
+    error: the probe reads as "no owner" and the clone proceeds."""
+
+    class _ExplodingStorage:
+        async def load(self, *a, **kw):  # noqa: ANN001, ANN003
+            raise RuntimeError("pool is down")
+
+        async def load_by_slug(self, *a, **kw):  # noqa: ANN001, ANN003
+            raise RuntimeError("pool is down")
+
+    registry.set_storage(_ExplodingStorage())
+    clone = await registry.clone_form(
+        sample_form.form_uid, "survives-probe-fault", persist=False
+    )
+    assert clone.form_id == "survives-probe-fault"


### PR DESCRIPTION
## Summary

`FormRegistry.clone_form` decided whether the target slug was taken by looking **only at the in-memory slug index**, which starts empty on every boot. A slug living only in the persisted table therefore went undetected, and the subsequent `register()` silently renamed the clone to `<slug>-2` instead of returning the **409** the docstring promises — the user asks for "copy" and gets "copy-2" with no warning.

This is the latent second half of the clone defect pair diagnosed alongside NAV-9370/9372; the first half (tenant read from the body instead of the request) was already fixed by FEAT-421's C1 review finding.

## Change

- Extracted the cold-cache storage probe that `_next_free_slug` already carried (fail-soft `load_by_slug`, isinstance-UUID guard) into a shared `_persisted_slug_owner()` helper.
- `clone_form` now consults it when the in-memory index says the slug is free, so a slug persisted in storage produces `FormAlreadyExistsError` → HTTP 409 at the handler, as documented.
- Probe stays fail-soft: a storage backend that raises reads as "no owner" — a flaky pool cannot turn a working clone into a 500.

## Tests

Two regressions in `tests/unit/test_clone_form.py`:
- slug taken **only in storage** → `FormAlreadyExistsError` (no silent rename);
- storage probe fault → clone still succeeds.

Full package suite: **38 failed / 1855 passed / 20 skipped / 81 errors** vs main's **38 / 1853 / 20 / 81** — identical failures and errors, only `passed` grows by the two new tests. `flake8` clean on both changed files. An independent adversarial review pass reported no correctness issues on the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)