### PR TITLE
fix(networkninja): a multi-photo question imports as MULTI_UPLOAD, not FILE with a flag

### DIFF
--- a/packages/parrot-formdesigner/CHANGELOG.md
+++ b/packages/parrot-formdesigner/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to `parrot-formdesigner` will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **NetworkNinja importer — multi-photo questions are `MULTI_UPLOAD`**:
+  `FIELD_IMAGE_UPLOAD_MULTIPLE` now imports as `FieldType.MULTI_UPLOAD`
+  (keeping `meta.accept = "image/*"`) instead of `FieldType.FILE` with a
+  `meta.multiple` flag. `FILE` is single-cardinality everywhere else in the
+  library (`is_single_cardinality`, the `/file-upload` handler, the
+  validator's list refusal), so the old spelling produced schemas the
+  library's own validator flagged on every real multi-photo answer.
+  Forms already imported keep working as they are stored; re-import (or a
+  registry-based patch) is what moves them to the new spelling.
+
 ### Added
 
 - **FEAT-456 — Relational Field Cardinality**: a new orthogonal

--- a/packages/parrot-formdesigner/src/parrot_formdesigner/tools/services/networkninja.py
+++ b/packages/parrot-formdesigner/src/parrot_formdesigner/tools/services/networkninja.py
@@ -266,9 +266,17 @@ _FIELD_TYPE_MAP: dict[str, tuple[FieldType, dict[str, Any]] | None] = {
         FieldType.GROUP,
         {"read_only": True, "meta": {"render_as": "subsection"}},
     ),
+    # A multi-photo question is MULTI_UPLOAD, not FILE-with-a-flag. FILE is
+    # single-cardinality everywhere else in the library (`is_single_cardinality`,
+    # the /file-upload handler rejects a second part, the validator refuses a
+    # list) so the old `FILE + meta.multiple` spelling produced schemas the
+    # library's own validator flagged on every real multi-photo answer.
+    # Measured on Epson's live form (2026-08-25): 65 such questions, 76/76
+    # upload fields consistent with networkninja.form_metadata — the
+    # cardinality was always right, only the spelling disagreed.
     "FIELD_IMAGE_UPLOAD_MULTIPLE": (
-        FieldType.FILE,
-        {"meta": {"accept": "image/*", "multiple": True}},
+        FieldType.MULTI_UPLOAD,
+        {"meta": {"accept": "image/*"}},
     ),
     "FIELD_DISPLAY_TEXT": (
         FieldType.TEXT,

--- a/packages/parrot-formdesigner/tests/unit/test_networkninja_importer.py
+++ b/packages/parrot-formdesigner/tests/unit/test_networkninja_importer.py
@@ -379,6 +379,7 @@ def test_networkninja_formula_dangling_reference():
     "data_type, expected_type",
     [
         ("FIELD_IMAGE_UPLOAD", FieldType.FILE),
+        ("FIELD_IMAGE_UPLOAD_MULTIPLE", FieldType.MULTI_UPLOAD),
         ("FIELD_AGREEMENT_CHECKBOX", FieldType.BOOLEAN),
         ("FIELD_DURATION", FieldType.TEXT),
         ("FIELD_DATETIME", FieldType.DATETIME),
@@ -1827,3 +1828,35 @@ async def test_store_group_alternatives_evaluate_for_either_answer_value():
             visit_context={"store_groups": ["Best Buy"]},
         )
         assert fired is False, f"answer={answer!r} must not fire at a non-matching store"
+
+
+# ---------------------------------------------------------------------------
+# Multi-photo questions are MULTI_UPLOAD, not FILE + meta.multiple
+# ---------------------------------------------------------------------------
+
+
+def test_multi_photo_question_is_multi_upload_not_file_with_a_flag():
+    """``FIELD_IMAGE_UPLOAD_MULTIPLE`` must import as ``MULTI_UPLOAD``.
+
+    FILE is single-cardinality across the library (``is_single_cardinality``,
+    the ``/file-upload`` handler, the validator's list refusal), so spelling
+    "many photos" as ``FILE + meta.multiple`` produced schemas the validator
+    flagged on every real multi-photo answer. The ``accept`` hint survives;
+    the ``multiple`` flag is gone because the TYPE now carries cardinality.
+    """
+    svc = _svc()
+    schema = svc.to_form_schema(_make_row("FIELD_IMAGE_UPLOAD_MULTIPLE"))
+    field = list(schema.iter_all_fields())[0]
+    assert field.field_type == FieldType.MULTI_UPLOAD
+    assert (field.meta or {}).get("accept") == "image/*"
+    assert "multiple" not in (field.meta or {})
+
+
+def test_single_photo_question_stays_a_single_file():
+    """The single-photo sibling is untouched: FILE, ``accept`` only."""
+    svc = _svc()
+    schema = svc.to_form_schema(_make_row("FIELD_IMAGE_UPLOAD"))
+    field = list(schema.iter_all_fields())[0]
+    assert field.field_type == FieldType.FILE
+    assert (field.meta or {}).get("accept") == "image/*"
+    assert "multiple" not in (field.meta or {})


### PR DESCRIPTION
## What

`FIELD_IMAGE_UPLOAD_MULTIPLE` now imports as `FieldType.MULTI_UPLOAD`
(keeping `meta.accept = "image/*"`), not `FieldType.FILE` + `meta.multiple`.

One mapping line in `tools/services/networkninja.py`, two pinning tests, a
CHANGELOG entry under Unreleased.

## Why

The importer and the validator disagreed about how to spell "many photos".

- The importer said `FILE` with a `multiple: true` flag in `meta`.
- Everything else in the library says `FILE` is single-cardinality:
  `file_envelope.is_single_cardinality(FILE)` is `True`, `/file-upload`
  rejects a second `file` part on a FILE field with 400, and
  `FormValidator._coerce_value` refuses a list on FILE
  (`"file value must be a string or a FileEnvelope object"`).

So every schema the importer produced for a multi-photo question was one the
library's own validator flags on the first real answer. Today that only shows
up as an observed `would_reject`; the moment a host enforces validation it is a
422 on every photo submit.

Measured on Epson's live form (`db-form-10-69`, 2026-08-25) against the
importer's real source `networkninja.form_metadata`: **76/76 upload fields
consistent** — 65 `FIELD_IMAGE_UPLOAD_MULTIPLE`, 7 `FIELD_IMAGE_UPLOAD`,
4 `FIELD_DISPLAY_IMAGE`. The cardinality was always right; only the spelling
disagreed with the type system. This PR picks the spelling the rest of the
library already uses.

## What it does NOT do

- Does not touch stored forms. Already-imported schemas keep the old
  spelling until they are re-imported or patched through the registry
  (FieldSync will patch Epson's live form by script — re-import would drop
  hand-applied store-group gating there).
- Does not touch the validator, `/file-upload`, or `FileEnvelope`.
- `FIELD_IMAGE_UPLOAD` (single) is unchanged: still `FILE` + `accept`.

## Tests

`tests/unit` + `tests/integration/test_feat300_integration.py` against the
worktree source: **1896 passed / 32 failed** with the change, **1893 / 32**
without it — the 3 new tests pass and no existing test moves. The 32 are
pre-existing and unrelated (`test_version_bumped` still pins `0.9.0`,
`test_form_controls_payload_shape` expects no `supported_effects`, venue,
ui-imports…).

## Related

Downstream half in FieldSync/navigator-svelte: switch the front to
`/file-upload` storing `FileEnvelope`, dual-shape attachment readers, and a
registry-based migration of Epson's 65 fields. FEAT-525 (media categories)
tags by `blob_ref` presence and is unaffected by the type change.
