### PR TITLE
sync: bring main-only #1167 networkninja fixes into dev

### DIFF
--- a/packages/parrot-formdesigner/src/parrot_formdesigner/api/handlers.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/api/handlers.py
@@ -1750,8 +1750,14 @@ class FormAPIHandler:
         tenant = self._get_tenant(request)
         from ..tools.database_form import DatabaseFormTool
         db_tool = DatabaseFormTool(registry=self.registry, tenant=tenant)
+        # persist=True: an import that only ever reached the in-memory registry
+        # is invisible to every table-backed reader (the caller's very next
+        # request usually IS one), which surfaced as a 404 on a form the
+        # importer had just reported loading. Safe only because import identity
+        # is now deterministic — with the former uuid4 this path silently
+        # created db-form-X-Y-2, -3, -4, one duplicate per import.
         result = await db_tool.execute(
-            service=service, formid=formid, orgid=orgid, persist=False
+            service=service, formid=formid, orgid=orgid, persist=True
         )
 
         if not result.success:

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/tools/services/networkninja.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/tools/services/networkninja.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import uuid
 from typing import Any, Literal, cast
 
 from datetime import datetime, timezone
@@ -17,9 +18,73 @@ from pydantic import BaseModel, ConfigDict
 
 from ...core.constraints import ConditionOperator, DependencyRule, FieldCondition
 from ...core.options import FieldOption
-from ...core.schema import FormField, FormSchema, FormSection, FormType
+from ...core.schema import (
+    FormField,
+    FormSchema,
+    FormSection,
+    FormSubsection,
+    FormType,
+)
 from ...core.types import FieldType
 from .abstract import AbstractFormService
+
+# ---------------------------------------------------------------------------
+# Stable import identity
+# ---------------------------------------------------------------------------
+
+#: Namespace for every UUIDv5 minted by this importer. Derived (not a magic
+#: literal) so the value is reproducible from the URI alone.
+_IDENTITY_NAMESPACE = uuid.uuid5(
+    uuid.NAMESPACE_URL, "https://parrot-formdesigner/import/networkninja"
+)
+
+
+def stable_form_uid(formid: int | str, orgid: int | str) -> uuid.UUID:
+    """Derive the deterministic ``form_uid`` for a networkninja source form.
+
+    The importer must be idempotent: re-importing the same source form has to
+    yield the SAME ``form_uid``, or ``FormRegistry.register`` rejects it as a
+    new form claiming an already-owned slug (``db-form-<formid>-<orgid>``),
+    and every ``field_uid``-keyed answer, partial save, and resolved rule is
+    orphaned.
+
+    Args:
+        formid: Numeric form identifier at the source.
+        orgid: Organization ID that owns the form.
+
+    Returns:
+        A UUIDv5 that is a pure function of ``(formid, orgid)``.
+    """
+    return uuid.uuid5(_IDENTITY_NAMESPACE, f"networkninja:{orgid}:{formid}")
+
+
+def _apply_stable_identity(schema: FormSchema, form_uid: uuid.UUID) -> None:
+    """Rewrite the schema's auto-generated UUID4 identities to stable UUIDv5s.
+
+    ``FormSchema``/``FormSection``/``FormField`` all default their ``*_uid``
+    to ``uuid.uuid4()``, which makes an import non-reproducible. Every uid is
+    re-derived here from the form's own identity plus the element's stable
+    local id (``section_id`` / ``field_id`` — both already validated unique
+    by ``FormSchema``'s post-init validator, which ran when the schema was
+    constructed).
+
+    Mutates ``schema`` in place.
+
+    Args:
+        schema: The freshly built schema whose uids are still random.
+        form_uid: The deterministic form identity to derive children from.
+    """
+    schema.form_uid = form_uid
+    for section in schema.sections:
+        section.section_uid = uuid.uuid5(form_uid, f"section:{section.section_id}")
+        for item in section.fields:
+            if isinstance(item, FormSubsection):
+                item.subsection_uid = uuid.uuid5(
+                    form_uid, f"subsection:{item.subsection_id}"
+                )
+    for field in schema.iter_fields_recursive():
+        field.field_uid = uuid.uuid5(form_uid, f"field:{field.field_id}")
+
 
 # ---------------------------------------------------------------------------
 # SQL Query
@@ -397,13 +462,20 @@ class NetworkninjaFormService(AbstractFormService):
             if section is not None:
                 sections.append(section)
 
-        return FormSchema(
+        schema = FormSchema(
             form_id=form_id,
             title=form_name,
             description=description,
             sections=sections,
             form_type=form_type,
         )
+
+        # Identity must be a pure function of the source row, never uuid4 —
+        # see stable_form_uid() for why a random uid breaks re-import.
+        _apply_stable_identity(
+            schema, stable_form_uid(row["formid"], row["orgid"])
+        )
+        return schema
 
     @staticmethod
     def _normalize_question_blocks(

--- a/packages/parrot-formdesigner/tests/unit/test_networkninja_importer.py
+++ b/packages/parrot-formdesigner/tests/unit/test_networkninja_importer.py
@@ -10,6 +10,7 @@ from parrot_formdesigner.tools.services.networkninja import (
     ImportDiffEntry,
     ImportDiffReport,
     NetworkninjaFormService,
+    stable_form_uid,
 )
 
 
@@ -847,3 +848,91 @@ def test_malformed_metadata_options_do_not_crash():
     assert not fields["field_2493"].options
     # select column: the one valid option survived, the non-dict was dropped
     assert [o.value for o in fields["field_2500"].options] == ["6091"]
+
+
+# ---------------------------------------------------------------------------
+# Stable import identity — re-import must be idempotent
+# ---------------------------------------------------------------------------
+
+
+def test_form_uid_is_stable_across_imports(networkninja_formula_row):
+    """Two imports of the same source row yield the SAME form_uid.
+
+    Regression: FormSchema.form_uid defaulted to uuid4(), so every import
+    minted a new identity and re-registering hit FormRegistry's slug
+    uniqueness check (FormAlreadyExistsError) while form_id stayed constant.
+    """
+    svc = _svc()
+    first = svc.to_form_schema(networkninja_formula_row)
+    second = svc.to_form_schema(networkninja_formula_row)
+
+    assert first.form_id == second.form_id
+    assert first.form_uid == second.form_uid
+    assert first.form_uid == stable_form_uid(999, 1)
+
+
+def test_child_uids_are_stable_across_imports(networkninja_survey_row):
+    """section_uid / field_uid are derived, not random.
+
+    field_uid-keyed state (answers, partial saves, resolved rules) must
+    survive a re-import of the same source form.
+    """
+    svc = _svc()
+    first = svc.to_form_schema(networkninja_survey_row)
+    second = svc.to_form_schema(networkninja_survey_row)
+
+    assert [s.section_uid for s in first.sections] == [
+        s.section_uid for s in second.sections
+    ]
+    assert {f.field_id: f.field_uid for f in first.iter_all_fields()} == {
+        f.field_id: f.field_uid for f in second.iter_all_fields()
+    }
+
+
+def test_distinct_source_forms_get_distinct_uids(networkninja_formula_row):
+    """A different (formid, orgid) must never collide with another form."""
+    svc = _svc()
+    base = svc.to_form_schema(networkninja_formula_row)
+
+    other_form = {**networkninja_formula_row, "formid": 1000}
+    other_org = {**networkninja_formula_row, "orgid": 2}
+
+    uids = {
+        base.form_uid,
+        svc.to_form_schema(other_form).form_uid,
+        svc.to_form_schema(other_org).form_uid,
+    }
+    assert len(uids) == 3
+
+
+def test_all_uids_within_a_form_are_unique(networkninja_survey_row):
+    """Deriving uids must not introduce duplicates inside one form."""
+    svc = _svc()
+    schema = svc.to_form_schema(networkninja_survey_row)
+
+    uids = (
+        [schema.form_uid]
+        + [s.section_uid for s in schema.sections]
+        + [f.field_uid for f in schema.iter_all_fields()]
+    )
+    assert len(uids) == len(set(uids))
+
+
+@pytest.mark.asyncio
+async def test_reimport_reregisters_without_slug_conflict(networkninja_formula_row):
+    """The end-to-end symptom: re-registering a re-imported form must not raise.
+
+    Before the fix this raised FormAlreadyExistsError ("Slug 'db-form-999-1'
+    already in use by form_uid=..."), which DatabaseFormTool surfaced to the
+    API as HTTP 500 "Form load succeeded but form_uid missing".
+    """
+    from parrot_formdesigner.services.registry import FormRegistry
+
+    svc = _svc()
+    registry = FormRegistry(require_tenant=False, default_tenant="troc")
+
+    for _ in range(3):
+        schema = svc.to_form_schema(networkninja_formula_row)
+        await registry.register(schema, persist=False, tenant="troc")
+
+    assert await registry.list_form_ids(tenant="troc") == ["db-form-999-1"]


### PR DESCRIPTION
## Summary

`main` and `dev` diverged in both directions: PR #1167 (deterministic networkninja import identity via `stable_form_uid`, + `persist=True` on imported forms) merged to `main` only, while feature work (FEAT-421/FEAT-429 spec+tasks, etc.) lives on `dev`. This PR closes the `main`-only side: a clean merge of `origin/main` into `dev` — exactly the two #1167 commits (`9957174b9`, `48a334225`), no conflicts.

## Why now

Downstream, fieldsync runs `parrot-formdesigner` as an editable install anchored to dev-based branches. Its temporary networkninja import hotfix self-retires only when `upstream_is_fixed()` detects `stable_form_uid` in the installed package — which dev-based checkouts currently lack, so the hotfix retirement (part of fieldsync's FEAT-494 cleanup) is blocked on this sync.

## Verification

- Golden identity vector on this branch: `stable_form_uid(999, 1) == 16abde97-8aad-5405-941a-14b62cc8c364` ✓ (matches fieldsync's pinned regression value).
- `pytest tests/unit/test_networkninja_importer.py` → 40 passed.

Note: #1170 (FEAT-429, /t/ removal) is also open against dev; the two touch different files (`tools/services/networkninja.py` + `api/handlers.py::load_from_db` here vs URL strings there) and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)