### PR TITLE
fix(agentd): align the UDS stream limit with max_line_bytes

### DIFF
--- a/packages/ai-parrot-integrations/src/parrot/integrations/agentd/client.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/agentd/client.py
@@ -170,8 +170,16 @@ class AgentDaemonClient:
         last_exc: Exception | None = None
         for attempt in range(1, retries + 1):
             try:
+                # `limit` MUST match the server's `max_line_bytes`. Without
+                # it asyncio caps the StreamReader at its 64 KiB default, so
+                # any reply larger than that makes `readuntil(b"\n")` raise
+                # LimitOverrunError, kills the reader task, and surfaces on
+                # every pending call as the very misleading "Connection
+                # closed by daemon" -- while the daemon had in fact answered
+                # correctly. Agent replies carrying a structured artifact,
+                # or a bridged tool result (FEAT-434), routinely exceed it.
                 reader, writer = await asyncio.open_unix_connection(
-                    path=str(socket_path)
+                    path=str(socket_path), limit=DEFAULT_MAX_LINE_BYTES
                 )
                 return cls(reader, writer, on_event=on_event)
             except OSError as exc:

--- a/packages/ai-parrot-integrations/src/parrot/integrations/agentd/server.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/agentd/server.py
@@ -261,8 +261,14 @@ class JsonRpcUnixServer:
         # looser permissions before the chmod() below lands.
         previous_umask = os.umask(0o177)
         try:
+            # Same 64 KiB StreamReader default as on the client side (see
+            # AgentDaemonClient.connect): without an explicit `limit` a
+            # request larger than that is unreadable no matter what
+            # `max_line_bytes` allows.
             self._server = await asyncio.start_unix_server(
-                self._handle_connection, path=str(self.socket_path)
+                self._handle_connection,
+                path=str(self.socket_path),
+                limit=self.max_line_bytes,
             )
         finally:
             os.umask(previous_umask)
@@ -450,9 +456,38 @@ class JsonRpcUnixServer:
                     id=request.id,
                     error=RpcError(code=INTERNAL_ERROR, message=str(exc)),
                 )
+            except asyncio.CancelledError:
+                # CancelledError derives from BaseException, so the clause
+                # above never sees it: the handler dies and the client gets a
+                # bare disconnect with no response. Report it, then let the
+                # cancellation keep unwinding.
+                self.logger.warning(
+                    "Handler for %r was cancelled before producing a result",
+                    request.method,
+                )
+                with contextlib.suppress(Exception):
+                    await session.send(
+                        RpcResponse(
+                            id=request.id,
+                            error=RpcError(
+                                code=INTERNAL_ERROR,
+                                message=f"{request.method} was cancelled",
+                            ),
+                        )
+                    )
+                raise
 
-        with contextlib.suppress(Exception):
+        try:
             await session.send(response)
+        except Exception:  # noqa: BLE001 - a failed send must not kill the server
+            # This is the ONLY path that delivers an answer, so swallowing a
+            # failure here reads to the client as "connection closed by
+            # daemon" with no clue why. Log it and keep serving.
+            self.logger.exception(
+                "Could not send the response for %r to session %s",
+                request.method,
+                session.session_id,
+            )
 
     async def _disconnect(self, session: Session) -> None:
         """Tear down a session: cancel tasks, unsubscribe, close the writer."""

--- a/packages/ai-parrot-integrations/tests/agentd/test_stream_limit.py
+++ b/packages/ai-parrot-integrations/tests/agentd/test_stream_limit.py
@@ -1,0 +1,76 @@
+"""Regression tests for the UDS stream-size limit.
+
+`AgentDaemonClient.connect()` used to call `asyncio.open_unix_connection()`
+without a `limit`, so the StreamReader kept asyncio's 64 KiB default while
+the server happily wrote up to `max_line_bytes` (10 MB). Any reply above
+64 KiB then made `readuntil(b"\\n")` raise `LimitOverrunError`, killing the
+reader task and surfacing on every pending call as
+`ConnectionClosed: Connection closed by daemon` -- with the daemon in fact
+having answered correctly.
+
+These tests drive a real Unix socket end to end, because the bug lives
+precisely in the stream plumbing that a mocked reader/writer would hide.
+"""
+import asyncio
+
+import pytest
+
+from parrot.integrations.agentd.client import AgentDaemonClient
+from parrot.integrations.agentd.protocol import DEFAULT_MAX_LINE_BYTES
+from parrot.integrations.agentd.server import JsonRpcUnixServer
+
+#: Comfortably past asyncio's 64 KiB StreamReader default, and in the size
+#: range a real agent reply with a structured artifact reaches.
+_BIG = 200_000
+
+
+@pytest.fixture
+async def echo_server(tmp_path):
+    """A server whose one method echoes back a payload of a requested size."""
+
+    async def big(_session, params):
+        return {"blob": "x" * int(params["size"])}
+
+    server = JsonRpcUnixServer(tmp_path / "test.sock", {"big": big})
+    await server.start()
+    try:
+        yield server
+    finally:
+        await server.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [1_000, _BIG])
+async def test_replies_survive_the_64kib_stream_default(echo_server, size):
+    """A reply larger than 64 KiB must arrive, not close the connection."""
+    client = await AgentDaemonClient.connect(echo_server.socket_path)
+    try:
+        result = await client.call("big", params={"size": size})
+    finally:
+        await client.close()
+    assert len(result["blob"]) == size
+
+
+@pytest.mark.asyncio
+async def test_client_limit_matches_the_protocol_default(echo_server):
+    """The client's reader limit is the protocol's, not asyncio's 64 KiB."""
+    client = await AgentDaemonClient.connect(echo_server.socket_path)
+    try:
+        # ``_limit`` is asyncio's own attribute on StreamReader; asserting it
+        # pins the contract that made the bug possible in the first place.
+        assert client._reader._limit == DEFAULT_MAX_LINE_BYTES
+        assert client._reader._limit > asyncio.streams._DEFAULT_LIMIT
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_server_accepts_requests_over_64kib(echo_server):
+    """The same limit applies to inbound requests, not just replies."""
+    client = await AgentDaemonClient.connect(echo_server.socket_path)
+    try:
+        # Round-trips a request whose own line is well over 64 KiB.
+        result = await client.call("big", params={"size": 1, "pad": "y" * _BIG})
+    finally:
+        await client.close()
+    assert result["blob"] == "x"


### PR DESCRIPTION
## Summary

`AgentDaemonClient.connect()` called `asyncio.open_unix_connection()` without a `limit`, so the StreamReader kept asyncio's **64 KiB** default while the server wrote up to `max_line_bytes` (**10 MB** by default). The two sides disagreed by 160×.

Any reply above 64 KiB made `readuntil(b"\n")` raise `LimitOverrunError`, which killed the client's reader task and surfaced on every pending call as:

```
ConnectionClosed: Connection closed by daemon
```

That message points at the daemon, but the daemon had answered correctly and kept serving — only the client could not read the line. It reads as an infrastructure failure while nothing is actually broken, which is what made it hard to find.

`start_unix_server()` had the same omission, so any **request** over 64 KiB was unreadable regardless of `max_line_bytes`.

## How it was found

Reproduced against a live `parrot serve` daemon. Some questions answered fine, one reproducibly "closed the connection" — while the daemon log showed the turn completing normally. Reading the reply with a raw client and a raised limit gave the number:

```
bytes de la respuesta: 123178
excede el limite por defecto de StreamReader (65536)? True
```

An agent reply carrying a structured artifact (A2UI / infographic payload) is routinely in that range. **FEAT-434's bridged tool results travel the same socket**, so the window where this bites just got wider.

## Also fixed: two gaps that hid the cause

- The `contextlib.suppress(Exception)` around the only `session.send()` that delivers an answer now logs instead of swallowing, so a non-serialisable field in a result stops looking like a bare disconnect.
- `asyncio.CancelledError` derives from `BaseException`, so the handler's `except Exception` never saw it and a cancelled handler produced **no response at all**. It now logs and returns a JSON-RPC error before re-raising.

## Test evidence

`packages/ai-parrot-integrations/tests/agentd/test_stream_limit.py` drives a real Unix socket end to end — the defect lives in exactly the stream plumbing a mocked reader/writer would hide.

| | result |
|---|---|
| without the fix | **3 failed, 1 passed** (200 KB reply, oversized request, limit assertion) |
| with the fix | **4 passed** |

The 1 KB case passes either way, as a control.

Full agentd suite on this branch: **118 passed, 2 failed** — both failures (`test_config.py::test_yaml_roundtrip`, `test_e2e.py::test_no_aiohttp_without_server_pkg`) reproduce identically on the baseline with the fix stashed, i.e. pre-existing and unrelated.

Developed with Spec Driven Development