### PR TITLE
fix(claude-agent): resume a conversation instead of re-creating its session

### DIFF
--- a/packages/ai-parrot/src/parrot/clients/claude_agent.py
+++ b/packages/ai-parrot/src/parrot/clients/claude_agent.py
@@ -311,11 +311,50 @@ class ClaudeAgentClient(AbstractClient):
         self.default_run_options: ClaudeAgentRunOptions = (
             run_options or ClaudeAgentRunOptions()
         )
+        # Maps an ai-parrot session id to the CLI's OWN session id, so a
+        # second turn on the same conversation resumes instead of trying to
+        # re-create a session the CLI already has. See _cli_session_for().
+        self._cli_sessions: Dict[str, str] = {}
         super().__init__(**kwargs)
 
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    def _cli_session_for(self, session_id: Optional[str]) -> Optional[str]:
+        """Return the CLI session to resume for an ai-parrot session id.
+
+        Args:
+            session_id: The ai-parrot conversation id, if any.
+
+        Returns:
+            The CLI's session id when this conversation already has one, else
+            ``None`` (meaning: create a new CLI session).
+        """
+        if not session_id:
+            return None
+        return self._cli_sessions.get(session_id)
+
+    def _remember_cli_session(
+        self, session_id: Optional[str], messages: List[Any]
+    ) -> None:
+        """Record the CLI session id the SDK reported for this conversation.
+
+        The CLI assigns its own session id, which is NOT the one passed in
+        via ``session_id`` — resuming with the wrong one fails — so the id is
+        read back off the message stream.
+
+        Args:
+            session_id: The ai-parrot conversation id, if any.
+            messages: The SDK message stream just collected.
+        """
+        if not session_id:
+            return
+        for message in reversed(messages):
+            cli_session = getattr(message, "session_id", None)
+            if isinstance(cli_session, str) and cli_session:
+                self._cli_sessions[session_id] = cli_session
+                return
 
     def _build_options(
         self,
@@ -412,10 +451,13 @@ class ClaudeAgentClient(AbstractClient):
             kwargs["strict_mcp_config"] = merged.strict_mcp_config
         if merged.extra_args is not None:
             kwargs["extra_args"] = dict(merged.extra_args)
-        if session_id is not None:
-            kwargs["session_id"] = session_id
+        # `resume` and `session_id` are mutually exclusive on the CLI, and
+        # `resume` is what continues a conversation, so it wins. Passing both
+        # (as resume() used to) makes the CLI exit 1 on every resume.
         if resume_id is not None:
             kwargs["resume"] = resume_id
+        elif session_id is not None:
+            kwargs["session_id"] = session_id
 
         # FEAT-434: bridge the agent's registered ToolManager tools to the
         # sub-agent as an in-process SDK-MCP server, unless disabled via
@@ -580,11 +622,18 @@ class ClaudeAgentClient(AbstractClient):
             )
             effective_run_options.expose_parrot_tools = False
 
+        # A conversation's SECOND turn must resume: the CLI's --session-id
+        # only ever CREATES a session, and handing it one it already knows
+        # makes it exit 1. Without this, any caller holding one conversation
+        # open — `parrot attach`, an agentd `chat.send` connection — died on
+        # its second message.
+        resume_id = self._cli_session_for(session_id)
         options = self._build_options(
             run_options=effective_run_options,
             model=resolved_model,
             system_prompt=system_prompt,
-            session_id=session_id,
+            session_id=None if resume_id else session_id,
+            resume_id=resume_id,
             prompt=prompt,
         )
 
@@ -601,6 +650,7 @@ class ClaudeAgentClient(AbstractClient):
         _lc_t0_ca = _lc_time_ca.perf_counter()
 
         messages = await self._collect_messages(prompt, options=options)
+        self._remember_cli_session(session_id, messages)
 
         ai_message = AIMessageFactory.from_claude_agent(
             messages=messages,
@@ -661,11 +711,18 @@ class ClaudeAgentClient(AbstractClient):
         """
         query, _, _ = _import_sdk()
         resolved_model = self._resolve_model(model, self._default_model)
+        # A conversation's SECOND turn must resume: the CLI's --session-id
+        # only ever CREATES a session, and passing an id it already knows
+        # makes it exit 1 ("Invalid session ID" / already exists). Without
+        # this, any client holding one conversation open — `parrot attach`,
+        # an agentd `chat.send` connection — died on the second message.
+        resume_id = self._cli_session_for(session_id)
         options = self._build_options(
             run_options=run_options,
             model=resolved_model,
             system_prompt=system_prompt,
-            session_id=session_id,
+            session_id=None if resume_id else session_id,
+            resume_id=resume_id,
         )
         async for msg in query(prompt=prompt, options=options):
             yield msg
@@ -823,7 +880,7 @@ class ClaudeAgentClient(AbstractClient):
         del state  # accepted for AbstractClient parity
         turn_id = str(uuid.uuid4())
         options = self._build_options(
-            resume_id=session_id, session_id=session_id, prompt=user_input
+            resume_id=session_id, prompt=user_input
         )
         messages = await self._collect_messages(user_input, options=options)
         return AIMessageFactory.from_claude_agent(

--- a/tests/clients/test_claude_agent.py
+++ b/tests/clients/test_claude_agent.py
@@ -709,3 +709,123 @@ async def test_claude_agent_live_smoke():
     client = ClaudeAgentClient()
     result = await client.ask("Say the word PONG and nothing else.")
     assert result.output
+
+
+class TestSessionResume:
+    """A conversation's second turn must resume, not re-create the session.
+
+    The CLI's ``--session-id`` only ever CREATES a session; handing it an id
+    it already knows makes it exit 1. Any caller holding one conversation
+    open — ``parrot attach``, an agentd ``chat.send`` connection — therefore
+    died on its second message before this behaviour existed.
+    """
+
+    @staticmethod
+    def _capturing_query(messages: list[Any], captured: list[Any]):
+        """A ``query`` stand-in that records the options it was handed."""
+
+        def _query(*args: Any, **kwargs: Any) -> _AsyncIter:
+            captured.append(kwargs.get("options"))
+            return _AsyncIter(messages)
+
+        return _query
+
+    @pytest.mark.asyncio
+    async def test_first_turn_creates_and_second_resumes(
+        self, fake_claude_agent_messages
+    ):
+        from parrot.clients import claude_agent as ca_module
+
+        captured: list[Any] = []
+        client = ca_module.ClaudeAgentClient()
+        with patch.object(
+            ca_module,
+            "_import_sdk",
+            return_value=(
+                self._capturing_query(fake_claude_agent_messages, captured),
+                object,
+                lambda **kw: SimpleNamespace(**kw),
+            ),
+        ):
+            await client.ask("first", session_id="conv-1")
+            await client.ask("second", session_id="conv-1")
+
+        first, second = captured
+        # Turn 1 creates the CLI session...
+        assert getattr(first, "session_id", None) == "conv-1"
+        assert getattr(first, "resume", None) is None
+        # ...turn 2 resumes it, and must NOT also pass session_id: the CLI
+        # rejects both together.
+        assert getattr(second, "resume", None) is not None
+        assert getattr(second, "session_id", None) is None
+
+    @pytest.mark.asyncio
+    async def test_distinct_conversations_do_not_share_a_session(
+        self, fake_claude_agent_messages
+    ):
+        from parrot.clients import claude_agent as ca_module
+
+        captured: list[Any] = []
+        client = ca_module.ClaudeAgentClient()
+        with patch.object(
+            ca_module,
+            "_import_sdk",
+            return_value=(
+                self._capturing_query(fake_claude_agent_messages, captured),
+                object,
+                lambda **kw: SimpleNamespace(**kw),
+            ),
+        ):
+            await client.ask("a", session_id="conv-a")
+            await client.ask("b", session_id="conv-b")
+
+        # Each conversation creates its own CLI session.
+        assert [getattr(o, "session_id", None) for o in captured] == [
+            "conv-a",
+            "conv-b",
+        ]
+        assert all(getattr(o, "resume", None) is None for o in captured)
+
+    @pytest.mark.asyncio
+    async def test_without_a_session_id_nothing_is_tracked(
+        self, fake_claude_agent_messages
+    ):
+        """A stateless caller must not accumulate session state."""
+        from parrot.clients import claude_agent as ca_module
+
+        client = ca_module.ClaudeAgentClient()
+        with patch.object(
+            ca_module,
+            "_import_sdk",
+            return_value=(
+                _fake_query_factory(fake_claude_agent_messages),
+                object,
+                lambda **kw: SimpleNamespace(**kw),
+            ),
+        ):
+            await client.ask("one")
+            await client.ask("two")
+        assert client._cli_sessions == {}
+
+    @pytest.mark.asyncio
+    async def test_resume_passes_only_resume(self, fake_claude_agent_messages):
+        """``resume()`` used to pass BOTH resume and session_id, so every
+        resume exited 1."""
+        from parrot.clients import claude_agent as ca_module
+
+        captured: list[Any] = []
+        client = ca_module.ClaudeAgentClient()
+        with patch.object(
+            ca_module,
+            "_import_sdk",
+            return_value=(
+                self._capturing_query(fake_claude_agent_messages, captured),
+                object,
+                lambda **kw: SimpleNamespace(**kw),
+            ),
+        ):
+            await client.resume("sess-9", "keep going")
+
+        (options,) = captured
+        assert getattr(options, "resume", None) == "sess-9"
+        assert getattr(options, "session_id", None) is None


### PR DESCRIPTION
## Summary

The `claude` CLI's `--session-id` only ever **creates** a session. Handing it an id it already knows makes it exit 1:

```
Error: Invalid session ID. Must be a valid UUID.
```

So any caller that holds one conversation open died on its **second** message. That covers:

- **`parrot attach`** — one connection for the whole REPL, so the second thing you type fails.
- **any agentd `chat.send` connection** — agentd derives the session id from the connection and passes it on every turn (`service.py`: `self.agent.ask(prompt, session_id=session.session_id)`).

The failure was also invisible: the SDK reports `ProcessError: Command failed with exit code 1 / Check stderr output for details`, and the real message only shows up if you run the CLI by hand.

`resume()` was broken for the same underlying reason from the other side: it passed **both** `resume` and `session_id` with the same value, and the CLI rejects the pair — so every resume exited 1 too.

## The fix

`ask()` (and the streaming path) now look up the CLI's own session id for the conversation and pass `resume` from the second turn on. `_build_options()` treats the two as mutually exclusive, with `resume` winning. `resume()` passes only `resume`.

The CLI assigns its own session id, which is read back off the message stream rather than assumed — resuming with the wrong id fails.

## Verified against the real CLI

Three shapes, before and after:

| | before | after |
|---|---|---|
| same session id on both turns | turn 2 exits 1 | both OK |
| a fresh id per turn | OK (no continuity) | OK |
| no session id at all | OK | OK |

And continuity is real, not just non-failing — a resumed turn recalls the earlier one:

```
crear (session_id) -> ok
resume             -> El 42.
```

Confirmed independently at the CLI level (`claude -p ... --session-id U`, then `claude -p ... --resume U`), which is what pointed at the fix.

## Tests

`tests/clients/test_claude_agent.py::TestSessionResume` — four tests over the option stream `query()` receives. Three fail on `dev`; the fourth (distinct conversations get distinct sessions) is a control that passes either way.

Other failures in `tests/clients/` are pre-existing on `dev` (`test_anthropic_fallback`, `test_bridged_hitl`, `test_client_fallback`, `test_google_fallback`) and vary between runs.

## How it turned up

Building a Telegram bridge that keeps one daemon connection per chat, so the agent remembers the thread. The first message always worked and the second always failed — which is what made it worth chasing rather than retrying.

Developed with Spec Driven Development