### PR TITLE
feat(agentsflow-result-fidelity): FEAT-447 — AgentsFlow Result Fidelity

### DIFF
--- a/docs/architecture/07-agentcrew.md
+++ b/docs/architecture/07-agentcrew.md
@@ -261,6 +261,165 @@ persists the `CrewResult` through the configured `ResultStorage`
 backend (file / Redis / Postgres) — fire-and-forget, tracked through
 `self._persist_tasks` so the crew can await them on shutdown.
 
+### 7.4.1 The `FlowResult` fidelity contract
+
+`FlowResult` (`parrot/bots/flows/core/result.py`) is the **single public
+result contract returned by both executors** — every `AgentCrew` mode and
+every `AgentsFlow` run. The two classes share no base class; they share this
+dataclass and the `build_node_metadata()` helper that fills its per-node
+entries.
+
+Every field below is populated by **both** executors, with exactly one
+documented exception:
+
+| Field | Meaning | `AgentCrew` | `AgentsFlow` | Notes |
+|---|---|---|---|---|
+| `output` | The run's final answer | ✅ | ✅ | Polymorphic — see "The `output` shape rule" below. |
+| `responses` | node_id → the raw object the node returned | ✅ | ✅ | **Shape differs by executor** — see "`responses` vs `node_results`". |
+| `summary` | LLM-synthesised merge of all results | ✅ | ⛔ **stays `""`** | The one exemption. See below. |
+| `nodes` | `list[NodeExecutionInfo]` — per-node metadata | ✅ | ✅ | For AgentsFlow, ordered by **actual completion order**. |
+| `execution_log` | `list[dict]` — one entry per terminal node | ✅ | ✅ | Entry shape below. |
+| `total_time` | Wall-clock seconds for the run | ✅ | ✅ | Monotonic clock; see the resume caveat below. |
+| `status` | `FlowStatus.COMPLETED` / `PARTIAL` / `FAILED` | ✅ | ✅ | Derived from completed-vs-failed counts. |
+| `errors` | node_id → stringified exception | ✅ | ✅ | |
+| `metadata` | Run-level extras | ✅ | ✅ | **Different keys per executor** — see below. |
+
+Each entry in `nodes` is a `NodeExecutionInfo` carrying `node_id`,
+`node_name`, `provider`, `model`, `execution_time`, `tool_calls`, `status`,
+`error`, `client` and `usage`. Both executors populate the LLM-derived
+fields (`model`/`provider`/`usage`/`tool_calls`) and `client` (the concrete
+client class name behind the node's agent, e.g. `"OpenAIClient"`).
+
+`packages/ai-parrot/tests/bots/flows/test_result_fidelity.py` is the
+contract test that holds the two executors to this table: it drives the same
+agent stubs through both and asserts their populated-field sets are equal
+modulo the `summary` exemption. Its `PARITY_EXEMPT_FIELDS` constant is the
+single place that exemption is encoded, so widening it requires a deliberate
+edit.
+
+#### The `summary` exemption
+
+`AgentsFlow` leaves `summary` as `""` **by design, not as a fidelity loss.**
+`AgentCrew` mixes in `SynthesisMixin` and can therefore merge every result
+into one LLM-generated summary (§7.4). `AgentsFlow` deliberately inherits
+only `PersistenceMixin`: a DAG run has no single "roster of results" to
+summarise by default, and paying for an extra LLM call on every flow would
+be a surprising cost.
+
+Synthesis is available to flows as an **opt-in**, in two forms:
+
+* the standalone `synthesize_results` util, called on the results you choose; or
+* a `SynthesisNode` placed explicitly in the graph, which makes the
+  synthesis a visible, scheduled node with its own usage accounting.
+
+#### The `output` shape rule
+
+`output` is polymorphic, and its shape depends on how many **leaf** nodes the
+run actually executed. A leaf is a node with no outgoing edge to another node
+in the graph; in explicit-edge mode leaf detection is *skip-aware*, so when
+every static leaf was skipped (an error-handler fan-in on the happy path, say)
+it falls back to the terminal nodes of the path actually taken.
+
+**One executed leaf → the leaf's scalar output.** The common case: any linear
+or converging graph, and every `AgentCrew` run.
+
+```python
+# a → b, single leaf `b`
+result = await flow.run_flow()
+result.output                 # "the answer from b"   (a scalar)
+result.metadata["leaves"]     # ["b"]
+```
+
+**Two or more executed leaves (a fan-out) → `dict[node_id, Any]`.**
+
+```python
+# a → {b, c}, two leaves
+result = await flow.run_flow()
+result.output                 # {"b": "answer from b", "c": "answer from c"}
+result.metadata["leaves"]     # ["b", "c"]
+```
+
+**No executed leaf** (an empty or fully-failed run) → `None`.
+
+`content` and `final_result` are aliases for `output` and inherit this rule
+verbatim. There is deliberately **no** plural `outputs` field: code that must
+not branch on shape should read `node_results`, which is always a
+`dict[node_id, scalar]` covering every node rather than just the leaves.
+
+#### `responses` vs `node_results`
+
+These two are easy to confuse, and only one of them is shape-stable:
+
+* **`responses`** holds whatever the node returned, and that differs by
+  executor. `AgentCrew` stores the `AgentResponse` object; `AgentsFlow` stores
+  the envelope dict `AgentNode.execute()` returns —
+  `{"response", "output", "execution_time", "prompt"}`. Reach into it only if
+  you specifically want the raw object.
+* **`node_results`** (and its `agent_results` alias) is the shape-stable read:
+  it unwraps both forms and always yields `dict[node_id, scalar]`. **No value
+  is ever an envelope dict.** Prefer it in consumer code.
+
+#### AgentsFlow `metadata` keys
+
+```python
+{
+    "mode": str,            # "explicit" | "definition" | "legacy"
+    "node_count": int,      # nodes materialized for the run
+    "completed_count": int,
+    "failed_count": int,
+    "skipped": list[str],   # skipped node_ids, sorted
+    "leaves": list[str],    # node_ids that produced `output`
+}
+```
+
+`mode` records **how the graph was declared** — `"explicit"` for
+`add_node()`/`add_edge()`, `"definition"` for a `FlowDefinition`, `"legacy"`
+for programmatic nodes carrying their own `successors`. Note this is a
+*different axis* from `AgentCrew`'s `metadata["mode"]`, which records the
+execution strategy (`"sequential"` / `"parallel"` / `"flow"` / `"loop"`). The
+two vocabularies are not comparable — do not switch on `metadata["mode"]`
+without knowing which executor produced the result.
+
+Skipped nodes appear **only** here. They get no `NodeExecutionInfo` entry,
+because `NodeExecutionInfo.status` is a closed literal
+(`completed`/`failed`/`pending`/`running`) with no `"skipped"` member.
+
+#### `execution_log` entry shape
+
+```python
+{
+    "node_id": str,
+    "node_name": str,
+    "status": str,            # "completed" | "failed"
+    "execution_time": float,
+    "error": str | None,
+}
+```
+
+One entry per completed-or-failed node, in the same order as `nodes`.
+
+#### Ordering and timing caveats
+
+* **`nodes` ordering is deterministic.** For AgentsFlow it follows the real
+  completion order (`FlowContext.completion_order`), with failed nodes — which
+  are never appended to that list — following in sorted order. It no longer
+  varies with string hashing between processes, so `nodes` can be rendered as
+  a run timeline.
+* **`execution_time` is the scheduler's measurement**, including spawn/queue
+  overhead — not the node's own inner timing (the envelope's
+  `execution_time`, which measures just the agent call). Both exist and they
+  legitimately differ.
+* **A retried node reports its last attempt**, since the scheduler overwrites
+  the node's duration on each completion event.
+* **On a resumed run, `total_time` covers the resumed segment only.** The run
+  clock is read in the current process, so it cannot include wall-clock time
+  from the original run that was checkpointed.
+
+After a run, the `FlowContext` carries the same fidelity as the `FlowResult`:
+`ctx.responses` holds the raw responses and `ctx.node_metadata` the per-node
+`NodeExecutionInfo` (including failed nodes). This is what makes a
+checkpointed or resumed context as informative as the result object itself.
+
 ## 7.5 When to pick which mode
 
 | Need                                                | Mode          | Why                                                                  |

--- a/docs/architecture/07-agentcrew.md
+++ b/docs/architecture/07-agentcrew.md
@@ -339,7 +339,14 @@ result.output                 # {"b": "answer from b", "c": "answer from c"}
 result.metadata["leaves"]     # ["b", "c"]
 ```
 
-**No executed leaf** (an empty or fully-failed run) → `None`.
+**No executed leaf** — an empty graph, or every leaf failed or was skipped →
+an **empty dict** `{}`. That case falls into the fan-out branch with nothing
+to collect. This is long-standing behaviour, documented rather than changed:
+normalising it to `None` would break an existing field's contract. So do not
+test `if result.output:` to decide whether the run produced anything — check
+`result.status` or `result.metadata["leaves"]` (which is `[]` in exactly this
+case), otherwise you cannot distinguish "produced nothing" from "produced a
+falsy value".
 
 `content` and `final_result` are aliases for `output` and inherit this rule
 verbatim. There is deliberately **no** plural `outputs` field: code that must

--- a/packages/ai-parrot/src/parrot/bots/flows/core/result.py
+++ b/packages/ai-parrot/src/parrot/bots/flows/core/result.py
@@ -616,6 +616,48 @@ def _normalise_status(
     return mapping.get(status.lower(), "pending")
 
 
+#: Maximum number of envelope layers ``_unwrap_response`` will peel. Real
+#: envelopes are one level deep (``AgentNode.execute()``); the cap only exists
+#: so a self-referential or maliciously nested mapping cannot recurse forever.
+_MAX_UNWRAP_DEPTH: int = 5
+
+
+def _unwrap_response(response: Optional[Any], _depth: int = 0) -> Optional[Any]:
+    """Normalise a node/agent return value to its metadata-bearing object.
+
+    ``AgentNode.execute()`` returns an *envelope* dict
+    (``{"response", "output", "execution_time", "prompt"}`` --
+    ``core/node.py``) rather than the ``AgentResponse`` itself, while
+    ``AgentCrew`` passes the ``AgentResponse`` directly. This helper collapses
+    the former to the latter and leaves the latter untouched, so
+    :func:`build_node_metadata` sees a single shape from both executors and
+    the two cannot drift apart again (FEAT-447 G5).
+
+    A mapping is treated as an envelope **only** when it carries a
+    ``"response"`` key; a plain ``{"output": ...}`` dict is returned unchanged.
+    The function is intentionally total: it never raises, and on anything
+    unexpected it returns its input unchanged so ``build_node_metadata``
+    degrades exactly as it did before FEAT-447.
+
+    Args:
+        response: Any node/agent return value (envelope dict,
+            ``AgentResponse``, ``AIMessage``, ``str``, ``None``, or an
+            arbitrary user object).
+        _depth: Internal recursion guard; callers should not pass it.
+
+    Returns:
+        The metadata-bearing object, or ``response`` unchanged.
+    """
+    if _depth >= _MAX_UNWRAP_DEPTH:
+        return response
+    try:
+        if isinstance(response, dict) and "response" in response:
+            return _unwrap_response(response["response"], _depth + 1)
+    except Exception:  # noqa: BLE001 — defensive: arbitrary user objects
+        return response
+    return response
+
+
 def build_node_metadata(
     node_id: str,
     agent: Optional[Any],
@@ -630,11 +672,17 @@ def build_node_metadata(
     Mirrors ``build_agent_metadata()`` from ``parrot.models.crew`` but
     returns a ``NodeExecutionInfo`` instead of ``AgentExecutionInfo``.
 
+    ``response`` is first normalised through :func:`_unwrap_response`, so both
+    the bare ``AgentResponse`` an ``AgentCrew`` passes and the envelope dict an
+    ``AgentNode`` returns yield the same metadata (FEAT-447 G1/G5).
+
     Args:
         node_id: Unique identifier for this node instance.
-        agent: The agent object (used to extract name/provider/model).
-        response: Raw response object from the agent.
-        output: Extracted output value.
+        agent: The agent object (used to extract name/provider/model/client).
+        response: Raw response object from the agent, or the envelope dict
+            returned by ``AgentNode.execute()``.
+        output: Extracted output value. Passed through untouched -- it is
+            *not* unwrapped, so ``NodeExecutionInfo`` semantics are unchanged.
         execution_time: Wall-clock time for the execution.
         status: Status string (normalised to allowed literals).
         error: Error message if execution failed.
@@ -642,6 +690,11 @@ def build_node_metadata(
     Returns:
         Populated ``NodeExecutionInfo`` instance.
     """
+    # FEAT-447: collapse an AgentNode envelope to its AgentResponse *before*
+    # the isinstance ladder below; crew's bare AgentResponse passes through
+    # unchanged, so crew behaviour is bit-identical.
+    response = _unwrap_response(response)
+
     model: Optional[str] = None
     provider: Optional[str] = None
     usage: Optional[Dict[str, Any]] = None
@@ -688,10 +741,17 @@ def build_node_metadata(
             provider = getattr(response, "provider", None)
 
     # Fall back to agent attributes
+    client: Optional[str] = None
     if agent is not None:
         provider = provider or getattr(agent, "use_llm", None) or getattr(agent, "provider", None)
         if client_obj := getattr(agent, "llm", None) or getattr(agent, "_llm", None):
             model = model or getattr(client_obj, "model", None)
+            # FEAT-447: revive the declared-but-never-assigned `client` field.
+            # `agent.llm` is normally an AbstractClient instance; before
+            # `configure()` it can still hold the raw config (a str/dict), and
+            # a bare type name there would be noise rather than information.
+            if not isinstance(client_obj, (str, bytes, dict, list, tuple)):
+                client = type(client_obj).__name__
 
     node_name = getattr(agent, "name", node_id) if agent is not None else node_id
 
@@ -704,5 +764,6 @@ def build_node_metadata(
         tool_calls=tool_calls,
         status=_normalise_status(status),
         error=error,
+        client=client,
         usage=usage,
     )

--- a/packages/ai-parrot/src/parrot/bots/flows/core/result.py
+++ b/packages/ai-parrot/src/parrot/bots/flows/core/result.py
@@ -377,7 +377,13 @@ class FlowResult:
       case: a linear or converging graph, and every ``AgentCrew`` run.
     * **A fan-out (two or more executed leaves)** -> a
       ``dict[node_id, Any]`` mapping each leaf's node_id to its scalar output.
-    * **No executed leaf** (empty or fully-failed run) -> ``None``.
+    * **No executed leaf** (an empty graph, or every leaf failed/skipped) ->
+      an **empty dict** ``{}``, since that case takes the fan-out branch with
+      nothing to collect. Long-standing behaviour, documented here rather
+      than changed: normalising it to ``None`` would be a breaking change to
+      an existing field's contract. Check ``status`` /
+      ``metadata["leaves"]`` — not the truthiness of ``output`` — to tell
+      "produced nothing" from "produced a falsy value".
 
     Consumers that must not branch on shape should read
     :attr:`node_results` instead, which is *always* a

--- a/packages/ai-parrot/src/parrot/bots/flows/core/result.py
+++ b/packages/ai-parrot/src/parrot/bots/flows/core/result.py
@@ -13,6 +13,7 @@ in ``parrot.models.crew`` (wired up in TASK-920).
 
 ``AgentResult`` stays in ``parrot.models.crew`` for any remaining consumers.
 """
+
 from __future__ import annotations
 
 import uuid
@@ -31,6 +32,7 @@ if TYPE_CHECKING:
 # ResponseType alias — mirrors the one in parrot.models.crew
 try:
     from parrot.models.responses import AIMessage, AgentResponse  # noqa: F401
+
     ResponseType = Any  # Union[AIMessage, AgentResponse, Any] but avoids heavy import
 except ImportError:
     ResponseType = Any
@@ -204,12 +206,14 @@ class NodeResult:
         if isinstance(self.result, dict):
             try:
                 from datamodel.parsers.json import json_encoder  # type: ignore[import]
+
                 content = (
                     f"\nKeys: {', '.join(str(k) for k in self.result.keys())}\n"
                     f"Content:\n{json_encoder(self.result)}\n            "
                 )
             except ImportError:
                 import json
+
                 content = (
                     f"\nKeys: {', '.join(str(k) for k in self.result.keys())}\n"
                     f"Content:\n{json.dumps(self.result, default=str)}\n            "
@@ -219,9 +223,11 @@ class NodeResult:
         if isinstance(self.result, list):
             try:
                 from datamodel.parsers.json import json_encoder  # type: ignore[import]
+
                 sample = json_encoder(self.result[:10]) if self.result else "[]"
             except ImportError:
                 import json
+
                 sample = json.dumps(self.result[:10], default=str) if self.result else "[]"
             item_types = set(type(item).__name__ for item in self.result[:100])
             content = (
@@ -238,6 +244,7 @@ class NodeResult:
 # ---------------------------------------------------------------------------
 # Helpers (copied/adapted from parrot.models.crew)
 # ---------------------------------------------------------------------------
+
 
 def determine_run_status(
     success_count: int,
@@ -437,11 +444,7 @@ class FlowResult:
         return str(self.output) if self.output is not None else ""
 
     def __repr__(self) -> str:
-        return (
-            f"FlowResult(status={self.status!r}, "
-            f"nodes={len(self.nodes)}, "
-            f"time={self.total_time:.2f}s)"
-        )
+        return f"FlowResult(status={self.status!r}, " f"nodes={len(self.nodes)}, " f"time={self.total_time:.2f}s)"
 
     # ── Primary computed properties ───────────────────────────────────────
 
@@ -569,14 +572,8 @@ class FlowResult:
             "content": self.content,
             "node_results": self.node_results,
             "agent_results": self.agent_results,  # backward compat
-            "nodes": [
-                n.to_dict() if isinstance(n, NodeExecutionInfo) else n
-                for n in self.nodes
-            ],
-            "agents": [  # backward compat
-                n.to_dict() if isinstance(n, NodeExecutionInfo) else n
-                for n in self.nodes
-            ],
+            "nodes": [n.to_dict() if isinstance(n, NodeExecutionInfo) else n for n in self.nodes],
+            "agents": [n.to_dict() if isinstance(n, NodeExecutionInfo) else n for n in self.nodes],  # backward compat
             "errors": self.errors,
             "execution_log": self.execution_log,
             "total_time": self.total_time,
@@ -600,10 +597,7 @@ class FlowResult:
         Returns:
             Dictionary containing all essential fields.
         """
-        serialised_nodes = [
-            n.to_dict() if isinstance(n, NodeExecutionInfo) else n
-            for n in self.nodes
-        ]
+        serialised_nodes = [n.to_dict() if isinstance(n, NodeExecutionInfo) else n for n in self.nodes]
 
         serialised_responses: Dict[str, Any] = {}
         for node_id, resp in self.responses.items():
@@ -761,16 +755,10 @@ def build_node_metadata(
         from parrot.models.responses import AIMessage, AgentResponse
 
         if isinstance(response, AgentResponse):
-            ai_message = (
-                response.response if isinstance(response.response, AIMessage) else None
-            )
+            ai_message = response.response if isinstance(response.response, AIMessage) else None
             model = getattr(response, "model", None) or getattr(ai_message, "model", None)
             provider = getattr(response, "provider", None) or getattr(ai_message, "provider", None)
-            raw_tc = (
-                getattr(response, "tool_calls", None)
-                or getattr(ai_message, "tool_calls", None)
-                or []
-            )
+            raw_tc = getattr(response, "tool_calls", None) or getattr(ai_message, "tool_calls", None) or []
             tool_calls = _serialise_tool_calls(raw_tc)
             if output is None:
                 output = response.output or getattr(ai_message, "output", None)

--- a/packages/ai-parrot/src/parrot/bots/flows/core/result.py
+++ b/packages/ai-parrot/src/parrot/bots/flows/core/result.py
@@ -366,7 +366,26 @@ class FlowResult:
     """
 
     output: Any
-    """Final output from the workflow."""
+    """Final output from the workflow.
+
+    **Shape contract (normative, FEAT-447 G4).** ``output`` is deliberately
+    polymorphic, and its shape is decided by how many *leaf* nodes the run
+    actually executed (see ``AgentsFlow._aggregate_result``):
+
+    * **Exactly one executed leaf** -> the leaf's own **scalar** output (the
+      node's answer, already unwrapped from its envelope). This is the common
+      case: a linear or converging graph, and every ``AgentCrew`` run.
+    * **A fan-out (two or more executed leaves)** -> a
+      ``dict[node_id, Any]`` mapping each leaf's node_id to its scalar output.
+    * **No executed leaf** (empty or fully-failed run) -> ``None``.
+
+    Consumers that must not branch on shape should read
+    :attr:`node_results` instead, which is *always* a
+    ``dict[node_id, scalar]`` for every node, not just the leaves.
+
+    This polymorphism is intentional and pinned by tests; it is not a bug to
+    "fix", and there is no plural ``outputs`` field.
+    """
 
     responses: Dict[str, Any] = field(default_factory=dict)
     """Mapping of node IDs → raw response objects."""
@@ -422,12 +441,22 @@ class FlowResult:
 
     @property
     def content(self) -> Optional[Any]:
-        """Alias for ``output`` (OutputFormatter compatibility)."""
+        """Alias for ``output`` (OutputFormatter compatibility).
+
+        Inherits :attr:`output`'s shape contract verbatim: a **scalar** when
+        the run had a single executed leaf, a ``dict[node_id, Any]`` on a
+        fan-out, ``None`` when nothing produced a result.
+        """
         return self.output
 
     @property
     def final_result(self) -> Optional[Any]:
-        """Compatibility alias for previous API."""
+        """Compatibility alias for previous API.
+
+        Inherits :attr:`output`'s shape contract verbatim: a **scalar** when
+        the run had a single executed leaf, a ``dict[node_id, Any]`` on a
+        fan-out, ``None`` when nothing produced a result.
+        """
         return self.output
 
     @property
@@ -437,11 +466,32 @@ class FlowResult:
 
     @property
     def node_results(self) -> Dict[str, Any]:
-        """Map node IDs to their output values extracted from responses."""
+        """Map node IDs to their scalar output values.
+
+        Handles both response shapes the two executors store in
+        ``responses``, so callers get a scalar answer either way (FEAT-447 G4):
+
+        * ``AgentCrew`` stores ``AgentResponse`` objects -> read ``.output``.
+        * ``AgentsFlow`` stores the ``AgentNode.execute()`` envelope dict
+          (``{"response", "output", "execution_time", "prompt"}``) -> read
+          the ``"output"`` key. Before FEAT-447 these fell through to the
+          ``else`` branch and callers received the whole envelope.
+
+        Anything else is returned as-is, and ``None`` stays ``None``. This is
+        a read-only projection: ``self.responses`` is never mutated.
+
+        Returns:
+            Mapping of node_id -> scalar output. Never an envelope dict.
+        """
         result: Dict[str, Any] = {}
         for node_id, resp in self.responses.items():
             if resp is None:
                 result[node_id] = None
+            # The envelope check must be explicit: a dict has no `.output`
+            # attribute, so it would otherwise fall through to `else` and
+            # leak the whole mapping to the caller.
+            elif isinstance(resp, dict) and "output" in resp:
+                result[node_id] = resp["output"]
             elif hasattr(resp, "output"):
                 result[node_id] = resp.output
             else:

--- a/packages/ai-parrot/src/parrot/bots/flows/flow/flow.py
+++ b/packages/ai-parrot/src/parrot/bots/flows/flow/flow.py
@@ -1981,7 +1981,23 @@ class AgentsFlow(PersistenceMixin):
                 errors[nid] = event.error
                 failed.add(nid)
                 if isinstance(event.error, Exception):
-                    ctx.mark_failed(nid, event.error)
+                    # FEAT-447: `metadata=` (an existing parameter) fills
+                    # ctx.node_metadata, so a context inspected after the run
+                    # -- including a checkpointed/resumed one -- carries the
+                    # same fidelity as the FlowResult.
+                    ctx.mark_failed(
+                        nid,
+                        event.error,
+                        metadata=build_node_metadata(
+                            node_id=nid,
+                            agent=getattr(nodes[nid], "agent", None),
+                            response=None,
+                            output=None,
+                            execution_time=durations[nid],
+                            status="failed",
+                            error=str(event.error),
+                        ),
+                    )
                 self.logger.warning("Node %r failed: %s", nid, event.error)
                 self._notify_node_event(
                     "node_failed", nid,
@@ -1996,7 +2012,28 @@ class AgentsFlow(PersistenceMixin):
             else:
                 results[nid] = event.result
                 completed.add(nid)
-                ctx.mark_completed(nid, result=event.result)
+                # FEAT-447: `response=` carries the raw envelope verbatim (NOT
+                # pre-unwrapped -- consumers read scalars through
+                # FlowResult.node_results / ctx-level readers), and `metadata=`
+                # fills ctx.node_metadata. Both parameters already existed;
+                # AgentsFlow simply never passed them. The NodeExecutionInfo is
+                # deliberately built here as well as in _aggregate_result --
+                # the two paths stay independent rather than one consuming the
+                # other's state.
+                ctx.mark_completed(
+                    nid,
+                    result=event.result,
+                    response=event.result,
+                    metadata=build_node_metadata(
+                        node_id=nid,
+                        agent=getattr(nodes[nid], "agent", None),
+                        response=event.result,
+                        output=event.result,
+                        execution_time=durations[nid],
+                        status="completed",
+                        error=None,
+                    ),
+                )
                 self.logger.info("Node %r completed", nid)
                 self._notify_node_event(
                     "node_completed", nid,
@@ -2042,6 +2079,12 @@ class AgentsFlow(PersistenceMixin):
             nodes, results, errors, completed, failed,
             edges=edges if explicit_mode else None,
             durations=durations,
+            # FEAT-447: hand the aggregator what the scheduler already
+            # measured -- true completion order, the run clock, and the
+            # skipped set -- instead of discarding it.
+            ctx=ctx,
+            run_started_at=run_started_at,
+            skipped=skipped,
         )
         self._notify_node_event(
             "flow_completed", "",

--- a/packages/ai-parrot/src/parrot/bots/flows/flow/flow.py
+++ b/packages/ai-parrot/src/parrot/bots/flows/flow/flow.py
@@ -976,7 +976,11 @@ class AgentsFlow(PersistenceMixin):
           from its ``AgentNode.execute()`` envelope);
         * a fan-out of two or more executed leaves -> a ``dict[node_id, Any]``
           of each leaf's scalar output;
-        * no executed leaf -> ``None``.
+        * no executed leaf (empty graph, or every leaf failed/skipped) -> an
+          empty dict ``{}`` -- that case falls into the fan-out branch with
+          nothing to collect. Pre-existing behaviour, left unchanged here
+          because normalising it to ``None`` would break an existing field's
+          contract; use ``status`` / ``metadata["leaves"]`` to detect it.
 
         The node_ids that produced ``output`` are echoed in
         ``metadata["leaves"]``. This polymorphism is deliberate and pinned by

--- a/packages/ai-parrot/src/parrot/bots/flows/flow/flow.py
+++ b/packages/ai-parrot/src/parrot/bots/flows/flow/flow.py
@@ -961,8 +961,36 @@ class AgentsFlow(PersistenceMixin):
         failed: set[str],
         edges: Optional[list[Any]] = None,
         durations: Optional[dict[str, float]] = None,
+        *,
+        ctx: Optional[FlowContext] = None,
+        run_started_at: Optional[float] = None,
+        skipped: Optional[set[str]] = None,
     ) -> FlowResult:
         """Build a FlowResult from scheduler state after the main loop exits.
+
+        **Output shape contract (normative, FEAT-447 G4).** ``FlowResult.output``
+        is polymorphic and its shape is decided here, by how many *leaf* nodes
+        the run actually executed:
+
+        * exactly one executed leaf -> that leaf's **scalar** output (unwrapped
+          from its ``AgentNode.execute()`` envelope);
+        * a fan-out of two or more executed leaves -> a ``dict[node_id, Any]``
+          of each leaf's scalar output;
+        * no executed leaf -> ``None``.
+
+        The node_ids that produced ``output`` are echoed in
+        ``metadata["leaves"]``. This polymorphism is deliberate and pinned by
+        tests -- see :attr:`FlowResult.output`.
+
+        **Timing notes.** ``NodeExecutionInfo.execution_time`` comes from the
+        scheduler's ``durations`` (which include spawn/queue overhead), *not*
+        from the node's own ``envelope["execution_time"]``; the two coexist and
+        measure different spans. Because ``durations[nid]`` is rewritten on
+        every completion event, a retried node reports its **last** attempt.
+        ``total_time`` is measured against ``run_started_at`` on the event
+        loop's monotonic clock -- the same clock the scheduler uses -- so on a
+        **resumed** run it is the wall clock of the resumed *segment*, not of
+        the original run.
 
         Args:
             nodes: All materialized nodes for this run.
@@ -975,12 +1003,47 @@ class AgentsFlow(PersistenceMixin):
                 or ``node.successors`` respectively).
             durations: Optional node_id → wall-clock seconds of the last
                 execution attempt, used for ``NodeExecutionInfo.execution_time``.
+            ctx: Optional run context. When supplied, ``nodes`` are ordered by
+                its ``completion_order`` (the true execution order) instead of
+                by set-iteration order. Failed nodes are absent from
+                ``completion_order`` -- ``mark_failed`` does not append -- so
+                they are appended afterwards in sorted order.
+            run_started_at: Optional ``loop.time()`` reading from the start of
+                the run, used for ``total_time``. ``total_time`` stays ``0.0``
+                when it is omitted.
+            skipped: Optional set of skipped node_ids. Reported through
+                ``metadata["skipped"]`` only: ``NodeExecutionInfo.status`` is a
+                closed literal with no ``"skipped"`` member, so skipped nodes
+                deliberately get no ``NodeExecutionInfo`` entry.
 
         Returns:
-            Populated FlowResult.
+            Populated FlowResult. ``summary`` is intentionally left empty --
+            ``AgentsFlow`` does not inherit ``SynthesisMixin``; synthesis stays
+            opt-in through ``synthesize_results``.
         """
+        # Deterministic node ordering (FEAT-447 G3). `completed | failed` is a
+        # set union, so iterating it directly discards execution order and
+        # varies with string hashing across processes. `ctx.completion_order`
+        # carries the true order; `mark_failed` does NOT append to it, so the
+        # residue (failures, and anything seeded by a resume) is appended in
+        # sorted order for stability. Without a ctx we still sort rather than
+        # iterate the union -- it costs nothing and removes the hash-order
+        # nondeterminism unconditionally.
+        terminal: set[str] = completed | failed
+        ordered: list[str] = []
+        if ctx is not None:
+            seen: set[str] = set()
+            for nid in ctx.completion_order:
+                if nid in terminal and nid not in seen:
+                    ordered.append(nid)
+                    seen.add(nid)
+            ordered.extend(sorted(terminal - seen))
+        else:
+            ordered = sorted(terminal)
+
         node_infos = []
-        for nid in completed | failed:
+        execution_log: list[dict[str, Any]] = []
+        for nid in ordered:
             node = nodes[nid]
             resp = results.get(nid)
             err = errors.get(nid)
@@ -995,6 +1058,15 @@ class AgentsFlow(PersistenceMixin):
                 error=str(err) if err else None,
             )
             node_infos.append(info)
+            execution_log.append(
+                {
+                    "node_id": info.node_id,
+                    "node_name": info.node_name,
+                    "status": info.status,
+                    "execution_time": info.execution_time,
+                    "error": info.error,
+                }
+            )
 
         # Identify leaf nodes: nodes with no outgoing edges to known nodes.
         # Explicit/definition modes use their edge lists; legacy programmatic
@@ -1025,6 +1097,8 @@ class AgentsFlow(PersistenceMixin):
             # Leaf = node with empty successors set.
             leaves = [nid for nid, node in nodes.items() if not node.successors]
 
+        # node_ids that actually contributed to `output` (echoed in metadata).
+        output_leaves: list[str] = []
         if len(leaves) == 1 and leaves[0] in results:
             leaf_result = results[leaves[0]]
             # AgentNode.execute() returns a dict with an "output" key holding
@@ -1034,6 +1108,7 @@ class AgentsFlow(PersistenceMixin):
                 output: Any = leaf_result["output"]
             else:
                 output = leaf_result
+            output_leaves = [leaves[0]]
         else:
             # Multi-leaf fan-out: collect each leaf's scalar output.
             output_map: dict[str, Any] = {}
@@ -1042,11 +1117,51 @@ class AgentsFlow(PersistenceMixin):
                     lr = results[nid]
                     output_map[nid] = lr["output"] if isinstance(lr, dict) and "output" in lr else lr
             output = output_map
+            output_leaves = list(output_map)
 
         from ..core.types import FlowStatus
 
         status_str = determine_run_status(len(completed), len(failed))
         flow_status = FlowStatus(status_str)
+
+        # Run wall clock (FEAT-447 G2). The scheduler measures `run_started_at`
+        # on the event loop's monotonic clock, so it must be read back from the
+        # same clock -- mixing in time.time()/time.monotonic() would compare
+        # unrelated epochs.
+        total_time = 0.0
+        if run_started_at is not None:
+            try:
+                total_time = max(
+                    0.0, asyncio.get_running_loop().time() - run_started_at
+                )
+            except RuntimeError:
+                # Called outside a running loop (only reachable from a direct
+                # synchronous call): the scheduler's epoch is unavailable, so
+                # leave total_time at its default rather than invent a figure.
+                self.logger.debug(
+                    "No running loop while aggregating %r; total_time left at 0.0",
+                    self.name,
+                )
+
+        # `mode` uses the flow's own internal vocabulary. Note this is a
+        # DIFFERENT axis from AgentCrew's metadata['mode']
+        # ('sequential'/'parallel'/'loop'), which describes an execution
+        # strategy rather than how the graph was declared.
+        if edges is not None:
+            mode = "explicit"
+        elif self._definition is not None:
+            mode = "definition"
+        else:
+            mode = "legacy"
+
+        metadata: dict[str, Any] = {
+            "mode": mode,
+            "node_count": len(nodes),
+            "completed_count": len(completed),
+            "failed_count": len(failed),
+            "skipped": sorted(skipped) if skipped else [],
+            "leaves": output_leaves,
+        }
 
         return FlowResult(
             output=output,
@@ -1054,6 +1169,9 @@ class AgentsFlow(PersistenceMixin):
             responses=dict(results),
             errors={k: str(v) for k, v in errors.items()},
             status=flow_status,
+            execution_log=execution_log,
+            total_time=total_time,
+            metadata=metadata,
         )
 
     async def run_flow(

--- a/packages/ai-parrot/src/parrot/bots/flows/flow/flow.py
+++ b/packages/ai-parrot/src/parrot/bots/flows/flow/flow.py
@@ -14,6 +14,7 @@ Key components:
 
 See sdd/specs/agentsflow-refactor-spec3.spec.md for the full design.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -73,7 +74,6 @@ from .node_configs import (
 
 # AgentRegistry (type annotation only)
 from parrot.registry.registry import AgentRegistry  # type: ignore[import-untyped]
-
 
 logger = logging.getLogger(__name__)
 
@@ -185,24 +185,16 @@ def register_node(
         TypeError: If the decorated class is not a ``Node`` subclass, or
             ``config_model`` is not a ``BaseModel`` subclass.
     """
-    if config_model is not None and not (
-        isinstance(config_model, type) and issubclass(config_model, BaseModel)
-    ):
+    if config_model is not None and not (isinstance(config_model, type) and issubclass(config_model, BaseModel)):
         raise TypeError(
-            f"register_node({name!r}, config_model=...) expects a pydantic "
-            f"BaseModel subclass, got {config_model!r}"
+            f"register_node({name!r}, config_model=...) expects a pydantic " f"BaseModel subclass, got {config_model!r}"
         )
 
     def decorator(cls: Type[Node]) -> Type[Node]:
         if not (isinstance(cls, type) and issubclass(cls, Node)):
-            raise TypeError(
-                f"@register_node({name!r}) target must be a Node subclass, got {cls!r}"
-            )
+            raise TypeError(f"@register_node({name!r}) target must be a Node subclass, got {cls!r}")
         if name in NODE_REGISTRY:
-            raise ValueError(
-                f"Node type {name!r} already registered to "
-                f"{NODE_REGISTRY[name].__name__}"
-            )
+            raise ValueError(f"Node type {name!r} already registered to " f"{NODE_REGISTRY[name].__name__}")
         NODE_REGISTRY[name] = cls
         if config_model is not None:
             NODE_CONFIG_MODELS[name] = config_model
@@ -294,9 +286,7 @@ class AgentsFlow(PersistenceMixin):
         # factory closes over live dependencies (dispatcher, toolkits, …) and
         # is called as ``factory(node_def, deps, succs) -> Node`` afresh per
         # ``run_flow()`` so concurrent runs do not share node state.
-        self._node_factories: dict[
-            str, Callable[["NodeDefinition", set[str], set[str]], Node]
-        ] = {}
+        self._node_factories: dict[str, Callable[["NodeDefinition", set[str], set[str]], Node]] = {}
         # node_id → single resolved agent (agent nodes), and node_id →
         # {agent_name: instance} for multi-agent types (decision). Both are
         # populated by ``from_definition``; empty in programmatic mode.
@@ -304,9 +294,7 @@ class AgentsFlow(PersistenceMixin):
         self._resolved_agent_groups: dict[str, dict[str, Any]] = {}
         self._nodes: dict[str, Node] = {}
         self._edges: list[FlowEdge] = []
-        self._node_event_listeners: list[
-            Callable[[str, str, Dict[str, Any]], Any]
-        ] = []
+        self._node_event_listeners: list[Callable[[str, str, Dict[str, Any]], Any]] = []
         if on_node_event is not None:
             if callable(on_node_event):
                 self._node_event_listeners.append(on_node_event)
@@ -317,14 +305,8 @@ class AgentsFlow(PersistenceMixin):
         # ── Checkpointing (FEAT-399) ────────────────────────────────────
         self.flow_id: str = flow_id or str(uuid.uuid4())
         self._checkpoint_enabled = checkpoint
-        self._checkpoint_retention = (
-            FLOW_CHECKPOINT_REDIS_TTL
-            if checkpoint_retention is None
-            else checkpoint_retention
-        )
-        self._checkpoint_history = (
-            FLOW_CHECKPOINT_HISTORY if checkpoint_history is None else checkpoint_history
-        )
+        self._checkpoint_retention = FLOW_CHECKPOINT_REDIS_TTL if checkpoint_retention is None else checkpoint_retention
+        self._checkpoint_history = FLOW_CHECKPOINT_HISTORY if checkpoint_history is None else checkpoint_history
         self._checkpoint_include_responses = checkpoint_include_responses
         self._checkpoint_durable = durable
         self._checkpoint_store_arg = checkpoint_store
@@ -357,9 +339,7 @@ class AgentsFlow(PersistenceMixin):
             ValueError: If a node with the same ``node_id`` is already present.
         """
         if node.node_id in self._nodes:
-            raise ValueError(
-                f"Node {node.node_id!r} already added to flow {self.name!r}"
-            )
+            raise ValueError(f"Node {node.node_id!r} already added to flow {self.name!r}")
         self._nodes[node.node_id] = node
         self.logger.debug("Added node %r to flow %r", node.node_id, self.name)
 
@@ -401,27 +381,17 @@ class AgentsFlow(PersistenceMixin):
         if predicate is not None and condition == "always":
             condition = "on_condition"
         if condition not in EDGE_CONDITIONS:
-            raise ValueError(
-                f"Unknown edge condition {condition!r}. "
-                f"Expected one of {EDGE_CONDITIONS}"
-            )
+            raise ValueError(f"Unknown edge condition {condition!r}. " f"Expected one of {EDGE_CONDITIONS}")
         if condition == "on_condition" and predicate is None:
-            raise ValueError(
-                "Edge condition 'on_condition' requires a predicate "
-                "(CEL string or callable)"
-            )
+            raise ValueError("Edge condition 'on_condition' requires a predicate " "(CEL string or callable)")
         edge = FlowEdge(from_=from_, to=to, condition=condition, predicate=predicate)
         self._edges.append(edge)
-        self.logger.debug(
-            "Added edge %r → %r (%s) to flow %r", from_, to, condition, self.name
-        )
+        self.logger.debug("Added edge %r → %r (%s) to flow %r", from_, to, condition, self.name)
         return edge
 
     # ── Node-event notification ───────────────────────────────────────────
 
-    def add_node_event_listener(
-        self, callback: Callable[[str, str, Dict[str, Any]], Any]
-    ) -> None:
+    def add_node_event_listener(self, callback: Callable[[str, str, Dict[str, Any]], Any]) -> None:
         """Attach an additional node-event listener.
 
         Listeners are invoked in registration order with the same
@@ -434,9 +404,7 @@ class AgentsFlow(PersistenceMixin):
         """
         self._node_event_listeners.append(callback)
 
-    def _notify_node_event(
-        self, event: str, node_id: str, info: Dict[str, Any]
-    ) -> None:
+    def _notify_node_event(self, event: str, node_id: str, info: Dict[str, Any]) -> None:
         """Invoke every node-event listener, shielding the scheduler.
 
         Sync callbacks run inline; coroutines are scheduled as fire-and-forget
@@ -460,7 +428,9 @@ class AgentsFlow(PersistenceMixin):
             except Exception as exc:  # noqa: BLE001 - telemetry must not break runs
                 self.logger.warning(
                     "node-event listener raised for %s/%s: %s",
-                    event, node_id, exc,
+                    event,
+                    node_id,
+                    exc,
                 )
 
     def _log_event_task_error(self, task: "asyncio.Task[Any]") -> None:
@@ -479,9 +449,7 @@ class AgentsFlow(PersistenceMixin):
         definition: FlowDefinition,
         *,
         agent_registry: Optional[AgentRegistry] = None,
-        node_factories: Optional[
-            dict[str, Callable[["NodeDefinition", set[str], set[str]], Node]]
-        ] = None,
+        node_factories: Optional[dict[str, Callable[["NodeDefinition", set[str], set[str]], Node]]] = None,
         checkpoint: Optional[bool] = None,
         checkpoint_retention: Optional[int] = None,
         checkpoint_history: Optional[int] = None,
@@ -542,8 +510,7 @@ class AgentsFlow(PersistenceMixin):
 
         if agent_registry is None:
             raise ValueError(
-                "AgentsFlow.from_definition() requires an agent_registry. "
-                "Pass an AgentRegistry instance explicitly."
+                "AgentsFlow.from_definition() requires an agent_registry. " "Pass an AgentRegistry instance explicitly."
             )
 
         # Eagerly resolve every agent-type node's agent_ref.
@@ -564,9 +531,7 @@ class AgentsFlow(PersistenceMixin):
             # AgentRegistry.get_bot_instance is the sync getter (matches TASK-1061 pattern).
             agent = agent_registry.get_bot_instance(agent_ref)
             if agent is None:
-                raise AgentNotFoundError(
-                    f"Cannot resolve agent_ref {agent_ref!r} for node {node_def.id!r}"
-                )
+                raise AgentNotFoundError(f"Cannot resolve agent_ref {agent_ref!r} for node {node_def.id!r}")
             # Keyed by node_id so _materialize_nodes can look up by node_def.id.
             resolved_agents[node_def.id] = agent
 
@@ -592,10 +557,7 @@ class AgentsFlow(PersistenceMixin):
             for ref in refs:
                 agent = agent_registry.get_bot_instance(ref)
                 if agent is None:
-                    raise AgentNotFoundError(
-                        f"Cannot resolve agent_refs entry {ref!r} for node "
-                        f"{node_def.id!r}"
-                    )
+                    raise AgentNotFoundError(f"Cannot resolve agent_refs entry {ref!r} for node " f"{node_def.id!r}")
                 group[ref] = agent
             resolved_groups[node_def.id] = group
 
@@ -609,15 +571,9 @@ class AgentsFlow(PersistenceMixin):
             agent_registry=agent_registry,
             checkpoint=checkpoint if checkpoint is not None else meta.checkpoint,
             checkpoint_retention=(
-                checkpoint_retention
-                if checkpoint_retention is not None
-                else meta.checkpoint_retention
+                checkpoint_retention if checkpoint_retention is not None else meta.checkpoint_retention
             ),
-            checkpoint_history=(
-                checkpoint_history
-                if checkpoint_history is not None
-                else meta.checkpoint_history
-            ),
+            checkpoint_history=(checkpoint_history if checkpoint_history is not None else meta.checkpoint_history),
             checkpoint_include_responses=(
                 checkpoint_include_responses
                 if checkpoint_include_responses is not None
@@ -704,9 +660,7 @@ class AgentsFlow(PersistenceMixin):
                         f"cannot export flow {self.name!r} to a FlowDefinition."
                     )
 
-            node_defs.append(
-                NodeDefinition(id=node_id, type=type_name, agent_ref=agent_ref)
-            )
+            node_defs.append(NodeDefinition(id=node_id, type=type_name, agent_ref=agent_ref))
 
         edge_defs: list[EdgeDefinition] = []
         for edge in self._edges:
@@ -749,9 +703,7 @@ class AgentsFlow(PersistenceMixin):
             # concurrent run_flow() calls do not share FSM state (B-lite contract).
             fresh: dict[str, Node] = {}
             for nid, node in self._nodes.items():
-                new_fsm = AgentTaskMachine(
-                    agent_name=getattr(node, "node_id", nid)
-                )
+                new_fsm = AgentTaskMachine(agent_name=getattr(node, "node_id", nid))
                 try:
                     fresh[nid] = node.model_copy(update={"fsm": new_fsm})
                 except Exception:
@@ -770,8 +722,7 @@ class AgentsFlow(PersistenceMixin):
             cls = NODE_REGISTRY.get(node_type)
             if cls is None:
                 raise ValueError(
-                    f"Unknown node type {node_type!r} in flow {self.name!r}. "
-                    f"Available: {sorted(NODE_REGISTRY)}"
+                    f"Unknown node type {node_type!r} in flow {self.name!r}. " f"Available: {sorted(NODE_REGISTRY)}"
                 )
 
             # Build dependencies and successors from edges.
@@ -821,9 +772,7 @@ class AgentsFlow(PersistenceMixin):
                     dependencies=deps,
                     successors=succs,
                 )
-                fresh[nid] = start_end_node.model_copy(
-                    update={"fsm": AgentTaskMachine(agent_name=nid)}
-                )
+                fresh[nid] = start_end_node.model_copy(update={"fsm": AgentTaskMachine(agent_name=nid)})
             else:
                 # Custom node type: prefer a registered factory so the node can
                 # close over live dependencies (dispatcher, toolkits, …) that a
@@ -940,16 +889,16 @@ class AgentsFlow(PersistenceMixin):
         """
         try:
             # FSM: idle → ready → running
-            node.fsm.schedule()    # idle → ready
-            node.fsm.start()       # ready → running
+            node.fsm.schedule()  # idle → ready
+            node.fsm.start()  # ready → running
             result = await node.execute(ctx, deps)
-            node.fsm.succeed()     # running → completed
+            node.fsm.succeed()  # running → completed
             await queue.put(CompletionEvent(node_id=node.node_id, result=result))
         except BaseException as exc:
             try:
-                node.fsm.fail()    # any → failed
+                node.fsm.fail()  # any → failed
             except Exception:
-                pass               # ignore double-transition errors
+                pass  # ignore double-transition errors
             await queue.put(CompletionEvent(node_id=node.node_id, error=exc))
 
     def _aggregate_result(
@@ -1089,14 +1038,9 @@ class AgentsFlow(PersistenceMixin):
                 # taken — executed nodes with no executed successor.
                 outgoing: dict[str, set[str]] = {}
                 for edge in edge_list:
-                    targets = (
-                        [edge.to] if isinstance(edge.to, str) else list(edge.to)
-                    )
+                    targets = [edge.to] if isinstance(edge.to, str) else list(edge.to)
                     outgoing.setdefault(edge.from_, set()).update(targets)
-                leaves = [
-                    nid for nid in results
-                    if not any(t in results for t in outgoing.get(nid, ()))
-                ]
+                leaves = [nid for nid in results if not any(t in results for t in outgoing.get(nid, ()))]
         else:
             # Leaf = node with empty successors set.
             leaves = [nid for nid, node in nodes.items() if not node.successors]
@@ -1135,9 +1079,7 @@ class AgentsFlow(PersistenceMixin):
         total_time = 0.0
         if run_started_at is not None:
             try:
-                total_time = max(
-                    0.0, asyncio.get_running_loop().time() - run_started_at
-                )
+                total_time = max(0.0, asyncio.get_running_loop().time() - run_started_at)
             except RuntimeError:
                 # Called outside a running loop (only reachable from a direct
                 # synchronous call): the scheduler's epoch is unavailable, so
@@ -1345,8 +1287,7 @@ class AgentsFlow(PersistenceMixin):
         """
         if self._checkpointer is None:
             raise ValueError(
-                f"AgentsFlow {self.name!r} has no active checkpointer; "
-                "suspend() requires checkpoint=True."
+                f"AgentsFlow {self.name!r} has no active checkpointer; " "suspend() requires checkpoint=True."
             )
         if self._active_ctx is None:
             raise ValueError(
@@ -1396,9 +1337,7 @@ class AgentsFlow(PersistenceMixin):
                 lease for ``flow_id``.
         """
         ephemeral_store = get_checkpoint_store(store)
-        durable: Optional[CheckpointStore] = (
-            get_checkpoint_store(durable_store) if durable_store is not None else None
-        )
+        durable: Optional[CheckpointStore] = get_checkpoint_store(durable_store) if durable_store is not None else None
 
         checkpoint: Optional[FlowCheckpoint] = None
         if durable is not None:
@@ -1416,11 +1355,7 @@ class AgentsFlow(PersistenceMixin):
         if checkpoint is None:
             raise CheckpointNotFoundError(
                 f"No checkpoint found for flow_id={flow_id!r}"
-                + (
-                    f", checkpoint_id={checkpoint_id}"
-                    if checkpoint_id is not None
-                    else " (no latest checkpoint)"
-                )
+                + (f", checkpoint_id={checkpoint_id}" if checkpoint_id is not None else " (no latest checkpoint)")
             )
 
         if checkpoint.lossy:
@@ -1467,14 +1402,10 @@ class AgentsFlow(PersistenceMixin):
         seed_ctx.shared_data.update(checkpoint.context.shared_data)
 
         decoded_results = {
-            node_id: serializer.from_safe(value)
-            for node_id, value in checkpoint.context.results.items()
+            node_id: serializer.from_safe(value) for node_id, value in checkpoint.context.results.items()
         }
         decoded_responses = (
-            {
-                node_id: serializer.from_safe(value)
-                for node_id, value in checkpoint.context.responses.items()
-            }
+            {node_id: serializer.from_safe(value) for node_id, value in checkpoint.context.responses.items()}
             if checkpoint.context.responses is not None
             else {}
         )
@@ -1528,8 +1459,7 @@ class AgentsFlow(PersistenceMixin):
             for edge in edges:
                 if edge.from_ not in nodes or edge.to not in nodes:
                     raise ValueError(
-                        f"Edge {edge.from_!r} → {edge.to!r} references a "
-                        f"node not added to flow {self.name!r}"
+                        f"Edge {edge.from_!r} → {edge.to!r} references a " f"node not added to flow {self.name!r}"
                     )
         else:
             # Build a synthetic edge list from node.successors / node.dependencies.
@@ -1541,7 +1471,7 @@ class AgentsFlow(PersistenceMixin):
 
         completion_queue: asyncio.Queue[CompletionEvent] = asyncio.Queue()
         attempts: dict[str, int] = {nid: 0 for nid in nodes}
-        tasks: dict[str, asyncio.Task] = {}   # type: ignore[type-arg]
+        tasks: dict[str, asyncio.Task] = {}  # type: ignore[type-arg]
         # Resume (FEAT-399): seed from ctx.completed_tasks/.results when the
         # caller pre-populated a FlowContext (AgentsFlow.resume()) — a no-op
         # (identical to the prior `set()`/`{}`) for every ordinary run, where
@@ -1556,7 +1486,7 @@ class AgentsFlow(PersistenceMixin):
         loop = asyncio.get_running_loop()
         run_started_at = loop.time()
         started_at: dict[str, float] = {}
-        durations: dict[str, float] = {}      # node_id → seconds (last attempt)
+        durations: dict[str, float] = {}  # node_id → seconds (last attempt)
 
         # Incoming-edge index (explicit mode joins + derived dependencies).
         incoming: dict[str, list[Any]] = {nid: [] for nid in nodes}
@@ -1582,8 +1512,7 @@ class AgentsFlow(PersistenceMixin):
             # cycle still raises — those edges have no predicate to bound
             # iteration.
             unique_sources = {
-                nid: {e.from_ for e in in_edges if e.condition != "on_condition"}
-                for nid, in_edges in incoming.items()
+                nid: {e.from_ for e in in_edges if e.condition != "on_condition"} for nid, in_edges in incoming.items()
             }
             in_degree = {nid: len(srcs) for nid, srcs in unique_sources.items()}
             succ_sets: dict[str, set[str]] = {}
@@ -1600,9 +1529,7 @@ class AgentsFlow(PersistenceMixin):
                     if in_degree[tgt] == 0:
                         frontier.append(tgt)
             if visited < len(nodes):
-                cyclic = sorted(
-                    nid for nid, deg in in_degree.items() if deg > 0
-                )
+                cyclic = sorted(nid for nid, deg in in_degree.items() if deg > 0)
                 raise ValueError(
                     f"Flow {self.name!r} contains a cycle: nodes {cyclic} "
                     "are never reachable from an entry node. Break the "
@@ -1715,8 +1642,7 @@ class AgentsFlow(PersistenceMixin):
                     _back_edge_ids.add(id(edge))
 
         _forward_in_edges: Dict[str, List[Any]] = {
-            nid: [e for e in in_edges if id(e) not in _back_edge_ids]
-            for nid, in_edges in incoming.items()
+            nid: [e for e in in_edges if id(e) not in _back_edge_ids] for nid, in_edges in incoming.items()
         }
 
         def _deps_for(node_id: str) -> DependencyResults:
@@ -1726,24 +1652,19 @@ class AgentsFlow(PersistenceMixin):
                 dep_ids |= set(nodes[node_id].dependencies)
             else:
                 dep_ids = set(nodes[node_id].dependencies)
-            return {
-                dep: str(results[dep])
-                for dep in dep_ids
-                if dep in results
-            }
+            return {dep: str(results[dep]) for dep in dep_ids if dep in results}
 
         def _spawn(node_id: str) -> None:
             nonlocal active_count
             node = nodes[node_id]
             deps = _deps_for(node_id)
             started_at[node_id] = loop.time()
-            tasks[node_id] = asyncio.create_task(
-                self._run_node(node, ctx, deps, completion_queue)
-            )
+            tasks[node_id] = asyncio.create_task(self._run_node(node, ctx, deps, completion_queue))
             active_count += 1
             self.logger.info("Dispatched node %r", node_id)
             self._notify_node_event(
-                "node_started", node_id,
+                "node_started",
+                node_id,
                 {"flow": self.name, "context": ctx},
             )
 
@@ -1778,7 +1699,9 @@ class AgentsFlow(PersistenceMixin):
                     except Exception as exc:  # noqa: BLE001 - predicate guard
                         self.logger.warning(
                             "Predicate callable failed for edge %r → %r: %s",
-                            edge.from_, edge.to, exc,
+                            edge.from_,
+                            edge.to,
+                            exc,
                         )
                         return False
                 try:
@@ -1830,10 +1753,7 @@ class AgentsFlow(PersistenceMixin):
                 for tgt, in_edges in _forward_in_edges.items():
                     if not in_edges:
                         continue  # entry node — dispatched at start
-                    if (
-                        tgt in completed or tgt in failed
-                        or tgt in skipped or tgt in tasks
-                    ):
+                    if tgt in completed or tgt in failed or tgt in skipped or tgt in tasks:
                         continue
                     if not all(_edge_resolved(e) for e in in_edges):
                         continue
@@ -1848,11 +1768,10 @@ class AgentsFlow(PersistenceMixin):
                             nodes[tgt].fsm.block()
                         except Exception:  # noqa: BLE001 - telemetry only
                             pass
-                        self.logger.info(
-                            "Node %r skipped (no incoming edge fired)", tgt
-                        )
+                        self.logger.info("Node %r skipped (no incoming edge fired)", tgt)
                         self._notify_node_event(
-                            "node_skipped", tgt,
+                            "node_skipped",
+                            tgt,
                             {"flow": self.name, "context": ctx},
                         )
                     progress = True
@@ -1890,15 +1809,15 @@ class AgentsFlow(PersistenceMixin):
                     tasks.pop(member, None)
                     old_node = nodes[member]
                     try:
-                        nodes[member] = old_node.model_copy(
-                            update={"fsm": AgentTaskMachine(agent_name=member)}
-                        )
+                        nodes[member] = old_node.model_copy(update={"fsm": AgentTaskMachine(agent_name=member)})
                     except Exception:  # noqa: BLE001 - fallback: keep old node
                         pass
                 self.logger.info(
-                    "Repair-loop retry: edge %r -> %r fired; reset %s and "
-                    "re-dispatched %r",
-                    src, tgt, sorted(members), tgt,
+                    "Repair-loop retry: edge %r -> %r fired; reset %s and " "re-dispatched %r",
+                    src,
+                    tgt,
+                    sorted(members),
+                    tgt,
                 )
                 _spawn(tgt)
                 return True
@@ -1906,7 +1825,8 @@ class AgentsFlow(PersistenceMixin):
 
         # Run-level bracket: flow_started precedes every node_started.
         self._notify_node_event(
-            "flow_started", "",
+            "flow_started",
+            "",
             {"flow": self.name, "context": ctx, "node_count": len(nodes)},
         )
 
@@ -1944,10 +1864,7 @@ class AgentsFlow(PersistenceMixin):
                 while progress:
                     progress = False
                     for nid, node in nodes.items():
-                        if (
-                            nid in completed or nid in failed
-                            or nid in skipped or nid in tasks
-                        ):
+                        if nid in completed or nid in failed or nid in skipped or nid in tasks:
                             continue
                         deps = node.dependencies
                         if deps and all(d in completed for d in deps):
@@ -1969,7 +1886,9 @@ class AgentsFlow(PersistenceMixin):
                     attempts[nid] += 1
                     self.logger.info(
                         "Retrying node %r (attempt %d/%d)",
-                        nid, attempts[nid], max_r,
+                        nid,
+                        attempts[nid],
+                        max_r,
                     )
                     # Replace the node with a fresh copy (new FSM in idle state)
                     # so that _run_node can call fsm.schedule() without hitting
@@ -2004,7 +1923,8 @@ class AgentsFlow(PersistenceMixin):
                     )
                 self.logger.warning("Node %r failed: %s", nid, event.error)
                 self._notify_node_event(
-                    "node_failed", nid,
+                    "node_failed",
+                    nid,
                     {
                         "flow": self.name,
                         "context": ctx,
@@ -2040,7 +1960,8 @@ class AgentsFlow(PersistenceMixin):
                 )
                 self.logger.info("Node %r completed", nid)
                 self._notify_node_event(
-                    "node_completed", nid,
+                    "node_completed",
+                    nid,
                     {
                         "flow": self.name,
                         "context": ctx,
@@ -2080,7 +2001,11 @@ class AgentsFlow(PersistenceMixin):
                         _spawn(tgt)
 
         aggregated = self._aggregate_result(
-            nodes, results, errors, completed, failed,
+            nodes,
+            results,
+            errors,
+            completed,
+            failed,
             edges=edges if explicit_mode else None,
             durations=durations,
             # FEAT-447: hand the aggregator what the scheduler already
@@ -2091,7 +2016,8 @@ class AgentsFlow(PersistenceMixin):
             skipped=skipped,
         )
         self._notify_node_event(
-            "flow_completed", "",
+            "flow_completed",
+            "",
             {
                 "flow": self.name,
                 "context": ctx,
@@ -2146,9 +2072,7 @@ class DecisionNode(Node):
     def model_post_init(self, __context: Any) -> None:
         """Auto-create FSM and call parent hook."""
         if self.fsm is None:
-            object.__setattr__(
-                self, "fsm", AgentTaskMachine(agent_name=self.node_id)
-            )
+            object.__setattr__(self, "fsm", AgentTaskMachine(agent_name=self.node_id))
 
     @property
     def name(self) -> str:
@@ -2222,9 +2146,7 @@ class InteractiveDecisionFlowNode(Node):
     def model_post_init(self, __context: Any) -> None:
         """Auto-create FSM and call parent hook."""
         if self.fsm is None:
-            object.__setattr__(
-                self, "fsm", AgentTaskMachine(agent_name=self.node_id)
-            )
+            object.__setattr__(self, "fsm", AgentTaskMachine(agent_name=self.node_id))
 
     @property
     def name(self) -> str:
@@ -2301,9 +2223,7 @@ class SynthesisNode(Node):
     def model_post_init(self, __context: Any) -> None:
         """Auto-create FSM and call parent hook."""
         if self.fsm is None:
-            object.__setattr__(
-                self, "fsm", AgentTaskMachine(agent_name=self.node_id)
-            )
+            object.__setattr__(self, "fsm", AgentTaskMachine(agent_name=self.node_id))
 
     @property
     def name(self) -> str:

--- a/packages/ai-parrot/tests/bots/flows/test_agents_flow.py
+++ b/packages/ai-parrot/tests/bots/flows/test_agents_flow.py
@@ -540,3 +540,160 @@ class TestOnCompleteHookFires:
         result = await flow.run_flow(on_complete=(broken_hook,))
         # Status must remain completed despite hook failure.
         assert result.status == FlowStatus.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# FEAT-447 / TASK-2329 — run_flow wiring: fidelity end-to-end
+# ---------------------------------------------------------------------------
+
+
+class UsageAgent:
+    """Agent stub returning a REAL AgentResponse carrying usage + tool_calls.
+
+    A `MagicMock` would be useless here: `build_node_metadata` calls
+    `usage.model_dump()`, so the usage object must be a real
+    `CompletionUsage` for the assertions to mean anything.
+    """
+
+    def __init__(self, name: str, reply: str = "ok", delay: float = 0.0) -> None:
+        self._name = name
+        self.reply = reply
+        self.delay = delay
+        # `build_node_metadata` reads the concrete client class name off
+        # `agent.llm` for NodeExecutionInfo.client (spec AC3).
+        self.llm = type("FakeOpenAIClient", (), {"model": "gpt-4o"})()
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    async def invoke(self, prompt: str, **kwargs: Any) -> Any:
+        # Required by the AgentLike protocol (core/types.py).
+        return self.reply
+
+    async def ask(self, question: str = "", **kwargs: Any) -> Any:
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        from parrot.models.basic import CompletionUsage, ToolCall
+        from parrot.models.responses import AgentResponse, AIMessage
+
+        message = AIMessage(
+            input=question,
+            output=self.reply,
+            model="gpt-4o",
+            provider="openai",
+            usage=CompletionUsage(
+                prompt_tokens=13, completion_tokens=5, total_tokens=18
+            ),
+            tool_calls=[
+                ToolCall(id="tc-1", name="search", arguments={"q": question})
+            ],
+        )
+        return AgentResponse(
+            agent_name=self._name, question=question,
+            response=message, output=self.reply,
+        )
+
+
+def _make_usage_flow(delay: float = 0.0) -> AgentsFlow:
+    """Linear a → b flow whose agents report usage and tool calls.
+
+    Args:
+        delay: Per-agent sleep, used when a test needs a run long enough to
+            be visible at ``FlowResult.__repr__``'s two-decimal resolution.
+    """
+    node_a = AgentNode(
+        agent=UsageAgent("agent_a", reply="out_a", delay=delay),
+        node_id="a", dependencies=set(), successors={"b"},
+    )
+    node_b = AgentNode(
+        agent=UsageAgent("agent_b", reply="out_b", delay=delay),
+        node_id="b", dependencies={"a"}, successors=set(),
+    )
+    flow = AgentsFlow("usage-fidelity-test")
+    flow.add_node(node_a)
+    flow.add_node(node_b)
+    return flow
+
+
+class TestFlowResultFidelityEndToEnd:
+    """The fidelity guarantees, observed through a real run_flow()."""
+
+    async def test_flow_run_populates_usage(self) -> None:
+        """Every nodes[i].usage is non-None after a run (spec AC2/AC3)."""
+        result = await _make_usage_flow().run_flow()
+
+        assert len(result.nodes) == 2
+        for info in result.nodes:
+            assert info.usage is not None, f"{info.node_id} lost its usage"
+            assert info.usage["total_tokens"] == 18
+            assert info.tool_calls, f"{info.node_id} lost its tool_calls"
+            assert info.tool_calls[0]["name"] == "search"
+            assert info.model == "gpt-4o"
+            assert info.provider == "openai"
+            # AC3: the previously-dead `client` field.
+            assert info.client == "FakeOpenAIClient"
+        # AC7: ordered by real completion order, not set-iteration order.
+        assert [n.node_id for n in result.nodes] == ["a", "b"]
+        # AC8: node_results yields scalars, never envelopes, end-to-end.
+        assert result.node_results == {"a": "out_a", "b": "out_b"}
+
+    async def test_flow_run_total_time_nonzero(self) -> None:
+        """total_time > 0 and repr() no longer prints time=0.00s (spec AC4)."""
+        # 15ms per node: enough to be visible at __repr__'s 2-decimal
+        # resolution, so the repr assertion below is a real check and not
+        # satisfied by rounding.
+        result = await _make_usage_flow(delay=0.015).run_flow()
+
+        assert result.total_time > 0
+        assert result.total_execution_time == result.total_time
+        assert "time=0.00s" not in repr(result)
+        # AC5/AC6: the other previously-default run-level fields.
+        assert len(result.execution_log) == 2
+        assert result.metadata["completed_count"] == 2
+        assert result.metadata["failed_count"] == 0
+        assert result.metadata["leaves"] == ["b"]
+        # AC12: summary stays empty — AgentsFlow has no SynthesisMixin.
+        assert result.summary == ""
+
+    async def test_flow_context_carries_metadata(self) -> None:
+        """After run_flow, ctx.responses and ctx.node_metadata are populated."""
+        ctx = FlowContext(initial_task="do the thing")
+        result = await _make_usage_flow().run_flow(ctx=ctx)
+
+        assert set(ctx.responses) == {"a", "b"}
+        assert set(ctx.node_metadata) == {"a", "b"}
+        # ctx carries the SAME fidelity as the FlowResult (spec AC10).
+        for nid in ("a", "b"):
+            info = ctx.node_metadata[nid]
+            assert info.usage is not None
+            assert info.tool_calls
+            assert info.client == "FakeOpenAIClient"
+            assert info.status == "completed"
+        assert ctx.completion_order == ["a", "b"]
+        assert [n.node_id for n in result.nodes] == ctx.completion_order
+
+    async def test_flow_context_metadata_for_failed_node(self) -> None:
+        """A failed node also lands in ctx.node_metadata, marked failed."""
+        node_a = AgentNode(
+            agent=MockAgent("agent_a", reply="out_a"),
+            node_id="a", dependencies=set(), successors={"b"},
+        )
+        node_b = AgentNode(
+            agent=MockAgent("agent_b", fail=True),
+            node_id="b", dependencies={"a"}, successors=set(),
+        )
+        flow = AgentsFlow("failed-metadata-test")
+        flow.add_node(node_a)
+        flow.add_node(node_b)
+
+        ctx = FlowContext(initial_task="t")
+        result = await flow.run_flow(ctx=ctx)
+
+        assert set(ctx.node_metadata) == {"a", "b"}
+        assert ctx.node_metadata["b"].status == "failed"
+        assert "failed intentionally" in ctx.node_metadata["b"].error
+        # The failed node is absent from completion_order but still reported.
+        assert ctx.completion_order == ["a"]
+        assert [n.node_id for n in result.nodes] == ["a", "b"]
+        assert result.metadata["failed_count"] == 1

--- a/packages/ai-parrot/tests/bots/flows/test_agents_flow.py
+++ b/packages/ai-parrot/tests/bots/flows/test_agents_flow.py
@@ -11,6 +11,7 @@ Covers the 7 scenarios from Spec §4:
 
 All tests use stub agents and an in-memory StubRegistry — no real LLM calls.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -37,7 +38,6 @@ from parrot.bots.flows.flow.nodes import (
     DecisionResult,
     DecisionType,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -293,7 +293,11 @@ class TestBranchingFanIn:
                 return "merged"
 
             async def ask(self, question: str = "", **kw: Any) -> Any:
-                received_deps.update(dict(question.split("=") for segment in question.split(",") if "=" in segment) if "," in question else {})
+                received_deps.update(
+                    dict(question.split("=") for segment in question.split(",") if "=" in segment)
+                    if "," in question
+                    else {}
+                )
                 return type("R", (), {"content": "merged"})()
 
         stub_registry.register(RecordingAgent("a"))
@@ -582,16 +586,14 @@ class UsageAgent:
             output=self.reply,
             model="gpt-4o",
             provider="openai",
-            usage=CompletionUsage(
-                prompt_tokens=13, completion_tokens=5, total_tokens=18
-            ),
-            tool_calls=[
-                ToolCall(id="tc-1", name="search", arguments={"q": question})
-            ],
+            usage=CompletionUsage(prompt_tokens=13, completion_tokens=5, total_tokens=18),
+            tool_calls=[ToolCall(id="tc-1", name="search", arguments={"q": question})],
         )
         return AgentResponse(
-            agent_name=self._name, question=question,
-            response=message, output=self.reply,
+            agent_name=self._name,
+            question=question,
+            response=message,
+            output=self.reply,
         )
 
 
@@ -604,11 +606,15 @@ def _make_usage_flow(delay: float = 0.0) -> AgentsFlow:
     """
     node_a = AgentNode(
         agent=UsageAgent("agent_a", reply="out_a", delay=delay),
-        node_id="a", dependencies=set(), successors={"b"},
+        node_id="a",
+        dependencies=set(),
+        successors={"b"},
     )
     node_b = AgentNode(
         agent=UsageAgent("agent_b", reply="out_b", delay=delay),
-        node_id="b", dependencies={"a"}, successors=set(),
+        node_id="b",
+        dependencies={"a"},
+        successors=set(),
     )
     flow = AgentsFlow("usage-fidelity-test")
     flow.add_node(node_a)
@@ -677,11 +683,15 @@ class TestFlowResultFidelityEndToEnd:
         """A failed node also lands in ctx.node_metadata, marked failed."""
         node_a = AgentNode(
             agent=MockAgent("agent_a", reply="out_a"),
-            node_id="a", dependencies=set(), successors={"b"},
+            node_id="a",
+            dependencies=set(),
+            successors={"b"},
         )
         node_b = AgentNode(
             agent=MockAgent("agent_b", fail=True),
-            node_id="b", dependencies={"a"}, successors=set(),
+            node_id="b",
+            dependencies={"a"},
+            successors=set(),
         )
         flow = AgentsFlow("failed-metadata-test")
         flow.add_node(node_a)

--- a/packages/ai-parrot/tests/bots/flows/test_result_fidelity.py
+++ b/packages/ai-parrot/tests/bots/flows/test_result_fidelity.py
@@ -25,6 +25,7 @@ to from a test — a test that invokes pytest would recurse):
            packages/ai-parrot/tests/test_crew_parallel_regression.py \\
            packages/ai-parrot/tests/test_crew_final_regression.py -v
 """
+
 from __future__ import annotations
 
 import dataclasses
@@ -39,16 +40,18 @@ from parrot.bots.flows.flow import AgentsFlow
 # The exemption list — widening this must be a deliberate, reviewed edit.
 # ---------------------------------------------------------------------------
 
-PARITY_EXEMPT_FIELDS = frozenset({
-    # `summary` is the ONE legitimate divergence. AgentCrew mixes in
-    # SynthesisMixin and can synthesise a summary; AgentsFlow deliberately
-    # inherits only PersistenceMixin (flow/flow.py class declaration and its
-    # module docstring say so explicitly), leaving synthesis opt-in through
-    # the standalone `synthesize_results` util. An empty `summary` on a flow
-    # run is therefore a DESIGN DECISION (FEAT-447 Non-Goals / AC12), not a
-    # fidelity loss. Do not "fix" it by adding SynthesisMixin to AgentsFlow.
-    "summary",
-})
+PARITY_EXEMPT_FIELDS = frozenset(
+    {
+        # `summary` is the ONE legitimate divergence. AgentCrew mixes in
+        # SynthesisMixin and can synthesise a summary; AgentsFlow deliberately
+        # inherits only PersistenceMixin (flow/flow.py class declaration and its
+        # module docstring say so explicitly), leaving synthesis opt-in through
+        # the standalone `synthesize_results` util. An empty `summary` on a flow
+        # run is therefore a DESIGN DECISION (FEAT-447 Non-Goals / AC12), not a
+        # fidelity loss. Do not "fix" it by adding SynthesisMixin to AgentsFlow.
+        "summary",
+    }
+)
 
 #: `NodeExecutionInfo` fields both executors must populate for a successful
 #: LLM-backed node. `error` is excluded (it is `None` on success by design)
@@ -118,9 +121,7 @@ class ParityAgent:
         """AgentLike protocol method — delegates to `ask`."""
         return await self.ask(question=prompt, **kwargs)
 
-    async def ask(
-        self, prompt: str = "", *, question: str = "", **kwargs: Any
-    ) -> Any:
+    async def ask(self, prompt: str = "", *, question: str = "", **kwargs: Any) -> Any:
         import asyncio
 
         from parrot.models.basic import CompletionUsage, ToolCall
@@ -136,16 +137,15 @@ class ParityAgent:
             output=self.reply,
             model="gpt-4o",
             provider="openai",
-            usage=CompletionUsage(
-                prompt_tokens=13, completion_tokens=5, total_tokens=18
-            ),
-            tool_calls=[
-                ToolCall(id="tc-1", name="search", arguments={"q": effective})
-            ],
+            usage=CompletionUsage(prompt_tokens=13, completion_tokens=5, total_tokens=18),
+            tool_calls=[ToolCall(id="tc-1", name="search", arguments={"q": effective})],
         )
         return AgentResponse(
-            agent_id=self._name, agent_name=self._name, question=effective,
-            response=message, output=self.reply,
+            agent_id=self._name,
+            agent_name=self._name,
+            question=effective,
+            response=message,
+            output=self.reply,
         )
 
 
@@ -181,9 +181,7 @@ def _populated_fields(result: FlowResult) -> set[str]:
     return populated
 
 
-def _describe_divergence(
-    crew_fields: set[str], flow_fields: set[str]
-) -> str:
+def _describe_divergence(crew_fields: set[str], flow_fields: set[str]) -> str:
     """Render a directional, self-explaining parity failure message."""
     crew_only = sorted((crew_fields - flow_fields) - PARITY_EXEMPT_FIELDS)
     flow_only = sorted((flow_fields - crew_fields) - PARITY_EXEMPT_FIELDS)
@@ -202,9 +200,7 @@ def _describe_divergence(
             f"  ONLY the flow populates {flow_only} — the crew regressed, or a "
             "new field needs a documented exemption."
         )
-    lines.append(
-        f"  exempt (not compared): {sorted(PARITY_EXEMPT_FIELDS)}"
-    )
+    lines.append(f"  exempt (not compared): {sorted(PARITY_EXEMPT_FIELDS)}")
     return "\n".join(lines)
 
 
@@ -237,13 +233,17 @@ async def _run_flow() -> FlowResult:
     flow.add_node(
         AgentNode(
             agent=ParityAgent("a1", reply="out_a", delay=0.015),
-            node_id="a1", dependencies=set(), successors={"a2"},
+            node_id="a1",
+            dependencies=set(),
+            successors={"a2"},
         )
     )
     flow.add_node(
         AgentNode(
             agent=ParityAgent("a2", reply="out_b", delay=0.015),
-            node_id="a2", dependencies={"a1"}, successors=set(),
+            node_id="a2",
+            dependencies={"a1"},
+            successors=set(),
         )
     )
     return await flow.run_flow()
@@ -265,14 +265,13 @@ class TestCrewFlowParity:
         crew_fields = _populated_fields(crew_result)
         flow_fields = _populated_fields(flow_result)
 
-        assert (crew_fields - PARITY_EXEMPT_FIELDS) == (
-            flow_fields - PARITY_EXEMPT_FIELDS
-        ), _describe_divergence(crew_fields, flow_fields)
+        assert (crew_fields - PARITY_EXEMPT_FIELDS) == (flow_fields - PARITY_EXEMPT_FIELDS), _describe_divergence(
+            crew_fields, flow_fields
+        )
 
         # Guard against the assertion above passing vacuously: the fields
         # FEAT-447 exists to populate must actually be in the compared set.
-        for field in ("output", "responses", "nodes", "execution_log",
-                      "total_time", "metadata"):
+        for field in ("output", "responses", "nodes", "execution_log", "total_time", "metadata"):
             assert field in flow_fields, (
                 f"AgentsFlow left {field!r} at its default — FEAT-447 "
                 "regression in _aggregate_result / run_flow wiring."
@@ -316,8 +315,7 @@ class TestCrewFlowParity:
             assert values, f"{label} produced no node_results"
             for value in values:
                 assert not (isinstance(value, dict) and "response" in value), (
-                    f"{label} leaked an AgentNode envelope through "
-                    f"node_results: {value!r}"
+                    f"{label} leaked an AgentNode envelope through " f"node_results: {value!r}"
                 )
             # The alias must agree with the primary property.
             assert result.agent_results == result.node_results

--- a/packages/ai-parrot/tests/bots/flows/test_result_fidelity.py
+++ b/packages/ai-parrot/tests/bots/flows/test_result_fidelity.py
@@ -1,0 +1,345 @@
+"""Crew/flow FlowResult parity contract — FEAT-447 TASK-2330.
+
+`AgentCrew` and `AgentsFlow` return the *same* public contract
+(`FlowResult`), and before FEAT-447 only the crew populated it faithfully:
+AgentsFlow lost every node's `usage`/`tool_calls` and left `total_time`,
+`execution_log` and `metadata` at their dataclass defaults.
+
+This module is the regression guard that keeps the two executors from
+drifting apart again (spec G5). It drives the *same* agent stubs through both
+executors and asserts that the same `FlowResult` fields — and the same
+`NodeExecutionInfo` fields — come back populated, with exactly one documented
+exemption.
+
+It deliberately asserts **populated-ness, not equality of values**: the two
+executors orchestrate differently, so node ids, timings and log contents
+legitimately differ.
+
+Regression command (the AC-level check, run manually rather than shelled out
+to from a test — a test that invokes pytest would recurse):
+
+    pytest packages/ai-parrot/tests/bots/flows/ \\
+           packages/ai-parrot/tests/test_flow_primitives/ \\
+           packages/ai-parrot/tests/flows/checkpoint/ \\
+           packages/ai-parrot/tests/test_crew_sequential_regression.py \\
+           packages/ai-parrot/tests/test_crew_parallel_regression.py \\
+           packages/ai-parrot/tests/test_crew_final_regression.py -v
+"""
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+from parrot.bots.flows.core.node import AgentNode
+from parrot.bots.flows.core.result import FlowResult, NodeExecutionInfo
+from parrot.bots.flows.crew import AgentCrew
+from parrot.bots.flows.flow import AgentsFlow
+
+# ---------------------------------------------------------------------------
+# The exemption list — widening this must be a deliberate, reviewed edit.
+# ---------------------------------------------------------------------------
+
+PARITY_EXEMPT_FIELDS = frozenset({
+    # `summary` is the ONE legitimate divergence. AgentCrew mixes in
+    # SynthesisMixin and can synthesise a summary; AgentsFlow deliberately
+    # inherits only PersistenceMixin (flow/flow.py class declaration and its
+    # module docstring say so explicitly), leaving synthesis opt-in through
+    # the standalone `synthesize_results` util. An empty `summary` on a flow
+    # run is therefore a DESIGN DECISION (FEAT-447 Non-Goals / AC12), not a
+    # fidelity loss. Do not "fix" it by adding SynthesisMixin to AgentsFlow.
+    "summary",
+})
+
+#: `NodeExecutionInfo` fields both executors must populate for a successful
+#: LLM-backed node. `error` is excluded (it is `None` on success by design)
+#: and so are `node_id`/`node_name` (always set, and their *values* differ
+#: between executors by construction).
+NODE_PARITY_FIELDS = (
+    "model",
+    "provider",
+    "usage",
+    "tool_calls",
+    "client",
+    "execution_time",
+    "status",
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared agent stub — driven through BOTH executors
+# ---------------------------------------------------------------------------
+
+
+class ParityAgent:
+    """Agent stub returning a REAL `AgentResponse` carrying usage + tool calls.
+
+    Deliberately usable by both executors without adaptation:
+
+    * `AgentCrew._execute_agent` calls
+      ``ask(question=..., session_id=..., user_id=..., model=...,
+      max_tokens=..., use_conversation_history=...)``;
+    * `AgentNode.execute` calls ``ask(question=..., _trusted_source=True)``.
+
+    A real `CompletionUsage` is mandatory — `build_node_metadata` calls
+    ``usage.model_dump()``, so a `MagicMock` would make every downstream
+    assertion vacuous.
+    """
+
+    # AgentCrew lazily configures agents unless they report ready, and
+    # registers listeners against these event-name constants (same surface
+    # the shared `DummyAgent` in tests/_crew_test_helpers.py exposes).
+    is_configured: bool = True
+    EVENT_STATUS_CHANGED: str = "status_changed"
+    EVENT_TASK_STARTED: str = "task_started"
+    EVENT_TASK_COMPLETED: str = "task_completed"
+    EVENT_TASK_FAILED: str = "task_failed"
+
+    def __init__(self, name: str, reply: str = "ok", delay: float = 0.0) -> None:
+        self._name = name
+        self.reply = reply
+        self.delay = delay
+        self.description = f"Parity agent {name}"
+        self.prompts_received: list[str] = []
+        # `build_node_metadata` derives NodeExecutionInfo.client from the
+        # concrete class of `agent.llm` (spec AC3).
+        self.llm = type("FakeOpenAIClient", (), {"model": "gpt-4o"})()
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    async def configure(self) -> None:
+        """No-op — the stub is always ready."""
+
+    def add_event_listener(self, event: str, handler: Any) -> None:
+        """No-op; AgentCrew registers listeners on its members."""
+
+    async def invoke(self, prompt: str = "", **kwargs: Any) -> Any:
+        """AgentLike protocol method — delegates to `ask`."""
+        return await self.ask(question=prompt, **kwargs)
+
+    async def ask(
+        self, prompt: str = "", *, question: str = "", **kwargs: Any
+    ) -> Any:
+        import asyncio
+
+        from parrot.models.basic import CompletionUsage, ToolCall
+        from parrot.models.responses import AgentResponse, AIMessage
+
+        effective = question or prompt
+        self.prompts_received.append(effective)
+        if self.delay:
+            await asyncio.sleep(self.delay)
+
+        message = AIMessage(
+            input=effective,
+            output=self.reply,
+            model="gpt-4o",
+            provider="openai",
+            usage=CompletionUsage(
+                prompt_tokens=13, completion_tokens=5, total_tokens=18
+            ),
+            tool_calls=[
+                ToolCall(id="tc-1", name="search", arguments={"q": effective})
+            ],
+        )
+        return AgentResponse(
+            agent_id=self._name, agent_name=self._name, question=effective,
+            response=message, output=self.reply,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _populated_fields(result: FlowResult) -> set[str]:
+    """Field names whose value differs from the dataclass default.
+
+    Args:
+        result: The `FlowResult` to inspect.
+
+    Returns:
+        Set of field names carrying a non-default value. Fields with no
+        declared default (i.e. `output`) count as populated when truthy.
+    """
+    populated: set[str] = set()
+    for field in dataclasses.fields(result):
+        value = getattr(result, field.name)
+        if field.default is not dataclasses.MISSING:
+            default: Any = field.default
+        elif field.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
+            default = field.default_factory()  # type: ignore[misc]
+        else:
+            # No default declared (`output`): treat any truthy value as set.
+            if value:
+                populated.add(field.name)
+            continue
+        if value != default:
+            populated.add(field.name)
+    return populated
+
+
+def _describe_divergence(
+    crew_fields: set[str], flow_fields: set[str]
+) -> str:
+    """Render a directional, self-explaining parity failure message."""
+    crew_only = sorted((crew_fields - flow_fields) - PARITY_EXEMPT_FIELDS)
+    flow_only = sorted((flow_fields - crew_fields) - PARITY_EXEMPT_FIELDS)
+    lines = [
+        "FlowResult field parity broken between AgentCrew and AgentsFlow.",
+        f"  crew populated: {sorted(crew_fields)}",
+        f"  flow populated: {sorted(flow_fields)}",
+    ]
+    if crew_only:
+        lines.append(
+            f"  ONLY the crew populates {crew_only} — AgentsFlow regressed "
+            "(see FEAT-447 TASK-2328/2329: _aggregate_result / run_flow wiring)."
+        )
+    if flow_only:
+        lines.append(
+            f"  ONLY the flow populates {flow_only} — the crew regressed, or a "
+            "new field needs a documented exemption."
+        )
+    lines.append(
+        f"  exempt (not compared): {sorted(PARITY_EXEMPT_FIELDS)}"
+    )
+    return "\n".join(lines)
+
+
+def _unpopulated_node_fields(info: NodeExecutionInfo) -> list[str]:
+    """Names of `NODE_PARITY_FIELDS` left empty/None on a successful node."""
+    missing = []
+    for name in NODE_PARITY_FIELDS:
+        value = getattr(info, name)
+        if value is None or value == [] or value == {} or value == 0.0:
+            missing.append(name)
+    return missing
+
+
+async def _run_crew() -> FlowResult:
+    """Drive two ParityAgents through AgentCrew.run_sequential()."""
+    crew = AgentCrew(
+        name="ParityCrew",
+        agents=[
+            ParityAgent("a1", reply="out_a", delay=0.015),
+            ParityAgent("a2", reply="out_b", delay=0.015),
+        ],
+        auto_configure=False,
+    )
+    return await crew.run_sequential("start", generate_summary=False)
+
+
+async def _run_flow() -> FlowResult:
+    """Drive two ParityAgents through AgentsFlow.run_flow()."""
+    flow = AgentsFlow("parity-flow")
+    flow.add_node(
+        AgentNode(
+            agent=ParityAgent("a1", reply="out_a", delay=0.015),
+            node_id="a1", dependencies=set(), successors={"a2"},
+        )
+    )
+    flow.add_node(
+        AgentNode(
+            agent=ParityAgent("a2", reply="out_b", delay=0.015),
+            node_id="a2", dependencies={"a1"}, successors=set(),
+        )
+    )
+    return await flow.run_flow()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCrewFlowParity:
+    """The contract test that keeps the two executors from drifting."""
+
+    async def test_flow_vs_crew_field_parity(self) -> None:
+        """Both executors populate the same FlowResult fields, modulo `summary`."""
+        crew_result = await _run_crew()
+        flow_result = await _run_flow()
+
+        crew_fields = _populated_fields(crew_result)
+        flow_fields = _populated_fields(flow_result)
+
+        assert (crew_fields - PARITY_EXEMPT_FIELDS) == (
+            flow_fields - PARITY_EXEMPT_FIELDS
+        ), _describe_divergence(crew_fields, flow_fields)
+
+        # Guard against the assertion above passing vacuously: the fields
+        # FEAT-447 exists to populate must actually be in the compared set.
+        for field in ("output", "responses", "nodes", "execution_log",
+                      "total_time", "metadata"):
+            assert field in flow_fields, (
+                f"AgentsFlow left {field!r} at its default — FEAT-447 "
+                "regression in _aggregate_result / run_flow wiring."
+            )
+
+    async def test_node_execution_info_parity(self) -> None:
+        """NodeExecutionInfo carries the same metadata for both executors."""
+        crew_result = await _run_crew()
+        flow_result = await _run_flow()
+
+        assert crew_result.nodes, "crew produced no NodeExecutionInfo entries"
+        assert flow_result.nodes, "flow produced no NodeExecutionInfo entries"
+
+        for label, result in (("crew", crew_result), ("flow", flow_result)):
+            for info in result.nodes:
+                missing = _unpopulated_node_fields(info)
+                assert not missing, (
+                    f"{label} node {info.node_id!r} left {missing} unpopulated; "
+                    f"the other executor populates them. Fields compared: "
+                    f"{list(NODE_PARITY_FIELDS)}"
+                )
+
+        # Same *values* where the two executors genuinely must agree: these
+        # come from the shared agent stub, not from the orchestration.
+        for result in (crew_result, flow_result):
+            for info in result.nodes:
+                assert info.model == "gpt-4o"
+                assert info.provider == "openai"
+                assert info.usage["total_tokens"] == 18
+                assert info.tool_calls[0]["name"] == "search"
+                assert info.client == "FakeOpenAIClient"
+                assert info.status == "completed"
+
+    async def test_node_results_parity(self) -> None:
+        """`node_results` yields scalars for both executors, never envelopes."""
+        crew_result = await _run_crew()
+        flow_result = await _run_flow()
+
+        for label, result in (("crew", crew_result), ("flow", flow_result)):
+            values = list(result.node_results.values())
+            assert values, f"{label} produced no node_results"
+            for value in values:
+                assert not (isinstance(value, dict) and "response" in value), (
+                    f"{label} leaked an AgentNode envelope through "
+                    f"node_results: {value!r}"
+                )
+            # The alias must agree with the primary property.
+            assert result.agent_results == result.node_results
+
+    def test_parity_exemptions_are_explicit(self) -> None:
+        """PARITY_EXEMPT_FIELDS == {"summary"} — widening it must be deliberate."""
+        assert PARITY_EXEMPT_FIELDS == frozenset({"summary"}), (
+            "The parity exemption list changed. Adding an exemption means "
+            "accepting that the two executors may diverge on that field — "
+            "document WHY in the PARITY_EXEMPT_FIELDS comment before "
+            "updating this test."
+        )
+        # Every exempt name must be a real FlowResult field, so a typo can
+        # never silently exempt nothing.
+        field_names = {f.name for f in dataclasses.fields(FlowResult)}
+        assert PARITY_EXEMPT_FIELDS <= field_names
+
+    async def test_flow_summary_stays_empty(self) -> None:
+        """The exemption is real: AgentsFlow leaves `summary` empty (AC12)."""
+        flow_result = await _run_flow()
+        assert flow_result.summary == ""
+        # ...and AgentsFlow must not have gained SynthesisMixin.
+        assert not any(
+            base.__name__ == "SynthesisMixin" for base in AgentsFlow.__mro__
+        ), "AgentsFlow gained SynthesisMixin — FEAT-447 Non-Goal violated."

--- a/packages/ai-parrot/tests/bots/flows/test_scheduler.py
+++ b/packages/ai-parrot/tests/bots/flows/test_scheduler.py
@@ -242,3 +242,202 @@ class TestOnCompleteHooks:
         ctx = FlowContext(initial_task="hello")
         await flow.run_flow(ctx=ctx, on_complete=(hook,))
         assert received_ctx[0] is ctx
+
+
+# ---------------------------------------------------------------------------
+# FEAT-447 / TASK-2328 — faithful _aggregate_result
+# ---------------------------------------------------------------------------
+
+
+def _envelope(output: object, prompt: str = "q") -> dict:
+    """The shape AgentNode.execute() returns (core/node.py)."""
+    return {
+        "response": None,
+        "output": output,
+        "execution_time": 0.01,
+        "prompt": prompt,
+    }
+
+
+class TestAggregateResultFidelity:
+    """`_aggregate_result` must not discard what the scheduler measured."""
+
+    async def test_aggregate_result_total_time(self) -> None:
+        """total_time > 0 and approximates now - run_started_at."""
+        flow = _make_linear_flow()
+        loop = asyncio.get_running_loop()
+        run_started_at = loop.time() - 0.25
+
+        result = flow._aggregate_result(
+            flow._nodes,
+            {"a": _envelope("out_a"), "b": _envelope("out_b")},
+            {},
+            {"a", "b"},
+            set(),
+            durations={"a": 0.1, "b": 0.1},
+            run_started_at=run_started_at,
+        )
+        assert result.total_time > 0
+        assert result.total_time == pytest.approx(
+            loop.time() - run_started_at, abs=0.5
+        )
+        # The alias and __repr__ follow it (spec AC4).
+        assert result.total_execution_time == result.total_time
+        assert "time=0.00s" not in repr(result)
+
+    async def test_aggregate_result_execution_log(self) -> None:
+        """One entry per completed+failed node, with the five documented keys."""
+        flow = _make_partial_flow()
+        result = flow._aggregate_result(
+            flow._nodes,
+            {"a": _envelope("out_a")},
+            {"b": RuntimeError("b exploded")},
+            {"a"},
+            {"b"},
+            durations={"a": 0.4, "b": 0.2},
+        )
+        assert len(result.execution_log) == 2
+        for entry in result.execution_log:
+            assert set(entry) == {
+                "node_id", "node_name", "status", "execution_time", "error",
+            }
+        by_id = {e["node_id"]: e for e in result.execution_log}
+        assert by_id["a"]["status"] == "completed"
+        assert by_id["a"]["error"] is None
+        assert by_id["a"]["execution_time"] == 0.4
+        assert by_id["b"]["status"] == "failed"
+        assert "b exploded" in by_id["b"]["error"]
+        # Same order as result.nodes.
+        assert [e["node_id"] for e in result.execution_log] == [
+            n.node_id for n in result.nodes
+        ]
+
+    async def test_aggregate_result_metadata_keys(self) -> None:
+        """All six metadata keys present and correctly valued."""
+        flow = _make_fan_out_flow()
+        result = flow._aggregate_result(
+            flow._nodes,
+            {"a": _envelope("root"), "b": _envelope("branch_b")},
+            {"c": RuntimeError("c failed")},
+            {"a", "b"},
+            {"c"},
+            durations={"a": 0.1, "b": 0.1, "c": 0.1},
+            skipped={"z", "y"},
+        )
+        meta = result.metadata
+        assert set(meta) == {
+            "mode", "node_count", "completed_count", "failed_count",
+            "skipped", "leaves",
+        }
+        # Programmatic flow, no definition and no explicit edges → "legacy".
+        assert meta["mode"] == "legacy"
+        assert meta["node_count"] == 3
+        assert meta["completed_count"] == 2
+        assert meta["failed_count"] == 1
+        assert meta["skipped"] == ["y", "z"]     # sorted for determinism
+        assert meta["leaves"] == ["b"]           # only executed leaf
+        # AC12: summary stays empty for AgentsFlow.
+        assert result.summary == ""
+
+    async def test_aggregate_result_node_order(self) -> None:
+        """[n.node_id for n in result.nodes] == ctx.completion_order."""
+        flow = _make_fan_out_flow()
+        ctx = FlowContext(initial_task="t")
+        # Deliberately NOT alphabetical, and not the set-iteration order.
+        for nid in ("c", "a", "b"):
+            ctx.mark_completed(nid, result=_envelope(f"out_{nid}"))
+        assert ctx.completion_order == ["c", "a", "b"]
+
+        result = flow._aggregate_result(
+            flow._nodes,
+            {nid: _envelope(f"out_{nid}") for nid in ("a", "b", "c")},
+            {},
+            {"a", "b", "c"},
+            set(),
+            ctx=ctx,
+        )
+        assert [n.node_id for n in result.nodes] == ctx.completion_order
+
+    async def test_aggregate_result_node_order_is_deterministic(self) -> None:
+        """Ordering never depends on set-iteration order, with or without ctx."""
+        flow = _make_fan_out_flow()
+        results = {nid: _envelope(f"out_{nid}") for nid in ("a", "b", "c")}
+
+        # Without ctx: sorted, not hash-ordered.
+        no_ctx = flow._aggregate_result(
+            flow._nodes, results, {}, {"a", "b", "c"}, set(),
+        )
+        assert [n.node_id for n in no_ctx.nodes] == ["a", "b", "c"]
+
+        # Repeated aggregation is stable (the union is rebuilt each time).
+        for _ in range(5):
+            again = flow._aggregate_result(
+                flow._nodes, results, {}, {"c", "b", "a"}, set(),
+            )
+            assert [n.node_id for n in again.nodes] == ["a", "b", "c"]
+
+    async def test_aggregate_result_failed_node_included(self) -> None:
+        """A node failed via mark_failed (absent from completion_order) still appears."""
+        flow = _make_partial_flow()
+        ctx = FlowContext(initial_task="t")
+        ctx.mark_completed("a", result=_envelope("out_a"))
+        ctx.mark_failed("b", RuntimeError("b exploded"))
+        # mark_failed must NOT append to completion_order — that is why the
+        # residue has to be appended explicitly.
+        assert ctx.completion_order == ["a"]
+
+        result = flow._aggregate_result(
+            flow._nodes,
+            {"a": _envelope("out_a")},
+            {"b": RuntimeError("b exploded")},
+            {"a"},
+            {"b"},
+            ctx=ctx,
+        )
+        assert [n.node_id for n in result.nodes] == ["a", "b"]
+        assert result.failed == ["b"]
+
+    async def test_aggregate_result_backward_compatible_call(self) -> None:
+        """Calling without ctx/run_started_at/skipped returns a valid FlowResult."""
+        flow = _make_linear_flow()
+        # Exactly the pre-FEAT-447 argument list, positional edges/durations.
+        result = flow._aggregate_result(
+            flow._nodes,
+            {"a": _envelope("out_a"), "b": _envelope("out_b")},
+            {},
+            {"a", "b"},
+            set(),
+            None,
+            {"a": 0.1, "b": 0.2},
+        )
+        assert isinstance(result, FlowResult)
+        assert result.output == "out_b"
+        assert result.total_time == 0.0          # no run_started_at supplied
+        assert result.metadata["skipped"] == []
+        assert len(result.nodes) == 2
+        assert len(result.execution_log) == 2
+
+
+class TestOutputShapeContract:
+    """Contract lock for FlowResult.output's scalar-vs-dict polymorphism."""
+
+    async def test_output_single_leaf_is_scalar(self) -> None:
+        """Single executed leaf -> scalar output."""
+        flow = _make_linear_flow()
+        result = await flow.run_flow()
+        assert not isinstance(result.output, dict)
+        assert result.output == "result_b"
+        assert result.metadata["leaves"] == ["b"]
+
+    async def test_output_multi_leaf_is_dict(self) -> None:
+        """Fan-out -> dict[node_id, scalar]."""
+        flow = _make_fan_out_flow()
+        result = await flow.run_flow()
+        assert isinstance(result.output, dict)
+        assert set(result.output) == {"b", "c"}
+        assert result.output == {"b": "branch_b", "c": "branch_c"}
+        # Every value is a scalar, never a nested envelope.
+        assert not any(
+            isinstance(v, dict) and "response" in v for v in result.output.values()
+        )
+        assert sorted(result.metadata["leaves"]) == ["b", "c"]

--- a/packages/ai-parrot/tests/bots/flows/test_scheduler.py
+++ b/packages/ai-parrot/tests/bots/flows/test_scheduler.py
@@ -12,6 +12,7 @@ Tests verify:
 - FlowResult has status "failed" when all nodes fail.
 - FlowResult has status "partial" when some succeed, some fail.
 """
+
 import asyncio
 import inspect
 
@@ -22,7 +23,6 @@ from parrot.bots.flows.flow import AgentsFlow, NODE_REGISTRY, register_node
 from parrot.bots.flows.core.node import AgentNode, Node
 from parrot.bots.flows.core.context import FlowContext
 from parrot.bots.flows.core.result import FlowResult
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -111,9 +111,7 @@ class TestSchedulerSourceConstraints:
         import parrot.bots.flows.flow as flow_module
 
         src = inspect.getsource(flow_module)
-        assert "asyncio.gather" not in src, (
-            "asyncio.gather found in flow.py — forbidden by scheduler design."
-        )
+        assert "asyncio.gather" not in src, "asyncio.gather found in flow.py — forbidden by scheduler design."
 
 
 # ---------------------------------------------------------------------------
@@ -278,9 +276,7 @@ class TestAggregateResultFidelity:
             run_started_at=run_started_at,
         )
         assert result.total_time > 0
-        assert result.total_time == pytest.approx(
-            loop.time() - run_started_at, abs=0.5
-        )
+        assert result.total_time == pytest.approx(loop.time() - run_started_at, abs=0.5)
         # The alias and __repr__ follow it (spec AC4).
         assert result.total_execution_time == result.total_time
         assert "time=0.00s" not in repr(result)
@@ -299,7 +295,11 @@ class TestAggregateResultFidelity:
         assert len(result.execution_log) == 2
         for entry in result.execution_log:
             assert set(entry) == {
-                "node_id", "node_name", "status", "execution_time", "error",
+                "node_id",
+                "node_name",
+                "status",
+                "execution_time",
+                "error",
             }
         by_id = {e["node_id"]: e for e in result.execution_log}
         assert by_id["a"]["status"] == "completed"
@@ -308,9 +308,7 @@ class TestAggregateResultFidelity:
         assert by_id["b"]["status"] == "failed"
         assert "b exploded" in by_id["b"]["error"]
         # Same order as result.nodes.
-        assert [e["node_id"] for e in result.execution_log] == [
-            n.node_id for n in result.nodes
-        ]
+        assert [e["node_id"] for e in result.execution_log] == [n.node_id for n in result.nodes]
 
     async def test_aggregate_result_metadata_keys(self) -> None:
         """All six metadata keys present and correctly valued."""
@@ -326,16 +324,20 @@ class TestAggregateResultFidelity:
         )
         meta = result.metadata
         assert set(meta) == {
-            "mode", "node_count", "completed_count", "failed_count",
-            "skipped", "leaves",
+            "mode",
+            "node_count",
+            "completed_count",
+            "failed_count",
+            "skipped",
+            "leaves",
         }
         # Programmatic flow, no definition and no explicit edges → "legacy".
         assert meta["mode"] == "legacy"
         assert meta["node_count"] == 3
         assert meta["completed_count"] == 2
         assert meta["failed_count"] == 1
-        assert meta["skipped"] == ["y", "z"]     # sorted for determinism
-        assert meta["leaves"] == ["b"]           # only executed leaf
+        assert meta["skipped"] == ["y", "z"]  # sorted for determinism
+        assert meta["leaves"] == ["b"]  # only executed leaf
         # AC12: summary stays empty for AgentsFlow.
         assert result.summary == ""
 
@@ -365,14 +367,22 @@ class TestAggregateResultFidelity:
 
         # Without ctx: sorted, not hash-ordered.
         no_ctx = flow._aggregate_result(
-            flow._nodes, results, {}, {"a", "b", "c"}, set(),
+            flow._nodes,
+            results,
+            {},
+            {"a", "b", "c"},
+            set(),
         )
         assert [n.node_id for n in no_ctx.nodes] == ["a", "b", "c"]
 
         # Repeated aggregation is stable (the union is rebuilt each time).
         for _ in range(5):
             again = flow._aggregate_result(
-                flow._nodes, results, {}, {"c", "b", "a"}, set(),
+                flow._nodes,
+                results,
+                {},
+                {"c", "b", "a"},
+                set(),
             )
             assert [n.node_id for n in again.nodes] == ["a", "b", "c"]
 
@@ -412,7 +422,7 @@ class TestAggregateResultFidelity:
         )
         assert isinstance(result, FlowResult)
         assert result.output == "out_b"
-        assert result.total_time == 0.0          # no run_started_at supplied
+        assert result.total_time == 0.0  # no run_started_at supplied
         assert result.metadata["skipped"] == []
         assert len(result.nodes) == 2
         assert len(result.execution_log) == 2
@@ -437,9 +447,7 @@ class TestOutputShapeContract:
         assert set(result.output) == {"b", "c"}
         assert result.output == {"b": "branch_b", "c": "branch_c"}
         # Every value is a scalar, never a nested envelope.
-        assert not any(
-            isinstance(v, dict) and "response" in v for v in result.output.values()
-        )
+        assert not any(isinstance(v, dict) and "response" in v for v in result.output.values())
         assert sorted(result.metadata["leaves"]) == ["b", "c"]
 
     async def test_output_no_executed_leaf_is_empty_dict(self) -> None:

--- a/packages/ai-parrot/tests/bots/flows/test_scheduler.py
+++ b/packages/ai-parrot/tests/bots/flows/test_scheduler.py
@@ -441,3 +441,24 @@ class TestOutputShapeContract:
             isinstance(v, dict) and "response" in v for v in result.output.values()
         )
         assert sorted(result.metadata["leaves"]) == ["b", "c"]
+
+    async def test_output_no_executed_leaf_is_empty_dict(self) -> None:
+        """No executed leaf -> `{}` (NOT None) — locks the real behaviour.
+
+        Added after review: the FEAT-447 docstrings originally claimed `None`
+        here, but the no-leaf case falls into the fan-out branch with nothing
+        to collect, and that predates FEAT-447. Normalising it to `None` would
+        break an existing field's contract, so the behaviour is pinned and
+        documented instead. `metadata["leaves"] == []` is the reliable
+        "produced nothing" signal.
+        """
+        # Empty graph.
+        empty = await AgentsFlow("empty-test").run_flow()
+        assert empty.output == {}
+        assert empty.metadata["leaves"] == []
+
+        # Single leaf that failed → still `{}`, not the scalar branch.
+        failed = await _make_failing_flow().run_flow()
+        assert failed.output == {}
+        assert failed.metadata["leaves"] == []
+        assert failed.metadata["failed_count"] == 1

--- a/packages/ai-parrot/tests/test_flow_primitives/test_result.py
+++ b/packages/ai-parrot/tests/test_flow_primitives/test_result.py
@@ -225,3 +225,194 @@ class TestBuildNodeMetadata:
             error="Something went wrong",
         )
         assert info.error == "Something went wrong"
+
+
+# ---------------------------------------------------------------------------
+# FEAT-447 / TASK-2326 — shared envelope unwrapping + NodeExecutionInfo.client
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def agent_response_with_usage():
+    """AgentResponse whose AIMessage carries REAL usage + tool_calls.
+
+    NOTE: a real ``CompletionUsage`` is mandatory -- ``build_node_metadata``
+    calls ``usage_obj.model_dump()``, and a ``MagicMock`` would return another
+    Mock, making every assertion vacuous.
+    """
+    from parrot.models.basic import CompletionUsage, ToolCall
+    from parrot.models.responses import AgentResponse, AIMessage
+
+    message = AIMessage(
+        input="q",
+        output="answer",
+        model="gpt-4o",
+        provider="openai",
+        usage=CompletionUsage(
+            prompt_tokens=11, completion_tokens=7, total_tokens=18
+        ),
+        tool_calls=[
+            ToolCall(id="tc-1", name="get_weather", arguments={"city": "Madrid"})
+        ],
+    )
+    return AgentResponse(
+        agent_id="a1", agent_name="agent-one", question="q",
+        response=message, output="answer",
+    )
+
+
+@pytest.fixture
+def node_envelope(agent_response_with_usage):
+    """The exact dict ``AgentNode.execute()`` returns (``core/node.py``)."""
+    return {
+        "response": agent_response_with_usage,
+        "output": "answer",
+        "execution_time": 0.42,
+        "prompt": "q",
+    }
+
+
+class TestUnwrapResponse:
+    """Unit tests for the shared ``_unwrap_response`` helper."""
+
+    def test_unwrap_response_envelope(self, node_envelope, agent_response_with_usage):
+        """An envelope resolves to its inner AgentResponse."""
+        from parrot.bots.flows.core.result import _unwrap_response
+
+        assert _unwrap_response(node_envelope) is agent_response_with_usage
+
+    def test_unwrap_response_passthrough(self, agent_response_with_usage):
+        """AgentResponse, AIMessage, str and None pass through unchanged."""
+        from parrot.bots.flows.core.result import _unwrap_response
+
+        message = agent_response_with_usage.response
+        assert _unwrap_response(agent_response_with_usage) is agent_response_with_usage
+        assert _unwrap_response(message) is message
+        assert _unwrap_response("plain string") == "plain string"
+        assert _unwrap_response(None) is None
+
+        sentinel = object()
+        assert _unwrap_response(sentinel) is sentinel
+
+    def test_unwrap_response_nested_envelope(self, agent_response_with_usage):
+        """An envelope wrapping an envelope resolves; recursion is bounded."""
+        from parrot.bots.flows.core.result import (
+            _MAX_UNWRAP_DEPTH,
+            _unwrap_response,
+        )
+
+        inner = {"response": agent_response_with_usage, "output": "answer"}
+        outer = {"response": inner, "output": "answer"}
+        assert _unwrap_response(outer) is agent_response_with_usage
+
+        # Self-referential envelope: bounded, returns without raising.
+        cyclic: dict = {"output": "x"}
+        cyclic["response"] = cyclic
+        assert _unwrap_response(cyclic) is cyclic
+
+        # A chain deeper than the cap stops at the cap instead of recursing.
+        deep: object = agent_response_with_usage
+        for _ in range(_MAX_UNWRAP_DEPTH + 3):
+            deep = {"response": deep, "output": "answer"}
+        result = _unwrap_response(deep)
+        assert isinstance(result, dict)
+
+    def test_unwrap_response_dict_without_response_key(self):
+        """A dict with no ``"response"`` key is NOT an envelope."""
+        from parrot.bots.flows.core.result import _unwrap_response
+
+        plain = {"output": "answer", "execution_time": 0.1}
+        assert _unwrap_response(plain) is plain
+        assert _unwrap_response({}) == {}
+
+
+class TestBuildNodeMetadataEnvelope:
+    """``build_node_metadata`` fidelity for envelopes, crews, and ``client``."""
+
+    def test_build_node_metadata_from_envelope(self, node_envelope):
+        """Envelope input yields non-None usage and non-empty tool_calls."""
+        info = build_node_metadata(
+            node_id="n1",
+            agent=None,
+            response=node_envelope,
+            output="answer",
+            execution_time=1.25,
+            status="completed",
+        )
+        assert info.usage is not None
+        assert info.usage["prompt_tokens"] == 11
+        assert info.usage["completion_tokens"] == 7
+        assert info.tool_calls
+        assert info.tool_calls[0]["name"] == "get_weather"
+        assert info.model == "gpt-4o"
+        assert info.provider == "openai"
+        assert info.execution_time == 1.25
+        assert info.status == "completed"
+
+    def test_build_node_metadata_crew_shape_unchanged(self, agent_response_with_usage):
+        """A bare AgentResponse yields the same metadata as its envelope."""
+        crew_info = build_node_metadata(
+            node_id="n1",
+            agent=None,
+            response=agent_response_with_usage,
+            output="answer",
+            execution_time=1.25,
+            status="completed",
+        )
+        assert crew_info.model == "gpt-4o"
+        assert crew_info.provider == "openai"
+        assert crew_info.usage is not None
+        assert crew_info.usage["total_tokens"] == 18
+        assert crew_info.tool_calls[0]["name"] == "get_weather"
+        # Crew (bare response) and flow (envelope) must agree field-for-field.
+        flow_info = build_node_metadata(
+            node_id="n1",
+            agent=None,
+            response={
+                "response": agent_response_with_usage,
+                "output": "answer",
+                "execution_time": 0.42,
+                "prompt": "q",
+            },
+            output="answer",
+            execution_time=1.25,
+            status="completed",
+        )
+        assert flow_info.to_dict() == crew_info.to_dict()
+
+    def test_build_node_metadata_sets_client(self):
+        """client is the concrete client class name, not None."""
+        class OpenAIClient:
+            model = "gpt-4o"
+
+        class FakeAgent:
+            name = "agent-one"
+            llm = OpenAIClient()
+
+        info = build_node_metadata(
+            node_id="n1",
+            agent=FakeAgent(),
+            response=None,
+            output=None,
+            execution_time=0.0,
+            status="completed",
+        )
+        assert info.client == "OpenAIClient"
+        assert info.model == "gpt-4o"
+        assert info.to_dict()["client"] == "OpenAIClient"
+
+    def test_build_node_metadata_client_none_without_agent(self):
+        """No agent (or an unconfigured string llm) leaves client as None."""
+        assert build_node_metadata(
+            node_id="n1", agent=None, response=None, output=None,
+            execution_time=0.0, status="completed",
+        ).client is None
+
+        class UnconfiguredAgent:
+            name = "agent-one"
+            llm = "openai:gpt-4o"
+
+        assert build_node_metadata(
+            node_id="n1", agent=UnconfiguredAgent(), response=None, output=None,
+            execution_time=0.0, status="completed",
+        ).client is None

--- a/packages/ai-parrot/tests/test_flow_primitives/test_result.py
+++ b/packages/ai-parrot/tests/test_flow_primitives/test_result.py
@@ -1,4 +1,5 @@
 """Unit tests for parrot.bots.flows.core.result (TASK-915)."""
+
 import pytest
 from parrot.bots.flows.core.result import (
     FlowResult,
@@ -52,9 +53,7 @@ class TestNodeExecutionInfo:
         assert info.usage == {"tokens": 100}
 
     def test_error_field(self):
-        info = NodeExecutionInfo(
-            node_id="n4", node_name="agent-4", status="failed", error="Timeout"
-        )
+        info = NodeExecutionInfo(node_id="n4", node_name="agent-4", status="failed", error="Timeout")
         assert info.error == "Timeout"
         d = info.to_dict()
         assert d["error"] == "Timeout"
@@ -248,16 +247,15 @@ def agent_response_with_usage():
         output="answer",
         model="gpt-4o",
         provider="openai",
-        usage=CompletionUsage(
-            prompt_tokens=11, completion_tokens=7, total_tokens=18
-        ),
-        tool_calls=[
-            ToolCall(id="tc-1", name="get_weather", arguments={"city": "Madrid"})
-        ],
+        usage=CompletionUsage(prompt_tokens=11, completion_tokens=7, total_tokens=18),
+        tool_calls=[ToolCall(id="tc-1", name="get_weather", arguments={"city": "Madrid"})],
     )
     return AgentResponse(
-        agent_id="a1", agent_name="agent-one", question="q",
-        response=message, output="answer",
+        agent_id="a1",
+        agent_name="agent-one",
+        question="q",
+        response=message,
+        output="answer",
     )
 
 
@@ -382,6 +380,7 @@ class TestBuildNodeMetadataEnvelope:
 
     def test_build_node_metadata_sets_client(self):
         """client is the concrete client class name, not None."""
+
         class OpenAIClient:
             model = "gpt-4o"
 
@@ -403,19 +402,33 @@ class TestBuildNodeMetadataEnvelope:
 
     def test_build_node_metadata_client_none_without_agent(self):
         """No agent (or an unconfigured string llm) leaves client as None."""
-        assert build_node_metadata(
-            node_id="n1", agent=None, response=None, output=None,
-            execution_time=0.0, status="completed",
-        ).client is None
+        assert (
+            build_node_metadata(
+                node_id="n1",
+                agent=None,
+                response=None,
+                output=None,
+                execution_time=0.0,
+                status="completed",
+            ).client
+            is None
+        )
 
         class UnconfiguredAgent:
             name = "agent-one"
             llm = "openai:gpt-4o"
 
-        assert build_node_metadata(
-            node_id="n1", agent=UnconfiguredAgent(), response=None, output=None,
-            execution_time=0.0, status="completed",
-        ).client is None
+        assert (
+            build_node_metadata(
+                node_id="n1",
+                agent=UnconfiguredAgent(),
+                response=None,
+                output=None,
+                execution_time=0.0,
+                status="completed",
+            ).client
+            is None
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -449,10 +462,7 @@ class TestNodeResultsEnvelope:
         # The alias inherits the fix.
         assert result.agent_results == {"n1": "answer-1", "n2": {"structured": True}}
         # No value is an envelope dict (spec AC8).
-        assert not any(
-            isinstance(v, dict) and "response" in v
-            for v in result.node_results.values()
-        )
+        assert not any(isinstance(v, dict) and "response" in v for v in result.node_results.values())
         # Read-only projection: `responses` is untouched.
         assert result.responses["n1"]["prompt"] == "q"
 

--- a/packages/ai-parrot/tests/test_flow_primitives/test_result.py
+++ b/packages/ai-parrot/tests/test_flow_primitives/test_result.py
@@ -416,3 +416,60 @@ class TestBuildNodeMetadataEnvelope:
             node_id="n1", agent=UnconfiguredAgent(), response=None, output=None,
             execution_time=0.0, status="completed",
         ).client is None
+
+
+# ---------------------------------------------------------------------------
+# FEAT-447 / TASK-2327 — envelope-aware FlowResult.node_results
+# ---------------------------------------------------------------------------
+
+
+class TestNodeResultsEnvelope:
+    """``node_results`` must yield scalars for BOTH executors' shapes."""
+
+    def test_node_results_unwraps_envelope(self, agent_response_with_usage):
+        """A FlowResult whose responses hold AgentNode envelopes yields scalars."""
+        result = FlowResult(
+            output="x",
+            responses={
+                "n1": {
+                    "response": agent_response_with_usage,
+                    "output": "answer-1",
+                    "execution_time": 0.1,
+                    "prompt": "q",
+                },
+                "n2": {
+                    "response": agent_response_with_usage,
+                    "output": {"structured": True},
+                    "execution_time": 0.2,
+                    "prompt": "q2",
+                },
+            },
+        )
+        assert result.node_results == {"n1": "answer-1", "n2": {"structured": True}}
+        # The alias inherits the fix.
+        assert result.agent_results == {"n1": "answer-1", "n2": {"structured": True}}
+        # No value is an envelope dict (spec AC8).
+        assert not any(
+            isinstance(v, dict) and "response" in v
+            for v in result.node_results.values()
+        )
+        # Read-only projection: `responses` is untouched.
+        assert result.responses["n1"]["prompt"] == "q"
+
+    def test_node_results_crew_shape_unchanged(self, agent_response_with_usage):
+        """AgentResponse responses still unwrap via .output; None stays None."""
+        result = FlowResult(
+            output="x",
+            responses={
+                "a1": agent_response_with_usage,
+                "a2": None,
+                "a3": "plain",
+                # A dict WITHOUT an "output" key is not an envelope.
+                "a4": {"other": 1},
+            },
+        )
+        assert result.node_results["a1"] == agent_response_with_usage.output
+        assert result.node_results["a2"] is None
+        assert result.node_results["a3"] == "plain"
+        assert result.node_results["a4"] == {"other": 1}
+        assert result.agent_results == result.node_results

--- a/sdd/tasks/completed/TASK-2326-shared-unwrap-response.md
+++ b/sdd/tasks/completed/TASK-2326-shared-unwrap-response.md
@@ -318,10 +318,67 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
+**Completed by**: sdd-worker (Claude Opus 5)
+**Date**: 2026-08-24
 **Notes**:
 
-**Deviations from spec**: none | describe if any
+Module 1 landed as specified, at the single shared seam.
+
+- `_unwrap_response(response, _depth=0)` added to `core/result.py` immediately
+  above `build_node_metadata`, with `_MAX_UNWRAP_DEPTH = 5` as the explicit
+  recursion cap. It treats a mapping as an envelope only when a `"response"`
+  key is present, wraps the membership test in a bare `except Exception` so an
+  exotic `__contains__` cannot make it raise, and returns its input unchanged
+  in every other case. It needs no `parrot.models.responses` import (it keys on
+  dict shape, not on types), so the `try/except ImportError` guard below it is
+  untouched.
+- `build_node_metadata` now calls it as the first statement of its body,
+  before the metadata locals and the `isinstance` ladder. The `output`
+  argument is deliberately NOT unwrapped (per Scope / spec G6).
+- `client=` is now passed to the `NodeExecutionInfo(...)` constructor, derived
+  from the already-resolved `client_obj` as `type(client_obj).__name__`. Added
+  guard: when `agent.llm` still holds raw config (a `str`/`dict`/`list`/
+  `tuple`/`bytes` — the pre-`configure()` state) `client` stays `None` rather
+  than reporting a useless `"str"`. Covered by
+  `test_build_node_metadata_client_none_without_agent`.
+- Rewrote the walrus `if` into an explicit block to hoist `client`; truthiness
+  semantics of the original are preserved exactly.
+
+Tests: 8 added to `tests/test_flow_primitives/test_result.py` (the 7 the task
+specified plus `test_build_node_metadata_client_none_without_agent` for the
+raw-config guard). `test_build_node_metadata_crew_shape_unchanged` asserts
+crew/flow parity the strong way — `flow_info.to_dict() == crew_info.to_dict()`
+for a bare `AgentResponse` vs. the same response inside an envelope.
+
+Verification:
+- `test_flow_primitives/test_result.py`: 39 passed (31 pre-existing + 8 new).
+- Crew regression suites (AC13): 32 passed, unchanged from baseline.
+- `tests/bots/flows/` + `tests/test_flow_primitives/`: 707 passed
+  (measured baseline on clean `dev` was 699; +8 new).
+- `tests/flows/checkpoint/`: 65 passed, 9 skipped.
+
+**Environment notes (not defects introduced by this task)**:
+1. pytest hangs at *interpreter exit* (post-summary) in suites that touch
+   DocumentDB/`ExecutionWikiRecorder`; reproduced on clean `dev` in the main
+   checkout. Worked around with a `timeout`-wrapped runner that reads the
+   summary line.
+2. Running `tests/bots/flows/` + `tests/test_flow_primitives/` +
+   `tests/flows/checkpoint/` in ONE process yields 9 `ContextSnapshot`
+   model-identity failures in `flows/checkpoint/`. Reproduced identically on
+   clean `dev` in the main checkout (9 failed, 755 passed) — pre-existing
+   cross-suite import pollution, unrelated to FEAT-447. Each suite is green in
+   isolation. Relevant to AC14, which asks for the three directories in one
+   command; recorded for the reviewer rather than fixed (out of scope).
+
+**Deviations from spec**: none.
+
+Notes on AC16 (`ruff`/`mypy` clean): the repo declares no `[tool.ruff]`
+config, so `ruff check` runs with defaults and reports 56 pre-existing
+findings on `core/result.py` (mostly `UP006`/`UP045` — the file annotates with
+`Optional[...]`/`Dict[...]` throughout). My additions add exactly 3 `UP045`
+hits, all from `Optional[Any]` annotations that match the surrounding file's
+style; converting only my lines to `X | None` would make the new code
+inconsistent with the other 17 annotations in the same file, and converting
+the whole file is scope creep. The one new `I001` in the test file WAS fixed.
+`mypy` reports the same 2 pre-existing errors (lines 36, 616) before and
+after — no new type errors.

--- a/sdd/tasks/completed/TASK-2327-node-results-envelope-unwrap.md
+++ b/sdd/tasks/completed/TASK-2327-node-results-envelope-unwrap.md
@@ -240,10 +240,46 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
+**Completed by**: sdd-worker (Claude Opus 5)
+**Date**: 2026-08-24
 **Notes**:
 
-**Deviations from spec**: none | describe if any
+Module 2 landed as specified.
+
+- `FlowResult.node_results` gained one branch, placed **before** the generic
+  `hasattr(resp, "output")` check: `isinstance(resp, dict) and "output" in resp`
+  -> `resp["output"]`. A comment states why the check must be explicit (a dict
+  has no `.output` attribute, so envelopes previously fell through to `else`
+  and leaked the whole mapping). `None` -> `None`, `AgentResponse` -> `.output`,
+  and any other value -> itself are all unchanged, so the `agent_results`
+  alias inherits the fix for free. No mutation of `self.responses`.
+- Documented the `output` scalar-vs-dict contract in three places, as the task
+  listed: the `output` field docstring (the normative statement — single
+  executed leaf -> scalar, fan-out -> `dict[node_id, Any]`, nothing executed ->
+  `None`, plus a pointer to `node_results` for consumers that must not branch
+  on shape and an explicit "there is no plural `outputs` field"), and the
+  `content` / `final_result` property docstrings, which state they inherit that
+  contract verbatim.
+
+Tests: the 2 specified tests, in a new `TestNodeResultsEnvelope` class. They go
+slightly beyond the scaffold on the negative side: a dict-without-`"output"`
+(`{"other": 1}`) is asserted to pass through unchanged, the AC8 property is
+asserted directly (no value in `node_results` is an envelope dict), and the
+read-only-projection guarantee is asserted (`responses` still holds the full
+envelope afterwards).
+
+Verification:
+- `test_flow_primitives/test_result.py`: 41 passed (+2).
+- Crew regression suites: 32 passed, unchanged.
+- `tests/bots/flows/` + `tests/test_flow_primitives/`: 709 passed
+  (699 clean-`dev` baseline + 8 from TASK-2326 + 2 here).
+- `ruff`: byte-for-byte the same finding set as before this task (the file's
+  56 pre-existing defaults-only findings + the 3 `UP045` from TASK-2326); this
+  task introduced none. `mypy`: the same 2 pre-existing errors (lines 36, 666),
+  no new ones.
+
+**Deviations from spec**: none. In particular `FlowResult.responses` still
+stores raw envelopes for AgentsFlow (spec §8 open question — status quo kept
+deliberately; unwrapping on read in `node_results` is what makes it acceptable,
+and changing the stored contents would be a breaking change to an existing
+field).

--- a/sdd/tasks/completed/TASK-2328-aggregate-result-fidelity.md
+++ b/sdd/tasks/completed/TASK-2328-aggregate-result-fidelity.md
@@ -382,12 +382,85 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
+**Completed by**: sdd-worker (Claude Opus 5)
+**Date**: 2026-08-24
 **Notes**:
 
-**`total_time` consumer audit**: (findings from the grep required in Gotchas)
+Module 3 landed as specified. `_aggregate_result` now has three keyword-only
+defaulted parameters (`ctx`, `run_started_at`, `skipped`) after the existing
+`edges`/`durations` positionals, so every pre-change call site still type-checks
+and still works.
 
-**Deviations from spec**: none | describe if any
+- **Ordering (G3)**: `terminal = completed | failed` is materialised once, then
+  walked in `ctx.completion_order` order (de-duplicated), with the residue
+  `terminal - seen` appended `sorted()`. Without a `ctx` the whole set is
+  `sorted()` rather than iterated — as the task asked, determinism is now
+  unconditional, not merely available.
+- **`total_time` (G2)**: `max(0.0, asyncio.get_running_loop().time() -
+  run_started_at)`, i.e. the *same* monotonic clock the scheduler reads at
+  `run_started_at`. A direct synchronous call (no running loop) logs at debug
+  via `self.logger` and leaves `0.0` instead of splicing in a foreign epoch.
+- **`execution_log`**: built in the same loop as `node_infos`, from the
+  `NodeExecutionInfo` just constructed, so the two lists are guaranteed
+  index-aligned and same-ordered. Exactly the five documented keys.
+- **`metadata`**: all six keys. `skipped` is `sorted()` (determinism);
+  `leaves` is the node_ids that actually produced `output` — `[leaf]` in the
+  single-leaf branch, `list(output_map)` in the fan-out branch — captured by a
+  new `output_leaves` variable that does not touch the existing leaf-detection
+  or `output` computation.
+- **`mode`**: resolved `"explicit"` / `"definition"` / `"legacy"` from
+  `edges is not None` / `self._definition is not None` / else. Per the spec's
+  open question I defaulted to the internal flow vocabulary, and the docstring
+  states explicitly that this is a DIFFERENT axis from AgentCrew's
+  `metadata['mode']` (`'sequential'`/`'parallel'`/`'loop'`), so nobody reads
+  them as comparable.
+- **Docstring**: the output shape contract verbatim, plus the three timing
+  caveats the task required (scheduler `durations` vs. the node envelope's own
+  `execution_time`; retries overwrite `durations[nid]` so the figure is the
+  LAST attempt; on a resumed run `total_time` covers the resumed segment only)
+  and the note that `summary` stays empty by design.
+
+Untouched, as required: the `output=resp` argument, leaf detection, the
+`output` computation, `NodeExecutionInfo.execution_time`'s source, and the
+class's inheritance (no `SynthesisMixin`). No `NodeExecutionInfo` is emitted
+for skipped nodes.
+
+Tests: 8 added to `tests/bots/flows/test_scheduler.py` — the 7 named plus
+`test_aggregate_result_node_order_is_deterministic` (asserts the no-`ctx` path
+sorts and that repeated aggregation over a differently-ordered input set is
+stable). `test_scheduler.py`: 23 passed (15 pre-existing + 8).
+
+**AC7 determinism proof**: the ordering/output tests were run under
+`PYTHONHASHSEED` = 0, 1, 42 and 12345 — 7 passed at every seed, so the order
+is provably independent of string-hash randomisation, not just incidentally
+stable.
+
+Verification:
+- `tests/bots/flows/` + `tests/test_flow_primitives/`: 718 passed
+  (699 clean-`dev` baseline + 8 + 2 + 8 + the pre-existing count; no failures).
+- `ruff` on `flow/flow.py`: 133 pre-existing findings -> 136, the delta being
+  exactly 3 `UP045` from the three new `Optional[...]` parameter annotations,
+  which match the file's 43 existing `Optional` annotations (the repo declares
+  no `[tool.ruff]` config, so these are defaults-only findings that predate
+  this feature). `test_scheduler.py` went 6 -> 5 findings: my use of
+  `pytest.approx` retired a pre-existing `F401` unused-`pytest` import.
+- `mypy` on `flow/flow.py`: 28 errors before, 28 after, the two sets identical
+  once line numbers are normalised — no new type errors.
+
+**`total_time` consumer audit** (the grep the Gotchas required, to rule out
+double-counting when `total_time` stops being `0.0`): **no consumer works
+around `total_time == 0.0`.**
+- `parrot/flows/` (dev_flow, dev_loop runners) and `parrot/handlers/`: zero
+  references to `total_time` / `total_execution_time` at all.
+- The only place that *sums* per-node `execution_time` is
+  `crew/crew.py:3381` (`total_time = sum(log['execution_time'] for log in
+  self.execution_log)`) — that is AgentCrew computing its OWN `total_time`
+  from its own `execution_log`, an input to a `FlowResult`, not a consumer
+  compensating for AgentsFlow's zero. It is untouched by this feature.
+- Remaining references are pure pass-throughs that now simply carry a real
+  number: `core/result.py` (`total_execution_time` alias, `to_dict`),
+  `core/storage/document.py:102` (persistence), `crew/crew.py:3691`
+  (`last_crew_result.total_time`), and `models/crew.py` (the legacy
+  `CrewResult`). None of them add or scale the value.
+
+**Deviations from spec**: none.

--- a/sdd/tasks/completed/TASK-2329-run-flow-context-wiring.md
+++ b/sdd/tasks/completed/TASK-2329-run-flow-context-wiring.md
@@ -261,12 +261,77 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
+**Completed by**: sdd-worker (Claude Opus 5)
+**Date**: 2026-08-24
 **Notes**:
 
-**Checkpoint round-trip**: (how `node_metadata` was serialised, and whether the snapshot path needed a change)
+Module 4 landed as three surgical edits inside `run_flow`, no refactor:
 
-**Deviations from spec**: none | describe if any
+1. The `_aggregate_result` call site now passes `ctx=ctx`,
+   `run_started_at=run_started_at`, `skipped=skipped`.
+2. `ctx.mark_completed(...)` now also passes `response=event.result` (the
+   envelope **verbatim**, not pre-unwrapped) and `metadata=<NodeExecutionInfo>`.
+3. `ctx.mark_failed(...)` likewise passes `metadata=<NodeExecutionInfo>` with
+   `status="failed"` and the error string.
+
+Note on (3): the task's scope said "store each node's built
+`NodeExecutionInfo` into `ctx.node_metadata`" without prescribing the
+mechanism. `mark_failed` **already** accepts an optional `metadata`
+parameter (`core/context.py:206-225`), exactly like `mark_completed`, so both
+writes go through the existing documented API — no direct
+`ctx.node_metadata[...] = ...` poking, and no signature change anywhere. This
+also means a failed node appears in `ctx.node_metadata` (marked `"failed"`)
+even though it is deliberately absent from `completion_order`.
+
+As the task required, the `NodeExecutionInfo` is built here *in addition to*
+`_aggregate_result` building its own; the two paths stay independent and
+`_aggregate_result` was NOT restructured to consume `ctx.node_metadata`.
+
+Tests: 4 added to `tests/bots/flows/test_agents_flow.py` — the 3 named plus
+`test_flow_context_metadata_for_failed_node` (covers the `mark_failed` metadata
+path and the completion_order-residue interaction). A new `UsageAgent` stub
+returns a REAL `AgentResponse`/`AIMessage`/`CompletionUsage`/`ToolCall` (a
+`MagicMock` would make the `usage.model_dump()` assertions vacuous) and exposes
+an `llm` so `NodeExecutionInfo.client` is exercised end-to-end. It needs
+`invoke()` as well as `ask()` — the `AgentLike` protocol is `runtime_checkable`
+and `AgentNode`'s pydantic validation rejects a stub without it.
+
+One test detail worth flagging: `test_flow_run_total_time_nonzero` runs the
+flow with a 15 ms per-agent delay. `FlowResult.__repr__` formats `total_time`
+with `:.2f`, so a sub-5ms stub run prints `time=0.00s` **even when
+`total_time > 0`** — the delay keeps the "no longer shows time=0.00s"
+assertion a genuine check instead of something rounding could defeat.
+
+**Checkpoint round-trip**: **no change to the snapshot path was needed, and
+`node_metadata` is not serialised by it.** Verified by reading
+`FlowContext.to_snapshot()` (`core/context.py:261-320`): it captures
+`initial_task`/`results`/`responses`/`completed_tasks`/`completion_order`/
+`shared_data`/`errors` and never touches `node_metadata`, so the declared
+`Dict[str, NodeExecutionInfo]` type is honoured as-is (no `to_dict()`
+downgrade required). The one path that *does* read it is
+`FlowCheckpointer._build_checkpoint`, which maps it to
+`NodeStateSnapshot(fsm_state=info.status)`; since `status` is a plain `str`
+literal this validates cleanly. Proved empirically with a probe that runs a
+real 2-node flow, builds a checkpoint from the resulting ctx, and does a full
+`model_dump_json()` -> `model_validate_json()` round trip:
+`node_metadata keys: ['a','b']`, `node_states: [('a','completed'),
+('b','completed')]`, round trip OK at 1600 JSON bytes. Net effect: checkpoints
+now carry real per-node FSM states where the list used to be **empty**.
+
+Verification:
+- `tests/bots/flows/test_agents_flow.py`: 18 passed (14 pre-existing + 4).
+- `tests/bots/flows/` + `tests/test_flow_primitives/`: 722 passed.
+- `tests/flows/checkpoint/`: 70 passed, 2 skipped, 2 failed — the 2 failures
+  are `test_durable_store.py`'s Postgres tests failing on
+  `password authentication failed for user "postgres"`, and the identical
+  result (2 failed / 70 passed / 2 skipped) is reproduced on clean `dev` in
+  the main checkout. Environmental, not caused by this task.
+  `test_flow_export.py` (the snapshot round-trip) is green.
+- Crew regression suites: 32 passed, unchanged.
+- `ruff` on `flow/flow.py` and `test_agents_flow.py`: finding sets **byte-for-
+  byte identical** to before this task (zero new findings). `mypy` on
+  `flow/flow.py`: 28 errors before, 28 after, identical set.
+
+**Deviations from spec**: none. `FlowResult.responses` still holds raw
+envelopes (spec §8 open question left at status quo, as this task's scope
+directed).

--- a/sdd/tasks/completed/TASK-2330-crew-flow-parity-test.md
+++ b/sdd/tasks/completed/TASK-2330-crew-flow-parity-test.md
@@ -252,12 +252,82 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
+**Completed by**: sdd-worker (Claude Opus 5)
+**Date**: 2026-08-24
 **Notes**:
 
-**Parity findings**: (any field that diverged and which upstream task owns the fix)
+Created `packages/ai-parrot/tests/bots/flows/test_result_fidelity.py` — tests
+only, zero production-code changes. 5 tests, all passing.
 
-**Deviations from spec**: none | describe if any
+- `PARITY_EXEMPT_FIELDS = frozenset({"summary"})` with the full rationale in a
+  comment (AgentsFlow inherits only `PersistenceMixin` by design; synthesis is
+  opt-in via `synthesize_results`), and `test_parity_exemptions_are_explicit`
+  pins it to exactly `{"summary"}` *and* asserts every exempt name is a real
+  `FlowResult` field, so a typo can never silently exempt nothing.
+- `_populated_fields()` compares each dataclass field against its declared
+  default (handling `default`, `default_factory`, and `output`'s no-default
+  case) and the two executors' populated-field sets must match modulo the
+  exemption. Values are NOT compared, per scope — except where they legitimately
+  must agree because they come from the shared agent stub rather than the
+  orchestration (`model`, `provider`, `usage["total_tokens"]`, `tool_calls[0]`,
+  `client`, `status`).
+- `_describe_divergence()` gives the failure message teeth: it prints both
+  populated sets, then names the diverging fields *with direction* — "ONLY the
+  crew populates [...] — AgentsFlow regressed (see TASK-2328/2329)" vs. "ONLY
+  the flow populates [...] — the crew regressed, or a new field needs a
+  documented exemption" — plus the exemption list.
+- A single `ParityAgent` stub is driven through BOTH executors unmodified. It
+  returns a real `AgentResponse`/`AIMessage`/`CompletionUsage`/`ToolCall` (a
+  `MagicMock` would make the `usage.model_dump()` assertions vacuous), exposes
+  `llm` so `client` is exercised, and satisfies both call conventions:
+  `AgentCrew._execute_agent` passes `question=/session_id=/user_id=/model=/
+  max_tokens=/use_conversation_history=`, `AgentNode.execute` passes
+  `question=/_trusted_source=`. It also needs `invoke()` (the `AgentLike`
+  protocol is `runtime_checkable` and `AgentNode` validates against it) and the
+  four `EVENT_*` class constants that `AgentCrew` registers listeners against —
+  the same surface `tests/_crew_test_helpers.DummyAgent` exposes.
+- Two tests beyond the 3 specified: `test_node_results_parity` (neither
+  executor may leak an envelope through `node_results`, and `agent_results`
+  must agree) and `test_flow_summary_stays_empty` (proves the exemption is real
+  and asserts `SynthesisMixin` is absent from `AgentsFlow.__mro__`, so the
+  Non-Goal cannot be violated silently).
+- The AC-level "existing suites unchanged" check is documented as a runnable
+  command in the module docstring rather than implemented as a test that shells
+  out to pytest, exactly as the scope directed.
+
+**Falsification (this matters — the test was vacuous on first write)**: I
+verified the guard actually bites by temporarily restoring the pre-FEAT-447
+`core/result.py` and `flow/flow.py` in the worktree (`git checkout 20d58fc71 --
+<the two files>`) and re-running the suite: **3 failed / 2 passed**, with
+`crew-only: ['execution_log', 'metadata', 'total_time']` and every flow node
+reporting `usage=None`. Restoring the fixed sources returns it to 5 passed. So
+the parity assertions genuinely detect the regression this feature fixes rather
+than passing by construction.
+
+An important environment finding surfaced during that check:
+`packages/ai-parrot/conftest.py` already prepends the *worktree's*
+`packages/ai-parrot/src` to `sys.path` at collection time, so pytest run from
+this worktree always exercises worktree code — no `PYTHONPATH` needed. Setting
+`PYTHONPATH` **as well** duplicates the path entry and is what produced the 9
+spurious `ContextSnapshot` model-identity failures I noted in TASK-2326's
+completion note when the checkpoint suite ran in the same process as the flow
+suites. (The 9 combined-run failures also reproduce on clean `dev`, so they are
+pre-existing regardless; but the correct local invocation is without
+`PYTHONPATH`.)
+
+**Parity findings**: **none — no field diverged.** With TASK-2326/2327/2328/
+2329 landed, `AgentsFlow` and `AgentCrew` populate identical `FlowResult` field
+sets (`output`, `responses`, `nodes`, `execution_log`, `total_time`,
+`metadata`) and identical `NodeExecutionInfo` field coverage (`model`,
+`provider`, `usage`, `tool_calls`, `client`, `execution_time`, `status`).
+No upstream task needs a fix.
+
+Verification:
+- `test_result_fidelity.py`: 5 passed.
+- `tests/bots/flows/` + `tests/test_flow_primitives/`: 727 passed.
+- Crew regression suites (AC13): 32 passed, unchanged.
+- `ruff check` on the new file: **clean** (0 findings — this is a new file, so
+  unlike the pre-existing modules there was no inherited baseline to respect;
+  the initial unused-`pytest` import and import-block ordering were fixed).
+
+**Deviations from spec**: none.

--- a/sdd/tasks/completed/TASK-2331-docs-flowresult-contract.md
+++ b/sdd/tasks/completed/TASK-2331-docs-flowresult-contract.md
@@ -201,12 +201,81 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
+**Completed by**: sdd-worker (Claude Opus 5)
+**Date**: 2026-08-24
 **Notes**:
 
-**`metadata["mode"]` vocabulary as shipped**: (what TASK-2328 actually chose)
+Documentation only — `git diff --name-only` showed exactly one file,
+`docs/architecture/07-agentcrew.md`. No production code or test touched.
 
-**Deviations from spec**: none | describe if any
+Added **§7.4.1 "The `FlowResult` fidelity contract"** (~7.4 KB) directly under
+the existing §7.4 "Result aggregation, synthesis and persistence", so it sits
+with the other result-lifecycle material and before §7.5. Written against the
+*shipped* code, not the spec draft. Contents:
+
+- A 9-row field table (field / meaning / crew / flow / notes) covering every
+  `FlowResult` field, plus a paragraph listing the `NodeExecutionInfo` fields
+  both executors populate, and a pointer to
+  `tests/bots/flows/test_result_fidelity.py` + its `PARITY_EXEMPT_FIELDS` as
+  the enforcement mechanism.
+- **The `summary` exemption**, with the actual reason (`AgentCrew` mixes in
+  `SynthesisMixin`; `AgentsFlow` inherits only `PersistenceMixin`) and *why*
+  that is a sane default rather than a defect, plus BOTH opt-in routes: the
+  standalone `synthesize_results` util and an explicit `SynthesisNode` in the
+  graph.
+- **The `output` shape rule** with a worked example of each case (single leaf
+  -> scalar; fan-out -> `dict[node_id, Any]`; nothing executed -> `None`),
+  each showing the matching `metadata["leaves"]`. It states the leaf
+  definition and notes that explicit mode's leaf detection is skip-aware and
+  falls back to the terminal nodes of the path actually taken. It also records
+  that `content`/`final_result` inherit the rule and that there is deliberately
+  no plural `outputs` field.
+- **`responses` vs `node_results`** as its own subsection, since this is the
+  easiest thing to get wrong: `responses` is executor-dependent
+  (`AgentResponse` for crew, the `AgentNode.execute()` envelope for flow),
+  while `node_results`/`agent_results` is the shape-stable read that always
+  yields `dict[node_id, scalar]` and never an envelope.
+- The AgentsFlow `metadata` keys and the `execution_log` entry shape as code
+  blocks, transcribed from the shipped dict literals.
+- An "Ordering and timing caveats" subsection: deterministic `nodes` ordering
+  (completion order, failures appended sorted, no hash-order dependence), the
+  scheduler-`durations` vs node-envelope `execution_time` distinction, the
+  retry/last-attempt behaviour, and the resumed-run `total_time` caveat.
+- A closing note that `ctx.responses` / `ctx.node_metadata` now carry the same
+  fidelity as the `FlowResult`, which is what makes a checkpointed/resumed
+  context as informative as the result.
+
+Per the scope I documented the **contract, not the mechanism** — neither
+`_unwrap_response` nor `_aggregate_result`'s new parameters are mentioned;
+they are private.
+
+**Verification of every code reference in the new prose** (re-grepped against
+post-implementation source, not transcribed from the task):
+- `class FlowResult` — `core/result.py:353` ✓
+- `NodeExecutionInfo.status` closed literal
+  `["completed","failed","pending","running"]` — `core/result.py:298` ✓ (so
+  the "skipped nodes get no NodeExecutionInfo" claim holds)
+- `class AgentsFlow(PersistenceMixin)` — `flow/flow.py:217` ✓ (no
+  `SynthesisMixin`)
+- `class AgentCrew(PersistenceMixin, SynthesisMixin)` — `crew/crew.py:106` ✓
+- `synthesize_results` — `core/storage/synthesis.py:139` ✓
+- `SynthesisNode` — `flow/flow.py:2271`, exported from `flow/__init__.py` ✓
+  (it is NOT in `flow/nodes.py`, where I first looked)
+- `agent_results` alias — `core/result.py:542` ✓
+- metadata dict literal — `flow/flow.py:1157-1164` ✓
+- execution_log entry literal — `flow/flow.py:1063-1067` ✓
+- crew `metadata['mode']` values `'sequential'`/`'parallel'`/`'flow'`/`'loop'`
+  — `crew/crew.py:1377,1840,2207,…` ✓
+
+**`metadata["mode"]` vocabulary as shipped**: TASK-2328 shipped the **internal
+flow vocabulary** — `"explicit"` (from `add_node()`/`add_edge()`),
+`"definition"` (from a `FlowDefinition`), `"legacy"` (programmatic nodes with
+their own `successors`), resolved by `edges is not None` /
+`self._definition is not None` / else at `flow/flow.py:1150-1155`. This matches
+the spec's stated default for that open question. The docs make the divergence
+from `AgentCrew`'s `metadata["mode"]` explicit — crew records the *execution
+strategy* (`'sequential'`/`'parallel'`/`'flow'`/`'loop'`), flow records *how
+the graph was declared* — and warn the reader not to switch on the key without
+knowing which executor produced the result.
+
+**Deviations from spec**: none.

--- a/sdd/tasks/index/agentsflow-result-fidelity.json
+++ b/sdd/tasks/index/agentsflow-result-fidelity.json
@@ -5,7 +5,7 @@
   "type": "feature",
   "base_branch": "dev",
   "created_at": "2026-08-22T00:57:00.481030+00:00",
-  "completed_at": null,
+  "completed_at": "2026-08-24T09:52:52+00:00",
   "tasks": [
     {
       "id": "TASK-2326",
@@ -23,7 +23,8 @@
       "assigned_to": null,
       "started_at": "2026-08-23T23:10:15+00:00",
       "completed_at": "2026-08-23T23:48:01+00:00",
-      "file": "sdd/tasks/completed/TASK-2326-shared-unwrap-response.md"
+      "file": "sdd/tasks/completed/TASK-2326-shared-unwrap-response.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2327",
@@ -41,7 +42,8 @@
       "assigned_to": null,
       "started_at": "2026-08-23T23:10:15+00:00",
       "completed_at": "2026-08-23T23:53:07+00:00",
-      "file": "sdd/tasks/completed/TASK-2327-node-results-envelope-unwrap.md"
+      "file": "sdd/tasks/completed/TASK-2327-node-results-envelope-unwrap.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2328",
@@ -61,7 +63,8 @@
       "assigned_to": null,
       "started_at": "2026-08-23T23:10:15+00:00",
       "completed_at": "2026-08-24T00:01:14+00:00",
-      "file": "sdd/tasks/completed/TASK-2328-aggregate-result-fidelity.md"
+      "file": "sdd/tasks/completed/TASK-2328-aggregate-result-fidelity.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2329",
@@ -81,7 +84,8 @@
       "assigned_to": null,
       "started_at": "2026-08-23T23:10:15+00:00",
       "completed_at": "2026-08-24T00:08:44+00:00",
-      "file": "sdd/tasks/completed/TASK-2329-run-flow-context-wiring.md"
+      "file": "sdd/tasks/completed/TASK-2329-run-flow-context-wiring.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2330",
@@ -104,7 +108,8 @@
       "assigned_to": null,
       "started_at": "2026-08-23T23:10:15+00:00",
       "completed_at": "2026-08-24T00:36:33+00:00",
-      "file": "sdd/tasks/completed/TASK-2330-crew-flow-parity-test.md"
+      "file": "sdd/tasks/completed/TASK-2330-crew-flow-parity-test.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2331",
@@ -125,7 +130,8 @@
       "assigned_to": null,
       "started_at": "2026-08-23T23:10:15+00:00",
       "completed_at": "2026-08-24T00:38:25+00:00",
-      "file": "sdd/tasks/completed/TASK-2331-docs-flowresult-contract.md"
+      "file": "sdd/tasks/completed/TASK-2331-docs-flowresult-contract.md",
+      "verification": "verified"
     }
   ]
 }

--- a/sdd/tasks/index/agentsflow-result-fidelity.json
+++ b/sdd/tasks/index/agentsflow-result-fidelity.json
@@ -50,7 +50,7 @@
       "feature_id": "FEAT-447",
       "feature": "agentsflow-result-fidelity",
       "spec": "sdd/specs/agentsflow-result-fidelity.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "depends_on": [
@@ -60,8 +60,8 @@
       "parallelism_notes": "Depends on TASK-2326: only after the shared helper unwraps envelopes does the metadata this method builds actually carry usage/tool_calls. Edits flow/flow.py, shared with TASK-2329.",
       "assigned_to": null,
       "started_at": "2026-08-23T23:10:15+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2328-aggregate-result-fidelity.md"
+      "completed_at": "2026-08-24T00:01:14+00:00",
+      "file": "sdd/tasks/completed/TASK-2328-aggregate-result-fidelity.md"
     },
     {
       "id": "TASK-2329",

--- a/sdd/tasks/index/agentsflow-result-fidelity.json
+++ b/sdd/tasks/index/agentsflow-result-fidelity.json
@@ -32,7 +32,7 @@
       "feature_id": "FEAT-447",
       "feature": "agentsflow-result-fidelity",
       "spec": "sdd/specs/agentsflow-result-fidelity.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "S",
       "depends_on": [],
@@ -40,8 +40,8 @@
       "parallelism_notes": "Logically independent of TASK-2326 (different method, no shared logic) but edits the SAME file, core/result.py, so it cannot run in a parallel worktree. Sequence it after 2326 to avoid conflicting hunks.",
       "assigned_to": null,
       "started_at": "2026-08-23T23:10:15+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2327-node-results-envelope-unwrap.md"
+      "completed_at": "2026-08-23T23:53:07+00:00",
+      "file": "sdd/tasks/completed/TASK-2327-node-results-envelope-unwrap.md"
     },
     {
       "id": "TASK-2328",

--- a/sdd/tasks/index/agentsflow-result-fidelity.json
+++ b/sdd/tasks/index/agentsflow-result-fidelity.json
@@ -113,7 +113,7 @@
       "feature_id": "FEAT-447",
       "feature": "agentsflow-result-fidelity",
       "spec": "sdd/specs/agentsflow-result-fidelity.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "low",
       "effort": "S",
       "depends_on": [
@@ -124,8 +124,8 @@
       "parallelism_notes": "The ONLY parallelizable task in FEAT-447: touches docs/architecture/ 07-agentcrew.md exclusively, sharing no file with any other task. Can run in a separate worktree concurrently with TASK-2330 once 2328/2329 land.",
       "assigned_to": null,
       "started_at": "2026-08-23T23:10:15+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2331-docs-flowresult-contract.md"
+      "completed_at": "2026-08-24T00:38:25+00:00",
+      "file": "sdd/tasks/completed/TASK-2331-docs-flowresult-contract.md"
     }
   ]
 }

--- a/sdd/tasks/index/agentsflow-result-fidelity.json
+++ b/sdd/tasks/index/agentsflow-result-fidelity.json
@@ -14,7 +14,7 @@
       "feature_id": "FEAT-447",
       "feature": "agentsflow-result-fidelity",
       "spec": "sdd/specs/agentsflow-result-fidelity.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [],
@@ -22,8 +22,8 @@
       "parallelism_notes": "Edits core/result.py, the shared metadata seam used by BOTH executors (5 crew call sites + flow + decision nodes). Must land FIRST and ALONE, gated on the crew regression suites — it is the only change in FEAT-447 that can silently break AgentCrew.",
       "assigned_to": null,
       "started_at": "2026-08-23T23:10:15+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2326-shared-unwrap-response.md"
+      "completed_at": "2026-08-23T23:48:01+00:00",
+      "file": "sdd/tasks/completed/TASK-2326-shared-unwrap-response.md"
     },
     {
       "id": "TASK-2327",

--- a/sdd/tasks/index/agentsflow-result-fidelity.json
+++ b/sdd/tasks/index/agentsflow-result-fidelity.json
@@ -70,7 +70,7 @@
       "feature_id": "FEAT-447",
       "feature": "agentsflow-result-fidelity",
       "spec": "sdd/specs/agentsflow-result-fidelity.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -80,8 +80,8 @@
       "parallelism_notes": "Edits the same file and the adjacent call sites as TASK-2328 (flow/flow.py:1881 and :1926). Strictly sequential — parallel execution would conflict on every hunk.",
       "assigned_to": null,
       "started_at": "2026-08-23T23:10:15+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2329-run-flow-context-wiring.md"
+      "completed_at": "2026-08-24T00:08:44+00:00",
+      "file": "sdd/tasks/completed/TASK-2329-run-flow-context-wiring.md"
     },
     {
       "id": "TASK-2330",

--- a/sdd/tasks/index/agentsflow-result-fidelity.json
+++ b/sdd/tasks/index/agentsflow-result-fidelity.json
@@ -90,7 +90,7 @@
       "feature_id": "FEAT-447",
       "feature": "agentsflow-result-fidelity",
       "spec": "sdd/specs/agentsflow-result-fidelity.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "M",
       "depends_on": [
@@ -103,8 +103,8 @@
       "parallelism_notes": "Asserts the end state of all four implementation tasks, so it can only run once they are all complete. New file, no edit conflicts, but the dependency is total.",
       "assigned_to": null,
       "started_at": "2026-08-23T23:10:15+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2330-crew-flow-parity-test.md"
+      "completed_at": "2026-08-24T00:36:33+00:00",
+      "file": "sdd/tasks/completed/TASK-2330-crew-flow-parity-test.md"
     },
     {
       "id": "TASK-2331",


### PR DESCRIPTION
## Summary

`AgentCrew` and `AgentsFlow` both return the same public `FlowResult`
contract, but only the crew populated it faithfully. This makes `AgentsFlow`
match it, fixing at the **shared seam** so the two executors cannot drift
apart again.

Five verified fidelity losses, all closed:

1. **Per-node LLM metadata was lost.** `AgentNode.execute()` returns an
   *envelope dict*, which `build_node_metadata` did not understand, so every
   node of every flow run reported `usage is None` / `tool_calls == []`.
2. **Run-level fields stayed at their defaults** — `total_time == 0.0`,
   `execution_log == []`, `metadata == {}`, even though the scheduler already
   measured all of it (`repr()` always printed `time=0.00s`).
3. **`FlowResult.nodes` ordering was nondeterministic** (iterated a set union,
   so order varied with string hashing across processes).
4. **`node_results` returned envelopes instead of scalar outputs.**
5. **`NodeExecutionInfo.client` was dead** — declared and serialised, never assigned.

## Tasks

6/6 verified.

| Task | Change |
|---|---|
| TASK-2326 | Shared `_unwrap_response()` (recursion-bounded, never raises) called by `build_node_metadata`; populate `client` |
| TASK-2327 | Envelope-aware `FlowResult.node_results`; `output` shape contract docstrings |
| TASK-2328 | Faithful `_aggregate_result` — deterministic ordering, `total_time`, `execution_log`, `metadata` |
| TASK-2329 | Wire `run_flow` to the aggregator; fill `ctx.responses` / `ctx.node_metadata` |
| TASK-2330 | Crew/flow `FlowResult` parity contract test (the anti-drift guard) |
| TASK-2331 | `docs/architecture/07-agentcrew.md` §7.4.1 — the contract, made public |

## Design notes

- **Strictly additive.** Production diff is +293/−11 before formatting. No
  `FlowResult`/`NodeExecutionInfo` field added, removed or retyped; the three
  new `_aggregate_result` parameters are keyword-only and defaulted, and the
  pre-change positional call still works (asserted by
  `test_aggregate_result_backward_compatible_call`).
- **Non-goals respected**: no `SynthesisMixin` on `AgentsFlow` (`summary`
  stays `""` by design), no plural `outputs` field, no `AgentCrew` refactor,
  no `"skipped"` status literal, `execution_time` still sourced from the
  scheduler's `durations`, and the `output=` argument to
  `build_node_metadata` is deliberately left un-unwrapped.
- `metadata["mode"]` uses the flow's own vocabulary (`explicit`/`definition`/
  `legacy`) — a *different axis* from crew's `sequential`/`parallel`/`loop`.
  Documented so nobody switches on the key without knowing the producer.

## Testing

- `tests/bots/flows/`: **494 passed** · `tests/test_flow_primitives/`: **234 passed**
- Crew regression suites (the silent-regression risk): **32 passed**, unchanged
- New parity suite `test_result_fidelity.py`: **5 passed**
- Ordering determinism proven under 4 different `PYTHONHASHSEED` values
- Checkpoint round-trip re-verified with non-empty `ctx.node_metadata`
  (checkpoints now carry real per-node FSM states where the list used to be empty)
- `mypy`: error set byte-identical to `dev` (zero new errors)

The parity test was **falsified before being trusted**: run against the
pre-FEAT-447 sources it fails 3/5 with `crew-only: ['execution_log',
'metadata', 'total_time']` and every node reporting `usage=None`. It detects
the regression rather than passing by construction.

## Reviewer notes (not blocking)

- **`output` is `{}`, not `None`, when no leaf executed** (empty graph, or all
  leaves failed/skipped). Byte-identical to `dev` and out of scope to change —
  normalising it would break an existing field's contract. Review caught the
  docs claiming `None`; corrected in `645052b83` and pinned by
  `test_output_no_executed_leaf_is_empty_dict`. Use `status` /
  `metadata["leaves"]`, not `output`'s truthiness, to detect "produced nothing".
- **Latent edge case, pre-existing and untouched**: a non-`Exception`
  `BaseException` (e.g. `CancelledError`) skips `ctx.mark_failed`, so such a
  node lands in `FlowResult.errors` but not `ctx.node_metadata`. Fixing it
  would mean fabricating an exception type; flagged rather than patched.
- **Cyclic repair-loop ordering**: a node re-run via the FEAT-377 cyclic path
  keeps its *first* position in `completion_order` while its metadata reflects
  the latest attempt. `max_retries` retries are handled correctly.
- `build_node_metadata` runs twice per node (once for `ctx.node_metadata`,
  once in `_aggregate_result`) — deliberate, keeps the two paths independent.
- **Two pre-existing failures, reproduced identically on clean `dev`**:
  `flows/checkpoint/test_durable_store.py` Postgres tests fail on
  `password authentication failed`, and running `bots/flows/` +
  `test_flow_primitives/` + `flows/checkpoint/` in *one* process yields 9
  `ContextSnapshot` model-identity failures (cross-suite import pollution).
  Each suite is green in isolation. Worth fixing separately — it makes the
  spec's own AC14 single-command form misleading.
- This branch also carries a **`black` formatting commit** (`e9ce657bd`) that
  restyles the touched files beyond the feature's own lines. All suites were
  re-run after it. Review the behavioural commits (`57781ded3`..`645052b83`)
  separately from that one for an easier read.

---
_Closed by /sdd-done_