### PR TITLE
fix(comm_center): honour the documented nested "extra" shape on JSON ingestion

### DIFF
--- a/packages/ai-parrot-server/src/parrot/services/comm_center/ingest.py
+++ b/packages/ai-parrot-server/src/parrot/services/comm_center/ingest.py
@@ -173,6 +173,20 @@ def _row_to_recipient(raw: dict, reserved_used: set) -> RecipientIn | None:
     for key, value in raw.items():
         norm = _normalize_column(key)
         cleaned = _clean_value(value)
+        # The documented JSON contract nests extra columns under "extra"
+        # (docs/comm_center_api.md, and RecipientIn.extra is declared for exactly that),
+        # while a spreadsheet row arrives flat. Both reach this function, so accept both.
+        # Treating the documented shape as just another column double-nests it --
+        # extra == {"extra": {...}} -- so no extra column ever became a pass-2 kwarg and
+        # every {{ own_column }} placeholder rendered literally, in the preview and in the
+        # delivered message alike.
+        if norm == "extra" and isinstance(value, dict):
+            for extra_key, extra_value in value.items():
+                extra_norm = _normalize_column(extra_key)
+                if extra_norm in _RESERVED_NAMES:
+                    reserved_used.add(extra_norm)
+                extra[extra_norm] = _clean_value(extra_value)
+            continue
         if norm in _RESERVED_NAMES:
             reserved_used.add(norm)
         if norm in _CANONICAL_FIELDS:

--- a/packages/ai-parrot-server/tests/handlers/test_comm_center_ingest.py
+++ b/packages/ai-parrot-server/tests/handlers/test_comm_center_ingest.py
@@ -133,3 +133,54 @@ class TestIngest:
         assert rows[0].phone == "+34600000000"
         assert rows[0].username == "agomez"
         assert rows[0].extra["department"] == "Sales"
+
+    async def test_json_nested_extra_becomes_pass2_kwargs(self):
+        """The documented JSON shape nests extras; treating it as a column broke them.
+
+        `docs/comm_center_api.md` defines a recipient as
+        `{"name": ..., "extra": {"any_extra_column": "value"}}`, and `RecipientIn.extra`
+        is declared for exactly that. But every JSON request reaches
+        `_row_to_recipient`, which classifies unknown keys as columns -- so "extra" itself
+        landed in `extra`, giving `{"extra": {...}}`. No extra column ever became a pass-2
+        kwarg, and `{{ ciudad }}` rendered literally in the preview and in the delivered
+        message alike.
+        """
+        rows = [
+            {
+                "name": "Ana Gomez",
+                "email": "ana@example.com",
+                "extra": {"ciudad": "Bogota", "  Plan  ": "gold"},
+            }
+        ]
+
+        recipients = await ingest_recipients(rows=rows)
+
+        assert recipients[0].extra["ciudad"] == "Bogota"
+        # Keys are normalized inside the nested object too, exactly as flat columns are:
+        # trimmed and lower-cased (no space folding — `_normalize_column` does not do it
+        # for flat columns either).
+        assert recipients[0].extra["plan"] == "gold"
+        # And the wrapper key is gone rather than nested one level deeper.
+        assert "extra" not in recipients[0].extra
+
+    async def test_flat_extra_columns_still_work(self):
+        """A spreadsheet row arrives flat; both shapes must keep working."""
+        rows = [{"name": "Ana", "email": "a@e.com", "ciudad": "Bogota"}]
+
+        recipients = await ingest_recipients(rows=rows)
+
+        assert recipients[0].extra["ciudad"] == "Bogota"
+
+    async def test_reserved_name_inside_nested_extra_is_reported(self):
+        """A reserved name must warn wherever it comes from.
+
+        `message` is filled in by the render context, so a column of that name cannot be
+        used as a placeholder. The flat path already warned; the nested path has to warn
+        for the same reason.
+        """
+        rows = [{"name": "Ana", "email": "a@e.com", "extra": {"message": "x"}}]
+
+        _rows, warnings = await ingest_recipients(rows=rows, return_warnings=True)
+
+        assert any("message" in w for w in warnings)
+


### PR DESCRIPTION
## Why

A recipient with an extra column of its own (`ciudad`) and a message reading
`… en {{ ciudad }}.` came back from the dry run with the placeholder **literal**:

```
<p>Prueba de QA del 2026-08-27 en {{ ciudad }}.</p>
```

`{{ name }}` and `{{ email }}` resolved in that same preview — only the extra columns
failed. And since `build_preview()` deliberately uses the very payload a real send uses
(*"the preview is guaranteed to match what a real send would deliver"*), **the delivered
message carried `{{ ciudad }}` literally too**. Personalising with your own columns is a
headline capability of this module, and on the JSON path it never worked.

## Cause

`docs/comm_center_api.md` defines a recipient with its extras **nested**:

```json
{ "name": "Ana Gomez", "email": "ana@example.com", "extra": {"any_extra_column": "value"} }
```

`RecipientIn` is declared for exactly that (`extra: dict`). But nothing ever builds a
`RecipientIn` straight from the body: `_ingest_from_request` routes JSON through
`ingest_recipients(rows=…)` and on to `_row_to_recipient`, which assumes **flat columns**
and classifies every unknown key as one:

```python
for key, value in raw.items():
    norm = _normalize_column(key)
    if norm in _CANONICAL_FIELDS: canonical[norm] = cleaned
    else:                          extra[norm] = cleaned
```

`extra` is not canonical, so it fell into the `else` and nested one level deeper:

```python
RecipientIn.extra == {"extra": {"ciudad": "Bogota"}}
```

`build_wire_payload` then forwarded a key named `extra` and never one named `ciudad`, so no
extra column ever became a pass-2 render kwarg.

## Scope

**Only the JSON path.** A spreadsheet reaches this function already flat, so uploads worked.
The frontend parses the file in the browser — to report recognized columns and skipped rows
before anything is sent — and posts the documented JSON, which is the shape that broke.

## The fix

`_row_to_recipient` accepts both shapes now: nested (the documented JSON contract) and flat
(a spreadsheet row). Nested keys are normalized and reserved-name-checked exactly like flat
ones, so a `message` column inside `extra` warns for the same reason it does at top level.

## Verification

- `pytest` over the ten `test_comm_center_*` files: **142 passed**
- Three new tests: the nested shape, the flat shape still working, and the reserved-name
  warning inside `extra`. The first and third verified failing without the fix
  (`KeyError: 'ciudad'` and `assert False` respectively)
- Confirmed end to end in the browser afterwards: the same dry run now previews
  `en Bogotá.`

## Noticed while here, not fixed

`message` is in the catalog's `reserved` names but **not** in `_PROTECTED_PAYLOAD_KEYS`, so
a column of that name still reaches `payload` and can shadow the message body in the pass-2
render context — `recipient` and `subject`, its siblings in that catalog, are both
protected. Left alone because it is a separate decision from how ingestion parses a row.

Found during the Compose QA pass of Trocdigital/navigator-frontend-next#169.
