### PR TITLE
fix(codex-agent): do not require the SDK when backend is "cli"

### DIFF
--- a/packages/ai-parrot/src/parrot/clients/codex_agent.py
+++ b/packages/ai-parrot/src/parrot/clients/codex_agent.py
@@ -25,6 +25,11 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 
 
 Backend = Literal["auto", "sdk", "cli"]
+
+#: Placeholder cached by ``AbstractClient`` when the CLI backend is active.
+#: The CLI path owns its own lifecycle, so no SDK object is ever needed —
+#: see :meth:`OpenAICodexClient.get_client`.
+_CLI_BACKEND_HANDLE = object()
 SandboxMode = Literal["read-only", "workspace-write", "danger-full-access"]
 ApprovalPolicy = Literal["untrusted", "on-request", "never"]
 
@@ -89,6 +94,22 @@ class OpenAICodexClient(AbstractClient):
         self.run_options.codex_bin = codex_bin
 
     async def get_client(self) -> Any:
+        """Return the SDK client, or an inert handle for the CLI backend.
+
+        With ``backend="cli"`` there is no SDK client to build: ``ask()``
+        drives the ``codex`` binary itself and never touches the cached
+        handle (``AbstractClient`` only stores it per event loop). Importing
+        the SDK here would make the CLI backend depend on the very package
+        it exists to avoid — which is what happened to every caller that
+        goes through ``async with client`` instead of ``complete()``, e.g.
+        an agent turn via ``execute_llm_call()``.
+
+        Returns:
+            The ``AsyncCodex`` SDK client, or ``_CLI_BACKEND_HANDLE`` when
+            running the CLI backend.
+        """
+        if self.run_options.backend == "cli":
+            return _CLI_BACKEND_HANDLE
         sdk = self._import_sdk()
         return sdk.AsyncCodex()
 

--- a/packages/ai-parrot/tests/unit/clients/test_codex_agent.py
+++ b/packages/ai-parrot/tests/unit/clients/test_codex_agent.py
@@ -157,3 +157,69 @@ async def test_tool_bridge_routes_through_tool_manager() -> None:
     assert [tool.name for tool in tools] == ["echo"]
     assert result.isError is False
     assert result.content[0].text == "echo:x"
+
+
+@pytest.mark.asyncio
+async def test_cli_backend_get_client_does_not_import_the_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``backend="cli"`` must not need ``openai-codex``.
+
+    The CLI backend exists precisely so Codex can be driven through its own
+    binary and session instead of an SDK plus API key. ``get_client()`` used
+    to import the SDK unconditionally, so every caller that goes through
+    ``async with client`` — which is every agent turn, via
+    ``execute_llm_call()`` — failed with "SDK backend requires openai-codex"
+    even though it never needed one.
+    """
+
+    def _boom() -> Any:
+        raise AssertionError("the CLI backend must not import the SDK")
+
+    client = OpenAICodexClient(backend="cli")
+    monkeypatch.setattr(client, "_import_sdk", _boom)
+
+    handle = await client.get_client()
+    assert handle is not None
+
+    # The same handle every time: AbstractClient caches it per event loop and
+    # never calls into it, so it stays inert.
+    assert await client.get_client() is handle
+
+
+@pytest.mark.asyncio
+async def test_cli_backend_survives_the_client_context_manager() -> None:
+    """Entering the client is what an agent turn does before ask()."""
+    client = _FakeCodexClient(backend="cli")
+    async with client:
+        message = await client.ask(
+            "hello",
+            run_options=CodexAgentRunOptions(
+                backend="cli", model="", cwd="/tmp", expose_parrot_tools=False
+            ),
+        )
+    assert message.response == "ok"
+
+
+@pytest.mark.asyncio
+async def test_sdk_backend_still_imports_the_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The SDK path is unchanged: it must still resolve the SDK."""
+    calls: list[bool] = []
+
+    def _fake_import() -> Any:
+        calls.append(True)
+
+        class _Sdk:
+            @staticmethod
+            def AsyncCodex() -> str:  # noqa: N802 - mirrors the SDK name
+                return "sdk-client"
+
+        return _Sdk
+
+    client = OpenAICodexClient(backend="sdk")
+    monkeypatch.setattr(client, "_import_sdk", _fake_import)
+
+    assert await client.get_client() == "sdk-client"
+    assert calls == [True]


### PR DESCRIPTION
## Summary

`OpenAICodexClient.get_client()` imported `openai-codex` unconditionally, so the **CLI backend could not be used by an agent at all** — even though its whole purpose is to drive the `codex` binary and inherit its session instead of holding an SDK and an API key:

```
ImportError: OpenAICodexClient SDK backend requires openai-codex.
Install with: pip install ai-parrot[codex-agent]
```

Anything that goes through `async with client` hits it, which is every agent turn: `execute_llm_call()` enters the client before calling `ask()`.

## This was already known, half

The file works around the same problem once, in `complete()`:

> The base `AbstractClient.complete()` enters the SDK client before calling `ask()`. That is useful for HTTP SDK clients, but it defeats this client's CLI fallback because `__aenter__` would import `openai-codex` even when `backend="cli"`.

That fixed one caller by bypassing the context manager. This fixes the cause, so the agent path works too.

## The fix

With `backend="cli"` there is no SDK client to build: `ask()` drives the subprocess itself, and `AbstractClient` only caches the handle per event loop without ever calling into it (`_ensure_client()` stores the result and nothing else touches it). So an inert sentinel is returned instead of importing the SDK.

The SDK backend is untouched.

## Verified end to end

An ai-parrot agent with `backend="cli"` answering through a **ChatGPT-account** `codex` session, with `OPENAI_API_KEY` removed from the environment, reaching its own registered tools through `CodexToolBridge`:

```
respuesta -> El grafo FKB cubre 12 repositorios.
```

(That answer came from a tool call into a knowledge graph, so the bridge round-trip is exercised, not just text generation.)

## Tests

`packages/ai-parrot/tests/unit/clients/test_codex_agent.py` — 3 added: `get_client()` on the CLI backend never calls `_import_sdk` and returns a stable handle; an `async with client` block completes on the CLI backend; the SDK backend still resolves the SDK. The first two fail on `dev`. Full file: **8 passed**.

## Two adjacent papercuts, not fixed here

Found while getting this working; both have clean workarounds, so I left them alone rather than widening the PR:

1. `__init__` does `self.run_options.backend = backend` with its own `"auto"` default, so it **overwrites** a backend set inside a `run_options` object. Callers have to pass `backend=` twice — as the kwarg and in `run_options` — which is surprising.
2. `_effective_run_options()` substitutes the client's `default_model` (`gpt-5.1-codex`) whenever `run_options.model is None`, and a ChatGPT account rejects that model outright (`The 'gpt-5.1-codex' model is not supported when using Codex with a ChatGPT account`). The escape hatch is `model=""`, which is falsy so `--model` is omitted and the user's `~/.codex/config.toml` wins — already covered by `test_cli_ask_can_use_codex_default_model`. Worth considering whether the CLI backend should default to that, since deferring to the CLI's own configuration is the point of inheriting its session.

Developed with Spec Driven Development