### PR TITLE
fix(bedrock,wiki): make the Bedrock API key authoritative; wire the PageIndex plane

### DIFF
--- a/examples/dev_loop/server.py
+++ b/examples/dev_loop/server.py
@@ -623,6 +623,70 @@ def _build_git_toolkit() -> GitToolkit:
     )
 
 
+def _build_pageindex_toolkit(wiki_dir: Path) -> object | None:
+    """Build the ``PageIndexToolkit`` backing the wiki's authoring plane.
+
+    ``LLMWikiToolkit.create_page`` writes to two planes: the WikiStore
+    retrieval plane (always) and the PageIndex authoring plane (this
+    toolkit). Passing ``None`` for the latter made every ``create_page``
+    call raise ``AttributeError`` inside the toolkit's own best-effort
+    ``except``, logging ``'NoneType' object has no attribute
+    'insert_markdown'`` on every handed-off feature and falling back to a
+    fabricated ``page-<slug>`` id instead of a real PageIndex node id.
+
+    Mirrors the construction ``wikitoolkit ingest`` uses
+    (``knowledge/wiki/cli.py``): one LLM client from the ``WIKI_MODEL``
+    spec, wrapped in a :class:`PageIndexLLMAdapter`, over
+    ``<wiki_dir>/pageindex``.
+
+    Args:
+        wiki_dir: The wiki's storage directory (``project.storage_path``).
+
+    Returns:
+        A ready ``PageIndexToolkit``, or ``None`` when no ``WIKI_MODEL`` is
+        configured or construction fails — the caller then runs without an
+        authoring plane, which ``create_page`` degrades on cleanly.
+    """
+    try:
+        from navconfig import config as _nav
+
+        model_spec = _nav.get("WIKI_MODEL", fallback=None)
+    except Exception:  # noqa: BLE001 - navconfig optional; env is enough
+        model_spec = os.environ.get("WIKI_MODEL")
+
+    if not model_spec:
+        logger.warning(
+            "WIKI_MODEL is not configured — feature-handoff pages will be "
+            "written to the WikiStore retrieval plane only, not the "
+            "PageIndex authoring plane. Set WIKI_MODEL (format "
+            "'provider:model', e.g. 'google:gemini-3.1-flash-lite-preview') "
+            "to enable it."
+        )
+        return None
+
+    try:
+        from parrot.clients.factory import LLMFactory
+        from parrot.knowledge.pageindex.llm_adapter import PageIndexLLMAdapter
+        from parrot.knowledge.pageindex.toolkit import PageIndexToolkit
+
+        _, model_id = LLMFactory.parse_llm_string(model_spec)
+        adapter = PageIndexLLMAdapter(LLMFactory.create(model_spec), model=model_id)
+        pageindex_dir = Path(wiki_dir) / "pageindex"
+        pageindex_dir.mkdir(parents=True, exist_ok=True)
+        toolkit = PageIndexToolkit(adapter, storage_dir=pageindex_dir)
+        logger.info(
+            "PageIndexToolkit ready (model=%s, storage=%s)",
+            model_spec, pageindex_dir,
+        )
+        return toolkit
+    except Exception as exc:  # noqa: BLE001 - authoring plane is best-effort
+        logger.warning(
+            "PageIndexToolkit unavailable (%s); feature-handoff pages will "
+            "skip the authoring plane.", exc,
+        )
+        return None
+
+
 def _build_wiki_toolkit() -> object | None:
     """Build the optional ``LLMWikiToolkit`` for feature-mode handoff.
 
@@ -644,10 +708,35 @@ def _build_wiki_toolkit() -> object | None:
         )
         return None
     try:
+        from pathlib import Path
+
+        from parrot.knowledge.wiki.models import WikiConfig
+        from parrot.knowledge.wiki.project import (
+            find_project_root,
+            load_project_config,
+        )
         from parrot.knowledge.wiki.toolkit import LLMWikiToolkit
 
-        toolkit = LLMWikiToolkit()
-        logger.info("LLMWikiToolkit ready for feature-mode docs ingest")
+        root = find_project_root(Path.cwd())
+        project = load_project_config(root)          # reads .parrot/wiki.json
+        wiki_config = WikiConfig(
+            wiki_name=project.wiki_name,
+            storage_dir=project.storage_path(root),
+            storage_backend=project.backend,
+            # The GraphIndex mirror needs a real graphindex_toolkit; with
+            # None it would only warn on every ingest, so keep it off.
+            sync_graph=False,
+        )
+        pageindex_toolkit = _build_pageindex_toolkit(project.storage_path(root))
+        toolkit = LLMWikiToolkit(
+            pageindex_toolkit, None, None, wiki_config, agent_id="dev-loop"
+        )
+        logger.info(
+            "LLMWikiToolkit ready for feature-mode docs ingest "
+            "(wiki=%s, store=%s, pageindex=%s)",
+            project.wiki_name, project.storage_path(root),
+            "on" if pageindex_toolkit is not None else "off",
+        )
         return toolkit
     except Exception as exc:  # noqa: BLE001 - wiki ingest is best-effort
         logger.warning(

--- a/packages/ai-parrot/src/parrot/clients/bedrock.py
+++ b/packages/ai-parrot/src/parrot/clients/bedrock.py
@@ -32,7 +32,6 @@ See ``sdd/specs/bedrock-client-llm.spec.md`` and
 from __future__ import annotations
 
 import json
-import os
 import time
 import uuid
 from pathlib import Path
@@ -51,6 +50,34 @@ from ..models.bedrock_models import translate as translate_bedrock_model
 from ..models.responses import AIMessage, AIMessageFactory, InvokeResult
 from ..models.outputs import StructuredOutputConfig
 from ..tools.manager import ToolFormat
+
+
+class _StaticBedrockTokenProvider:
+    """Serves a fixed Bedrock API key as a botocore auth token.
+
+    Registered as a session's ``token_provider`` component so
+    ``signature_version="bearer"`` resolves to the operator's configured
+    key instead of falling through to SigV4 credentials. Deliberately
+    minimal — botocore only requires ``load_token()``, and aiobotocore
+    awaits ``get_frozen_token()``, so the latter is a coroutine here
+    (botocore's own providers are sync; aiobotocore wraps them).
+
+    Args:
+        token: The Bedrock API key (bearer token, ``"ABSK..."``).
+    """
+
+    def __init__(self, token: str) -> None:
+        from botocore.tokens import FrozenAuthToken
+
+        self._frozen = FrozenAuthToken(token)
+
+    def load_token(self) -> _StaticBedrockTokenProvider:
+        """Return self — this provider is its own (already-loaded) token."""
+        return self
+
+    async def get_frozen_token(self) -> Any:
+        """Return the immutable token botocore's ``BearerAuth`` signs with."""
+        return self._frozen
 
 
 class BedrockConverseBase(AbstractClient):
@@ -247,10 +274,38 @@ class BedrockConverseBase(AbstractClient):
             if self._aws_session_token:
                 client_kwargs["aws_session_token"] = self._aws_session_token
         elif self._aws_bearer_token:
-            # botocore >= 1.36 reads bearer tokens from the environment only
-            # (``AWS_BEARER_TOKEN_<SIGNING_NAME>`` — no constructor kwarg
-            # exists); exporting it here is the only supported hand-off.
-            os.environ["AWS_BEARER_TOKEN_BEDROCK"] = self._aws_bearer_token
+            # A configured Bedrock API key is AUTHORITATIVE: bind the token
+            # to this session explicitly and pin the auth scheme to
+            # ``bearer``, rather than exporting AWS_BEARER_TOKEN_BEDROCK and
+            # hoping botocore prefers it.
+            #
+            # The env-var hand-off (the previous approach) silently lost
+            # whenever SigV4 credentials were resolvable — and navconfig
+            # itself exports AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY from
+            # env/.env into os.environ, so botocore's credential chain
+            # found them first and signed as that IAM identity. Every call
+            # then failed with AccessDeniedException naming an identity the
+            # operator never intended to use for Bedrock, while the
+            # configured API key sat unused. It is also unsupported below
+            # botocore 1.36 (this project pins 1.35.x), where reading
+            # AWS_BEARER_TOKEN_* does not exist at all.
+            #
+            # ``signature_version="bearer"`` selects botocore's BearerAuth
+            # (auth.AUTH_TYPE_MAPS), which takes its token from the
+            # session's ``token_provider`` component — supported on both
+            # 1.35.x and later.
+            # ``_session`` is boto3/aioboto3's only handle on the underlying
+            # botocore session — there is no public accessor.
+            session._session.register_component(
+                "token_provider", _StaticBedrockTokenProvider(self._aws_bearer_token)
+            )
+            client_kwargs["config"] = client_kwargs["config"].merge(
+                BotoConfig(signature_version="bearer")
+            )
+            self.logger.debug(
+                "Bedrock auth: using the configured API key (bearer); "
+                "ambient SigV4 credentials, if any, are bypassed."
+            )
         # else: no static keys or bearer token resolved from parrot config —
         # fall through to botocore's own default credential chain (env vars,
         # AWS_BEARER_TOKEN_BEDROCK if already exported, shared credentials

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/toolkit.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/toolkit.py
@@ -669,17 +669,29 @@ class LLMWikiToolkit(AbstractToolkit):
         markdown = f"# {title}\n\n<!-- category: {category} -->\n\n{content}"
 
         page_id: Optional[str] = None
-        try:
-            pi_result = await self._pi.insert_markdown(
-                wiki_name, markdown, doc_name=title
+        if self._pi is None:
+            # Composed without an authoring plane (the caller passed None
+            # for ``pageindex_toolkit``). Say so plainly, instead of
+            # letting the AttributeError fall into the except below and
+            # surface as "'NoneType' object has no attribute
+            # 'insert_markdown'" on every single page.
+            self.logger.debug(
+                "create_page: no PageIndexToolkit composed — writing to the "
+                "WikiStore retrieval plane only (page id derived from the "
+                "title, not a PageIndex node id)."
             )
-            if isinstance(pi_result, dict):
-                # PageIndexToolkit.insert_markdown() contract:
-                # {"tree_name", "new_node_ids"}
-                new_ids = pi_result.get("new_node_ids") or []
-                page_id = str(new_ids[0]) if new_ids else None
-        except Exception as exc:  # noqa: BLE001
-            self.logger.warning("create_page PageIndex insert failed: %s", exc)
+        else:
+            try:
+                pi_result = await self._pi.insert_markdown(
+                    wiki_name, markdown, doc_name=title
+                )
+                if isinstance(pi_result, dict):
+                    # PageIndexToolkit.insert_markdown() contract:
+                    # {"tree_name", "new_node_ids"}
+                    new_ids = pi_result.get("new_node_ids") or []
+                    page_id = str(new_ids[0]) if new_ids else None
+            except Exception as exc:  # noqa: BLE001
+                self.logger.warning("create_page PageIndex insert failed: %s", exc)
 
         if not page_id:
             page_id = f"page-{title[:40].lower().replace(' ', '-')}"

--- a/packages/ai-parrot/tests/clients/test_bedrock_credentials.py
+++ b/packages/ai-parrot/tests/clients/test_bedrock_credentials.py
@@ -111,12 +111,44 @@ class TestBearerTokenResolution:
         assert c._aws_bearer_token is None
 
     @pytest.mark.asyncio
-    async def test_get_client_exports_bearer_token_env_var(self, monkeypatch):
-        import os
+    async def test_get_client_pins_bearer_auth_scheme(self, monkeypatch):
+        """A configured API key pins ``signature_version="bearer"``.
 
+        Regression: this used to export ``AWS_BEARER_TOKEN_BEDROCK`` and
+        rely on botocore preferring it. botocore 1.35.x (this project's
+        pin) has no AWS_BEARER_TOKEN support at all, so the export was
+        inert and every call fell through to SigV4 — signing as whatever
+        ambient IAM identity the credential chain found (navconfig itself
+        exports AWS_ACCESS_KEY_ID from env/.env), then failing with
+        AccessDeniedException while the API key sat unused.
+        """
         monkeypatch.setattr("parrot.clients.bedrock.AWS_CREDENTIALS", {})
-        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        # Ambient SigV4 credentials present — the bearer key must still win.
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIA-AMBIENT")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "ambient-secret")
+
         c = BedrockConverseClient(aws_bearer_token="ABSK-EXPORTED")
-        await c.get_client()
-        assert os.environ["AWS_BEARER_TOKEN_BEDROCK"] == "ABSK-EXPORTED"
-        del os.environ["AWS_BEARER_TOKEN_BEDROCK"]
+        client = await c.get_client()
+
+        assert client.meta.config.signature_version == "bearer"
+
+    @pytest.mark.asyncio
+    async def test_get_client_uses_sigv4_for_static_keys(self, monkeypatch):
+        """A static keypair still signs with SigV4, not bearer."""
+        monkeypatch.setattr("parrot.clients.bedrock.AWS_CREDENTIALS", {})
+        c = BedrockConverseClient(
+            aws_access_key="AKIA-EXPLICIT", aws_secret_key="explicit-secret"
+        )
+        client = await c.get_client()
+
+        assert client.meta.config.signature_version != "bearer"
+
+    @pytest.mark.asyncio
+    async def test_static_token_provider_serves_the_configured_key(self):
+        """The provider hands botocore's BearerAuth the configured token."""
+        from parrot.clients.bedrock import _StaticBedrockTokenProvider
+
+        provider = _StaticBedrockTokenProvider("ABSK-TOKEN")
+        frozen = await provider.load_token().get_frozen_token()
+
+        assert frozen.token == "ABSK-TOKEN"

--- a/packages/ai-parrot/tests/flows/dev_loop/test_server_repo_wiring.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_server_repo_wiring.py
@@ -540,3 +540,85 @@ async def test_server_invalid_agent_lists_zai(monkeypatch) -> None:
     with pytest.raises(RuntimeError, match="zai"):
         await server_mod._on_startup(app)
 
+
+
+# ---------------------------------------------------------------------------
+# PageIndex authoring plane (create_page wiring)
+# ---------------------------------------------------------------------------
+
+
+def test_build_pageindex_toolkit_without_wiki_model(monkeypatch, tmp_path, caplog):
+    """No WIKI_MODEL configured -> None, with an actionable warning.
+
+    Regression: ``_build_wiki_toolkit`` used to pass ``None`` for the
+    PageIndex toolkit unconditionally, so every ``create_page`` raised
+    ``AttributeError`` inside LLMWikiToolkit's best-effort except and
+    logged "'NoneType' object has no attribute 'insert_markdown'" with no
+    hint about what to configure.
+    """
+    server = _load_server_module()
+    monkeypatch.setattr(
+        server, "_build_pageindex_toolkit", server._build_pageindex_toolkit
+    )
+    import navconfig
+
+    monkeypatch.setattr(
+        navconfig.config, "get", lambda name, fallback=None: fallback
+    )
+    monkeypatch.delenv("WIKI_MODEL", raising=False)
+
+    with caplog.at_level("WARNING"):
+        result = server._build_pageindex_toolkit(tmp_path)
+
+    assert result is None
+    assert any("WIKI_MODEL" in rec.message for rec in caplog.records)
+
+
+def test_build_pageindex_toolkit_with_wiki_model(monkeypatch, tmp_path):
+    """A configured WIKI_MODEL yields a real PageIndexToolkit."""
+    server = _load_server_module()
+    import navconfig
+
+    monkeypatch.setattr(
+        navconfig.config,
+        "get",
+        lambda name, fallback=None: (
+            "google:gemini-3.1-flash-lite-preview" if name == "WIKI_MODEL" else fallback
+        ),
+    )
+
+    from parrot.clients.factory import LLMFactory
+
+    monkeypatch.setattr(LLMFactory, "create", staticmethod(lambda spec: MagicMock()))
+
+    result = server._build_pageindex_toolkit(tmp_path)
+
+    assert result is not None
+    assert (tmp_path / "pageindex").is_dir()
+
+
+def test_build_pageindex_toolkit_degrades_on_failure(monkeypatch, tmp_path, caplog):
+    """Client construction blowing up degrades to None, never raises."""
+    server = _load_server_module()
+    import navconfig
+
+    monkeypatch.setattr(
+        navconfig.config,
+        "get",
+        lambda name, fallback=None: (
+            "bogus:model" if name == "WIKI_MODEL" else fallback
+        ),
+    )
+
+    from parrot.clients.factory import LLMFactory
+
+    def _boom(spec):
+        raise RuntimeError("no such provider")
+
+    monkeypatch.setattr(LLMFactory, "create", staticmethod(_boom))
+
+    with caplog.at_level("WARNING"):
+        result = server._build_pageindex_toolkit(tmp_path)
+
+    assert result is None
+    assert any("PageIndexToolkit unavailable" in rec.message for rec in caplog.records)

--- a/tests/knowledge/wiki/test_authoring.py
+++ b/tests/knowledge/wiki/test_authoring.py
@@ -353,3 +353,77 @@ class TestUpdatePageRegression:
         assert second["status"] == "updated"
         page = await toolkit._store.get_page(first["page_id"])
         assert page["origin"] == "memory"
+
+
+class TestCreatePageWithoutAuthoringPlane:
+    """``create_page`` composed with ``pageindex_toolkit=None``.
+
+    Regression: the PageIndex insert was called unconditionally, so a
+    ``None`` toolkit raised ``AttributeError`` into the best-effort
+    except and logged "'NoneType' object has no attribute
+    'insert_markdown'" on every page — noise that named neither the cause
+    nor the remedy.
+    """
+
+    def _toolkit(self, tmp_path, pageindex_toolkit):
+        from parrot.knowledge.wiki.models import WikiConfig
+        from parrot.knowledge.wiki.toolkit import LLMWikiToolkit
+
+        config = WikiConfig(wiki_name="test-wiki", storage_dir=tmp_path / "wiki")
+        return LLMWikiToolkit(
+            pageindex_toolkit=pageindex_toolkit,
+            graphindex_toolkit=None,
+            okf_toolkit=None,
+            config=config,
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_pageindex_still_writes_the_retrieval_plane(
+        self, tmp_path, caplog
+    ):
+        toolkit = self._toolkit(tmp_path, None)
+
+        with caplog.at_level("WARNING"):
+            result = await toolkit.create_page("test-wiki", "My Page", "body")
+
+        assert result["status"] == "created"
+        # Falls back to a title-derived id, and says nothing alarming.
+        assert result["page_id"] == "page-my-page"
+        assert not any(
+            "NoneType" in rec.message or "insert failed" in rec.message
+            for rec in caplog.records
+        )
+        page = await toolkit._store.get_page(result["page_id"])
+        assert page["body"] == "body"
+
+    @pytest.mark.asyncio
+    async def test_pageindex_node_id_is_used_when_available(self, tmp_path):
+        class _StubPI:
+            async def insert_markdown(self, *a, **k):
+                return {"tree_name": "t", "new_node_ids": ["node-42"]}
+
+        toolkit = self._toolkit(tmp_path, _StubPI())
+
+        result = await toolkit.create_page("test-wiki", "My Page", "body")
+
+        assert result["page_id"] == "node-42"
+
+    @pytest.mark.asyncio
+    async def test_pageindex_failure_still_degrades_with_a_warning(
+        self, tmp_path, caplog
+    ):
+        """A real toolkit that throws keeps the existing warning path."""
+
+        class _BoomPI:
+            async def insert_markdown(self, *a, **k):
+                raise RuntimeError("tree write failed")
+
+        toolkit = self._toolkit(tmp_path, _BoomPI())
+
+        with caplog.at_level("WARNING"):
+            result = await toolkit.create_page("test-wiki", "My Page", "body")
+
+        assert result["status"] == "created"
+        assert any(
+            "PageIndex insert failed" in rec.message for rec in caplog.records
+        )


### PR DESCRIPTION
Two unrelated warnings observed in one feature-handoff run.

## 1. Bedrock: the configured API key was never used

```
[WARNING] parrot.node.feature_handoff(nova.py:552) :: PR summary enrichment
unavailable for model 'us.amazon.nova-2-lite-v1:0' (AccessDeniedException:
User: arn:aws:iam::…:user/… is not authorized to perform: bedrock:InvokeModel
on resource: …/us.amazon.nova-2-lite-v1:0)
```

**The model was never the problem.** Measured against the live account:

| Credential | `us.amazon.nova-2-lite-v1:0` | `nova-lite` / `nova-micro` / `nova-pro` |
|---|---|---|
| `AWS_NOVA_API_KEY` (bearer) | ✅ works | ✅ works |
| ambient IAM user | ❌ denied | ❌ denied |

So retargeting `DEV_LOOP_NOVA_MECHANICAL_MODEL` could not have fixed it —
there is no Nova id that identity can call. The wrong *credential* was
being used.

`_get_client()` handed the key over by exporting `AWS_BEARER_TOKEN_BEDROCK`
and trusting botocore to prefer it. Two independent reasons that fails:

1. **botocore 1.35.x has no `AWS_BEARER_TOKEN` support at all** (`grep -r
   AWS_BEARER_TOKEN botocore/` → nothing). It arrived in 1.36; this project
   pins 1.35.36, so the export was inert. The AWS CLI honours the same key
   only because it bundles its own newer botocore.
2. **navconfig exports `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` from
   `env/.env` into `os.environ`**, so the credential chain always resolved
   SigV4 keys first — visible in the logs as
   `aiobotocore.credentials :: Found credentials in environment variables.`

A configured API key is now **authoritative**: the token is bound to the
session through a `token_provider` component and the auth scheme is pinned
via `signature_version="bearer"` (botocore's `BearerAuth`). Deterministic,
supported on 1.35.x *and* later, and unaffected by ambient credentials.
Static keypairs (explicit kwarg or `aws_id` profile) still use SigV4,
unchanged.

Verified live — `NovaClient.ask` and `summarize_pr_changes` both succeed
against `us.amazon.nova-2-lite-v1:0` **with the ambient SigV4 keys still
present** in `os.environ`.

## 2. Wiki: `create_page` had no authoring plane

```
[WARNING] parrot.knowledge.wiki.toolkit(toolkit.py:682) :: create_page
PageIndex insert failed: 'NoneType' object has no attribute 'insert_markdown'
```

`examples/dev_loop/server.py` built `LLMWikiToolkit(None, None, None, …)`.
The author had noticed the *graph* equivalent would warn on every ingest and
set `sync_graph=False` for it — but `create_page` calls
`self._pi.insert_markdown` unguarded, one field over. Every handed-off
feature logged that `AttributeError` and fell back to a fabricated
`page-<slug>` id instead of a real PageIndex node id.

`server.py` now builds a real `PageIndexToolkit`, mirroring the construction
`wikitoolkit ingest` uses (`WIKI_MODEL` → `LLMFactory` →
`PageIndexLLMAdapter` over `<wiki_dir>/pageindex`). When `WIKI_MODEL` is
unset it degrades to `None` with a warning that **names the setting**, and
`create_page` guards the `None` case explicitly so the residual path
explains itself instead of leaking an internal error.

Before / after, same call:

| | page_id | log |
|---|---|---|
| before | `page-my-feature-page` | `'NoneType' object has no attribute …` |
| after, no `WIKI_MODEL` | `page-my-feature-page` | one clear debug line |
| after, with toolkit | `node-42` (real node id) | — |

> **Operator note:** `WIKI_MODEL` is currently unset in this deployment, so
> the authoring plane stays off until it is configured (format
> `provider:model`). The warning now says exactly that.

## Verification

- clients + wiki suites: **1108 passed**, 6 failed — all 6 reproduce on
  `dev` (5 client, 1 wiki-installer); none touched here.
- dev_loop suite: **1063 passed**, 3 failed — the same pre-existing
  `sdd-secondopinion` prompt drift, identical on `dev`.
- `ruff` on `bedrock.py` is byte-identical to the `dev` baseline; no new
  violation kinds in `toolkit.py` or `server.py`.
- `mypy` unchanged (one pre-existing `InvokeError` attr-defined error, also
  present on `dev`).

## Notes for review

- The bearer path is exercised with ambient SigV4 credentials deliberately
  set in the test, since that is the exact condition that used to break it.
- `session._session` is boto3/aioboto3's only handle on the underlying
  botocore session — there is no public accessor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)