### PR TITLE
feat(agentd): derive LLM tools from exposed_methods

### DIFF
--- a/packages/ai-parrot-integrations/src/parrot/integrations/agentd/config.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/agentd/config.py
@@ -243,6 +243,16 @@ class AgentServiceConfig(BaseModel):
         socket: Explicit UDS path. `None` means `default_socket_path(name)`
             is used at daemon start time.
         scheduler: Headless scheduler bootstrap options.
+        expose_as_tools: Which allowlisted methods also become LLM tools, so
+            the agent can call them mid-conversation instead of only
+            answering RPC. `None` (the default) derives a tool for every
+            name in `exposed_methods`; an explicit list narrows it (use it
+            to keep slow or destructive methods RPC-only); `[]` disables
+            derivation entirely. A tool the agent already registers itself
+            always wins over a derived one. Composes with FEAT-434: the
+            derived tools land in the agent's `ToolManager`, so a
+            `claude-agent` LLM reaches them through the bridge as
+            `mcp__parrot__<method>` like any other registered tool.
         exposed_methods: Allowlist of agent method names exposed via the
             `agent.invoke` RPC method; when non-empty it is also a hard
             requirement for the MCP `invoke_method` tool to be registered
@@ -260,6 +270,7 @@ class AgentServiceConfig(BaseModel):
     socket: Path | None = None
     scheduler: SchedulerConfig = Field(default_factory=SchedulerConfig)
     exposed_methods: list[str] = Field(default_factory=list)
+    expose_as_tools: list[str] | None = None
     log_level: str = "INFO"
     max_line_bytes: int = _DEFAULT_MAX_LINE_BYTES
     shutdown_grace: float = 30.0

--- a/packages/ai-parrot-integrations/src/parrot/integrations/agentd/service.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/agentd/service.py
@@ -315,6 +315,7 @@ class AgentDaemon:
         await self._install_signal_handlers()
 
         self.agent = await resolve_agent(self.config.agent)
+        self._register_method_tools()
         await self._configure_hitl()
 
         await self._start_scheduler()
@@ -439,6 +440,56 @@ class AgentDaemon:
         )
         await self._hitl_channel._response_callback(response)
         return {"ok": True}
+
+    def _register_method_tools(self) -> None:
+        """Give the LLM tools for the allowlisted agent methods.
+
+        `exposed_methods` governs `agent.invoke`; the model's toolbox comes
+        from the agent's own `agent_tools()`. Without this step the two
+        never meet, and an agent asked to do the very thing one of its
+        exposed methods does has no way to call it -- it apologises instead
+        of acting (see `parrot.integrations.agentd.tools`).
+
+        The derived tools go into the agent's `ToolManager`, so FEAT-434's
+        bridge picks them up for a `claude-agent` LLM as
+        `mcp__parrot__<method>` with no extra wiring.
+
+        Best-effort by design: an agent that cannot register tools (no
+        `register_tools`, no tool manager) still serves RPC perfectly well,
+        so a failure here is logged, never raised.
+        """
+        names = (
+            self.config.exposed_methods
+            if self.config.expose_as_tools is None
+            else self.config.expose_as_tools
+        )
+        if not names:
+            return
+        register = getattr(self.agent, "register_tools", None)
+        if not callable(register):
+            self.logger.warning(
+                "Agent %s has no register_tools(); exposed methods stay "
+                "RPC-only and the LLM cannot call them",
+                type(self.agent).__name__,
+            )
+            return
+        try:
+            from parrot.integrations.agentd.tools import build_method_tools
+
+            existing = self.agent.get_available_tools()
+            tools = build_method_tools(self.agent, names, skip_existing=existing)
+            if not tools:
+                return
+            register(tools)
+            self.logger.info(
+                "Registered %d LLM tool(s) from exposed_methods: %s",
+                len(tools),
+                ", ".join(t.name for t in tools),
+            )
+        except Exception as exc:  # noqa: BLE001 - see docstring
+            self.logger.warning(
+                "Could not register LLM tools from exposed_methods: %s", exc
+            )
 
     async def _start_scheduler(self) -> None:
         """Best-effort headless scheduler bootstrap (spec §2, step 3).

--- a/packages/ai-parrot-integrations/src/parrot/integrations/agentd/tools.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/agentd/tools.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import inspect
 import logging
-from typing import Any, Callable, Iterable, Sequence
+from typing import Any, Callable, Iterable, Sequence, get_type_hints
 
 from pydantic import BaseModel, Field, create_model
 
@@ -131,21 +131,61 @@ def _schema_from_signature(name: str, method: Callable[..., Any]) -> type[BaseMo
         A pydantic model class usable as ``args_schema``.
     """
     signature = inspect.signature(method)
+    hints = _resolved_hints(method)
     fields: dict[str, Any] = {}
     for param in signature.parameters.values():
         if param.name in ("self", "cls"):
             continue
         if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
             continue
-        annotation = (
-            Any if param.annotation is inspect.Parameter.empty else param.annotation
-        )
+        annotation = hints.get(param.name, param.annotation)
+        if annotation is inspect.Parameter.empty or isinstance(annotation, str):
+            # An unresolved string annotation would make pydantic raise
+            # "<Model> is not fully defined" the first time anything asks
+            # for its JSON schema — which, for a bridged tool, is at
+            # tool-call time and far from the cause. `Any` keeps the field
+            # usable instead.
+            annotation = Any
         if param.default is inspect.Parameter.empty:
             fields[param.name] = (annotation, Field(...))
         else:
             fields[param.name] = (annotation, Field(default=param.default))
     model_name = f"{name.title().replace('_', '')}Args"
-    return create_model(model_name, **fields)
+    model = create_model(model_name, **fields)
+    # Force resolution now, so a bad annotation surfaces here (and is caught
+    # by build_method_tools) rather than mid-conversation.
+    model.model_rebuild()
+    return model
+
+
+def _resolved_hints(method: Callable[..., Any]) -> dict[str, Any]:
+    """Resolve a method's annotations to real types.
+
+    A module with ``from __future__ import annotations`` — the norm in
+    modern code — stores every annotation as a **string**, and
+    :func:`inspect.signature` hands those strings straight through.
+    Feeding them to :func:`pydantic.create_model` builds a model that
+    cannot be resolved, so :func:`typing.get_type_hints` is used to
+    evaluate them against the function's own globals first.
+
+    Args:
+        method: The bound method to inspect.
+
+    Returns:
+        Mapping of parameter name to resolved type; empty when the
+        annotations cannot be evaluated (a forward reference to a type
+        that is not importable at runtime, say), in which case the caller
+        falls back to ``Any``.
+    """
+    try:
+        return get_type_hints(method)
+    except Exception as exc:  # noqa: BLE001 — see docstring
+        logger.debug(
+            "Could not resolve type hints for %r (%s); falling back to Any",
+            getattr(method, "__qualname__", method),
+            exc,
+        )
+        return {}
 
 
 def _description(name: str, method: Callable[..., Any]) -> str:

--- a/packages/ai-parrot-integrations/src/parrot/integrations/agentd/tools.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/agentd/tools.py
@@ -1,0 +1,169 @@
+"""Derive LLM tools from an agentd daemon's ``exposed_methods`` allowlist.
+
+``exposed_methods`` and the agent's LLM toolbox were two disconnected
+surfaces: the allowlist governs ``agent.invoke`` (RPC, the MCP proxy,
+``/invoke`` in the REPL), while the tools the model may call during a
+conversation come from the agent's own ``agent_tools()``. A daemon could
+therefore expose ``sync_transcripts`` over RPC while the agent, asked the
+very thing that method answers, had no way to call it — it would apologise
+instead of acting.
+
+This module closes that gap: for each allowlisted method it builds an
+`AbstractTool` whose argument schema is derived from the method signature
+and whose description comes from its docstring, so declaring a method in
+``exposed_methods`` is enough for the model to reach it.
+
+Wired from `AgentDaemon.run()`; opt out (or narrow the set) with
+`AgentServiceConfig.expose_as_tools`.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Any, Callable, Iterable, Sequence
+
+from pydantic import BaseModel, Field, create_model
+
+from parrot.tools.abstract import AbstractTool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+
+def build_method_tools(
+    agent: Any,
+    method_names: Sequence[str],
+    skip_existing: Iterable[str] = (),
+) -> list[AbstractTool]:
+    """Build one `AbstractTool` per agent method name.
+
+    Methods that cannot be turned into a tool are skipped with a warning
+    rather than raising: a malformed signature on one method must not stop
+    a daemon from booting.
+
+    Args:
+        agent: The agent instance owning the methods.
+        method_names: Method names to expose (typically
+            `AgentServiceConfig.exposed_methods`).
+        skip_existing: Tool names the agent already registers, so a
+            hand-written tool always wins over a derived one.
+
+    Returns:
+        The derived tools, in the order the names were given.
+    """
+    already = set(skip_existing)
+    tools: list[AbstractTool] = []
+    for name in method_names:
+        if name.startswith("_"):
+            continue
+        if name in already:
+            logger.debug(
+                "agentd: %r already exposed as a tool by the agent; not deriving one",
+                name,
+            )
+            continue
+        method = getattr(agent, name, None)
+        if method is None or not callable(method):
+            logger.warning(
+                "agentd: exposed_methods names %r, which is not a callable "
+                "on %s — no tool derived",
+                name,
+                type(agent).__name__,
+            )
+            continue
+        try:
+            tools.append(_build_tool(name, method))
+        except Exception as exc:  # noqa: BLE001 — see docstring
+            logger.warning(
+                "agentd: could not derive a tool for %r: %s", name, exc
+            )
+    return tools
+
+
+def _build_tool(name: str, method: Callable[..., Any]) -> AbstractTool:
+    """Build a single tool wrapping one bound method.
+
+    Args:
+        name: Method (and resulting tool) name.
+        method: The bound method to call.
+
+    Returns:
+        A ready-to-register tool.
+    """
+    schema = _schema_from_signature(name, method)
+    description = _description(name, method)
+
+    class _MethodTool(AbstractTool):
+        """Tool that forwards its arguments to one agent method."""
+
+        args_schema = schema
+
+        async def _execute(self, **kwargs: Any) -> ToolResult:
+            try:
+                result = method(**kwargs)
+                if inspect.isawaitable(result):
+                    result = await result
+                return ToolResult(result=result)
+            except Exception as exc:  # noqa: BLE001 — surfaced to the model
+                # The model gets the failure as a tool result and can retry
+                # or explain, instead of the whole turn blowing up.
+                return ToolResult(
+                    success=False, status="error", result=None, error=str(exc)
+                )
+
+    _MethodTool.__name__ = f"{name.title().replace('_', '')}Tool"
+    return _MethodTool(name=name, description=description)
+
+
+def _schema_from_signature(name: str, method: Callable[..., Any]) -> type[BaseModel]:
+    """Derive a pydantic argument schema from a method signature.
+
+    Parameters with annotations keep them; unannotated ones fall back to
+    ``Any``. Parameters with defaults become optional. ``*args`` and
+    ``**kwargs`` are ignored — a tool schema has to be a closed set of
+    named arguments for the model to fill in.
+
+    Args:
+        name: Method name, used for the generated model's name.
+        method: The bound method to inspect.
+
+    Returns:
+        A pydantic model class usable as ``args_schema``.
+    """
+    signature = inspect.signature(method)
+    fields: dict[str, Any] = {}
+    for param in signature.parameters.values():
+        if param.name in ("self", "cls"):
+            continue
+        if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
+            continue
+        annotation = (
+            Any if param.annotation is inspect.Parameter.empty else param.annotation
+        )
+        if param.default is inspect.Parameter.empty:
+            fields[param.name] = (annotation, Field(...))
+        else:
+            fields[param.name] = (annotation, Field(default=param.default))
+    model_name = f"{name.title().replace('_', '')}Args"
+    return create_model(model_name, **fields)
+
+
+def _description(name: str, method: Callable[..., Any]) -> str:
+    """Build the tool description from the method's docstring.
+
+    Uses the docstring up to the ``Args:`` section — the summary and any
+    prose explaining when to use the method, which is exactly what the
+    model needs at tool-selection time — and falls back to the method
+    name when there is no docstring at all.
+
+    Args:
+        name: Method name, used for the fallback text.
+        method: The bound method to inspect.
+
+    Returns:
+        A description string.
+    """
+    doc = inspect.getdoc(method) or ""
+    body = doc.split("\nArgs:")[0].split("\nReturns:")[0].split("\nRaises:")[0]
+    text = " ".join(line.strip() for line in body.strip().splitlines()).strip()
+    return text or f"Call the agent's {name}() method."

--- a/packages/ai-parrot-integrations/tests/agentd/test_method_tools.py
+++ b/packages/ai-parrot-integrations/tests/agentd/test_method_tools.py
@@ -104,3 +104,40 @@ async def test_method_failure_becomes_a_failed_tool_result():
     result = await tool._execute()
     assert result.success is False
     assert "kaboom" in result.error
+
+
+class _LazyAnnotations:
+    """Agent whose annotations are strings, as `from __future__ import
+    annotations` leaves them — the common case in modern modules."""
+
+    async def query(self, question, repos=None, limit=5):
+        """Search with lazily-annotated parameters."""
+        return {"question": question, "repos": repos, "limit": limit}
+
+    # Set after the fact so the module itself needs no __future__ import.
+    query.__annotations__ = {
+        "question": "str",
+        "repos": "Optional[list[str]]",
+        "limit": "int",
+        "return": "dict",
+    }
+
+
+def test_string_annotations_do_not_break_the_schema():
+    """A string annotation must not leave the model unresolvable.
+
+    Unresolved, pydantic raises "<Model> is not fully defined" the first
+    time anything asks for the JSON schema — which for a bridged tool is at
+    tool-call time, far from the cause.
+    """
+    (tool,) = build_method_tools(_LazyAnnotations(), ["query"])
+    schema = tool.args_schema.model_json_schema()
+    assert set(schema["properties"]) == {"question", "repos", "limit"}
+
+
+@pytest.mark.asyncio
+async def test_string_annotated_tool_still_executes():
+    (tool,) = build_method_tools(_LazyAnnotations(), ["query"])
+    result = await tool._execute(question="graph", limit=3)
+    assert result.result["question"] == "graph"
+    assert result.result["limit"] == 3

--- a/packages/ai-parrot-integrations/tests/agentd/test_method_tools.py
+++ b/packages/ai-parrot-integrations/tests/agentd/test_method_tools.py
@@ -1,0 +1,106 @@
+"""Tests for deriving LLM tools from `exposed_methods`.
+
+Covers `parrot.integrations.agentd.tools.build_method_tools`: the schema
+comes from the method signature, the description from the docstring, and
+malformed or missing entries are skipped rather than raising (a bad name in
+`exposed_methods` must not stop a daemon from booting).
+"""
+from typing import Optional
+
+import pytest
+
+from parrot.integrations.agentd.tools import build_method_tools
+
+
+class _Agent:
+    """Stand-in agent with a representative method surface."""
+
+    async def query(
+        self,
+        question: str,
+        limit: int = 5,
+        repos: Optional[list[str]] = None,
+    ) -> dict:
+        """Search the graph for something.
+
+        Longer prose the model should see at selection time.
+
+        Args:
+            question: What to look for.
+        """
+        return {"question": question, "limit": limit, "repos": repos}
+
+    def sync(self) -> str:
+        """Synchronous method — no docstring sections."""
+        return "done"
+
+    async def boom(self) -> None:
+        """Always fails."""
+        raise RuntimeError("kaboom")
+
+    not_callable = 42
+
+
+def test_builds_one_tool_per_named_method():
+    tools = build_method_tools(_Agent(), ["query", "sync"])
+    assert [t.name for t in tools] == ["query", "sync"]
+
+
+def test_schema_mirrors_the_signature():
+    (tool,) = build_method_tools(_Agent(), ["query"])
+    fields = tool.args_schema.model_fields
+    assert set(fields) == {"question", "limit", "repos"}
+    assert fields["question"].is_required()
+    # Defaults carry over, so the model may omit them.
+    assert fields["limit"].default == 5
+    assert fields["repos"].default is None
+
+
+def test_description_is_the_docstring_before_args():
+    (tool,) = build_method_tools(_Agent(), ["query"])
+    assert tool.description.startswith("Search the graph for something.")
+    assert "Longer prose" in tool.description
+    # The Args: block is for humans, not for tool selection.
+    assert "question: What to look for" not in tool.description
+
+
+def test_description_falls_back_when_undocumented():
+    class _Bare:
+        def go(self):  # noqa: D102 - deliberately undocumented
+            return None
+
+    (tool,) = build_method_tools(_Bare(), ["go"])
+    assert "go()" in tool.description
+
+
+@pytest.mark.parametrize("name", ["missing", "not_callable", "_private"])
+def test_unusable_names_are_skipped_not_raised(name):
+    assert build_method_tools(_Agent(), [name]) == []
+
+
+def test_existing_agent_tool_wins():
+    assert build_method_tools(_Agent(), ["query"], skip_existing=["query"]) == []
+
+
+@pytest.mark.asyncio
+async def test_execute_forwards_arguments_and_awaits():
+    (tool,) = build_method_tools(_Agent(), ["query"])
+    result = await tool._execute(question="graph", limit=2)
+    assert result.success is True
+    assert result.result == {"question": "graph", "limit": 2, "repos": None}
+
+
+@pytest.mark.asyncio
+async def test_execute_forwards_sync_methods_too():
+    tools = {t.name: t for t in build_method_tools(_Agent(), ["sync"])}
+    result = await tools["sync"]._execute()
+    assert result.result == "done"
+
+
+@pytest.mark.asyncio
+async def test_method_failure_becomes_a_failed_tool_result():
+    """A raising method must not blow up the conversation turn."""
+    (tool,) = build_method_tools(_Agent(), ["boom"])
+    result = await tool._execute()
+    assert result.success is False
+    assert "kaboom" in result.error


### PR DESCRIPTION
## Summary

`exposed_methods` and the agent's LLM toolbox were two disconnected surfaces:

- `exposed_methods` → allowlist for `agent.invoke` (RPC, the MCP proxy, `/invoke` in the REPL)
- `agent_tools()` → the tools the **model** may call during a conversation

A daemon could expose `sync_transcripts` over RPC while the agent, asked the very thing that method answers, had no way to call it — it apologises instead of acting. Every agent had to hand-write tool wrappers around methods it had already declared.

`parrot.integrations.agentd.tools.build_method_tools()` closes the gap: for each allowlisted method it derives an `AbstractTool` whose argument schema comes from the method **signature** (annotations kept, defaults preserved as optional) and whose description comes from the **docstring** text before `Args:` — the summary plus any prose about when to use it, which is what the model needs at selection time. `AgentDaemon.run()` registers them right after the agent resolves:

```
Registered 4 LLM tool(s) from exposed_methods: query_graph, read_page, related_pages, graph_status
```

## `expose_as_tools`

| value | effect |
|---|---|
| omitted (default) | one tool per `exposed_methods` |
| explicit list | only those — keeps slow or destructive methods RPC-only |
| `[]` | no derivation |

A tool the agent registers itself always wins over a derived one.

The narrowing matters in practice: a method that reindexes a corpus takes minutes and has no business being triggered by a conversation turn, but should still be reachable by `agent.invoke` and the scheduler.

## Composes with FEAT-434

This is not a second bridge. The derived tools land in the agent's `ToolManager`, so a `claude-agent` LLM reaches them through #1180's bridge as `mcp__parrot__<method>` — and therefore through `ToolManager.execute_tool()`, keeping guardrails, grants, HITL confirmation and tool-result compression. For an `AnthropicClient`-style LLM they are just ordinary registered tools.

## Failure containment

By design, none of these stop a daemon from booting:

- a name that is missing, private or not callable → skipped with a warning
- a malformed signature → that one method is skipped, the rest register
- an agent with no `register_tools()` → warning, RPC keeps working
- a method that raises → failed `ToolResult`, the turn continues

## Test evidence

`packages/ai-parrot-integrations/tests/agentd/test_method_tools.py` — 11 tests covering schema derivation from the signature, description extraction (and that the `Args:` block is excluded), the undocumented fallback, skip rules, `skip_existing` precedence, async and sync forwarding, and the raising-method path.

Full agentd suite on this branch: **114 passed, 2 failed** — both failures (`test_config.py::test_yaml_roundtrip`, `test_e2e.py::test_no_aiohttp_without_server_pkg`) reproduce identically on `dev`, i.e. pre-existing and unrelated.

## Field verification

Ran against a real daemon: an agent declaring five methods, four of them in `expose_as_tools`, answered graph questions by calling the derived tools and left the fifth (a multi-minute reindex) reachable only over RPC.

Developed with Spec Driven Development