### PR TITLE
fix(security): unblock CodeQL pipeline and close the last real alert

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,13 @@ jobs:
         with:
           version: "latest"
 
-      - name: Install all packages
+      # Best-effort only. CodeQL's Python extractor works without installed
+      # dependencies (it just loses some import-resolution precision), and a
+      # monorepo-wide resolution failure must never blind security scanning
+      # again -- an unsatisfiable `uv sync` kept CodeQL dark from 2026-08-21
+      # onward while the alert list silently went stale.
+      - name: Install all packages (best-effort)
+        continue-on-error: true
         run: uv sync --all-packages
 
       - name: Initialize CodeQL

--- a/packages/ai-parrot/src/parrot/handlers/spatial_filter_handler.py
+++ b/packages/ai-parrot/src/parrot/handlers/spatial_filter_handler.py
@@ -372,7 +372,8 @@ class SpatialFilterHandler:
         try:
             req = DirectSpatialRequest(**body)
         except Exception as exc:
-            return await self._json_response({"error": f"Invalid request: {exc}"}, status=422)
+            self.logger.warning("SpatialFilterHandler: invalid direct request: %s", exc)
+            return await self._json_response({"error": "Invalid request parameters"}, status=422)
 
         try:
             spec = SpatialFilterSpec(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,6 +176,15 @@ conflicts = [
         { package = "ai-parrot", extra = "observability-openlit" },
         { package = "ai-parrot-workspace", group = "dev" },
     ],
+    [
+        # flowtask 5.12.3 pins azure-identity==1.20.0, while async-notify[all]
+        # (pulled by all-fast) needs azure-identity>=1.23.0. Unbounded
+        # requires-python (>=3.11) makes uv explore a python>=3.14 split where
+        # both are required at once, so an uncached `uv sync --all-packages`
+        # is unsatisfiable and every CI/CodeQL run fails at install.
+        { package = "ai-parrot", extra = "all-fast" },
+        { package = "ai-parrot", extra = "flowtask" },
+    ],
     # flowtask/psutil vs liveavatar-voice — RESOLVED (flowtask 5.12.1).
     # openlit vs liveavatar-voice otel — RESOLVED via override-dependencies:
     # livekit-agents 1.6.1 pins otel~=1.39.0 (<1.40), but otel 1.39→1.42 is

--- a/scripts/dismiss_codeql_false_positives.sh
+++ b/scripts/dismiss_codeql_false_positives.sh
@@ -28,7 +28,19 @@ CLEARTEXT_LOG=(142 159)
 # generate_keys.py (L133), google/tools.py (L1302), databasequery/tool.py (L831)
 CLEARTEXT_STORE=(67 68 138)
 
-ALL_ALERTS=("${PATH_INJECTION[@]}" "${SQL_INJECTION[@]}" "${CLEARTEXT_LOG[@]}" "${CLEARTEXT_STORE[@]}")
+# --- URL redirection: redirect_uri checked against client.redirect_uris allowlist ---
+# mcp/oauth_server.py (L502, L671) — exact-membership check returns 400 before use
+URL_REDIRECTION=(122 123)
+
+# --- Overly-large-range: deliberate Unicode emoji block U+2600-U+27BF ---
+# voice/tts/supertonic_inference.py (L132)
+LARGE_RANGE=(162 163)
+
+# --- Stack-trace exposure: callers pass controlled message strings, never exceptions ---
+# handlers/openai_compat.py (L175)
+STACK_TRACE=(107)
+
+ALL_ALERTS=("${PATH_INJECTION[@]}" "${SQL_INJECTION[@]}" "${CLEARTEXT_LOG[@]}" "${CLEARTEXT_STORE[@]}" "${URL_REDIRECTION[@]}" "${LARGE_RANGE[@]}" "${STACK_TRACE[@]}")
 
 SUCCESS=0
 FAIL=0
@@ -36,14 +48,14 @@ for alert_num in "${ALL_ALERTS[@]}"; do
   if gh api -X PATCH \
     "repos/${REPO}/code-scanning/alerts/${alert_num}" \
     -f state=dismissed \
-    -f dismissed_reason=false-positive \
+    -f dismissed_reason="false positive" \
     -f dismissed_comment="${COMMENT}" \
     --silent 2>/dev/null; then
     echo "✅ Dismissed alert #${alert_num}"
-    ((SUCCESS++))
+    SUCCESS=$((SUCCESS + 1))
   else
     echo "❌ Failed alert #${alert_num}"
-    ((FAIL++))
+    FAIL=$((FAIL + 1))
   fi
 done
 


### PR DESCRIPTION
CodeQL had been failing on every run since 2026-08-21, so the alert list on GitHub was a frozen snapshot of commit 875e9c4ea (2026-08-20, 95 results). The paths-ignore config added in fbc8f85d6 never once ran, and the remediation commits were never re-verified.

Root cause: `uv sync --all-packages` is unsatisfiable from a cold cache. flowtask 5.12.3 pins azure-identity==1.20.0 while async-notify[all] (via all-fast) needs >=1.23.0; unbounded requires-python (>=3.11) makes uv explore a python>=3.14 split requiring both at once. uv.lock is gitignored, so CI resolves from scratch and hits it every time. This also broke CI — Monorepo (6 consecutive failures).

- pyproject.toml: declare all-fast x flowtask as a conflicting extra pair, matching the 12 pairs already in the table.
- codeql-analysis.yml: make the install step best-effort. The Python extractor does not need installed dependencies, and security scanning must never again go dark because dependency resolution broke.
- spatial_filter_handler.py: the direct path leaked raw exception text to clients via f"Invalid request: {exc}" (alert #109) — the only genuine unfixed defect among the 95 open alerts. Now logs the detail server-side and returns a generic 422, matching the NL path at :441.
- dismiss_codeql_false_positives.sh: fix three bugs that made the script a no-op — dismissed_reason must be "false positive" (with a space), not "false-positive"; and ((VAR++)) returns exit status 1 when VAR is 0, aborting the script under `set -e` on the first success. Also extend it to the 5 production false positives verified this round (#122/#123 allowlisted redirect_uri, #162/#163 deliberate emoji range, #107 controlled error messages).

Note: inline suppression comments do not work in GitHub code scanning. The last scan included the `# lgtm[...]` comments from f2c34cb44 and those alerts stayed open — suppression must go through the API or paths-ignore. Existing comments are left as documentation only.

Verified: 8/8 spatial filter tests pass; ruff rule counts on the changed handler are identical before and after; 30 alerts dismissed via API (30 dismissed / 0 failed), leaving 65 open of which 62 are paths-ignore-excluded and 3 are code-fixed pending a re-scan. The dependency resolution fix could NOT be verified locally — uv lock OOM-kills at 62GB (7.9M resolver forks) and a dry-run sync exceeds 5 minutes. It needs a CI run to confirm.