### PR TITLE
Add project-local RTK filters configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -367,3 +367,6 @@ corpus/compliance_soc2_hipaa/raw/
 corpus/compliance_soc2_hipaa/trees/
 # parrot LLM-wiki state (local retrieval plane)
 .parrot/
+
+#MCP Custom Local configs
+.mcp.json

--- a/.rtk/filters.toml
+++ b/.rtk/filters.toml
@@ -1,0 +1,13 @@
+# Project-local RTK filters — commit this file with your repo.
+# Filters here override user-global and built-in filters.
+# Docs: https://github.com/rtk-ai/rtk#custom-filters
+schema_version = 1
+
+# Example: suppress build noise from a custom tool
+# [filters.my-tool]
+# description = "Compact my-tool output"
+# match_command = "^my-tool\\s+build"
+# strip_ansi = true
+# strip_lines_matching = ["^\\s*$", "^Downloading", "^Installing"]
+# max_lines = 30
+# on_empty = "my-tool: ok"


### PR DESCRIPTION
Create a `.rtk/filters.toml` file to allow overriding built-in and user-global filters with project-specific customizations. This enables developers to define filters that tailor output processing to their project's needs, such as suppressing noise from custom tools.