### PR TITLE
feat(dev-loop): make the loop startable by an agent, and reproduce bugs at intake

### DIFF
--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/bug_intake.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/bug_intake.py
@@ -1,14 +1,21 @@
 """BugIntakeNode — bug-specific intake hook for the dev-loop flow.
 
-FEAT-132 scope-down: universal validation (allowlist heads, path-traversal)
-has moved to :class:`IntentClassifierNode`, which runs before this node on
-the bug path. ``BugIntakeNode`` is now a thin extension hook reserved for
-future bug-only enrichment (severity classification, stack-trace parsing,
-etc.). For v1 it re-emits ``flow.bug_brief_validated`` so existing
-downstream observers keep working, and returns the brief unchanged.
+FEAT-132 scope-down moved universal validation (allowlist heads,
+path-traversal) to :class:`IntentClassifierNode`, which runs before this
+node on the bug path. What is left here is the bug-only enrichment the node
+was reserved for: parse the stack trace, classify severity, and — when a
+replication target is configured — reproduce the failure against a real
+environment and document what was actually observed.
 
-This node deliberately does NOT call the dispatcher; the most
-expensive thing it does is one ``XADD`` to the flow event stream.
+Enrichment is additive and best-effort. Without a replication target, or
+when the brief carries no trace, the node behaves exactly as before:
+re-emit ``flow.bug_brief_validated`` and return the brief. A bug report
+that cannot be enriched still has to reach Research.
+
+The point of reproducing is evidence over narration. A brief that says
+"returns 500" sends Research looking; one that carries the observed status,
+the response body, the culprit frame and a regression test that currently
+fails tells it where to look and how the fix will be judged.
 """
 
 from __future__ import annotations
@@ -21,6 +28,16 @@ from parrot.bots.flows.core.context import FlowContext
 from parrot.bots.flows.core.types import DependencyResults
 from parrot.flows.dev_loop.models import BugBrief
 from parrot.flows.dev_loop.nodes.base import DevLoopNode, register_dev_loop_node
+from parrot.flows.dev_loop.replication import (
+    ReplicationResult,
+    ReplicationTarget,
+    StackTrace,
+    classify_severity,
+    extract_endpoint,
+    parse_stack_trace,
+    proposed_regression_test,
+    replicate_endpoint,
+)
 
 
 @register_dev_loop_node("dev_loop.bug_intake")
@@ -37,6 +54,14 @@ class BugIntakeNode(DevLoopNode):
             The connection is lazy: the node is safe to construct without
             a live Redis. The actual publish happens on first ``execute``.
         name: Node id, defaults to ``"bug_intake"``.
+        replication_target: Environment to reproduce the failure against
+            (dev, staging). ``None`` skips reproduction and the node only
+            parses what the report already carries. The target is an
+            environment on purpose: reproducing where the 500 actually
+            happens beats standing up the service and its database locally
+            for every bug.
+        replicate: Set ``False`` to parse and classify but never issue a
+            request — for a bug whose endpoint must not be touched again.
     """
 
     def __init__(
@@ -44,10 +69,14 @@ class BugIntakeNode(DevLoopNode):
         *,
         redis_url: str,
         name: str = "bug_intake",
+        replication_target: Optional[ReplicationTarget] = None,
+        replicate: bool = True,
     ) -> None:
         super().__init__(node_id=name)
         object.__setattr__(self, "_redis_url", redis_url)
         object.__setattr__(self, "_redis", None)
+        object.__setattr__(self, "_replication_target", replication_target)
+        object.__setattr__(self, "_replicate", replicate)
 
     # ------------------------------------------------------------------
     # Execute
@@ -82,10 +111,178 @@ class BugIntakeNode(DevLoopNode):
         """
         shared = self.shared_state(ctx)
         brief = self._load_brief(self.initial_prompt(ctx), shared)
+        findings = await self._enrich(brief)
+        if findings:
+            # The findings also travel in shared state, unflattened, so
+            # downstream nodes can use the parsed pieces instead of
+            # re-parsing the prose we appended to the description.
+            shared["bug_findings"] = findings
         if run_id := shared.get("run_id", ""):
             await self._emit_validated_event(run_id, brief)
         shared["bug_brief"] = brief
         return brief
+
+    # ------------------------------------------------------------------
+    # Enrichment
+    # ------------------------------------------------------------------
+
+    async def _enrich(self, brief: BugBrief) -> Dict[str, Any]:
+        """Parse, reproduce and document — mutating ``brief`` in place.
+
+        Best-effort throughout: anything that cannot be determined is left
+        out rather than guessed, and no failure here stops the brief from
+        reaching Research.
+
+        Args:
+            brief: The validated brief, enriched in place.
+
+        Returns:
+            The structured findings (also stored in shared state), empty
+            when there was nothing to add.
+        """
+        trace = self._parse_reported_trace(brief)
+        replication = await self._reproduce(brief)
+        severity = classify_severity(trace, replication)
+
+        findings: Dict[str, Any] = {"severity": severity}
+        notes = [f"severidad observada: {severity}"]
+
+        if trace is not None and (trace.frames or trace.exception_type):
+            findings["trace"] = {
+                "language": trace.language,
+                "exception_type": trace.exception_type,
+                "message": trace.message,
+                "culprit": (
+                    {
+                        "file": trace.culprit.file,
+                        "line": trace.culprit.line,
+                        "function": trace.culprit.function,
+                    }
+                    if trace.culprit is not None
+                    else None
+                ),
+            }
+            notes.append(f"trace reportado: {trace.summary()}")
+
+        if replication is not None:
+            findings["replication"] = {
+                "attempted": replication.attempted,
+                "reproduced": replication.reproduced,
+                "target": replication.target,
+                "url": replication.url,
+                "method": replication.method,
+                "status": replication.status,
+                "error": replication.error,
+            }
+            notes.append(f"reproduccion: {replication.summary()}")
+            if replication.reproduced and replication.body_excerpt:
+                # The observed body is stronger evidence than the pasted
+                # excerpt, so it becomes a log source of its own.
+                brief.log_sources.append(
+                    _inline_source(
+                        f"--- Respuesta observada en {replication.target} "
+                        f"({replication.status}) ---\n"
+                        f"{replication.body_excerpt}"
+                    )
+                )
+            observed = replication.trace
+            if observed is not None:
+                findings["observed_trace"] = observed.summary()
+                notes.append(f"trace observado: {observed.summary()}")
+
+        test = (
+            proposed_regression_test(replication, replication.trace or trace)
+            if replication is not None
+            else None
+        )
+        if test is not None:
+            findings["regression_test"] = test
+            notes.append(
+                f"test de regresion propuesto: {test['path']} "
+                f"(criterio: {test['command']})"
+            )
+            self._add_acceptance_command(brief, test["command"])
+
+        if notes:
+            brief.description = (
+                f"{brief.description}\n\n"
+                f"--- Intake automatico ---\n"
+                + "\n".join(f"- {note}" for note in notes)
+            ).strip()
+        return findings
+
+    def _parse_reported_trace(self, brief: BugBrief) -> Optional[StackTrace]:
+        """Parse the stack trace the reporter pasted, if any.
+
+        Only ``inline`` sources are read: the remote kinds are fetched by
+        ``ResearchNode`` later, and this node must not do network I/O for
+        logs it was not given.
+
+        Args:
+            brief: The brief to read.
+
+        Returns:
+            The parsed trace, or ``None`` when there is no inline source.
+        """
+        for source in brief.log_sources:
+            if getattr(source, "kind", None) != "inline":
+                continue
+            trace = parse_stack_trace(getattr(source, "locator", ""))
+            if trace.frames or trace.exception_type:
+                return trace
+        return None
+
+    async def _reproduce(self, brief: BugBrief) -> Optional[ReplicationResult]:
+        """Reproduce the failure against the configured environment.
+
+        Args:
+            brief: The brief, read for the endpoint to hit.
+
+        Returns:
+            The result, or ``None`` when reproduction is off, no target is
+            configured, or no endpoint could be read from the report.
+        """
+        if not self._replicate or self._replication_target is None:
+            return None
+        method, path = extract_endpoint(f"{brief.summary}\n{brief.description}")
+        if not path:
+            return ReplicationResult(
+                attempted=False,
+                target=self._replication_target.name,
+                error="el reporte no nombra ninguna ruta reproducible",
+            )
+        return await replicate_endpoint(self._replication_target, method, path)
+
+    @staticmethod
+    def _add_acceptance_command(brief: BugBrief, command: str) -> None:
+        """Add the regression test as an acceptance criterion.
+
+        QA runs every criterion, so this is what turns "the bug is fixed"
+        from a judgement call into something checkable: a fix that does not
+        make the reproduction pass is not a fix.
+
+        It is *added*, not substituted — the reporter's own criteria stay,
+        and this raises the bar rather than replacing it. (It could not
+        substitute anyway: ``acceptance_criteria`` must be non-empty for the
+        brief to validate, so the list is never empty by the time this runs.)
+        Re-running intake is idempotent: an identical command is not added
+        twice.
+
+        Args:
+            brief: The brief to extend in place.
+            command: The shell command that runs the regression test.
+        """
+        from parrot.flows.dev_loop.models import ShellCriterion
+
+        existing = {
+            getattr(criterion, "command", None)
+            for criterion in brief.acceptance_criteria
+        }
+        if command in existing:
+            return
+        brief.acceptance_criteria.append(
+            ShellCriterion(name="regression", command=command)
+        )
 
     # ------------------------------------------------------------------
     # Internal
@@ -176,3 +373,19 @@ class BugIntakeNode(DevLoopNode):
 
 
 __all__ = ["BugIntakeNode"]
+
+
+def _inline_source(text: str) -> Any:
+    """Build an ``inline`` LogSource carrying ``text``.
+
+    Imported lazily so this module keeps its light import surface.
+
+    Args:
+        text: The log/trace content itself.
+
+    Returns:
+        A ``LogSource`` with ``kind="inline"``.
+    """
+    from parrot.flows.dev_loop.models import LogSource
+
+    return LogSource(kind="inline", locator=text)

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/replication.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/replication.py
@@ -1,0 +1,403 @@
+"""Captura y replicación del error de un bug, antes de investigarlo.
+
+``log_sources`` trae logs ya escritos. Esto hace lo otro: leer el trace que
+pegó quien reporta, y **volver a provocar** el error contra un entorno para
+verlo de primera mano — estado, cuerpo y traceback observados, no relatados.
+
+Es lo que ``BugIntakeNode`` declaraba como su razón de ser ("severity
+classification, stack-trace parsing") y no implementaba.
+
+El objetivo del blanco es un **entorno** (dev, staging), no la app corriendo
+en la máquina de quien pide: reproducir contra el entorno donde el 500 pasa
+de verdad evita montar el servicio y su base localmente para cada bug.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Literal, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+#: Severidad derivada de lo observado, no declarada por quien reporta.
+Severity = Literal["critical", "high", "medium", "low"]
+
+#: `File "path", line N, in func` — un frame de traceback de Python.
+_PY_FRAME_RE = re.compile(
+    r'File "(?P<file>[^"]+)", line (?P<line>\d+), in (?P<func>\S+)'
+)
+
+#: `TipoDeError: mensaje` en la última línea de un traceback de Python.
+_PY_EXC_RE = re.compile(
+    r"^(?P<type>[A-Z][A-Za-z0-9_.]*(?:Error|Exception|Warning|Exit))"
+    r"(?::\s*(?P<message>.*))?$"
+)
+
+#: `at Object.foo (/ruta/archivo.ts:12:34)` — un frame de Node/TypeScript.
+_JS_FRAME_RE = re.compile(
+    r"at\s+(?P<func>[^\s(]+)\s*\((?P<file>[^):]+):(?P<line>\d+)(?::\d+)?\)"
+)
+
+#: `GET /api/v1/xyz` o `/api/v1/xyz` dentro de texto libre.
+_ENDPOINT_RE = re.compile(
+    r"\b(?P<method>GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)?\s*"
+    r"(?P<path>/[A-Za-z0-9._~\-/{}]*)",
+)
+
+#: Directorios de dependencias: un frame acá casi nunca es el bug propio,
+#: solo el camino por donde pasó.
+_VENDOR_MARKERS = (
+    "/node_modules/", "/site-packages/", "/dist-packages/", "/.venv/",
+    "/vendor/", "<frozen ",
+)
+
+#: Excepciones que casi siempre significan "se cae para todos", no "para un
+#: caso raro": arrancar mal, perder la base, quedarse sin memoria.
+_CRITICAL_EXCEPTIONS = frozenset({
+    "ImportError", "ModuleNotFoundError", "SystemExit", "MemoryError",
+    "OperationalError", "InterfaceError", "ConnectionError",
+})
+
+
+@dataclass(frozen=True)
+class StackFrame:
+    """Un frame de un traceback.
+
+    Attributes:
+        file: Archivo del frame.
+        line: Línea.
+        function: Función o método.
+    """
+
+    file: str
+    line: int
+    function: str
+
+
+@dataclass
+class StackTrace:
+    """Un traceback parseado.
+
+    Attributes:
+        language: ``python``, ``javascript`` o ``unknown``.
+        exception_type: Tipo de la excepción, si se pudo identificar.
+        message: Mensaje de la excepción.
+        frames: Frames, en el orden del texto.
+        raw: El texto original.
+    """
+
+    language: str = "unknown"
+    exception_type: Optional[str] = None
+    message: str = ""
+    frames: List[StackFrame] = field(default_factory=list)
+    raw: str = ""
+
+    @property
+    def culprit(self) -> Optional[StackFrame]:
+        """El frame que mejor identifica el bug propio.
+
+        Dos cuidados. El orden de los frames depende del stack: Python los
+        imprime de afuera hacia adentro (el último es donde reventó) y
+        Node/V8 al revés (el primero). Y en cualquiera de los dos, el frame
+        más interno suele caer en ``node_modules`` o ``site-packages``, que
+        es por dónde pasó el error y no dónde está el bug.
+
+        Así que se recorre desde el frame más interno hacia afuera y se
+        devuelve el primero que no sea de una dependencia; si todos lo son,
+        se devuelve el más interno, que es mejor que nada.
+        """
+        if not self.frames:
+            return None
+        # Del más interno al más externo, según el stack.
+        inner_first = (
+            self.frames if self.language == "javascript" else self.frames[::-1]
+        )
+        for frame in inner_first:
+            if not any(marker in frame.file for marker in _VENDOR_MARKERS):
+                return frame
+        return inner_first[0]
+
+    def summary(self) -> str:
+        """Una línea con lo esencial del trace."""
+        if not self.exception_type and not self.frames:
+            return "sin traceback reconocible"
+        parts = []
+        if self.exception_type:
+            parts.append(f"{self.exception_type}: {self.message[:120]}")
+        if self.culprit is not None:
+            parts.append(f"en {self.culprit.file}:{self.culprit.line}")
+        return " ".join(parts)
+
+
+@dataclass(frozen=True)
+class ReplicationTarget:
+    """Entorno contra el que reproducir el error.
+
+    Attributes:
+        base_url: Raíz del servicio (``https://dev.example.com``).
+        name: Etiqueta del entorno, para documentar contra qué se reprodujo.
+        headers: Cabeceras fijas (autenticación, tenant).
+        timeout_seconds: Tope por request.
+        verify_ssl: ``False`` para entornos con certificado propio.
+    """
+
+    base_url: str
+    name: str = "dev"
+    headers: Dict[str, str] = field(default_factory=dict)
+    timeout_seconds: float = 30.0
+    verify_ssl: bool = True
+
+
+@dataclass
+class ReplicationResult:
+    """Lo que pasó al intentar reproducir el error.
+
+    Attributes:
+        attempted: Si se llegó a hacer el request.
+        reproduced: Si se observó una respuesta de error (>= 500).
+        target: Nombre del entorno.
+        url: URL exacta que se pidió.
+        method: Método HTTP usado.
+        status: Código devuelto.
+        body_excerpt: Comienzo del cuerpo de la respuesta.
+        trace: Traceback encontrado en el cuerpo, si vino.
+        error: Por qué no se pudo intentar o completar.
+    """
+
+    attempted: bool = False
+    reproduced: bool = False
+    target: str = ""
+    url: str = ""
+    method: str = "GET"
+    status: Optional[int] = None
+    body_excerpt: str = ""
+    trace: Optional[StackTrace] = None
+    error: str = ""
+
+    def summary(self) -> str:
+        """Una línea para el brief."""
+        if not self.attempted:
+            return f"no se intentó reproducir: {self.error or 'sin blanco configurado'}"
+        if self.error:
+            return f"{self.method} {self.url} falló al reproducir: {self.error}"
+        verdict = "REPRODUCIDO" if self.reproduced else "no reproducido"
+        return f"{verdict} — {self.method} {self.url} -> {self.status}"
+
+
+def parse_stack_trace(text: str) -> StackTrace:
+    """Parsear un traceback pegado en el reporte.
+
+    Reconoce Python y Node/TypeScript, que son los dos stacks de la
+    plataforma. Un texto sin frames devuelve un :class:`StackTrace` vacío en
+    lugar de fallar: que el reportante no haya pegado un trace es lo normal,
+    no un error.
+
+    Args:
+        text: Texto libre que puede contener un traceback.
+
+    Returns:
+        El trace parseado, posiblemente vacío.
+    """
+    if not text or not text.strip():
+        return StackTrace(raw=text or "")
+
+    frames = [
+        StackFrame(file=m.group("file"), line=int(m.group("line")),
+                   function=m.group("func"))
+        for m in _PY_FRAME_RE.finditer(text)
+    ]
+    language = "python" if frames else "unknown"
+    if not frames:
+        frames = [
+            StackFrame(file=m.group("file"), line=int(m.group("line")),
+                       function=m.group("func"))
+            for m in _JS_FRAME_RE.finditer(text)
+        ]
+        if frames:
+            language = "javascript"
+
+    exception_type: Optional[str] = None
+    message = ""
+    # La excepción está en la última línea del bloque, así que se recorre de
+    # atrás hacia adelante y se corta en la primera que matchea.
+    for line in reversed([l.strip() for l in text.strip().splitlines() if l.strip()]):
+        match = _PY_EXC_RE.match(line)
+        if match:
+            exception_type = match.group("type")
+            message = (match.group("message") or "").strip()
+            break
+
+    return StackTrace(
+        language=language,
+        exception_type=exception_type,
+        message=message,
+        frames=frames,
+        raw=text,
+    )
+
+
+def extract_endpoint(text: str) -> Tuple[str, Optional[str]]:
+    """Sacar del reporte el método y la ruta a reproducir.
+
+    Se ignoran las rutas que son claramente de archivo (con extensión) o
+    que salen de un traceback: ``/usr/lib/python3/site-packages/x.py`` no es
+    un endpoint. Sin ruta reconocible no hay nada que reproducir.
+
+    Args:
+        text: Resumen y descripción del reporte.
+
+    Returns:
+        ``(method, path)``; ``path`` es ``None`` si no se encontró ninguna.
+    """
+    for match in _ENDPOINT_RE.finditer(text or ""):
+        path = match.group("path")
+        if not path or path == "/":
+            continue
+        tail = path.rsplit("/", 1)[-1]
+        if "." in tail:  # archivo, no endpoint
+            continue
+        if path.startswith(("/usr/", "/home/", "/opt/", "/var/", "/etc/")):
+            continue
+        return (match.group("method") or "GET").upper(), path
+    return "GET", None
+
+
+def classify_severity(
+    trace: Optional[StackTrace],
+    replication: Optional[ReplicationResult] = None,
+) -> Severity:
+    """Clasificar la severidad con lo que se observó.
+
+    La escala es deliberadamente simple y se apoya en evidencia, no en la
+    urgencia que declare quien reporta: un error reproducido pesa más que
+    uno relatado, y una excepción de arranque o de base de datos pesa más
+    que una de dominio.
+
+    Args:
+        trace: Traceback parseado, si hay.
+        replication: Resultado de la reproducción, si se intentó.
+
+    Returns:
+        La severidad.
+    """
+    exception_type = (trace.exception_type if trace else None) or ""
+    reproduced = bool(replication and replication.reproduced)
+
+    if exception_type in _CRITICAL_EXCEPTIONS:
+        return "critical"
+    if reproduced and (replication.status or 0) >= 500:
+        return "high"
+    if reproduced:
+        return "medium"
+    if exception_type:
+        return "medium"
+    return "low"
+
+
+async def replicate_endpoint(
+    target: ReplicationTarget,
+    method: str,
+    path: str,
+    *,
+    payload: Optional[Any] = None,
+) -> ReplicationResult:
+    """Pegarle al endpoint en el entorno y quedarse con lo que devuelva.
+
+    Un error de red no es un fallo del análisis: se registra en
+    ``error`` y el flujo sigue con lo que haya. Lo que no puede pasar es
+    que un entorno caído aborte el intake entero.
+
+    Args:
+        target: Entorno contra el que reproducir.
+        method: Método HTTP.
+        path: Ruta, relativa a ``target.base_url``.
+        payload: Cuerpo JSON opcional, para métodos que lo llevan.
+
+    Returns:
+        El :class:`ReplicationResult`.
+    """
+    import aiohttp
+
+    url = f"{target.base_url.rstrip('/')}/{path.lstrip('/')}"
+    result = ReplicationResult(
+        attempted=True, target=target.name, url=url, method=method.upper()
+    )
+    timeout = aiohttp.ClientTimeout(total=target.timeout_seconds)
+    try:
+        connector = aiohttp.TCPConnector(ssl=target.verify_ssl)
+        async with aiohttp.ClientSession(
+            timeout=timeout, connector=connector, headers=target.headers
+        ) as session:
+            async with session.request(
+                method.upper(), url, json=payload
+            ) as response:
+                body = await response.text()
+                result.status = response.status
+                result.body_excerpt = body[:2000]
+                result.reproduced = response.status >= 500
+    except Exception as exc:  # noqa: BLE001 — ver docstring
+        result.error = f"{type(exc).__name__}: {exc}"
+        logger.warning("No se pudo reproducir %s %s: %s", method, url, exc)
+        return result
+
+    # Muchos servicios devuelven el traceback en el cuerpo del 500; si está,
+    # es mejor evidencia que la que pegó quien reporta.
+    trace = parse_stack_trace(result.body_excerpt)
+    if trace.frames or trace.exception_type:
+        result.trace = trace
+    return result
+
+
+def proposed_regression_test(
+    result: ReplicationResult, trace: Optional[StackTrace] = None
+) -> Optional[Dict[str, str]]:
+    """Proponer el test de regresión que cierra el bug.
+
+    No escribe archivos: a la hora del intake todavía no existe el worktree
+    (se provisiona antes de Development). Devuelve el contenido propuesto y
+    el comando que lo corre, para que Development lo materialice y QA lo use
+    como criterio de aceptación — el fix está listo cuando este test pasa.
+
+    ``pytest`` está en ``ACCEPTANCE_CRITERION_ALLOWLIST``, así que el comando
+    es ejecutable como criterio sin más permisos.
+
+    Args:
+        result: La reproducción observada.
+        trace: Traceback asociado, para el docstring del test.
+
+    Returns:
+        ``{"path", "content", "command"}``, o ``None`` si no hubo nada
+        reproducido que testear.
+    """
+    if not result.reproduced or not result.url:
+        return None
+    slug = re.sub(r"[^a-z0-9]+", "_", result.url.rsplit("/", 2)[-1].lower()).strip("_")
+    slug = slug or "endpoint"
+    path = f"tests/regression/test_bug_{slug}.py"
+    detail = trace.summary() if trace else f"status {result.status}"
+    content = f'''"""Regresión: {result.method} {result.url} devolvía {result.status}.
+
+Observado al hacer el intake contra el entorno {result.target!r}:
+{detail}
+
+El bug está arreglado cuando este test pasa.
+"""
+import os
+
+import pytest
+import requests
+
+BASE_URL = os.environ.get("TARGET_BASE_URL", "{result.url.rsplit(result.method, 1)[0] or ''}")
+
+
+@pytest.mark.regression
+def test_endpoint_does_not_return_server_error():
+    response = requests.request("{result.method}", "{result.url}", timeout=30)
+    assert response.status_code < 500, (
+        f"{result.method} {result.url} devolvió {{response.status_code}}: "
+        f"{{response.text[:500]}}"
+    )
+'''
+    return {"path": path, "content": content, "command": f"pytest {path}"}

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/toolkit.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/toolkit.py
@@ -1,0 +1,648 @@
+"""``DevLoopToolkit`` — the dev loop as tools an agent can call.
+
+The dev loop (``parrot.flows.dev_loop``) could only be started three ways:
+``DevLoopRunner.run(brief)`` in code, the two HTTP consoles under
+``examples/dev_loop/``, or the webhook. None of those is reachable from a
+conversation, so an agent asked to fix a bug could describe the pipeline but
+never start it.
+
+This toolkit closes that: ``start_dev_loop`` builds the brief and launches a
+run, ``dev_loop_status`` reports where it got to, and ``dev_loop_approve``
+resolves a HITL gate. Every public async method here becomes a tool
+automatically (``AbstractToolkit``), named ``devloop_<method>``.
+
+Two seams keep it useful without knowing anything about the caller's world:
+
+* ``brief_enricher`` — fills in what a one-line report cannot say
+  (``affected_component``, the right repo, acceptance criteria). A caller
+  with a codebase index plugs it in here; without one the toolkit still
+  works, it just needs a fuller brief.
+* ``flow_builder`` — the approval gates are baked in at flow-construction
+  time, not per run, so a flow is built (and cached) per approval mode.
+
+Runs are launched in the background and the tool returns a ``run_id``
+immediately. A dev-loop run takes minutes: returning its result would block
+the caller — and, for an agentd daemon, its socket — for the whole run.
+
+Autonomy is decided *after* seeing the plan, not before. A run starts with
+every gate enabled, so the first thing that happens is the plan coming back
+for approval; approving it with ``then="autonomous"`` hands the rest of the
+run over, and ``then="ask"`` keeps the later gates. This is deliberate: the
+gates are compiled into the flow at construction time, so a run cannot gain
+a gate later — it can only be relieved of one. Starting locked down and
+loosening on request is therefore the only order that lets the choice come
+after the plan.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from typing import Any, Callable, Dict, List, Literal, Optional, Protocol
+
+from parrot.flows.dev_loop.models import WorkBrief
+from parrot.flows.dev_loop.runner import DevLoopRunner
+from parrot.tools.toolkit import AbstractToolkit
+
+logger = logging.getLogger(__name__)
+
+#: How much of the run a human still gates.
+#:
+#: ``"plan"``       — approve the plan, then the run finishes on its own.
+#: ``"every_step"`` — also approve before the PR is handed off.
+#: ``"none"``       — fully autonomous, no gates.
+ApprovalMode = Literal["plan", "every_step", "none"]
+
+#: Gate flags per approval mode, as ``build_dev_loop_flow`` expects them.
+#: The flow offers exactly two gates today (plan and deployment), so
+#: ``"every_step"`` means "both", not "one per node".
+_MODE_GATES: Dict[str, Dict[str, bool]] = {
+    "none": {"require_plan_approval": False, "require_deployment_approval": False},
+    "plan": {"require_plan_approval": True, "require_deployment_approval": False},
+    "every_step": {
+        "require_plan_approval": True,
+        "require_deployment_approval": True,
+    },
+}
+
+
+class BriefEnricher(Protocol):
+    """Fills in a brief that a one-line bug report cannot fully specify.
+
+    Implementations resolve things like "the api returns 500 on /xyz" into
+    the repo and component that actually own the endpoint.
+    """
+
+    async def enrich(self, draft: Dict[str, Any]) -> Dict[str, Any]:
+        """Return ``draft`` with missing fields filled in.
+
+        Args:
+            draft: Partial ``WorkBrief`` kwargs.
+
+        Returns:
+            The same mapping, enriched. Implementations must not raise for
+            "could not resolve" — leave the field alone and let validation
+            report it.
+        """
+        ...
+
+
+class DevLoopToolkit(AbstractToolkit):
+    """Start and supervise dev-loop runs from an agent conversation.
+
+    Tool names (with ``tool_prefix="devloop"``):
+      - ``devloop_start_dev_loop``  — start a run from a bug/enhancement report
+      - ``devloop_dev_loop_status`` — phase, nodes, pending gates of a run
+      - ``devloop_dev_loop_runs``   — the runs this toolkit has started
+      - ``devloop_dev_loop_approve``— resolve a pending HITL gate
+      - ``devloop_dev_loop_cancel`` — request cancellation of a run
+
+    Example::
+
+        toolkit = DevLoopToolkit(
+            flow_kwargs={"git_toolkit": git, "repos": repos},
+            brief_enricher=my_enricher,
+        )
+        agent.register_tools(toolkit.get_tools())
+    """
+
+    #: Namespace prefix applied to every auto-generated tool name.
+    tool_prefix: Optional[str] = "devloop"
+
+    #: Starting a run writes code and opens a PR — worth a confirmation when
+    #: the host wires HITL for tools.
+    confirming_tools: frozenset = frozenset({"start_dev_loop"})
+
+    def __init__(
+        self,
+        *,
+        flow_builder: Optional[Callable[..., Any]] = None,
+        flow_kwargs: Optional[Dict[str, Any]] = None,
+        runner_kwargs: Optional[Dict[str, Any]] = None,
+        brief_enricher: Optional[BriefEnricher] = None,
+        default_reporter: str = "agent",
+        default_assignee: str = "unassigned",
+        default_approval_mode: ApprovalMode = "every_step",
+        gate_poll_seconds: float = 5.0,
+        **kwargs: Any,
+    ) -> None:
+        """Initialise the toolkit.
+
+        Args:
+            flow_builder: Callable building a dev-loop flow. Defaults to
+                :func:`parrot.flows.dev_loop.flow.build_dev_loop_flow`,
+                imported lazily so constructing the toolkit stays cheap.
+            flow_kwargs: Forwarded to ``flow_builder`` (toolkits,
+                dispatchers, repos, ...). The gate flags are set per
+                approval mode and must not be passed here.
+            runner_kwargs: Forwarded to :class:`DevLoopRunner`.
+            brief_enricher: Optional :class:`BriefEnricher`.
+            default_reporter: ``WorkBrief.reporter`` when the caller gives
+                none — an agent-started run still needs an author.
+            default_assignee: ``WorkBrief.escalation_assignee`` default.
+            default_approval_mode: Approval mode when the caller gives none.
+                Defaults to ``"every_step"`` so a run starts locked down and
+                the autonomy decision can be made after the plan is seen
+                (see the module docstring).
+            gate_poll_seconds: How often the watcher checks for gates to
+                auto-approve on a run set to autonomous.
+            **kwargs: Forwarded to :class:`AbstractToolkit`.
+        """
+        super().__init__(**kwargs)
+        self._flow_builder = flow_builder
+        self._flow_kwargs = dict(flow_kwargs or {})
+        self._runner_kwargs = dict(runner_kwargs or {})
+        self._enricher = brief_enricher
+        self._default_reporter = default_reporter
+        self._default_assignee = default_assignee
+        self._default_mode: ApprovalMode = default_approval_mode
+        #: One runner per approval mode — the gates are compiled into the flow.
+        self._runners: Dict[str, DevLoopRunner] = {}
+        #: run_id -> bookkeeping for the runs this toolkit started.
+        self._runs: Dict[str, Dict[str, Any]] = {}
+        self._tasks: Dict[str, asyncio.Task] = {}
+        self._watchers: Dict[str, asyncio.Task] = {}
+        self._gate_poll_seconds = gate_poll_seconds
+        overlap = set(self._flow_kwargs) & {
+            "require_plan_approval",
+            "require_deployment_approval",
+        }
+        if overlap:
+            raise ValueError(
+                "flow_kwargs must not set the gate flags "
+                f"({', '.join(sorted(overlap))}) — they are derived from "
+                "approval_mode per run."
+            )
+
+    # ------------------------------------------------------------------
+    # Tools
+    # ------------------------------------------------------------------
+
+    async def start_dev_loop(
+        self,
+        summary: str,
+        description: str = "",
+        kind: str = "bug",
+        repo: Optional[str] = None,
+        error_text: Optional[str] = None,
+        acceptance_commands: Optional[List[str]] = None,
+        approval_mode: Optional[str] = None,
+        reporter: Optional[str] = None,
+        existing_issue_key: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Start a dev-loop run for a bug or enhancement, and return its id.
+
+        Runs research, development, QA and PR hand-off. This returns as soon
+        as the run is accepted — a run takes minutes, so poll
+        ``dev_loop_status`` instead of waiting on this call.
+
+        Approval: with ``approval_mode="plan"`` (the default) the run pauses
+        for a human to approve the plan and then finishes on its own; with
+        ``"every_step"`` it also pauses before the PR hand-off; with
+        ``"none"`` it never pauses. Report the mode back to the user — it
+        decides how autonomous the run is.
+
+        Args:
+            summary: One-line statement of the problem ("500 on /api/v1/xyz").
+            description: Everything else known: steps, expected vs actual.
+            kind: ``bug``, ``enhancement`` or ``new_feature``.
+            repo: Repository that owns the code. Inferred when omitted and
+                an enricher is configured.
+            error_text: Pasted stack trace / error body. Attached as an
+                ``inline`` log source, which is what the intake and research
+                nodes read.
+            acceptance_commands: Shell commands QA runs to decide the work
+                is done — a criterion is executed, not read, so this takes
+                commands (``pytest tests/test_xyz.py``) rather than prose.
+                The command head is allow-listed at intake.
+            approval_mode: ``plan`` | ``every_step`` | ``none``.
+            reporter: Who is asking. Defaults to the configured reporter.
+            existing_issue_key: Attach to this Jira issue instead of
+                creating one.
+
+        Returns:
+            ``{"run_id", "status", "approval_mode", "gates", "brief"}``.
+
+        Raises:
+            ValueError: ``kind``/``approval_mode`` invalid, or the brief is
+                still incomplete after enrichment.
+        """
+        mode = self._resolve_mode(approval_mode)
+        draft: Dict[str, Any] = {
+            "kind": kind,
+            "summary": summary,
+            "description": description or summary,
+            "reporter": reporter or self._default_reporter,
+            "escalation_assignee": self._default_assignee,
+        }
+        if repo:
+            draft["affected_component"] = repo
+        if existing_issue_key:
+            draft["existing_issue_key"] = existing_issue_key
+        if error_text:
+            draft["log_sources"] = [
+                {"kind": "inline", "locator": error_text}
+            ]
+        if acceptance_commands:
+            draft["acceptance_criteria"] = [
+                {
+                    "kind": "shell",
+                    "name": f"acceptance-{index}",
+                    "command": command,
+                }
+                for index, command in enumerate(acceptance_commands, start=1)
+            ]
+
+        if self._enricher is not None:
+            try:
+                draft = await self._enricher.enrich(draft)
+            except Exception as exc:  # noqa: BLE001 — enrichment is advisory
+                logger.warning(
+                    "Brief enrichment failed (%s); continuing with the raw "
+                    "report", exc,
+                )
+
+        brief = self._validate(draft)
+        run_id = f"run-{uuid.uuid4().hex[:8]}"
+        runner = self._runner_for(mode)
+
+        self._runs[run_id] = {
+            "run_id": run_id,
+            "approval_mode": mode,
+            "summary": brief.summary,
+            "kind": brief.kind,
+            "status": "running",
+            "result": None,
+            "error": None,
+            # Set by dev_loop_approve(then="autonomous"): from then on the
+            # watcher resolves this run's gates instead of waiting for a human.
+            "autonomous": False,
+            "auto_approved": [],
+            # The runner that started this run. Held here rather than looked
+            # up by mode: a run belongs to the runner that launched it, and
+            # the mode is only how that runner was chosen.
+            "runner": runner,
+        }
+        task = asyncio.create_task(self._execute(runner, brief, run_id))
+        self._tasks[run_id] = task
+        task.add_done_callback(lambda _t, rid=run_id: self._tasks.pop(rid, None))
+
+        return {
+            "run_id": run_id,
+            "status": "running",
+            "approval_mode": mode,
+            "gates": [
+                name.replace("require_", "").replace("_approval", "")
+                for name, on in _MODE_GATES[mode].items()
+                if on
+            ],
+            "brief": {
+                "kind": brief.kind,
+                "summary": brief.summary,
+                "affected_component": brief.affected_component,
+                "log_sources": len(brief.log_sources),
+                "acceptance_criteria": len(brief.acceptance_criteria),
+            },
+        }
+
+    async def dev_loop_status(self, run_id: str) -> Dict[str, Any]:
+        """Report where a dev-loop run got to, and what it is waiting for.
+
+        Use the ``run_id`` that ``start_dev_loop`` returned. Pending gates
+        are what a human has to act on: pass one to ``dev_loop_approve``.
+
+        Args:
+            run_id: The run to inspect.
+
+        Returns:
+            ``{"run_id", "status", "phase", "nodes", "pending_gates",
+            "error"}``.
+
+        Raises:
+            KeyError: This toolkit never started ``run_id``.
+        """
+        record = self._require_run(run_id)
+        out: Dict[str, Any] = {
+            "run_id": run_id,
+            "status": record["status"],
+            "approval_mode": record["approval_mode"],
+            "autonomous": record.get("autonomous", False),
+            "auto_approved": list(record.get("auto_approved", [])),
+            "summary": record["summary"],
+            "error": record["error"],
+            "phase": None,
+            "nodes": {},
+            "pending_gates": [],
+        }
+        runner = record.get("runner")
+        host = runner.get_host(run_id) if runner is not None else None
+        if host is not None:
+            state = host.state
+            out["phase"] = getattr(state, "phase", None)
+            out["pending_gates"] = [
+                {
+                    "gate_id": gate_id,
+                    "kind": getattr(gate, "kind", None),
+                    "prompt": getattr(gate, "prompt", None),
+                }
+                for gate_id, gate in getattr(state, "gates", {}).items()
+                if getattr(gate, "status", None) == "pending"
+            ]
+        result = record.get("result")
+        if result is not None:
+            out["nodes"] = {
+                node: str(response)[:400]
+                for node, response in getattr(result, "responses", {}).items()
+            }
+        return out
+
+    async def dev_loop_runs(self) -> Dict[str, Any]:
+        """List the dev-loop runs this agent has started.
+
+        Returns:
+            ``{"runs": [{"run_id", "status", "kind", "summary",
+            "approval_mode"}]}``, newest last.
+        """
+        return {
+            "runs": [
+                {
+                    key: record[key]
+                    for key in (
+                        "run_id", "status", "kind", "summary", "approval_mode",
+                    )
+                }
+                for record in self._runs.values()
+            ]
+        }
+
+    async def dev_loop_approve(
+        self,
+        run_id: str,
+        gate_id: str,
+        resolution: str = "approved",
+        then: str = "ask",
+        comment: str = "",
+        resolved_by: str = "",
+    ) -> Dict[str, Any]:
+        """Resolve a pending approval gate so a paused run can continue.
+
+        Get ``gate_id`` from ``dev_loop_status``, which also returns the plan
+        the gate is asking about. ``resolution="rejected"`` aborts instead of
+        continuing.
+
+        ``then`` is how much of the rest of the run still needs a human, and
+        is the decision to put to the user once they have read the plan:
+        ``"ask"`` keeps stopping at every later gate, ``"autonomous"`` lets
+        the run finish on its own — including opening the PR. Ask before
+        choosing ``"autonomous"``; do not assume it.
+
+        Args:
+            run_id: The paused run.
+            gate_id: The gate to resolve.
+            resolution: ``approved`` or ``rejected``.
+            then: ``ask`` (default) or ``autonomous``.
+            comment: Free-text audit comment.
+            resolved_by: Who approved. Defaults to the configured reporter.
+
+        Returns:
+            ``{"run_id", "gate_id", "resolution", "then", "sequence"}``.
+
+        Raises:
+            KeyError: Unknown run, or the run has no live host.
+            ValueError: ``resolution`` or ``then`` is not a valid value.
+        """
+        if resolution not in ("approved", "rejected"):
+            raise ValueError(
+                f"resolution must be 'approved' or 'rejected', got {resolution!r}"
+            )
+        if then not in ("ask", "autonomous"):
+            raise ValueError(
+                f"then must be 'ask' or 'autonomous', got {then!r}"
+            )
+        record = self._require_run(run_id)
+        runner = record.get("runner")
+        if runner is None:  # pragma: no cover - set when the run is created
+            raise KeyError(f"no runner for run_id={run_id!r}")
+        envelope = await runner.resolve_gate(
+            run_id,
+            gate_id,
+            resolution,
+            resolved_by or self._default_reporter,
+            comment=comment,
+        )
+        if resolution == "approved" and then == "autonomous":
+            record["autonomous"] = True
+            self._ensure_watcher(run_id)
+            logger.info(
+                "dev-loop run %s continues autonomously; later gates will be "
+                "auto-approved", run_id,
+            )
+        return {
+            "run_id": run_id,
+            "gate_id": gate_id,
+            "resolution": resolution,
+            "then": then,
+            "sequence": getattr(envelope, "sequence", None),
+        }
+
+    async def dev_loop_cancel(
+        self, run_id: str, requested_by: str = ""
+    ) -> Dict[str, Any]:
+        """Request cancellation of a running dev-loop run.
+
+        Args:
+            run_id: The run to cancel.
+            requested_by: Who asked. Defaults to the configured reporter.
+
+        Returns:
+            ``{"run_id", "cancelled"}``.
+
+        Raises:
+            KeyError: Unknown run, or the run has no live host.
+        """
+        record = self._require_run(run_id)
+        runner = record.get("runner")
+        if runner is None:  # pragma: no cover - set when the run is created
+            raise KeyError(f"no runner for run_id={run_id!r}")
+        await runner.cancel_run(run_id, requested_by or self._default_reporter)
+        record["status"] = "cancelled"
+        return {"run_id": run_id, "cancelled": True}
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _resolve_mode(self, approval_mode: Optional[str]) -> str:
+        """Validate an approval mode, falling back to the configured default."""
+        mode = approval_mode or self._default_mode
+        if mode not in _MODE_GATES:
+            raise ValueError(
+                f"approval_mode must be one of {sorted(_MODE_GATES)}, "
+                f"got {mode!r}"
+            )
+        return mode
+
+    def _validate(self, draft: Dict[str, Any]) -> WorkBrief:
+        """Validate the draft, or say what is missing and who fills it.
+
+        ``affected_component`` and ``acceptance_criteria`` are required and
+        have no defaults, so a one-line report never validates on its own.
+        Pydantic's raw error is poor guidance for a caller (and worse for a
+        model deciding what to do next), so it is translated into the
+        question that actually needs answering.
+
+        Args:
+            draft: Partial ``WorkBrief`` kwargs.
+
+        Returns:
+            The validated brief.
+
+        Raises:
+            ValueError: The brief is incomplete, naming each missing field
+                and how to supply it.
+        """
+        from pydantic import ValidationError
+
+        try:
+            return WorkBrief.model_validate(draft)
+        except ValidationError as exc:
+            hints = {
+                "affected_component": (
+                    "which repository/service owns the code — pass `repo`"
+                ),
+                "acceptance_criteria": (
+                    "how to verify the fix — pass `acceptance_commands`, e.g. "
+                    "['pytest tests/test_xyz.py']"
+                ),
+            }
+            missing = [
+                str(err["loc"][0])
+                for err in exc.errors()
+                if err.get("type") == "missing" and err.get("loc")
+            ]
+            if not missing:
+                raise
+            detail = "; ".join(
+                f"{field} ({hints.get(field, 'required')})" for field in missing
+            )
+            enricher = (
+                "" if self._enricher is not None else
+                " No brief enricher is configured, so nothing can infer these."
+            )
+            raise ValueError(
+                f"The report is not specific enough to start a run. Missing: "
+                f"{detail}.{enricher}"
+            ) from exc
+
+    def _require_run(self, run_id: str) -> Dict[str, Any]:
+        """Look up a run this toolkit started, or fail with the known ids."""
+        record = self._runs.get(run_id)
+        if record is None:
+            known = ", ".join(self._runs) or "none"
+            raise KeyError(f"unknown run_id={run_id!r} (known: {known})")
+        return record
+
+    def _ensure_watcher(self, run_id: str) -> None:
+        """Start the task that auto-approves this run's remaining gates.
+
+        Polls rather than subscribing to the event stream: the gate set is
+        small, the run already takes minutes, and a poll needs no Redis and
+        no ordering guarantees. Idempotent — a second call is a no-op while
+        the first watcher is alive.
+
+        Args:
+            run_id: The run to watch.
+        """
+        existing = self._watchers.get(run_id)
+        if existing is not None and not existing.done():
+            return
+        task = asyncio.create_task(self._watch_gates(run_id))
+        self._watchers[run_id] = task
+        task.add_done_callback(lambda _t, rid=run_id: self._watchers.pop(rid, None))
+
+    async def _watch_gates(self, run_id: str) -> None:
+        """Approve gates on an autonomous run until it finishes.
+
+        Stops as soon as the run leaves ``running``, so a finished or
+        cancelled run does not leave a task polling forever.
+
+        Args:
+            run_id: The run to watch.
+        """
+        record = self._runs.get(run_id)
+        if record is None:  # pragma: no cover - watcher starts after the record
+            return
+        runner = record.get("runner")
+        while record.get("autonomous") and record.get("status") == "running":
+            await asyncio.sleep(self._gate_poll_seconds)
+            host = runner.get_host(run_id) if runner is not None else None
+            if host is None:
+                continue
+            pending = [
+                gate_id
+                for gate_id, gate in getattr(host.state, "gates", {}).items()
+                if getattr(gate, "status", None) == "pending"
+            ]
+            for gate_id in pending:
+                try:
+                    await runner.resolve_gate(
+                        run_id,
+                        gate_id,
+                        "approved",
+                        self._default_reporter,
+                        comment="auto-approved: run set to autonomous",
+                    )
+                except Exception as exc:  # noqa: BLE001 — see below
+                    # A gate that expired or was resolved by a human in the
+                    # meantime is not our problem; anything else would only
+                    # be surfaced as an unretrieved task exception.
+                    logger.info(
+                        "could not auto-approve gate %s on %s: %s",
+                        gate_id, run_id, exc,
+                    )
+                    continue
+                record["auto_approved"].append(gate_id)
+                logger.info("auto-approved gate %s on run %s", gate_id, run_id)
+
+    def _runner_for(self, mode: str) -> DevLoopRunner:
+        """Return (building once) the runner whose flow carries ``mode``'s gates.
+
+        The gate flags are compiled into the flow by ``build_dev_loop_flow``,
+        so a mode change needs a different flow — hence one runner per mode
+        rather than one per run.
+        """
+        runner = self._runners.get(mode)
+        if runner is not None:
+            return runner
+        builder = self._flow_builder
+        if builder is None:
+            from parrot.flows.dev_loop.flow import build_dev_loop_flow
+
+            builder = build_dev_loop_flow
+        flow = builder(**self._flow_kwargs, **_MODE_GATES[mode])
+        runner = DevLoopRunner(flow, **self._runner_kwargs)
+        self._runners[mode] = runner
+        return runner
+
+    async def _execute(
+        self, runner: DevLoopRunner, brief: WorkBrief, run_id: str
+    ) -> None:
+        """Run the flow to completion, recording the outcome on the record.
+
+        Failures are recorded, never raised: nothing awaits this task, so an
+        escaping exception would only surface as "Task exception was never
+        retrieved" long after the fact.
+        """
+        record = self._runs[run_id]
+        try:
+            result = await runner.run(brief, run_id=run_id)
+            record["result"] = result
+            record["status"] = getattr(result, "status", "finished")
+        except asyncio.CancelledError:
+            record["status"] = "cancelled"
+            raise
+        except Exception as exc:  # noqa: BLE001 — see docstring
+            logger.exception("dev-loop run %s failed", run_id)
+            record["status"] = "failed"
+            record["error"] = str(exc)

--- a/packages/ai-parrot/tests/unit/flows/test_dev_loop_replication.py
+++ b/packages/ai-parrot/tests/unit/flows/test_dev_loop_replication.py
@@ -1,0 +1,181 @@
+"""Tests for stack-trace parsing, severity and endpoint reproduction."""
+from __future__ import annotations
+
+import pytest
+from aiohttp import web
+
+from parrot.flows.dev_loop.replication import (
+    ReplicationResult,
+    ReplicationTarget,
+    classify_severity,
+    extract_endpoint,
+    parse_stack_trace,
+    proposed_regression_test,
+    replicate_endpoint,
+)
+
+PY_TRACE = '''Traceback (most recent call last):
+  File "/app/navigator/handlers/base.py", line 210, in dispatch
+    return await handler(request)
+  File "/app/resources/users/views.py", line 48, in get_session
+    return payload["user"]["tenant"]
+  File "/usr/lib/python3.11/site-packages/asyncpg/pool.py", line 12, in acquire
+    raise KeyError(key)
+KeyError: 'tenant'
+'''
+
+JS_TRACE = '''TypeError: Cannot read properties of undefined
+    at load (/app/src/routes/proxy/queries/+server.ts:41:18)
+    at Module.respond (/app/node_modules/@sveltejs/kit/src/runtime/respond.js:312:20)
+'''
+
+
+class TestParseStackTrace:
+    def test_python_trace(self):
+        trace = parse_stack_trace(PY_TRACE)
+        assert trace.language == "python"
+        assert trace.exception_type == "KeyError"
+        assert trace.message == "'tenant'"
+        assert len(trace.frames) == 3
+
+    def test_python_culprit_skips_site_packages(self):
+        """The deepest frame is a dependency; the bug is in our code."""
+        culprit = parse_stack_trace(PY_TRACE).culprit
+        assert culprit.file == "/app/resources/users/views.py"
+        assert culprit.line == 48
+
+    def test_javascript_trace_is_ordered_inner_first(self):
+        """V8 prints innermost first — the opposite of Python."""
+        trace = parse_stack_trace(JS_TRACE)
+        assert trace.language == "javascript"
+        assert trace.exception_type == "TypeError"
+        assert trace.culprit.file == "/app/src/routes/proxy/queries/+server.ts"
+
+    def test_javascript_culprit_skips_node_modules(self):
+        trace = parse_stack_trace(JS_TRACE)
+        assert "node_modules" not in trace.culprit.file
+
+    def test_all_vendor_frames_still_yield_a_culprit(self):
+        """Better the innermost dependency frame than nothing."""
+        trace = parse_stack_trace(
+            'File "/usr/lib/python3.11/site-packages/x/y.py", line 3, in f\n'
+            "ValueError: boom"
+        )
+        assert trace.culprit is not None
+
+    @pytest.mark.parametrize("text", ["", "   ", "the api is broken"])
+    def test_prose_is_not_an_error(self, text):
+        """Most reporters paste no trace at all."""
+        trace = parse_stack_trace(text)
+        assert trace.frames == []
+        assert trace.summary() == "sin traceback reconocible"
+
+
+class TestExtractEndpoint:
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("500 on GET /api/v1/user/session", ("GET", "/api/v1/user/session")),
+            ("el api devuelve 500 en /queries/slug", ("GET", "/queries/slug")),
+            ("POST /orders falla", ("POST", "/orders")),
+            ("no hay ruta aca", ("GET", None)),
+        ],
+    )
+    def test_reads_method_and_path(self, text, expected):
+        assert extract_endpoint(text) == expected
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            'File "/usr/lib/python3.11/json/decoder.py", line 355',
+            "abrí /home/user/notes.txt",
+            "mirá /app/src/main.py",
+        ],
+    )
+    def test_file_paths_are_not_endpoints(self, text):
+        """A traceback path is not something to send a request to."""
+        assert extract_endpoint(text)[1] is None
+
+
+class TestClassifySeverity:
+    def test_startup_and_db_exceptions_are_critical(self):
+        trace = parse_stack_trace("ImportError: No module named 'x'")
+        assert classify_severity(trace) == "critical"
+
+    def test_reproduced_5xx_is_high(self):
+        result = ReplicationResult(attempted=True, reproduced=True, status=500)
+        assert classify_severity(parse_stack_trace(PY_TRACE), result) == "high"
+
+    def test_merely_reported_is_medium(self):
+        assert classify_severity(parse_stack_trace(PY_TRACE), None) == "medium"
+
+    def test_nothing_known_is_low(self):
+        assert classify_severity(None, None) == "low"
+
+
+class TestReplicateEndpoint:
+    @pytest.fixture
+    async def server(self, aiohttp_server):
+        async def boom(_request):
+            return web.Response(status=500, text=PY_TRACE)
+
+        async def fine(_request):
+            return web.Response(status=200, text="ok")
+
+        app = web.Application()
+        app.router.add_get("/boom", boom)
+        app.router.add_get("/fine", fine)
+        return await aiohttp_server(app)
+
+    @pytest.mark.asyncio
+    async def test_a_500_is_reproduced_and_captured(self, server):
+        target = ReplicationTarget(base_url=str(server.make_url("")), name="test")
+        result = await replicate_endpoint(target, "GET", "/boom")
+        assert result.reproduced is True
+        assert result.status == 500
+        assert "KeyError" in result.body_excerpt
+
+    @pytest.mark.asyncio
+    async def test_the_trace_in_the_body_is_parsed(self, server):
+        """The observed body is better evidence than the pasted excerpt."""
+        target = ReplicationTarget(base_url=str(server.make_url("")), name="test")
+        result = await replicate_endpoint(target, "GET", "/boom")
+        assert result.trace is not None
+        assert result.trace.exception_type == "KeyError"
+
+    @pytest.mark.asyncio
+    async def test_a_healthy_endpoint_is_not_reproduced(self, server):
+        target = ReplicationTarget(base_url=str(server.make_url("")), name="test")
+        result = await replicate_endpoint(target, "GET", "/fine")
+        assert result.attempted is True
+        assert result.reproduced is False
+        assert result.status == 200
+
+    @pytest.mark.asyncio
+    async def test_an_unreachable_env_is_recorded_not_raised(self):
+        """A dead environment must not abort intake."""
+        target = ReplicationTarget(
+            base_url="http://127.0.0.1:9", name="dead", timeout_seconds=2
+        )
+        result = await replicate_endpoint(target, "GET", "/boom")
+        assert result.attempted is True
+        assert result.reproduced is False
+        assert result.error
+
+
+class TestProposedRegressionTest:
+    def test_reproduced_failure_yields_a_pytest_command(self):
+        result = ReplicationResult(
+            attempted=True, reproduced=True, status=500,
+            url="http://dev.example.com/api/v1/user/session",
+            method="GET", target="dev",
+        )
+        test = proposed_regression_test(result)
+        assert test["path"].endswith(".py")
+        # pytest is in ACCEPTANCE_CRITERION_ALLOWLIST, so QA can run it.
+        assert test["command"].startswith("pytest ")
+        assert "assert response.status_code < 500" in test["content"]
+
+    def test_nothing_is_proposed_when_nothing_reproduced(self):
+        result = ReplicationResult(attempted=True, reproduced=False, status=200)
+        assert proposed_regression_test(result) is None

--- a/packages/ai-parrot/tests/unit/flows/test_dev_loop_toolkit.py
+++ b/packages/ai-parrot/tests/unit/flows/test_dev_loop_toolkit.py
@@ -1,0 +1,322 @@
+"""Tests for ``DevLoopToolkit`` — the dev loop as agent tools.
+
+The runner and flow are stubbed: what is under test is the toolkit's own
+behaviour (tool generation, brief assembly, the deferred autonomy decision,
+gate handling), not the eight-node flow it delegates to.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+import pytest
+
+from parrot.flows.dev_loop.toolkit import DevLoopToolkit
+
+
+class _Gate:
+    """A pending approval gate, as the session host exposes it."""
+
+    def __init__(self, kind: str) -> None:
+        self.kind = kind
+        self.status = "pending"
+        self.prompt = f"approve {kind}?"
+
+
+class _Host:
+    """Minimal stand-in for ``SessionHost``."""
+
+    def __init__(self, gates: Dict[str, _Gate]) -> None:
+        self.state = SimpleNamespace(phase="awaiting_gate", gates=gates)
+
+
+class _Runner:
+    """Records what the toolkit asked of the runner."""
+
+    def __init__(self, gates: Dict[str, _Gate] | None = None) -> None:
+        self.gates = gates or {}
+        self.host = _Host(self.gates)
+        self.resolved: List[tuple] = []
+        self.cancelled: List[str] = []
+        self.briefs: List[Any] = []
+        self._release = asyncio.Event()
+
+    async def run(self, brief: Any, run_id: str = "", **_kw: Any) -> Any:
+        self.briefs.append(brief)
+        await self._release.wait()
+        return SimpleNamespace(status="completed", responses={"qa": "ok"})
+
+    def finish(self) -> None:
+        self._release.set()
+
+    def get_host(self, run_id: str) -> Any:
+        return self.host
+
+    async def resolve_gate(
+        self, run_id: str, gate_id: str, resolution: str, resolved_by: str, **kw: Any
+    ) -> Any:
+        self.resolved.append((run_id, gate_id, resolution, resolved_by))
+        self.gates[gate_id].status = resolution
+        return SimpleNamespace(sequence=len(self.resolved))
+
+    async def cancel_run(self, run_id: str, requested_by: str) -> Any:
+        self.cancelled.append(run_id)
+        return SimpleNamespace(sequence=0)
+
+
+def _toolkit(runner: _Runner, **kwargs: Any) -> DevLoopToolkit:
+    """A toolkit wired to a stub runner, bypassing flow construction."""
+    toolkit = DevLoopToolkit(gate_poll_seconds=0.01, **kwargs)
+    toolkit._runner_for = lambda mode: runner  # type: ignore[method-assign]
+    return toolkit
+
+
+_FULL_BRIEF = {
+    "summary": "500 on GET /api/v1/xyz",
+    "description": "always",
+    "repo": "navigator-api",
+    "acceptance_commands": ["pytest tests/test_xyz.py"],
+}
+
+
+class TestToolGeneration:
+    def test_every_public_method_becomes_a_prefixed_tool(self):
+        names = {tool.name for tool in DevLoopToolkit().get_tools()}
+        assert names == {
+            "devloop_start_dev_loop",
+            "devloop_dev_loop_status",
+            "devloop_dev_loop_runs",
+            "devloop_dev_loop_approve",
+            "devloop_dev_loop_cancel",
+        }
+
+    def test_start_schema_exposes_the_report_fields(self):
+        (tool,) = [
+            t for t in DevLoopToolkit().get_tools()
+            if t.name.endswith("start_dev_loop")
+        ]
+        properties = tool.args_schema.model_json_schema()["properties"]
+        assert {"summary", "repo", "error_text", "approval_mode"} <= set(properties)
+
+    def test_gate_flags_in_flow_kwargs_are_rejected(self):
+        """They are derived per run, so accepting them would be a silent lie."""
+        with pytest.raises(ValueError, match="must not set the gate flags"):
+            DevLoopToolkit(flow_kwargs={"require_deployment_approval": True})
+
+
+class TestStart:
+    @pytest.mark.asyncio
+    async def test_returns_immediately_with_a_run_id(self):
+        """A run takes minutes; the tool must not wait for it."""
+        runner = _Runner()
+        toolkit = _toolkit(runner)
+        out = await asyncio.wait_for(
+            toolkit.start_dev_loop(**_FULL_BRIEF), timeout=1
+        )
+        assert out["run_id"].startswith("run-")
+        assert out["status"] == "running"
+        runner.finish()
+
+    @pytest.mark.asyncio
+    async def test_error_text_becomes_an_inline_log_source(self):
+        runner = _Runner()
+        toolkit = _toolkit(runner)
+        await toolkit.start_dev_loop(**_FULL_BRIEF, error_text="KeyError: 'x'")
+        await asyncio.sleep(0)
+        brief = runner.briefs[0]
+        assert [s.kind for s in brief.log_sources] == ["inline"]
+        assert "KeyError" in brief.log_sources[0].locator
+        runner.finish()
+
+    @pytest.mark.asyncio
+    async def test_acceptance_commands_become_shell_criteria(self):
+        runner = _Runner()
+        toolkit = _toolkit(runner)
+        await toolkit.start_dev_loop(**_FULL_BRIEF)
+        await asyncio.sleep(0)
+        criteria = runner.briefs[0].acceptance_criteria
+        assert [c.kind for c in criteria] == ["shell"]
+        assert criteria[0].command == "pytest tests/test_xyz.py"
+        runner.finish()
+
+    @pytest.mark.asyncio
+    async def test_starts_locked_down_by_default(self):
+        """Autonomy is decided after the plan, so both gates start on."""
+        runner = _Runner()
+        toolkit = _toolkit(runner)
+        out = await toolkit.start_dev_loop(**_FULL_BRIEF)
+        assert out["approval_mode"] == "every_step"
+        assert sorted(out["gates"]) == ["deployment", "plan"]
+        runner.finish()
+
+    @pytest.mark.asyncio
+    async def test_an_underspecified_report_says_what_is_missing(self):
+        toolkit = _toolkit(_Runner())
+        with pytest.raises(ValueError) as excinfo:
+            await toolkit.start_dev_loop(summary="the api is broken")
+        message = str(excinfo.value)
+        assert "affected_component" in message and "repo" in message
+        assert "acceptance_criteria" in message
+        assert "No brief enricher is configured" in message
+
+    @pytest.mark.asyncio
+    async def test_the_enricher_fills_what_the_report_omits(self):
+        class _Enricher:
+            async def enrich(self, draft):
+                draft["affected_component"] = "navigator-api"
+                draft["acceptance_criteria"] = [
+                    {"kind": "shell", "name": "suite", "command": "pytest"}
+                ]
+                return draft
+
+        runner = _Runner()
+        toolkit = _toolkit(runner, brief_enricher=_Enricher())
+        out = await toolkit.start_dev_loop(summary="500 on /api/v1/xyz")
+        assert out["brief"]["affected_component"] == "navigator-api"
+        runner.finish()
+
+    @pytest.mark.asyncio
+    async def test_a_failing_enricher_does_not_block_a_complete_report(self):
+        """Enrichment is advisory; a full brief must still start."""
+        class _Broken:
+            async def enrich(self, draft):
+                raise RuntimeError("graph down")
+
+        runner = _Runner()
+        toolkit = _toolkit(runner, brief_enricher=_Broken())
+        out = await toolkit.start_dev_loop(**_FULL_BRIEF)
+        assert out["status"] == "running"
+        runner.finish()
+
+    @pytest.mark.asyncio
+    async def test_invalid_approval_mode_is_rejected(self):
+        toolkit = _toolkit(_Runner())
+        with pytest.raises(ValueError, match="approval_mode must be one of"):
+            await toolkit.start_dev_loop(**_FULL_BRIEF, approval_mode="whenever")
+
+
+class TestApprovalAndAutonomy:
+    @pytest.mark.asyncio
+    async def test_status_reports_pending_gates(self):
+        runner = _Runner({"g1": _Gate("plan_approval")})
+        toolkit = _toolkit(runner)
+        out = await toolkit.start_dev_loop(**_FULL_BRIEF)
+        status = await toolkit.dev_loop_status(out["run_id"])
+        assert [g["gate_id"] for g in status["pending_gates"]] == ["g1"]
+        assert status["pending_gates"][0]["kind"] == "plan_approval"
+        runner.finish()
+
+    @pytest.mark.asyncio
+    async def test_approving_with_ask_keeps_later_gates_manual(self):
+        runner = _Runner({"g1": _Gate("plan_approval")})
+        toolkit = _toolkit(runner)
+        out = await toolkit.start_dev_loop(**_FULL_BRIEF)
+        run_id = out["run_id"]
+        await toolkit.dev_loop_approve(run_id, "g1", then="ask")
+        # A later gate appears and must stay pending.
+        runner.gates["g2"] = _Gate("deployment_approval")
+        await asyncio.sleep(0.05)
+        assert runner.gates["g2"].status == "pending"
+        assert (await toolkit.dev_loop_status(run_id))["autonomous"] is False
+        runner.finish()
+
+    @pytest.mark.asyncio
+    async def test_approving_with_autonomous_auto_approves_later_gates(self):
+        runner = _Runner({"g1": _Gate("plan_approval")})
+        toolkit = _toolkit(runner)
+        out = await toolkit.start_dev_loop(**_FULL_BRIEF)
+        run_id = out["run_id"]
+        await toolkit.dev_loop_approve(run_id, "g1", then="autonomous")
+        runner.gates["g2"] = _Gate("deployment_approval")
+        for _ in range(100):
+            await asyncio.sleep(0.01)
+            if runner.gates["g2"].status == "approved":
+                break
+        assert runner.gates["g2"].status == "approved"
+        status = await toolkit.dev_loop_status(run_id)
+        assert status["autonomous"] is True
+        assert "g2" in status["auto_approved"]
+        runner.finish()
+
+    @pytest.mark.asyncio
+    async def test_rejecting_does_not_grant_autonomy(self):
+        """`then` must not be honoured on a rejection."""
+        runner = _Runner({"g1": _Gate("plan_approval")})
+        toolkit = _toolkit(runner)
+        out = await toolkit.start_dev_loop(**_FULL_BRIEF)
+        await toolkit.dev_loop_approve(
+            out["run_id"], "g1", resolution="rejected", then="autonomous"
+        )
+        assert (await toolkit.dev_loop_status(out["run_id"]))["autonomous"] is False
+        runner.finish()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "kwargs,match",
+        [
+            ({"resolution": "maybe"}, "resolution must be"),
+            ({"then": "later"}, "then must be"),
+        ],
+    )
+    async def test_invalid_approval_arguments(self, kwargs, match):
+        runner = _Runner({"g1": _Gate("plan_approval")})
+        toolkit = _toolkit(runner)
+        out = await toolkit.start_dev_loop(**_FULL_BRIEF)
+        with pytest.raises(ValueError, match=match):
+            await toolkit.dev_loop_approve(out["run_id"], "g1", **kwargs)
+        runner.finish()
+
+    @pytest.mark.asyncio
+    async def test_unknown_run_lists_the_known_ones(self):
+        toolkit = _toolkit(_Runner())
+        with pytest.raises(KeyError, match="unknown run_id"):
+            await toolkit.dev_loop_status("run-nope")
+
+
+class TestLifecycle:
+    @pytest.mark.asyncio
+    async def test_runs_lists_what_was_started(self):
+        runner = _Runner()
+        toolkit = _toolkit(runner)
+        await toolkit.start_dev_loop(**_FULL_BRIEF)
+        listing = await toolkit.dev_loop_runs()
+        assert len(listing["runs"]) == 1
+        assert listing["runs"][0]["kind"] == "bug"
+        runner.finish()
+
+    @pytest.mark.asyncio
+    async def test_completion_is_recorded(self):
+        runner = _Runner()
+        toolkit = _toolkit(runner)
+        out = await toolkit.start_dev_loop(**_FULL_BRIEF)
+        runner.finish()
+        await asyncio.sleep(0.05)
+        status = await toolkit.dev_loop_status(out["run_id"])
+        assert status["status"] == "completed"
+        assert status["nodes"] == {"qa": "ok"}
+
+    @pytest.mark.asyncio
+    async def test_a_failing_run_is_recorded_not_raised(self):
+        """Nothing awaits the run task, so a failure must land on the record."""
+        class _Boom(_Runner):
+            async def run(self, brief, run_id="", **_kw):
+                raise RuntimeError("flow exploded")
+
+        runner = _Boom()
+        toolkit = _toolkit(runner)
+        out = await toolkit.start_dev_loop(**_FULL_BRIEF)
+        await asyncio.sleep(0.05)
+        status = await toolkit.dev_loop_status(out["run_id"])
+        assert status["status"] == "failed"
+        assert "flow exploded" in status["error"]
+
+    @pytest.mark.asyncio
+    async def test_cancel_marks_the_run(self):
+        runner = _Runner()
+        toolkit = _toolkit(runner)
+        out = await toolkit.start_dev_loop(**_FULL_BRIEF)
+        result = await toolkit.dev_loop_cancel(out["run_id"])
+        assert result["cancelled"] is True
+        assert runner.cancelled == [out["run_id"]]
+        runner.finish()


### PR DESCRIPTION
## Summary

Turns the dev loop into tooling an agent can drive from a conversation, and implements the bug-intake enrichment the node was reserved for. Premise: *"I have a bug in the api returning 500 on endpoint XYZ"* → capture, reproduce, document, fix, test, PR.

Three gaps stood in the way. Two needed no flow changes.

### 1. No tool

The loop could only start via `DevLoopRunner.run(brief)`, the two HTTP consoles under `examples/dev_loop/`, or the webhook. None is reachable from a conversation, so an agent asked to fix a bug could describe the pipeline but never start it.

`DevLoopToolkit` (`AbstractToolkit`, prefix `devloop`) exposes five tools:

| tool | what |
|---|---|
| `start_dev_loop` | build the brief and launch a run |
| `dev_loop_status` | phase, nodes, pending gates |
| `dev_loop_runs` | what this agent has started |
| `dev_loop_approve` | resolve a gate, and decide the rest |
| `dev_loop_cancel` | request cancellation |

Runs launch in the background and the tool returns a `run_id` immediately. A run takes minutes: returning its result would block the caller — for an agentd daemon, its socket — for the whole run.

### 2. Autonomy was decided before the plan existed

The gate flags are compiled into the flow by `build_dev_loop_flow`, not chosen per run, so **a run can never gain a gate later — only be relieved of one**. Runs therefore start with every gate enabled, and the choice comes after the plan is read:

```python
await tk.dev_loop_approve(run_id, gate_id, then="autonomous")  # finish on its own
await tk.dev_loop_approve(run_id, gate_id, then="ask")         # keep later gates
```

`then="autonomous"` starts a watcher that resolves that run's remaining gates. Starting locked down and loosening on request is the only ordering that lets the decision follow the plan rather than precede it.

### 3. An underspecified report cannot start anything

`affected_component` and `acceptance_criteria` are required with no defaults (the latter `min_length=1`), so a one-line report never validates. Instead of surfacing pydantic's raw error, the toolkit names each missing field and how to supply it:

```
The report is not specific enough to start a run. Missing: affected_component
(which repository/service owns the code — pass `repo`); acceptance_criteria
(how to verify the fix — pass `acceptance_commands`, e.g. ['pytest ...']).
No brief enricher is configured, so nothing can infer these.
```

A `BriefEnricher` protocol lets a host with a codebase index resolve them. parrot stays ignorant of any such index — the dependency points one way.

## BugIntakeNode now does what it promised

It was a thin no-op whose own docstring reserved it for *"severity classification, stack-trace parsing, etc."*. New `replication.py` plus the node wiring:

- **Parses** the pasted trace — Python and V8. Picking the culprit frame is not "take the last one": V8 orders frames innermost-first, the opposite of Python, and in both the innermost frame is usually `site-packages`/`node_modules`, i.e. where the error *passed through*, not where the bug is. So it walks inward-to-outward per language and returns the first non-vendor frame.
- **Reproduces** the failure against a configured environment and captures status, body, and any traceback the body carries — observed evidence rather than narration. A dead environment is recorded, never raised: it must not abort intake.
- **Classifies severity** from what was observed (`critical` for import/DB/OOM exceptions, `high` for a reproduced 5xx, down to `low`).
- **Documents** it: findings into `shared["bug_findings"]`, the observed response as a second inline log source, and a prose summary appended to the description that Research actually reads.
- **Proposes a regression test** when something reproduced, added as a `ShellCriterion`. `pytest` is in `ACCEPTANCE_CRITERION_ALLOWLIST`, so QA runs it — which makes "the bug is fixed" checkable instead of a judgement call. It is *added*, not substituted: the reporter's criteria stay and the bar goes up.

The target is an **environment** (dev, staging), not the app on the reporter's machine: reproducing where the 500 actually happens beats standing up the service and its database for every bug.

Everything here is additive and best-effort. With no replication target, or a brief with no trace, the node behaves exactly as before — re-emit `flow.bug_brief_validated` and return the brief. A report that cannot be enriched still has to reach Research.

## Test evidence

`packages/ai-parrot/tests/unit/flows/` — **47 passed**:

- `test_dev_loop_toolkit.py` (25): tool generation, immediate return, brief assembly, the deferred autonomy decision (including that a *rejection* never grants autonomy), gate handling, and that a failing run lands on the record rather than as an unretrieved task exception.
- `test_dev_loop_replication.py` (22): trace parsing for both languages and both culprit orderings, endpoint extraction rejecting traceback file paths, severity, and reproduction against a live `aiohttp` server — 500 captured, healthy endpoint not reproduced, unreachable environment recorded.

The existing `test_bug_intake.py` passes unchanged (7). Under `tests/flows/dev_loop/` there are 57 pre-existing failures on `dev`; the set is **byte-identical** with and without this change (verified by stashing `bug_intake.py` and diffing the failure lists).

## Note on `examples/dev_loop/`

Unchanged. The consoles and webhook keep working exactly as they did; this adds a fourth way in.

Developed with Spec Driven Development