### PR TITLE
fix(deps): port the FEAT-426 research-extra resolution fix to main

### DIFF
--- a/packages/ai-parrot-tools/pyproject.toml
+++ b/packages/ai-parrot-tools/pyproject.toml
@@ -85,8 +85,14 @@ security = []  # cloudsploit is a Docker/Node.js tool, not a PyPI package
 # All three already arrive transitively via ai-parrot; this makes them explicit.
 workday = ["zeep[async]>=4.3.3", "pandas>=2.0", "aiohttp>=3.9"]
 # FEAT-426: OpenDataToolkit + AcademicResearchToolkit external data libraries.
+# habanero is capped at <2.4 on purpose: every habanero >=2.4 requires
+# packaging>=26.2 and tqdm>=4.67.3, but xai-sdk (ai-parrot[all-fast]) caps
+# packaging<26 in *all* published versions and querysource caps tqdm<=4.67.1,
+# so >=2.4 makes the `all` extra unresolvable. 2.3.x needs only
+# packaging>=24.1 / tqdm>=4.66.5 and exposes the same Crossref API used by
+# research/academic.py. Lift the cap once xai-sdk relaxes its packaging pin.
 research = [
-    "wbgapi>=1.0", "sdmx1>=2.27", "habanero>=2.9",
+    "wbgapi>=1.0", "sdmx1>=2.27", "habanero>=2.3,<2.4",
     "biopython>=1.80", "arxiv>=3.0.0",
 ]
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,13 @@ override-dependencies = [
     # flowtask in one split, so they collide. Patch-level diff; force a single
     # version (4.3.3, matching agents) so both extras resolve.
     "zeep[async]==4.3.3",
+    # xai-sdk caps packaging<26 in *every* published version (1.12 - 1.19),
+    # but the research extra's sdmx1>=2.25.1 requires packaging>=26. The cap is
+    # a preemptive major-version bound, not a real incompatibility: xai-sdk
+    # touches packaging in exactly one place (xai_sdk/proto/__init__.py,
+    # `version.parse(protobuf.__version__).major`), an API unchanged in 26.
+    # Override the ceiling open so xai-sdk and sdmx1 share one packaging.
+    "packaging>=26.2",
 ]
 constraint-dependencies = [
     # Narrow the otel instrumentation search space. openlit pulls 15+ otel


### PR DESCRIPTION
## Summary

CI on `main` has been red since the FEAT-426 `research` extra landed: `uv sync` cannot resolve the workspace, so **every** job dies before importing anything, on every open PR.

This is not a new fix. `dev` already carries it as 62a87e99 (@phenobarbital), and `main` never received it. This PR is that commit, cherry-picked unchanged — original author and message preserved.

## The conflict

```
querysource (all versions <=4.5.11) caps tqdm<=4.67.1
habanero >=2.4                      requires tqdm>=4.67.3
→ ai-parrot-tools[all] is unsatisfiable
```

`main` declares `habanero>=2.9` in `packages/ai-parrot-tools/pyproject.toml`. The commit caps it at `>=2.3,<2.4` and adds a `packaging>=26.2` override for a related `sdmx1` / `xai-sdk` clash. The reasoning is recorded in the commit message and in a comment above the pin.

## Verification

Ran `uv lock` on both states in the same environment:

| deps | resolution | outcome |
|---|---|---|
| `main` as-is | **fails** | `Because querysource>=4.1.11 depends on tqdm>=4.65.0,<=4.67.1 ... habanero>=2.9 depends on tqdm>=4.67.3` — the exact error CI reports |
| with this commit | **passes** | proceeds past the solve into wheel builds |

Full disclosure on the second row: `uv lock` still exits non-zero here, but on an unrelated build step — `pytrec-eval` (via `bm25s[full]`) fetches `trec_eval` from GitHub at build time and my sandbox's proxy returns 502. Resolution itself completed, which is the part that was broken. The original commit reports `uv lock` resolving 979 packages on an unrestricted network.

## Note for merge ordering

Because this content already exists on `dev`, a later `dev → main` merge should see it as already applied. If you would rather land it by merging `dev` into `main` wholesale, close this — it exists only to unblock CI without waiting for the rest of `dev`.

Found while diagnosing red CI on #1186, which is unaffected by its own changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_011CsABzZysq27TLFKbnrHxR)_