### PR TITLE
feat(forms): rules can ask about the store, and ask two things at once (FEAT-440)

### DIFF
--- a/packages/parrot-formdesigner/src/parrot_formdesigner/core/__init__.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/core/__init__.py
@@ -10,6 +10,7 @@ from .constraints import (
     DependencyOperation,
     DependencyRule,
     FieldCondition,
+    LogicGroup,
     FieldConstraints,
     PostDependency,
 )
@@ -61,6 +62,7 @@ __all__ = [
     "FieldConstraints",
     "ConditionOperator",
     "FieldCondition",
+    "LogicGroup",
     "DependencyRule",
     "DependencyOperation",
     "PostDependency",

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/core/constraints.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/core/constraints.py
@@ -138,6 +138,12 @@ class ConditionOperator(str, Enum):
     LTE = "lte"
     IN = "in"
     NOT_IN = "not_in"
+    # CONTAINS is IN read the other way round. IN asks "is the answer one of
+    # these values"; CONTAINS asks "does this multi-valued source hold that
+    # value" — the shape a store's group membership takes, where the context
+    # supplies the list and the rule names the one entry it needs.
+    CONTAINS = "contains"
+    NOT_CONTAINS = "not_contains"
     IS_EMPTY = "is_empty"
     IS_NOT_EMPTY = "is_not_empty"
 
@@ -175,10 +181,36 @@ class FieldCondition(BaseModel):
     key: str | None = None
 
 
+class LogicGroup(BaseModel):
+    """One alternative inside a :class:`DependencyRule`.
+
+    Conditions inside a group are AND'd; the groups themselves are OR'd
+    against each other. That nesting is what a flat ``conditions`` list
+    cannot express — "the store is in one of these groups AND the visit is
+    one of these types" needs two groups, not thirteen conditions under a
+    single gate, where ``and`` demands all thirteen and ``or`` settles for
+    one.
+
+    The shape matches the frontend's ``LogicGroup`` (navigator-svelte
+    ``formbuilder/types/schema.ts``), which has evaluated groups since
+    before the server could express them.
+
+    Attributes:
+        conditions: Conditions that must ALL hold for this group to match.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    conditions: list["FieldCondition"]
+
+
 class DependencyRule(BaseModel):
     """Rule controlling conditional visibility/behavior of a field or section.
 
     Attributes:
+        groups: Alternatives, each AND'd internally and OR'd against the
+            others. When present it REPLACES ``conditions``/``logic`` — the
+            flat pair stays for every rule that does not need nesting.
         conditions: List of field conditions that must be evaluated.
         logic: How conditions are combined. One of:
             - ``"and"``: all conditions must be true (default; backward-compatible).
@@ -193,6 +225,7 @@ class DependencyRule(BaseModel):
     # model_config intentionally omits extra="forbid" for forward-compatible
     # unknown keys — existing forms with unrecognised rule keys must round-trip unchanged.
 
+    groups: list[LogicGroup] | None = None
     conditions: list[FieldCondition]
     logic: Literal["and", "or", "xor", "not"] = "and"
     effect: Literal["show", "hide", "require", "disable"] = "show"

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/core/resolution.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/core/resolution.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any
 from .schema import walk_fields
 
 if TYPE_CHECKING:
-    from .constraints import FieldCondition
+    from .constraints import FieldCondition, DependencyRule
     from .schema import FormField, FormSchema, FormSection
 
 
@@ -98,10 +98,23 @@ def resolve_rule_references(form: FormSchema) -> FormSchema:
             return
         cond.field_uid = uuid.UUID(_uid_for(cond.field_id or "", owner, "condition"))
 
+    def _resolve_rule(rule: DependencyRule, owner: str) -> None:
+        """Resolve a rule's conditions, flat list AND nested groups.
+
+        A condition inside ``groups`` is a condition like any other: left
+        unresolved it keeps ``field_uid=None``, and ``_eval_condition``
+        reads the answer through that uid, so the whole group silently
+        never matches.
+        """
+        for c in rule.conditions:
+            _resolve_condition(c, owner)
+        for g in rule.groups or []:
+            for c in g.conditions:
+                _resolve_condition(c, owner)
+
     for f in form.iter_fields_recursive():
         if f.depends_on:
-            for c in f.depends_on.conditions:
-                _resolve_condition(c, f.field_id)
+            _resolve_rule(f.depends_on, f.field_id)
             for op in f.depends_on.operations or []:
                 op.operands = [
                     _uid_for(o, f.field_id, "operation operand") for o in op.operands
@@ -127,8 +140,7 @@ def resolve_rule_references(form: FormSchema) -> FormSchema:
     for section in form.sections:
         if not section.depends_on:
             continue
-        for c in section.depends_on.conditions:
-            _resolve_condition(c, section.section_id)
+        _resolve_rule(section.depends_on, section.section_id)
         for op in section.depends_on.operations or []:
             op.operands = [
                 _uid_for(o, section.section_id, "operation operand")

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/services/rule_evaluator.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/services/rule_evaluator.py
@@ -140,6 +140,29 @@ def _answer_for_ref(ref: str, form: FormSchema, answers: dict[str, Any]) -> Any:
     return resolve_answer(form, field_uid, answers)
 
 
+def _holds(raw: Any, expected: Any) -> bool:
+    """True when the multi-valued ``raw`` source holds ``expected``.
+
+    The source side of a CONTAINS is a collection — a store's group
+    membership, a multi-select answer. A scalar is treated as a
+    one-element collection so a single-group store still matches, and a
+    string is NOT walked character by character, which is the trap in
+    using ``in`` directly here.
+
+    Args:
+        raw: The value read from the condition's source.
+        expected: The single value the rule is looking for.
+
+    Returns:
+        Whether ``expected`` is present in ``raw``.
+    """
+    if raw is None:
+        return False
+    if isinstance(raw, (list, tuple, set)):
+        return expected in [_to_comparable(v) for v in raw]
+    return _to_comparable(raw) == expected
+
+
 def _eval_condition(
     condition: FieldCondition,
     answers: dict[str, Any],
@@ -205,6 +228,10 @@ def _eval_condition(
             if isinstance(expected, list):
                 return actual not in [_to_comparable(v) for v in expected]
             return actual != exp
+        case ConditionOperator.CONTAINS:
+            return _holds(raw, exp)
+        case ConditionOperator.NOT_CONTAINS:
+            return not _holds(raw, exp)
         case ConditionOperator.GT:
             try:
                 return float(actual) > float(exp)  # type: ignore[arg-type]
@@ -269,6 +296,44 @@ def _eval_logic(
         case _:
             logger.warning("Unknown logic gate: %s; defaulting to 'and'", logic)
             return all(results)
+
+
+def _eval_rule(
+    rule: DependencyRule,
+    answers: dict[str, Any],
+    form: FormSchema,
+    location_vars: dict[str, Any] | None = None,
+    visit_context: dict[str, Any] | None = None,
+) -> bool:
+    """Evaluate a whole rule, honouring ``groups`` when it carries them.
+
+    Groups are alternatives: each is satisfied only if ALL its conditions
+    hold, and the rule fires when ANY group is satisfied. A rule without
+    groups falls back to the flat ``conditions``/``logic`` pair, so every
+    existing rule keeps its exact behaviour.
+
+    An empty group list is treated as no groups at all rather than as
+    "nothing can satisfy this" — the same reading ``_eval_logic`` gives an
+    empty condition list.
+
+    Args:
+        rule: The dependency rule to evaluate.
+        answers: Current answer dict, keyed by field_id.
+        form: The form the rule belongs to.
+        location_vars: Org-graph location variables, keyed by name.
+        visit_context: Visit-level metadata, keyed by name.
+
+    Returns:
+        Whether the rule fires.
+    """
+    if rule.groups:
+        return any(
+            _eval_logic(g.conditions, "and", answers, form, location_vars, visit_context)
+            for g in rule.groups
+        )
+    return _eval_logic(
+        rule.conditions, rule.logic, answers, form, location_vars, visit_context
+    )
 
 
 def _apply_operation(
@@ -608,10 +673,7 @@ class RuleEvaluator:
             if rule is None:
                 continue
 
-            fired = _eval_logic(
-                rule.conditions, rule.logic, answers, form,
-                location_vars, visit_context,
-            )
+            fired = _eval_rule(rule, answers, form, location_vars, visit_context)
             shown = fired if rule.effect != "hide" else not fired
             if shown:
                 continue
@@ -646,7 +708,7 @@ class RuleEvaluator:
         if rule is None:
             return
 
-        fired = _eval_logic(rule.conditions, rule.logic, answers, form, location_vars, visit_context)
+        fired = _eval_rule(rule, answers, form, location_vars, visit_context)
 
         # Apply visibility/required effect
         effect = rule.effect

--- a/packages/parrot-formdesigner/tests/unit/core/test_resolution.py
+++ b/packages/parrot-formdesigner/tests/unit/core/test_resolution.py
@@ -248,3 +248,71 @@ def test_resolve_answer_reads_by_field_id(form_with_rules: FormSchema):
 
 def test_resolve_answer_unknown_field_returns_none(form_with_rules: FormSchema):
     assert resolve_answer(form_with_rules, uuid.uuid4(), {"a": "hello"}) is None
+
+
+def test_conditions_inside_logic_groups_are_resolved_too():
+    """A grouped condition is a condition: unresolved it can never fire.
+
+    `_eval_condition` reads the answer through `field_uid`, so a group whose
+    conditions kept `field_uid=None` silently never matches — the same class
+    of defect that made every imported networkninja rule inert.
+    """
+    from parrot_formdesigner.core.constraints import LogicGroup
+
+    driver = FormField(field_id="driver", field_type=FieldType.TEXT, label="driver")
+    gated = FormField(
+        field_id="gated", field_type=FieldType.TEXT, label="gated",
+        depends_on=DependencyRule(conditions=[], effect="show", groups=[
+            LogicGroup(conditions=[
+                FieldCondition(field_id="driver", operator="eq", value="yes"),
+            ]),
+        ]),
+    )
+    form = FormSchema(form_id="t", title="T",
+                      sections=[FormSection(section_id="s", fields=[driver, gated])])
+
+    resolve_rule_references(form)
+
+    cond = gated.depends_on.groups[0].conditions[0]
+    assert cond.field_uid == driver.field_uid
+
+
+def test_section_rule_groups_are_resolved_too():
+    """Same for a section's rule — sections resolve alongside fields."""
+    from parrot_formdesigner.core.constraints import LogicGroup
+
+    driver = FormField(field_id="driver", field_type=FieldType.TEXT, label="driver")
+    form = FormSchema(form_id="t", title="T", sections=[
+        FormSection(section_id="open", fields=[driver]),
+        FormSection(
+            section_id="gated",
+            fields=[FormField(field_id="inside", field_type=FieldType.TEXT, label="inside")],
+            depends_on=DependencyRule(conditions=[], effect="show", groups=[
+                LogicGroup(conditions=[
+                    FieldCondition(field_id="driver", operator="eq", value="yes"),
+                ]),
+            ]),
+        ),
+    ])
+
+    resolve_rule_references(form)
+
+    assert form.sections[1].depends_on.groups[0].conditions[0].field_uid == driver.field_uid
+
+
+def test_a_context_condition_in_a_group_needs_no_field_reference():
+    """`visit_context` conditions are key-based; resolution must skip them."""
+    from parrot_formdesigner.core.constraints import LogicGroup
+
+    form = FormSchema(form_id="t", title="T", sections=[FormSection(section_id="s", fields=[
+        FormField(field_id="f", field_type=FieldType.TEXT, label="f",
+                  depends_on=DependencyRule(conditions=[], effect="show", groups=[
+                      LogicGroup(conditions=[FieldCondition(
+                          source="visit_context", key="store_groups",
+                          operator="contains", value="Ring of Fire")]),
+                  ])),
+    ])])
+
+    resolve_rule_references(form)   # must not raise
+
+    assert form.sections[0].fields[0].depends_on.groups[0].conditions[0].field_uid is None

--- a/packages/parrot-formdesigner/tests/unit/services/test_rule_evaluator.py
+++ b/packages/parrot-formdesigner/tests/unit/services/test_rule_evaluator.py
@@ -7,6 +7,7 @@ from parrot_formdesigner.core import (
     DependencyOperation,
     DependencyRule,
     FieldCondition,
+    LogicGroup,
     FieldType,
     FormField,
     FormSchema,
@@ -856,3 +857,163 @@ class TestSectionVisibility:
 
         assert res.visible["plain"] is True
         assert res.required["plain"] is True
+
+
+# ---------------------------------------------------------------------------
+# Store context: CONTAINS + logic groups
+# ---------------------------------------------------------------------------
+
+
+def _ctx_cond(key: str, value: str, op: str = "contains") -> FieldCondition:
+    return FieldCondition(source="visit_context", key=key, operator=op, value=value)
+
+
+class TestContainsOperator:
+    """`IN` asks whether the answer is one of several values; `CONTAINS` asks
+    whether a multi-valued source holds one — the shape a store's group
+    membership takes."""
+
+    async def test_list_source_holding_the_value(self) -> None:
+        form = _form(_field("f", depends_on=DependencyRule(
+            conditions=[_ctx_cond("store_groups", "Ring of Fire")], effect="show")))
+
+        res = await RuleEvaluator().resolve(
+            form, {}, visit_context={"store_groups": ["Best Buy", "Ring of Fire"]})
+
+        assert res.visible["f"] is True
+
+    async def test_list_source_without_the_value(self) -> None:
+        form = _form(_field("f", depends_on=DependencyRule(
+            conditions=[_ctx_cond("store_groups", "Ring of Fire")], effect="show")))
+
+        res = await RuleEvaluator().resolve(
+            form, {}, visit_context={"store_groups": ["Best Buy"]})
+
+        assert res.visible["f"] is False
+
+    async def test_scalar_source_counts_as_a_one_element_collection(self) -> None:
+        """A store in exactly one group still matches."""
+        form = _form(_field("f", depends_on=DependencyRule(
+            conditions=[_ctx_cond("store_groups", "Ring of Fire")], effect="show")))
+
+        res = await RuleEvaluator().resolve(
+            form, {}, visit_context={"store_groups": "Ring of Fire"})
+
+        assert res.visible["f"] is True
+
+    async def test_a_string_source_is_not_walked_character_by_character(self) -> None:
+        """The trap in using `in` directly: "Ring of Fire" contains "Fire"."""
+        form = _form(_field("f", depends_on=DependencyRule(
+            conditions=[_ctx_cond("store_groups", "Fire")], effect="show")))
+
+        res = await RuleEvaluator().resolve(
+            form, {}, visit_context={"store_groups": "Ring of Fire"})
+
+        assert res.visible["f"] is False
+
+    async def test_missing_context_does_not_reveal(self) -> None:
+        form = _form(_field("f", depends_on=DependencyRule(
+            conditions=[_ctx_cond("store_groups", "Ring of Fire")], effect="show")))
+
+        res = await RuleEvaluator().resolve(form, {})
+
+        assert res.visible["f"] is False
+
+    async def test_not_contains_is_the_negation(self) -> None:
+        form = _form(_field("f", depends_on=DependencyRule(
+            conditions=[_ctx_cond("store_groups", "Ring of Fire", "not_contains")],
+            effect="show")))
+
+        yes = await RuleEvaluator().resolve(
+            form, {}, visit_context={"store_groups": ["Best Buy"]})
+        no = await RuleEvaluator().resolve(
+            form, {}, visit_context={"store_groups": ["Ring of Fire"]})
+
+        assert yes.visible["f"] is True
+        assert no.visible["f"] is False
+
+
+class TestLogicGroups:
+    """Groups are alternatives: AND inside, OR between. A flat list under a
+    single gate cannot express "in one of these stores AND one of these visit
+    types" — `and` demands all of them, `or` settles for one."""
+
+    def _gated(self) -> FormSchema:
+        rule = DependencyRule(conditions=[], effect="show", groups=[
+            LogicGroup(conditions=[
+                _ctx_cond("store_groups", "Ring of Fire"),
+                _cond("visit_type", "in", ["Brand Ambassador", "Assisted Sales"]),
+            ]),
+        ])
+        return _form(_field("visit_type"), _field("photo", depends_on=rule))
+
+    async def test_both_halves_satisfied(self) -> None:
+        res = await RuleEvaluator().resolve(
+            self._gated(), {"visit_type": "Brand Ambassador"},
+            visit_context={"store_groups": ["Ring of Fire"]})
+
+        assert res.visible["photo"] is True
+
+    async def test_right_store_wrong_visit_type(self) -> None:
+        res = await RuleEvaluator().resolve(
+            self._gated(), {"visit_type": "Time Off"},
+            visit_context={"store_groups": ["Ring of Fire"]})
+
+        assert res.visible["photo"] is False
+
+    async def test_right_visit_type_wrong_store(self) -> None:
+        res = await RuleEvaluator().resolve(
+            self._gated(), {"visit_type": "Brand Ambassador"},
+            visit_context={"store_groups": ["Best Buy"]})
+
+        assert res.visible["photo"] is False
+
+    async def test_a_second_group_is_an_alternative(self) -> None:
+        rule = DependencyRule(conditions=[], effect="show", groups=[
+            LogicGroup(conditions=[_ctx_cond("store_groups", "Ring of Fire")]),
+            LogicGroup(conditions=[_ctx_cond("store_groups", "Epson Test Store")]),
+        ])
+        form = _form(_field("f", depends_on=rule))
+
+        a = await RuleEvaluator().resolve(form, {}, visit_context={"store_groups": ["Ring of Fire"]})
+        b = await RuleEvaluator().resolve(form, {}, visit_context={"store_groups": ["Epson Test Store"]})
+        c = await RuleEvaluator().resolve(form, {}, visit_context={"store_groups": ["Costco"]})
+
+        assert a.visible["f"] is True
+        assert b.visible["f"] is True
+        assert c.visible["f"] is False
+
+    async def test_groups_replace_the_flat_list(self) -> None:
+        """A rule carrying groups must ignore `conditions`/`logic` entirely."""
+        rule = DependencyRule(
+            conditions=[_cond("driver", value="never")], logic="and", effect="show",
+            groups=[LogicGroup(conditions=[_ctx_cond("store_groups", "Ring of Fire")])])
+        form = _form(_field("driver"), _field("f", depends_on=rule))
+
+        res = await RuleEvaluator().resolve(
+            form, {}, visit_context={"store_groups": ["Ring of Fire"]})
+
+        assert res.visible["f"] is True
+
+    async def test_an_empty_group_list_falls_back_to_the_flat_pair(self) -> None:
+        rule = DependencyRule(conditions=[_cond("driver")], logic="and",
+                              effect="show", groups=[])
+        form = _form(_field("driver"), _field("f", depends_on=rule))
+
+        assert (await RuleEvaluator().resolve(form, {"driver": "yes"})).visible["f"] is True
+        assert (await RuleEvaluator().resolve(form, {})).visible["f"] is False
+
+    async def test_section_rules_honour_groups_too(self) -> None:
+        rule = DependencyRule(conditions=[], effect="show", groups=[
+            LogicGroup(conditions=[_ctx_cond("store_groups", "Ring of Fire")])])
+        form = resolve_rule_references(FormSchema(
+            form_id="t", title="T",
+            sections=[FormSection(section_id="gated", fields=[_field("inside")],
+                                  depends_on=rule)]))
+
+        shown = await RuleEvaluator().resolve(
+            form, {}, visit_context={"store_groups": ["Ring of Fire"]})
+        hidden = await RuleEvaluator().resolve(form, {})
+
+        assert shown.visible["inside"] is True
+        assert hidden.visible["inside"] is False

--- a/sdd/specs/store-context-conditions.spec.md
+++ b/sdd/specs/store-context-conditions.spec.md
@@ -1,0 +1,325 @@
+---
+# SDD flow type and base branch (FEAT-145).
+type: feature
+base_branch: dev
+---
+
+# Feature Specification: Store-Context Conditions in the Rules Engine
+
+**Feature ID**: FEAT-440
+**Date**: 2026-08-21
+**Author**: Juan Franco (spec drafted with Claude Code)
+**Status**: draft
+**Target version**: 0.9.3
+
+> Source evidence: `Recap_10.xlsx` — the Recap Definition v390 export of
+> NetworkNinja form `db-form-10-69` (Epson Visit Form), 1.475 rows.
+> Measured against `navigator_staging` on 2026-08-20/21.
+> Downstream halves, reserved separately: fieldsync (data + context
+> assembly) and navigator-svelte (client rule engine).
+
+---
+
+## 1. Motivation & Business Requirements
+
+### Problem Statement
+
+A NetworkNinja form gates its blocks and questions on **two independent
+axes**, and the engine can express only one of them.
+
+The first axis is an answer: *"show this block when the visit type is Brand
+Ambassador or Assisted Sales"*. That works today.
+
+The second is the **store the visit is at**, and it is not an answer to
+anything — it is context the rep never types. On the Epson Visit Form,
+measured against the source export:
+
+| | count |
+|---|---|
+| blocks gated on a store group | 6 of 17 |
+| questions gated on a store group | 91 of 295 |
+| distinct store groups in use | 11 (of 36 defined) |
+| elements gated on BOTH axes at once | 26 |
+| …of those, needing AND-of-ORs | 23 |
+
+The clearest case is the `Ring of Fire Photos` block (source `block_id` 26,
+13 questions, 4 of them required). Measured over 883 visits in the three
+months after the form's 2026-05-08 revision: it appears in **exactly 20
+stores and in 254 others never**, with **zero** stores in between. It is a
+curated list, reproducible from no attribute we hold — the closest rule
+(`market_trainer_name = 'Joe Montoya' AND retailer_type = 'Direct'`) yields
+20 true positives and 17 false ones.
+
+Two distinct gaps stop the engine short.
+
+**1 — No operator asks the question.** `ConditionOperator.IN` asks whether
+the answer is one of several values. Store membership is the mirror image:
+the context supplies the list (`["Best Buy", "Epson Test Store", "Ring of
+Fire"]`) and the rule names the single entry it needs. Nothing expresses
+that direction.
+
+**2 — `DependencyRule` cannot nest.** It carries a flat `conditions` list
+under one `logic` gate, so *"the store is in one of these 8 groups AND the
+visit is one of these 5 types"* — the real shape of the `Compliance Images`
+block — is inexpressible: `and` demands all thirteen conditions hold,
+`or` settles for any one. Neither is the rule.
+
+The condition SOURCES already exist. `FieldCondition.source` accepts
+`"location_variable"` and `"visit_context"`, `_eval_condition` resolves
+both, and `RuleEvaluator.resolve()` takes `location_vars` / `visit_context`
+parameters (FEAT-301, `sdd/specs/conditional-logic-engine.spec.md`, approved).
+What is missing is the vocabulary to *use* them for set membership, and the
+nesting to combine them with an answer condition.
+
+### Goals
+
+- Express "this multi-valued context source holds this value" as a
+  first-class operator, usable by any condition source.
+- Restore nesting to `DependencyRule` so one rule can require an
+  alternative on one axis AND an alternative on another.
+- Match the frontend's existing `LogicGroup` contract exactly
+  (navigator-svelte `src/lib/formbuilder/types/schema.ts`), which has
+  evaluated groups since before the server could express them.
+- Keep every rule that does not use the new shape behaving identically.
+- Have the networkninja importer emit store-group conditions instead of
+  discarding the column.
+- Accept and propagate a caller-supplied store context through the HTTP
+  surface that serves and validates forms.
+
+### Non-Goals (explicitly out of scope)
+
+- **Sourcing store-group membership.** It exists in NO replicated table —
+  verified across `networkninja.stores` (39 columns + the full 43-key
+  `custom_fields` inventory), `epson.stores*`, and every `*group*` table
+  (`epson.trait_groups` has the right shape and is empty). It lands in
+  `<tenant>.fs_stores` and is the fieldsync half.
+- **Assembling the context.** Which store a visit belongs to is FieldSync's
+  knowledge, not this package's. This spec only accepts what it is handed.
+- **The client rule engine.** `DependencyCondition` in navigator-svelte has
+  no `source`/`key` and cannot evaluate a context condition at all; that is
+  its own feature.
+- **`location_variable` conditions.** The source is already supported and
+  untouched here; only `visit_context` is exercised.
+- **Page-level hierarchy.** NetworkNinja groups its 17 blocks into 10 named
+  pages. Real, and a separate concern from conditions.
+
+---
+
+## 2. Architectural Design
+
+### Overview
+
+Two additions to `core`, one evaluation change in `services`, and two
+plumbing changes at the edges.
+
+```
+core/constraints.py
+  ConditionOperator  += CONTAINS, NOT_CONTAINS
+  LogicGroup          (new)  conditions: list[FieldCondition]
+  DependencyRule     += groups: list[LogicGroup] | None
+
+core/resolution.py
+  resolve_rule_references()  also walks conditions INSIDE groups
+
+services/rule_evaluator.py
+  _holds()      (new)  set-membership over a possibly-scalar source
+  _eval_rule()  (new)  the ONE place a DependencyRule is evaluated
+
+tools/services/networkninja.py
+  emits a visit_context CONTAINS condition per store group
+
+api/handlers.py
+  accepts a store context and hands it to resolve()/validate()
+```
+
+### Integration Points
+
+- **`_eval_rule` is the single evaluation seam.** Field rules, section
+  rules and post-dependencies route through it, so groups work everywhere
+  at once rather than in whichever call site remembered.
+- **Resolution must walk groups.** `_eval_condition` reads a field
+  condition's answer through `field_uid`; a grouped condition left
+  unresolved keeps `field_uid=None` and can never match. This is the exact
+  defect class that made every imported networkninja rule inert
+  (`mem-bcb5469d8eb0`), and a new nesting level reintroduces it silently
+  unless resolution follows.
+- **`FormValidator.validate()`** already threads `visit_context` through to
+  the evaluator; nothing further is needed there.
+
+### Data Models
+
+```python
+class LogicGroup(BaseModel):
+    """One alternative: conditions AND'd inside, groups OR'd between."""
+    model_config = ConfigDict(extra="forbid")
+    conditions: list[FieldCondition]
+
+
+class DependencyRule(BaseModel):
+    groups: list[LogicGroup] | None = None   # replaces conditions/logic when set
+    conditions: list[FieldCondition]
+    logic: Literal["and", "or", "xor", "not"] = "and"
+    effect: Literal["show", "hide", "require", "disable"] = "show"
+```
+
+A store-gated block, as the importer should emit it:
+
+```python
+DependencyRule(conditions=[], effect="show", groups=[
+    LogicGroup(conditions=[
+        FieldCondition(source="visit_context", key="store_groups",
+                       operator="contains", value="Ring of Fire"),
+        FieldCondition(field_id="field_9050", operator="in",
+                       value=["4782", "4783"]),   # Brand Ambassador | Assisted Sales
+    ]),
+])
+```
+
+---
+
+## 3. Module Breakdown
+
+### Module 1: `CONTAINS` / `NOT_CONTAINS`
+
+Two enum members and a `_holds` helper. Semantics that must hold:
+
+- A list/tuple/set source matches when it holds the value.
+- A **scalar source counts as a one-element collection**, so a store in
+  exactly one group still matches.
+- A **string source is NOT walked character by character** — `"Ring of
+  Fire"` must not contain `"Fire"`. This is the trap in using `in`
+  directly and is the reason for a helper rather than an inline expression.
+- A missing source is `False`, never an error.
+
+### Module 2: `LogicGroup` + `_eval_rule`
+
+The model, its export from `core/__init__`, and the collapse of the three
+`_eval_logic(rule.conditions, rule.logic, …)` call sites into `_eval_rule`.
+An empty `groups` list falls back to the flat pair — the same reading
+`_eval_logic` gives an empty condition list, not "nothing can satisfy this".
+
+### Module 3: Resolution through groups
+
+`resolve_rule_references` gains an inner `_resolve_rule` applied to both
+field and section rules, walking `rule.conditions` and every
+`group.conditions`. Context conditions carry no field reference and are
+skipped, as they already are in the flat path.
+
+### Module 4: Importer emission
+
+`NetworkninjaFormService` currently reads structure from
+`forms.question_blocks`, where the store-group condition **does not
+appear** — it lives only in the Recap Definition export. This module
+defines the mapping from a per-element list of store-group names to a
+`LogicGroup`, and wires it wherever that list becomes available. Until the
+source supplies it, the mapping is exercised by fixtures only.
+
+### Module 5: HTTP passthrough
+
+The render and validate handlers accept a store context from the caller and
+pass it as `visit_context`. Absent context means no context: a rule that
+asks about a store the caller did not describe does not fire, which fails
+closed.
+
+---
+
+## 4. Test Specification
+
+### Unit Tests
+
+`CONTAINS`: list holding the value; list without it; scalar as a
+one-element collection; a string source NOT matching a substring; missing
+context; `NOT_CONTAINS` as the exact negation.
+
+`LogicGroup`: both halves satisfied; right store + wrong visit type; right
+visit type + wrong store; a second group as an alternative; groups
+overriding a flat list that would say otherwise; an empty group list
+falling back; section rules honouring groups.
+
+Resolution: a grouped field condition gets its `field_uid`; the same for a
+section rule's groups; a grouped context condition resolves without raising
+and keeps `field_uid=None`.
+
+### Test Data / Fixtures
+
+Built from the real gating of `db-form-10-69`: the `Ring of Fire` group and
+the `field_9050` visit-type driver, so the fixture asserts the shape the
+source actually produces rather than an invented one.
+
+---
+
+## 5. Acceptance Criteria
+
+- **AC1** A rule whose group requires `store_groups CONTAINS "Ring of Fire"`
+  AND `field_9050 IN [Brand Ambassador, Assisted Sales]` shows only when
+  both hold, and stays hidden when either fails or the context is absent.
+- **AC2** `CONTAINS` against the string `"Ring of Fire"` does not match
+  `"Fire"`.
+- **AC3** A store in one group, supplied as a scalar, matches.
+- **AC4** Two groups behave as alternatives.
+- **AC5** A rule without `groups` produces byte-identical behaviour to
+  before, verified by the existing suite passing unchanged.
+- **AC6** Every condition inside a group carries a resolved `field_uid`
+  after `resolve_rule_references`, and a context condition does not.
+- **AC7** Section rules, field rules and post-dependencies all honour
+  groups, because all three route through `_eval_rule`.
+- **AC8** The failing-test set is identical to `dev`'s before and after —
+  no regression is absorbed into the pre-existing count.
+
+---
+
+## 6. Codebase Contract
+
+### Verified Imports
+
+```python
+from parrot_formdesigner.core.constraints import (
+    ConditionOperator, DependencyRule, FieldCondition, LogicGroup,
+)
+from parrot_formdesigner.core.resolution import resolve_rule_references
+from parrot_formdesigner.services.rule_evaluator import RuleEvaluator
+```
+
+### Existing Signatures This Builds On
+
+```python
+# services/rule_evaluator.py — already accept the context, nothing populates it
+async def RuleEvaluator.resolve(form, answers, *, locale="en",
+                                location_vars=None, visit_context=None) -> RuleResolution
+def _eval_condition(condition, answers, form, location_vars=None, visit_context=None) -> bool
+    # source == "visit_context" -> raw = (visit_context or {}).get(condition.key)
+
+# services/validators.py — threads the context to the evaluator
+async def FormValidator.validate(form, data, *, locale="en", auth_context=None,
+                                 location_vars=None, visit_context=None) -> ValidationResult
+```
+
+### Frontend Contract to Match
+
+```ts
+// navigator-svelte src/lib/formbuilder/types/schema.ts
+export interface LogicGroup { conditions: DependencyCondition[] }
+export interface DependencyRule {
+  groups?: LogicGroup[]   // AND inside, OR between; replaces conditions/logic
+  conditions: DependencyCondition[]
+  logic?: 'and' | 'or'
+  effect?: DependencyEffect
+}
+```
+
+---
+
+## 7. Risks
+
+- **A new nesting level is a new place for references to go unresolved.**
+  Mitigated by Module 3 and AC6; the failure is silent by nature, so the
+  test is the control, not review.
+- **Nothing produces the context yet.** Until fieldsync supplies it, every
+  store-gated rule fails closed and the affected elements stay hidden. That
+  is why the importer must not emit these conditions against a live form
+  before its half lands — a correct rule with no context is stricter than
+  no rule at all.
+- **The client cannot evaluate these conditions.** Shipping server-side
+  enforcement before the client understands the same rules reproduces, in
+  mirror, the divergence between what the rep sees and what the server
+  validates.

--- a/sdd/tasks/active/TASK-2315-importer-emits-store-groups.md
+++ b/sdd/tasks/active/TASK-2315-importer-emits-store-groups.md
@@ -1,0 +1,46 @@
+# TASK-2315: the networkninja importer emits store-group conditions
+
+**Feature**: store-context-conditions (FEAT-440) · **Spec**: §3 Module 4
+**Status**: pending · **Effort**: M · **Depends on**: TASK-2312, TASK-2313
+
+## Why
+
+`NetworkninjaFormService` reads structure from `forms.question_blocks`,
+where the store-group condition **does not appear**. Measured 2026-08-21:
+all 15 blocks with `block_logic_groups` condition on question 566 (visit
+type); none reference a store group, and the 11 group names appear nowhere
+in the replicated database. The gating lives only in the Recap Definition
+export (`Recap_10.xlsx`), which is not a source this importer reads.
+
+## What
+
+Define and implement the mapping from a per-element list of store-group
+names to a rule:
+
+```python
+LogicGroup(conditions=[
+    FieldCondition(source="visit_context", key="store_groups",
+                   operator="contains", value=<group name>)
+    for <group name> in groups            # OR'd → one group each
+])
+```
+
+Groups on an element are alternatives (any one of them shows it), so each
+becomes its OWN `LogicGroup`; an existing visit-type condition joins EVERY
+group, since it must hold as well.
+
+Wire it wherever that list becomes available. Until the source supplies it,
+the mapping is exercised by fixtures only.
+
+## Hazard — do not emit against a live form before fieldsync lands
+
+Nothing populates `visit_context` yet. A correct store-gated rule with no
+context fails closed, which is STRICTER than no rule at all: the affected
+blocks would vanish for every rep. Emission must not reach a live import
+before the fieldsync half supplies the context.
+
+## Acceptance
+
+Fixture-driven: a source element carrying two store groups and a visit-type
+condition produces two `LogicGroup`s, each holding one group condition plus
+the shared visit-type condition, and evaluates correctly for both groups.

--- a/sdd/tasks/active/TASK-2316-http-context-passthrough.md
+++ b/sdd/tasks/active/TASK-2316-http-context-passthrough.md
@@ -1,0 +1,32 @@
+# TASK-2316: accept and propagate the store context through the HTTP surface
+
+**Feature**: store-context-conditions (FEAT-440) · **Spec**: §3 Module 5
+**Status**: pending · **Effort**: M · **Depends on**: TASK-2313
+
+## Why
+
+`RuleEvaluator.resolve()` and `FormValidator.validate()` both accept
+`visit_context`, and **no caller anywhere populates it** — verified across
+the package. The evaluation path is complete and unreachable.
+
+## What
+
+The render and validate handlers accept a caller-supplied store context and
+pass it through as `visit_context`. The caller is FieldSync, which knows
+which store a visit belongs to; this package only accepts what it is handed
+and never resolves a store itself.
+
+## Notes
+
+Absent context means no context: a rule that asks about a store the caller
+did not describe does not fire. Failing closed is deliberate — the
+alternative reveals store-gated questions to every store.
+
+The contract for the key (`store_groups`) and its value shape (a list of
+group names) is shared with the fieldsync half and must be agreed there
+before this lands, not invented here.
+
+## Acceptance
+
+An end-to-end request carrying a store context resolves a store-gated rule
+correctly; the same request without it leaves the rule unfired.

--- a/sdd/tasks/completed/TASK-2312-contains-operator.md
+++ b/sdd/tasks/completed/TASK-2312-contains-operator.md
@@ -1,0 +1,37 @@
+# TASK-2312: `CONTAINS` / `NOT_CONTAINS` — set membership over a condition source
+
+**Feature**: store-context-conditions (FEAT-440) · **Spec**: `sdd/specs/store-context-conditions.spec.md` §3 Module 1
+**Status**: done · **Effort**: S · **Depends on**: —
+
+## Why
+
+`ConditionOperator.IN` asks whether the answer is one of several values.
+Store-group membership is the mirror image: the context supplies the list
+(`["Best Buy", "Epson Test Store", "Ring of Fire"]`) and the rule names the
+single entry it needs. No operator expresses that direction, so a rule
+cannot ask "is this store in the Ring of Fire group".
+
+## What
+
+`core/constraints.py` — add `CONTAINS = "contains"` and
+`NOT_CONTAINS = "not_contains"` to `ConditionOperator`.
+
+`services/rule_evaluator.py` — add `_holds(raw, expected)` and route both
+operators through it from `_eval_condition`'s match.
+
+## Semantics that must hold
+
+- A `list` / `tuple` / `set` source matches when it holds the value.
+- A **scalar source counts as a one-element collection** — a store in
+  exactly one group still matches.
+- A **string source is NOT walked character by character**: `"Ring of Fire"`
+  must not contain `"Fire"`. This is the trap in using `in` directly and is
+  the whole reason for a helper instead of an inline expression.
+- A missing source is `False`, never an error. Absent context fails closed.
+
+## Acceptance
+
+Spec AC2, AC3. Six unit tests in
+`tests/unit/services/test_rule_evaluator.py::TestContainsOperator`: list
+holding it, list without it, scalar, the substring trap, missing context,
+and `NOT_CONTAINS` as the exact negation.

--- a/sdd/tasks/completed/TASK-2313-logic-groups.md
+++ b/sdd/tasks/completed/TASK-2313-logic-groups.md
@@ -1,0 +1,41 @@
+# TASK-2313: `LogicGroup` — one rule, two independent axes
+
+**Feature**: store-context-conditions (FEAT-440) · **Spec**: §3 Module 2
+**Status**: done · **Effort**: M · **Depends on**: —
+
+## Why
+
+`DependencyRule` carries a flat `conditions` list under one `logic` gate, so
+the real shape of the `Compliance Images` block — *the store is in one of
+these 8 groups AND the visit is one of these 5 types* — cannot be written:
+`and` demands all thirteen conditions hold, `or` settles for any one.
+
+The frontend has evaluated `groups` since before the server could express
+them (`navigator-svelte src/lib/formbuilder/types/schema.ts`), so this is
+aligning the server with a contract that already exists, not inventing one.
+
+## What
+
+`core/constraints.py` — `LogicGroup` (`conditions: list[FieldCondition]`,
+`extra="forbid"`) and `DependencyRule.groups: list[LogicGroup] | None`.
+Export `LogicGroup` from `core/__init__`.
+
+`services/rule_evaluator.py` — `_eval_rule(rule, …)`: when `rule.groups` is
+non-empty, OR the groups and AND within each; otherwise fall back to the
+flat `conditions`/`logic` pair. Collapse the three
+`_eval_logic(rule.conditions, rule.logic, …)` call sites into it.
+
+## Notes
+
+`_eval_rule` must be the ONE place a `DependencyRule` is evaluated, so field
+rules, section rules and post-dependencies inherit groups together rather
+than in whichever call site remembered.
+
+An empty `groups` list falls back to the flat pair — the same reading
+`_eval_logic` gives an empty condition list, not "nothing can satisfy this".
+
+## Acceptance
+
+Spec AC1, AC4, AC5, AC7. Seven tests in
+`test_rule_evaluator.py::TestLogicGroups`, including a rule whose flat list
+would say otherwise, and a section rule.

--- a/sdd/tasks/completed/TASK-2314-resolve-inside-groups.md
+++ b/sdd/tasks/completed/TASK-2314-resolve-inside-groups.md
@@ -1,0 +1,31 @@
+# TASK-2314: `resolve_rule_references` must walk conditions INSIDE groups
+
+**Feature**: store-context-conditions (FEAT-440) · **Spec**: §3 Module 3
+**Status**: done · **Effort**: S · **Depends on**: TASK-2313
+
+## Why
+
+`_eval_condition` reads a field condition's answer through `field_uid`. A
+condition left unresolved keeps `field_uid=None`, so the read returns
+`None` and the condition never matches — silently.
+
+That is exactly the defect class that made every imported networkninja rule
+inert (`mem-bcb5469d8eb0`), and adding a nesting level reintroduces it
+unless resolution follows the nesting. It is not hypothetical here: the
+first end-to-end run of TASK-2313 returned `False` for all four cases for
+precisely this reason.
+
+## What
+
+`core/resolution.py` — an inner `_resolve_rule(rule, owner)` that walks
+`rule.conditions` AND every `group.conditions`, applied to both field rules
+and section rules.
+
+Context conditions (`source="visit_context"` / `"location_variable"`) carry
+no field reference and are skipped, as they already are in the flat path.
+
+## Acceptance
+
+Spec AC6. Three tests in `tests/unit/core/test_resolution.py`: a grouped
+field condition gets its `field_uid`; the same for a section rule; a grouped
+context condition resolves without raising and keeps `field_uid=None`.

--- a/sdd/tasks/index/store-context-conditions.json
+++ b/sdd/tasks/index/store-context-conditions.json
@@ -1,0 +1,113 @@
+{
+  "feature": "store-context-conditions",
+  "feature_id": "FEAT-440",
+  "spec": "sdd/specs/store-context-conditions.spec.md",
+  "type": "feature",
+  "base_branch": "dev",
+  "created_at": "2026-08-21T22:05:00+00:00",
+  "completed_at": null,
+  "tasks": [
+    {
+      "id": "TASK-2312",
+      "feature": "store-context-conditions",
+      "feature_id": "FEAT-440",
+      "slug": "contains-operator",
+      "title": "CONTAINS / NOT_CONTAINS \u2014 set membership over a condition source",
+      "status": "done",
+      "effort": "S",
+      "priority": "high",
+      "depends_on": [],
+      "file": "sdd/tasks/completed/TASK-2312-contains-operator.md",
+      "spec": "sdd/specs/store-context-conditions.spec.md",
+      "assigned_to": null,
+      "parallel": true,
+      "parallelism_notes": "Touches constraints.py + rule_evaluator.py, both also touched by TASK-2313. Run sequentially in one worktree.",
+      "started_at": "2026-08-21T22:05:00+00:00",
+      "completed_at": "2026-08-21T22:05:00+00:00",
+      "verification": "verified"
+    },
+    {
+      "id": "TASK-2313",
+      "feature": "store-context-conditions",
+      "feature_id": "FEAT-440",
+      "slug": "logic-groups",
+      "title": "LogicGroup \u2014 one rule, two independent axes",
+      "status": "done",
+      "effort": "M",
+      "priority": "high",
+      "depends_on": [],
+      "file": "sdd/tasks/completed/TASK-2313-logic-groups.md",
+      "spec": "sdd/specs/store-context-conditions.spec.md",
+      "assigned_to": null,
+      "parallel": false,
+      "parallelism_notes": "Shares constraints.py and rule_evaluator.py with TASK-2312 and is a prerequisite of 2314.",
+      "started_at": "2026-08-21T22:05:00+00:00",
+      "completed_at": "2026-08-21T22:05:00+00:00",
+      "verification": "verified"
+    },
+    {
+      "id": "TASK-2314",
+      "feature": "store-context-conditions",
+      "feature_id": "FEAT-440",
+      "slug": "resolve-inside-groups",
+      "title": "resolve_rule_references must walk conditions INSIDE groups",
+      "status": "done",
+      "effort": "S",
+      "priority": "high",
+      "depends_on": [
+        "TASK-2313"
+      ],
+      "file": "sdd/tasks/completed/TASK-2314-resolve-inside-groups.md",
+      "spec": "sdd/specs/store-context-conditions.spec.md",
+      "assigned_to": null,
+      "parallel": false,
+      "parallelism_notes": "Needs LogicGroup to exist before it has anything to walk.",
+      "started_at": "2026-08-21T22:05:00+00:00",
+      "completed_at": "2026-08-21T22:05:00+00:00",
+      "verification": "verified"
+    },
+    {
+      "id": "TASK-2315",
+      "feature": "store-context-conditions",
+      "feature_id": "FEAT-440",
+      "slug": "importer-emits-store-groups",
+      "title": "The networkninja importer emits store-group conditions",
+      "status": "pending",
+      "effort": "M",
+      "priority": "high",
+      "depends_on": [
+        "TASK-2312",
+        "TASK-2313"
+      ],
+      "file": "sdd/tasks/active/TASK-2315-importer-emits-store-groups.md",
+      "spec": "sdd/specs/store-context-conditions.spec.md",
+      "assigned_to": null,
+      "parallel": true,
+      "parallelism_notes": "Only touches tools/services/networkninja.py; independent of TASK-2316.",
+      "started_at": null,
+      "completed_at": null,
+      "verification": null
+    },
+    {
+      "id": "TASK-2316",
+      "feature": "store-context-conditions",
+      "feature_id": "FEAT-440",
+      "slug": "http-context-passthrough",
+      "title": "Accept and propagate the store context through the HTTP surface",
+      "status": "pending",
+      "effort": "M",
+      "priority": "high",
+      "depends_on": [
+        "TASK-2313"
+      ],
+      "file": "sdd/tasks/active/TASK-2316-http-context-passthrough.md",
+      "spec": "sdd/specs/store-context-conditions.spec.md",
+      "assigned_to": null,
+      "parallel": true,
+      "parallelism_notes": "Only touches api/handlers.py; independent of TASK-2315. Its key/value contract is agreed with the fieldsync half first.",
+      "started_at": null,
+      "completed_at": null,
+      "verification": null
+    }
+  ]
+}


### PR DESCRIPTION
## Why

A NetworkNinja form gates its content on **two independent axes**, and the
engine could express only one.

The first is an answer — *"show this block when the visit type is Brand
Ambassador"* — and that works today. The second is the **store the visit is
at**, which the rep never types. On the Epson Visit Form (`db-form-10-69`),
measured against the Recap Definition v390 export:

| | count |
|---|---|
| blocks gated on a store group | 6 of 17 |
| questions gated on a store group | 91 of 295 |
| store groups in use | 11 (of 36 defined) |
| elements gated on BOTH axes | 26 |
| …needing AND-of-ORs | 23 |

The clearest case is the `Ring of Fire Photos` block. Over 883 visits in the
three months after the form's 2026-05-08 revision it appears in **exactly 20
stores and in 254 others never**, with **zero** stores in between. It is a
curated list: the closest attribute rule
(`market_trainer_name = 'Joe Montoya' AND retailer_type = 'Direct'`) gives 20
true positives and 17 false ones.

## What was missing

The condition SOURCES already existed — `FieldCondition.source` accepts
`"visit_context"`, `_eval_condition` resolves it, and `RuleEvaluator.resolve()`
takes the parameter (FEAT-301). What was missing was the vocabulary to use
them.

**No operator asks the question.** `IN` asks whether the answer is one of
several values; membership is the mirror image — the context supplies the
list and the rule names the one entry it needs.

**`DependencyRule` could not nest.** A flat list under one gate cannot say
*"the store is in one of these 8 groups AND the visit is one of these 5
types"* — the real shape of `Compliance Images`. `and` demands all thirteen
conditions; `or` settles for one.

## What this adds

`CONTAINS` / `NOT_CONTAINS`, through a `_holds` helper rather than an inline
`in`, because three behaviours are load-bearing: a scalar source counts as a
one-element collection (a store in one group still matches), a string source
is **not** walked character by character (`"Ring of Fire"` must not contain
`"Fire"`), and a missing source is `False` — absent context fails closed.

`LogicGroup` — AND inside, OR between — matching the frontend's contract
(`navigator-svelte src/lib/formbuilder/types/schema.ts`), which has evaluated
groups since before the server could express them. `_eval_rule` becomes the
ONE place a rule is evaluated, so field rules, section rules and
post-dependencies inherit it together instead of one call site at a time.
Rules without groups keep the flat pair and behave identically.

`resolve_rule_references` now walks conditions **inside** groups. This was
not foreseen — the first end-to-end test returned `False` for all four cases
because a grouped condition kept `field_uid=None`, and `_eval_condition`
reads the answer through that uid. It is the same defect class that made
every imported networkninja rule inert, reintroduced by a new nesting level.

## Verification

16 new tests. Against current `dev`: **1932 → 1948 passing**, with the
failing set identical (37 failed / 81 errors, all pre-existing).

The end-to-end case behaves as the source requires:

```
Ring of Fire + Brand Ambassador  → visible
Ring of Fire + Time Off          → hidden
another group + Brand Ambassador → hidden
no store context                 → hidden
```

## Scope — two of five tasks are deliberately not done

`TASK-2315` (importer emission) and `TASK-2316` (HTTP passthrough) ship as
`pending`, with reasons recorded in their task files.

Nothing populates `visit_context` yet, and the store-group membership is in
**no** replicated table — verified across `networkninja.stores` (39 columns
plus the full 43-key `custom_fields` inventory), `epson.stores*`, and every
`*group*` table. A correct store-gated rule with no context fails closed,
which is **stricter than no rule at all**: those blocks would vanish for
every rep. So emission must not reach a live import before the fieldsync half
lands, and `TASK-2316`'s key/value contract is agreed there rather than
invented here.

The client cannot evaluate these conditions either — `DependencyCondition` in
navigator-svelte has no `source`/`key`. Shipping server-side enforcement
before the client understands the same rules would reproduce, in mirror, the
divergence between what the rep sees and what the server validates.

Spec and task breakdown travel on the branch: `sdd/specs/store-context-conditions.spec.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)