### PR TITLE
fix(comm_center): splat query params instead of passing them as a tuple

### DIFF
--- a/packages/ai-parrot-server/src/parrot/handlers/comm_center.py
+++ b/packages/ai-parrot-server/src/parrot/handlers/comm_center.py
@@ -494,8 +494,12 @@ class CommCenterHandler(BaseHandler):
 
         db = _get_db()
         async with await db.connection() as conn:
-            rows = await conn.fetchall(list_query, (*params, limit, offset))
-            count_rows = await conn.fetchall(count_query, tuple(params))
+            # asyncdb's signature is fetchall(sentence, *args): a tuple counts as ONE
+            # argument, so passing (*params, limit, offset) made every request fail with
+            # "the server expects 2 arguments for this query, 1 was passed" before this
+            # endpoint could ever return a 200. Splat them.
+            rows = await conn.fetchall(list_query, *params, limit, offset)
+            count_rows = await conn.fetchall(count_query, *params)
         total = count_rows[0]["total"] if count_rows else 0
 
         batches = [

--- a/packages/ai-parrot-server/src/parrot/services/comm_center/dispatch.py
+++ b/packages/ai-parrot-server/src/parrot/services/comm_center/dispatch.py
@@ -365,7 +365,12 @@ async def aggregate_batch_status(
     async with await db.connection() as conn:
         table = f"{PARROT_SCHEMA}.{NotificationBatchRecipient.Meta.name}"
         query = f"SELECT status, COUNT(*) AS count FROM {table} WHERE batch_id = $1 GROUP BY status"
-        counts = await conn.fetchall(query, (batch_id,))
+        # asyncdb's signature is fetchall(sentence, *args), so a tuple arrives as the
+        # *value* of $1 rather than as its argument list. Unlike the arity mismatch this
+        # module had in get_batches(), that fails on type — "invalid input for query
+        # argument $1: (UUID(...),) (bytes is not a 16-char string)" — and made every
+        # request to this endpoint a 500, with or without details=true.
+        counts = await conn.fetchall(query, batch_id)
         by_status = {row["status"]: row["count"] for row in (counts or [])}
 
         result = {

--- a/packages/ai-parrot-server/tests/handlers/test_comm_center_dispatch.py
+++ b/packages/ai-parrot-server/tests/handlers/test_comm_center_dispatch.py
@@ -8,6 +8,7 @@ test suite. No real Redis or Postgres connection is ever attempted.
 """
 
 import asyncio
+import re
 import uuid
 
 import pytest
@@ -281,6 +282,65 @@ class TestRetry:
         assert row_store[stuck.id].status == "queued"
 
 
+class StrictFetchConn:
+    """A connection double that fails the way asyncdb/asyncpg actually fail.
+
+    The previous doubles here were declared ``fetchall(self, query, params=None)``,
+    which happily accepted a whole tuple of parameters as one argument. The real
+    driver is ``fetchall(sentence, *args)`` and forwards to ``stmt.fetch(*args)``,
+    so it rejects that on two independent grounds:
+
+    - **arity** — a tuple counts as ONE argument, so a two-placeholder query gets
+      "the server expects 2 arguments for this query, 1 was passed";
+    - **type** — for a single-placeholder query the tuple becomes the *value* of
+      ``$1``, and Postgres refuses it with "invalid input for query argument $1:
+      (UUID(...),) (bytes is not a 16-char string)".
+
+    ``aggregate_batch_status`` shipped with the second form and returned 500 for
+    every request. A double that cannot reproduce the driver's own errors cannot
+    catch this class of bug, so this one enforces both rules.
+    """
+
+    def __init__(self, rows: list):
+        self.rows = rows
+        self.calls: list = []
+
+    async def fetchall(self, query, *args):
+        self.calls.append((query, args))
+        expected = len({placeholder for placeholder in re.findall(r"\$\d+", query)})
+        if len(args) != expected:
+            raise RuntimeError(
+                f"Error on Fetch: the server expects {expected} arguments for "
+                f"this query, {len(args)} was passed"
+            )
+        for position, value in enumerate(args, start=1):
+            if isinstance(value, (tuple, list)):
+                raise RuntimeError(
+                    f"Postgres Error: invalid input for query argument "
+                    f"${position}: {value!r} (bytes is not a 16-char string)"
+                )
+        return self.rows
+
+
+class StrictConnCtx:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+
+class StrictAsyncDB:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def connection(self):
+        return StrictConnCtx(self._conn)
+
+
 class TestAggregation:
     """Batch progress aggregation and paginated details."""
 
@@ -342,6 +402,29 @@ class TestAggregation:
         result = await dispatch.aggregate_batch_status(batch_id, details=True, limit=10_000)
 
         assert len(result["rows"]) == 5  # clamped internally, but only 5 rows exist
+
+    async def test_batch_id_is_splatted_not_passed_as_a_tuple(self, row_store, monkeypatch):
+        """Regression: every call to this endpoint used to 500 before this fix.
+
+        ``fetchall(query, (batch_id,))`` passes the tuple as the value of ``$1``.
+        It survives an arity check — one argument, one placeholder — so only a
+        double that also validates the *type* catches it, which is why
+        :class:`StrictFetchConn` rejects tuples outright.
+
+        This is the same defect as the one fixed in ``get_batches()``, in a
+        different file: there it failed on arity, here on type.
+        """
+        batch_id = uuid.uuid4()
+        conn = StrictFetchConn([{"status": "queued", "count": 1}])
+        monkeypatch.setattr(dispatch, "_get_db", lambda: StrictAsyncDB(conn))
+
+        result = await dispatch.aggregate_batch_status(batch_id)
+
+        assert result["by_status"] == {"queued": 1}
+        # One flat argument, the UUID itself — not a tuple wrapping it.
+        _query, args = conn.calls[0]
+        assert args == (batch_id,)
+        assert not isinstance(args[0], (tuple, list))
 
 
 class TestLazyImport:

--- a/packages/ai-parrot-server/tests/handlers/test_comm_center_handler.py
+++ b/packages/ai-parrot-server/tests/handlers/test_comm_center_handler.py
@@ -10,6 +10,7 @@ dispatch, template-source resolution, and error mapping — plus the
 concrete route-registration test the spec does provide verbatim.
 """
 
+import re
 import json
 import uuid
 from datetime import UTC, datetime
@@ -255,6 +256,16 @@ class _FakeBatchConn:
     paginated, aggregated batch list (query contains ``ORDER BY``), then the
     total-batch-count query (no ``ORDER BY``). Distinguishing on that
     substring avoids coupling the test to exact SQL text.
+
+    **The signature mirrors asyncdb's ``fetchall(sentence, *args)`` on
+    purpose.** It previously read ``fetchall(self, query, params=None)``,
+    which accepted a single tuple of parameters — something the real driver
+    rejects, because a tuple counts as one argument. That made this double
+    more permissive than production and let the endpoint ship failing every
+    request with "the server expects 2 arguments for this query, 1 was
+    passed". The placeholder count is validated here for the same reason: a
+    fake that cannot reproduce the driver's own error cannot catch this class
+    of bug again.
     """
 
     def __init__(self, list_rows: list, total: int):
@@ -262,8 +273,14 @@ class _FakeBatchConn:
         self.total = total
         self.queries: list = []
 
-    async def fetchall(self, query, params=None):
-        self.queries.append((query, params))
+    async def fetchall(self, query, *args):
+        self.queries.append((query, args))
+        expected = len({placeholder for placeholder in re.findall(r"\$\d+", query)})
+        if len(args) != expected:
+            raise RuntimeError(
+                f"Error on Fetch: the server expects {expected} arguments for "
+                f"this query, {len(args)} was passed"
+            )
         if "ORDER BY" in query:
             return self.list_rows
         return [{"total": self.total}]
@@ -421,6 +438,57 @@ class TestGetBatches:
         assert batch["publishing"] == 0
         assert batch["template_ref"] == "monthly-report"
         assert batch["provider"] == "email"
+
+    async def test_query_params_are_splatted_not_passed_as_a_tuple(self, monkeypatch):
+        """Regression: every request used to fail before reaching Postgres.
+
+        asyncdb's signature is ``fetchall(sentence, *args)``, so
+        ``fetchall(query, (limit, offset))`` hands it a single tuple and the
+        driver refuses with "the server expects 2 arguments for this query, 1
+        was passed". The endpoint shipped that way and returned 500 for every
+        request, with any combination of filters, until this was fixed.
+
+        Asserting the shape of the captured arguments — rather than only that
+        the values are present somewhere — is what makes the tuple form fail
+        here instead of in production.
+        """
+        import parrot.handlers.comm_center as comm_center_module
+
+        conn = _FakeBatchConn(list_rows=[], total=0)
+        monkeypatch.setattr(comm_center_module, "_get_db", lambda: _FakeBatchAsyncDB(conn))
+
+        handler = CommCenterHandler()
+        response = await _call_get_batches(
+            handler, _fake_request({"status": "queued", "limit": "10", "offset": "5"})
+        )
+
+        assert response.status == 200
+        list_query, list_args = conn.queries[0]
+        # One argument per placeholder, flat: the filter value, then limit, then offset.
+        assert list_args == ("queued", 10, 5)
+        assert len(list_args) == len({p for p in re.findall(r"\$\d+", list_query)})
+        # The count query carries only the filter values — no limit/offset.
+        _count_query, count_args = conn.queries[1]
+        assert count_args == ("queued",)
+
+    async def test_unfiltered_count_query_takes_no_arguments(self, monkeypatch):
+        """With no filters the count query has no placeholders at all.
+
+        ``fetchall(count_query, tuple(params))`` passed an empty tuple, which
+        is still one argument for a query that takes none — the second half of
+        the same bug.
+        """
+        import parrot.handlers.comm_center as comm_center_module
+
+        conn = _FakeBatchConn(list_rows=[], total=0)
+        monkeypatch.setattr(comm_center_module, "_get_db", lambda: _FakeBatchAsyncDB(conn))
+
+        handler = CommCenterHandler()
+        response = await _call_get_batches(handler, _fake_request({}))
+
+        assert response.status == 200
+        _count_query, count_args = conn.queries[1]
+        assert count_args == ()
 
     async def test_publishing_status_counted_and_included(self, monkeypatch):
         """Code-review fix: a batch with an in-flight (``publishing``) row


### PR DESCRIPTION
## Why

Both CommCenter endpoints that build raw SQL handed asyncdb a **tuple** of query
parameters. Its signature is `fetchall(sentence, *args)`, forwarding to `stmt.fetch(*args)`,
so a tuple arrives as **one** argument — and each endpoint failed differently for it.

Neither ever worked. This was found while wiring the frontend to `GET /sender`
(Trocdigital/navigator-frontend-next#169), which could not get a single 200 out of it.

### `get_batches()` — failed on arity

`handlers/comm_center.py:497-498`

```
line 497 -> "the server expects 2 arguments for this query, 1 was passed"
line 498 -> "the server expects 0 arguments for this query, 1 was passed"
```

It fails on the **first** query, always, with any combination of filters, so every request
to `GET /api/v1/comm_center/sender` returned a 500. The endpoint FEAT-445 TASK-2319 added
could never return a 200.

### `aggregate_batch_status()` — failed on type

`services/comm_center/dispatch.py:368`. Here the query has a single placeholder, so the
tuple survives an arity check and becomes the **value** of `$1` instead:

```
ProviderError: Postgres Error: invalid input for query argument $1:
(UUID('8f0e8d82-…'),) (bytes is not a 16-char string)
```

That query runs unconditionally, so `GET /sender/{batch_id}` returned a 500 with and
without `details=true` — the per-recipient row panel was unusable.

## The fix

```diff
-            rows = await conn.fetchall(list_query, (*params, limit, offset))
-            count_rows = await conn.fetchall(count_query, tuple(params))
+            rows = await conn.fetchall(list_query, *params, limit, offset)
+            count_rows = await conn.fetchall(count_query, *params)
```

```diff
-        counts = await conn.fetchall(query, (batch_id,))
+        counts = await conn.fetchall(query, batch_id)
```

**The SQL itself was correct in both.** The grouping and the `COUNT(*) FILTER` columns
return what the contract documents; only the argument passing was wrong.

Both were reproduced read-only against the live schema before and after the change:
`fetchall(q, 25, 0)` returns rows where `fetchall(q, (25, 0))` raises, and
`fetchall(q, batch_id)` returns `[{'status': 'pending', 'count': 1}]` where
`fetchall(q, (batch_id,))` raises the type error above.

A sweep of the module found no third case: the three raw query calls under
`services/comm_center/` and `handlers/comm_center.py` are these two plus the count query
already covered here. Everything else goes through the ORM.

## Why the suite did not catch either

This is the part worth keeping. Both test doubles were declared

```python
async def fetchall(self, query, params=None):
```

which accepts a single tuple of parameters — something the real driver rejects. The doubles
were more permissive than production, so the mismatch was invisible to the suite while
being fatal in it.

They now reproduce the driver's own failures:

- `_FakeBatchConn` (handler tests) validates the **placeholder count** and raises asyncdb's
  own wording when it does not match.
- `StrictFetchConn` (dispatch tests) validates **arity and type**, rejecting a tuple or list
  passed as the value of a scalar placeholder — reproducing the production error text
  verbatim.

Reverting either fix now fails the suite with the same message the server produced.

## Verification

- `pytest packages/ai-parrot-server/tests/handlers/test_comm_center_dispatch.py
  packages/ai-parrot-server/tests/handlers/test_comm_center_handler.py` → **60 passed**
- Each regression test checked the other way round: reverting its fix makes it fail
- Both endpoints exercised end to end from the frontend against production data — batch
  list with correct counters, per-row detail, and a retry moving a batch
  `pending → publishing → queued`

## Noted while here, not fixed

`aggregate_batch_status()` never passes `limit`/`offset` to SQL — it fetches the batch in
full and slices in Python:

```python
rows = await NotificationBatchRecipient.filter(**filters)
result["rows"] = (rows or [])[offset : offset + limit]
```

A 10 000-row batch asked for `limit=50` reads all 10 000 and discards 9 950;
`MAX_DETAILS_LIMIT` caps what is returned, not what is read. Left alone because it changes
the shape of the query rather than how its arguments are passed.
