### PR TITLE
fix(formdesigner): a cloned form must not inherit its source's child uids

### DIFF
--- a/packages/parrot-formdesigner/src/parrot_formdesigner/core/schema.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/core/schema.py
@@ -489,6 +489,46 @@ class FormSchema(BaseModel):
         return self
 
 
+
+def derive_stable_identities(schema: FormSchema, form_uid: uuid.UUID) -> None:
+    """Re-derive a schema's child identities from ``form_uid``, in place.
+
+    ``section_uid``, ``subsection_uid`` and ``field_uid`` default to random
+    UUID4s (see the ``Field(default_factory=uuid.uuid4)`` declarations above),
+    which is correct when a form is authored but wrong whenever a whole schema
+    is copied: the copy inherits the original's identities verbatim, so two
+    distinct forms end up claiming the same ``field_uid``.
+
+    Each uid is derived as a UUID5 of the owning form's identity plus the
+    element's stable local id (``section_id`` / ``subsection_id`` /
+    ``field_id``), all of which ``FormSchema``'s post-init validator already
+    guarantees unique within the form. That makes this:
+
+    * **collision-free** — a different ``form_uid`` yields a different uid for
+      every child, so no two forms can share one;
+    * **deterministic** — the same (form_uid, local id) pair always produces
+      the same uid, so the operation is idempotent and reproducible;
+    * **structure-preserving** — nothing but the uids changes.
+
+    Args:
+        schema: The schema to rewrite. Mutated in place.
+        form_uid: The form identity to derive children from. Normally
+            ``schema.form_uid``; passed explicitly so callers that mint a new
+            identity cannot accidentally derive from the stale one.
+    """
+    for section in schema.sections:
+        section.section_uid = uuid.uuid5(
+            form_uid, f"section:{section.section_id}"
+        )
+        for item in section.fields:
+            if isinstance(item, FormSubsection):
+                item.subsection_uid = uuid.uuid5(
+                    form_uid, f"subsection:{item.subsection_id}"
+                )
+    for field in schema.iter_fields_recursive():
+        field.field_uid = uuid.uuid5(form_uid, f"field:{field.field_id}")
+
+
 class RenderWarning(BaseModel):
     """Warning emitted when a renderer uses degraded fallback for a field type.
 

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/registry.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/registry.py
@@ -38,7 +38,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
-from ..core.schema import FormSchema
+from ..core.schema import FormSchema, derive_stable_identities
 from ..core.style import StyleSchema
 from .validators import FormValidator
 
@@ -849,6 +849,17 @@ class FormRegistry:
             clone = FormSchema.model_validate(merged)
             clone.created_at = None
             clone.tenant = resolved
+
+        # A deep copy inherits the SOURCE's section/subsection/field uids, so
+        # without this the clone and its original would claim the same
+        # `field_uid` — the identity FEAT-393 documents as "stable, immutable
+        # ... the primary key for edit operations, rule references, blob
+        # storage keys". `FormSchema`'s own validator only enforces uniqueness
+        # WITHIN a form, so it cannot catch the collision across two.
+        # Derived AFTER the patch so a patch that adds fields gets stable uids
+        # too, and so the invariant holds on both code paths: every child uid
+        # of a clone comes from the clone's own form_uid.
+        derive_stable_identities(clone, clone.form_uid)
 
         errors = FormValidator().check_schema(clone)
         if errors:

--- a/packages/parrot-formdesigner/tests/unit/test_clone_form.py
+++ b/packages/parrot-formdesigner/tests/unit/test_clone_form.py
@@ -11,10 +11,16 @@ instead of the literal slug string.
 
 from __future__ import annotations
 
+import uuid
 from datetime import UTC, datetime
 
 import pytest
-from parrot_formdesigner.core.schema import FormField, FormSchema, FormSection
+from parrot_formdesigner.core.schema import (
+    FormField,
+    FormSchema,
+    FormSection,
+    derive_stable_identities,
+)
 from parrot_formdesigner.core.types import FieldType
 from parrot_formdesigner.services.registry import FormRegistry
 
@@ -353,3 +359,105 @@ async def test_clone_storage_probe_fault_is_fail_soft(
         sample_form.form_uid, "survives-probe-fault", persist=False
     )
     assert clone.form_id == "survives-probe-fault"
+
+
+# ---------------------------------------------------------------------------
+# Stable child identity on clone (field_uid / section_uid / subsection_uid)
+# ---------------------------------------------------------------------------
+
+
+async def test_clone_regenerates_field_uids(
+    registry: FormRegistry, sample_form: FormSchema
+) -> None:
+    """A clone must not share a single field_uid with its source.
+
+    A deep copy inherits them verbatim; FormSchema's validator only checks
+    uniqueness WITHIN a form, so nothing else catches the collision.
+    """
+    await registry.register(sample_form)
+    clone = await registry.clone_form(sample_form.form_uid, "cloned-form")
+
+    source_uids = {f.field_uid for f in sample_form.iter_fields_recursive()}
+    clone_uids = {f.field_uid for f in clone.iter_fields_recursive()}
+
+    assert source_uids, "fixture must expose at least one field"
+    assert len(clone_uids) == len(source_uids)
+    assert source_uids.isdisjoint(clone_uids)
+
+
+async def test_clone_regenerates_section_uids(
+    registry: FormRegistry, sample_form: FormSchema
+) -> None:
+    """Section identities are re-derived too, not carried over."""
+    await registry.register(sample_form)
+    clone = await registry.clone_form(sample_form.form_uid, "cloned-form")
+
+    source_uids = {s.section_uid for s in sample_form.sections}
+    clone_uids = {s.section_uid for s in clone.sections}
+
+    assert source_uids
+    assert source_uids.isdisjoint(clone_uids)
+
+
+async def test_clone_field_uids_are_derived_from_the_clone_form_uid(
+    registry: FormRegistry, sample_form: FormSchema
+) -> None:
+    """Each uid is uuid5(clone.form_uid, "field:<field_id>") — deterministic.
+
+    Pinning the derivation (not merely "it changed") is what makes the
+    identity reproducible: re-deriving must be a no-op.
+    """
+    await registry.register(sample_form)
+    clone = await registry.clone_form(sample_form.form_uid, "cloned-form")
+
+    for field in clone.iter_fields_recursive():
+        assert field.field_uid == uuid.uuid5(
+            clone.form_uid, f"field:{field.field_id}"
+        )
+
+
+async def test_clone_of_a_clone_has_distinct_uids(
+    registry: FormRegistry, sample_form: FormSchema
+) -> None:
+    """Cloning transitively keeps identities distinct at every generation."""
+    await registry.register(sample_form)
+    first = await registry.clone_form(sample_form.form_uid, "clone-one")
+    second = await registry.clone_form(first.form_uid, "clone-two")
+
+    a = {f.field_uid for f in sample_form.iter_fields_recursive()}
+    b = {f.field_uid for f in first.iter_fields_recursive()}
+    c = {f.field_uid for f in second.iter_fields_recursive()}
+
+    assert a.isdisjoint(b) and b.isdisjoint(c) and a.isdisjoint(c)
+
+
+async def test_clone_with_patch_still_derives_stable_uids(
+    registry: FormRegistry, sample_form: FormSchema
+) -> None:
+    """The invariant holds on the patched path too, not just the plain one."""
+    await registry.register(sample_form)
+    clone = await registry.clone_form(
+        sample_form.form_uid,
+        "patched-clone",
+        patch={"title": "Patched Clone"},
+    )
+
+    assert clone.title == "Patched Clone"
+    source_uids = {f.field_uid for f in sample_form.iter_fields_recursive()}
+    for field in clone.iter_fields_recursive():
+        assert field.field_uid not in source_uids
+        assert field.field_uid == uuid.uuid5(
+            clone.form_uid, f"field:{field.field_id}"
+        )
+
+
+async def test_derive_stable_identities_is_idempotent(
+    sample_form: FormSchema,
+) -> None:
+    """Applying the derivation twice changes nothing the second time."""
+    derive_stable_identities(sample_form, sample_form.form_uid)
+    first = {f.field_id: f.field_uid for f in sample_form.iter_fields_recursive()}
+    derive_stable_identities(sample_form, sample_form.form_uid)
+    second = {f.field_id: f.field_uid for f in sample_form.iter_fields_recursive()}
+
+    assert first == second


### PR DESCRIPTION
A cloned form currently shares every `field_uid`, `section_uid` and `subsection_uid` with the form it was cloned from.

`clone_form()` deep-copies the source and mints a new `form_uid` (`services/registry.py:822`), but the child identities ride along unchanged. `FormSchema`s post-init validator only enforces `field_uid` uniqueness **within** a form, so nothing catches the collision across two.

That contradicts the contract the schema itself states:

> `field_uid`: Stable, immutable UUID4 identity for this field (FEAT-393). Auto-generated on creation and never changes for the lifetime of the field — **the primary key for edit operations, rule references, blob storage keys**, and internal lookups.

Cloning a single **field** already does the right thing (`api/operations.py` drops `field_uid` so the default factory regenerates it). Cloning a whole **form** did not.

## The fix

Adds `core.schema.derive_stable_identities(schema, form_uid)`, which re-derives each child uid as `uuid5(form_uid, "<kind>:<local id>")`, and calls it from `clone_form()`.

This deliberately mirrors the derivation the NetworkNinja importer already uses on `main` (`tools/services/networkninja.py`, commit `9957174b9`), so the codebase converges on one notion of stable identity instead of gaining a second ad-hoc one. Compared with regenerating `uuid4`s it is also:

- **deterministic** — the same `(form_uid, local id)` always yields the same uid, so the operation is reproducible and idempotent;
- **collision-free by construction** — a different `form_uid` yields a different uid for every child.

It is applied **after** the merge-patch, so fields introduced by a patch get stable uids too and the invariant holds on both code paths.

## Blast radius: none today

Measured read-only against `navigator_dev` and `navigator_staging`:

| | dev | staging |
|---|---|---|
| Forms | 81 | 97 |
| Distinct `field_uid` | 1084 | 1121 |
| `field_uid` shared by two forms | **0** | **0** |
| Forms declaring `meta.cloned_from` | **0** | **0** |

No clone has ever succeeded in either environment, so no row carries a duplicated identity. The defect becomes reachable the moment cloning starts working — which is why it is worth fixing now rather than after.

## Tests

Six tests in `tests/unit/test_clone_form.py`, covering: source/clone disjointness for fields and sections, the exact `uuid5` derivation (not merely "it changed"), clone-of-a-clone, the patched path, and idempotency of the helper.

Verified by mutation: with the `derive_stable_identities()` call removed, **5 of the 6 fail**. The sixth exercises the helper directly and is expected to pass either way.

## Suite status

`pytest tests/unit` in `packages/parrot-formdesigner`:

- `origin/dev` baseline: **31 failed, 1469 passed, 18 errors**
- this branch: **31 failed, 1475 passed, 18 errors**

Identical failures and errors; the delta is exactly the six new tests. The pre-existing 31/18 are unrelated to this change and are not touched here.

## Follow-up, not in this PR

`main`s NetworkNinja importer carries its own private copy of this derivation. When `main` merges into `dev` the two should converge on `derive_stable_identities()` rather than living side by side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)