### PR TITLE
feat(dev-loop-run-fidelity): FEAT-466 — Dev-Loop Run Fidelity

### DIFF
--- a/.claude/agents/sdd-research.md
+++ b/.claude/agents/sdd-research.md
@@ -61,16 +61,30 @@ criteria) you must:
    derived from the affected component, fill in the motivation and
    acceptance criteria from the brief. **Flow type — pass it explicitly,
    do not let `/sdd-spec` infer it (FEAT-466):**
+
+   **Check the brief's own `flow_type` / `base_branch` fields FIRST** —
+   these are an explicit console/operator override (FEAT-466 TASK-2508)
+   and, when present, WIN OVER the `kind`-derived default below. A
+   `kind == "bug"` brief with `flow_type: "feature"` set means the
+   operator decided this particular fix does not need to be a hotfix
+   (e.g. a hardening change with no live incident behind it) — pass
+   `--type feature` (and `--base-branch <brief.base_branch or "dev">"`),
+   not `--type hotfix`. Only fall back to the `kind`-derived default when
+   the brief's `flow_type`/`base_branch` are absent (`null`):
    ```
    /sdd-spec <slug> --type hotfix --base-branch main       # kind == "bug"
    /sdd-spec <slug> --type feature --base-branch dev        # kind == "enhancement" | "new_feature"
    ```
    `kind == "bug"` → `type: hotfix` / `base_branch: main` (bug fixes land
-   on `main`). `kind == "enhancement"` or `"new_feature"` → `type: feature`
-   / `base_branch: dev`. **When `kind == "bug"`, no `FEAT-<NNN>`/`TASK-<NNN>`
-   id is reserved at all** — `/sdd-spec` skips the ledger allocator entirely
-   for `type: hotfix` (a bugfix is not a feature); the Jira issue key from
-   step 2 is this run's identity instead.
+   on `main`), UNLESS the brief overrode `flow_type` to `"feature"` (see
+   above). `kind == "enhancement"` or `"new_feature"` → `type: feature` /
+   `base_branch: dev`. **When the resolved `type` (after applying any
+   override) is `hotfix`, no `FEAT-<NNN>`/`TASK-<NNN>` id is reserved at
+   all** — `/sdd-spec` skips the ledger allocator entirely for
+   `type: hotfix` (a bugfix is not a feature); the Jira issue key from
+   step 2 is this run's identity instead. A `kind == "bug"` brief
+   overridden to `type: feature` DOES reserve a `FEAT-<NNN>` normally — it
+   is now a feature run in every respect, not just for the base branch.
 4. **Decompose into tasks — `type: feature` only.** Run
    ``/sdd-task <spec-path>``. **For `type: hotfix`, SKIP this step
    entirely** — a one-or-two-commit bugfix is handled directly by the

--- a/.claude/agents/sdd-research.md
+++ b/.claude/agents/sdd-research.md
@@ -4,8 +4,10 @@ description: |
   Research-phase subagent for the dev-loop flow (FEAT-129).
   Given a BugBrief and log excerpts, this agent triages the failure,
   creates a Jira ticket, scaffolds an SDD spec via /sdd-spec, decomposes
-  it into tasks via /sdd-task, and creates the feature worktree at
-  .claude/worktrees/feat-<id>-<slug>/.
+  it into tasks via /sdd-task (feature runs only — FEAT-466 skips this for
+  hotfixes), and creates the worktree at
+  .claude/worktrees/feat-<id>-<slug>/ (feature) or
+  .claude/worktrees/hotfix-<JIRA-KEY>-<slug>/ (hotfix, no id reserved).
 
   The agent emits ONE final JSON object matching the ResearchOutput
   Pydantic contract — no prose, no markdown fences, just JSON.
@@ -57,15 +59,28 @@ criteria) you must:
    the brief). Assignee = the dev-loop service account (``flow-bot``).
 3. **Scaffold an SDD spec**. Run ``/sdd-spec`` with a feature slug
    derived from the affected component, fill in the motivation and
-   acceptance criteria from the brief. **Flow type**: when the brief's
-   ``kind`` is ``"bug"`` use ``type: hotfix`` / ``base_branch: main``
-   in the spec frontmatter (bug fixes land on ``main``). When ``kind``
-   is ``"enhancement"`` or ``"new_feature"`` use ``type: feature`` /
-   ``base_branch: dev``.
-4. **Decompose into tasks**. Run ``/sdd-task <spec-path>``.
-5. **Create the worktree**. The base ref depends on the spec's
-   ``type``:
-   - ``hotfix``: ``git worktree add -b feat-<id>-<slug> .claude/worktrees/feat-<id>-<slug> origin/main``
+   acceptance criteria from the brief. **Flow type — pass it explicitly,
+   do not let `/sdd-spec` infer it (FEAT-466):**
+   ```
+   /sdd-spec <slug> --type hotfix --base-branch main       # kind == "bug"
+   /sdd-spec <slug> --type feature --base-branch dev        # kind == "enhancement" | "new_feature"
+   ```
+   `kind == "bug"` → `type: hotfix` / `base_branch: main` (bug fixes land
+   on `main`). `kind == "enhancement"` or `"new_feature"` → `type: feature`
+   / `base_branch: dev`. **When `kind == "bug"`, no `FEAT-<NNN>`/`TASK-<NNN>`
+   id is reserved at all** — `/sdd-spec` skips the ledger allocator entirely
+   for `type: hotfix` (a bugfix is not a feature); the Jira issue key from
+   step 2 is this run's identity instead.
+4. **Decompose into tasks — `type: feature` only.** Run
+   ``/sdd-task <spec-path>``. **For `type: hotfix`, SKIP this step
+   entirely** — a one-or-two-commit bugfix is handled directly by the
+   dev-loop's single-agent development path from the spec alone; there is
+   no per-spec task index and no `TASK-<NNN>` id to reserve. Proceed
+   straight to step 5.
+5. **Create the worktree**. The base ref and branch/worktree naming depend
+   on the spec's ``type`` (FEAT-466 — a hotfix has no reserved id, so its
+   name is built from the Jira key instead):
+   - ``hotfix``: ``git worktree add -b hotfix-<JIRA-KEY>-<slug> .claude/worktrees/hotfix-<JIRA-KEY>-<slug> origin/main``
    - ``feature``: ``git worktree add -b feat-<id>-<slug> .claude/worktrees/feat-<id>-<slug> origin/dev``
 
 ## Cardinal rules
@@ -78,14 +93,16 @@ criteria) you must:
   ``sdd/`` (specs, tasks) and to git plumbing for the worktree.
 - The Jira ticket MUST be created BEFORE the spec/tasks/worktree, so the
   reporter sees a ticket even if scaffolding fails later.
-- The worktree branch name MUST match ``feat-<id>-<slug>`` so the
-  ``pull_request.closed`` webhook can clean it up automatically.
+- The worktree branch name MUST match ``feat-<id>-<slug>`` (features) or
+  ``hotfix-<JIRA-KEY>-<slug>`` (hotfixes — no id is reserved, FEAT-466) so
+  the ``pull_request.closed`` webhook can clean it up automatically.
 
 ## Output Contract
 
 When all steps succeed, emit a single JSON object as your **final**
-assistant turn (no markdown fences, no prose around it):
+assistant turn (no markdown fences, no prose around it).
 
+**Feature run** (``kind`` is ``"enhancement"`` / ``"new_feature"``):
 ```json
 {
   "jira_issue_key": "OPS-1234",
@@ -93,6 +110,20 @@ assistant turn (no markdown fences, no prose around it):
   "feat_id": "FEAT-130",
   "branch_name": "feat-130-<slug>",
   "worktree_path": "/abs/.claude/worktrees/feat-130-<slug>",
+  "log_excerpts": ["...", "..."]
+}
+```
+
+**Hotfix run** (``kind == "bug"``) — ``feat_id`` is ``""`` (FEAT-466: a
+bugfix reserves no id; ``ResearchOutput.feat_id == ""`` is a supported
+shape and every run-labelling consumer falls back to ``jira_issue_key``):
+```json
+{
+  "jira_issue_key": "OPS-1234",
+  "spec_path": "sdd/specs/<slug>.spec.md",
+  "feat_id": "",
+  "branch_name": "hotfix-OPS-1234-<slug>",
+  "worktree_path": "/abs/.claude/worktrees/hotfix-OPS-1234-<slug>",
   "log_excerpts": ["...", "..."]
 }
 ```

--- a/.claude/commands/sdd-spec.md
+++ b/.claude/commands/sdd-spec.md
@@ -4,8 +4,13 @@ Scaffold a new Feature Specification using the SDD methodology.
 
 ## Usage
 ```
-/sdd-spec <feature-name> [-- free-form description and notes]
+/sdd-spec <feature-name> [--type feature|hotfix] [--base-branch <branch>] [-- free-form description and notes]
 ```
+
+`--type` / `--base-branch` are explicit overrides for the flow resolved in
+§2d — they win over any brainstorm/proposal frontmatter and over the
+`WorkKind` mapping (FEAT-466). Omit both to let §2d resolve the flow from
+the exploration doc (or default to `feature`/`dev` when none exists).
 
 ## Guardrails
 - Always use the official template at `sdd/templates/spec.md`.
@@ -127,24 +132,48 @@ Loaded brainstorm: sdd/proposals/<feature-name>.brainstorm.md
 
 If K is zero, proceed directly to §4 without asking anything.
 
-#### 2d. Sync the Base Branch (FEAT-145)
+#### 2d. Sync the Base Branch (FEAT-145, resolver added FEAT-466)
 
-Read the brainstorm/proposal frontmatter (or default to `feature`/`dev` when
-no exploration doc exists) via `scripts.sdd.sdd_meta`:
+Resolve `(TYPE, BASE_BRANCH)` deterministically via
+`scripts.sdd.sdd_meta.resolve_flow()` — explicit `--type`/`--base-branch`
+flags win over the brainstorm/proposal frontmatter, which wins over the
+default (`feature`/`dev`). Unlike a bare `parse()` call, `resolve_flow()`
+does NOT raise `FileNotFoundError` when no exploration doc exists — that is
+exactly the dev-loop bug path's normal situation (no brainstorm, no
+proposal), and it is why this step no longer calls `parse()` directly:
 
 ```bash
-META=$(python -c "from pathlib import Path; from scripts.sdd.sdd_meta import parse; m = parse(Path('<brainstorm-or-proposal-path>')); print(m.type, m.base_branch)")
+META=$(python -c "
+from pathlib import Path
+from scripts.sdd.sdd_meta import resolve_flow
+m = resolve_flow(
+    doc_path=Path('<brainstorm-or-proposal-path>') if '<exploration-doc-exists>' else None,
+    type_override='<--type value, or empty string if not passed>' or None,
+    base_branch_override='<--base-branch value, or empty string if not passed>' or None,
+)
+print(m.type, m.base_branch)")
 TYPE=$(echo "$META" | awk '{print $1}')
 BASE_BRANCH=$(echo "$META" | awk '{print $2}')
 ```
 
-**Validation:** if `TYPE == "hotfix"` and `BASE_BRANCH != "main"`, abort:
+**Validation (hotfix/main):** `resolve_flow()` enforces `type='hotfix' ⇒
+base_branch='main'` internally (it returns a `FlowMeta`, whose own
+cross-field validator raises `ValueError` — this is NOT re-derived as a
+separate bash check). The `python -c` call above therefore exits non-zero
+and prints a traceback when a `--type hotfix --base-branch dev`-style
+combination (or hotfix frontmatter with a non-`main` base) is resolved. On
+that failure, abort with the same message as before:
 ```
 ⚠️  type='hotfix' requires base_branch='main' (got base_branch='<value>').
-   Fix the brainstorm/proposal frontmatter and re-run /sdd-spec.
+   Fix the brainstorm/proposal frontmatter (or --base-branch flag) and
+   re-run /sdd-spec.
 ```
 
-**Validation:** if `TYPE == "feature"` and `BASE_BRANCH == "main"`, abort:
+**Validation (feature/not-main):** `FlowMeta` does NOT reject
+`type='feature', base_branch='main'` at the schema layer (that refusal is
+intentionally a command-layer guard, FEAT-187) — so this check stays a
+manual bash condition after the resolver returns successfully. If
+`TYPE == "feature"` and `BASE_BRANCH == "main"`, abort:
 ```
 ⚠️  type='feature' cannot base on 'main'. Features land on dev (default)
    or staging (during a release freeze). For changes that must base on
@@ -238,8 +267,23 @@ This step prevents AI hallucinations during implementation. You MUST:
      #   skip the reserve_ids.py call below and use this ID verbatim.
      ---
      ```
-   - **Feature ID** — reserve via the ledger allocator (FEAT-387), never
-     hand-compute by checking existing specs and incrementing the last one:
+   - **Feature ID — SKIP ENTIRELY when `TYPE == "hotfix"` (FEAT-466).** A
+     bugfix is not a feature and reserves no `FEAT-<NNN>`: ledger ids exist
+     for features and the brainstorm → spec → task SDD flow, and a hotfix is
+     identified by its **Jira issue key** instead. Do NOT call
+     `reserve_ids.py --kind feature` on the hotfix path — write no
+     `FEAT-<NNN>` anywhere in the spec, and use the Jira key as the
+     document's identity line (`**Jira**: <KEY>` in place of `**Feature
+     ID**: FEAT-<NNN>`). This is not an oversight to fix later: it is the
+     whole point — the allocator's "current branch must equal
+     `--base-branch`" precondition (`reserve_ids.py:140`) would otherwise be
+     unreachable for a hotfix that has to reserve on `main` while another
+     worktree already has `main` checked out. Skipping reservation removes
+     the problem rather than solving it.
+
+     For `TYPE == "feature"`, reserve via the ledger allocator (FEAT-387),
+     never hand-compute by checking existing specs and incrementing the
+     last one:
      ```bash
      FEAT_ID=$(python -m scripts.sdd.reserve_ids --kind feature --count 1 \
        --base-branch "$BASE_BRANCH" --label <feature-name>)
@@ -307,6 +351,8 @@ git commit -m "sdd: add spec for FEAT-<ID> — <feature-name>"
 ```
 
 ### 7. Output
+
+**`TYPE == "feature"`:**
 ```
 ✅ Spec created and committed: sdd/specs/<feature-name>.spec.md
 
@@ -321,6 +367,26 @@ Next:
   1. Review the spec — check Acceptance Criteria and Architectural Design.
   2. Mark status: approved when ready.
   3. Run /sdd-task sdd/specs/<feature-name>.spec.md
+```
+
+**`TYPE == "hotfix"` (FEAT-466 — no id reserved):**
+```
+✅ Spec created and committed: sdd/specs/<feature-name>.spec.md
+
+   Identity: Jira <KEY> (no FEAT-<NNN> reserved — a bugfix is not a feature)
+   Base branch: main
+
+   To create the worktree (origin/main, never HEAD/dev):
+     git worktree add -b hotfix-<KEY>-<feature-name> \
+       .claude/worktrees/hotfix-<KEY>-<feature-name> origin/main
+
+Next:
+  1. Review the spec — check Acceptance Criteria and Architectural Design.
+  2. Mark status: approved when ready.
+  3. Normally: skip /sdd-task and dispatch straight to development (the
+     single-agent path handles a one-or-two-commit hotfix directly from
+     the spec). Only run /sdd-task if this hotfix genuinely needs
+     decomposition — it will not reserve TASK-<NNN> ids either.
 ```
 
 ## Reference

--- a/.claude/commands/sdd-task.md
+++ b/.claude/commands/sdd-task.md
@@ -42,6 +42,19 @@ For `type: hotfix`, `BASE` MUST be `main`. For `type: feature`, `BASE` defaults
 to `dev` and may be `staging` (during a release freeze) or any non-main branch
 (sub-features extend a parent feature branch — see `CLAUDE.md`).
 
+**A hotfix normally does not reach this command at all (FEAT-466).**
+`sdd-research.md` skips `/sdd-task` entirely for `type: hotfix` runs — a
+one-or-two-commit bugfix is handled directly by the dev-loop's single-agent
+path (spec §3 Module 2's "Interaction with Module 7": no per-spec task index
+⇒ `DevelopmentNode._build_scheduler` returns `None` ⇒ single-agent dispatch,
+made to honour the operator's declared dev agent by TASK-2506). If a human
+invokes `/sdd-task` directly against a `type: hotfix` spec anyway (e.g. an
+unusually large hotfix that genuinely benefits from decomposition), proceed
+but see §4's hotfix branch below — it does **not** reserve `TASK-<NNN>` ids.
+A hotfix's per-spec index header carries `"feature_id": null` (there is no
+reserved `FEAT-<NNN>`) and a `"jira_issue_key"` field carrying the Jira key
+instead — the identity the rest of the flow labels this run by.
+
 **Validation:** if `TYPE == "feature"` and `BASE_BRANCH == "main"`, abort:
 ```
 ⚠️  type='feature' cannot base on 'main'. Features land on dev (default)
@@ -101,8 +114,11 @@ explicit, verified code anchors.
 ### 4. Generate Tasks
 1. Ensure `sdd/tasks/active/` directory exists (create if needed).
 2. Read the task template at `sdd/templates/task.md`.
-3. **Reserve `TASK-<NNN>` IDs via the git-native compare-and-swap ledger
-   (FEAT-387) — never scan existing files and increment by hand:**
+3. **Reserve task IDs — the mechanism depends on `TYPE` (FEAT-466):**
+
+   **`TYPE == "feature"`** — reserve `TASK-<NNN>` IDs via the git-native
+   compare-and-swap ledger (FEAT-387), never scan existing files and
+   increment by hand:
    ```bash
    TASK_IDS=$(python -m scripts.sdd.reserve_ids --kind task --count <N> \
      --base-branch "$BASE" --label <feature-slug>)
@@ -122,9 +138,21 @@ explicit, verified code anchors.
    non-zero (retries exhausted, or the working tree wasn't clean), **STOP**
    and report the error to the user — do NOT fall back to hand-computing a
    number.
-4. For each task, create `sdd/tasks/active/TASK-<NNN>-<slug>.md` using the
-   template — consume the reserved IDs from `$TASK_IDS`, in order, one per
-   task. Use each ID verbatim for both the filename and every `id` field
+
+   **`TYPE == "hotfix"`** — do **NOT** call
+   `reserve_ids.py --kind task`. A hotfix is not a feature and reserves no
+   ledger id at all (same rationale as `/sdd-spec` §5's `FEAT-<NNN>` skip).
+   Number tasks **locally within this spec only**, as
+   `HOTFIX-<JIRA-KEY>-1`, `HOTFIX-<JIRA-KEY>-2`, … — these are literal
+   string ids scoped to this hotfix's own index file, never compared
+   against or drawn from `sdd/tasks/.id_ledger.json`'s `TASK-<NNN>`
+   namespace. (Note: this is the defensive path for the rare case a human
+   runs `/sdd-task` directly against a hotfix spec — the *normal* hotfix
+   flow skips `/sdd-task` entirely; see §1 above.)
+4. For each task, create `sdd/tasks/active/<id>-<slug>.md` using the
+   template (`<id>` is `TASK-<NNN>` for a feature, `HOTFIX-<JIRA-KEY>-N`
+   for a hotfix) — consume the reserved/assigned ids in order, one per
+   task. Use each id verbatim for both the filename and every `id` field
    in the per-spec index; never invent, recompute, or reuse a `TASK-<NNN>`
    number outside of what `reserve_ids.py` returned.
 
@@ -190,6 +218,8 @@ mkdir -p "$(dirname "$INDEX")"
 
 **Field clarification:**
 - `feature_id`: Formal Feature ID from the spec (e.g., `"FEAT-014"`).
+  **`null` for a hotfix** (FEAT-466 — no id reserved); use `jira_issue_key`
+  as the identity instead.
 - `feature`: Kebab-case slug (e.g., `"videoreel-visual-changes"`).
 
 ### 5. Commit Tasks and Per-Spec Index to `<BASE>`
@@ -219,29 +249,39 @@ git diff --cached --name-only
 git commit -m "sdd: add <N> tasks for FEAT-<ID> — <feature-name>"
 ```
 
-### 6. Create the Feature Worktree
+### 6. Create the Worktree
 
-After committing to `dev`, create the worktree so it inherits the tasks:
+After committing to `<BASE>`, create the worktree so it inherits the tasks.
+Naming and base ref depend on `TYPE` (FEAT-466 — a hotfix has no reserved
+id, so it is named from its Jira key, and always branches from
+`origin/main`, never `HEAD`):
 
 ```bash
+# type: feature
 git worktree add -b feat-<FEAT-ID>-<slug> \
   .claude/worktrees/feat-<FEAT-ID>-<slug> HEAD
+
+# type: hotfix (the rare case /sdd-task ran directly against a hotfix spec)
+git worktree add -b hotfix-<JIRA-KEY>-<slug> \
+  .claude/worktrees/hotfix-<JIRA-KEY>-<slug> origin/main
 ```
 
 ### 7. Output
 ```
 ✅ Generated and committed <N> tasks for FEAT-<ID> — <feature-name>
+   (hotfix: for Jira <KEY> — <feature-name>, no FEAT-<NNN>/TASK-<NNN> reserved)
 
 Tasks created:
-  TASK-<NNN> — <title> [<priority>/<effort>]
-  ...
+  TASK-<NNN> — <title> [<priority>/<effort>]      # feature
+  HOTFIX-<JIRA-KEY>-<N> — <title> [<priority>/<effort>]  # hotfix
 
-Feature worktree created:
-  .claude/worktrees/feat-<FEAT-ID>-<slug>
+Worktree created:
+  .claude/worktrees/feat-<FEAT-ID>-<slug>              # feature
+  .claude/worktrees/hotfix-<JIRA-KEY>-<slug>           # hotfix
 
 Next:
-  cd .claude/worktrees/feat-<FEAT-ID>-<slug>
-  /sdd-start TASK-<NNN>   # begin first task
+  cd .claude/worktrees/<worktree-name>
+  /sdd-start <task-id>   # begin first task
 ```
 
 ## Reference

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,24 @@ declaratively in this repo — set via GitHub repo settings.
 git worktree add -b <branch-name> .claude/worktrees/<worktree-name> HEAD
 ```
 
+> **Carve-out (FEAT-466): "from the current branch … `HEAD`" is shorthand,
+> not the rule.** The actual rule is **worktrees branch from `base_branch`**
+> (§ Git Configuration above). `HEAD` only works as shorthand when `HEAD`
+> already *is* the intended base — true for `/sdd-task` and `sdd-worker`,
+> which always `git checkout "$BASE_BRANCH"` immediately beforehand. It is
+> **not** true for a hotfix: `sdd-research.md` branches
+> `hotfix-<JIRA-KEY>-<slug>` explicitly from `origin/main`, regardless of
+> what branch happens to be checked out in the main repo at the time (a
+> hotfix must never inherit unreleased `dev` commits — this is the FEAT-466
+> root cause, PR #1250). When base and `HEAD` might differ, name the ref
+> explicitly:
+> ```bash
+> # Feature — from the base branch (dev, or staging during a freeze)
+> git worktree add -b feat-<id>-<slug> .claude/worktrees/feat-<id>-<slug> origin/dev
+> # Hotfix — ALWAYS from origin/main, never from HEAD/dev
+> git worktree add -b hotfix-<JIRA-KEY>-<slug> .claude/worktrees/hotfix-<JIRA-KEY>-<slug> origin/main
+> ```
+
 ### Quick reference
 
 ```bash
@@ -297,6 +315,14 @@ Commit message convention:
 ```
 sdd: <action> for <feature-name>
 ```
+
+**Note (FEAT-466)**: the `/sdd-spec` and `/sdd-task` reservation commits in
+the table above do **not** occur for `type: hotfix`. A bugfix is not a
+feature and reserves no `FEAT-<NNN>`/`TASK-<NNN>` id — `/sdd-spec` skips
+`reserve_ids.py --kind feature` and `/sdd-task` is normally skipped
+entirely (the single-agent dev-loop path handles a hotfix directly from the
+spec). The hotfix's identity is its Jira issue key instead; see
+`sdd/specs/dev-loop-run-fidelity.spec.md` §3 Module 2.
 
 **Note (FEAT-145)**: `/sdd-start` no longer needs to `cd` back to the main
 repo to update SDD state — per-spec indexes mean each feature owns its own

--- a/examples/dev_loop/server.py
+++ b/examples/dev_loop/server.py
@@ -207,8 +207,7 @@ def _log_development_agent_selection(backend: str, profile: Any) -> None:
         )
     elif backend == "moonshot":
         logger.info(
-            "Development node using Moonshot code dispatcher (model=%s, "
-            "reasoning_effort=%s)",
+            "Development node using Moonshot code dispatcher (model=%s, " "reasoning_effort=%s)",
             profile.model,
             profile.reasoning_effort,
         )
@@ -373,9 +372,7 @@ def _ensure_adversarial_judge(judges: list[JudgeSpec]) -> list[JudgeSpec]:
     ]
 
 
-def _codex_dispatcher_for(
-    development_dispatcher: object, redis_url: str
-) -> CodexCodeDispatcher:
+def _codex_dispatcher_for(development_dispatcher: object, redis_url: str) -> CodexCodeDispatcher:
     """Reuse the development Codex dispatcher, or build a dedicated one.
 
     Avoids a second CLI-spawning dispatcher instance when the Development
@@ -495,13 +492,9 @@ def _resolve_codereview_dispatcher(
             adversarial scope is misconfigured (see
             :func:`_build_adversarial_reviewer`).
     """
-    configured = conf.config.get(
-        "DEV_LOOP_CODEREVIEW_AGENT", fallback="parallel"
-    ).strip().lower()
+    configured = conf.config.get("DEV_LOOP_CODEREVIEW_AGENT", fallback="parallel").strip().lower()
 
-    adversary, adversary_key = _build_adversarial_reviewer(
-        _codex_dispatcher_for(development_dispatcher, redis_url)
-    )
+    adversary, adversary_key = _build_adversarial_reviewer(_codex_dispatcher_for(development_dispatcher, redis_url))
 
     if configured == "codex-adversarial":
         # Advisory-only review: already adversarial, nothing to upgrade.
@@ -535,9 +528,7 @@ def _resolve_codereview_dispatcher(
     )
 
 
-def _build_judge_panel_dispatcher(
-    *, redis_url: str, judges: Optional[list[JudgeSpec]] = None
-) -> object:
+def _build_judge_panel_dispatcher(*, redis_url: str, judges: Optional[list[JudgeSpec]] = None) -> object:
     """Build the feature-mode ``judge-panel`` reviewer (FEAT-378 Module 4).
 
     Args:
@@ -551,12 +542,7 @@ def _build_judge_panel_dispatcher(
         mandatory Codex adversarial judge.
     """
     resolved = _ensure_adversarial_judge(
-        judges
-        if judges is not None
-        else [
-            JudgeSpec(**spec)
-            for spec in llm_catalog.default_judge_panel_payload()
-        ]
+        judges if judges is not None else [JudgeSpec(**spec) for spec in llm_catalog.default_judge_panel_payload()]
     )
     logger.info(
         "Feature-mode QA judge panel: %s",
@@ -676,13 +662,14 @@ def _build_pageindex_toolkit(wiki_dir: Path) -> object | None:
         toolkit = PageIndexToolkit(adapter, storage_dir=pageindex_dir)
         logger.info(
             "PageIndexToolkit ready (model=%s, storage=%s)",
-            model_spec, pageindex_dir,
+            model_spec,
+            pageindex_dir,
         )
         return toolkit
     except Exception as exc:  # noqa: BLE001 - authoring plane is best-effort
         logger.warning(
-            "PageIndexToolkit unavailable (%s); feature-handoff pages will "
-            "skip the authoring plane.", exc,
+            "PageIndexToolkit unavailable (%s); feature-handoff pages will " "skip the authoring plane.",
+            exc,
         )
         return None
 
@@ -702,10 +689,7 @@ def _build_wiki_toolkit() -> object | None:
         disabled or the toolkit cannot be constructed.
     """
     if not conf.DEV_LOOP_WIKI_PAGE_INGEST:
-        logger.info(
-            "DEV_LOOP_WIKI_PAGE_INGEST is off — feature handoff will skip "
-            "the wiki page ingest."
-        )
+        logger.info("DEV_LOOP_WIKI_PAGE_INGEST is off — feature handoff will skip " "the wiki page ingest.")
         return None
     try:
         from pathlib import Path
@@ -718,7 +702,7 @@ def _build_wiki_toolkit() -> object | None:
         from parrot.knowledge.wiki.toolkit import LLMWikiToolkit
 
         root = find_project_root(Path.cwd())
-        project = load_project_config(root)          # reads .parrot/wiki.json
+        project = load_project_config(root)  # reads .parrot/wiki.json
         wiki_config = WikiConfig(
             wiki_name=project.wiki_name,
             storage_dir=project.storage_path(root),
@@ -728,20 +712,18 @@ def _build_wiki_toolkit() -> object | None:
             sync_graph=False,
         )
         pageindex_toolkit = _build_pageindex_toolkit(project.storage_path(root))
-        toolkit = LLMWikiToolkit(
-            pageindex_toolkit, None, None, wiki_config, agent_id="dev-loop"
-        )
+        toolkit = LLMWikiToolkit(pageindex_toolkit, None, None, wiki_config, agent_id="dev-loop")
         logger.info(
-            "LLMWikiToolkit ready for feature-mode docs ingest "
-            "(wiki=%s, store=%s, pageindex=%s)",
-            project.wiki_name, project.storage_path(root),
+            "LLMWikiToolkit ready for feature-mode docs ingest " "(wiki=%s, store=%s, pageindex=%s)",
+            project.wiki_name,
+            project.storage_path(root),
             "on" if pageindex_toolkit is not None else "off",
         )
         return toolkit
     except Exception as exc:  # noqa: BLE001 - wiki ingest is best-effort
         logger.warning(
-            "LLMWikiToolkit unavailable (%s); feature handoff will skip the "
-            "wiki page ingest.", exc,
+            "LLMWikiToolkit unavailable (%s); feature handoff will skip the " "wiki page ingest.",
+            exc,
         )
         return None
 
@@ -916,7 +898,8 @@ def _build_brief_from_form(form: dict[str, Any]) -> dict[str, Any]:
             "Bug run without a CloudWatch source (skip_cloudwatch=%s, "
             "DEV_LOOP_CLOUDWATCH_ENABLED=%s) — research triages from the "
             "description and the codebase only.",
-            skip_cloudwatch, cloudwatch_available,
+            skip_cloudwatch,
+            cloudwatch_available,
         )
 
     payload: dict[str, Any] = {
@@ -1067,8 +1050,7 @@ def _parse_dev_agents(raw: Any) -> Optional[list[DevAgentSpec]]:
             continue
         if llm_catalog.get_backend(agent) is None:
             raise ValueError(
-                f"unknown dev agent backend {agent!r} — supported: "
-                f"{', '.join(b.id for b in llm_catalog.BACKENDS)}"
+                f"unknown dev agent backend {agent!r} — supported: " f"{', '.join(b.id for b in llm_catalog.BACKENDS)}"
             )
         specs.append(
             DevAgentSpec(
@@ -1106,8 +1088,7 @@ def _parse_judge_panel(raw: Any) -> Optional[list[JudgeSpec]]:
             continue
         if agent not in llm_catalog.JUDGE_BACKENDS:
             raise ValueError(
-                f"backend {agent!r} cannot serve as a QA judge — supported: "
-                f"{', '.join(llm_catalog.JUDGE_BACKENDS)}"
+                f"backend {agent!r} cannot serve as a QA judge — supported: " f"{', '.join(llm_catalog.JUDGE_BACKENDS)}"
             )
         judges.append(JudgeSpec(agent=agent, model=str(row.get("model") or "").strip()))
     return judges or None
@@ -1157,10 +1138,7 @@ def _build_feature_brief_from_form(form: dict[str, Any]) -> FeatureBrief:
         )
     document_kind = (form.get("document_kind") or "").strip().lower()
     if document_kind not in {"brainstorm", "proposal", "spec"}:
-        raise ValueError(
-            "document_kind must be 'brainstorm', 'proposal' or 'spec', got "
-            f"{document_kind!r}"
-        )
+        raise ValueError("document_kind must be 'brainstorm', 'proposal' or 'spec', got " f"{document_kind!r}")
 
     payload: dict[str, Any] = {
         "kind": "feature",
@@ -1217,16 +1195,10 @@ async def handle_config(request: web.Request) -> web.Response:
             "shell_criteria_heads": sorted(_ALLOWED_SHELL_HEADS),
             "document_kinds": ["brainstorm", "proposal", "spec"],
             "defaults": {
-                "development_agent": conf.config.get(
-                    "DEV_LOOP_DEVELOPMENT_AGENT", fallback="claude-code"
-                ),
+                "development_agent": conf.config.get("DEV_LOOP_DEVELOPMENT_AGENT", fallback="claude-code"),
                 "codereview_agent": app.get("codereview_agent_key", "parallel"),
-                "codereview_agent_configured": conf.config.get(
-                    "DEV_LOOP_CODEREVIEW_AGENT", fallback="parallel"
-                ),
-                "log_group": conf.config.get(
-                    "CLOUDWATCH_LOG_GROUP", fallback="fluent-bit-cloudwatch"
-                ),
+                "codereview_agent_configured": conf.config.get("DEV_LOOP_CODEREVIEW_AGENT", fallback="parallel"),
+                "log_group": conf.config.get("CLOUDWATCH_LOG_GROUP", fallback="fluent-bit-cloudwatch"),
                 "time_window_minutes": 60,
                 "cloudwatch_enabled": bool(conf.DEV_LOOP_CLOUDWATCH_ENABLED),
                 "jira_project": conf.config.get("JIRA_PROJECT") or "NAV",
@@ -1236,9 +1208,7 @@ async def handle_config(request: web.Request) -> web.Response:
                 "wiki_search": app.get("wiki_search") is not None,
                 "skip_qa": bool(getattr(conf, "DEV_LOOP_SKIP_QA", False)),
                 "development_pool_max": app.get("development_pool_max", 4),
-                "max_concurrent_runs": getattr(
-                    app.get("runner"), "max_concurrent_runs", None
-                ),
+                "max_concurrent_runs": getattr(app.get("runner"), "max_concurrent_runs", None),
             },
             "adversarial_review": {
                 "mandatory": True,
@@ -1320,7 +1290,11 @@ async def handle_run(request: web.Request) -> web.Response:
         try:
             logger.info(
                 "Starting %s flow run_id=%s (%s) skip_qa=%s skip_jira=%s",
-                "FEATURE" if is_feature else "bug", run_id, label, skip_qa, skip_jira,
+                "FEATURE" if is_feature else "bug",
+                run_id,
+                label,
+                skip_qa,
+                skip_jira,
             )
             result = await runner.run(
                 brief,
@@ -1406,9 +1380,7 @@ async def handle_bundle(request: web.Request) -> web.Response:
 
     fmt = (request.query.get("format") or "md").strip().lower()
     if fmt not in {"md", "json"}:
-        return web.json_response(
-            {"error": "format must be 'md' or 'json'"}, status=400
-        )
+        return web.json_response({"error": "format must be 'md' or 'json'"}, status=400)
 
     suffix = "report.md" if fmt == "md" else "bundle.json"
     path = (RUN_ARTIFACT_DIR / f"{run_id}.{suffix}").resolve()
@@ -1419,10 +1391,7 @@ async def handle_bundle(request: web.Request) -> web.Response:
     if not path.is_file():
         return web.json_response(
             {
-                "error": (
-                    f"no run bundle for {run_id} yet — the export is written "
-                    "when the run terminates."
-                ),
+                "error": (f"no run bundle for {run_id} yet — the export is written " "when the run terminates."),
                 "expected_path": str(path),
             },
             status=404,
@@ -1542,9 +1511,7 @@ async def _on_startup(app: web.Application) -> None:
         stream_ttl_seconds=conf.FLOW_STREAM_TTL_SECONDS,
     )
     if development_pool_config is not None:
-        backends_summary = ", ".join(
-            f"{spec.agent}x{spec.count}" for spec in development_pool_config.agents
-        )
+        backends_summary = ", ".join(f"{spec.agent}x{spec.count}" for spec in development_pool_config.agents)
         logger.info(
             "Dev-agent pool configured: %s (isolation=%s, pool_max=%d)",
             backends_summary,
@@ -1584,9 +1551,7 @@ async def _on_startup(app: web.Application) -> None:
 
     # FEAT-377 TASK-1916 (G5): opt-in plan_approval gate. False (default)
     # preserves current behavior exactly.
-    require_plan_approval = bool(
-        getattr(conf, "DEV_LOOP_REQUIRE_PLAN_APPROVAL", False)
-    )
+    require_plan_approval = bool(getattr(conf, "DEV_LOOP_REQUIRE_PLAN_APPROVAL", False))
     skip_qa = bool(getattr(conf, "DEV_LOOP_SKIP_QA", False))
 
     jira_toolkit = _build_jira_toolkit()
@@ -1669,8 +1634,8 @@ async def _on_startup(app: web.Application) -> None:
     except Exception as exc:  # noqa: BLE001 - feature mode is additive
         app["feature_mode_reason"] = str(exc)
         logger.warning(
-            "Feature-mode topology unavailable (%s); the console will only "
-            "offer bug/enhancement/new_feature runs.", exc,
+            "Feature-mode topology unavailable (%s); the console will only " "offer bug/enhancement/new_feature runs.",
+            exc,
         )
 
     app["runner"] = runner

--- a/examples/dev_loop/server.py
+++ b/examples/dev_loop/server.py
@@ -941,6 +941,9 @@ def _build_brief_from_form(form: dict[str, Any]) -> dict[str, Any]:
         isolation = (form.get("dev_isolation") or "").strip().lower()
         if isolation in {"shared", "isolated"}:
             payload["dev_isolation"] = isolation
+
+    # FEAT-466 TASK-2508: per-run flow-type/base-branch override.
+    _apply_flow_override(payload, form)
     return payload
 
 
@@ -1007,6 +1010,34 @@ def _normalise_criteria(raw: Any) -> list[dict[str, Any]]:
                 }
             )
     return out
+
+
+_FLOW_TYPES = {"feature", "hotfix"}
+
+
+def _apply_flow_override(payload: dict[str, Any], form: dict[str, Any]) -> None:
+    """Parse the console's flow-type/base-branch override into ``payload``.
+
+    FEAT-466 TASK-2508: mirrors the ``dev_isolation`` validation idiom
+    verbatim — read, normalise, validate against a literal set, add only on
+    success. ``flow_type`` is a closed set and is rejected (omitted) when
+    invalid rather than passed to pydantic; ``base_branch`` is deliberately
+    open (CLAUDE.md allows sub-feature branches as a base), so any non-empty
+    string is accepted and left to ``resolve_flow``/``FlowMeta`` to reject an
+    invalid *combination*. The console's ``"auto"`` sentinel must never reach
+    here — both consoles omit the key entirely instead of sending ``"auto"``.
+
+    Args:
+        payload: The brief payload dict being built; mutated in place.
+        form: The raw decoded form/JSON body.
+    """
+    flow_type = (form.get("flow_type") or "").strip().lower()
+    if flow_type in _FLOW_TYPES:
+        payload["flow_type"] = flow_type
+
+    base_branch = (form.get("base_branch") or "").strip()
+    if base_branch:
+        payload["base_branch"] = base_branch
 
 
 def _parse_dev_agents(raw: Any) -> Optional[list[DevAgentSpec]]:
@@ -1145,6 +1176,14 @@ def _build_feature_brief_from_form(form: dict[str, Any]) -> FeatureBrief:
     judges = _parse_judge_panel(form.get("judge_panel"))
     if judges:
         payload["judge_panel"] = JudgePanelConfig(judges=judges)
+
+    # FEAT-466 TASK-2508: same override parsing as the bug/work-brief path,
+    # for consistency. NOTE: FeatureBrief.kind is a fixed Literal["feature"]
+    # and the model does not declare `flow_type`/`base_branch` fields (out
+    # of scope for this task — see FeatureBrief in models/base.py), so
+    # Pydantic's default `extra="ignore"` silently drops these keys today;
+    # they are parsed here only to keep both payload builders symmetric.
+    _apply_flow_override(payload, form)
     return FeatureBrief.model_validate(payload)
 
 

--- a/examples/dev_loop/server_dev.py
+++ b/examples/dev_loop/server_dev.py
@@ -178,6 +178,13 @@ def _build_dev_brief_from_form(
     judges = ops_server._parse_judge_panel(form.get("judge_panel"))
     if judges:
         payload["judge_panel"] = JudgePanelConfig(judges=judges)
+
+    # FEAT-466 TASK-2508: reuse the ops-server override parser. Note:
+    # DevRequestBrief (like FeatureBrief) declares no flow_type/base_branch
+    # fields — this flow never handles kind="bug", so the override is
+    # currently inert here (Pydantic's default extra="ignore" drops the
+    # keys); parsed only to keep every payload builder symmetric.
+    ops_server._apply_flow_override(payload, form)
     return DevRequestBrief.model_validate(payload)
 
 

--- a/examples/dev_loop/server_dev.py
+++ b/examples/dev_loop/server_dev.py
@@ -106,9 +106,7 @@ def _normalise_kind(raw: Any) -> str:
     return (str(raw or "")).strip().lower().replace(" ", "_").replace("-", "_")
 
 
-def _build_dev_brief_from_form(
-    form: dict[str, Any]
-) -> DevRequestBrief | Any:
+def _build_dev_brief_from_form(form: dict[str, Any]) -> DevRequestBrief | Any:
     """Translate the dev console's form into a dev-flow brief.
 
     Two shapes, selected by ``kind``:
@@ -143,16 +141,12 @@ def _build_dev_brief_from_form(
     if kind == "feature":
         return ops_server._build_feature_brief_from_form(form)
     if kind not in ("enhancement", "new_feature"):
-        raise ValueError(
-            "kind must be 'enhancement', 'new_feature' or 'feature', got "
-            f"{kind!r}"
-        )
+        raise ValueError("kind must be 'enhancement', 'new_feature' or 'feature', got " f"{kind!r}")
 
     title = (form.get("title") or "").strip()
     if not title:
         raise ValueError(
-            "title is required — it names the request and is the slug source "
-            "for sdd/proposals/<slug>.*.md"
+            "title is required — it names the request and is the slug source " "for sdd/proposals/<slug>.*.md"
         )
     description = (form.get("description") or "").strip()
     if not description:
@@ -220,31 +214,17 @@ async def handle_config(request: web.Request) -> web.Response:
             # The intents whose runs go through ideation (the UI shows the
             # natural-language intake for these, a document picker otherwise).
             "nl_kinds": ["enhancement", "new_feature"],
-            "gate_resolve_url_template": (
-                "/api/flow/{run_id}/gates/{gate_id}/resolve"
-            ),
+            "gate_resolve_url_template": ("/api/flow/{run_id}/gates/{gate_id}/resolve"),
             "defaults": {
-                "development_agent": conf.config.get(
-                    "DEV_LOOP_DEVELOPMENT_AGENT", fallback="claude-code"
-                ),
+                "development_agent": conf.config.get("DEV_LOOP_DEVELOPMENT_AGENT", fallback="claude-code"),
                 "codereview_agent": app.get("codereview_agent_key", "parallel"),
-                "codereview_agent_configured": conf.config.get(
-                    "DEV_LOOP_CODEREVIEW_AGENT", fallback="parallel"
-                ),
+                "codereview_agent_configured": conf.config.get("DEV_LOOP_CODEREVIEW_AGENT", fallback="parallel"),
                 "qa_max_retries": conf.DEV_LOOP_QA_MAX_RETRIES,
                 "development_pool_max": app.get("development_pool_max", 4),
-                "max_concurrent_runs": getattr(
-                    runner, "max_concurrent_runs", None
-                ),
-                "ideation_max_rounds": getattr(
-                    conf, "DEV_FLOW_IDEATION_MAX_ROUNDS", 2
-                ),
-                "gate_ttl_questions": getattr(
-                    conf, "DEV_FLOW_GATE_TTL_QUESTIONS", 86400
-                ),
-                "require_plan_approval": bool(
-                    app.get("require_plan_approval", False)
-                ),
+                "max_concurrent_runs": getattr(runner, "max_concurrent_runs", None),
+                "ideation_max_rounds": getattr(conf, "DEV_FLOW_IDEATION_MAX_ROUNDS", 2),
+                "gate_ttl_questions": getattr(conf, "DEV_FLOW_GATE_TTL_QUESTIONS", 86400),
+                "require_plan_approval": bool(app.get("require_plan_approval", False)),
                 "skip_qa": bool(getattr(conf, "DEV_LOOP_SKIP_QA", False)),
                 "docs_artifact_dir": conf.DEV_LOOP_DOCS_ARTIFACT_DIR,
                 "wiki_page_ingest": conf.DEV_LOOP_WIKI_PAGE_INGEST,
@@ -310,15 +290,16 @@ async def handle_run(request: web.Request) -> web.Response:
     # the form actually carries the field, so an absent toggle falls back to
     # the flow's build-time default instead of silently overriding it.
     if "require_plan_approval" in form:
-        extra_shared["require_plan_approval"] = bool(
-            form.get("require_plan_approval")
-        )
+        extra_shared["require_plan_approval"] = bool(form.get("require_plan_approval"))
 
     async def _run() -> None:
         try:
             logger.info(
                 "Starting dev-flow run_id=%s kind=%s (%s) extra_shared=%s",
-                run_id, kind, label, sorted(extra_shared),
+                run_id,
+                kind,
+                label,
+                sorted(extra_shared),
             )
             result = await runner.run(
                 brief,
@@ -328,7 +309,9 @@ async def handle_run(request: web.Request) -> web.Response:
             )
             logger.info(
                 "dev-flow run_id=%s finished status=%s in %.1fs",
-                run_id, result.status, time.time() - started_at,
+                run_id,
+                result.status,
+                time.time() - started_at,
             )
         except Exception:
             logger.exception("dev-flow run_id=%s failed", run_id)
@@ -389,16 +372,13 @@ def _build_optional_jira_toolkit() -> Any | None:
     """
     if not (conf.config.get("JIRA_INSTANCE") and conf.config.get("JIRA_USERNAME")):
         logger.info(
-            "JIRA_* not configured — dev-flow runs with jira_toolkit=None "
-            "(Jira is link-only and optional here)."
+            "JIRA_* not configured — dev-flow runs with jira_toolkit=None " "(Jira is link-only and optional here)."
         )
         return None
     try:
         return ops_server._build_jira_toolkit()
     except Exception as exc:  # noqa: BLE001 - Jira is optional in dev-flow
-        logger.warning(
-            "JiraToolkit unavailable (%s) — continuing without Jira.", exc
-        )
+        logger.warning("JiraToolkit unavailable (%s) — continuing without Jira.", exc)
         return None
 
 
@@ -419,11 +399,7 @@ async def _on_startup(app: web.Application) -> None:
 
     # -- development backend selection (same cascade as the ops console) --
     development_dispatcher: object = dispatcher
-    development_agent = (
-        conf.config.get("DEV_LOOP_DEVELOPMENT_AGENT", fallback="claude-code")
-        .strip()
-        .lower()
-    )
+    development_agent = conf.config.get("DEV_LOOP_DEVELOPMENT_AGENT", fallback="claude-code").strip().lower()
     env_map = ops_server._DEVELOPMENT_AGENT_MAX_CONCURRENT_ENV
     if development_agent in {"claude", "claude-code"}:
         pass
@@ -438,9 +414,7 @@ async def _on_startup(app: web.Application) -> None:
             ),
             stream_ttl_seconds=conf.FLOW_STREAM_TTL_SECONDS,
         )
-        ops_server._log_development_agent_selection(
-            backend, development_profile
-        )
+        ops_server._log_development_agent_selection(backend, development_profile)
         # NOTE: like feature-mode (`build_dev_loop_feature_flow`), the dev-flow
         # builder takes no `development_dispatcher`/`development_profile`, so
         # this selection currently applies to the code-review reviewer
@@ -449,7 +423,8 @@ async def _on_startup(app: web.Application) -> None:
         logger.info(
             "DEV_LOOP_DEVELOPMENT_AGENT=%r selected; dev-flow dispatches "
             "development through the shared claude-code dispatcher unless a "
-            "pool is declared per run.", development_agent,
+            "pool is declared per run.",
+            development_agent,
         )
     else:
         raise RuntimeError(
@@ -464,15 +439,14 @@ async def _on_startup(app: web.Application) -> None:
         development_dispatcher=development_dispatcher,
         redis_url=redis_url,
     )
-    judge_panel_dispatcher = ops_server._build_judge_panel_dispatcher(
-        redis_url=redis_url
-    )
+    judge_panel_dispatcher = ops_server._build_judge_panel_dispatcher(redis_url=redis_url)
 
     repos = parse_repo_specs(conf.DEV_LOOP_REPOS)
     if repos:
         logger.info(
             "DEV_LOOP_REPOS configured: %d repo(s) — primary alias=%r",
-            len(repos), repos[0].alias,
+            len(repos),
+            repos[0].alias,
         )
 
     # -- dev-agent pool (FEAT-323) ---------------------------------------
@@ -496,10 +470,7 @@ async def _on_startup(app: web.Application) -> None:
             "NOT inject it: the pool is planner-sized (cap pool_max=%d) or set "
             "per run via the brief's dev_agents. Use the console's "
             "'Agents & models' tab to pin a pool for a run.",
-            ", ".join(
-                f"{spec.agent}x{spec.count}"
-                for spec in development_pool_config.agents
-            ),
+            ", ".join(f"{spec.agent}x{spec.count}" for spec in development_pool_config.agents),
             development_pool_config.isolation_mode,
             development_pool_max,
         )
@@ -513,9 +484,7 @@ async def _on_startup(app: web.Application) -> None:
     git_toolkit = ops_server._build_git_toolkit()
     wiki_toolkit = ops_server._build_wiki_toolkit()
 
-    require_plan_approval = bool(
-        getattr(conf, "DEV_LOOP_REQUIRE_PLAN_APPROVAL", False)
-    )
+    require_plan_approval = bool(getattr(conf, "DEV_LOOP_REQUIRE_PLAN_APPROVAL", False))
     skip_qa = bool(getattr(conf, "DEV_LOOP_SKIP_QA", False))
 
     app["flow"] = build_dev_flow(
@@ -580,9 +549,7 @@ def build_app(redis_url: str = "redis://localhost:6379/0") -> web.Application:
     app.router.add_post("/api/flow/{run_id}/cancel", ops_server.handle_cancel)
     # THE HITL write path server.py never mounts — under /api/flow to match
     # the console's other routes.
-    app.router.add_post(
-        "/api/flow/{run_id}/gates/{gate_id}/resolve", handle_resolve_gate
-    )
+    app.router.add_post("/api/flow/{run_id}/gates/{gate_id}/resolve", handle_resolve_gate)
     return app
 
 
@@ -596,9 +563,7 @@ def main() -> None:
     host = os.environ.get("HOST", "127.0.0.1")
     port = int(os.environ.get("PORT", "8081"))
     app = build_app(redis_url=redis_url)
-    logger.info(
-        "dev-flow console on http://%s:%s (Redis=%s)", host, port, redis_url
-    )
+    logger.info("dev-flow console on http://%s:%s (Redis=%s)", host, port, redis_url)
     web.run_app(app, host=host, port=port, print=None)
 
 

--- a/examples/dev_loop/static/dev.html
+++ b/examples/dev_loop/static/dev.html
@@ -439,6 +439,7 @@ const app = {
     documentPath: "", documentKind: "proposal",
     jiraIssueKey: "",
     devAgents: [], devIsolation: "shared",
+    flowType: "auto", baseBranch: "auto",
     judges: [], skipQa: false, skipJira: false,
     // FEAT-412: per-run plan-approval gate toggle.
     requirePlanApproval: false,
@@ -742,14 +743,38 @@ function slugify(s) {
     .replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
 }
 
+// FEAT-466 TASK-2508: mirror the ops console's resolvedFlow(). This
+// console's `kind` is never "bug" (enhancement | new_feature | feature),
+// so the kind-derived default is always "feature" here — but an explicit
+// operator override to "hotfix" is still honoured (composes field-wise,
+// same precedence as resolve_flow()).
+function resolvedFlow() {
+  const f = app.form;
+  const type = f.flowType !== "auto" ? f.flowType : "feature";
+  const base = f.baseBranch !== "auto" ? f.baseBranch : (type === "hotfix" ? "main" : "dev");
+  return { type, base };
+}
+
+// FEAT-466 TASK-2508 guard (§F): resolve_flow() raises ValueError for
+// type=hotfix + base_branch != main. Never let a stale "dev"/"staging"
+// base_branch survive a switch into an effective hotfix type.
+function sanitizeFlowOverride() {
+  const f = app.form;
+  if (resolvedFlow().type === "hotfix" && f.baseBranch !== "auto" && f.baseBranch !== "main") {
+    f.baseBranch = "auto";
+  }
+}
+
 function renderReady() {
   const f = app.form;
   const maxRounds = app.config?.defaults?.ideation_max_rounds ?? 2;
+  const rf = resolvedFlow();
   const rows = app.mode === "feature"
     ? [
         ["intent", "feature (ideation skipped)"],
         ["document", f.documentPath ? f.documentPath.split("/").pop() : "— required —"],
         ["doc kind", f.documentKind],
+        ["flow", `${rf.type} → ${rf.base}`],
         ["dev agents", f.devAgents.length ? f.devAgents.map((a) => `${a.agent}×${a.count}`).join(" ") : "planner-sized"],
         ["judges", `${effectiveJudges().length} · majority`],
         ["jira", f.jiraIssueKey || "none (optional)"],
@@ -761,6 +786,7 @@ function renderReady() {
         ["will write", docTargetHint()],
         ["description", f.description.trim() ? `${f.description.trim().length} chars` : "— required —"],
         ["HITL rounds", `≤ ${maxRounds}`],
+        ["flow", `${rf.type} → ${rf.base}`],
         ["dev agents", f.devAgents.length ? f.devAgents.map((a) => `${a.agent}×${a.count}`).join(" ") : "planner-sized"],
         ["judges", `${effectiveJudges().length} · majority`],
         ["plan gate", f.requirePlanApproval ? "REQUIRED" : "off"],
@@ -1329,6 +1355,21 @@ function tabBodyHtml(tab) {
       ${["shared", "isolated"].map((v) =>
         `<label class="seg-opt ${f.devIsolation === v ? "on" : ""}" data-val="${v}">${v}</label>`).join("")}
     </div>`;
+  // FEAT-466 TASK-2508: console flow-type / base-branch override (mirrors
+  // examples/dev_loop/static/index.html's implementation verbatim).
+  const flowTypeSeg = `
+    <div class="seg" data-seg="flowType">
+      ${["auto", "feature", "hotfix"].map((v) =>
+        `<label class="seg-opt ${f.flowType === v ? "on" : ""}" data-val="${v}">${v}</label>`).join("")}
+    </div>`;
+  // Filter on the RESOLVED (effective) type — see sanitizeFlowOverride().
+  const baseBranchValues = resolvedFlow().type === "hotfix"
+    ? ["auto", "main"] : ["auto", "dev", "main", "staging"];
+  const baseBranchSeg = `
+    <div class="seg" data-seg="baseBranch">
+      ${baseBranchValues.map((v) =>
+        `<label class="seg-opt ${f.baseBranch === v ? "on" : ""}" data-val="${v}">${v}</label>`).join("")}
+    </div>`;
 
   if (tab === "ideation") {
     const d = app.config?.defaults || {};
@@ -1382,6 +1423,16 @@ function tabBodyHtml(tab) {
       <div class="field" style="max-width:280px">
         <span class="field-label">Worktree isolation</span>
         ${isolationSeg}
+      </div>
+      <div class="field" style="max-width:280px">
+        <span class="field-label">Flow type (FEAT-466)</span>
+        ${flowTypeSeg}
+        <p class="hint">auto = feature (this console never files a bug).</p>
+      </div>
+      <div class="field" style="max-width:360px">
+        <span class="field-label">Base branch (FEAT-466)</span>
+        ${baseBranchSeg}
+        <p class="hint">auto = derive from flow type (hotfix → main, feature → dev). Hotfix only allows main.</p>
       </div>
     </div>`;
   }
@@ -1513,6 +1564,9 @@ function buildPayload() {
   if (f.judges.length) payload.judge_panel = f.judges;
   if (f.skipQa) payload.skip_qa = true;
   if (f.skipJira) payload.skip_jira = true;
+  // FEAT-466 TASK-2508: "auto" is a UI-only sentinel — never reaches Python.
+  if (f.flowType !== "auto") payload.flow_type = f.flowType;
+  if (f.baseBranch !== "auto") payload.base_branch = f.baseBranch;
   // FEAT-412: ALWAYS send the boolean, both true and false.
   // The checkbox is initialised from the server's own default at boot, so its
   // state is always a deliberate, user-visible value — and the server only
@@ -1638,11 +1692,21 @@ document.addEventListener("click", (e) => {
   const t = e.target;
 
   const kind = t.closest("[data-kind]");
-  if (kind) { app.kind = kind.dataset.kind; applyMode(); return; }
+  if (kind) {
+    app.kind = kind.dataset.kind;
+    sanitizeFlowOverride(); // FEAT-466 TASK-2508
+    applyMode(); return;
+  }
   const dk = t.closest("[data-dockind]");
   if (dk) { app.form.documentKind = dk.dataset.dockind; renderKindPicker(); renderReady(); return; }
   const view = t.closest("[data-view]");
   if (view) { app.view = view.dataset.view; renderKindPicker(); renderExecution(); return; }
+  const flowSeg = t.closest('[data-seg="flowType"] [data-val]');
+  if (flowSeg) {
+    app.form.flowType = flowSeg.dataset.val;
+    sanitizeFlowOverride();
+    renderTabs(); renderReady(); return;
+  }
   const seg = t.closest("[data-seg] [data-val]");
   if (seg) {
     app.form[seg.closest("[data-seg]").dataset.seg] = seg.dataset.val;

--- a/examples/dev_loop/static/index.html
+++ b/examples/dev_loop/static/index.html
@@ -416,6 +416,7 @@ const app = {
     affectedComponent: "", existingIssueKey: "", jiraIssueKey: "",
     logGroup: "", timeWindow: "60",
     devAgents: [], devIsolation: "shared",
+    flowType: "auto", baseBranch: "auto",
     judges: [], skipQa: false, skipJira: false, skipCloudwatch: false,
   },
 };
@@ -715,12 +716,38 @@ function criteriaSummary() {
   return `${shell} shell · ${manual} manual`;
 }
 
+// FEAT-466 TASK-2508: mirror scripts.sdd.sdd_meta.WORK_KIND_FLOW's mapping
+// so the "ready" summary shows the RESOLVED outcome, never the literal
+// "auto" string — an operator override composes field-wise, exactly like
+// resolve_flow()'s precedence (explicit override > kind mapping > default).
+function resolvedFlow() {
+  const f = app.form;
+  const kindDerivedType = app.kind === "bug" ? "hotfix" : "feature";
+  const type = f.flowType !== "auto" ? f.flowType : kindDerivedType;
+  const base = f.baseBranch !== "auto" ? f.baseBranch : (type === "hotfix" ? "main" : "dev");
+  return { type, base };
+}
+
+// FEAT-466 TASK-2508 guard (§F): resolve_flow() raises ValueError for
+// type=hotfix + base_branch != main. The EFFECTIVE type can go hotfix
+// either by an explicit flowType="hotfix" override OR implicitly, when
+// flowType is still "auto" on a kind="bug" run — both must be guarded.
+// Call after any change that could affect app.kind or app.form.flowType.
+function sanitizeFlowOverride() {
+  const f = app.form;
+  if (resolvedFlow().type === "hotfix" && f.baseBranch !== "auto" && f.baseBranch !== "main") {
+    f.baseBranch = "auto";
+  }
+}
+
 function renderReady() {
   const f = app.form;
+  const rf = resolvedFlow();
   const rows = app.mode === "feature"
     ? [
         ["document", f.documentPath ? f.documentPath.split("/").pop() : "— required —"],
         ["doc kind", f.documentKind],
+        ["flow", `${rf.type} → ${rf.base}`],
         ["dev agents", f.devAgents.length ? f.devAgents.map((a) => `${a.agent}×${a.count}`).join(" ") : "planner-sized"],
         ["judges", `${effectiveJudges().length} · majority`],
         ["jira", f.jiraIssueKey || "none (optional)"],
@@ -729,6 +756,7 @@ function renderReady() {
       ]
     : [
         ["kind", app.kind],
+        ["flow", `${rf.type} → ${rf.base}`],
         ["component", f.affectedComponent || "— required —"],
         ["criteria", criteriaSummary()],
         ["dev agents", f.devAgents.length ? f.devAgents.map((a) => `${a.agent}×${a.count}`).join(" ") : "server default"],
@@ -1131,6 +1159,27 @@ function tabBodyHtml(tab) {
       ${["shared", "isolated"].map((v) =>
         `<label class="seg-opt ${f.devIsolation === v ? "on" : ""}" data-val="${v}">${v}</label>`).join("")}
     </div>`;
+  // FEAT-466 TASK-2508: console flow-type / base-branch override.
+  // "auto" is a UI-only sentinel — it is never sent to the server (§F,
+  // buildPayload). When flowType === "hotfix" the base-branch choices are
+  // restricted to auto/main so the invalid hotfix+non-main combination is
+  // unreachable from the UI (resolve_flow() rejects it server-side too).
+  const flowTypeSeg = `
+    <div class="seg" data-seg="flowType">
+      ${["auto", "feature", "hotfix"].map((v) =>
+        `<label class="seg-opt ${f.flowType === v ? "on" : ""}" data-val="${v}">${v}</label>`).join("")}
+    </div>`;
+  // Filter on the RESOLVED (effective) type, not the literal flowType field:
+  // on a kind="bug" run with flowType still "auto", the effective type is
+  // already "hotfix" (WORK_KIND_FLOW's mapping) — the guard must apply
+  // there too, not only once the operator explicitly picks "hotfix".
+  const baseBranchValues = resolvedFlow().type === "hotfix"
+    ? ["auto", "main"] : ["auto", "dev", "main", "staging"];
+  const baseBranchSeg = `
+    <div class="seg" data-seg="baseBranch">
+      ${baseBranchValues.map((v) =>
+        `<label class="seg-opt ${f.baseBranch === v ? "on" : ""}" data-val="${v}">${v}</label>`).join("")}
+    </div>`;
 
   if (tab === "criteria") {
     return grid(`
@@ -1218,6 +1267,16 @@ function tabBodyHtml(tab) {
       <div class="field" style="max-width:280px">
         <span class="field-label">Worktree isolation</span>
         ${isolationSeg}
+      </div>
+      <div class="field" style="max-width:280px">
+        <span class="field-label">Flow type (FEAT-466)</span>
+        ${flowTypeSeg}
+        <p class="hint">auto = derive from kind (bug → hotfix, else feature).</p>
+      </div>
+      <div class="field" style="max-width:360px">
+        <span class="field-label">Base branch (FEAT-466)</span>
+        ${baseBranchSeg}
+        <p class="hint">auto = derive from flow type (hotfix → main, feature → dev). Hotfix only allows main.</p>
       </div>
     </div>`;
   }
@@ -1345,6 +1404,9 @@ function buildPayload() {
     if (f.judges.length) payload.judge_panel = f.judges;
     if (f.skipQa) payload.skip_qa = true;
     if (f.skipJira) payload.skip_jira = true;
+    // FEAT-466 TASK-2508: "auto" is a UI-only sentinel — never reaches Python.
+    if (f.flowType !== "auto") payload.flow_type = f.flowType;
+    if (f.baseBranch !== "auto") payload.base_branch = f.baseBranch;
     return payload;
   }
   const payload = {
@@ -1362,6 +1424,9 @@ function buildPayload() {
     payload.dev_agents = f.devAgents;
     payload.dev_isolation = f.devIsolation;
   }
+  // FEAT-466 TASK-2508: "auto" is a UI-only sentinel — never reaches Python.
+  if (f.flowType !== "auto") payload.flow_type = f.flowType;
+  if (f.baseBranch !== "auto") payload.base_branch = f.baseBranch;
   if (f.skipQa) payload.skip_qa = true;
   if (f.skipJira) payload.skip_jira = true;
   return payload;
@@ -1487,12 +1552,20 @@ document.addEventListener("click", (e) => {
   if (kind) {
     const v = kind.dataset.kind;
     if (v === "feature" && !app.config?.feature_mode?.available) return;
-    app.kind = v; applyMode(); return;
+    app.kind = v;
+    sanitizeFlowOverride(); // FEAT-466 TASK-2508: kind="bug" implies hotfix
+    applyMode(); return;
   }
   const dk = t.closest("[data-dockind]");
   if (dk) { app.form.documentKind = dk.dataset.dockind; renderKindPicker(); renderReady(); return; }
   const view = t.closest("[data-view]");
   if (view) { app.view = view.dataset.view; renderKindPicker(); renderExecution(); return; }
+  const flowSeg = t.closest('[data-seg="flowType"] [data-val]');
+  if (flowSeg) {
+    app.form.flowType = flowSeg.dataset.val;
+    sanitizeFlowOverride();
+    renderTabs(); renderReady(); return;
+  }
   const seg = t.closest("[data-seg] [data-val]");
   if (seg) {
     app.form[seg.closest("[data-seg]").dataset.seg] = seg.dataset.val;

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/_subagent_data/sdd-research.md
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/_subagent_data/sdd-research.md
@@ -61,16 +61,30 @@ criteria) you must:
    derived from the affected component, fill in the motivation and
    acceptance criteria from the brief. **Flow type — pass it explicitly,
    do not let `/sdd-spec` infer it (FEAT-466):**
+
+   **Check the brief's own `flow_type` / `base_branch` fields FIRST** —
+   these are an explicit console/operator override (FEAT-466 TASK-2508)
+   and, when present, WIN OVER the `kind`-derived default below. A
+   `kind == "bug"` brief with `flow_type: "feature"` set means the
+   operator decided this particular fix does not need to be a hotfix
+   (e.g. a hardening change with no live incident behind it) — pass
+   `--type feature` (and `--base-branch <brief.base_branch or "dev">"`),
+   not `--type hotfix`. Only fall back to the `kind`-derived default when
+   the brief's `flow_type`/`base_branch` are absent (`null`):
    ```
    /sdd-spec <slug> --type hotfix --base-branch main       # kind == "bug"
    /sdd-spec <slug> --type feature --base-branch dev        # kind == "enhancement" | "new_feature"
    ```
    `kind == "bug"` → `type: hotfix` / `base_branch: main` (bug fixes land
-   on `main`). `kind == "enhancement"` or `"new_feature"` → `type: feature`
-   / `base_branch: dev`. **When `kind == "bug"`, no `FEAT-<NNN>`/`TASK-<NNN>`
-   id is reserved at all** — `/sdd-spec` skips the ledger allocator entirely
-   for `type: hotfix` (a bugfix is not a feature); the Jira issue key from
-   step 2 is this run's identity instead.
+   on `main`), UNLESS the brief overrode `flow_type` to `"feature"` (see
+   above). `kind == "enhancement"` or `"new_feature"` → `type: feature` /
+   `base_branch: dev`. **When the resolved `type` (after applying any
+   override) is `hotfix`, no `FEAT-<NNN>`/`TASK-<NNN>` id is reserved at
+   all** — `/sdd-spec` skips the ledger allocator entirely for
+   `type: hotfix` (a bugfix is not a feature); the Jira issue key from
+   step 2 is this run's identity instead. A `kind == "bug"` brief
+   overridden to `type: feature` DOES reserve a `FEAT-<NNN>` normally — it
+   is now a feature run in every respect, not just for the base branch.
 4. **Decompose into tasks — `type: feature` only.** Run
    ``/sdd-task <spec-path>``. **For `type: hotfix`, SKIP this step
    entirely** — a one-or-two-commit bugfix is handled directly by the

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/_subagent_data/sdd-research.md
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/_subagent_data/sdd-research.md
@@ -4,8 +4,10 @@ description: |
   Research-phase subagent for the dev-loop flow (FEAT-129).
   Given a BugBrief and log excerpts, this agent triages the failure,
   creates a Jira ticket, scaffolds an SDD spec via /sdd-spec, decomposes
-  it into tasks via /sdd-task, and creates the feature worktree at
-  .claude/worktrees/feat-<id>-<slug>/.
+  it into tasks via /sdd-task (feature runs only — FEAT-466 skips this for
+  hotfixes), and creates the worktree at
+  .claude/worktrees/feat-<id>-<slug>/ (feature) or
+  .claude/worktrees/hotfix-<JIRA-KEY>-<slug>/ (hotfix, no id reserved).
 
   The agent emits ONE final JSON object matching the ResearchOutput
   Pydantic contract — no prose, no markdown fences, just JSON.
@@ -57,15 +59,28 @@ criteria) you must:
    the brief). Assignee = the dev-loop service account (``flow-bot``).
 3. **Scaffold an SDD spec**. Run ``/sdd-spec`` with a feature slug
    derived from the affected component, fill in the motivation and
-   acceptance criteria from the brief. **Flow type**: when the brief's
-   ``kind`` is ``"bug"`` use ``type: hotfix`` / ``base_branch: main``
-   in the spec frontmatter (bug fixes land on ``main``). When ``kind``
-   is ``"enhancement"`` or ``"new_feature"`` use ``type: feature`` /
-   ``base_branch: dev``.
-4. **Decompose into tasks**. Run ``/sdd-task <spec-path>``.
-5. **Create the worktree**. The base ref depends on the spec's
-   ``type``:
-   - ``hotfix``: ``git worktree add -b feat-<id>-<slug> .claude/worktrees/feat-<id>-<slug> origin/main``
+   acceptance criteria from the brief. **Flow type — pass it explicitly,
+   do not let `/sdd-spec` infer it (FEAT-466):**
+   ```
+   /sdd-spec <slug> --type hotfix --base-branch main       # kind == "bug"
+   /sdd-spec <slug> --type feature --base-branch dev        # kind == "enhancement" | "new_feature"
+   ```
+   `kind == "bug"` → `type: hotfix` / `base_branch: main` (bug fixes land
+   on `main`). `kind == "enhancement"` or `"new_feature"` → `type: feature`
+   / `base_branch: dev`. **When `kind == "bug"`, no `FEAT-<NNN>`/`TASK-<NNN>`
+   id is reserved at all** — `/sdd-spec` skips the ledger allocator entirely
+   for `type: hotfix` (a bugfix is not a feature); the Jira issue key from
+   step 2 is this run's identity instead.
+4. **Decompose into tasks — `type: feature` only.** Run
+   ``/sdd-task <spec-path>``. **For `type: hotfix`, SKIP this step
+   entirely** — a one-or-two-commit bugfix is handled directly by the
+   dev-loop's single-agent development path from the spec alone; there is
+   no per-spec task index and no `TASK-<NNN>` id to reserve. Proceed
+   straight to step 5.
+5. **Create the worktree**. The base ref and branch/worktree naming depend
+   on the spec's ``type`` (FEAT-466 — a hotfix has no reserved id, so its
+   name is built from the Jira key instead):
+   - ``hotfix``: ``git worktree add -b hotfix-<JIRA-KEY>-<slug> .claude/worktrees/hotfix-<JIRA-KEY>-<slug> origin/main``
    - ``feature``: ``git worktree add -b feat-<id>-<slug> .claude/worktrees/feat-<id>-<slug> origin/dev``
 
 ## Cardinal rules
@@ -78,14 +93,16 @@ criteria) you must:
   ``sdd/`` (specs, tasks) and to git plumbing for the worktree.
 - The Jira ticket MUST be created BEFORE the spec/tasks/worktree, so the
   reporter sees a ticket even if scaffolding fails later.
-- The worktree branch name MUST match ``feat-<id>-<slug>`` so the
-  ``pull_request.closed`` webhook can clean it up automatically.
+- The worktree branch name MUST match ``feat-<id>-<slug>`` (features) or
+  ``hotfix-<JIRA-KEY>-<slug>`` (hotfixes — no id is reserved, FEAT-466) so
+  the ``pull_request.closed`` webhook can clean it up automatically.
 
 ## Output Contract
 
 When all steps succeed, emit a single JSON object as your **final**
-assistant turn (no markdown fences, no prose around it):
+assistant turn (no markdown fences, no prose around it).
 
+**Feature run** (``kind`` is ``"enhancement"`` / ``"new_feature"``):
 ```json
 {
   "jira_issue_key": "OPS-1234",
@@ -93,6 +110,20 @@ assistant turn (no markdown fences, no prose around it):
   "feat_id": "FEAT-130",
   "branch_name": "feat-130-<slug>",
   "worktree_path": "/abs/.claude/worktrees/feat-130-<slug>",
+  "log_excerpts": ["...", "..."]
+}
+```
+
+**Hotfix run** (``kind == "bug"``) — ``feat_id`` is ``""`` (FEAT-466: a
+bugfix reserves no id; ``ResearchOutput.feat_id == ""`` is a supported
+shape and every run-labelling consumer falls back to ``jira_issue_key``):
+```json
+{
+  "jira_issue_key": "OPS-1234",
+  "spec_path": "sdd/specs/<slug>.spec.md",
+  "feat_id": "",
+  "branch_name": "hotfix-OPS-1234-<slug>",
+  "worktree_path": "/abs/.claude/worktrees/hotfix-OPS-1234-<slug>",
   "log_excerpts": ["...", "..."]
 }
 ```

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/models/base.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/models/base.py
@@ -417,15 +417,9 @@ class DevAgentSpec(BaseModel):
     backend/model share the same dispatcher (and its semaphore).
     """
 
-    agent: DevAgentBackend = Field(
-        ..., description="Backend → existing dispatcher (claude-code, codex, ...)."
-    )
-    model: str = Field(
-        default="", description="'' ⇒ use the backend's default model."
-    )
-    count: int = Field(
-        default=1, ge=1, description="Number of replicas of this spec in the pool."
-    )
+    agent: DevAgentBackend = Field(..., description="Backend → existing dispatcher (claude-code, codex, ...).")
+    model: str = Field(default="", description="'' ⇒ use the backend's default model.")
+    count: int = Field(default=1, ge=1, description="Number of replicas of this spec in the pool.")
     escalation_model: str = Field(
         default="",
         description=(
@@ -450,9 +444,7 @@ class DevAgentPoolConfig(BaseModel):
     path unchanged.
     """
 
-    agents: List[DevAgentSpec] = Field(
-        ..., min_length=1, description="Dev-agent specs that make up the pool."
-    )
+    agents: List[DevAgentSpec] = Field(..., min_length=1, description="Dev-agent specs that make up the pool.")
     isolation_mode: Literal["shared", "isolated"] = Field(
         default="shared",
         description=(
@@ -483,17 +475,11 @@ class WorkerSummary(BaseModel):
     runs in pool mode.
     """
 
-    worker_id: str = Field(
-        ..., description="Synthetic node id, e.g. 'development.w1'."
-    )
+    worker_id: str = Field(..., description="Synthetic node id, e.g. 'development.w1'.")
     agent: str = Field(..., description="Backend used for this worker, e.g. 'codex'.")
     model: str = Field(..., description="Model name/id used by this worker.")
-    tasks_completed: List[str] = Field(
-        default_factory=list, description="TASK-NNN ids completed by this worker."
-    )
-    tasks_failed: List[str] = Field(
-        default_factory=list, description="TASK-NNN ids that failed on this worker."
-    )
+    tasks_completed: List[str] = Field(default_factory=list, description="TASK-NNN ids completed by this worker.")
+    tasks_failed: List[str] = Field(default_factory=list, description="TASK-NNN ids that failed on this worker.")
     summary: str = Field(default="", description="Free-text summary from the worker.")
 
 
@@ -567,12 +553,7 @@ class QAReport(BaseModel):
         CodeReviewFinding-shaped dicts instead of strings.
         """
         if isinstance(v, list):
-            return [
-                item.get("message", "") or str(item)
-                if isinstance(item, dict)
-                else item
-                for item in v
-            ]
+            return [item.get("message", "") or str(item) if isinstance(item, dict) else item for item in v]
         return v
 
     attempt: int = Field(
@@ -842,8 +823,7 @@ class FeatureBrief(BaseModel):
         for suffix, expected_kind in suffix_map.items():
             if name.endswith(suffix) and expected_kind != self.document_kind:
                 logging.getLogger(__name__).warning(
-                    "FeatureBrief.document_kind=%r does not match the "
-                    "filename convention for %r (expected %r)",
+                    "FeatureBrief.document_kind=%r does not match the " "filename convention for %r (expected %r)",
                     self.document_kind,
                     name,
                     expected_kind,
@@ -868,12 +848,8 @@ class JudgeSpec(BaseModel):
     finding).
     """
 
-    agent: DevAgentBackend = Field(
-        ..., description="Backend → existing dispatcher (claude-code, codex, ...)."
-    )
-    model: str = Field(
-        default="", description="'' ⇒ use the backend's default model."
-    )
+    agent: DevAgentBackend = Field(..., description="Backend → existing dispatcher (claude-code, codex, ...).")
+    model: str = Field(default="", description="'' ⇒ use the backend's default model.")
 
     @field_validator("agent")
     @classmethod
@@ -926,9 +902,7 @@ class PlannerOutput(BaseModel):
     """
 
     spec_path: str = Field(..., description="Path to the spec, inside the worktree.")
-    task_index_path: str = Field(
-        ..., description="Path to the per-spec task index JSON."
-    )
+    task_index_path: str = Field(..., description="Path to the per-spec task index JSON.")
     feat_id: str = Field(..., description="e.g. 'FEAT-378'")
     branch_name: str = Field(..., description="e.g. 'feat-378-devloop-enhancement'")
     worktree_path: str = Field(..., description="Absolute on-disk worktree path.")

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/models/base.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/models/base.py
@@ -374,6 +374,16 @@ class ResearchOutput(BaseModel):
         default_factory=list,
         description="Short, redacted log excerpts gathered during research.",
     )
+    base_branch: str = Field(
+        default="",
+        description=(
+            "Branch this run's branch was cut from, resolved deterministically "
+            "by ResearchNode from the COMMITTED spec frontmatter — never from "
+            "the subagent's self-report. '' means unresolved; handoff nodes "
+            "must block rather than guess a default (FEAT-466)."
+        ),
+        validation_alias=AliasChoices("base_branch", "base"),
+    )
 
 
 # ─────────────────────────────────────────────────────────────────────

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/models/base.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/models/base.py
@@ -216,6 +216,20 @@ class WorkBrief(BaseModel):
             "'shared'), when unset."
         ),
     )
+    flow_type: Optional[Literal["feature", "hotfix"]] = Field(
+        default=None,
+        description=(
+            "FEAT-466 per-run override of the SDD flow type. None ⇒ derive "
+            "from `kind` (bug ⇒ hotfix, otherwise feature)."
+        ),
+    )
+    base_branch: Optional[str] = Field(
+        default=None,
+        description=(
+            "FEAT-466 per-run override of the base branch. None ⇒ derive from "
+            "`flow_type`/`kind` (hotfix ⇒ main, feature ⇒ dev)."
+        ),
+    )
 
 
 # Back-compat alias: existing `from parrot.flows.dev_loop import BugBrief`

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/base.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/base.py
@@ -171,6 +171,31 @@ def condense_qa_failure(report: QAReport, *, max_chars: int = 2000) -> str:
     return summary[:max_chars]
 
 
+def run_label(output: Any, *, default: str = "run") -> str:
+    """Return the best available human label for a run.
+
+    FEAT-466: a hotfix reserves no ``FEAT-<NNN>`` (a bugfix is not a
+    feature), so ``feat_id`` is legitimately ``""`` on those runs and the
+    Jira issue key carries the identity. Follows the precedence already used
+    at ``nodes/qa.py:194,342``.
+
+    Args:
+        output: Any object exposing ``feat_id`` / ``jira_issue_key``
+            (``ResearchOutput`` or ``PlannerOutput``).
+        default: Returned when neither identifier is available, so callers
+            never interpolate an empty string into user-facing text.
+
+    Returns:
+        ``feat_id`` when set, else ``jira_issue_key`` when set, else
+        ``default``.
+    """
+    for attr in ("feat_id", "jira_issue_key"):
+        value = (getattr(output, attr, "") or "").strip()
+        if value:
+            return value
+    return default
+
+
 def register_dev_loop_node(name: str):
     """Idempotent ``@register_node`` for the dev-loop node types (FEAT-250).
 

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/base.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/base.py
@@ -67,7 +67,14 @@ async def _git(cwd: str, *args: str) -> Tuple[int, str, str]:
 
     Mirrors the subprocess idiom used by ``DeploymentHandoffNode._push_branch``
     — ``asyncio.create_subprocess_exec``, never a blocking call.
+
+    Forces ``LC_ALL=C`` (and ``LANG=C``) so git's error messages are always
+    emitted in English — ``assert_base_is_clean`` pattern-matches stderr
+    (e.g. ``"couldn't find remote ref"``) to distinguish a genuinely-absent
+    ref from a real fetch failure, and that match must not depend on the
+    host's locale (FEAT-466 TASK-2505 code-review follow-up).
     """
+    env = dict(os.environ, LC_ALL="C", LANG="C")
     proc = await asyncio.create_subprocess_exec(
         "git",
         "-C",
@@ -75,6 +82,7 @@ async def _git(cwd: str, *args: str) -> Tuple[int, str, str]:
         *args,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        env=env,
     )
     out, err = await proc.communicate()
     return (
@@ -82,6 +90,24 @@ async def _git(cwd: str, *args: str) -> Tuple[int, str, str]:
         out.decode(errors="replace").strip(),
         err.decode(errors="replace").strip(),
     )
+
+
+def _cwd_is_unusable_repo(err: str) -> bool:
+    """Detect the two git error shapes meaning "cwd is not a usable repo".
+
+    Both are structural preconditions about ``cwd`` itself, not about a
+    fetch/network/ref problem:
+
+    * ``cannot change to '<path>': No such file or directory`` — ``cwd``
+      does not exist at all.
+    * ``not a git repository (or any of the parent directories): .git`` —
+      ``cwd`` exists but was never ``git init``'d.
+
+    Both messages are forced to English by ``_git``'s ``LC_ALL=C`` so this
+    match is locale-independent.
+    """
+    lowered = err.lower()
+    return "not a git repository" in lowered or "cannot change to" in lowered
 
 
 async def assert_base_is_clean(
@@ -130,19 +156,67 @@ async def assert_base_is_clean(
 
     Raises:
         BaseBranchMismatch: When the branch carries sibling commits.
-        RuntimeError: When a git command fails outright.
+        RuntimeError: When a git command fails outright for a reason other
+            than ``cwd`` not being a git repository at all (see below) —
+            including a failure to fetch ``base``, or a sibling fetch that
+            fails for a reason OTHER than the ref genuinely not existing on
+            the remote (FEAT-466 TASK-2505 code-review follow-up: a
+            transient fetch failure must never be silently treated the
+            same as "this sibling doesn't exist" — that would let exactly
+            the sibling that matters go unchecked).
+
+    Note (code-review follow-up): ``cwd`` not being a git repository at all
+    is treated as "cannot check, skip" (logged at INFO), not a hard
+    failure — deliberately, not an oversight. In production this call
+    always runs AFTER a successful push to ``cwd`` (both call sites push
+    first), so a real run never reaches this function with an invalid
+    ``cwd`` — the push itself would already have failed loudly. This shape
+    is therefore purely a test-fixture artifact (many existing tests pass
+    a throwaway ``tmp_path`` with no real git history for unrelated
+    reasons — Jira wiring, docs artifacts, etc.), not a live failure mode
+    worth hard-failing on.
     """
     candidates = [s for s in (siblings if siblings is not None else _LONG_LIVED_BRANCHES) if s != base]
 
-    # Fetch base + candidates, and keep only refs that actually exist —
-    # `staging` may not exist on the remote, and passing a missing ref as an
-    # exclusion bound fails the entire command.
-    await _git(cwd, "fetch", "origin", base)
+    # Fetch base FIRST. Two distinct failure shapes:
+    #  - `cwd` is not a usable git repository at all (missing entirely, or
+    #    present but not initialized as one) — see the Note above; skip.
+    #  - any OTHER fetch failure (network, auth, missing base ref on the
+    #    remote, ...) is a real problem the guard must not silently
+    #    swallow — raise loudly rather than fail open.
+    rc, _, err = await _git(cwd, "fetch", "origin", base)
+    if rc != 0:
+        if _cwd_is_unusable_repo(err):
+            if logger:
+                logger.info(
+                    "%r is not a usable git repository; skipping "
+                    "base-branch guard.",
+                    cwd,
+                )
+            return
+        raise RuntimeError(
+            f"assert_base_is_clean: could not fetch origin/{base} — "
+            f"refusing to guess: {scrub_git_output(err)}"
+        )
+
+    # Fetch candidates, and keep only refs that actually exist — `staging`
+    # may not exist on the remote, and passing a missing ref as an
+    # exclusion bound fails the entire command. A sibling ref that is
+    # genuinely absent fails with git's own "couldn't find remote ref"
+    # message (forced to English by `_git`'s LC_ALL=C) — ONLY that shape is
+    # treated as "not applicable, skip it". Any other fetch failure
+    # (network, auth, ...) is a real error and must not be silently
+    # downgraded to "ref absent".
     existing: List[str] = []
     for sib in sorted(candidates):
-        rc, _, _ = await _git(cwd, "fetch", "origin", sib)
+        rc, _, err = await _git(cwd, "fetch", "origin", sib)
         if rc != 0:
-            continue
+            if "couldn't find remote ref" in err.lower():
+                continue
+            raise RuntimeError(
+                f"assert_base_is_clean: could not fetch origin/{sib} — "
+                f"refusing to guess: {scrub_git_output(err)}"
+            )
         rc, _, _ = await _git(cwd, "rev-parse", "--verify", f"origin/{sib}")
         if rc == 0:
             existing.append(sib)
@@ -309,8 +383,13 @@ def run_label(output: Any, *, default: str = "run") -> str:
 
     FEAT-466: a hotfix reserves no ``FEAT-<NNN>`` (a bugfix is not a
     feature), so ``feat_id`` is legitimately ``""`` on those runs and the
-    Jira issue key carries the identity. Follows the precedence already used
-    at ``nodes/qa.py:194,342``.
+    Jira issue key carries the identity — the same underlying fallback
+    ``nodes/qa.py:194,342`` relies on (``jira_issue_key or feat_id``,
+    checked in that order there because ``jira_issue_key`` is a required,
+    always-non-empty field on ``ResearchOutput``). This helper checks
+    ``feat_id`` first instead, because it is also used for
+    ``PlannerOutput`` (feature-mode), where a `FEAT-<NNN>` id is the
+    stronger, more specific identity when both are present.
 
     Args:
         output: Any object exposing ``feat_id`` / ``jira_issue_key``

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/base.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/base.py
@@ -189,14 +189,12 @@ async def assert_base_is_clean(
         if _cwd_is_unusable_repo(err):
             if logger:
                 logger.info(
-                    "%r is not a usable git repository; skipping "
-                    "base-branch guard.",
+                    "%r is not a usable git repository; skipping " "base-branch guard.",
                     cwd,
                 )
             return
         raise RuntimeError(
-            f"assert_base_is_clean: could not fetch origin/{base} — "
-            f"refusing to guess: {scrub_git_output(err)}"
+            f"assert_base_is_clean: could not fetch origin/{base} — " f"refusing to guess: {scrub_git_output(err)}"
         )
 
     # Fetch candidates, and keep only refs that actually exist — `staging`
@@ -214,8 +212,7 @@ async def assert_base_is_clean(
             if "couldn't find remote ref" in err.lower():
                 continue
             raise RuntimeError(
-                f"assert_base_is_clean: could not fetch origin/{sib} — "
-                f"refusing to guess: {scrub_git_output(err)}"
+                f"assert_base_is_clean: could not fetch origin/{sib} — " f"refusing to guess: {scrub_git_output(err)}"
             )
         rc, _, _ = await _git(cwd, "rev-parse", "--verify", f"origin/{sib}")
         if rc == 0:

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/base.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/base.py
@@ -31,7 +31,6 @@ from parrot.bots.flows.core.node import Node
 from parrot.bots.flows.flow.flow import NODE_REGISTRY, register_node
 from parrot.flows.dev_loop.models import QAReport
 
-
 # Matches the userinfo (``user:secret@``) of an https remote URL, e.g. the
 # ``x-access-token:<token>@github.com`` form GitToolkit injects for private
 # clones — so a token can never surface in git CLI error output (R2).
@@ -70,7 +69,10 @@ async def _git(cwd: str, *args: str) -> Tuple[int, str, str]:
     — ``asyncio.create_subprocess_exec``, never a blocking call.
     """
     proc = await asyncio.create_subprocess_exec(
-        "git", "-C", cwd, *args,
+        "git",
+        "-C",
+        cwd,
+        *args,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
@@ -130,10 +132,7 @@ async def assert_base_is_clean(
         BaseBranchMismatch: When the branch carries sibling commits.
         RuntimeError: When a git command fails outright.
     """
-    candidates = [
-        s for s in (siblings if siblings is not None else _LONG_LIVED_BRANCHES)
-        if s != base
-    ]
+    candidates = [s for s in (siblings if siblings is not None else _LONG_LIVED_BRANCHES) if s != base]
 
     # Fetch base + candidates, and keep only refs that actually exist —
     # `staging` may not exist on the remote, and passing a missing ref as an
@@ -173,7 +172,11 @@ async def assert_base_is_clean(
     if logger:
         logger.info(
             "Base check for %s onto %s: adds=%d own=%d siblings=%s",
-            branch, base, adds, own, existing,
+            branch,
+            base,
+            adds,
+            own,
+            existing,
         )
     if adds != own:
         raise BaseBranchMismatch(
@@ -233,13 +236,9 @@ async def transition_issue_with_candidates(
         try:
             transition_to = getattr(jira, "jira_transition_to", None)
             if transition_to is not None:
-                result = await transition_to(
-                    issue=issue, target_status=label, **kwargs
-                )
+                result = await transition_to(issue=issue, target_status=label, **kwargs)
             else:  # pragma: no cover - older toolkit without the walker
-                result = await jira.jira_transition_issue(
-                    issue=issue, transition=label, **kwargs
-                )
+                result = await jira.jira_transition_issue(issue=issue, transition=label, **kwargs)
             if label != preferred:
                 logger.info(
                     "Applied fallback transition %r for %s (preferred %r unavailable).",
@@ -371,9 +370,7 @@ class DevLoopNode(Node):
         """Auto-create the FSM; initialise the base logger."""
         super().model_post_init(__context)
         if self.fsm is None:
-            object.__setattr__(
-                self, "fsm", AgentTaskMachine(agent_name=self.node_id)
-            )
+            object.__setattr__(self, "fsm", AgentTaskMachine(agent_name=self.node_id))
 
     @property
     def name(self) -> str:
@@ -401,9 +398,7 @@ class DevLoopNode(Node):
             return ctx.shared_data
         if isinstance(ctx, dict):
             return ctx
-        raise TypeError(
-            f"dev-loop nodes expect FlowContext or dict, got {type(ctx)!r}"
-        )
+        raise TypeError(f"dev-loop nodes expect FlowContext or dict, got {type(ctx)!r}")
 
     @staticmethod
     def initial_prompt(ctx: Union[FlowContext, Dict[str, Any]]) -> str:

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/base.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/base.py
@@ -17,10 +17,11 @@ Cross-node payloads (``bug_brief``, ``research_output``,
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import re
-from typing import Any, Dict, List, Optional, Sequence, Set, Union
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
 
 from pydantic import Field
 
@@ -36,6 +37,13 @@ from parrot.flows.dev_loop.models import QAReport
 # clones — so a token can never surface in git CLI error output (R2).
 _GIT_URL_USERINFO_RE = re.compile(r"(https://)[^@/\s]+:[^@/\s]+@")
 
+# FEAT-466 TASK-2505: the Git Parrot Flow's long-lived branches. Deliberately
+# a LOCAL copy of scripts.sdd.sdd_meta.KNOWN_BRANCHES — NOT an import.
+# `scripts.sdd` is not importable from this package's actual install/test
+# context (verified in TASK-2504's Completion Note: it fails once the
+# interpreter's cwd is anything other than the repo root).
+_LONG_LIVED_BRANCHES: frozenset[str] = frozenset({"main", "staging", "dev"})
+
 
 def scrub_git_output(text: str) -> str:
     """Redact credentials from raw git CLI output before surfacing it.
@@ -49,6 +57,132 @@ def scrub_git_output(text: str) -> str:
     if token:
         redacted = redacted.replace(token, "***")
     return redacted
+
+
+class BaseBranchMismatch(RuntimeError):
+    """The head branch was cut from the wrong base (FEAT-466)."""
+
+
+async def _git(cwd: str, *args: str) -> Tuple[int, str, str]:
+    """Run a git subcommand, returning ``(returncode, stdout, stderr)``.
+
+    Mirrors the subprocess idiom used by ``DeploymentHandoffNode._push_branch``
+    — ``asyncio.create_subprocess_exec``, never a blocking call.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        "git", "-C", cwd, *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    out, err = await proc.communicate()
+    return (
+        proc.returncode,
+        out.decode(errors="replace").strip(),
+        err.decode(errors="replace").strip(),
+    )
+
+
+async def assert_base_is_clean(
+    branch: str,
+    base: str,
+    cwd: str,
+    *,
+    siblings: Optional[Iterable[str]] = None,
+    logger: Any = None,
+) -> None:
+    """Raise when ``branch`` carries commits belonging to a sibling branch.
+
+    FEAT-466: the backstop for any path that still drifts. An ancestry check
+    is deliberately NOT the test. Measured on the FEAT-466 incident (PR
+    #1250): ``git merge-base --is-ancestor <old main> <feat-465 tip>``
+    returns true, because ``main`` was an ancestor of ``dev`` — so a branch
+    cut from ``dev`` still descends from ``origin/main``. The discriminating
+    signal is commit *membership*:
+
+        adds = git rev-list --count origin/<base>..<branch>
+        own  = git rev-list --count <branch> ^origin/<base> ^origin/<sib>...
+        adds != own  =>  the branch carries a sibling's history.
+
+    NOTE on the ``own`` form: this uses explicit ``^origin/<ref>`` exclusion
+    prefixes, NOT ``origin/<base>..<branch> --not origin/<sib1> --not
+    origin/<sib2> ...``. Empirically verified (real git repos, FEAT-466
+    TASK-2505) that chaining multiple ``--not`` flags after a ``..`` range
+    shorthand gives WRONG counts — each ``--not`` toggles the
+    interesting/uninteresting state for what follows rather than
+    accumulating exclusions, so two or more sibling refs chained this way
+    can silently over- or under-count. The ``^``-prefixed form does not
+    have this failure mode and was confirmed correct across the same
+    scenarios (clean branch, incident topology, cherry-pick, 2+ siblings).
+
+    Cherry-picked commits have distinct SHAs and therefore do not count as
+    sibling commits, so a legitimately back-ported hotfix is not flagged.
+
+    Args:
+        branch: Local head branch name.
+        base: Resolved base branch (no ``origin/`` prefix).
+        cwd: Repository or worktree directory to run git in.
+        siblings: Long-lived branches to treat as foreign. Defaults to
+            ``_LONG_LIVED_BRANCHES`` minus ``base``, filtered to refs that
+            exist on the remote.
+        logger: Optional logger for the INFO/measurement trail.
+
+    Raises:
+        BaseBranchMismatch: When the branch carries sibling commits.
+        RuntimeError: When a git command fails outright.
+    """
+    candidates = [
+        s for s in (siblings if siblings is not None else _LONG_LIVED_BRANCHES)
+        if s != base
+    ]
+
+    # Fetch base + candidates, and keep only refs that actually exist —
+    # `staging` may not exist on the remote, and passing a missing ref as an
+    # exclusion bound fails the entire command.
+    await _git(cwd, "fetch", "origin", base)
+    existing: List[str] = []
+    for sib in sorted(candidates):
+        rc, _, _ = await _git(cwd, "fetch", "origin", sib)
+        if rc != 0:
+            continue
+        rc, _, _ = await _git(cwd, "rev-parse", "--verify", f"origin/{sib}")
+        if rc == 0:
+            existing.append(sib)
+
+    if not existing:
+        if logger:
+            logger.info(
+                "No sibling branches to check against base %r; guard passes.",
+                base,
+            )
+        return
+
+    rng = f"origin/{base}..{branch}"
+    rc, adds_out, err = await _git(cwd, "rev-list", "--count", rng)
+    if rc != 0:
+        raise RuntimeError(f"git rev-list failed: {scrub_git_output(err)}")
+
+    # Explicit ^-prefixed exclusions — NOT `rng --not origin/<sib1> --not
+    # origin/<sib2>`. See the docstring NOTE: chained --not flags proved
+    # order-sensitive and gave wrong counts with 2+ siblings.
+    exclude_args = [f"^origin/{base}"] + [f"^origin/{sib}" for sib in existing]
+    rc, own_out, err = await _git(cwd, "rev-list", "--count", branch, *exclude_args)
+    if rc != 0:
+        raise RuntimeError(f"git rev-list failed: {scrub_git_output(err)}")
+
+    adds, own = int(adds_out or 0), int(own_out or 0)
+    if logger:
+        logger.info(
+            "Base check for %s onto %s: adds=%d own=%d siblings=%s",
+            branch, base, adds, own, existing,
+        )
+    if adds != own:
+        raise BaseBranchMismatch(
+            f"branch {branch!r} would add {adds} commit(s) to {base!r} but "
+            f"only {own} are its own work — the remaining {adds - own} "
+            f"already exist on {existing}. The branch was almost certainly "
+            f"cut from the wrong base. Re-cut it from origin/{base} and "
+            "re-run."
+        )
 
 
 async def transition_issue_with_candidates(

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/deployment_handoff.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/deployment_handoff.py
@@ -134,6 +134,16 @@ class DeploymentHandoffNode(DevLoopNode):
         # that guess is what produced PR #1250 (branch cut from `dev`, PR
         # opened against `main`). "" means nothing resolved it; block
         # rather than silently default to the "dev" constructor default.
+        #
+        # NOTE (code-review follow-up): as of TASK-2504,
+        # ResearchNode._resolve_base_branch always falls back to the
+        # kind-derived mapping (with a loud WARNING) when the spec is
+        # unreadable — it never actually leaves this "". This branch is
+        # therefore defensive-only in normal operation today (exercised
+        # directly by test_base_branch_guard.py::test_blocks_on_empty_base_branch
+        # via a hand-constructed ResearchOutput), not dead code to delete —
+        # it is the correct behavior if a future caller's resolver ever
+        # does legitimately leave base_branch unresolved.
         base = (getattr(research, "base_branch", "") or "").strip()
         if not base:
             error = (
@@ -381,7 +391,10 @@ class DeploymentHandoffNode(DevLoopNode):
         )
         out, err = await proc.communicate()
         if proc.returncode != 0:
-            raise RuntimeError(f"gh pr create failed: {err.decode(errors='replace')}")
+            raise RuntimeError(
+                f"gh pr create failed: "
+                f"{scrub_git_output(err.decode(errors='replace'))}"
+            )
         text = out.decode().strip()
         # The last line of `gh pr create` output is the PR URL.
         return text.splitlines()[-1] if text else ""
@@ -451,7 +464,9 @@ class DeploymentHandoffNode(DevLoopNode):
             async with session.post(url, json=payload, headers=headers) as resp:
                 data = await resp.json()
                 if resp.status >= 300:
-                    raise RuntimeError(f"GitHub REST {resp.status}: {data}")
+                    raise RuntimeError(
+                        f"GitHub REST {resp.status}: {scrub_git_output(str(data))}"
+                    )
                 return data.get("html_url", "")
 
     # ------------------------------------------------------------------

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/deployment_handoff.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/deployment_handoff.py
@@ -37,7 +37,9 @@ from parrot.flows.dev_loop.models import (
     ResearchOutput,
 )
 from parrot.flows.dev_loop.nodes.base import (
+    BaseBranchMismatch,
     DevLoopNode,
+    assert_base_is_clean,
     register_dev_loop_node,
     run_label,
     scrub_git_output,
@@ -129,9 +131,22 @@ class DeploymentHandoffNode(DevLoopNode):
         qa_report: QAReport = shared.get("qa_report")
         issue_key = research.jira_issue_key
 
-        # Bug fixes branch from main; the PR target must match.
-        if getattr(brief, "kind", "bug") == "bug":
-            object.__setattr__(self, "_base_branch", "main")
+        # FEAT-466: the base branch is READ from the deterministically
+        # resolved record (TASK-2504), never guessed from `brief.kind` —
+        # that guess is what produced PR #1250 (branch cut from `dev`, PR
+        # opened against `main`). "" means nothing resolved it; block
+        # rather than silently default to the "dev" constructor default.
+        base = (getattr(research, "base_branch", "") or "").strip()
+        if not base:
+            error = (
+                "research_output.base_branch is empty — the run's base "
+                "branch was never resolved. Refusing to guess a PR target "
+                "(FEAT-466)."
+            )
+            self.logger.error(error)
+            await self._mark_blocked(issue_key, error)
+            return {"status": "blocked", "error": error}
+        object.__setattr__(self, "_base_branch", base)
 
         # 1. Push.
         try:
@@ -142,6 +157,21 @@ class DeploymentHandoffNode(DevLoopNode):
             self.logger.error("git push failed: %s", exc)
             await self._mark_blocked(issue_key, str(exc))
             return {"status": "blocked", "error": f"push: {exc}"}
+
+        # FEAT-466: sibling-overlap guard — the backstop. Blocks before any
+        # PR is opened when the branch carries commits that already live on
+        # a sibling long-lived branch (the exact #1250 shape).
+        try:
+            await assert_base_is_clean(
+                research.branch_name,
+                self._base_branch,
+                research.worktree_path,
+                logger=self.logger,
+            )
+        except BaseBranchMismatch as exc:
+            self.logger.error("base-branch guard blocked the PR: %s", exc)
+            await self._mark_blocked(issue_key, str(exc))
+            return {"status": "blocked", "error": str(exc)}
 
         # 2. Open PR with retry-once.
         title = self._build_title(brief, research)

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/deployment_handoff.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/deployment_handoff.py
@@ -391,10 +391,7 @@ class DeploymentHandoffNode(DevLoopNode):
         )
         out, err = await proc.communicate()
         if proc.returncode != 0:
-            raise RuntimeError(
-                f"gh pr create failed: "
-                f"{scrub_git_output(err.decode(errors='replace'))}"
-            )
+            raise RuntimeError(f"gh pr create failed: " f"{scrub_git_output(err.decode(errors='replace'))}")
         text = out.decode().strip()
         # The last line of `gh pr create` output is the PR URL.
         return text.splitlines()[-1] if text else ""
@@ -464,9 +461,7 @@ class DeploymentHandoffNode(DevLoopNode):
             async with session.post(url, json=payload, headers=headers) as resp:
                 data = await resp.json()
                 if resp.status >= 300:
-                    raise RuntimeError(
-                        f"GitHub REST {resp.status}: {scrub_git_output(str(data))}"
-                    )
+                    raise RuntimeError(f"GitHub REST {resp.status}: {scrub_git_output(str(data))}")
                 return data.get("html_url", "")
 
     # ------------------------------------------------------------------

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/deployment_handoff.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/deployment_handoff.py
@@ -94,9 +94,7 @@ class DeploymentHandoffNode(DevLoopNode):
             target_repo or os.environ.get("GITHUB_REPOSITORY", ""),
         )
         object.__setattr__(self, "_base_branch", base_branch)
-        object.__setattr__(
-            self, "_require_deployment_approval", require_deployment_approval
-        )
+        object.__setattr__(self, "_require_deployment_approval", require_deployment_approval)
 
     # ------------------------------------------------------------------
     # Execute
@@ -150,9 +148,7 @@ class DeploymentHandoffNode(DevLoopNode):
 
         # 1. Push.
         try:
-            await self._push_branch(
-                research.branch_name, research.worktree_path
-            )
+            await self._push_branch(research.branch_name, research.worktree_path)
         except RuntimeError as exc:
             self.logger.error("git push failed: %s", exc)
             await self._mark_blocked(issue_key, str(exc))
@@ -180,9 +176,7 @@ class DeploymentHandoffNode(DevLoopNode):
         last_error: Optional[str] = None
         for attempt in range(2):
             try:
-                pr_url = await self._create_pr(
-                    research.branch_name, title, body
-                )
+                pr_url = await self._create_pr(research.branch_name, title, body)
                 break
             except Exception as exc:  # noqa: BLE001 - retry boundary
                 last_error = str(exc)
@@ -194,14 +188,10 @@ class DeploymentHandoffNode(DevLoopNode):
                     )
                     await asyncio.sleep(2)
                 else:
-                    self.logger.error(
-                        "PR create failed after retry: %s", exc
-                    )
+                    self.logger.error("PR create failed after retry: %s", exc)
 
         if pr_url is None:
-            await self._mark_blocked(
-                issue_key, last_error or "unknown PR error"
-            )
+            await self._mark_blocked(issue_key, last_error or "unknown PR error")
             return {
                 "status": "blocked",
                 "error": last_error or "unknown PR error",
@@ -223,7 +213,10 @@ class DeploymentHandoffNode(DevLoopNode):
         host = shared.get("session_host")
         if self._require_deployment_approval and host is not None:
             gate_status, gate_error = await self._await_deployment_approval(
-                host, shared.get("run_id", ""), issue_key, pr_url,
+                host,
+                shared.get("run_id", ""),
+                issue_key,
+                pr_url,
             )
             if gate_status != "approved":
                 await self._mark_blocked(issue_key, gate_error)
@@ -240,8 +233,8 @@ class DeploymentHandoffNode(DevLoopNode):
         skip_jira = shared.get("skip_jira", False)
         if skip_jira:
             self.logger.info(
-                "Jira bypass enabled (skip_jira=True) — skipping "
-                "transition and comment for %s", pr_url,
+                "Jira bypass enabled (skip_jira=True) — skipping " "transition and comment for %s",
+                pr_url,
             )
         else:
             try:
@@ -252,18 +245,13 @@ class DeploymentHandoffNode(DevLoopNode):
                     logger=self.logger,
                 )
             except Exception as exc:  # noqa: BLE001 - degraded path
-                self.logger.warning(
-                    "Jira transition failed (continuing): %s", exc
-                )
+                self.logger.warning("Jira transition failed (continuing): %s", exc)
 
             # 4. Comment with PR link.
             try:
                 await self._jira.jira_add_comment(
                     issue=issue_key,
-                    body=(
-                        f"flow-bot: PR opened — {pr_url}\n"
-                        f"QA passed all acceptance criteria."
-                    ),
+                    body=(f"flow-bot: PR opened — {pr_url}\n" f"QA passed all acceptance criteria."),
                 )
             except Exception as exc:  # noqa: BLE001 - degraded path
                 self.logger.warning("Jira add_comment failed: %s", exc)
@@ -279,7 +267,11 @@ class DeploymentHandoffNode(DevLoopNode):
     # ------------------------------------------------------------------
 
     async def _await_deployment_approval(
-        self, host: Any, run_id: str, issue_key: str, pr_url: str,
+        self,
+        host: Any,
+        run_id: str,
+        issue_key: str,
+        pr_url: str,
     ) -> tuple[str, str]:
         """Open the ``deployment_approval`` gate and await its resolution.
 
@@ -314,10 +306,7 @@ class DeploymentHandoffNode(DevLoopNode):
         gate = await host.wait_gate(gate_id)
         if gate.status == "approved":
             return "approved", ""
-        reason = (
-            f"deployment_approval {gate.status} by "
-            f"{gate.resolved_by or 'ttl'}"
-        )
+        reason = f"deployment_approval {gate.status} by " f"{gate.resolved_by or 'ttl'}"
         return gate.status, reason
 
     # ------------------------------------------------------------------
@@ -338,9 +327,7 @@ class DeploymentHandoffNode(DevLoopNode):
         )
         _stdout, stderr = await proc.communicate()
         if proc.returncode != 0:
-            raise RuntimeError(
-                f"git push failed: {scrub_git_output(stderr.decode(errors='replace'))}"
-            )
+            raise RuntimeError(f"git push failed: {scrub_git_output(stderr.decode(errors='replace'))}")
 
     # ------------------------------------------------------------------
     # Internal — PR creation
@@ -371,14 +358,10 @@ class DeploymentHandoffNode(DevLoopNode):
             try:
                 return await self._create_pr_with_gh(branch, title, body)
             except RuntimeError as exc:
-                self.logger.warning(
-                    "gh CLI failed, falling back to REST API: %s", exc
-                )
+                self.logger.warning("gh CLI failed, falling back to REST API: %s", exc)
         return await self._create_pr_via_rest(branch, title, body)
 
-    async def _create_pr_with_gh(
-        self, branch: str, title: str, body: str
-    ) -> str:
+    async def _create_pr_with_gh(self, branch: str, title: str, body: str) -> str:
         gh_path = self._gh_cli_path or "gh"
         proc = await asyncio.create_subprocess_exec(
             gh_path,
@@ -398,21 +381,22 @@ class DeploymentHandoffNode(DevLoopNode):
         )
         out, err = await proc.communicate()
         if proc.returncode != 0:
-            raise RuntimeError(
-                f"gh pr create failed: {err.decode(errors='replace')}"
-            )
+            raise RuntimeError(f"gh pr create failed: {err.decode(errors='replace')}")
         text = out.decode().strip()
         # The last line of `gh pr create` output is the PR URL.
         return text.splitlines()[-1] if text else ""
 
-    _GITHUB_REMOTE_RE = re.compile(
-        r"github\.com[:/](?P<owner>[^/]+)/(?P<repo>[^/.]+?)(?:\.git)?$"
-    )
+    _GITHUB_REMOTE_RE = re.compile(r"github\.com[:/](?P<owner>[^/]+)/(?P<repo>[^/.]+?)(?:\.git)?$")
 
     async def _detect_target_repo(self, cwd: str = ".") -> str:
         """Derive ``owner/repo`` from ``git remote get-url origin``."""
         proc = await asyncio.create_subprocess_exec(
-            "git", "-C", cwd, "remote", "get-url", "origin",
+            "git",
+            "-C",
+            cwd,
+            "remote",
+            "get-url",
+            "origin",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -431,16 +415,16 @@ class DeploymentHandoffNode(DevLoopNode):
         if not shutil.which(gh):
             return ""
         proc = await asyncio.create_subprocess_exec(
-            gh, "auth", "token",
+            gh,
+            "auth",
+            "token",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
         out, _ = await proc.communicate()
         return out.decode().strip() if proc.returncode == 0 else ""
 
-    async def _create_pr_via_rest(
-        self, branch: str, title: str, body: str
-    ) -> str:
+    async def _create_pr_via_rest(self, branch: str, title: str, body: str) -> str:
         # Pure HTTP fallback. We import aiohttp lazily so test harnesses
         # can monkeypatch the helper without aiohttp involvement at all.
         import aiohttp  # noqa: WPS433 - intentional lazy import
@@ -448,9 +432,7 @@ class DeploymentHandoffNode(DevLoopNode):
         token = await self._resolve_github_token()
         repo = self._target_repo or await self._detect_target_repo()
         if not repo or not token:
-            raise RuntimeError(
-                "GitHub REST fallback requires target_repo + GITHUB_TOKEN"
-            )
+            raise RuntimeError("GitHub REST fallback requires target_repo + GITHUB_TOKEN")
         url = f"https://api.github.com/repos/{repo}/pulls"
         payload = {
             "title": title,
@@ -466,14 +448,10 @@ class DeploymentHandoffNode(DevLoopNode):
         }
         timeout = aiohttp.ClientTimeout(total=30)
         async with aiohttp.ClientSession(timeout=timeout) as session:
-            async with session.post(
-                url, json=payload, headers=headers
-            ) as resp:
+            async with session.post(url, json=payload, headers=headers) as resp:
                 data = await resp.json()
                 if resp.status >= 300:
-                    raise RuntimeError(
-                        f"GitHub REST {resp.status}: {data}"
-                    )
+                    raise RuntimeError(f"GitHub REST {resp.status}: {data}")
                 return data.get("html_url", "")
 
     # ------------------------------------------------------------------
@@ -522,9 +500,7 @@ class DeploymentHandoffNode(DevLoopNode):
         try:
             summary = await summarize_pr_changes(body, logger=self.logger)
         except Exception:  # noqa: BLE001 - enrichment must never break handoff
-            self.logger.warning(
-                "PR summary enrichment failed; using template only.", exc_info=True
-            )
+            self.logger.warning("PR summary enrichment failed; using template only.", exc_info=True)
             summary = ""
         if not summary:
             return body
@@ -542,11 +518,7 @@ class DeploymentHandoffNode(DevLoopNode):
         dev_out: Optional[DevelopmentOutput],
         qa_report: Optional[QAReport],
     ) -> str:
-        files = (
-            ", ".join(dev_out.files_changed[:10])
-            if dev_out
-            else "(none)"
-        )
+        files = ", ".join(dev_out.files_changed[:10]) if dev_out else "(none)"
         criteria = (
             "\n".join(
                 f"- {r.name}: {'PASS' if r.passed else 'FAIL'}"

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/deployment_handoff.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/deployment_handoff.py
@@ -39,6 +39,7 @@ from parrot.flows.dev_loop.models import (
 from parrot.flows.dev_loop.nodes.base import (
     DevLoopNode,
     register_dev_loop_node,
+    run_label,
     scrub_git_output,
     transition_issue_with_candidates,
 )
@@ -502,7 +503,8 @@ class DeploymentHandoffNode(DevLoopNode):
     @staticmethod
     def _build_title(brief: BugBrief, research: ResearchOutput) -> str:
         first_line = brief.summary.splitlines()[0][:80]
-        return f"{research.feat_id}: {first_line}"
+        label = run_label(research, default="")
+        return f"{label}: {first_line}" if label else first_line
 
     @staticmethod
     def _build_body(

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/development.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/development.py
@@ -495,6 +495,13 @@ class DevelopmentNode(DevLoopNode):
             The ``feature`` slug, or ``None`` if no matching index is found
             (or the index dir does not exist / no file is readable).
         """
+        if not feat_id:
+            # FEAT-466: hotfix runs carry feat_id == "" and have no per-spec
+            # task index. Returning None here (rather than scanning) keeps us
+            # from matching an unrelated index whose feature_id key is absent
+            # — json .get() returns None, and None == "" is False, but a file
+            # with an explicit "feature_id": "" would match.
+            return None
         index_dir = Path(worktree_path) / "sdd" / "tasks" / "index"
         if not index_dir.is_dir():
             return None

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/development.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/development.py
@@ -200,8 +200,7 @@ class DevelopmentNode(DevLoopNode):
         scheduler = await self._build_scheduler(research)
         if scheduler is None:
             self.logger.warning(
-                "No readable per-spec task index found for %s under %s; "
-                "degrading to single-agent.",
+                "No readable per-spec task index found for %s under %s; " "degrading to single-agent.",
                 research.feat_id,
                 research.worktree_path,
             )
@@ -224,9 +223,7 @@ class DevelopmentNode(DevLoopNode):
     # plan_approval HITL gate (FEAT-377 TASK-1916 — G5)
     # ------------------------------------------------------------------
 
-    async def _check_plan_approval(
-        self, shared: Dict[str, Any], research: ResearchOutput
-    ) -> None:
+    async def _check_plan_approval(self, shared: Dict[str, Any], research: ResearchOutput) -> None:
         """Open and await the ``plan_approval`` gate on this run's FIRST
         entry into this node (opt-in via ``require_plan_approval``).
 
@@ -263,9 +260,7 @@ class DevelopmentNode(DevLoopNode):
         # suppress a gate the constructor flag would have opened, while an
         # absent key (or an explicit None) must fall back to that flag.
         override = shared.get("require_plan_approval")
-        required = (
-            self._require_plan_approval if override is None else bool(override)
-        )
+        required = self._require_plan_approval if override is None else bool(override)
         if not required or shared.get("_plan_gate_checked"):
             return
         shared["_plan_gate_checked"] = True
@@ -301,9 +296,7 @@ class DevelopmentNode(DevLoopNode):
         )
         gate = await host.wait_gate(gate_id)
         if gate.status != "approved":
-            raise RuntimeError(
-                f"plan_approval {gate.status} by {gate.resolved_by or 'ttl'}"
-            )
+            raise RuntimeError(f"plan_approval {gate.status} by {gate.resolved_by or 'ttl'}")
 
     async def _count_tasks(self, research: ResearchOutput) -> Optional[int]:
         """Best-effort total task count from the per-spec index, for the
@@ -319,9 +312,7 @@ class DevelopmentNode(DevLoopNode):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _with_prior_work_context(
-        shared: Dict[str, Any], research: ResearchOutput
-    ) -> ResearchOutput:
+    def _with_prior_work_context(shared: Dict[str, Any], research: ResearchOutput) -> ResearchOutput:
         """Inject prior-work context when reusing a worktree.
 
         When ``ResearchNode`` detects an existing worktree with prior
@@ -363,17 +354,13 @@ class DevelopmentNode(DevLoopNode):
         )
 
         note = "\n".join(lines)
-        return research.model_copy(
-            update={"log_excerpts": [note, *research.log_excerpts]}
-        )
+        return research.model_copy(update={"log_excerpts": [note, *research.log_excerpts]})
 
     # ------------------------------------------------------------------
     # QA repair-loop re-entry (FEAT-377 TASK-1911)
     # ------------------------------------------------------------------
 
-    def _with_repair_feedback(
-        self, shared: Dict[str, Any], research: ResearchOutput
-    ) -> ResearchOutput:
+    def _with_repair_feedback(self, shared: Dict[str, Any], research: ResearchOutput) -> ResearchOutput:
         """Bump the attempt counter and carry prior-QA feedback on re-entry.
 
         Re-entry is detected via a failing ``QAReport`` already in shared
@@ -403,12 +390,8 @@ class DevelopmentNode(DevLoopNode):
             return research
         shared["qa_attempt"] = shared.get("qa_attempt", 1) + 1
         feedback = condense_qa_failure(prior_report)
-        note = (
-            f"[QA repair-loop feedback — attempt {shared['qa_attempt']}]\n{feedback}"
-        )
-        return research.model_copy(
-            update={"log_excerpts": [*research.log_excerpts, note]}
-        )
+        note = f"[QA repair-loop feedback — attempt {shared['qa_attempt']}]\n{feedback}"
+        return research.model_copy(update={"log_excerpts": [*research.log_excerpts, note]})
 
     # ------------------------------------------------------------------
     # Config cascade
@@ -469,8 +452,7 @@ class DevelopmentNode(DevLoopNode):
             spec = pool_cfg.agents[0]  # min_length=1 -> always safe
             if len(pool_cfg.agents) > 1 or spec.count > 1:
                 self.logger.warning(
-                    "Pool declared %d spec(s)/%d replica(s) but this run is "
-                    "single-agent; using only %s/%s.",
+                    "Pool declared %d spec(s)/%d replica(s) but this run is " "single-agent; using only %s/%s.",
                     len(pool_cfg.agents),
                     spec.count,
                     spec.agent,
@@ -487,9 +469,7 @@ class DevelopmentNode(DevLoopNode):
                 "Pool declared (%s) but no dispatcher_builder is configured; "
                 "falling back to the env-configured dispatcher. The operator's "
                 "selection is NOT being honoured.",
-                ", ".join(
-                    f"{s.agent}/{s.model or 'default'}" for s in pool_cfg.agents
-                ),
+                ", ".join(f"{s.agent}/{s.model or 'default'}" for s in pool_cfg.agents),
             )
 
         profile = profile or ClaudeCodeDispatchProfile(
@@ -538,8 +518,7 @@ class DevelopmentNode(DevLoopNode):
                             WorkerSummary(
                                 worker_id=f"{self.name}.single",
                                 agent=spec.agent,
-                                model=spec.model
-                                or self._env_model_name(profile),
+                                model=spec.model or self._env_model_name(profile),
                                 summary="single-agent dispatch",
                             ),
                         ]
@@ -547,8 +526,7 @@ class DevelopmentNode(DevLoopNode):
                 )
             except Exception:
                 self.logger.warning(
-                    "Could not record WorkerSummary for the single-agent "
-                    "dispatch.",
+                    "Could not record WorkerSummary for the single-agent " "dispatch.",
                     exc_info=True,
                 )
 
@@ -622,14 +600,10 @@ class DevelopmentNode(DevLoopNode):
         """
         # Index discovery + parsing are small local filesystem reads; keep
         # them off the event loop to honour the async-first rule.
-        feature_slug = await asyncio.to_thread(
-            self._find_feature_slug, research.worktree_path, research.feat_id
-        )
+        feature_slug = await asyncio.to_thread(self._find_feature_slug, research.worktree_path, research.feat_id)
         if feature_slug is None:
             return None
-        return await asyncio.to_thread(
-            TaskScheduler.from_worktree, research.worktree_path, feature_slug
-        )
+        return await asyncio.to_thread(TaskScheduler.from_worktree, research.worktree_path, feature_slug)
 
     async def _execute_pool(
         self,
@@ -676,9 +650,7 @@ class DevelopmentNode(DevLoopNode):
             return research.worktree_path
 
         async def _resolver(path: str, description: str) -> bool:
-            return await self._resolve_conflict(
-                path, description, pool=pool, research=research, run_id=run_id
-            )
+            return await self._resolve_conflict(path, description, pool=pool, research=research, run_id=run_id)
 
         # FEAT-377 TASK-1912 (G3): on a QA repair-loop redispatch
         # (attempt >= 2 — stamped by `_with_repair_feedback` above), every
@@ -694,7 +666,10 @@ class DevelopmentNode(DevLoopNode):
                     break
 
                 result = await pool.run_wave(
-                    wave, research=research, run_id=run_id, cwd_for=_cwd_for,
+                    wave,
+                    research=research,
+                    run_id=run_id,
+                    cwd_for=_cwd_for,
                     escalate=escalate,
                 )
                 wave_results.append(result)
@@ -779,17 +754,13 @@ class DevelopmentNode(DevLoopNode):
             )
             return True
         except Exception as exc:  # noqa: BLE001 - any dispatch failure triggers fallback/failure
-            self.logger.warning(
-                "Conflict resolver (%s) failed on %s: %s", first_worker.spec.agent, path, exc
-            )
+            self.logger.warning("Conflict resolver (%s) failed on %s: %s", first_worker.spec.agent, path, exc)
 
         if first_worker.spec.agent == "claude-code" or self._dispatcher_builder is None:
             return False
 
         try:
-            fallback_dispatcher, fallback_profile = self._dispatcher_builder(
-                DevAgentSpec(agent="claude-code")
-            )
+            fallback_dispatcher, fallback_profile = self._dispatcher_builder(DevAgentSpec(agent="claude-code"))
             await fallback_dispatcher.dispatch(
                 brief=brief,
                 profile=fallback_profile,

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/development.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/development.py
@@ -40,6 +40,7 @@ from parrot.flows.dev_loop.models import (
     QAReport,
     ResearchOutput,
     TaskScopedBrief,
+    WorkerSummary,
 )
 from parrot.flows.dev_loop.nodes.base import (
     DevLoopNode,
@@ -194,7 +195,7 @@ class DevelopmentNode(DevLoopNode):
                 "Pool config present but no dispatcher_builder was configured "
                 "on DevelopmentNode; degrading to single-agent."
             )
-            return await self._execute_single(shared, research)
+            return await self._execute_single(shared, research, pool_cfg=pool_cfg)
 
         scheduler = await self._build_scheduler(research)
         if scheduler is None:
@@ -204,7 +205,7 @@ class DevelopmentNode(DevLoopNode):
                 research.feat_id,
                 research.worktree_path,
             )
-            return await self._execute_single(shared, research)
+            return await self._execute_single(shared, research, pool_cfg=pool_cfg)
 
         first_wave = scheduler.next_wave()
         if not should_fan_out(first_wave, pool_cfg):
@@ -435,18 +436,63 @@ class DevelopmentNode(DevLoopNode):
     # ------------------------------------------------------------------
 
     async def _execute_single(
-        self, shared: Dict[str, Any], research: ResearchOutput
+        self,
+        shared: Dict[str, Any],
+        research: ResearchOutput,
+        pool_cfg: Optional[DevAgentPoolConfig] = None,
     ) -> DevelopmentOutput:
-        """The exact single-dispatch path used before FEAT-323.
+        """Dispatch exactly one dev agent.
+
+        FEAT-466: when a pool config resolved but the pool path was not
+        reachable (no readable per-spec task index — the normal case for a
+        hotfix, which reserves no ids), this path must still run on the
+        backend/model the OPERATOR declared, not on the server's
+        env-configured default. Falling back to ``self._dispatcher`` silently
+        substituted the operator's choice.
 
         Args:
             shared: The flow's shared state dict.
             research: The upstream research output.
+            pool_cfg: The resolved pool config, when one resolved. ``None``
+                means no pool was declared and the legacy env dispatcher is
+                correct.
 
         Returns:
-            The validated :class:`DevelopmentOutput`.
+            The validated :class:`DevelopmentOutput`, carrying one
+            ``WorkerSummary`` describing the backend/model actually used.
         """
-        profile = self._dispatch_profile or ClaudeCodeDispatchProfile(
+        dispatcher = self._dispatcher
+        profile = self._dispatch_profile
+        spec: Optional[DevAgentSpec] = None
+
+        if pool_cfg is not None and self._dispatcher_builder is not None:
+            spec = pool_cfg.agents[0]  # min_length=1 -> always safe
+            if len(pool_cfg.agents) > 1 or spec.count > 1:
+                self.logger.warning(
+                    "Pool declared %d spec(s)/%d replica(s) but this run is "
+                    "single-agent; using only %s/%s.",
+                    len(pool_cfg.agents),
+                    spec.count,
+                    spec.agent,
+                    spec.model or "<backend default>",
+                )
+            dispatcher, profile = self._dispatcher_builder(spec)  # sync call
+            self.logger.info(
+                "Single-agent dispatch honouring declared dev agent %s/%s.",
+                spec.agent,
+                spec.model or "<backend default>",
+            )
+        elif pool_cfg is not None:
+            self.logger.warning(
+                "Pool declared (%s) but no dispatcher_builder is configured; "
+                "falling back to the env-configured dispatcher. The operator's "
+                "selection is NOT being honoured.",
+                ", ".join(
+                    f"{s.agent}/{s.model or 'default'}" for s in pool_cfg.agents
+                ),
+            )
+
+        profile = profile or ClaudeCodeDispatchProfile(
             subagent="sdd-worker",
             permission_mode="acceptEdits",
             allowed_tools=[
@@ -460,7 +506,7 @@ class DevelopmentNode(DevLoopNode):
             setting_sources=["project"],
         )
 
-        dev_out: DevelopmentOutput = await self._dispatcher.dispatch(
+        dev_out: DevelopmentOutput = await dispatcher.dispatch(
             brief=research,
             profile=profile,
             output_model=DevelopmentOutput,
@@ -473,8 +519,50 @@ class DevelopmentNode(DevLoopNode):
             # outside the runner). `dispatch()` defaults this to None.
             session_host=shared.get("session_host"),
         )
+
+        # Record what actually ran, so a substitution is auditable on the
+        # run bundle. This ONLY applies when a declared pool spec was
+        # actually materialized via the dispatcher_builder: appending here
+        # unconditionally would return a *copy* of ``dev_out`` (breaking
+        # object identity) on the legacy env-dispatcher path — the exact
+        # path ``test_no_pool_exact_current_behavior`` and
+        # ``test_no_dispatcher_builder_degrades_to_single`` assert must stay
+        # byte-identical to pre-FEAT-466 behaviour. A labelling failure must
+        # never fail a successful dispatch.
+        if spec is not None:
+            try:
+                dev_out = dev_out.model_copy(
+                    update={
+                        "worker_summaries": [
+                            *dev_out.worker_summaries,
+                            WorkerSummary(
+                                worker_id=f"{self.name}.single",
+                                agent=spec.agent,
+                                model=spec.model
+                                or self._env_model_name(profile),
+                                summary="single-agent dispatch",
+                            ),
+                        ]
+                    }
+                )
+            except Exception:
+                self.logger.warning(
+                    "Could not record WorkerSummary for the single-agent "
+                    "dispatch.",
+                    exc_info=True,
+                )
+
         shared["development_output"] = dev_out
         return dev_out
+
+    @staticmethod
+    def _env_model_name(profile: Any) -> str:
+        """Best-effort model label pulled from a dispatch profile.
+
+        Profiles differ per backend; this stays defensive rather than
+        assuming a specific profile class.
+        """
+        return getattr(profile, "model", "") or ""
 
     # ------------------------------------------------------------------
     # Pool path

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/feature_handoff.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/feature_handoff.py
@@ -205,10 +205,17 @@ class FeatureHandoffNode(DevLoopNode):
         # FEAT-466: source the base from the committed spec's frontmatter —
         # the same "resolve once, record it, read the record" principle as
         # DeploymentHandoffNode, never the hardcoded "dev" constructor
-        # default (never overridden by factories.py:244 today). "" (never
-        # actually produced by _resolve_base_branch below, which always
-        # falls back to "dev") blocks defensively for symmetry with
-        # DeploymentHandoffNode rather than silently guessing.
+        # default (never overridden by factories.py:244 today).
+        #
+        # NOTE (code-review follow-up, mirrors DeploymentHandoffNode's
+        # equivalent note): _resolve_base_branch below always falls back to
+        # "dev" when the spec is unreadable, so this never actually
+        # produces "" in normal operation today — the block below is
+        # defensive-only (exercised directly by
+        # test_base_branch_guard.py::TestFeatureHandoffWiring via a
+        # hand-constructed empty base), kept for symmetry with
+        # DeploymentHandoffNode and as the correct behavior should a future
+        # resolver genuinely leave the base unresolved.
         base = self._resolve_base_branch(planner)
         if not base:
             error = (
@@ -422,7 +429,10 @@ class FeatureHandoffNode(DevLoopNode):
         )
         out, err = await proc.communicate()
         if proc.returncode != 0:
-            raise RuntimeError(f"gh pr create failed: {err.decode(errors='replace')}")
+            raise RuntimeError(
+                f"gh pr create failed: "
+                f"{scrub_git_output(err.decode(errors='replace'))}"
+            )
         text = out.decode().strip()
         return text.splitlines()[-1] if text else ""
 
@@ -450,7 +460,9 @@ class FeatureHandoffNode(DevLoopNode):
             async with session.post(url, json=payload, headers=headers) as resp:
                 data = await resp.json()
                 if resp.status >= 300:
-                    raise RuntimeError(f"GitHub REST {resp.status}: {data}")
+                    raise RuntimeError(
+                        f"GitHub REST {resp.status}: {scrub_git_output(str(data))}"
+                    )
                 return data.get("html_url", "")
 
     # ------------------------------------------------------------------

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/feature_handoff.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/feature_handoff.py
@@ -149,16 +149,16 @@ class FeatureHandoffNode(DevLoopNode):
         object.__setattr__(self, "_wiki", wiki_toolkit)
         object.__setattr__(self, "_wiki_name", wiki_name)
         object.__setattr__(self, "_gh_cli_path", gh_cli_path)
-        object.__setattr__(
-            self, "_target_repo", target_repo or os.environ.get("GITHUB_REPOSITORY", "")
-        )
+        object.__setattr__(self, "_target_repo", target_repo or os.environ.get("GITHUB_REPOSITORY", ""))
         object.__setattr__(self, "_base_branch", base_branch)
         object.__setattr__(
-            self, "_docs_artifact_dir",
+            self,
+            "_docs_artifact_dir",
             docs_artifact_dir or conf.DEV_LOOP_DOCS_ARTIFACT_DIR,
         )
         object.__setattr__(
-            self, "_wiki_page_ingest",
+            self,
+            "_wiki_page_ingest",
             conf.DEV_LOOP_WIKI_PAGE_INGEST if wiki_page_ingest is None else wiki_page_ingest,
         )
         # FEAT-377 TASK-1915 (G2 seam 3): opt-in graph write-back, built
@@ -212,8 +212,7 @@ class FeatureHandoffNode(DevLoopNode):
         base = self._resolve_base_branch(planner)
         if not base:
             error = (
-                "Could not resolve a base branch for this feature run — "
-                "refusing to guess a PR target (FEAT-466)."
+                "Could not resolve a base branch for this feature run — " "refusing to guess a PR target (FEAT-466)."
             )
             self.logger.error(error)
             await self._mark_blocked(issue_key, error)
@@ -222,9 +221,7 @@ class FeatureHandoffNode(DevLoopNode):
 
         # 1. Push.
         try:
-            await self._run_git(
-                planner.worktree_path, "push", "-u", "origin", planner.branch_name
-            )
+            await self._run_git(planner.worktree_path, "push", "-u", "origin", planner.branch_name)
         except RuntimeError as exc:
             self.logger.error("git push failed: %s", exc)
             await self._mark_blocked(issue_key, str(exc))
@@ -246,9 +243,7 @@ class FeatureHandoffNode(DevLoopNode):
 
         # 2. Open draft PR with retry-once (mirrors DeploymentHandoffNode).
         title = self._build_title(planner)
-        body = await self._build_body_async(
-            planner, development, synthesis, qa_report, accept_notes
-        )
+        body = await self._build_body_async(planner, development, synthesis, qa_report, accept_notes)
         pr_url: Optional[str] = None
         last_error: Optional[str] = None
         for attempt in range(2):
@@ -259,7 +254,9 @@ class FeatureHandoffNode(DevLoopNode):
                 last_error = str(exc)
                 if attempt == 0:
                     self.logger.warning(
-                        "PR create failed (attempt %s), retrying: %s", attempt + 1, exc,
+                        "PR create failed (attempt %s), retrying: %s",
+                        attempt + 1,
+                        exc,
                     )
                     await asyncio.sleep(2)
                 else:
@@ -274,7 +271,12 @@ class FeatureHandoffNode(DevLoopNode):
         # 3. Docs artifact — generate, commit, push to the PR branch.
         docs_path = self._docs_rel_path(planner)
         docs_content = self._build_docs_content(
-            planner, development, synthesis, qa_report, accept_notes, pr_url,
+            planner,
+            development,
+            synthesis,
+            qa_report,
+            accept_notes,
+            pr_url,
         )
         try:
             await self._write_and_push_docs(planner.worktree_path, docs_path, docs_content)
@@ -298,7 +300,9 @@ class FeatureHandoffNode(DevLoopNode):
         if session_host is not None:
             session_host.apply(
                 DocsArtifactLinked(
-                    docs_path=docs_path, wiki_page_id=wiki_page_id, pr_url=pr_url,
+                    docs_path=docs_path,
+                    wiki_page_id=wiki_page_id,
+                    pr_url=pr_url,
                 )
             )
 
@@ -306,7 +310,9 @@ class FeatureHandoffNode(DevLoopNode):
         if issue_key and self._jira is not None:
             try:
                 await transition_issue_with_candidates(
-                    self._jira, issue_key, conf.DEV_LOOP_JIRA_TRANSITIONS_READY,
+                    self._jira,
+                    issue_key,
+                    conf.DEV_LOOP_JIRA_TRANSITIONS_READY,
                     logger=self.logger,
                 )
             except Exception as exc:  # noqa: BLE001 - degraded path
@@ -364,15 +370,16 @@ class FeatureHandoffNode(DevLoopNode):
         this node ever issues are ``push``, ``add``, and ``commit``.
         """
         proc = await asyncio.create_subprocess_exec(
-            "git", "-C", cwd, *args,
-            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+            "git",
+            "-C",
+            cwd,
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
         )
         out, err = await proc.communicate()
         if proc.returncode != 0:
-            raise RuntimeError(
-                f"git {' '.join(args)} failed: "
-                f"{scrub_git_output(err.decode(errors='replace'))}"
-            )
+            raise RuntimeError(f"git {' '.join(args)} failed: " f"{scrub_git_output(err.decode(errors='replace'))}")
         return out.decode(errors="replace")
 
     # ------------------------------------------------------------------
@@ -398,10 +405,20 @@ class FeatureHandoffNode(DevLoopNode):
     async def _create_pr_with_gh(self, branch: str, title: str, body: str) -> str:
         gh_path = self._gh_cli_path or "gh"
         proc = await asyncio.create_subprocess_exec(
-            gh_path, "pr", "create", "--draft",
-            "--base", self._base_branch, "--head", branch,
-            "--title", title, "--body", body,
-            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+            gh_path,
+            "pr",
+            "create",
+            "--draft",
+            "--base",
+            self._base_branch,
+            "--head",
+            branch,
+            "--title",
+            title,
+            "--body",
+            body,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
         )
         out, err = await proc.communicate()
         if proc.returncode != 0:
@@ -414,13 +431,14 @@ class FeatureHandoffNode(DevLoopNode):
 
         token = os.environ.get("GITHUB_TOKEN", "")
         if not self._target_repo or not token:
-            raise RuntimeError(
-                "GitHub REST fallback requires target_repo + GITHUB_TOKEN"
-            )
+            raise RuntimeError("GitHub REST fallback requires target_repo + GITHUB_TOKEN")
         url = f"https://api.github.com/repos/{self._target_repo}/pulls"
         payload = {
-            "title": title, "body": body, "head": branch,
-            "base": self._base_branch, "draft": True,
+            "title": title,
+            "body": body,
+            "head": branch,
+            "base": self._base_branch,
+            "draft": True,
         }
         headers = {
             "Authorization": f"Bearer {token}",
@@ -444,14 +462,17 @@ class FeatureHandoffNode(DevLoopNode):
             return
         try:
             await transition_issue_with_candidates(
-                self._jira, issue_key, conf.DEV_LOOP_JIRA_TRANSITIONS_BLOCKED,
+                self._jira,
+                issue_key,
+                conf.DEV_LOOP_JIRA_TRANSITIONS_BLOCKED,
                 logger=self.logger,
             )
         except Exception as exc:  # noqa: BLE001 - degraded path
             self.logger.warning("Blocked transition failed: %s", exc)
         try:
             await self._jira.jira_add_comment(
-                issue=issue_key, body=f"flow-bot: handoff blocked — {error}",
+                issue=issue_key,
+                body=f"flow-bot: handoff blocked — {error}",
             )
         except Exception as exc:  # noqa: BLE001
             self.logger.warning("Blocked comment failed: %s", exc)
@@ -496,10 +517,7 @@ class FeatureHandoffNode(DevLoopNode):
         )
         notes_block = accept_notes or "(none)"
         test_block = (
-            "\n".join(
-                f"- {r.name}: {'PASS' if r.passed else 'FAIL'}"
-                for r in qa_report.criterion_results
-            )
+            "\n".join(f"- {r.name}: {'PASS' if r.passed else 'FAIL'}" for r in qa_report.criterion_results)
             if qa_report and qa_report.criterion_results
             else "(no acceptance-criteria evidence recorded)"
         )
@@ -516,9 +534,7 @@ class FeatureHandoffNode(DevLoopNode):
             f"---\n_Generated by flow-bot via the dev-loop (feature-mode)._\n"
         )
 
-    async def _write_and_push_docs(
-        self, worktree_path: str, docs_rel_path: str, content: str
-    ) -> None:
+    async def _write_and_push_docs(self, worktree_path: str, docs_rel_path: str, content: str) -> None:
         """Write, commit, and push the docs artifact to the feature branch.
 
         Args:
@@ -540,18 +556,14 @@ class FeatureHandoffNode(DevLoopNode):
             fh.write(content)
 
         await self._run_git(worktree_path, "add", docs_rel_path)
-        await self._run_git(
-            worktree_path, "commit", "-m", f"docs: add feature handoff artifact ({docs_rel_path})"
-        )
+        await self._run_git(worktree_path, "commit", "-m", f"docs: add feature handoff artifact ({docs_rel_path})")
         await self._run_git(worktree_path, "push", "origin", "HEAD")
 
     # ------------------------------------------------------------------
     # Internal — wiki ingest (optional, degrades independently)
     # ------------------------------------------------------------------
 
-    async def _ingest_wiki_page(
-        self, planner: PlannerOutput, content: str
-    ) -> Optional[str]:
+    async def _ingest_wiki_page(self, planner: PlannerOutput, content: str) -> Optional[str]:
         """Ingest the docs artifact as a wiki page, when enabled and available.
 
         Returns:
@@ -579,7 +591,8 @@ class FeatureHandoffNode(DevLoopNode):
         except Exception as exc:  # noqa: BLE001 - wiki ingest is best-effort
             self.logger.warning(
                 "Wiki page ingest failed for %s (degrading): %s",
-                planner.feat_id, exc,
+                planner.feat_id,
+                exc,
             )
             return None
 
@@ -610,7 +623,10 @@ class FeatureHandoffNode(DevLoopNode):
         if self._graph_memory is None:
             return
         await self._graph_memory.publish_run_outcome(
-            run_id, qa_report, "succeeded", summary,
+            run_id,
+            qa_report,
+            "succeeded",
+            summary,
         )
 
     # ------------------------------------------------------------------
@@ -639,9 +655,7 @@ class FeatureHandoffNode(DevLoopNode):
         try:
             summary = await summarize_pr_changes(body, logger=self.logger)
         except Exception:  # noqa: BLE001 - enrichment must never break handoff
-            self.logger.warning(
-                "PR summary enrichment failed; using template only.", exc_info=True
-            )
+            self.logger.warning("PR summary enrichment failed; using template only.", exc_info=True)
             summary = ""
         if not summary:
             return body
@@ -659,9 +673,7 @@ class FeatureHandoffNode(DevLoopNode):
         qa_report: Optional[QAReport],
         accept_notes: str,
     ) -> str:
-        files = (
-            ", ".join(development.files_changed[:10]) if development else "(none)"
-        )
+        files = ", ".join(development.files_changed[:10]) if development else "(none)"
         criteria = (
             "\n".join(
                 f"- {r.name}: {'PASS' if r.passed else 'FAIL'}"
@@ -670,9 +682,7 @@ class FeatureHandoffNode(DevLoopNode):
             or "(none)"
         )
         notes_section = f"\n\n## Notes\n\n{accept_notes}" if accept_notes else ""
-        reconciliation = (
-            f"\n\n## Synthesis\n\n{synthesis.summary}" if synthesis else ""
-        )
+        reconciliation = f"\n\n## Synthesis\n\n{synthesis.summary}" if synthesis else ""
         return (
             f"## Summary\n\n"
             f"Spec: `{planner.spec_path}`\n"

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/feature_handoff.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/feature_handoff.py
@@ -28,7 +28,10 @@ from __future__ import annotations
 import asyncio
 import os
 import re
+from pathlib import Path
 from typing import Any, Dict, Optional, Union
+
+import yaml
 
 from parrot import conf
 from parrot.bots.flows.core.context import FlowContext
@@ -43,7 +46,9 @@ from parrot.flows.dev_loop.models import (
     SynthesisReport,
 )
 from parrot.flows.dev_loop.nodes.base import (
+    BaseBranchMismatch,
     DevLoopNode,
+    assert_base_is_clean,
     register_dev_loop_node,
     scrub_git_output,
     transition_issue_with_candidates,
@@ -57,6 +62,40 @@ def _slugify(text: str) -> str:
     """Lowercase, hyphen-separated fallback slug (no external deps)."""
     slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
     return slug or "feature"
+
+
+def _parse_flow_frontmatter(spec_path: Path) -> Optional[str]:
+    """Read the ``base_branch`` declared in a spec's YAML frontmatter.
+
+    FEAT-466 TASK-2505: local duplicate of
+    ``nodes.research._parse_flow_frontmatter`` (not a shared import —
+    ``research.py`` is not in this task's file list, and ``scripts.sdd`` is
+    not importable from this package's context; see TASK-2504's Completion
+    Note). Feature-mode always resolves ``type: feature`` (``FeatureBrief.
+    kind`` is a fixed literal), so unlike ``ResearchNode`` there is no
+    ``kind``-derived hotfix path here — the only question is which base a
+    pre-existing spec (``document_kind == "spec"``) already declares (e.g.
+    ``staging`` during a release freeze). Returns ``None`` — never raises —
+    when the file is missing, has no frontmatter, or is malformed; the
+    caller falls back to ``"dev"``.
+    """
+    try:
+        text = spec_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    if not text.startswith("---"):
+        return None
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return None
+    try:
+        block = yaml.safe_load(parts[1]) or {}
+    except yaml.YAMLError:
+        return None
+    if not isinstance(block, dict):
+        return None
+    base = block.get("base_branch")
+    return base if isinstance(base, str) and base else None
 
 
 @register_dev_loop_node("dev_loop.feature_handoff")
@@ -163,6 +202,24 @@ class FeatureHandoffNode(DevLoopNode):
         if feedback is not None and feedback.decision == "accept_with_notes":
             accept_notes = feedback.notes
 
+        # FEAT-466: source the base from the committed spec's frontmatter —
+        # the same "resolve once, record it, read the record" principle as
+        # DeploymentHandoffNode, never the hardcoded "dev" constructor
+        # default (never overridden by factories.py:244 today). "" (never
+        # actually produced by _resolve_base_branch below, which always
+        # falls back to "dev") blocks defensively for symmetry with
+        # DeploymentHandoffNode rather than silently guessing.
+        base = self._resolve_base_branch(planner)
+        if not base:
+            error = (
+                "Could not resolve a base branch for this feature run — "
+                "refusing to guess a PR target (FEAT-466)."
+            )
+            self.logger.error(error)
+            await self._mark_blocked(issue_key, error)
+            return {"status": "blocked", "error": error}
+        object.__setattr__(self, "_base_branch", base)
+
         # 1. Push.
         try:
             await self._run_git(
@@ -172,6 +229,20 @@ class FeatureHandoffNode(DevLoopNode):
             self.logger.error("git push failed: %s", exc)
             await self._mark_blocked(issue_key, str(exc))
             return {"status": "blocked", "error": f"push: {exc}"}
+
+        # FEAT-466: sibling-overlap guard — the backstop. Same shared
+        # implementation DeploymentHandoffNode calls.
+        try:
+            await assert_base_is_clean(
+                planner.branch_name,
+                self._base_branch,
+                planner.worktree_path,
+                logger=self.logger,
+            )
+        except BaseBranchMismatch as exc:
+            self.logger.error("base-branch guard blocked the PR: %s", exc)
+            await self._mark_blocked(issue_key, str(exc))
+            return {"status": "blocked", "error": str(exc)}
 
         # 2. Open draft PR with retry-once (mirrors DeploymentHandoffNode).
         title = self._build_title(planner)
@@ -255,6 +326,32 @@ class FeatureHandoffNode(DevLoopNode):
             "docs_path": docs_path,
             "wiki_page_id": wiki_page_id,
         }
+
+    # ------------------------------------------------------------------
+    # Internal — base-branch resolution (FEAT-466 TASK-2505)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _resolve_base_branch(planner: PlannerOutput) -> str:
+        """Resolve this feature run's base branch from the committed spec.
+
+        The spec on disk is authoritative — same principle as
+        ``ResearchNode._resolve_base_branch`` (TASK-2504). Feature-mode
+        always resolves ``type: feature`` (no ``kind``-derived hotfix path
+        exists here), so an unreadable/absent spec falls back to ``"dev"``
+        rather than a kind mapping — this never returns ``""``.
+
+        Args:
+            planner: The upstream planner output (for ``spec_path`` and
+                ``worktree_path``).
+
+        Returns:
+            The resolved base branch name; never ``""``.
+        """
+        spec_path = Path(planner.spec_path)
+        if not spec_path.is_absolute():
+            spec_path = Path(planner.worktree_path) / spec_path
+        return _parse_flow_frontmatter(spec_path) or "dev"
 
     # ------------------------------------------------------------------
     # Internal — git plumbing (mirrors DeploymentHandoffNode's subprocess pattern)

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/feature_handoff.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/feature_handoff.py
@@ -429,10 +429,7 @@ class FeatureHandoffNode(DevLoopNode):
         )
         out, err = await proc.communicate()
         if proc.returncode != 0:
-            raise RuntimeError(
-                f"gh pr create failed: "
-                f"{scrub_git_output(err.decode(errors='replace'))}"
-            )
+            raise RuntimeError(f"gh pr create failed: " f"{scrub_git_output(err.decode(errors='replace'))}")
         text = out.decode().strip()
         return text.splitlines()[-1] if text else ""
 
@@ -460,9 +457,7 @@ class FeatureHandoffNode(DevLoopNode):
             async with session.post(url, json=payload, headers=headers) as resp:
                 data = await resp.json()
                 if resp.status >= 300:
-                    raise RuntimeError(
-                        f"GitHub REST {resp.status}: {scrub_git_output(str(data))}"
-                    )
+                    raise RuntimeError(f"GitHub REST {resp.status}: {scrub_git_output(str(data))}")
                 return data.get("html_url", "")
 
     # ------------------------------------------------------------------

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/qa.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/qa.py
@@ -51,7 +51,6 @@ from parrot.flows.dev_loop.models import (
 from parrot.flows.dev_loop.nodes.base import DevLoopNode, condense_qa_failure, register_dev_loop_node
 from parrot.flows.dev_loop.session_state import QaAttemptRecorded
 
-
 _DEFAULT_LINT_COMMAND = "ruff check . && mypy --no-incremental"
 
 # Prefix of the synthetic finding emitted when the code-review gate could not
@@ -61,10 +60,7 @@ _CODE_REVIEW_SKIP_PREFIX = "code-review could not run:"
 
 # Matches a positional ``.`` target in lint commands (e.g. ``ruff check .``).
 # Preceded by whitespace, followed by whitespace, chain operator, or EOL.
-_LINT_TARGET_RE = re.compile(
-    r"(?<=\s)\."
-    r"(?=\s|&&|;|$)"
-)
+_LINT_TARGET_RE = re.compile(r"(?<=\s)\." r"(?=\s|&&|;|$)")
 
 
 class _NoBugBrief(BaseModel):
@@ -191,7 +187,8 @@ class QANode(DevLoopNode):
         if self._skip_qa or runtime_skip:
             self.logger.info(
                 "QA bypass enabled (skip_qa=True, runtime=%s) for %s — returning synthetic pass.",
-                runtime_skip, research.jira_issue_key or research.feat_id,
+                runtime_skip,
+                research.jira_issue_key or research.feat_id,
             )
             report = QAReport(
                 passed=True,
@@ -206,21 +203,15 @@ class QANode(DevLoopNode):
             shared["qa_report"] = report
             return report
 
-        manual: List[ManualCriterion] = [
-            c for c in brief.acceptance_criteria
-            if isinstance(c, ManualCriterion)
-        ]
+        manual: List[ManualCriterion] = [c for c in brief.acceptance_criteria if isinstance(c, ManualCriterion)]
         # FEAT-322: per-criterion opt-in HITL gating. Default ``blocking=False``
         # preserves today's behavior byte-identically via
         # ``_merge_manual_results`` below; only ``blocking=True`` criteria open
         # a gate and await resolution before this method returns.
         blocking_manual: List[ManualCriterion] = [c for c in manual if c.blocking]
-        non_blocking_manual: List[ManualCriterion] = [
-            c for c in manual if not c.blocking
-        ]
+        non_blocking_manual: List[ManualCriterion] = [c for c in manual if not c.blocking]
         executable: List[AcceptanceCriterion] = [
-            c for c in brief.acceptance_criteria
-            if not isinstance(c, ManualCriterion)
+            c for c in brief.acceptance_criteria if not isinstance(c, ManualCriterion)
         ]
 
         is_advisory = getattr(self._codereview_dispatcher, "advisory", False)
@@ -236,25 +227,15 @@ class QANode(DevLoopNode):
         #   replaces the old QA → review → re-run-QA three-step with a
         #   two-step (review → QA), eliminating the redundant re-run.
         if is_advisory:
-            self.logger.info(
-                "Advisory reviewer — running deterministic QA and code review concurrently"
-            )
-            qa_coro = self._run_deterministic_qa(
-                shared, research, brief, executable
-            )
+            self.logger.info("Advisory reviewer — running deterministic QA and code review concurrently")
+            qa_coro = self._run_deterministic_qa(shared, research, brief, executable)
             cr_coro = self._run_code_review(shared, research, brief)
-            report, (cr_passed, cr_findings, files_modified) = (
-                await asyncio.gather(qa_coro, cr_coro)
-            )
+            report, (cr_passed, cr_findings, files_modified) = await asyncio.gather(qa_coro, cr_coro)
             deterministic_passed = report.passed
         else:
-            cr_passed, cr_findings, files_modified = await self._run_code_review(
-                shared, research, brief
-            )
+            cr_passed, cr_findings, files_modified = await self._run_code_review(shared, research, brief)
 
-        cr_skipped = any(
-            f.startswith(_CODE_REVIEW_SKIP_PREFIX) for f in cr_findings
-        )
+        cr_skipped = any(f.startswith(_CODE_REVIEW_SKIP_PREFIX) for f in cr_findings)
 
         # FEAT-377 TASK-1915 (G2 seam 4): ground code-review findings — an
         # infra-degrade skip marker is never a real finding, so it is never
@@ -280,8 +261,8 @@ class QANode(DevLoopNode):
         if not cr_skipped and is_advisory:
             triage_findings = self._collect_triage_findings(shared)
             if triage_findings:
-                triage_notes, triage_files_modified, escalation_passed = (
-                    await self._run_finding_triage(shared, research, brief, triage_findings)
+                triage_notes, triage_files_modified, escalation_passed = await self._run_finding_triage(
+                    shared, research, brief, triage_findings
                 )
                 for path in triage_files_modified:
                     if path not in files_modified:
@@ -300,7 +281,10 @@ class QANode(DevLoopNode):
                     files_modified,
                 )
             report = await self._run_deterministic_qa(
-                shared, research, brief, executable,
+                shared,
+                research,
+                brief,
+                executable,
                 cwd_override=research.worktree_path,
             )
             deterministic_passed = report.passed
@@ -310,7 +294,10 @@ class QANode(DevLoopNode):
                 files_modified,
             )
             report = await self._run_deterministic_qa(
-                shared, research, brief, executable,
+                shared,
+                research,
+                brief,
+                executable,
                 cwd_override=research.worktree_path,
             )
             deterministic_passed = report.passed
@@ -320,9 +307,7 @@ class QANode(DevLoopNode):
 
         blocking_passed = True
         if blocking_manual:
-            report, blocking_passed = await self._resolve_blocking_manual_criteria(
-                shared, blocking_manual, report
-            )
+            report, blocking_passed = await self._resolve_blocking_manual_criteria(shared, blocking_manual, report)
 
         update: Dict[str, Any] = {
             "passed": deterministic_passed and cr_passed and blocking_passed,
@@ -396,9 +381,7 @@ class QANode(DevLoopNode):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _briefless_summary(
-        shared: Dict[str, Any], research: ResearchOutput
-    ) -> str:
+    def _briefless_summary(shared: Dict[str, Any], research: ResearchOutput) -> str:
         """Best-effort run label when there is no intake brief (FEAT-412).
 
         Used only to populate ``_NoBugBrief.summary``, which the downstream
@@ -414,13 +397,7 @@ class QANode(DevLoopNode):
         """
         feature_brief = shared.get("feature_brief")
         document = getattr(feature_brief, "document_path", "") or ""
-        return (
-            document
-            or research.spec_path
-            or research.feat_id
-            or research.jira_issue_key
-            or ""
-        )
+        return document or research.spec_path or research.feat_id or research.jira_issue_key or ""
 
     async def _run_deterministic_qa(
         self,
@@ -495,19 +472,20 @@ class QANode(DevLoopNode):
         for upstream in ("origin/dev", "origin/main"):
             try:
                 proc = await asyncio.create_subprocess_exec(
-                    "git", "diff", "--name-only", "--diff-filter=d",
-                    f"{upstream}...HEAD", "--", "*.py",
+                    "git",
+                    "diff",
+                    "--name-only",
+                    "--diff-filter=d",
+                    f"{upstream}...HEAD",
+                    "--",
+                    "*.py",
                     cwd=worktree_path,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
                 stdout, _ = await proc.communicate()
                 if proc.returncode == 0 and stdout:
-                    return [
-                        f.strip()
-                        for f in stdout.decode().strip().splitlines()
-                        if f.strip()
-                    ]
+                    return [f.strip() for f in stdout.decode().strip().splitlines() if f.strip()]
             except Exception:
                 continue
         return []
@@ -532,10 +510,7 @@ class QANode(DevLoopNode):
             return scoped
 
         parts = re.split(r"(&&|;)", command)
-        return "".join(
-            _scope_part(p) if i % 2 == 0 else p
-            for i, p in enumerate(parts)
-        )
+        return "".join(_scope_part(p) if i % 2 == 0 else p for i, p in enumerate(parts))
 
     @classmethod
     def _scope_criteria(
@@ -553,15 +528,7 @@ class QANode(DevLoopNode):
                 and _LINT_TARGET_RE.search(c.command)
                 and re.search(r"\b(ruff|mypy|flake8|pylint)\b", c.command)
             ):
-                scoped.append(
-                    c.model_copy(
-                        update={
-                            "command": cls._scope_lint_to_files(
-                                c.command, files
-                            )
-                        }
-                    )
-                )
+                scoped.append(c.model_copy(update={"command": cls._scope_lint_to_files(c.command, files)}))
             else:
                 scoped.append(c)
         return scoped
@@ -739,9 +706,7 @@ class QANode(DevLoopNode):
 
         def _missing(indexed: Dict[str, AdversarialFinding]) -> List[AdversarialFinding]:
             return [
-                f for f in findings
-                if indexed.get(f.finding_id) is None
-                or indexed[f.finding_id].disposition is None
+                f for f in findings if indexed.get(f.finding_id) is None or indexed[f.finding_id].disposition is None
             ]
 
         report = await _dispatch_once()
@@ -764,29 +729,29 @@ class QANode(DevLoopNode):
             resolved = indexed.get(finding.finding_id)
             if resolved is None or resolved.disposition is None:
                 # Fail-closed: still undispositioned after the retry.
-                resolved = finding.model_copy(update={
-                    "disposition": "escalate",
-                    "triage_reason": (
-                        "no disposition returned by the triage worker after one retry"
-                    ),
-                })
-            elif resolved.disposition == "confirm" and not self._confirm_has_evidence(
-                resolved, files_modified_set
-            ):
+                resolved = finding.model_copy(
+                    update={
+                        "disposition": "escalate",
+                        "triage_reason": ("no disposition returned by the triage worker after one retry"),
+                    }
+                )
+            elif resolved.disposition == "confirm" and not self._confirm_has_evidence(resolved, files_modified_set):
                 # FEAT-375 code-review fix: a CONFIRM MUST be backed by an
                 # actual file change — otherwise "confirmed" is
                 # indistinguishable from "silently dropped" (nothing else
                 # would have surfaced this in QAReport.notes, and the
                 # deterministic rerun never triggers). Fail closed to
                 # ESCALATE rather than let an agreed-upon defect disappear.
-                resolved = resolved.model_copy(update={
-                    "disposition": "escalate",
-                    "triage_reason": (
-                        f"disposed as 'confirm' but no corresponding fix was found "
-                        f"in files_modified (worker's stated reason: "
-                        f"{resolved.triage_reason or '(none)'}) — escalating fail-closed"
-                    ),
-                })
+                resolved = resolved.model_copy(
+                    update={
+                        "disposition": "escalate",
+                        "triage_reason": (
+                            f"disposed as 'confirm' but no corresponding fix was found "
+                            f"in files_modified (worker's stated reason: "
+                            f"{resolved.triage_reason or '(none)'}) — escalating fail-closed"
+                        ),
+                    }
+                )
 
             if resolved.disposition == "reject":
                 notes.append(f"rejected: {resolved.message} — {resolved.triage_reason}")
@@ -808,9 +773,7 @@ class QANode(DevLoopNode):
 
         escalation_passed = True
         if escalated_gate_ids and session_host is not None:
-            resolved_gates = await asyncio.gather(
-                *(session_host.wait_gate(gate_id) for gate_id in escalated_gate_ids)
-            )
+            resolved_gates = await asyncio.gather(*(session_host.wait_gate(gate_id) for gate_id in escalated_gate_ids))
             escalation_passed = all(gate.status == "approved" for gate in resolved_gates)
 
         return notes, list(report.files_modified), escalation_passed
@@ -830,9 +793,7 @@ class QANode(DevLoopNode):
         return bool(files_modified)
 
     @staticmethod
-    def _merge_manual_results(
-        report: QAReport, manual: List[ManualCriterion]
-    ) -> QAReport:
+    def _merge_manual_results(report: QAReport, manual: List[ManualCriterion]) -> QAReport:
         """Append synthesized ``passed=True`` results for each manual criterion.
 
         Manual criteria don't gate the flow; they surface in the Jira
@@ -856,9 +817,7 @@ class QANode(DevLoopNode):
         manual_block = "\n".join(f"- {m.name}: {m.text}" for m in manual)
         existing_notes = report.notes or ""
         sep = "\n\n" if existing_notes else ""
-        new_notes = (
-            f"{existing_notes}{sep}Manual verification required:\n{manual_block}"
-        )
+        new_notes = f"{existing_notes}{sep}Manual verification required:\n{manual_block}"
         return report.model_copy(
             update={
                 "criterion_results": merged_results,
@@ -922,9 +881,7 @@ class QANode(DevLoopNode):
             )
             opened.append((criterion, gate_id))
 
-        resolved_gates = await asyncio.gather(
-            *[host.wait_gate(gate_id) for _, gate_id in opened]
-        )
+        resolved_gates = await asyncio.gather(*[host.wait_gate(gate_id) for _, gate_id in opened])
 
         synthesized: List[CriterionResult] = []
         audit_lines: List[str] = []
@@ -932,31 +889,32 @@ class QANode(DevLoopNode):
         for (criterion, _gate_id), gate in zip(opened, resolved_gates):
             passed = gate.status == "approved"
             all_passed = all_passed and passed
-            synthesized.append(CriterionResult(
-                name=criterion.name,
-                kind="manual",
-                exit_code=0 if passed else 1,
-                duration_seconds=0.0,
-                stdout_tail="",
-                stderr_tail="",
-                passed=passed,
-            ))
+            synthesized.append(
+                CriterionResult(
+                    name=criterion.name,
+                    kind="manual",
+                    exit_code=0 if passed else 1,
+                    duration_seconds=0.0,
+                    stdout_tail="",
+                    stderr_tail="",
+                    passed=passed,
+                )
+            )
             audit_lines.append(
-                f"{criterion.name}: {gate.status} by "
-                f"{gate.resolved_by or 'system'} — {gate.comment}"
+                f"{criterion.name}: {gate.status} by " f"{gate.resolved_by or 'system'} — {gate.comment}"
             )
 
         merged_results = list(report.criterion_results) + synthesized
         existing_notes = report.notes or ""
         sep = "\n\n" if existing_notes else ""
         audit_block = "\n".join(audit_lines)
-        new_notes = (
-            f"{existing_notes}{sep}Blocking manual criteria (HITL):\n{audit_block}"
+        new_notes = f"{existing_notes}{sep}Blocking manual criteria (HITL):\n{audit_block}"
+        report = report.model_copy(
+            update={
+                "criterion_results": merged_results,
+                "notes": new_notes,
+            }
         )
-        report = report.model_copy(update={
-            "criterion_results": merged_results,
-            "notes": new_notes,
-        })
         return report, all_passed
 
 

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/qa.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/qa.py
@@ -414,7 +414,13 @@ class QANode(DevLoopNode):
         """
         feature_brief = shared.get("feature_brief")
         document = getattr(feature_brief, "document_path", "") or ""
-        return document or research.spec_path or research.feat_id or ""
+        return (
+            document
+            or research.spec_path
+            or research.feat_id
+            or research.jira_issue_key
+            or ""
+        )
 
     async def _run_deterministic_qa(
         self,

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/research.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/research.py
@@ -501,6 +501,13 @@ class ResearchNode(DevLoopNode):
 
         Returns:
             The resolved base branch name; never ``""``.
+
+        Note (code-review follow-up, FEAT-466 TASK-2505): because this
+        always falls back to the work-kind mapping when the spec is
+        unreadable, ``ResearchOutput.base_branch`` never actually reaches
+        ``DeploymentHandoffNode`` as ``""`` in normal operation — that
+        node's "block on empty" branch is defensive-only (see its own
+        NOTE), not a path a legitimate run ever takes today.
         """
         spec_path = Path(research_out.spec_path)
         if not spec_path.is_absolute():

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/research.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/research.py
@@ -24,8 +24,10 @@ from __future__ import annotations
 import asyncio
 import os
 import re
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
+import yaml
 from navconfig import BASE_DIR
 
 from parrot import conf
@@ -49,6 +51,17 @@ from parrot.flows.dev_loop.nodes.base import (
     transition_issue_with_candidates,
 )
 
+
+# FEAT-466 TASK-2504: WorkKind -> base branch, used ONLY as the fallback
+# when the committed spec's frontmatter cannot be read. Deliberately a
+# LOCAL copy of scripts/sdd/sdd_meta.WORK_KIND_FLOW's base-branch half
+# (not an import — `scripts.sdd` is not importable from this package's
+# actual install/test context; see TASK-2504 Completion Note).
+_WORK_KIND_BASE_BRANCH: Dict[str, str] = {
+    "bug": "main",
+    "enhancement": "dev",
+    "new_feature": "dev",
+}
 
 # Atlassian caps the description field at 32 767 chars; leave a 2K
 # headroom for the rest of the JSON body and any unicode-byte expansion.
@@ -138,6 +151,45 @@ def _plan_llm_default() -> str:
     if pinned:
         return pinned
     return _summarizer_llm_default()
+
+
+def _parse_flow_frontmatter(spec_path: Path) -> Optional[str]:
+    """Read the ``base_branch`` declared in a spec's YAML frontmatter.
+
+    FEAT-466 TASK-2504: mirrors ``scripts/sdd/sdd_meta.parse()``'s body
+    locally rather than importing it — ``scripts.sdd`` is not importable
+    from this package's actual install/test context (verified: it fails
+    once the interpreter's cwd is anything other than the repo root,
+    which is the normal case for an installed ``parrot`` package and for
+    this package's own test suite, run from ``packages/ai-parrot``). See
+    TASK-2504 Completion Note for the full verification.
+
+    Args:
+        spec_path: Path to the committed spec markdown file.
+
+    Returns:
+        The frontmatter's ``base_branch`` string when present and
+        non-empty, else ``None`` (missing file, no frontmatter, malformed
+        YAML, or a non-string/empty value) — callers must treat ``None``
+        as "unresolved", never as an error.
+    """
+    try:
+        text = spec_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    if not text.startswith("---"):
+        return None
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return None
+    try:
+        block = yaml.safe_load(parts[1]) or {}
+    except yaml.YAMLError:
+        return None
+    if not isinstance(block, dict):
+        return None
+    base = block.get("base_branch")
+    return base if isinstance(base, str) and base else None
 
 
 @register_dev_loop_node("dev_loop.research")
@@ -417,8 +469,61 @@ class ResearchNode(DevLoopNode):
             update={"repo_path": repo_path}
         )
 
+        # 8. FEAT-466 TASK-2504: stamp the deterministically-resolved base
+        # branch — read from the COMMITTED spec, never trusted from the
+        # subagent's self-report. See _resolve_base_branch.
+        research_out = research_out.model_copy(
+            update={"base_branch": self._resolve_base_branch(research_out, brief)}
+        )
+
         shared["research_output"] = research_out
         return research_out
+
+    def _resolve_base_branch(
+        self, research_out: ResearchOutput, brief: WorkBrief
+    ) -> str:
+        """Resolve the run's base branch from the committed spec.
+
+        The spec file on disk is authoritative: it was written and committed
+        by ``/sdd-spec``, whereas anything on ``research_out`` was produced by
+        an LLM and may have drifted. When the spec cannot be read we fall
+        back to the work-kind mapping and say so loudly, because a wrong base
+        branch is what FEAT-466 exists to prevent.
+
+        Args:
+            research_out: The validated dispatch output (for ``spec_path``
+                and ``worktree_path``).
+            brief: This run's brief, for the ``kind`` fallback.
+
+        Returns:
+            The resolved base branch name; never ``""``.
+        """
+        spec_path = Path(research_out.spec_path)
+        if not spec_path.is_absolute():
+            spec_path = Path(research_out.worktree_path) / spec_path
+
+        resolved = _parse_flow_frontmatter(spec_path)
+        if resolved is None:
+            kind = getattr(brief, "kind", None)
+            resolved = _WORK_KIND_BASE_BRANCH.get(kind, "dev")
+            self.logger.warning(
+                "Could not resolve base_branch from spec %s; falling back "
+                "to the kind mapping for kind=%r -> %r.",
+                spec_path,
+                kind,
+                resolved,
+            )
+
+        reported = (research_out.base_branch or "").strip()
+        if reported and reported != resolved:
+            self.logger.warning(
+                "sdd-research reported base_branch=%r but the committed "
+                "spec %s resolves to %r; using the spec's value.",
+                reported,
+                spec_path,
+                resolved,
+            )
+        return resolved
 
     # ------------------------------------------------------------------
     # Internal — repo provisioning (FEAT-250)

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/research.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/research.py
@@ -51,7 +51,6 @@ from parrot.flows.dev_loop.nodes.base import (
     transition_issue_with_candidates,
 )
 
-
 # FEAT-466 TASK-2504: WorkKind -> base branch, used ONLY as the fallback
 # when the committed spec's frontmatter cannot be read. Deliberately a
 # LOCAL copy of scripts/sdd/sdd_meta.WORK_KIND_FLOW's base-branch half
@@ -239,8 +238,7 @@ class ResearchNode(DevLoopNode):
         mode = (log_fetch_mode or "").strip().lower() or _log_fetch_mode_default()
         if mode not in _LOG_FETCH_MODES:
             raise ValueError(
-                f"Invalid log_fetch_mode {log_fetch_mode!r}; "
-                f"expected one of {sorted(_LOG_FETCH_MODES)}."
+                f"Invalid log_fetch_mode {log_fetch_mode!r}; " f"expected one of {sorted(_LOG_FETCH_MODES)}."
             )
         object.__setattr__(self, "_log_fetch_mode", mode)
         object.__setattr__(self, "_summarizer_llm", summarizer_llm or _summarizer_llm_default())
@@ -286,8 +284,7 @@ class ResearchNode(DevLoopNode):
         if skip_jira:
             issue_key = "SKIP-0"
             self.logger.info(
-                "Jira bypass enabled (skip_jira=True) for run_id=%s — "
-                "no ticket created.",
+                "Jira bypass enabled (skip_jira=True) for run_id=%s — " "no ticket created.",
                 shared.get("run_id", "?"),
             )
         else:
@@ -304,7 +301,8 @@ class ResearchNode(DevLoopNode):
                 issue_key = existing_key
                 self.logger.info(
                     "Re-using existing Jira ticket %s for run_id=%s",
-                    issue_key, shared.get("run_id", "?"),
+                    issue_key,
+                    shared.get("run_id", "?"),
                 )
                 await self._comment_retriggered(
                     issue_key=issue_key,
@@ -314,9 +312,7 @@ class ResearchNode(DevLoopNode):
             else:
                 reporter_fields = await self._reporter_fields(brief.reporter)
                 # FEAT-132: pick the issuetype from the kind→type mapping.
-                issuetype = _ISSUE_TYPE_BY_KIND.get(
-                    getattr(brief, "kind", "bug"), "Bug"
-                )
+                issuetype = _ISSUE_TYPE_BY_KIND.get(getattr(brief, "kind", "bug"), "Bug")
                 jira_resp = await self._jira.jira_create_issue(
                     summary=brief.summary,
                     issuetype=issuetype,
@@ -327,14 +323,14 @@ class ResearchNode(DevLoopNode):
                 issue_key = self._extract_issue_key(jira_resp)
                 self.logger.info(
                     "Created new Jira ticket %s (kind=%s) for run_id=%s",
-                    issue_key, getattr(brief, "kind", "bug"), shared.get("run_id", "?"),
+                    issue_key,
+                    getattr(brief, "kind", "bug"),
+                    shared.get("run_id", "?"),
                 )
                 # FEAT-132 G4: post plan-summary as first comment on new tickets.
                 run_id = shared.get("run_id", "")
                 plan = await self._build_plan_summary(brief, excerpts)
-                await self._post_plan_summary_comment(
-                    issue_key=issue_key, plan=plan, run_id=run_id
-                )
+                await self._post_plan_summary_comment(issue_key=issue_key, plan=plan, run_id=run_id)
         shared["jira_issue_key"] = issue_key
 
         # Transition the ticket out of Backlog so downstream nodes
@@ -354,7 +350,8 @@ class ResearchNode(DevLoopNode):
             except Exception as exc:  # noqa: BLE001
                 self.logger.warning(
                     "Initial Jira transition failed for %s (continuing): %s",
-                    issue_key, exc,
+                    issue_key,
+                    exc,
                 )
 
         # 3. FEAT-253: Provision repos BEFORE the sdd-research dispatch so
@@ -364,12 +361,12 @@ class ResearchNode(DevLoopNode):
         # configured (local fallback) and the clone path otherwise.
         repo_path = await self._provision_repos(shared.get("run_id", ""))
         is_clone = bool(self._repos and self._git_toolkit is not None)
-        dispatch_cwd: str = (
-            repo_path if is_clone else os.path.abspath(conf.WORKTREE_BASE_PATH)
-        )
+        dispatch_cwd: str = repo_path if is_clone else os.path.abspath(conf.WORKTREE_BASE_PATH)
         self.logger.info(
             "Base repository: %s (clone=%s), dispatch cwd: %s",
-            repo_path, is_clone, dispatch_cwd,
+            repo_path,
+            is_clone,
+            dispatch_cwd,
         )
 
         # 4. Dispatch the sdd-research subagent.
@@ -380,7 +377,12 @@ class ResearchNode(DevLoopNode):
             # Write: it scaffolds spec/task files under sdd/. Read/Grep/Glob
             # for triage, Bash for git worktree plumbing.
             allowed_tools=[
-                "Read", "Grep", "Glob", "Bash", "Write", "SlashCommand",
+                "Read",
+                "Grep",
+                "Glob",
+                "Bash",
+                "Write",
+                "SlashCommand",
             ],
             model="claude-sonnet-4-6",
         )
@@ -412,11 +414,11 @@ class ResearchNode(DevLoopNode):
 
         dispatch_brief = brief
         if extra_context_parts:
-            dispatch_brief = brief.model_copy(update={
-                "description": (
-                    brief.description + "\n\n" + "\n\n".join(extra_context_parts)
-                ).strip(),
-            })
+            dispatch_brief = brief.model_copy(
+                update={
+                    "description": (brief.description + "\n\n" + "\n\n".join(extra_context_parts)).strip(),
+                }
+            )
 
         research_out: ResearchOutput = await self._dispatcher.dispatch(
             brief=dispatch_brief,
@@ -433,17 +435,13 @@ class ResearchNode(DevLoopNode):
 
         # 5. If the subagent left jira_issue_key blank, inject ours.
         if not research_out.jira_issue_key:
-            research_out = research_out.model_copy(
-                update={"jira_issue_key": issue_key}
-            )
+            research_out = research_out.model_copy(update={"jira_issue_key": issue_key})
 
         # 6. Spec §7 R5 (relaxed) — reuse existing worktree if it's
         # already a registered git worktree on the expected branch;
         # fail fast only on the unsafe shapes (untracked directory or
         # mismatched branch).
-        worktree_reused = await self._ensure_worktree_safe(
-            research_out.branch_name
-        )
+        worktree_reused = await self._ensure_worktree_safe(research_out.branch_name)
 
         # 6b. When reusing a worktree, assess existing work so
         # DevelopmentNode can skip already-completed changes.
@@ -455,8 +453,7 @@ class ResearchNode(DevLoopNode):
             if prior:
                 shared["prior_work_context"] = prior
                 self.logger.info(
-                    "Prior work detected in reused worktree: %d commit(s), "
-                    "%d file(s) changed.",
+                    "Prior work detected in reused worktree: %d commit(s), " "%d file(s) changed.",
                     prior.get("commit_count", 0),
                     prior.get("files_changed", 0),
                 )
@@ -465,23 +462,17 @@ class ResearchNode(DevLoopNode):
         # repo_path is str(BASE_DIR) (local) or the clone path (declared
         # repo). worktree_path remains the per-run worktree — distinct from
         # repo_path (FEAT-253 G2/G3).
-        research_out = research_out.model_copy(
-            update={"repo_path": repo_path}
-        )
+        research_out = research_out.model_copy(update={"repo_path": repo_path})
 
         # 8. FEAT-466 TASK-2504: stamp the deterministically-resolved base
         # branch — read from the COMMITTED spec, never trusted from the
         # subagent's self-report. See _resolve_base_branch.
-        research_out = research_out.model_copy(
-            update={"base_branch": self._resolve_base_branch(research_out, brief)}
-        )
+        research_out = research_out.model_copy(update={"base_branch": self._resolve_base_branch(research_out, brief)})
 
         shared["research_output"] = research_out
         return research_out
 
-    def _resolve_base_branch(
-        self, research_out: ResearchOutput, brief: WorkBrief
-    ) -> str:
+    def _resolve_base_branch(self, research_out: ResearchOutput, brief: WorkBrief) -> str:
         """Resolve the run's base branch.
 
         Precedence, highest first (mirrors ``scripts.sdd.sdd_meta.
@@ -565,14 +556,10 @@ class ResearchNode(DevLoopNode):
         Never logs tokens — :class:`GitToolkit` handles scrubbing internally.
         """
         if not self._repos or self._git_toolkit is None:
-            self.logger.info(
-                "No repos declared; base repository = BASE_DIR (%s)", BASE_DIR
-            )
+            self.logger.info("No repos declared; base repository = BASE_DIR (%s)", BASE_DIR)
             return str(BASE_DIR)
 
-        base = os.path.join(
-            os.path.abspath(conf.DEV_LOOP_REPO_BASE_PATH), run_id or "run"
-        )
+        base = os.path.join(os.path.abspath(conf.DEV_LOOP_REPO_BASE_PATH), run_id or "run")
         os.makedirs(base, exist_ok=True)
 
         primary_path = ""
@@ -583,13 +570,15 @@ class ResearchNode(DevLoopNode):
             # against any normpath escape that slips through at the OS level.
             if not os.path.normpath(dest).startswith(os.path.normpath(base)):
                 raise ValueError(
-                    f"RepoSpec alias {repo.alias!r} would escape the clone "
-                    f"base {base!r} — refusing to provision."
+                    f"RepoSpec alias {repo.alias!r} would escape the clone " f"base {base!r} — refusing to provision."
                 )
 
             self.logger.info(
                 "Provisioning repo %r → %s (branch=%s, private=%s)",
-                repo.alias, dest, repo.branch, repo.private,
+                repo.alias,
+                dest,
+                repo.branch,
+                repo.private,
             )
             try:
                 result = await self._git_toolkit.clone_repo(
@@ -600,9 +589,10 @@ class ResearchNode(DevLoopNode):
                 )
             except Exception as exc:
                 self.logger.error(
-                    "Failed to provision repo %r → %s: %s. "
-                    "Falling back to local BASE_DIR checkout.",
-                    repo.alias, dest, exc,
+                    "Failed to provision repo %r → %s: %s. " "Falling back to local BASE_DIR checkout.",
+                    repo.alias,
+                    dest,
+                    exc,
                 )
                 return str(BASE_DIR)
             path = result.get("path", dest) if isinstance(result, dict) else dest
@@ -661,22 +651,19 @@ class ResearchNode(DevLoopNode):
                     "Skipping %s log fetch for %r (kind=%s, "
                     "log_fetch_mode=%s) — remote log fetching is only for "
                     "bug runs.",
-                    src.kind, src.locator, kind, self._log_fetch_mode,
+                    src.kind,
+                    src.locator,
+                    kind,
+                    self._log_fetch_mode,
                 )
                 continue
             try:
-                excerpts.extend(
-                    await self._fetch_logs(src, affected_component)
-                )
+                excerpts.extend(await self._fetch_logs(src, affected_component))
             except Exception as exc:  # never block the flow on log fetch
-                self.logger.warning(
-                    "Log fetch failed for %s/%s: %s", src.kind, src.locator, exc
-                )
+                self.logger.warning("Log fetch failed for %s/%s: %s", src.kind, src.locator, exc)
         return excerpts
 
-    async def _fetch_logs(
-        self, source: LogSource, affected_component: str = ""
-    ) -> List[str]:
+    async def _fetch_logs(self, source: LogSource, affected_component: str = "") -> List[str]:
         if source.kind == "inline":
             # The locator IS the pasted log/stack-trace text — nothing to
             # fetch. Keep the tail so oversized pastes don't bloat the
@@ -698,9 +685,7 @@ class ResearchNode(DevLoopNode):
             if source.locator and source.locator != toolkit.default_log_group:
                 kwargs["log_group_name"] = source.locator
             if affected_component:
-                kwargs["query_string"] = self._build_cw_query(
-                    affected_component
-                )
+                kwargs["query_string"] = self._build_cw_query(affected_component)
             result = await toolkit.aws_cloudwatch_query_logs(**kwargs)
             return self._tail_text(result)
         if source.kind == "elasticsearch":
@@ -716,9 +701,7 @@ class ResearchNode(DevLoopNode):
         if source.kind == "attached_file":
             # Blocking I/O off the event loop — large attached log files
             # would otherwise stall every concurrent flow run.
-            content = await asyncio.to_thread(
-                self._read_file_tail, source.locator, 4000
-            )
+            content = await asyncio.to_thread(self._read_file_tail, source.locator, 4000)
             return [content]
         raise ValueError(f"Unknown log source kind: {source.kind}")
 
@@ -735,9 +718,7 @@ class ResearchNode(DevLoopNode):
         return value.replace("\\", "\\\\").replace('"', '\\"')
 
     @classmethod
-    def _build_cw_query(
-        cls, affected_component: str, limit: int = 100
-    ) -> str:
+    def _build_cw_query(cls, affected_component: str, limit: int = 100) -> str:
         """Build a CloudWatch Insights query filtered by the affected component.
 
         Extracts the leaf name (e.g. ``MSWordLoader`` from
@@ -756,18 +737,10 @@ class ResearchNode(DevLoopNode):
         escaped_leaf = cls._escape_cw_string(leaf)
         if leaf != affected_component:
             escaped_full = cls._escape_cw_string(affected_component)
-            filter_clause = (
-                f'filter @message like "{escaped_full}" '
-                f'or @message like "{escaped_leaf}"'
-            )
+            filter_clause = f'filter @message like "{escaped_full}" ' f'or @message like "{escaped_leaf}"'
         else:
             filter_clause = f'filter @message like "{escaped_leaf}"'
-        return (
-            "fields @timestamp, @message "
-            f"| {filter_clause} "
-            "| sort @timestamp desc "
-            f"| limit {limit}"
-        )
+        return "fields @timestamp, @message " f"| {filter_clause} " "| sort @timestamp desc " f"| limit {limit}"
 
     @staticmethod
     def _read_file_tail(path: str, max_bytes: int) -> str:
@@ -819,18 +792,12 @@ class ResearchNode(DevLoopNode):
         formatted: List[str] = []
         for row in rows:
             if isinstance(row, dict):
-                fields = {
-                    k: v for k, v in row.items() if k not in _LOG_DROP_FIELDS
-                }
-                message = str(
-                    fields.get("@message") or fields.get("message") or ""
-                ).strip()
+                fields = {k: v for k, v in row.items() if k not in _LOG_DROP_FIELDS}
+                message = str(fields.get("@message") or fields.get("message") or "").strip()
                 if not message:
                     # No message field — keep a compact repr of the rest.
                     message = str(fields).strip()
-                timestamp = str(
-                    fields.get("@timestamp") or fields.get("timestamp") or ""
-                ).strip()
+                timestamp = str(fields.get("@timestamp") or fields.get("timestamp") or "").strip()
                 line = f"[{timestamp}] {message}" if timestamp else message
             else:
                 line = str(row).strip()
@@ -843,9 +810,7 @@ class ResearchNode(DevLoopNode):
             return []
         return ["\n".join(kept)]
 
-    async def _build_description(
-        self, brief: BugBrief, excerpts: List[str]
-    ) -> str:
+    async def _build_description(self, brief: BugBrief, excerpts: List[str]) -> str:
         """Render the Jira description, summarizing logs if it overflows.
 
         Progressive degradation:
@@ -866,7 +831,8 @@ class ResearchNode(DevLoopNode):
         if len(body) > _MAX_DESCRIPTION_CHARS:
             self.logger.info(
                 "Description %d chars > %d cap; summarizing log excerpts",
-                len(body), _MAX_DESCRIPTION_CHARS,
+                len(body),
+                _MAX_DESCRIPTION_CHARS,
             )
             digest = await self._summarize_excerpts(excerpts)
             body = self._render_body(
@@ -874,20 +840,16 @@ class ResearchNode(DevLoopNode):
                 [
                     "(Auto-summarized: the raw log excerpts exceeded "
                     "Jira's 32 767-char limit. The digest below was "
-                    f"produced by {self._summarizer_llm}.)\n\n"
-                    + digest
+                    f"produced by {self._summarizer_llm}.)\n\n" + digest
                 ],
             )
         if len(body) > _MAX_DESCRIPTION_CHARS:
             self.logger.warning(
-                "Description still %d chars after summarization; "
-                "hard-truncating to %d.",
-                len(body), _MAX_DESCRIPTION_CHARS,
+                "Description still %d chars after summarization; " "hard-truncating to %d.",
+                len(body),
+                _MAX_DESCRIPTION_CHARS,
             )
-            body = (
-                body[: _MAX_DESCRIPTION_CHARS - 32].rstrip()
-                + "\n\n... (truncated)"
-            )
+            body = body[: _MAX_DESCRIPTION_CHARS - 32].rstrip() + "\n\n... (truncated)"
         return body
 
     @staticmethod
@@ -898,20 +860,12 @@ class ResearchNode(DevLoopNode):
         def _fmt_criterion(c: Any) -> str:
             kind = getattr(c, "kind", "?")
             name = getattr(c, "name", "?")
-            detail = (
-                getattr(c, "command", None)
-                or getattr(c, "task_path", None)
-                or getattr(c, "text", "")
-            )
+            detail = getattr(c, "command", None) or getattr(c, "task_path", None) or getattr(c, "text", "")
             return f"- [{kind}] {name}: {detail}"
 
-        criteria_lines = "\n".join(
-            _fmt_criterion(c) for c in brief.acceptance_criteria
-        )
+        criteria_lines = "\n".join(_fmt_criterion(c) for c in brief.acceptance_criteria)
         excerpts_block = "\n---\n".join(excerpts) if excerpts else "(none)"
-        details_block = (
-            f"Details:\n{brief.description}\n\n" if brief.description else ""
-        )
+        details_block = f"Details:\n{brief.description}\n\n" if brief.description else ""
         return (
             f"Affected component: {brief.affected_component}\n\n"
             f"{details_block}"
@@ -953,9 +907,9 @@ class ResearchNode(DevLoopNode):
                 return text
         except Exception as exc:  # noqa: BLE001 - degraded fallback
             self.logger.warning(
-                "Log summarization via %s failed (%s); "
-                "falling back to deterministic tail",
-                self._summarizer_llm, exc,
+                "Log summarization via %s failed (%s); " "falling back to deterministic tail",
+                self._summarizer_llm,
+                exc,
             )
         # Deterministic fallback: keep the tail of each excerpt up to
         # the target budget.
@@ -972,9 +926,7 @@ class ResearchNode(DevLoopNode):
     # FEAT-132 — Plan-summary helpers
     # ------------------------------------------------------------------
 
-    async def _build_plan_summary(
-        self, brief: WorkBrief, excerpts: List[str]
-    ) -> str:
+    async def _build_plan_summary(self, brief: WorkBrief, excerpts: List[str]) -> str:
         """Generate a short action-oriented plan for the Jira ticket comment.
 
         Uses the plan LLM (``DEV_LOOP_PLAN_LLM`` or falls back to the
@@ -997,16 +949,14 @@ class ResearchNode(DevLoopNode):
                 return text
         except Exception as exc:  # noqa: BLE001 - degraded fallback
             self.logger.warning(
-                "Plan summarization via %s failed (%s); "
-                "falling back to deterministic stub",
-                self._plan_llm, exc,
+                "Plan summarization via %s failed (%s); " "falling back to deterministic stub",
+                self._plan_llm,
+                exc,
             )
         return self._deterministic_plan_stub(brief)
 
     @staticmethod
-    def _compose_plan_prompt(
-        brief: WorkBrief, excerpts: List[str]
-    ) -> str:
+    def _compose_plan_prompt(brief: WorkBrief, excerpts: List[str]) -> str:
         """Build the plan-generation prompt consumed by the plan LLM.
 
         Args:
@@ -1027,8 +977,7 @@ class ResearchNode(DevLoopNode):
             f"Summary: {brief.summary}\n"
             f"Component: {brief.affected_component}\n"
             f"Description: {brief.description or '(none)'}\n"
-            "Log excerpts (truncated):\n"
-            + ("\n---\n".join(excerpts) if excerpts else "(none)")
+            "Log excerpts (truncated):\n" + ("\n---\n".join(excerpts) if excerpts else "(none)")
         )
 
     @staticmethod
@@ -1067,7 +1016,8 @@ class ResearchNode(DevLoopNode):
         except Exception as exc:  # noqa: BLE001 - non-fatal
             self.logger.warning(
                 "Could not post plan-summary comment on %s: %s",
-                issue_key, exc,
+                issue_key,
+                exc,
             )
 
     def _get_plan_client(self) -> Any:
@@ -1100,22 +1050,20 @@ class ResearchNode(DevLoopNode):
                 result = await self._jira.jira_get_issue(brief.existing_issue_key)
             except Exception as exc:  # noqa: BLE001 - degrade to lookup
                 self.logger.warning(
-                    "existing_issue_key=%r could not be fetched (%s); "
-                    "falling back to summary search",
-                    brief.existing_issue_key, exc,
+                    "existing_issue_key=%r could not be fetched (%s); " "falling back to summary search",
+                    brief.existing_issue_key,
+                    exc,
                 )
             else:
                 # Toolkit responses carry a "status" key; treat a missing
                 # key as success so a bare issue payload also counts as a hit.
-                status = (
-                    result.get("status", "ok")
-                    if isinstance(result, dict) else "ok"
-                )
+                status = result.get("status", "ok") if isinstance(result, dict) else "ok"
                 if status == "ok":
                     return brief.existing_issue_key
                 self.logger.warning(
                     "existing_issue_key=%r returned %s; falling back",
-                    brief.existing_issue_key, status,
+                    brief.existing_issue_key,
+                    status,
                 )
 
         # 2. Summary search inside the configured project.
@@ -1145,25 +1093,24 @@ class ResearchNode(DevLoopNode):
             issues = result["data"]["issues"]
         else:
             self.logger.warning(
-                "Jira lookup failed: %s", result["message"],
+                "Jira lookup failed: %s",
+                result["message"],
             )
             return None
         # JQL `~` is fuzzy — verify the exact summary post-fetch so we
         # don't mistakenly merge unrelated tickets that share keywords.
         exact_matches = [
-            issue for issue in issues
-            if (
-                (issue.get("fields") or {}).get("summary") == brief.summary
-                or issue.get("summary") == brief.summary
-            )
+            issue
+            for issue in issues
+            if ((issue.get("fields") or {}).get("summary") == brief.summary or issue.get("summary") == brief.summary)
         ]
         if not exact_matches:
             return None
         if len(exact_matches) > 1:
             self.logger.warning(
-                "Found %d open Jira tickets with summary=%r; reusing "
-                "the most recently created one",
-                len(exact_matches), brief.summary,
+                "Found %d open Jira tickets with summary=%r; reusing " "the most recently created one",
+                len(exact_matches),
+                brief.summary,
             )
         chosen = exact_matches[0]
         return chosen.get("key") or chosen.get("issue_key")
@@ -1192,12 +1139,11 @@ class ResearchNode(DevLoopNode):
         except Exception as exc:  # noqa: BLE001 - non-fatal
             self.logger.warning(
                 "Could not post re-trigger comment on %s: %s",
-                issue_key, exc,
+                issue_key,
+                exc,
             )
 
-    async def _reporter_fields(
-        self, reporter: str
-    ) -> Optional[Dict[str, Any]]:
+    async def _reporter_fields(self, reporter: str) -> Optional[Dict[str, Any]]:
         """Build the ``fields={"reporter": {...}}`` blob for create_issue.
 
         Accepts either an email or an accountId. Emails are resolved to an
@@ -1247,8 +1193,9 @@ class ResearchNode(DevLoopNode):
             result = await self._jira.jira_find_user(reporter)
         except Exception as exc:  # noqa: BLE001 — never fail ticket creation
             self.logger.warning(
-                "Could not resolve reporter %r to an accountId: %s; "
-                "omitting reporter field", reporter, exc,
+                "Could not resolve reporter %r to an accountId: %s; " "omitting reporter field",
+                reporter,
+                exc,
             )
             return ""
         matches = (result or {}).get("matches") or []
@@ -1305,7 +1252,10 @@ class ResearchNode(DevLoopNode):
 
         try:
             proc = await asyncio.create_subprocess_exec(
-                "git", "worktree", "list", "--porcelain",
+                "git",
+                "worktree",
+                "list",
+                "--porcelain",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -1315,15 +1265,13 @@ class ResearchNode(DevLoopNode):
             stdout = stdout_bytes.decode()
         except FileNotFoundError as exc:
             raise RuntimeError(
-                f"Path {path!r} exists but `git worktree list` "
-                f"failed: {exc}. Investigate manually before retrying."
+                f"Path {path!r} exists but `git worktree list` " f"failed: {exc}. Investigate manually before retrying."
             ) from exc
         except RuntimeError:
             raise
         except Exception as exc:
             raise RuntimeError(
-                f"Path {path!r} exists but `git worktree list` "
-                f"failed: {exc}. Investigate manually before retrying."
+                f"Path {path!r} exists but `git worktree list` " f"failed: {exc}. Investigate manually before retrying."
             ) from exc
 
         info = self._find_worktree_entry(stdout, os.path.abspath(path))
@@ -1342,14 +1290,13 @@ class ResearchNode(DevLoopNode):
             )
         self.logger.info(
             "Reusing existing worktree %s on branch %s",
-            path, branch_name,
+            path,
+            branch_name,
         )
         return True
 
     @staticmethod
-    def _find_worktree_entry(
-        porcelain: str, abs_path: str
-    ) -> Optional[Dict[str, str]]:
+    def _find_worktree_entry(porcelain: str, abs_path: str) -> Optional[Dict[str, str]]:
         """Parse ``git worktree list --porcelain`` output for a path.
 
         Returns a dict with the entry's fields (notably ``branch``,
@@ -1369,7 +1316,7 @@ class ResearchNode(DevLoopNode):
             else:
                 key, value = line, ""
             if key == "branch" and value.startswith("refs/heads/"):
-                value = value[len("refs/heads/"):]
+                value = value[len("refs/heads/") :]
             current[key] = value
         if current.get("worktree") == abs_path:
             return current
@@ -1394,10 +1341,12 @@ class ResearchNode(DevLoopNode):
         The returned dict is stored in ``shared["prior_work_context"]``
         and consumed by ``DevelopmentNode`` to avoid repeating work.
         """
+
         async def _run_git(*args: str) -> Optional[str]:
             try:
                 proc = await asyncio.create_subprocess_exec(
-                    "git", *args,
+                    "git",
+                    *args,
                     cwd=worktree_path,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
@@ -1410,36 +1359,44 @@ class ResearchNode(DevLoopNode):
             return None
 
         merge_base = await _run_git(
-            "merge-base", "HEAD", "origin/dev",
+            "merge-base",
+            "HEAD",
+            "origin/dev",
         )
         if not merge_base:
             merge_base = await _run_git(
-                "merge-base", "HEAD", "origin/main",
+                "merge-base",
+                "HEAD",
+                "origin/main",
             )
         if not merge_base:
             return None
 
         log_output = await _run_git(
-            "log", "--oneline", "--no-decorate",
+            "log",
+            "--oneline",
+            "--no-decorate",
             f"{merge_base}..HEAD",
         )
         diff_stat = await _run_git(
-            "diff", "--stat", f"{merge_base}..HEAD",
+            "diff",
+            "--stat",
+            f"{merge_base}..HEAD",
         )
         diff_names = await _run_git(
-            "diff", "--name-only", "--diff-filter=d",
+            "diff",
+            "--name-only",
+            "--diff-filter=d",
             f"{merge_base}..HEAD",
         )
         uncommitted_diff = await _run_git(
-            "diff", "--stat", "HEAD",
+            "diff",
+            "--stat",
+            "HEAD",
         )
 
-        commits = [
-            line for line in (log_output or "").splitlines() if line.strip()
-        ]
-        changed_files = [
-            f for f in (diff_names or "").splitlines() if f.strip()
-        ]
+        commits = [line for line in (log_output or "").splitlines() if line.strip()]
+        changed_files = [f for f in (diff_names or "").splitlines() if f.strip()]
 
         if not commits and not changed_files and not uncommitted_diff:
             return None

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/research.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/research.py
@@ -482,18 +482,31 @@ class ResearchNode(DevLoopNode):
     def _resolve_base_branch(
         self, research_out: ResearchOutput, brief: WorkBrief
     ) -> str:
-        """Resolve the run's base branch from the committed spec.
+        """Resolve the run's base branch.
 
-        The spec file on disk is authoritative: it was written and committed
-        by ``/sdd-spec``, whereas anything on ``research_out`` was produced by
-        an LLM and may have drifted. When the spec cannot be read we fall
-        back to the work-kind mapping and say so loudly, because a wrong base
-        branch is what FEAT-466 exists to prevent.
+        Precedence, highest first (mirrors ``scripts.sdd.sdd_meta.
+        resolve_flow``'s documented precedence, FEAT-466 TASK-2508 — kept as
+        a local reimplementation here rather than an import; see TASK-2504's
+        Completion Note for why ``scripts.sdd`` is not importable from this
+        package's context):
+
+        1. ``brief.base_branch`` — an explicit operator override from the
+           console (FEAT-466 TASK-2508). This is genuine human intent
+           supplied *before* the run started, not an LLM self-report, so it
+           is trusted directly.
+        2. The committed spec's frontmatter — authoritative for everything
+           else: it was written and committed by ``/sdd-spec``, whereas
+           anything on ``research_out`` was produced by an LLM and may have
+           drifted.
+        3. The work-kind mapping, when the spec cannot be read — logged
+           loudly, because a wrong base branch is what FEAT-466 exists to
+           prevent.
 
         Args:
             research_out: The validated dispatch output (for ``spec_path``
                 and ``worktree_path``).
-            brief: This run's brief, for the ``kind`` fallback.
+            brief: This run's brief, for the ``base_branch`` override and the
+                ``kind`` fallback.
 
         Returns:
             The resolved base branch name; never ``""``.
@@ -502,17 +515,21 @@ class ResearchNode(DevLoopNode):
         if not spec_path.is_absolute():
             spec_path = Path(research_out.worktree_path) / spec_path
 
-        resolved = _parse_flow_frontmatter(spec_path)
-        if resolved is None:
-            kind = getattr(brief, "kind", None)
-            resolved = _WORK_KIND_BASE_BRANCH.get(kind, "dev")
-            self.logger.warning(
-                "Could not resolve base_branch from spec %s; falling back "
-                "to the kind mapping for kind=%r -> %r.",
-                spec_path,
-                kind,
-                resolved,
-            )
+        override = (getattr(brief, "base_branch", None) or "").strip()
+        if override:
+            resolved = override
+        else:
+            resolved = _parse_flow_frontmatter(spec_path)
+            if resolved is None:
+                kind = getattr(brief, "kind", None)
+                resolved = _WORK_KIND_BASE_BRANCH.get(kind, "dev")
+                self.logger.warning(
+                    "Could not resolve base_branch from spec %s; falling back "
+                    "to the kind mapping for kind=%r -> %r.",
+                    spec_path,
+                    kind,
+                    resolved,
+                )
 
         reported = (research_out.base_branch or "").strip()
         if reported and reported != resolved:

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/run_bundle.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/run_bundle.py
@@ -233,12 +233,8 @@ def build_run_bundle(
                 tool_use_count=dispatch.tool_use_count if dispatch else 0,
                 input_tokens=dispatch.input_tokens if dispatch else None,
                 output_tokens=dispatch.output_tokens if dispatch else None,
-                cache_creation_input_tokens=(
-                    dispatch.cache_creation_input_tokens if dispatch else None
-                ),
-                cache_read_input_tokens=(
-                    dispatch.cache_read_input_tokens if dispatch else None
-                ),
+                cache_creation_input_tokens=(dispatch.cache_creation_input_tokens if dispatch else None),
+                cache_read_input_tokens=(dispatch.cache_read_input_tokens if dispatch else None),
                 total_cost_usd=dispatch.total_cost_usd if dispatch else None,
                 num_turns=dispatch.num_turns if dispatch else None,
                 duration_ms=dispatch.duration_ms if dispatch else None,
@@ -264,11 +260,7 @@ def build_run_bundle(
     # -- totals --
     dispatches = [n.dispatch for n in state.nodes.values() if n.dispatch is not None]
     totals = RunTotals(
-        duration_seconds=(
-            state.finished_at - state.created_at
-            if state.finished_at is not None
-            else None
-        ),
+        duration_seconds=(state.finished_at - state.created_at if state.finished_at is not None else None),
         nodes_completed=sum(1 for n in state.nodes.values() if n.status == "completed"),
         nodes_failed=sum(1 for n in state.nodes.values() if n.status == "failed"),
         nodes_skipped=sum(1 for n in state.nodes.values() if n.status == "skipped"),
@@ -293,9 +285,7 @@ def build_run_bundle(
         task_ids.extend(getattr(worker, "tasks_completed", None) or [])
 
     criteria = [
-        CriterionOutcome(
-            name=c.name, passed=c.passed, duration_seconds=c.duration_seconds
-        )
+        CriterionOutcome(name=c.name, passed=c.passed, duration_seconds=c.duration_seconds)
         for c in (getattr(qa_report, "criterion_results", None) or [])
     ]
 
@@ -304,8 +294,7 @@ def build_run_bundle(
         docs_artifact_path = state.docs_artifacts[-1].docs_path
 
     developed = DevelopedWork(
-        jira_issue_key=state.jira_issue_key
-        or getattr(primary_output, "jira_issue_key", "") or "",
+        jira_issue_key=state.jira_issue_key or getattr(primary_output, "jira_issue_key", "") or "",
         pr_url=state.pr_url or "",
         pr_number=deployment_result.get("pr_number") or revision_result.get("pr_number"),
         feature_id=run_label(primary_output, default=""),
@@ -414,9 +403,7 @@ def render_markdown(bundle: RunBundle, usage_markdown: str = "") -> str:
     if bundle.nodes:
         lines.append("## Agents")
         lines.append("")
-        lines.append(
-            "| Node | Status | Duration | Dispatcher | Msgs | Tools | Tokens | Cost |"
-        )
+        lines.append("| Node | Status | Duration | Dispatcher | Msgs | Tools | Tokens | Cost |")
         lines.append("|---|---|---|---|---|---|---|---|")
         for n in bundle.nodes:
             lines.append(
@@ -439,18 +426,22 @@ def render_markdown(bundle: RunBundle, usage_markdown: str = "") -> str:
         lines.append("| Kind | Node | Status | Resolved by | Comment |")
         lines.append("|---|---|---|---|---|")
         for g in bundle.gates:
-            lines.append(
-                f"| {g.kind} | {g.node_id} | {g.status} | {g.resolved_by or 'n/a'} "
-                f"| {g.comment or ''} |"
-            )
+            lines.append(f"| {g.kind} | {g.node_id} | {g.status} | {g.resolved_by or 'n/a'} " f"| {g.comment or ''} |")
         lines.append("")
 
     # -- what was developed --
     has_developed_content = any(
         [
-            d.feature_id, d.spec_path, d.worktree_path, d.branch, d.task_ids,
-            d.qa_passed is not None, d.lint_passed is not None,
-            d.code_review_passed is not None, d.criteria, d.code_review_findings,
+            d.feature_id,
+            d.spec_path,
+            d.worktree_path,
+            d.branch,
+            d.task_ids,
+            d.qa_passed is not None,
+            d.lint_passed is not None,
+            d.code_review_passed is not None,
+            d.criteria,
+            d.code_review_findings,
             d.docs_artifact_path,
         ]
     )
@@ -482,9 +473,7 @@ def render_markdown(bundle: RunBundle, usage_markdown: str = "") -> str:
             lines.append("| Criterion | Passed | Duration |")
             lines.append("|---|---|---|")
             for c in d.criteria:
-                lines.append(
-                    f"| {c.name} | {c.passed} | {_format_duration(c.duration_seconds)} |"
-                )
+                lines.append(f"| {c.name} | {c.passed} | {_format_duration(c.duration_seconds)} |")
         if d.code_review_findings:
             lines.append("")
             lines.append("### Code Review Findings")

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/run_bundle.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/run_bundle.py
@@ -22,6 +22,7 @@ from typing import Any, List, Mapping, Optional, Sequence
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from parrot.flows.dev_loop.nodes.base import run_label
 from parrot.flows.dev_loop.session_state import (
     ActionEnvelope,
     GateKind,
@@ -307,7 +308,7 @@ def build_run_bundle(
         or getattr(primary_output, "jira_issue_key", "") or "",
         pr_url=state.pr_url or "",
         pr_number=deployment_result.get("pr_number") or revision_result.get("pr_number"),
-        feature_id=getattr(primary_output, "feat_id", "") or "",
+        feature_id=run_label(primary_output, default=""),
         spec_path=getattr(primary_output, "spec_path", "") or "",
         worktree_path=getattr(primary_output, "worktree_path", "") or "",
         branch=getattr(primary_output, "branch_name", "") or "",

--- a/packages/ai-parrot/tests/flows/dev_loop/test_base_branch_guard.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_base_branch_guard.py
@@ -1,0 +1,342 @@
+"""Unit tests for the sibling-overlap base-branch guard — FEAT-466 /
+TASK-2505.
+
+Reproduces the PR #1250 topology with a real (local, no-network) git repo:
+an ancestry check alone would wave the incident through, so
+``test_ancestry_alone_would_pass`` documents WHY the guard exists before the
+guard tests themselves run.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from parrot.flows.dev_loop import (
+    BugBrief,
+    DevelopmentOutput,
+    FlowtaskCriterion,
+    QAReport,
+    ResearchOutput,
+)
+from parrot.flows.dev_loop.nodes.base import (
+    BaseBranchMismatch,
+    assert_base_is_clean,
+)
+from parrot.flows.dev_loop.nodes.deployment_handoff import DeploymentHandoffNode
+from parrot.flows.dev_loop.nodes.feature_handoff import FeatureHandoffNode
+
+
+def _run(cwd, *args):
+    subprocess.run(
+        ["git", "-C", str(cwd), *args], check=True, capture_output=True
+    )
+
+
+@pytest.fixture
+def incident_repo(tmp_path):
+    """Reproduce the PR #1250 topology.
+
+        main:  A
+        dev:   A -- B -- C          (main is an ancestor of dev)
+        feat:  A -- B -- C -- D     (cut from dev, but targeting main)
+
+    So ``--is-ancestor origin/main feat`` is TRUE, yet feat carries B and C,
+    which belong to dev. adds(main..feat) = 3, own = 1.
+    """
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _run(origin, "init", "--bare", "-b", "main")
+
+    work = tmp_path / "work"
+    work.mkdir()
+    _run(work, "init", "-b", "main")
+    _run(work, "remote", "add", "origin", str(origin))
+    (work / "a.txt").write_text("A")
+    _run(work, "add", "-A")
+    _run(
+        work, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "A"
+    )
+    _run(work, "push", "origin", "main")
+
+    _run(work, "checkout", "-b", "dev")
+    for name in ("B", "C"):
+        (work / f"{name}.txt").write_text(name)
+        _run(work, "add", "-A")
+        _run(
+            work, "-c", "user.email=t@t", "-c", "user.name=t",
+            "commit", "-m", name,
+        )
+    _run(work, "push", "origin", "dev")
+
+    _run(work, "checkout", "-b", "feat-465")
+    (work / "D.txt").write_text("D")
+    _run(work, "add", "-A")
+    _run(
+        work, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "D"
+    )
+    _run(work, "push", "origin", "feat-465")
+    _run(work, "fetch", "origin")
+    return work
+
+
+@pytest.mark.asyncio
+class TestGuard:
+    async def test_ancestry_alone_would_pass(self, incident_repo):
+        """Documents WHY the guard is not an ancestry check."""
+        rc = subprocess.run(
+            [
+                "git", "-C", str(incident_repo), "merge-base",
+                "--is-ancestor", "origin/main", "feat-465",
+            ]
+        ).returncode
+        assert rc == 0, "ancestry passes — hence the sibling-overlap guard"
+
+    async def test_blocks_the_incident_topology(self, incident_repo):
+        with pytest.raises(BaseBranchMismatch, match="own work"):
+            await assert_base_is_clean(
+                "feat-465", "main", str(incident_repo), siblings=["dev"]
+            )
+
+    async def test_passes_for_correctly_cut_branch(self, incident_repo):
+        """feat-465 vs its real base (dev) is clean: adds == own."""
+        await assert_base_is_clean(
+            "feat-465", "dev", str(incident_repo), siblings=["main"]
+        )
+
+    async def test_missing_sibling_ref_is_skipped(self, incident_repo):
+        await assert_base_is_clean(
+            "feat-465", "dev", str(incident_repo), siblings=["staging"]
+        )
+
+    async def test_no_existing_siblings_passes(self, incident_repo, caplog):
+        logger = MagicMock()
+        await assert_base_is_clean(
+            "feat-465", "dev", str(incident_repo), siblings=["staging"],
+            logger=logger,
+        )
+        logger.info.assert_called_once()
+
+    async def test_cherry_pick_does_not_false_positive(self, incident_repo):
+        """Same content on a sibling under a different SHA must not count."""
+        work = incident_repo
+        # Cherry-pick D onto a new "backport" branch off main — new SHA,
+        # not a descendant relationship with dev at all.
+        _run(work, "checkout", "main")
+        _run(work, "checkout", "-b", "backport")
+        _run(work, "cherry-pick", "feat-465")
+        _run(work, "push", "origin", "backport")
+        _run(work, "fetch", "origin")
+
+        # backport vs main, checking against dev/feat-465 as siblings: the
+        # cherry-picked commit has a NEW sha, so it does not appear in
+        # dev's or feat-465's history by identity -> adds == own.
+        await assert_base_is_clean(
+            "backport", "main", str(work), siblings=["dev", "feat-465"]
+        )
+
+    async def test_default_siblings_used_when_none_passed(self, incident_repo):
+        """No explicit siblings -> defaults to _LONG_LIVED_BRANCHES - base,
+        filtered to existing refs. 'staging' does not exist here, so only
+        'dev'/'main' are candidates depending on base."""
+        with pytest.raises(BaseBranchMismatch):
+            await assert_base_is_clean(
+                "feat-465", "main", str(incident_repo)
+            )
+
+
+def _research(**over) -> ResearchOutput:
+    base = dict(
+        jira_issue_key="OPS-1",
+        spec_path="sdd/specs/x.spec.md",
+        feat_id="FEAT-130",
+        branch_name="feat-130-fix",
+        worktree_path="/tmp/does-not-matter",
+        log_excerpts=[],
+        base_branch="dev",
+    )
+    base.update(over)
+    return ResearchOutput(**base)
+
+
+def _brief(**over) -> BugBrief:
+    base = dict(
+        summary="customer sync drops the last row",
+        affected_component="etl/customers/sync.yaml",
+        log_sources=[],
+        acceptance_criteria=[FlowtaskCriterion(name="run", task_path="x.yaml")],
+        escalation_assignee="a",
+        reporter="b",
+    )
+    base.update(over)
+    return BugBrief(**base)
+
+
+def _jira() -> MagicMock:
+    j = MagicMock()
+    j.jira_transition_issue = AsyncMock(return_value={"ok": True})
+    j.jira_transition_to = AsyncMock(return_value={"ok": True})
+    j.jira_add_comment = AsyncMock(return_value={"id": "c1"})
+    return j
+
+
+async def _success_push(self, branch, cwd):
+    return None
+
+
+@pytest.mark.asyncio
+class TestDeploymentHandoffWiring:
+    async def test_blocks_on_empty_base_branch(self, monkeypatch):
+        monkeypatch.setattr(
+            DeploymentHandoffNode, "_push_branch", _success_push
+        )
+        create_pr = AsyncMock(return_value="https://github.com/x/y/pull/1")
+        monkeypatch.setattr(DeploymentHandoffNode, "_create_pr", create_pr)
+
+        node = DeploymentHandoffNode(jira_toolkit=_jira())
+        ctx = {
+            "run_id": "r1",
+            "research_output": _research(base_branch=""),
+            "bug_brief": _brief(),
+        }
+        result = await node.execute(ctx)
+
+        assert result["status"] == "blocked"
+        assert "base_branch" in result["error"]
+        create_pr.assert_not_awaited()
+
+    async def test_bug_kind_with_recorded_dev_base_targets_dev(
+        self, monkeypatch
+    ):
+        """Proves the kind override is gone: kind='bug' + recorded
+        base_branch='dev' opens the PR against dev, not main."""
+        monkeypatch.setattr(
+            DeploymentHandoffNode, "_push_branch", _success_push
+        )
+        monkeypatch.setattr(
+            "parrot.flows.dev_loop.nodes.deployment_handoff.assert_base_is_clean",
+            AsyncMock(return_value=None),
+        )
+        create_pr = AsyncMock(return_value="https://github.com/x/y/pull/1")
+        monkeypatch.setattr(DeploymentHandoffNode, "_create_pr", create_pr)
+
+        node = DeploymentHandoffNode(jira_toolkit=_jira())
+        ctx = {
+            "run_id": "r1",
+            "research_output": _research(base_branch="dev"),
+            "bug_brief": _brief(),
+        }
+        result = await node.execute(ctx)
+
+        assert result["status"] == "ready_to_deploy"
+        assert node._base_branch == "dev"
+
+    async def test_guard_failure_blocks_and_skips_pr(self, monkeypatch):
+        monkeypatch.setattr(
+            DeploymentHandoffNode, "_push_branch", _success_push
+        )
+        guard = AsyncMock(
+            side_effect=BaseBranchMismatch("branch carries sibling commits")
+        )
+        monkeypatch.setattr(
+            "parrot.flows.dev_loop.nodes.deployment_handoff.assert_base_is_clean",
+            guard,
+        )
+        create_pr = AsyncMock(return_value="https://github.com/x/y/pull/1")
+        monkeypatch.setattr(DeploymentHandoffNode, "_create_pr", create_pr)
+
+        jira = _jira()
+        node = DeploymentHandoffNode(jira_toolkit=jira)
+        ctx = {
+            "run_id": "r1",
+            "research_output": _research(base_branch="dev"),
+            "bug_brief": _brief(),
+        }
+        result = await node.execute(ctx)
+
+        assert result["status"] == "blocked"
+        assert "sibling" in result["error"]
+        create_pr.assert_not_awaited()
+        # The guard fires BEFORE any PR is opened, so the ticket is never
+        # moved to a "ready" state — only _mark_blocked's own "Deployment
+        # Blocked" transition happens (same shape as the existing
+        # push/PR-failure blocked paths in test_deployment_handoff.py).
+        jira.jira_transition_to.assert_awaited_once()
+        assert (
+            jira.jira_transition_to.await_args.kwargs["target_status"]
+            == "Deployment Blocked"
+        )
+
+
+def _planner(**over):
+    from parrot.flows.dev_loop.models import PlannerOutput
+
+    base = dict(
+        spec_path="sdd/specs/x.spec.md",
+        task_index_path="sdd/tasks/index/x.json",
+        feat_id="FEAT-378",
+        branch_name="feat-378-x",
+        worktree_path="/tmp/does-not-matter-feature",
+    )
+    base.update(over)
+    return PlannerOutput(**base)
+
+
+@pytest.mark.asyncio
+class TestFeatureHandoffWiring:
+    async def test_guard_applied(self, monkeypatch, tmp_path):
+        guard = AsyncMock(return_value=None)
+        monkeypatch.setattr(
+            "parrot.flows.dev_loop.nodes.feature_handoff.assert_base_is_clean",
+            guard,
+        )
+        monkeypatch.setattr(
+            FeatureHandoffNode, "_run_git", AsyncMock(return_value="")
+        )
+        monkeypatch.setattr(
+            FeatureHandoffNode, "_create_pr",
+            AsyncMock(return_value="https://github.com/x/y/pull/2"),
+        )
+        monkeypatch.setattr(
+            FeatureHandoffNode, "_docs_rel_path", lambda self, planner: "docs/x.md"
+        )
+        monkeypatch.setattr(
+            FeatureHandoffNode, "_write_and_push_docs", AsyncMock(return_value=None)
+        )
+        monkeypatch.setattr(
+            FeatureHandoffNode, "_ingest_wiki_page", AsyncMock(return_value=None)
+        )
+
+        node = FeatureHandoffNode()
+        planner = _planner(worktree_path=str(tmp_path))
+        ctx = {"run_id": "r1", "planner_output": planner}
+        result = await node.execute(ctx)
+
+        guard.assert_awaited_once()
+        called_args = guard.await_args.args
+        assert called_args[0] == planner.branch_name
+        assert result["status"] == "ready_to_deploy"
+
+    async def test_blocks_when_guard_fails(self, monkeypatch, tmp_path):
+        guard = AsyncMock(
+            side_effect=BaseBranchMismatch("branch carries sibling commits")
+        )
+        monkeypatch.setattr(
+            "parrot.flows.dev_loop.nodes.feature_handoff.assert_base_is_clean",
+            guard,
+        )
+        monkeypatch.setattr(
+            FeatureHandoffNode, "_run_git", AsyncMock(return_value="")
+        )
+        create_pr = AsyncMock(return_value="https://github.com/x/y/pull/2")
+        monkeypatch.setattr(FeatureHandoffNode, "_create_pr", create_pr)
+
+        node = FeatureHandoffNode()
+        planner = _planner(worktree_path=str(tmp_path))
+        ctx = {"run_id": "r1", "planner_output": planner}
+        result = await node.execute(ctx)
+
+        assert result["status"] == "blocked"
+        create_pr.assert_not_awaited()

--- a/packages/ai-parrot/tests/flows/dev_loop/test_base_branch_guard.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_base_branch_guard.py
@@ -126,13 +126,9 @@ class TestGuard:
         monkeypatch.setattr(base_module, "_git", _fail_base_fetch)
 
         with pytest.raises(RuntimeError, match="could not fetch origin/dev"):
-            await assert_base_is_clean(
-                "feat-465", "dev", str(incident_repo), siblings=["main"]
-            )
+            await assert_base_is_clean("feat-465", "dev", str(incident_repo), siblings=["main"])
 
-    async def test_sibling_transient_fetch_failure_raises_not_skips(
-        self, incident_repo, monkeypatch
-    ):
+    async def test_sibling_transient_fetch_failure_raises_not_skips(self, incident_repo, monkeypatch):
         """A sibling fetch failing for a reason OTHER than 'ref does not
         exist' must raise, never be silently treated the same as a
         genuinely-absent sibling — that would let exactly the sibling that
@@ -149,19 +145,13 @@ class TestGuard:
         monkeypatch.setattr(base_module, "_git", _flaky_sibling_fetch)
 
         with pytest.raises(RuntimeError, match="could not fetch origin/main"):
-            await assert_base_is_clean(
-                "feat-465", "dev", str(incident_repo), siblings=["main"]
-            )
+            await assert_base_is_clean("feat-465", "dev", str(incident_repo), siblings=["main"])
 
-    async def test_sibling_genuinely_absent_still_skipped(
-        self, incident_repo, monkeypatch
-    ):
+    async def test_sibling_genuinely_absent_still_skipped(self, incident_repo, monkeypatch):
         """The English 'couldn't find remote ref' shape (forced by LC_ALL=C)
         is still correctly treated as 'not applicable' — regression guard
         for the fetch-failure-vs-absent distinction above."""
-        await assert_base_is_clean(
-            "feat-465", "dev", str(incident_repo), siblings=["definitely-not-a-branch"]
-        )
+        await assert_base_is_clean("feat-465", "dev", str(incident_repo), siblings=["definitely-not-a-branch"])
 
     async def test_no_existing_siblings_passes(self, incident_repo, caplog):
         logger = MagicMock()

--- a/packages/ai-parrot/tests/flows/dev_loop/test_base_branch_guard.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_base_branch_guard.py
@@ -110,6 +110,59 @@ class TestGuard:
     async def test_missing_sibling_ref_is_skipped(self, incident_repo):
         await assert_base_is_clean("feat-465", "dev", str(incident_repo), siblings=["staging"])
 
+    async def test_base_fetch_failure_raises(self, incident_repo, monkeypatch):
+        """A real fetch failure on `base` must be loud, never silently
+        continued past — the whole comparison would be meaningless against
+        a stale/missing base ref (code-review follow-up, FEAT-466 TASK-2505)."""
+        from parrot.flows.dev_loop.nodes import base as base_module
+
+        real_git = base_module._git
+
+        async def _fail_base_fetch(cwd, *args):
+            if args == ("fetch", "origin", "dev"):
+                return (128, "", "fatal: unable to access remote")
+            return await real_git(cwd, *args)
+
+        monkeypatch.setattr(base_module, "_git", _fail_base_fetch)
+
+        with pytest.raises(RuntimeError, match="could not fetch origin/dev"):
+            await assert_base_is_clean(
+                "feat-465", "dev", str(incident_repo), siblings=["main"]
+            )
+
+    async def test_sibling_transient_fetch_failure_raises_not_skips(
+        self, incident_repo, monkeypatch
+    ):
+        """A sibling fetch failing for a reason OTHER than 'ref does not
+        exist' must raise, never be silently treated the same as a
+        genuinely-absent sibling — that would let exactly the sibling that
+        matters go unchecked (code-review follow-up, FEAT-466 TASK-2505)."""
+        from parrot.flows.dev_loop.nodes import base as base_module
+
+        real_git = base_module._git
+
+        async def _flaky_sibling_fetch(cwd, *args):
+            if args == ("fetch", "origin", "main"):
+                return (128, "", "fatal: the remote end hung up unexpectedly")
+            return await real_git(cwd, *args)
+
+        monkeypatch.setattr(base_module, "_git", _flaky_sibling_fetch)
+
+        with pytest.raises(RuntimeError, match="could not fetch origin/main"):
+            await assert_base_is_clean(
+                "feat-465", "dev", str(incident_repo), siblings=["main"]
+            )
+
+    async def test_sibling_genuinely_absent_still_skipped(
+        self, incident_repo, monkeypatch
+    ):
+        """The English 'couldn't find remote ref' shape (forced by LC_ALL=C)
+        is still correctly treated as 'not applicable' — regression guard
+        for the fetch-failure-vs-absent distinction above."""
+        await assert_base_is_clean(
+            "feat-465", "dev", str(incident_repo), siblings=["definitely-not-a-branch"]
+        )
+
     async def test_no_existing_siblings_passes(self, incident_repo, caplog):
         logger = MagicMock()
         await assert_base_is_clean(

--- a/packages/ai-parrot/tests/flows/dev_loop/test_base_branch_guard.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_base_branch_guard.py
@@ -30,9 +30,7 @@ from parrot.flows.dev_loop.nodes.feature_handoff import FeatureHandoffNode
 
 
 def _run(cwd, *args):
-    subprocess.run(
-        ["git", "-C", str(cwd), *args], check=True, capture_output=True
-    )
+    subprocess.run(["git", "-C", str(cwd), *args], check=True, capture_output=True)
 
 
 @pytest.fixture
@@ -56,9 +54,7 @@ def incident_repo(tmp_path):
     _run(work, "remote", "add", "origin", str(origin))
     (work / "a.txt").write_text("A")
     _run(work, "add", "-A")
-    _run(
-        work, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "A"
-    )
+    _run(work, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "A")
     _run(work, "push", "origin", "main")
 
     _run(work, "checkout", "-b", "dev")
@@ -66,17 +62,21 @@ def incident_repo(tmp_path):
         (work / f"{name}.txt").write_text(name)
         _run(work, "add", "-A")
         _run(
-            work, "-c", "user.email=t@t", "-c", "user.name=t",
-            "commit", "-m", name,
+            work,
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-m",
+            name,
         )
     _run(work, "push", "origin", "dev")
 
     _run(work, "checkout", "-b", "feat-465")
     (work / "D.txt").write_text("D")
     _run(work, "add", "-A")
-    _run(
-        work, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "D"
-    )
+    _run(work, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "D")
     _run(work, "push", "origin", "feat-465")
     _run(work, "fetch", "origin")
     return work
@@ -88,33 +88,35 @@ class TestGuard:
         """Documents WHY the guard is not an ancestry check."""
         rc = subprocess.run(
             [
-                "git", "-C", str(incident_repo), "merge-base",
-                "--is-ancestor", "origin/main", "feat-465",
+                "git",
+                "-C",
+                str(incident_repo),
+                "merge-base",
+                "--is-ancestor",
+                "origin/main",
+                "feat-465",
             ]
         ).returncode
         assert rc == 0, "ancestry passes — hence the sibling-overlap guard"
 
     async def test_blocks_the_incident_topology(self, incident_repo):
         with pytest.raises(BaseBranchMismatch, match="own work"):
-            await assert_base_is_clean(
-                "feat-465", "main", str(incident_repo), siblings=["dev"]
-            )
+            await assert_base_is_clean("feat-465", "main", str(incident_repo), siblings=["dev"])
 
     async def test_passes_for_correctly_cut_branch(self, incident_repo):
         """feat-465 vs its real base (dev) is clean: adds == own."""
-        await assert_base_is_clean(
-            "feat-465", "dev", str(incident_repo), siblings=["main"]
-        )
+        await assert_base_is_clean("feat-465", "dev", str(incident_repo), siblings=["main"])
 
     async def test_missing_sibling_ref_is_skipped(self, incident_repo):
-        await assert_base_is_clean(
-            "feat-465", "dev", str(incident_repo), siblings=["staging"]
-        )
+        await assert_base_is_clean("feat-465", "dev", str(incident_repo), siblings=["staging"])
 
     async def test_no_existing_siblings_passes(self, incident_repo, caplog):
         logger = MagicMock()
         await assert_base_is_clean(
-            "feat-465", "dev", str(incident_repo), siblings=["staging"],
+            "feat-465",
+            "dev",
+            str(incident_repo),
+            siblings=["staging"],
             logger=logger,
         )
         logger.info.assert_called_once()
@@ -133,18 +135,14 @@ class TestGuard:
         # backport vs main, checking against dev/feat-465 as siblings: the
         # cherry-picked commit has a NEW sha, so it does not appear in
         # dev's or feat-465's history by identity -> adds == own.
-        await assert_base_is_clean(
-            "backport", "main", str(work), siblings=["dev", "feat-465"]
-        )
+        await assert_base_is_clean("backport", "main", str(work), siblings=["dev", "feat-465"])
 
     async def test_default_siblings_used_when_none_passed(self, incident_repo):
         """No explicit siblings -> defaults to _LONG_LIVED_BRANCHES - base,
         filtered to existing refs. 'staging' does not exist here, so only
         'dev'/'main' are candidates depending on base."""
         with pytest.raises(BaseBranchMismatch):
-            await assert_base_is_clean(
-                "feat-465", "main", str(incident_repo)
-            )
+            await assert_base_is_clean("feat-465", "main", str(incident_repo))
 
 
 def _research(**over) -> ResearchOutput:
@@ -189,9 +187,7 @@ async def _success_push(self, branch, cwd):
 @pytest.mark.asyncio
 class TestDeploymentHandoffWiring:
     async def test_blocks_on_empty_base_branch(self, monkeypatch):
-        monkeypatch.setattr(
-            DeploymentHandoffNode, "_push_branch", _success_push
-        )
+        monkeypatch.setattr(DeploymentHandoffNode, "_push_branch", _success_push)
         create_pr = AsyncMock(return_value="https://github.com/x/y/pull/1")
         monkeypatch.setattr(DeploymentHandoffNode, "_create_pr", create_pr)
 
@@ -207,14 +203,10 @@ class TestDeploymentHandoffWiring:
         assert "base_branch" in result["error"]
         create_pr.assert_not_awaited()
 
-    async def test_bug_kind_with_recorded_dev_base_targets_dev(
-        self, monkeypatch
-    ):
+    async def test_bug_kind_with_recorded_dev_base_targets_dev(self, monkeypatch):
         """Proves the kind override is gone: kind='bug' + recorded
         base_branch='dev' opens the PR against dev, not main."""
-        monkeypatch.setattr(
-            DeploymentHandoffNode, "_push_branch", _success_push
-        )
+        monkeypatch.setattr(DeploymentHandoffNode, "_push_branch", _success_push)
         monkeypatch.setattr(
             "parrot.flows.dev_loop.nodes.deployment_handoff.assert_base_is_clean",
             AsyncMock(return_value=None),
@@ -234,12 +226,8 @@ class TestDeploymentHandoffWiring:
         assert node._base_branch == "dev"
 
     async def test_guard_failure_blocks_and_skips_pr(self, monkeypatch):
-        monkeypatch.setattr(
-            DeploymentHandoffNode, "_push_branch", _success_push
-        )
-        guard = AsyncMock(
-            side_effect=BaseBranchMismatch("branch carries sibling commits")
-        )
+        monkeypatch.setattr(DeploymentHandoffNode, "_push_branch", _success_push)
+        guard = AsyncMock(side_effect=BaseBranchMismatch("branch carries sibling commits"))
         monkeypatch.setattr(
             "parrot.flows.dev_loop.nodes.deployment_handoff.assert_base_is_clean",
             guard,
@@ -264,10 +252,7 @@ class TestDeploymentHandoffWiring:
         # Blocked" transition happens (same shape as the existing
         # push/PR-failure blocked paths in test_deployment_handoff.py).
         jira.jira_transition_to.assert_awaited_once()
-        assert (
-            jira.jira_transition_to.await_args.kwargs["target_status"]
-            == "Deployment Blocked"
-        )
+        assert jira.jira_transition_to.await_args.kwargs["target_status"] == "Deployment Blocked"
 
 
 def _planner(**over):
@@ -292,22 +277,15 @@ class TestFeatureHandoffWiring:
             "parrot.flows.dev_loop.nodes.feature_handoff.assert_base_is_clean",
             guard,
         )
+        monkeypatch.setattr(FeatureHandoffNode, "_run_git", AsyncMock(return_value=""))
         monkeypatch.setattr(
-            FeatureHandoffNode, "_run_git", AsyncMock(return_value="")
-        )
-        monkeypatch.setattr(
-            FeatureHandoffNode, "_create_pr",
+            FeatureHandoffNode,
+            "_create_pr",
             AsyncMock(return_value="https://github.com/x/y/pull/2"),
         )
-        monkeypatch.setattr(
-            FeatureHandoffNode, "_docs_rel_path", lambda self, planner: "docs/x.md"
-        )
-        monkeypatch.setattr(
-            FeatureHandoffNode, "_write_and_push_docs", AsyncMock(return_value=None)
-        )
-        monkeypatch.setattr(
-            FeatureHandoffNode, "_ingest_wiki_page", AsyncMock(return_value=None)
-        )
+        monkeypatch.setattr(FeatureHandoffNode, "_docs_rel_path", lambda self, planner: "docs/x.md")
+        monkeypatch.setattr(FeatureHandoffNode, "_write_and_push_docs", AsyncMock(return_value=None))
+        monkeypatch.setattr(FeatureHandoffNode, "_ingest_wiki_page", AsyncMock(return_value=None))
 
         node = FeatureHandoffNode()
         planner = _planner(worktree_path=str(tmp_path))
@@ -320,16 +298,12 @@ class TestFeatureHandoffWiring:
         assert result["status"] == "ready_to_deploy"
 
     async def test_blocks_when_guard_fails(self, monkeypatch, tmp_path):
-        guard = AsyncMock(
-            side_effect=BaseBranchMismatch("branch carries sibling commits")
-        )
+        guard = AsyncMock(side_effect=BaseBranchMismatch("branch carries sibling commits"))
         monkeypatch.setattr(
             "parrot.flows.dev_loop.nodes.feature_handoff.assert_base_is_clean",
             guard,
         )
-        monkeypatch.setattr(
-            FeatureHandoffNode, "_run_git", AsyncMock(return_value="")
-        )
+        monkeypatch.setattr(FeatureHandoffNode, "_run_git", AsyncMock(return_value=""))
         create_pr = AsyncMock(return_value="https://github.com/x/y/pull/2")
         monkeypatch.setattr(FeatureHandoffNode, "_create_pr", create_pr)
 

--- a/packages/ai-parrot/tests/flows/dev_loop/test_deployment_handoff.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_deployment_handoff.py
@@ -30,6 +30,10 @@ def ctx() -> dict:
             branch_name="feat-130-fix",
             worktree_path="/tmp/feat-130-fix",
             log_excerpts=[],
+            # FEAT-466 TASK-2505: DeploymentHandoffNode now blocks when this
+            # is "" (nothing resolved the base) rather than silently
+            # defaulting — the fixture must carry a resolved value.
+            base_branch="dev",
         ),
         "bug_brief": BugBrief(
             summary="customer sync drops the last row",

--- a/packages/ai-parrot/tests/flows/dev_loop/test_deployment_handoff.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_deployment_handoff.py
@@ -50,9 +50,7 @@ def ctx() -> dict:
             commit_shas=["abc"],
             summary="done",
         ),
-        "qa_report": QAReport(
-            passed=True, criterion_results=[], lint_passed=True
-        ),
+        "qa_report": QAReport(passed=True, criterion_results=[], lint_passed=True),
     }
 
 
@@ -90,9 +88,7 @@ async def _failing_push(self, branch, cwd):
 class TestRetriesPrOnce:
     @pytest.mark.asyncio
     async def test_first_pr_502_then_succeeds(self, ctx, jira, monkeypatch):
-        monkeypatch.setattr(
-            DeploymentHandoffNode, "_push_branch", _success_push
-        )
+        monkeypatch.setattr(DeploymentHandoffNode, "_push_branch", _success_push)
         # Force HTTP fallback (no gh).
         monkeypatch.setattr(
             "parrot.flows.dev_loop.nodes.deployment_handoff.shutil.which",
@@ -107,9 +103,8 @@ class TestRetriesPrOnce:
                 raise RuntimeError("502 bad gateway")
             return "https://github.com/x/y/pull/1"
 
-        monkeypatch.setattr(
-            DeploymentHandoffNode, "_create_pr_via_rest", _fake_pr
-        )
+        monkeypatch.setattr(DeploymentHandoffNode, "_create_pr_via_rest", _fake_pr)
+
         # Speed up the retry sleep.
         async def _instant_sleep(delay):
             return None
@@ -135,12 +130,8 @@ class TestRetriesPrOnce:
 
 class TestFinalPrFailure:
     @pytest.mark.asyncio
-    async def test_pr_fails_twice_marks_blocked(
-        self, ctx, jira, monkeypatch
-    ):
-        monkeypatch.setattr(
-            DeploymentHandoffNode, "_push_branch", _success_push
-        )
+    async def test_pr_fails_twice_marks_blocked(self, ctx, jira, monkeypatch):
+        monkeypatch.setattr(DeploymentHandoffNode, "_push_branch", _success_push)
         monkeypatch.setattr(
             "parrot.flows.dev_loop.nodes.deployment_handoff.shutil.which",
             lambda *a, **kw: None,
@@ -149,9 +140,7 @@ class TestFinalPrFailure:
         async def _always_fail(self, branch, title, body):
             raise RuntimeError("API unavailable")
 
-        monkeypatch.setattr(
-            DeploymentHandoffNode, "_create_pr_via_rest", _always_fail
-        )
+        monkeypatch.setattr(DeploymentHandoffNode, "_create_pr_via_rest", _always_fail)
 
         async def _instant_sleep(delay):
             return None
@@ -177,12 +166,8 @@ class TestFinalPrFailure:
 
 class TestPushFailureBlocks:
     @pytest.mark.asyncio
-    async def test_push_failure_marks_blocked_without_pr(
-        self, ctx, jira, monkeypatch
-    ):
-        monkeypatch.setattr(
-            DeploymentHandoffNode, "_push_branch", _failing_push
-        )
+    async def test_push_failure_marks_blocked_without_pr(self, ctx, jira, monkeypatch):
+        monkeypatch.setattr(DeploymentHandoffNode, "_push_branch", _failing_push)
 
         async def _should_not_be_called(self, branch, title, body):
             raise AssertionError("should not be called")
@@ -206,9 +191,7 @@ class TestPushFailureBlocks:
 class TestPRBody:
     def test_title_includes_feat_id_and_summary(self, ctx):
         node = _build_node(MagicMock())
-        title = node._build_title(
-            ctx["bug_brief"], ctx["research_output"]
-        )
+        title = node._build_title(ctx["bug_brief"], ctx["research_output"])
         assert title.startswith("FEAT-130:")
         assert "customer sync" in title.lower()
 

--- a/packages/ai-parrot/tests/flows/dev_loop/test_development_node.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_development_node.py
@@ -67,9 +67,7 @@ class FakeDispatcher:
         self.calls = []
         self.fail_ids = set(fail_ids)
 
-    async def dispatch(
-        self, *, brief, profile, output_model, run_id, node_id, cwd, **_kwargs
-    ):
+    async def dispatch(self, *, brief, profile, output_model, run_id, node_id, cwd, **_kwargs):
         # **_kwargs tolerates the single-agent path's ``session_host=``
         # (FEAT-466 TASK-2506); the pool path never passes it.
         task_id = getattr(brief, "task_id", None)
@@ -77,9 +75,7 @@ class FakeDispatcher:
         if task_id in self.fail_ids:
             self.fail_ids.discard(task_id)
             raise RuntimeError("boom")
-        return DevelopmentOutput(
-            files_changed=[f"{task_id}.py"], commit_shas=[f"sha-{task_id}"], summary=task_id or ""
-        )
+        return DevelopmentOutput(files_changed=[f"{task_id}.py"], commit_shas=[f"sha-{task_id}"], summary=task_id or "")
 
 
 class AlwaysFailDispatcher:
@@ -188,9 +184,7 @@ class TestShouldFanOut:
     def test_effective_slots_sum_across_multiple_specs(self):
         """Two specs with count=1 each still sum to 2 effective slots."""
         wave = [_task_ref("TASK-1"), _task_ref("TASK-2")]
-        pool_cfg = DevAgentPoolConfig(
-            agents=[DevAgentSpec(agent="claude-code"), DevAgentSpec(agent="codex")]
-        )
+        pool_cfg = DevAgentPoolConfig(agents=[DevAgentSpec(agent="claude-code"), DevAgentSpec(agent="codex")])
         assert should_fan_out(wave, pool_cfg) is True
 
 
@@ -369,9 +363,7 @@ class TestCascade:
         assert brief_dispatcher.calls  # brief's codex spec won
         assert not injected_dispatcher.calls
 
-    async def test_missing_index_degrades_to_single_via_declared_agent(
-        self, tmp_path
-    ):
+    async def test_missing_index_degrades_to_single_via_declared_agent(self, tmp_path):
         """FEAT-466 TASK-2506: a missing per-spec index (the normal case for
         a hotfix, which reserves no ids) must still honour the operator's
         declared dev agent via the builder — NOT silently fall back to the
@@ -382,9 +374,7 @@ class TestCascade:
         env_dispatcher = MagicMock()
         env_dispatcher.dispatch = AsyncMock()
         pool_dispatcher = FakeDispatcher()
-        pool_config = DevAgentPoolConfig(
-            agents=[DevAgentSpec(agent="codex", model="gpt-5.5")]
-        )
+        pool_config = DevAgentPoolConfig(agents=[DevAgentSpec(agent="codex", model="gpt-5.5")])
         builder_calls = []
 
         def _builder(spec: DevAgentSpec):
@@ -407,9 +397,7 @@ class TestCascade:
         assert result.worker_summaries[-1].model == "gpt-5.5"
 
     async def test_no_dispatcher_builder_degrades_to_single(self, tmp_path):
-        _write_index(
-            tmp_path, "FEAT-323", "my-feature", [{"id": "TASK-1", "status": "pending", "depends_on": []}]
-        )
+        _write_index(tmp_path, "FEAT-323", "my-feature", [{"id": "TASK-1", "status": "pending", "depends_on": []}])
         research = _research(str(tmp_path))
         dispatcher = MagicMock()
         dev_out = DevelopmentOutput(files_changed=[], commit_shas=[], summary="single")
@@ -442,9 +430,7 @@ class TestSingleAgentHonoursDeclaredAgent:
             builder_calls.append(spec)
             return pool_dispatcher, object()
 
-        pool_config = DevAgentPoolConfig(
-            agents=[DevAgentSpec(agent="codex", model="gpt-5.5")]
-        )
+        pool_config = DevAgentPoolConfig(agents=[DevAgentSpec(agent="codex", model="gpt-5.5")])
         node = DevelopmentNode(
             dispatcher=env_dispatcher,
             pool_config=pool_config,
@@ -462,9 +448,7 @@ class TestSingleAgentHonoursDeclaredAgent:
         """Regression guard — the path every existing run takes."""
         research = _research(str(tmp_path))
         dispatcher = MagicMock()
-        dev_out = DevelopmentOutput(
-            files_changed=[], commit_shas=[], summary="single"
-        )
+        dev_out = DevelopmentOutput(files_changed=[], commit_shas=[], summary="single")
         dispatcher.dispatch = AsyncMock(return_value=dev_out)
         node = DevelopmentNode(dispatcher=dispatcher)
 
@@ -483,9 +467,7 @@ class TestSingleAgentHonoursDeclaredAgent:
         )
         research = _research(str(tmp_path))
         dispatcher = MagicMock()
-        dev_out = DevelopmentOutput(
-            files_changed=[], commit_shas=[], summary="single"
-        )
+        dev_out = DevelopmentOutput(files_changed=[], commit_shas=[], summary="single")
         dispatcher.dispatch = AsyncMock(return_value=dev_out)
         pool_config = DevAgentPoolConfig(agents=[DevAgentSpec(agent="codex")])
         node = DevelopmentNode(dispatcher=dispatcher, pool_config=pool_config)
@@ -532,9 +514,7 @@ class TestSingleAgentHonoursDeclaredAgent:
         def _builder(spec: DevAgentSpec):
             return pool_dispatcher, object()
 
-        pool_config = DevAgentPoolConfig(
-            agents=[DevAgentSpec(agent="codex", model="gpt-5.5")]
-        )
+        pool_config = DevAgentPoolConfig(agents=[DevAgentSpec(agent="codex", model="gpt-5.5")])
         node = DevelopmentNode(
             dispatcher=env_dispatcher,
             pool_config=pool_config,
@@ -547,9 +527,7 @@ class TestSingleAgentHonoursDeclaredAgent:
         assert out.worker_summaries[-1].agent == "codex"
         assert out.worker_summaries[-1].model == "gpt-5.5"
 
-    async def test_worker_summary_failure_does_not_fail_dispatch(
-        self, tmp_path, monkeypatch
-    ):
+    async def test_worker_summary_failure_does_not_fail_dispatch(self, tmp_path, monkeypatch):
         """A labelling failure while building WorkerSummary must not fail an
         otherwise-successful dispatch."""
         research = _research(str(tmp_path))
@@ -560,9 +538,7 @@ class TestSingleAgentHonoursDeclaredAgent:
         def _builder(spec: DevAgentSpec):
             return pool_dispatcher, object()
 
-        pool_config = DevAgentPoolConfig(
-            agents=[DevAgentSpec(agent="codex", model="gpt-5.5")]
-        )
+        pool_config = DevAgentPoolConfig(agents=[DevAgentSpec(agent="codex", model="gpt-5.5")])
         node = DevelopmentNode(
             dispatcher=env_dispatcher,
             pool_config=pool_config,
@@ -662,9 +638,7 @@ class TestPoolPath:
         monkeypatch.setattr(development_module, "SubWorktreeManager", _manager_factory)
 
         d1, d2 = FakeDispatcher(), FakeDispatcher()
-        pool_config = DevAgentPoolConfig(
-            agents=[DevAgentSpec(agent="claude-code", count=2)], isolation_mode="isolated"
-        )
+        pool_config = DevAgentPoolConfig(agents=[DevAgentSpec(agent="claude-code", count=2)], isolation_mode="isolated")
         node = DevelopmentNode(
             dispatcher=MagicMock(),
             pool_config=pool_config,
@@ -706,9 +680,7 @@ class TestPoolPath:
 
         monkeypatch.setattr(development_module, "SubWorktreeManager", _manager_factory)
 
-        pool_config = DevAgentPoolConfig(
-            agents=[DevAgentSpec(agent="claude-code", count=2)], isolation_mode="isolated"
-        )
+        pool_config = DevAgentPoolConfig(agents=[DevAgentSpec(agent="claude-code", count=2)], isolation_mode="isolated")
         node = DevelopmentNode(
             dispatcher=MagicMock(),
             pool_config=pool_config,

--- a/packages/ai-parrot/tests/flows/dev_loop/test_development_node.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_development_node.py
@@ -67,7 +67,11 @@ class FakeDispatcher:
         self.calls = []
         self.fail_ids = set(fail_ids)
 
-    async def dispatch(self, *, brief, profile, output_model, run_id, node_id, cwd):
+    async def dispatch(
+        self, *, brief, profile, output_model, run_id, node_id, cwd, **_kwargs
+    ):
+        # **_kwargs tolerates the single-agent path's ``session_host=``
+        # (FEAT-466 TASK-2506); the pool path never passes it.
         task_id = getattr(brief, "task_id", None)
         self.calls.append((task_id, node_id, cwd))
         if task_id in self.fail_ids:
@@ -365,24 +369,42 @@ class TestCascade:
         assert brief_dispatcher.calls  # brief's codex spec won
         assert not injected_dispatcher.calls
 
-    async def test_missing_index_degrades_to_single(self, tmp_path):
+    async def test_missing_index_degrades_to_single_via_declared_agent(
+        self, tmp_path
+    ):
+        """FEAT-466 TASK-2506: a missing per-spec index (the normal case for
+        a hotfix, which reserves no ids) must still honour the operator's
+        declared dev agent via the builder — NOT silently fall back to the
+        server's env-configured dispatcher. Supersedes the pre-FEAT-466
+        version of this test, which asserted the bug this task fixes."""
         # No sdd/tasks/index/*.json written under tmp_path.
         research = _research(str(tmp_path))
-        dispatcher = MagicMock()
-        dev_out = DevelopmentOutput(files_changed=[], commit_shas=[], summary="single")
-        dispatcher.dispatch = AsyncMock(return_value=dev_out)
-        pool_config = DevAgentPoolConfig(agents=[DevAgentSpec(agent="claude-code")])
+        env_dispatcher = MagicMock()
+        env_dispatcher.dispatch = AsyncMock()
+        pool_dispatcher = FakeDispatcher()
+        pool_config = DevAgentPoolConfig(
+            agents=[DevAgentSpec(agent="codex", model="gpt-5.5")]
+        )
+        builder_calls = []
+
+        def _builder(spec: DevAgentSpec):
+            builder_calls.append(spec)
+            return pool_dispatcher, object()
+
         node = DevelopmentNode(
-            dispatcher=dispatcher,
+            dispatcher=env_dispatcher,
             pool_config=pool_config,
-            dispatcher_builder=_dispatcher_builder_factory([FakeDispatcher()]),
+            dispatcher_builder=_builder,
         )
 
         ctx = {"run_id": "r1", "research_output": research}
         result = await node.execute(ctx)
 
-        assert result is dev_out
-        dispatcher.dispatch.assert_awaited_once()
+        assert builder_calls == [DevAgentSpec(agent="codex", model="gpt-5.5")]
+        assert pool_dispatcher.calls
+        env_dispatcher.dispatch.assert_not_awaited()
+        assert result.worker_summaries[-1].agent == "codex"
+        assert result.worker_summaries[-1].model == "gpt-5.5"
 
     async def test_no_dispatcher_builder_degrades_to_single(self, tmp_path):
         _write_index(
@@ -399,6 +421,164 @@ class TestCascade:
         result = await node.execute(ctx)
 
         assert result is dev_out
+
+
+@pytest.mark.asyncio
+class TestSingleAgentHonoursDeclaredAgent:
+    """FEAT-466 TASK-2506 — Problem B: the single-agent path must honour the
+    operator's declared dev agent instead of silently substituting the
+    server's env-configured default."""
+
+    async def test_uses_pool_spec_when_no_task_index(self, tmp_path):
+        """The core FEAT-466 Problem B case: pool declared, no per-spec index
+        (as on every hotfix run), selection must still be honoured."""
+        research = _research(str(tmp_path))
+        env_dispatcher = MagicMock()
+        env_dispatcher.dispatch = AsyncMock()
+        pool_dispatcher = FakeDispatcher()
+        builder_calls = []
+
+        def _builder(spec: DevAgentSpec):
+            builder_calls.append(spec)
+            return pool_dispatcher, object()
+
+        pool_config = DevAgentPoolConfig(
+            agents=[DevAgentSpec(agent="codex", model="gpt-5.5")]
+        )
+        node = DevelopmentNode(
+            dispatcher=env_dispatcher,
+            pool_config=pool_config,
+            dispatcher_builder=_builder,
+        )
+
+        ctx = {"run_id": "r1", "research_output": research}
+        await node.execute(ctx)
+
+        assert builder_calls == [DevAgentSpec(agent="codex", model="gpt-5.5")]
+        assert pool_dispatcher.calls
+        env_dispatcher.dispatch.assert_not_awaited()
+
+    async def test_no_pool_uses_env_dispatcher(self, tmp_path):
+        """Regression guard — the path every existing run takes."""
+        research = _research(str(tmp_path))
+        dispatcher = MagicMock()
+        dev_out = DevelopmentOutput(
+            files_changed=[], commit_shas=[], summary="single"
+        )
+        dispatcher.dispatch = AsyncMock(return_value=dev_out)
+        node = DevelopmentNode(dispatcher=dispatcher)
+
+        ctx = {"run_id": "r1", "research_output": research}
+        result = await node.execute(ctx)
+
+        assert result is dev_out
+        assert result.worker_summaries == []
+
+    async def test_warns_when_builder_missing(self, tmp_path, caplog):
+        _write_index(
+            tmp_path,
+            "FEAT-323",
+            "my-feature",
+            [{"id": "TASK-1", "status": "pending", "depends_on": []}],
+        )
+        research = _research(str(tmp_path))
+        dispatcher = MagicMock()
+        dev_out = DevelopmentOutput(
+            files_changed=[], commit_shas=[], summary="single"
+        )
+        dispatcher.dispatch = AsyncMock(return_value=dev_out)
+        pool_config = DevAgentPoolConfig(agents=[DevAgentSpec(agent="codex")])
+        node = DevelopmentNode(dispatcher=dispatcher, pool_config=pool_config)
+
+        ctx = {"run_id": "r1", "research_output": research}
+        with caplog.at_level("WARNING"):
+            await node.execute(ctx)
+
+        assert "NOT being honoured" in caplog.text
+
+    async def test_warns_on_multi_spec_pool(self, tmp_path, caplog):
+        research = _research(str(tmp_path))
+        env_dispatcher = MagicMock()
+        env_dispatcher.dispatch = AsyncMock()
+        pool_dispatcher = FakeDispatcher()
+
+        def _builder(spec: DevAgentSpec):
+            return pool_dispatcher, object()
+
+        pool_config = DevAgentPoolConfig(
+            agents=[
+                DevAgentSpec(agent="codex", model="gpt-5.5"),
+                DevAgentSpec(agent="claude-code"),
+            ]
+        )
+        node = DevelopmentNode(
+            dispatcher=env_dispatcher,
+            pool_config=pool_config,
+            dispatcher_builder=_builder,
+        )
+
+        ctx = {"run_id": "r1", "research_output": research}
+        with caplog.at_level("WARNING"):
+            await node.execute(ctx)
+
+        assert "single-agent; using only" in caplog.text
+
+    async def test_worker_summary_records_actual_backend(self, tmp_path):
+        research = _research(str(tmp_path))
+        env_dispatcher = MagicMock()
+        env_dispatcher.dispatch = AsyncMock()
+        pool_dispatcher = FakeDispatcher()
+
+        def _builder(spec: DevAgentSpec):
+            return pool_dispatcher, object()
+
+        pool_config = DevAgentPoolConfig(
+            agents=[DevAgentSpec(agent="codex", model="gpt-5.5")]
+        )
+        node = DevelopmentNode(
+            dispatcher=env_dispatcher,
+            pool_config=pool_config,
+            dispatcher_builder=_builder,
+        )
+
+        ctx = {"run_id": "r1", "research_output": research}
+        out = await node.execute(ctx)
+
+        assert out.worker_summaries[-1].agent == "codex"
+        assert out.worker_summaries[-1].model == "gpt-5.5"
+
+    async def test_worker_summary_failure_does_not_fail_dispatch(
+        self, tmp_path, monkeypatch
+    ):
+        """A labelling failure while building WorkerSummary must not fail an
+        otherwise-successful dispatch."""
+        research = _research(str(tmp_path))
+        env_dispatcher = MagicMock()
+        env_dispatcher.dispatch = AsyncMock()
+        pool_dispatcher = FakeDispatcher()
+
+        def _builder(spec: DevAgentSpec):
+            return pool_dispatcher, object()
+
+        pool_config = DevAgentPoolConfig(
+            agents=[DevAgentSpec(agent="codex", model="gpt-5.5")]
+        )
+        node = DevelopmentNode(
+            dispatcher=env_dispatcher,
+            pool_config=pool_config,
+            dispatcher_builder=_builder,
+        )
+
+        def _boom(*a, **kw):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(development_module, "WorkerSummary", _boom)
+
+        ctx = {"run_id": "r1", "research_output": research}
+        result = await node.execute(ctx)
+
+        assert result is not None
+        assert pool_dispatcher.calls
 
 
 @pytest.mark.asyncio

--- a/packages/ai-parrot/tests/flows/dev_loop/test_empty_feat_id.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_empty_feat_id.py
@@ -51,19 +51,13 @@ class TestFindFeatureSlug:
         a hotfix run's empty feat_id."""
         idx = tmp_path / "sdd" / "tasks" / "index"
         idx.mkdir(parents=True)
-        (idx / "unrelated.json").write_text(
-            json.dumps({"feature_id": "", "feature": "unrelated"})
-        )
+        (idx / "unrelated.json").write_text(json.dumps({"feature_id": "", "feature": "unrelated"}))
         assert DevelopmentNode._find_feature_slug(str(tmp_path), "") is None
 
     def test_matching_feat_id_still_resolves(self, tmp_path):
         idx = tmp_path / "sdd" / "tasks" / "index"
         idx.mkdir(parents=True)
-        (idx / "x.json").write_text(
-            json.dumps(
-                {"feature_id": "FEAT-466", "feature": "dev-loop-run-fidelity"}
-            )
-        )
+        (idx / "x.json").write_text(json.dumps({"feature_id": "FEAT-466", "feature": "dev-loop-run-fidelity"}))
         got = DevelopmentNode._find_feature_slug(str(tmp_path), "FEAT-466")
         assert got == "dev-loop-run-fidelity"
 
@@ -88,17 +82,13 @@ def _bug_brief() -> BugBrief:
 class TestPrTitle:
     def test_title_uses_jira_key_when_no_feat_id(self):
         node = _build_node(MagicMock())
-        title = node._build_title(
-            _bug_brief(), _research(feat_id="", jira_issue_key="OPS-1")
-        )
+        title = node._build_title(_bug_brief(), _research(feat_id="", jira_issue_key="OPS-1"))
         assert title.startswith("OPS-1:")
         assert "sha-256" in title.lower()
 
     def test_title_has_no_dangling_colon_when_both_empty(self):
         node = _build_node(MagicMock())
-        title = node._build_title(
-            _bug_brief(), _research(feat_id="", jira_issue_key="")
-        )
+        title = node._build_title(_bug_brief(), _research(feat_id="", jira_issue_key=""))
         assert not title.startswith(":")
         assert "sha-256" in title.lower()
 

--- a/packages/ai-parrot/tests/flows/dev_loop/test_empty_feat_id.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_empty_feat_id.py
@@ -1,0 +1,108 @@
+"""Unit tests for empty ``feat_id`` fallback handling — FEAT-466 / TASK-2503."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+from parrot.flows.dev_loop import BugBrief, FlowtaskCriterion, ResearchOutput
+from parrot.flows.dev_loop.nodes.base import run_label
+from parrot.flows.dev_loop.nodes.deployment_handoff import DeploymentHandoffNode
+from parrot.flows.dev_loop.nodes.development import DevelopmentNode
+
+
+def _research(**over) -> ResearchOutput:
+    base = dict(
+        jira_issue_key="OPS-1",
+        spec_path="sdd/specs/x.spec.md",
+        feat_id="FEAT-466",
+        branch_name="feat-466-x",
+        worktree_path="/tmp/wt",
+        log_excerpts=[],
+    )
+    base.update(over)
+    return ResearchOutput(**base)
+
+
+class TestRunLabel:
+    def test_prefers_feat_id(self):
+        assert run_label(_research()) == "FEAT-466"
+
+    def test_falls_back_to_jira_key(self):
+        assert run_label(_research(feat_id="")) == "OPS-1"
+
+    def test_falls_back_to_default(self):
+        out = _research(feat_id="", jira_issue_key="")
+        assert run_label(out, default="run") == "run"
+
+    def test_strips_whitespace_only_values(self):
+        assert run_label(_research(feat_id="   ")) == "OPS-1"
+
+
+class TestEmptyFeatIdValidates:
+    def test_research_output_accepts_empty_feat_id(self):
+        """runner.py:1378 already relies on this."""
+        assert _research(feat_id="").feat_id == ""
+
+
+class TestFindFeatureSlug:
+    def test_empty_feat_id_returns_none_without_matching(self, tmp_path):
+        """An index whose feature_id is literally "" must NOT be matched by
+        a hotfix run's empty feat_id."""
+        idx = tmp_path / "sdd" / "tasks" / "index"
+        idx.mkdir(parents=True)
+        (idx / "unrelated.json").write_text(
+            json.dumps({"feature_id": "", "feature": "unrelated"})
+        )
+        assert DevelopmentNode._find_feature_slug(str(tmp_path), "") is None
+
+    def test_matching_feat_id_still_resolves(self, tmp_path):
+        idx = tmp_path / "sdd" / "tasks" / "index"
+        idx.mkdir(parents=True)
+        (idx / "x.json").write_text(
+            json.dumps(
+                {"feature_id": "FEAT-466", "feature": "dev-loop-run-fidelity"}
+            )
+        )
+        got = DevelopmentNode._find_feature_slug(str(tmp_path), "FEAT-466")
+        assert got == "dev-loop-run-fidelity"
+
+
+def _build_node(jira, **kwargs) -> DeploymentHandoffNode:
+    return DeploymentHandoffNode(jira_toolkit=jira, **kwargs)
+
+
+def _bug_brief() -> BugBrief:
+    return BugBrief(
+        summary="replace SHA-1 with SHA-256",
+        affected_component="arango/store.py",
+        log_sources=[],
+        acceptance_criteria=[
+            FlowtaskCriterion(name="run", task_path="x.yaml"),
+        ],
+        escalation_assignee="a",
+        reporter="b",
+    )
+
+
+class TestPrTitle:
+    def test_title_uses_jira_key_when_no_feat_id(self):
+        node = _build_node(MagicMock())
+        title = node._build_title(
+            _bug_brief(), _research(feat_id="", jira_issue_key="OPS-1")
+        )
+        assert title.startswith("OPS-1:")
+        assert "sha-256" in title.lower()
+
+    def test_title_has_no_dangling_colon_when_both_empty(self):
+        node = _build_node(MagicMock())
+        title = node._build_title(
+            _bug_brief(), _research(feat_id="", jira_issue_key="")
+        )
+        assert not title.startswith(":")
+        assert "sha-256" in title.lower()
+
+    def test_title_unchanged_when_feat_id_present(self):
+        node = _build_node(MagicMock())
+        title = node._build_title(_bug_brief(), _research())
+        assert title.startswith("FEAT-466:")

--- a/packages/ai-parrot/tests/flows/dev_loop/test_flow_type_override.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_flow_type_override.py
@@ -51,9 +51,7 @@ class TestBriefFields:
 
     def test_fields_survive_json_round_trip(self):
         """The dispatcher sends brief.model_dump_json() to the subagent."""
-        data = json.loads(
-            _brief(flow_type="feature", base_branch="dev").model_dump_json()
-        )
+        data = json.loads(_brief(flow_type="feature", base_branch="dev").model_dump_json())
         assert data["flow_type"] == "feature"
         assert data["base_branch"] == "dev"
 
@@ -111,9 +109,7 @@ class TestOverrideReachesResolution:
         dispatcher.dispatch = AsyncMock(return_value=dispatch_out)
         node = _build_node(dispatcher)
 
-        result = await node.execute(
-            {"bug_brief": _brief(base_branch="dev"), "run_id": "r1"}
-        )
+        result = await node.execute({"bug_brief": _brief(base_branch="dev"), "run_id": "r1"})
 
         assert result.base_branch == "dev"
 
@@ -139,9 +135,7 @@ class TestOverrideReachesResolution:
 
         assert result.base_branch == "main"
 
-    async def test_hotfix_off_main_override_reaches_output_verbatim(
-        self, tmp_path, monkeypatch
-    ):
+    async def test_hotfix_off_main_override_reaches_output_verbatim(self, tmp_path, monkeypatch):
         """_resolve_base_branch itself does not validate hotfix/main — it
         just records the requested base branch; the FlowMeta-style
         validation lives at the SDD-command layer (TASK-2507) and the
@@ -162,9 +156,7 @@ class TestOverrideReachesResolution:
         dispatcher.dispatch = AsyncMock(return_value=dispatch_out)
         node = _build_node(dispatcher)
 
-        result = await node.execute(
-            {"bug_brief": _brief(base_branch="dev"), "run_id": "r1"}
-        )
+        result = await node.execute({"bug_brief": _brief(base_branch="dev"), "run_id": "r1"})
 
         assert result.base_branch == "dev"
 
@@ -185,15 +177,8 @@ class TestServerPayloadParsing:
         import importlib.util
         from pathlib import Path as _Path
 
-        server_path = (
-            _Path(__file__).resolve().parents[5]
-            / "examples"
-            / "dev_loop"
-            / "server.py"
-        )
-        spec = importlib.util.spec_from_file_location(
-            "dev_loop_example_server", server_path
-        )
+        server_path = _Path(__file__).resolve().parents[5] / "examples" / "dev_loop" / "server.py"
+        spec = importlib.util.spec_from_file_location("dev_loop_example_server", server_path)
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
         return module
@@ -201,9 +186,7 @@ class TestServerPayloadParsing:
     def test_invalid_flow_type_is_omitted(self):
         server = self._load_server_module()
         payload: dict = {}
-        server._apply_flow_override(
-            payload, {"flow_type": "hotfixx", "base_branch": ""}
-        )
+        server._apply_flow_override(payload, {"flow_type": "hotfixx", "base_branch": ""})
         assert "flow_type" not in payload
 
     def test_auto_never_reaches_the_payload(self):
@@ -216,8 +199,6 @@ class TestServerPayloadParsing:
     def test_valid_values_are_applied(self):
         server = self._load_server_module()
         payload: dict = {}
-        server._apply_flow_override(
-            payload, {"flow_type": "hotfix", "base_branch": "main"}
-        )
+        server._apply_flow_override(payload, {"flow_type": "hotfix", "base_branch": "main"})
         assert payload["flow_type"] == "hotfix"
         assert payload["base_branch"] == "main"

--- a/packages/ai-parrot/tests/flows/dev_loop/test_flow_type_override.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_flow_type_override.py
@@ -1,0 +1,223 @@
+"""Unit tests for the console flow-type/base-branch override — FEAT-466 /
+TASK-2508."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from parrot.flows.dev_loop.models.base import (
+    FlowtaskCriterion,
+    ResearchOutput,
+    WorkBrief,
+)
+from parrot.flows.dev_loop.nodes.research import ResearchNode
+
+
+def _brief(**over) -> WorkBrief:
+    base = dict(
+        kind="bug",
+        summary="something broke badly",
+        affected_component="x",
+        log_sources=[],
+        acceptance_criteria=[FlowtaskCriterion(name="run", task_path="x.yaml")],
+        escalation_assignee="a",
+        reporter="b",
+    )
+    base.update(over)
+    return WorkBrief(**base)
+
+
+class TestBriefFields:
+    def test_defaults_are_none(self):
+        b = _brief()
+        assert b.flow_type is None and b.base_branch is None
+
+    def test_legacy_brief_still_validates(self):
+        """Regression guard — every existing caller omits both fields."""
+        assert _brief().kind == "bug"
+
+    def test_flow_type_is_a_closed_set(self):
+        with pytest.raises(ValidationError):
+            _brief(flow_type="hotfixx")
+
+    def test_base_branch_is_open(self):
+        """Sub-feature branches are legal bases (CLAUDE.md)."""
+        assert _brief(base_branch="feat/parent").base_branch == "feat/parent"
+
+    def test_fields_survive_json_round_trip(self):
+        """The dispatcher sends brief.model_dump_json() to the subagent."""
+        data = json.loads(
+            _brief(flow_type="feature", base_branch="dev").model_dump_json()
+        )
+        assert data["flow_type"] == "feature"
+        assert data["base_branch"] == "dev"
+
+
+def _spec(worktree_path: Path, *, type_: str = "hotfix", base: str = "main") -> Path:
+    d = worktree_path / "sdd" / "specs"
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / "x.spec.md"
+    p.write_text(f"---\ntype: {type_}\nbase_branch: {base}\n---\n# Spec\n")
+    return p
+
+
+def _build_node(dispatcher, jira=None, **kwargs) -> ResearchNode:
+    jira = jira or MagicMock()
+    jira.jira_create_issue = AsyncMock(return_value={"key": "OPS-1"})
+    jira.jira_add_comment = AsyncMock(return_value={"id": "c1"})
+    jira.jira_search_issues = AsyncMock(return_value={"status": "empty"})
+    jira.jira_get_issue = AsyncMock(return_value={"status": "error"})
+    jira.jira_find_user = AsyncMock(return_value={"found": False, "matches": []})
+    return ResearchNode(
+        dispatcher=dispatcher,
+        jira_toolkit=jira,
+        log_toolkits={},
+        **kwargs,
+    )
+
+
+def _pin_worktree_base(monkeypatch, tmp_path: Path) -> None:
+    empty_base = tmp_path / "wtbase"
+    empty_base.mkdir()
+    monkeypatch.setattr(
+        "parrot.flows.dev_loop.nodes.research.conf.WORKTREE_BASE_PATH",
+        str(empty_base),
+    )
+
+
+@pytest.mark.asyncio
+class TestOverrideReachesResolution:
+    async def test_bug_with_dev_override_resolves_to_dev(self, tmp_path, monkeypatch):
+        """PR #1250's motivating case: a `kind='bug'` run whose spec defaults
+        to hotfix/main, but the operator overrides the base branch to dev."""
+        _pin_worktree_base(monkeypatch, tmp_path)
+        worktree = tmp_path / "actual" / "hotfix-ops-1-x"
+        worktree.mkdir(parents=True)
+        _spec(worktree, type_="hotfix", base="main")
+
+        dispatch_out = ResearchOutput(
+            jira_issue_key="OPS-1",
+            spec_path="sdd/specs/x.spec.md",
+            feat_id="",
+            branch_name="hotfix-ops-1-x",
+            worktree_path=str(worktree),
+        )
+        dispatcher = MagicMock()
+        dispatcher.dispatch = AsyncMock(return_value=dispatch_out)
+        node = _build_node(dispatcher)
+
+        result = await node.execute(
+            {"bug_brief": _brief(base_branch="dev"), "run_id": "r1"}
+        )
+
+        assert result.base_branch == "dev"
+
+    async def test_empty_base_branch_is_not_an_override(self, tmp_path, monkeypatch):
+        _pin_worktree_base(monkeypatch, tmp_path)
+        worktree = tmp_path / "actual" / "hotfix-ops-1-x"
+        worktree.mkdir(parents=True)
+        _spec(worktree, type_="hotfix", base="main")
+
+        dispatch_out = ResearchOutput(
+            jira_issue_key="OPS-1",
+            spec_path="sdd/specs/x.spec.md",
+            feat_id="",
+            branch_name="hotfix-ops-1-x",
+            worktree_path=str(worktree),
+        )
+        dispatcher = MagicMock()
+        dispatcher.dispatch = AsyncMock(return_value=dispatch_out)
+        node = _build_node(dispatcher)
+
+        # No override supplied (default None) -> spec frontmatter wins.
+        result = await node.execute({"bug_brief": _brief(), "run_id": "r1"})
+
+        assert result.base_branch == "main"
+
+    async def test_hotfix_off_main_override_reaches_output_verbatim(
+        self, tmp_path, monkeypatch
+    ):
+        """_resolve_base_branch itself does not validate hotfix/main — it
+        just records the requested base branch; the FlowMeta-style
+        validation lives at the SDD-command layer (TASK-2507) and the
+        sibling-overlap guard (TASK-2505), not here."""
+        _pin_worktree_base(monkeypatch, tmp_path)
+        worktree = tmp_path / "actual" / "hotfix-ops-1-x"
+        worktree.mkdir(parents=True)
+        _spec(worktree, type_="hotfix", base="main")
+
+        dispatch_out = ResearchOutput(
+            jira_issue_key="OPS-1",
+            spec_path="sdd/specs/x.spec.md",
+            feat_id="",
+            branch_name="hotfix-ops-1-x",
+            worktree_path=str(worktree),
+        )
+        dispatcher = MagicMock()
+        dispatcher.dispatch = AsyncMock(return_value=dispatch_out)
+        node = _build_node(dispatcher)
+
+        result = await node.execute(
+            {"bug_brief": _brief(base_branch="dev"), "run_id": "r1"}
+        )
+
+        assert result.base_branch == "dev"
+
+
+class TestServerPayloadParsing:
+    """Import the payload helper from examples/dev_loop/server.py and feed
+    it dicts directly."""
+
+    def _load_server_module(self):
+        """Load examples/dev_loop/server.py via importlib without package
+        import — mirrors test_examples_form.py's ``_load_server``.
+
+        Test file is at:
+            packages/ai-parrot/tests/flows/dev_loop/test_flow_type_override.py
+        ``parents[5]`` resolves to the repository root, then examples/
+        lives at: ``<repo_root>/examples/dev_loop/server.py``
+        """
+        import importlib.util
+        from pathlib import Path as _Path
+
+        server_path = (
+            _Path(__file__).resolve().parents[5]
+            / "examples"
+            / "dev_loop"
+            / "server.py"
+        )
+        spec = importlib.util.spec_from_file_location(
+            "dev_loop_example_server", server_path
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def test_invalid_flow_type_is_omitted(self):
+        server = self._load_server_module()
+        payload: dict = {}
+        server._apply_flow_override(
+            payload, {"flow_type": "hotfixx", "base_branch": ""}
+        )
+        assert "flow_type" not in payload
+
+    def test_auto_never_reaches_the_payload(self):
+        server = self._load_server_module()
+        payload: dict = {}
+        server._apply_flow_override(payload, {"flow_type": "", "base_branch": ""})
+        assert "flow_type" not in payload
+        assert "base_branch" not in payload
+
+    def test_valid_values_are_applied(self):
+        server = self._load_server_module()
+        payload: dict = {}
+        server._apply_flow_override(
+            payload, {"flow_type": "hotfix", "base_branch": "main"}
+        )
+        assert payload["flow_type"] == "hotfix"
+        assert payload["base_branch"] == "main"

--- a/packages/ai-parrot/tests/flows/dev_loop/test_gate_integration.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_gate_integration.py
@@ -43,9 +43,7 @@ def test_manual_blocking_default_false_unchanged():
 
 
 def test_manual_blocking_explicit_true():
-    criterion = ManualCriterion(
-        name="ux-check", text="dashboard renders cleanly", blocking=True
-    )
+    criterion = ManualCriterion(name="ux-check", text="dashboard renders cleanly", blocking=True)
     assert criterion.blocking is True
 
 
@@ -77,9 +75,7 @@ async def test_qa_blocking_gate_approved_folds_passed(qa_node):
         host.resolve_gate(gate_id, "approved", resolved_by="alice", comment="lgtm")
 
     resolver = asyncio.ensure_future(_approve_soon())
-    report, all_passed = await qa_node._resolve_blocking_manual_criteria(
-        shared, [criterion], _base_report()
-    )
+    report, all_passed = await qa_node._resolve_blocking_manual_criteria(shared, [criterion], _base_report())
     await resolver
 
     assert all_passed is True
@@ -103,9 +99,7 @@ async def test_qa_blocking_gate_rejected_fails_report(qa_node):
         host.resolve_gate(gate_id, "rejected", resolved_by="bob", comment="nope")
 
     resolver = asyncio.ensure_future(_reject_soon())
-    report, all_passed = await qa_node._resolve_blocking_manual_criteria(
-        shared, [criterion], _base_report()
-    )
+    report, all_passed = await qa_node._resolve_blocking_manual_criteria(shared, [criterion], _base_report())
     await resolver
 
     assert all_passed is False
@@ -131,9 +125,7 @@ async def test_qa_multiple_blocking_criteria_awaited_concurrently(qa_node):
             host.resolve_gate(gate_id, "approved", resolved_by="alice")
 
     resolver = asyncio.ensure_future(_resolve_all_soon())
-    report, all_passed = await qa_node._resolve_blocking_manual_criteria(
-        shared, criteria, _base_report()
-    )
+    report, all_passed = await qa_node._resolve_blocking_manual_criteria(shared, criteria, _base_report())
     await resolver
 
     assert all_passed is True
@@ -146,9 +138,7 @@ async def test_qa_no_host_falls_back_with_warning(qa_node, caplog):
     criterion = ManualCriterion(name="ux-check", text="looks right", blocking=True)
 
     with caplog.at_level(logging.WARNING):
-        report, all_passed = await qa_node._resolve_blocking_manual_criteria(
-            shared, [criterion], _base_report()
-        )
+        report, all_passed = await qa_node._resolve_blocking_manual_criteria(shared, [criterion], _base_report())
 
     assert all_passed is True  # legacy synthesis: never blocks
     manual_results = [r for r in report.criterion_results if r.kind == "manual"]
@@ -184,7 +174,9 @@ def handoff_ctx() -> dict:
             reporter="b",
         ),
         "development_output": DevelopmentOutput(
-            files_changed=["a.py"], commit_shas=["abc"], summary="done",
+            files_changed=["a.py"],
+            commit_shas=["abc"],
+            summary="done",
         ),
         "qa_report": QAReport(passed=True, criterion_results=[], lint_passed=True),
     }
@@ -207,7 +199,8 @@ async def _success_push(self, branch, cwd):
 def _patch_push(monkeypatch):
     monkeypatch.setattr(DeploymentHandoffNode, "_push_branch", _success_push)
     monkeypatch.setattr(
-        DeploymentHandoffNode, "_create_pr",
+        DeploymentHandoffNode,
+        "_create_pr",
         AsyncMock(return_value="https://github.com/x/y/pull/42"),
     )
     # FEAT-466 TASK-2505: these are gate-mechanism tests, not base-branch
@@ -282,15 +275,13 @@ async def test_handoff_rejected_marks_blocked_no_transition(handoff_ctx, jira):
     # The READY-to-deploy transition must NEVER be attempted — only the
     # BLOCKED transition (via _mark_blocked) fires.
     ready_calls = [
-        c for c in jira.jira_transition_to.await_args_list
+        c
+        for c in jira.jira_transition_to.await_args_list
         if c.kwargs.get("target_status") in conf.DEV_LOOP_JIRA_TRANSITIONS_READY
     ]
     assert ready_calls == []
     jira.jira_transition_to.assert_awaited_once()
-    assert (
-        jira.jira_transition_to.await_args.kwargs["target_status"]
-        in conf.DEV_LOOP_JIRA_TRANSITIONS_BLOCKED
-    )
+    assert jira.jira_transition_to.await_args.kwargs["target_status"] in conf.DEV_LOOP_JIRA_TRANSITIONS_BLOCKED
     jira.jira_add_comment.assert_awaited()
 
 
@@ -331,16 +322,12 @@ def dev_ctx() -> dict:
 @pytest.fixture
 def dev_dispatcher() -> MagicMock:
     d = MagicMock()
-    d.dispatch = AsyncMock(
-        return_value=DevelopmentOutput(files_changed=["a.py"], commit_shas=["s1"], summary="ok")
-    )
+    d.dispatch = AsyncMock(return_value=DevelopmentOutput(files_changed=["a.py"], commit_shas=["s1"], summary="ok"))
     return d
 
 
 @pytest.mark.asyncio
-async def test_development_default_skips_plan_gate_even_with_host_present(
-    dev_ctx, dev_dispatcher
-):
+async def test_development_default_skips_plan_gate_even_with_host_present(dev_ctx, dev_dispatcher):
     """Regression guard (mirrors the deployment_approval one above):
     DevLoopRunner.run() always seeds a live SessionHost — the gate MUST
     stay off by default or every existing/legacy run would block forever."""
@@ -425,9 +412,7 @@ async def test_development_plan_gate_expiry_approves(dev_ctx, dev_dispatcher):
 
 
 @pytest.mark.asyncio
-async def test_development_plan_gate_no_host_falls_back_with_warning(
-    dev_ctx, dev_dispatcher, caplog
-):
+async def test_development_plan_gate_no_host_falls_back_with_warning(dev_ctx, dev_dispatcher, caplog):
     node = DevelopmentNode(dispatcher=dev_dispatcher, require_plan_approval=True)
 
     with caplog.at_level(logging.WARNING):
@@ -439,9 +424,7 @@ async def test_development_plan_gate_no_host_falls_back_with_warning(
 
 
 @pytest.mark.asyncio
-async def test_development_plan_gate_checked_only_once_across_retries(
-    dev_ctx, dev_dispatcher
-):
+async def test_development_plan_gate_checked_only_once_across_retries(dev_ctx, dev_dispatcher):
     """A QA-repair-loop re-entry (attempt >= 2) must NOT re-open the gate
     — the plan was already approved on the first entry."""
     node = DevelopmentNode(dispatcher=dev_dispatcher, require_plan_approval=True)

--- a/packages/ai-parrot/tests/flows/dev_loop/test_gate_integration.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_gate_integration.py
@@ -172,6 +172,8 @@ def handoff_ctx() -> dict:
             branch_name="feat-130-fix",
             worktree_path="/tmp/feat-130-fix",
             log_excerpts=[],
+            # FEAT-466 TASK-2505: DeploymentHandoffNode now blocks on "".
+            base_branch="dev",
         ),
         "bug_brief": BugBrief(
             summary="customer sync drops the last row",
@@ -207,6 +209,18 @@ def _patch_push(monkeypatch):
     monkeypatch.setattr(
         DeploymentHandoffNode, "_create_pr",
         AsyncMock(return_value="https://github.com/x/y/pull/42"),
+    )
+    # FEAT-466 TASK-2505: these are gate-mechanism tests, not base-branch
+    # guard tests (that logic has its own dedicated coverage in
+    # test_base_branch_guard.py) — no real git plumbing here, same
+    # rationale as patching _push_branch/_create_pr above. Also sidesteps a
+    # real environment hazard: assert_base_is_clean's real
+    # asyncio.create_subprocess_exec calls, combined with this file's
+    # manually-scheduled concurrent tasks (asyncio.ensure_future) and
+    # uvloop, were observed to hang the event loop across test boundaries.
+    monkeypatch.setattr(
+        "parrot.flows.dev_loop.nodes.deployment_handoff.assert_base_is_clean",
+        AsyncMock(return_value=None),
     )
 
 

--- a/packages/ai-parrot/tests/flows/dev_loop/test_research_base_branch.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_research_base_branch.py
@@ -1,0 +1,204 @@
+"""Unit tests for ``ResearchOutput.base_branch`` — FEAT-466 / TASK-2504."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from parrot.flows.dev_loop import BugBrief, FlowtaskCriterion, ResearchOutput
+from parrot.flows.dev_loop.nodes.research import ResearchNode
+
+
+def _spec(worktree_path: Path, *, type_: str = "hotfix", base: str = "main") -> Path:
+    d = worktree_path / "sdd" / "specs"
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / "x.spec.md"
+    p.write_text(f"---\ntype: {type_}\nbase_branch: {base}\n---\n# Spec\n")
+    return p
+
+
+class TestModelField:
+    def test_defaults_to_empty(self):
+        out = ResearchOutput(
+            jira_issue_key="OPS-1",
+            spec_path="sdd/specs/x.spec.md",
+            feat_id="FEAT-466",
+            branch_name="b",
+            worktree_path="/tmp/wt",
+        )
+        assert out.base_branch == ""
+
+    def test_accepts_base_alias(self):
+        out = ResearchOutput(
+            jira_issue_key="OPS-1",
+            spec_path="s",
+            feat_id="F",
+            branch_name="b",
+            worktree_path="/w",
+            base="main",
+        )
+        assert out.base_branch == "main"
+
+
+def _brief(**over) -> BugBrief:
+    base = dict(
+        summary="replace SHA-1 with SHA-256",
+        affected_component="arango/store.py",
+        log_sources=[],
+        acceptance_criteria=[
+            FlowtaskCriterion(name="run", task_path="x.yaml"),
+        ],
+        escalation_assignee="a",
+        reporter="b",
+    )
+    base.update(over)
+    return BugBrief(**base)
+
+
+def _build_node(dispatcher, jira=None, **kwargs) -> ResearchNode:
+    jira = jira or MagicMock()
+    jira.jira_create_issue = AsyncMock(return_value={"key": "OPS-1"})
+    jira.jira_add_comment = AsyncMock(return_value={"id": "c1"})
+    jira.jira_search_issues = AsyncMock(return_value={"status": "empty"})
+    jira.jira_get_issue = AsyncMock(return_value={"status": "error"})
+    jira.jira_find_user = AsyncMock(return_value={"found": False, "matches": []})
+    return ResearchNode(
+        dispatcher=dispatcher,
+        jira_toolkit=jira,
+        log_toolkits={},
+        **kwargs,
+    )
+
+
+def _pin_worktree_base(monkeypatch, tmp_path: Path) -> None:
+    """Point WORKTREE_BASE_PATH at an empty sibling dir so
+    ``_ensure_worktree_safe`` sees no path collision (it joins
+    WORKTREE_BASE_PATH/branch_name) and returns False immediately —
+    tests here exercise ``_resolve_base_branch``, not worktree reuse."""
+    empty_base = tmp_path / "wtbase"
+    empty_base.mkdir()
+    monkeypatch.setattr(
+        "parrot.flows.dev_loop.nodes.research.conf.WORKTREE_BASE_PATH",
+        str(empty_base),
+    )
+
+
+@pytest.mark.asyncio
+class TestResolveBaseBranch:
+    async def test_spec_frontmatter_is_authoritative(self, tmp_path, monkeypatch):
+        """Spec says hotfix/main; subagent claims dev. Spec must win."""
+        _pin_worktree_base(monkeypatch, tmp_path)
+        worktree = tmp_path / "actual" / "hotfix-ops-1-x"
+        worktree.mkdir(parents=True)
+        _spec(worktree, type_="hotfix", base="main")
+
+        dispatch_out = ResearchOutput(
+            jira_issue_key="OPS-1",
+            spec_path="sdd/specs/x.spec.md",
+            feat_id="",
+            branch_name="hotfix-ops-1-x",
+            worktree_path=str(worktree),
+            base_branch="dev",
+        )
+        dispatcher = MagicMock()
+        dispatcher.dispatch = AsyncMock(return_value=dispatch_out)
+        node = _build_node(dispatcher)
+
+        result = await node.execute({"bug_brief": _brief(), "run_id": "r1"})
+
+        assert result.base_branch == "main"
+
+    async def test_warns_on_disagreement(self, tmp_path, monkeypatch, caplog):
+        _pin_worktree_base(monkeypatch, tmp_path)
+        worktree = tmp_path / "actual" / "hotfix-ops-1-x"
+        worktree.mkdir(parents=True)
+        _spec(worktree, type_="hotfix", base="main")
+
+        dispatch_out = ResearchOutput(
+            jira_issue_key="OPS-1",
+            spec_path="sdd/specs/x.spec.md",
+            feat_id="",
+            branch_name="hotfix-ops-1-x",
+            worktree_path=str(worktree),
+            base_branch="dev",
+        )
+        dispatcher = MagicMock()
+        dispatcher.dispatch = AsyncMock(return_value=dispatch_out)
+        node = _build_node(dispatcher)
+
+        with caplog.at_level("WARNING"):
+            await node.execute({"bug_brief": _brief(), "run_id": "r1"})
+
+        assert "reported base_branch" in caplog.text
+
+    async def test_relative_spec_path_resolved_against_worktree(
+        self, tmp_path, monkeypatch
+    ):
+        _pin_worktree_base(monkeypatch, tmp_path)
+        worktree = tmp_path / "actual" / "feat-466-x"
+        worktree.mkdir(parents=True)
+        _spec(worktree, type_="feature", base="dev")
+
+        dispatch_out = ResearchOutput(
+            jira_issue_key="OPS-1",
+            spec_path="sdd/specs/x.spec.md",  # relative
+            feat_id="FEAT-466",
+            branch_name="feat-466-x",
+            worktree_path=str(worktree),
+        )
+        dispatcher = MagicMock()
+        dispatcher.dispatch = AsyncMock(return_value=dispatch_out)
+        node = _build_node(dispatcher)
+
+        result = await node.execute({"bug_brief": _brief(), "run_id": "r1"})
+
+        assert result.base_branch == "dev"
+
+    async def test_missing_spec_falls_back_to_kind_mapping(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """No spec file at all -> kind='bug' -> 'main', with a WARNING."""
+        _pin_worktree_base(monkeypatch, tmp_path)
+        worktree = tmp_path / "actual" / "hotfix-ops-1-x"
+        worktree.mkdir(parents=True)
+        # No sdd/specs/x.spec.md written.
+
+        dispatch_out = ResearchOutput(
+            jira_issue_key="OPS-1",
+            spec_path="sdd/specs/x.spec.md",
+            feat_id="",
+            branch_name="hotfix-ops-1-x",
+            worktree_path=str(worktree),
+        )
+        dispatcher = MagicMock()
+        dispatcher.dispatch = AsyncMock(return_value=dispatch_out)
+        node = _build_node(dispatcher)
+
+        with caplog.at_level("WARNING"):
+            result = await node.execute({"bug_brief": _brief(), "run_id": "r1"})
+
+        assert result.base_branch == "main"
+        assert "falling back to the kind mapping" in caplog.text
+
+    async def test_never_empty_after_execute(self, tmp_path, monkeypatch):
+        _pin_worktree_base(monkeypatch, tmp_path)
+        worktree = tmp_path / "actual" / "feat-466-x"
+        worktree.mkdir(parents=True)
+        # No spec written either -> falls back to kind mapping.
+
+        dispatch_out = ResearchOutput(
+            jira_issue_key="OPS-1",
+            spec_path="sdd/specs/x.spec.md",
+            feat_id="FEAT-466",
+            branch_name="feat-466-x",
+            worktree_path=str(worktree),
+        )
+        dispatcher = MagicMock()
+        dispatcher.dispatch = AsyncMock(return_value=dispatch_out)
+        node = _build_node(dispatcher)
+
+        result = await node.execute({"bug_brief": _brief(), "run_id": "r1"})
+
+        assert result.base_branch != ""

--- a/packages/ai-parrot/tests/flows/dev_loop/test_research_base_branch.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_research_base_branch.py
@@ -133,9 +133,7 @@ class TestResolveBaseBranch:
 
         assert "reported base_branch" in caplog.text
 
-    async def test_relative_spec_path_resolved_against_worktree(
-        self, tmp_path, monkeypatch
-    ):
+    async def test_relative_spec_path_resolved_against_worktree(self, tmp_path, monkeypatch):
         _pin_worktree_base(monkeypatch, tmp_path)
         worktree = tmp_path / "actual" / "feat-466-x"
         worktree.mkdir(parents=True)
@@ -156,9 +154,7 @@ class TestResolveBaseBranch:
 
         assert result.base_branch == "dev"
 
-    async def test_missing_spec_falls_back_to_kind_mapping(
-        self, tmp_path, monkeypatch, caplog
-    ):
+    async def test_missing_spec_falls_back_to_kind_mapping(self, tmp_path, monkeypatch, caplog):
         """No spec file at all -> kind='bug' -> 'main', with a WARNING."""
         _pin_worktree_base(monkeypatch, tmp_path)
         worktree = tmp_path / "actual" / "hotfix-ops-1-x"

--- a/scripts/sdd/sdd_meta.py
+++ b/scripts/sdd/sdd_meta.py
@@ -47,10 +47,7 @@ class FlowMeta(BaseModel):
     @model_validator(mode="after")
     def _hotfix_implies_main(self) -> "FlowMeta":
         if self.type == "hotfix" and self.base_branch != "main":
-            raise ValueError(
-                "type='hotfix' requires base_branch='main' "
-                f"(got base_branch={self.base_branch!r})"
-            )
+            raise ValueError("type='hotfix' requires base_branch='main' " f"(got base_branch={self.base_branch!r})")
         return self
 
 
@@ -155,8 +152,8 @@ def resolve_flow(
 
     if final_base not in KNOWN_BRANCHES:
         logger.warning(
-            "base_branch %r is not one of the canonical branches %s; "
-            "assuming a sub-feature branch.",
-            final_base, sorted(KNOWN_BRANCHES),
+            "base_branch %r is not one of the canonical branches %s; " "assuming a sub-feature branch.",
+            final_base,
+            sorted(KNOWN_BRANCHES),
         )
     return FlowMeta(type=final_type, base_branch=final_base)

--- a/scripts/sdd/sdd_meta.py
+++ b/scripts/sdd/sdd_meta.py
@@ -12,11 +12,14 @@ frontmatter is present (so legacy specs keep working), and a symmetric
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Literal
 
 import yaml
 from pydantic import BaseModel, model_validator
+
+logger = logging.getLogger(__name__)
 
 
 #: Canonical long-lived branches in the Git Parrot Flow (FEAT-187).
@@ -24,6 +27,15 @@ from pydantic import BaseModel, model_validator
 #: outside the set; ``FlowMeta`` itself accepts any string so
 #: sub-feature branches keep working (see CLAUDE.md).
 KNOWN_BRANCHES: frozenset[str] = frozenset({"main", "staging", "dev"})
+
+#: WorkKind -> (flow type, base branch). A bugfix is a hotfix and lands on
+#: main; everything else is a feature and lands on dev. This mapping used to
+#: live only as prose in .claude/agents/sdd-research.md (FEAT-466).
+WORK_KIND_FLOW: dict[str, tuple[str, str]] = {
+    "bug": ("hotfix", "main"),
+    "enhancement": ("feature", "dev"),
+    "new_feature": ("feature", "dev"),
+}
 
 
 class FlowMeta(BaseModel):
@@ -90,3 +102,61 @@ def emit(meta: FlowMeta) -> str:
     """
     body = yaml.safe_dump(meta.model_dump(), sort_keys=False).rstrip()
     return f"---\n{body}\n---\n"
+
+
+def resolve_flow(
+    *,
+    kind: str | None = None,
+    doc_path: Path | None = None,
+    type_override: str | None = None,
+    base_branch_override: str | None = None,
+) -> FlowMeta:
+    """Resolve the SDD flow type and base branch for a run.
+
+    Precedence, highest first:
+      1. ``type_override`` / ``base_branch_override`` (explicit caller intent)
+      2. ``doc_path`` frontmatter, when the path is given AND exists
+      3. ``WORK_KIND_FLOW[kind]``
+      4. ``("feature", "dev")``
+
+    Levels 1 and 2/3 compose: an explicit ``base_branch_override`` with no
+    ``type_override`` keeps the type resolved from the lower level, and vice
+    versa. This is what lets the console override only the base branch.
+
+    Args:
+        kind: A ``WorkKind`` value (``"bug"``/``"enhancement"``/
+            ``"new_feature"``). Unknown or ``None`` falls through to the
+            default.
+        doc_path: Optional brainstorm/proposal/spec whose frontmatter should
+            be consulted. A path that does not exist is treated as "no
+            document", NOT as an error.
+        type_override: Explicit ``"feature"``/``"hotfix"``.
+        base_branch_override: Explicit branch name.
+
+    Returns:
+        A validated ``FlowMeta``.
+
+    Raises:
+        ValueError: When the resolved combination is invalid — e.g.
+            ``type="hotfix"`` with a base branch other than ``"main"``. Raised
+            by ``FlowMeta``'s own validator, not re-implemented here.
+    """
+    resolved_type: str | None = None
+    resolved_base: str | None = None
+
+    if doc_path is not None and doc_path.exists():
+        from_doc = parse(doc_path)
+        resolved_type, resolved_base = from_doc.type, from_doc.base_branch
+    elif kind in WORK_KIND_FLOW:
+        resolved_type, resolved_base = WORK_KIND_FLOW[kind]
+
+    final_type = type_override or resolved_type or "feature"
+    final_base = base_branch_override or resolved_base or "dev"
+
+    if final_base not in KNOWN_BRANCHES:
+        logger.warning(
+            "base_branch %r is not one of the canonical branches %s; "
+            "assuming a sub-feature branch.",
+            final_base, sorted(KNOWN_BRANCHES),
+        )
+    return FlowMeta(type=final_type, base_branch=final_base)

--- a/sdd/tasks/completed/TASK-2502-resolve-flow-mapping.md
+++ b/sdd/tasks/completed/TASK-2502-resolve-flow-mapping.md
@@ -375,10 +375,19 @@ class TestResolveFlowValidation:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (autonomous)
+**Date**: 2026-08-27
+**Notes**: Added `WORK_KIND_FLOW` + `resolve_flow()` to `scripts/sdd/sdd_meta.py`
+exactly per the provided implementation notes, plus a co-located test file
+`tests/sdd_scripts/test_sdd_meta_resolve_flow.py` (an existing
+`tests/sdd_scripts/test_sdd_meta.py` was found via the documented grep, so no
+new `tests/sdd/` directory was created). All 21 tests pass (13 new + 8
+existing regression), `python -c "from scripts.sdd.sdd_meta import
+resolve_flow; print(resolve_flow(kind='bug'))"` works from repo root. `ruff
+check scripts/sdd/sdd_meta.py` reports one pre-existing UP037 finding at
+`_hotfix_implies_main` (line 48, unrelated to this task's diff — verified via
+`git diff` that the changed lines are only the new `resolve_flow`/
+`WORK_KIND_FLOW` additions); left untouched per "do not alter existing
+behaviour".
 
-**Completed by**:
-**Date**:
-**Notes**:
-
-**Deviations from spec**: none | describe if any
+**Deviations from spec**: none

--- a/sdd/tasks/completed/TASK-2503-feat-id-empty-fallbacks.md
+++ b/sdd/tasks/completed/TASK-2503-feat-id-empty-fallbacks.md
@@ -390,10 +390,27 @@ class TestPrTitle:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (autonomous)
+**Date**: 2026-08-27
+**Notes**: Added `run_label()` to `nodes/base.py` per spec, wired it into
+`_build_title` (deployment_handoff.py, drops the dangling `": "` when both
+identifiers are empty) and `run_bundle.py`'s `feature_id`. Extended
+`qa.py:417`'s chain with `jira_issue_key` (consistent with :194/:342).
+`_find_feature_slug` short-circuits to `None` on empty `feat_id` before
+touching the filesystem. Re-ran the full audit grep per the Agent
+Instructions; found `development.py:204,217,628` also reference
+`research.feat_id` but only inside internal WARNING/error log strings (no
+PR/bundle-facing text, no lookup semantics) — left untouched as out of
+scope for this task's explicit 4-site list. Added
+`packages/ai-parrot/tests/flows/dev_loop/test_empty_feat_id.py` (10 tests,
+all passing) following `test_deployment_handoff.py`'s node-construction
+fixtures. Full `pytest packages/ai-parrot/tests/flows/dev_loop/` run:
+1091 passed, 3 pre-existing failures confirmed unrelated (identical
+failures reproduced on the unmodified baseline via `git stash`) — no
+regressions introduced. `ruff check` on all 5 changed files shows the
+same or fewer findings than the unmodified baseline versions (pre-existing
+UP00x/S110 style debt, none attributable to this diff). `mypy` timed out
+on the whole-project run (pre-existing project-wide slowness, not
+specific to these files) — best-effort, not confirmed clean.
 
-**Completed by**:
-**Date**:
-**Notes**:
-
-**Deviations from spec**: none | describe if any
+**Deviations from spec**: none

--- a/sdd/tasks/completed/TASK-2504-research-output-base-branch.md
+++ b/sdd/tasks/completed/TASK-2504-research-output-base-branch.md
@@ -380,10 +380,45 @@ class TestResolveBaseBranch:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (autonomous)
+**Date**: 2026-08-27
+**Notes**: **`scripts.sdd` import decision (needed by TASK-2505/TASK-2507):
+NOT importable from this package's context.** Verified: `python -c "from
+scripts.sdd.sdd_meta import parse"` succeeds only when cwd is the repo
+root; running the actual test suite from `packages/ai-parrot` (its real
+pytest rootdir, confirmed via `configfile: pyproject.toml` in pytest's own
+output) raises `ModuleNotFoundError: No module named 'scripts.sdd'`. Per
+the task's Import-caution guidance, did NOT add a `sys.path` hack — instead
+added a small private module-level `_parse_flow_frontmatter()` in
+`research.py` that mirrors `sdd_meta.parse()`'s 6-line frontmatter-reading
+body locally, plus a local `_WORK_KIND_BASE_BRANCH` dict mirroring the
+base-branch half of TASK-2502's `WORK_KIND_FLOW` (only `base_branch` is
+needed here per the Codebase Contract's "Does NOT Exist" note — `type` is
+deliberately not threaded through). Added `ResearchOutput.base_branch`
+exactly per the field pattern given, and `ResearchNode._resolve_base_branch`
++ its `model_copy` stamp immediately after the existing `repo_path` stamp.
+Test file created as `test_research_base_branch.py` per the task; note the
+task's "reuse test_research_node.py fixtures" instruction referenced a
+stale filename — the actual sibling file is `test_research.py` (confirmed
+via `ls`), whose `node`/`good_brief` fixture shapes I followed. Had to
+route each new test's `worktree_path` to a directory OTHER than
+`WORKTREE_BASE_PATH/branch_name` — writing the spec at exactly that path
+tripped `_ensure_worktree_safe`'s "exists but not a registered git
+worktree" guard (unrelated pre-existing safety check, not a target of this
+task); added a `_pin_worktree_base` helper to keep worktree-safety
+untouched. 7/7 new tests pass. Full `pytest packages/ai-parrot/tests/flows/
+dev_loop/` run: 1104 passed (up from 1097 pre-task, same 3 pre-existing
+unrelated failures as TASK-2503/2506, confirmed not touched). `ruff check`:
+`models/base.py` unchanged finding count (49); `research.py` +2 (one
+`UP006 Dict`, one `UP045 Optional`), both consistent with the file's
+existing heavy use of `Dict`/`Optional` throughout (not `dict`/`X | None`)
+— left as-is per file convention, same reasoning as TASK-2506. New test
+file's 2 findings (import order, `dict()` literal) match the identical
+pattern already present in every other `_brief`-style test helper in this
+suite. `mypy` times out project-wide (60s) — same environment limitation
+noted in TASK-2503/2506, not confirmed clean.
 
-**Completed by**:
-**Date**:
-**Notes**:
-
-**Deviations from spec**: none | describe if any
+**Deviations from spec**: `scripts.sdd.sdd_meta.resolve_flow()` was NOT
+imported (see decision above) — used a local, behaviorally-equivalent
+reimplementation instead, exactly as the task's own Import-caution section
+pre-authorized as the fallback path.

--- a/sdd/tasks/completed/TASK-2505-sibling-overlap-guard.md
+++ b/sdd/tasks/completed/TASK-2505-sibling-overlap-guard.md
@@ -541,10 +541,95 @@ class TestFeatureHandoffWiring:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (autonomous)
+**Date**: 2026-08-27
+**Notes**: Added `BaseBranchMismatch` + `assert_base_is_clean()` as
+module-level names in `nodes/base.py`, plus a private `_git()` subprocess
+helper and a local `_LONG_LIVED_BRANCHES` frozenset (not importing
+`scripts.sdd.KNOWN_BRANCHES` — per TASK-2504's documented import
+decision). `DeploymentHandoffNode`: deleted the `kind == "bug"` override
+block entirely; sources `_base_branch` from `research.base_branch`,
+blocking with `status="blocked"` when it's `""`; calls the guard after
+`_push_branch`, before PR creation. `FeatureHandoffNode`: same shape,
+sourced via a NEW private `_resolve_base_branch()` static method + a local
+`_parse_flow_frontmatter()` (NOT a `PlannerOutput.base_branch` field —
+see Deviations below for the reasoning). `test_ancestry_alone_would_pass`
+built and confirmed FIRST per the Agent Instructions, using a real (local,
+no-network) git repo reproducing the exact PR #1250 topology.
 
-**Completed by**:
-**Date**:
-**Notes**:
+**Two deviations found and fixed during implementation** (both discovered
+via empirical, real-git testing — not assumed):
 
-**Deviations from spec**: none | describe if any
+1. **The task's own reference `own` calculation is buggy.** The Pattern-
+   to-Follow snippet computes `own` via
+   `git rev-list --count origin/<base>..<branch> --not origin/<sib1> --not
+   origin/<sib2> ...` (chained `--not` flags). Verified with a real repo
+   (3 independent experiments, documented in this note's git history) that
+   chaining 2+ `--not` flags after a `..` range gives WRONG counts — each
+   `--not` toggles interesting/uninteresting state for what follows rather
+   than accumulating exclusions, so results are silently order- and
+   count-dependent (e.g. same inputs gave `own=1` one way and `own=2` the
+   other, both wrong). Fixed by switching `own`'s calculation to explicit
+   `^`-prefixed exclusions (`git rev-list --count <branch> ^origin/<base>
+   ^origin/<sib1> ^origin/<sib2> ...`), confirmed correct across the clean-
+   branch, incident-topology, and cherry-pick scenarios. Documented
+   prominently in `assert_base_is_clean`'s docstring so nobody
+   "simplifies" it back to the `--not` form.
+2. **`PlannerOutput` did NOT gain a `base_branch` field** — per the task's
+   own NOT-in-scope guidance ("unless `FeatureHandoffNode` genuinely needs
+   it... mirror TASK-2504's approach and say so"). Since `PlannerNode` is
+   not in this task's file list and `PlannerOutput.spec_path`/
+   `.worktree_path` were already sufficient, `FeatureHandoffNode` instead
+   gained a local, private `_resolve_base_branch()` (reads the committed
+   spec's frontmatter directly, mirroring `ResearchNode`'s TASK-2504
+   pattern) with a hardcoded `"dev"` fallback (feature-mode's `kind` is a
+   fixed `Literal["feature"]` — there is no kind-derived hotfix path here,
+   unlike bug-mode). This never returns `""`, so the empty-base block path
+   in `FeatureHandoffNode` is currently unreachable dead code, kept only
+   for symmetry/defensiveness with `DeploymentHandoffNode`.
+
+**Real-environment hazard found and fixed (unrelated to the guard's
+logic):** `assert_base_is_clean`'s real `asyncio.create_subprocess_exec`
+calls, combined with `test_gate_integration.py`'s manually-scheduled
+concurrent tasks (`asyncio.ensure_future`) and uvloop, hung the event loop
+across test boundaries (single test passed in 0.48s; two together hung
+indefinitely — confirmed via `faulthandler`/`SIGABRT` traceback dump
+showing the loop stuck, and via a clean git-stash bisection proving the
+hang did not exist on the pre-task baseline). Fixed by extending that
+file's existing `_patch_push` autouse fixture to also mock
+`assert_base_is_clean` — those are gate-mechanism tests, not base-branch
+guard tests (which have dedicated coverage here), so no real git plumbing
+belongs there, matching the existing rationale for mocking `_push_branch`/
+`_create_pr` in the same fixture.
+
+**Existing fixture updates (necessary regression fixes, not scope creep —
+required by the explicit "all tests pass" acceptance criterion, same
+pattern as TASK-2506):** `test_deployment_handoff.py`'s `ctx` fixture and
+`test_gate_integration.py`'s `handoff_ctx` fixture construct
+`ResearchOutput` without `base_branch`, which now defaults to `""` and
+trips the new blocking behavior — added `base_branch="dev"` to both.
+
+Full `pytest packages/ai-parrot/tests/flows/dev_loop/
+packages/ai-parrot/tests/flows/dev_flow/` run (bounded timeout after the
+hang investigation): 1299 passed (up from 1287 pre-task), same 3
+pre-existing unrelated failures as every prior task in this feature
+(confirmed not touched). `ruff check`: `deployment_handoff.py`,
+`test_deployment_handoff.py`, `test_gate_integration.py` unchanged finding
+counts; `nodes/base.py` +4 (`List`/`Tuple`/`Optional`-style findings,
+consistent with the file's pervasive existing use of those forms, not
+`list`/`tuple`/`X | None`); `feature_handoff.py`'s one new import-order
+(I001) finding was auto-fixed via `ruff check --fix --select I001`
+(mechanical reorder only, re-verified tests still pass), leaving +1
+(`Optional`-style, same file-convention reasoning). New test file matches
+the same pre-existing I001/C408 pattern already present in every sibling
+`_brief`-style test helper. `mypy` times out project-wide (60s) — same
+environment limitation noted in every prior task of this feature, not
+confirmed clean.
+
+**Deviations from spec**: (1) `own`'s rev-list form changed from chained
+`--not` flags to explicit `^`-prefixed exclusions — a proven correctness
+fix, not a design change (documented above and in the docstring). (2)
+`FeatureHandoffNode` sources its base from a local frontmatter reader
+instead of a new `PlannerOutput.base_branch` field — explicitly
+pre-authorized by the task's own NOT-in-scope guidance, with the reasoning
+recorded here per that guidance's request.

--- a/sdd/tasks/completed/TASK-2506-single-agent-honours-dev-agent.md
+++ b/sdd/tasks/completed/TASK-2506-single-agent-honours-dev-agent.md
@@ -459,10 +459,54 @@ class TestSingleAgentHonoursDeclaredAgent:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (autonomous)
+**Date**: 2026-08-27
+**Notes**: Implemented `_execute_single(shared, research, pool_cfg=None)` per
+the task's pattern, with one deliberate, documented deviation (below).
+Updated all three `execute()` call sites to pass `pool_cfg` at lines 197/207
+(197: builder-missing degradation; 207: no-readable-index degradation) while
+leaving the `pool_cfg is None` call site (line 191) passing nothing, exactly
+as instructed. Verified the builder is called synchronously per
+`agent_pool.py:150` (`dispatcher, profile = dispatcher_builder(spec)`, not
+awaited). Extended `test_development_node.py`: added the
+`TestSingleAgentHonoursDeclaredAgent` class (6 new tests) and made
+`FakeDispatcher.dispatch` tolerate `**_kwargs` so it accepts the
+single-agent path's `session_host=` kwarg (the pool path never passes it).
+Baseline was 39 passing tests in `test_development_node.py` +
+`test_agent_builder.py`; now 45 (39 + 6 new), all passing. Full
+`pytest packages/ai-parrot/tests/flows/dev_loop/` run: 1097 passed (up from
+1091 pre-task), same 3 pre-existing unrelated failures as TASK-2503
+(confirmed via baseline diff, not touched by this task). `ruff check` on
+`development.py`: 32 findings vs 31 baseline — the +1 is two new
+`Optional[...]`-style UP045 findings (consistent with the file's existing
+10 UP045 instances and its established `Optional[X]` convention throughout,
+not `X | None`) minus one `RUF100 unused noqa` I removed after ruff flagged
+it as superfluous on my own new `except Exception:` block. `ruff check` on
+the test file: byte-identical finding count/content to baseline (2
+pre-existing, untouched). `mypy` times out project-wide (60s, same as
+TASK-2503) — environment limitation, not confirmed clean, not specific to
+these files.
 
-**Completed by**:
-**Date**:
-**Notes**:
-
-**Deviations from spec**: none | describe if any
+**Deviations from spec**: The task's own "Pattern to Follow" snippet
+unconditionally appends a `WorkerSummary` via `dev_out.model_copy(...)`
+regardless of whether a pool spec was actually used. Applied literally,
+this breaks object identity (`result is dev_out`) on BOTH the `pool_cfg is
+None` path AND the "pool declared but no `dispatcher_builder`" path — which
+directly contradicts (a) the task's own Key Constraint "The `pool_cfg is
+None` path must not change at all... Diff it carefully", and (b) two
+pre-existing regression tests (`test_no_pool_exact_current_behavior`,
+`test_no_dispatcher_builder_degrades_to_single`) that assert exactly that
+identity, protected by the acceptance criterion "All 39 pre-existing tests
+... still pass". Resolved by only appending the `WorkerSummary` when a pool
+`spec` was actually materialized via the builder (i.e. the one case where
+behaviour is intentionally changing) — this satisfies every literal
+acceptance criterion (all of which describe pool-declared scenarios) while
+keeping both explicitly-protected byte-identical paths untouched. Also
+rewrote the third existing test, `test_missing_index_degrades_to_single`
+(renamed `..._via_declared_agent`), because its assertions encoded the
+exact Problem-B bug this task exists to fix (pool declared + builder
+present + missing index → old code asserted the ENV dispatcher was used;
+new code correctly uses the builder) — this is the intended, in-scope
+behavior change per acceptance criterion "Pool config resolved + no
+readable task index → the dispatch runs on `pool_cfg.agents[0]`'s
+backend/model ... `self._dispatcher` was **not** used".

--- a/sdd/tasks/completed/TASK-2507-sdd-doc-plumbing-hotfix-no-id.md
+++ b/sdd/tasks/completed/TASK-2507-sdd-doc-plumbing-hotfix-no-id.md
@@ -336,12 +336,65 @@ into it — but do not invent one here.
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (autonomous)
+**Date**: 2026-08-27
+**Notes**: Edited all 5 target files (§A–D of Scope). `/sdd-spec.md`: added
+`--type`/`--base-branch` flags, rewrote §2d to call `resolve_flow()` instead
+of a bare `parse()` (keeping both existing abort messages verbatim, with a
+short note that the hotfix/main check is now raised by `FlowMeta`'s
+validator rather than a separate bash condition), added the hotfix
+FEAT-ID-skip instruction to §5, and split §7's output block into
+feature/hotfix variants (the original single block printed `FEAT-<ID>`
+unconditionally, which would have been wrong for a hotfix — caught during
+the "read all five files end to end" pass and fixed, per the task's own
+warning about exactly this failure mode). `/sdd-task.md`: added the
+"hotfix normally never reaches this command" note to §1, split §4's id
+reservation into feature/hotfix branches, added the hotfix index-header
+clarification, and updated §6/§7 similarly. `sdd-research.md`: passes
+`--type`/`--base-branch` flags derived from `brief.kind`, skips `/sdd-task`
+for `type: hotfix`, uses `hotfix-<JIRA-KEY>-<slug>` naming from
+`origin/main`, and the `ResearchOutput` example shows both the feature and
+hotfix (`feat_id: ""`) shapes. The `_subagent_data` mirror was byte-copied
+after editing the primary copy and `diff` confirmed identical (they were
+already byte-identical before this task, so no intentional differences
+existed to preserve). `CLAUDE.md` gained the worktree carve-out (explicit
+feature-vs-hotfix `git worktree add` commands, explaining `HEAD` is
+shorthand for "current base", not a hotfix-safe default) and the
+auto-commit-table hotfix note. Verification-by-execution (paste-and-run,
+per the task's Test Specification): reproduced the `parse()` crash on a
+missing path, then ran the documented `resolve_flow()` snippet for all 4
+cases (`kind=bug` → `hotfix main`; `kind=enhancement` → `feature dev`;
+explicit `--type hotfix --base-branch main` override; missing doc path
+with `kind=bug` → `hotfix main`, no crash) — all matched expectations
+exactly. `git diff --stat scripts/sdd/reserve_ids.py` is empty (confirmed
+untouched). Dispatched a fresh general-purpose subagent with ZERO prior
+context to read only `.claude/agents/sdd-research.md` cold and answer 6
+questions about a `kind="bug"` brief (Jira workflow, exact `/sdd-spec`
+command, whether an id is reserved, whether `/sdd-task` runs, the exact
+`git worktree add` command + base ref, and the final JSON's `feat_id`) —
+it derived every answer correctly, citing the exact lines, with no
+guessing. Full transcript summary preserved in this note.
 
-**Completed by**:
-**Date**:
-**Notes**:
+**Hotfix task-numbering decision**: **A hotfix normally produces NO task
+artifacts at all.** `sdd-research.md` skips `/sdd-task` entirely for
+`type: hotfix` (spec §3 Module 2's "Interaction with Module 7": no
+per-spec task index ⇒ `DevelopmentNode._build_scheduler` returns `None` ⇒
+single-agent dispatch, made to honour the operator's declared dev agent by
+TASK-2506 — the correct shape for a one-or-two-commit fix). `/sdd-task.md`
+itself is updated defensively for the rare case a human invokes it
+directly against a hotfix spec anyway: it skips
+`reserve_ids.py --kind task` and numbers tasks locally as
+`HOTFIX-<JIRA-KEY>-1`, `-2`, … — literal string ids scoped to that spec's
+own index file, never drawn from or compared against the ledger's
+`TASK-<NNN>` namespace. This resolves both halves of the task's "pick one
+and state it explicitly" instruction: the *normal* flow is "no artifacts";
+the *defensive* fallback (if invoked anyway) is local numbering.
 
-**Hotfix task-numbering decision**:
-
-**Deviations from spec**: none | describe if any
+**Deviations from spec**: Extended two output blocks (`/sdd-spec.md` §7,
+`/sdd-task.md` §6/§7) beyond the task's literal file-section list — they
+were not named in Scope, but both printed a `FEAT-<ID>`/worktree-naming
+template that is unconditionally wrong for a hotfix run and would have
+directly contradicted the new hotfix instructions three sections earlier
+in the same file. Fixed per the task's own explicit warning ("a local edit
+that contradicts a paragraph three sections away is the exact failure mode
+this task is fixing") rather than leaving a known contradiction in place.

--- a/sdd/tasks/completed/TASK-2508-console-base-branch-override.md
+++ b/sdd/tasks/completed/TASK-2508-console-base-branch-override.md
@@ -417,14 +417,90 @@ class TestServerPayloadParsing:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (autonomous)
+**Date**: 2026-08-27
+**Notes**: Added `WorkBrief.flow_type`/`.base_branch` (Optional, matching
+`dev_agents`/`dev_isolation`'s exact style). Threaded the operator override
+into `ResearchNode._resolve_base_branch` (TASK-2504) with precedence
+`brief.base_branch` (explicit) > committed spec frontmatter > kind mapping
+> `"dev"` default — the same precedence `resolve_flow()` documents, kept as
+a local reimplementation per TASK-2504's `scripts.sdd` decision. Confirmed
+(did not assume) `brief.model_dump_json()` at `dispatchers/claude.py:538`
+already serialises the whole brief, so no dispatcher change was needed.
 
-**Completed by**:
-**Date**:
-**Notes**:
+Added a shared `_apply_flow_override(payload, form)` helper in
+`server.py` (mirrors the `dev_isolation` validation idiom verbatim: closed
+set for `flow_type`, open string for `base_branch`) and wired it into all
+three payload builders: `_build_brief_from_form` (bug/enhancement/
+new_feature), `_build_feature_brief_from_form` (feature — payload keys are
+currently silently dropped by `FeatureBrief`'s default `extra="ignore"`,
+since `FeatureBrief` was intentionally NOT given these fields per this
+task's Files-to-Modify list; parsed anyway per the explicit "do the same"
+instruction to keep every builder symmetric), and `server_dev.py`'s
+`_build_dev_brief_from_form` (reused via `ops_server._apply_flow_override`,
+also currently inert on `DevRequestBrief` for the same reason — this
+console never handles `kind="bug"` either). Both consoles: added
+`flowType`/`baseBranch` form state (default `"auto"`), a `resolvedFlow()`
+JS helper mirroring `WORK_KIND_FLOW`, segmented controls in the "Agents &
+models" tab (the closest existing analog to a "flow settings" tab — there
+is no dedicated one), payload wiring that omits `"auto"`, and a `flow`
+summary row showing the *resolved* value (never the literal `"auto"`).
 
-**afd.html finding**:
+**Found and fixed a real gap during implementation**: the guard as
+initially written (§F) only restricted `base_branch` choices once the
+operator explicitly clicked "hotfix" — but on a `kind="bug"` run with
+`flowType` left on `"auto"`, the *effective* type is already `"hotfix"`
+(via `WORK_KIND_FLOW`), and the naive guard would have let the operator
+pick `base_branch="dev"` directly, producing exactly the PR #1250
+motivating scenario's invalid combination (`hotfix`+`dev`) without ever
+touching the `flowType` control. Fixed by filtering the base-branch choices
+on `resolvedFlow().type` (the *resolved* type) rather than the literal
+`flowType` field, and centralizing the reset logic in a
+`sanitizeFlowOverride()` helper called from both the flow-type-seg click
+handler AND the kind-picker click handler (switching `kind` to `"bug"`
+while an incompatible `base_branch` was set now resets it too). Verified
+with a standalone Node.js simulation of the extracted logic (5 scenarios,
+including the PR #1250 case: operator must set `flowType="feature"`
+explicitly to unlock a non-`main` base on a bug run — matches spec §8's
+resolved framing that the override is a genuine operator decision, not an
+automatic base-branch-only escape hatch) — all passed. Both consoles'
+inline `<script>` blocks verified with `node --check` after every edit
+(syntactically valid).
 
-**Observed payloads (manual console run)**:
+Full `pytest packages/ai-parrot/tests/flows/dev_loop/
+packages/ai-parrot/tests/flows/dev_flow/` run: 1287 passed (up from 1104
+pre-task), same 3 pre-existing unrelated failures as every prior task in
+this feature (confirmed unrelated, not touched). `ruff check`: `research.py`,
+`server.py`, `server_dev.py` unchanged finding counts; `models/base.py` +2
+(UP045 `Optional`, consistent with its own `dev_agents`/`dev_isolation`
+fields directly above using the same style); new test file matches the
+identical pre-existing I001/C408 pattern already present in every sibling
+`_brief`-style test helper. `mypy` times out project-wide (60s) — same
+environment limitation noted in every prior task of this feature, not
+confirmed clean.
 
-**Deviations from spec**: none | describe if any
+**afd.html finding**: `examples/dev_loop/static/afd.html` is a **static
+design-system mockup/prototype**, not a functional console — verified via
+`grep` for `fetch(`/`POST`/`buildPayload`/`api/flow`: zero matches. It uses
+a `<x-dc>`/`sc-for`/`onChange="{{...}}"` templating syntax bound to a
+design-system bundle (`_ds/industry-.../\_ds\_bundle.js`) with hardcoded
+demo event streams (`['flow.intake_validated', {kind:'bug', ...}], 620]`)
+— it never posts a real payload to `/api/flow/run`. Confirmed out of scope;
+left untouched.
+
+**Observed payloads (simulated console run — see the Node.js simulation
+above in lieu of a live server, which requires Jira/Redis dependencies not
+available in this sandboxed environment)**: `auto`/`auto` on a `kind="bug"`
+brief sends `{kind:"bug"}` only (no `flow_type`/`base_branch` keys — spec
+resolves hotfix/main from the mapping); `flowType="feature"`,
+`baseBranch="dev"` on the same brief sends
+`{kind:"bug", flow_type:"feature", base_branch:"dev"}`; `flowType="hotfix"`
+alone sends `{flow_type:"hotfix"}` (base_branch omitted, resolves to main).
+
+**Deviations from spec**: None on the Python/model side. On the console
+side, the guard implementation differs from the task's literal §F wording
+("when flowType === 'hotfix', restrict the base-branch select to main") —
+implemented instead against the *resolved* effective type
+(`resolvedFlow().type`), which is strictly more correct and is required to
+actually close the PR #1250 gap (see the "gap found and fixed" note
+above). Documented here rather than silently deviating.

--- a/sdd/tasks/index/dev-loop-run-fidelity.json
+++ b/sdd/tasks/index/dev-loop-run-fidelity.json
@@ -50,7 +50,7 @@
       "feature_id": "FEAT-466",
       "feature": "dev-loop-run-fidelity",
       "spec": "sdd/specs/dev-loop-run-fidelity.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -60,8 +60,8 @@
       "parallelism_notes": "Needs resolve_flow() from 2502. Its Completion Note records the scripts.sdd import decision that 2505 and 2508 both depend on, so it must finish before either starts.",
       "assigned_to": null,
       "started_at": "2026-08-27T15:22:57+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2504-research-output-base-branch.md"
+      "completed_at": "2026-08-27T15:47:05+00:00",
+      "file": "sdd/tasks/completed/TASK-2504-research-output-base-branch.md"
     },
     {
       "id": "TASK-2505",

--- a/sdd/tasks/index/dev-loop-run-fidelity.json
+++ b/sdd/tasks/index/dev-loop-run-fidelity.json
@@ -128,7 +128,7 @@
       "feature_id": "FEAT-466",
       "feature": "dev-loop-run-fidelity",
       "spec": "sdd/specs/dev-loop-run-fidelity.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "M",
       "depends_on": [
@@ -138,8 +138,8 @@
       "parallelism_notes": "Adds WorkBrief.flow_type/.base_branch and threads them into 2504's _resolve_base_branch, so it must follow 2504. Console edits (index.html, dev.html) and the example servers are otherwise untouched by every other task.",
       "assigned_to": null,
       "started_at": "2026-08-27T15:22:57+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2508-console-base-branch-override.md"
+      "completed_at": "2026-08-27T16:10:25+00:00",
+      "file": "sdd/tasks/completed/TASK-2508-console-base-branch-override.md"
     }
   ]
 }

--- a/sdd/tasks/index/dev-loop-run-fidelity.json
+++ b/sdd/tasks/index/dev-loop-run-fidelity.json
@@ -32,7 +32,7 @@
       "feature_id": "FEAT-466",
       "feature": "dev-loop-run-fidelity",
       "spec": "sdd/specs/dev-loop-run-fidelity.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [],
@@ -40,8 +40,8 @@
       "parallelism_notes": "Touches run_bundle.py, qa.py, development.py:_find_feature_slug, deployment_handoff.py:_build_title and adds a helper to nodes/base.py. Overlaps 2505 (nodes/base.py) and 2506 (development.py) — if run concurrently, land this one FIRST since its edits are additive and small.",
       "assigned_to": null,
       "started_at": "2026-08-27T15:22:57+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2503-feat-id-empty-fallbacks.md"
+      "completed_at": "2026-08-27T15:31:17+00:00",
+      "file": "sdd/tasks/completed/TASK-2503-feat-id-empty-fallbacks.md"
     },
     {
       "id": "TASK-2504",

--- a/sdd/tasks/index/dev-loop-run-fidelity.json
+++ b/sdd/tasks/index/dev-loop-run-fidelity.json
@@ -14,7 +14,7 @@
       "feature_id": "FEAT-466",
       "feature": "dev-loop-run-fidelity",
       "spec": "sdd/specs/dev-loop-run-fidelity.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "S",
       "depends_on": [],
@@ -22,8 +22,8 @@
       "parallelism_notes": "Pure function in scripts/sdd/sdd_meta.py; shares no files with any other task. Dependency root of the feature — 2504 and 2507 need it.",
       "assigned_to": null,
       "started_at": "2026-08-27T15:22:57+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2502-resolve-flow-mapping.md"
+      "completed_at": "2026-08-27T15:24:49+00:00",
+      "file": "sdd/tasks/completed/TASK-2502-resolve-flow-mapping.md"
     },
     {
       "id": "TASK-2503",

--- a/sdd/tasks/index/dev-loop-run-fidelity.json
+++ b/sdd/tasks/index/dev-loop-run-fidelity.json
@@ -5,7 +5,7 @@
   "type": "feature",
   "base_branch": "dev",
   "created_at": "2026-08-27T00:00:00+00:00",
-  "completed_at": null,
+  "completed_at": "2026-08-27T17:17:32+00:00",
   "tasks": [
     {
       "id": "TASK-2502",
@@ -23,7 +23,8 @@
       "assigned_to": null,
       "started_at": "2026-08-27T15:22:57+00:00",
       "completed_at": "2026-08-27T15:24:49+00:00",
-      "file": "sdd/tasks/completed/TASK-2502-resolve-flow-mapping.md"
+      "file": "sdd/tasks/completed/TASK-2502-resolve-flow-mapping.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2503",
@@ -41,7 +42,8 @@
       "assigned_to": null,
       "started_at": "2026-08-27T15:22:57+00:00",
       "completed_at": "2026-08-27T15:31:17+00:00",
-      "file": "sdd/tasks/completed/TASK-2503-feat-id-empty-fallbacks.md"
+      "file": "sdd/tasks/completed/TASK-2503-feat-id-empty-fallbacks.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2504",
@@ -61,7 +63,8 @@
       "assigned_to": null,
       "started_at": "2026-08-27T15:22:57+00:00",
       "completed_at": "2026-08-27T15:47:05+00:00",
-      "file": "sdd/tasks/completed/TASK-2504-research-output-base-branch.md"
+      "file": "sdd/tasks/completed/TASK-2504-research-output-base-branch.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2505",
@@ -81,7 +84,8 @@
       "assigned_to": null,
       "started_at": "2026-08-27T15:22:57+00:00",
       "completed_at": "2026-08-27T16:37:20+00:00",
-      "file": "sdd/tasks/completed/TASK-2505-sibling-overlap-guard.md"
+      "file": "sdd/tasks/completed/TASK-2505-sibling-overlap-guard.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2506",
@@ -99,7 +103,8 @@
       "assigned_to": null,
       "started_at": "2026-08-27T15:22:57+00:00",
       "completed_at": "2026-08-27T15:39:52+00:00",
-      "file": "sdd/tasks/completed/TASK-2506-single-agent-honours-dev-agent.md"
+      "file": "sdd/tasks/completed/TASK-2506-single-agent-honours-dev-agent.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2507",
@@ -119,7 +124,8 @@
       "assigned_to": null,
       "started_at": "2026-08-27T15:22:57+00:00",
       "completed_at": "2026-08-27T15:53:51+00:00",
-      "file": "sdd/tasks/completed/TASK-2507-sdd-doc-plumbing-hotfix-no-id.md"
+      "file": "sdd/tasks/completed/TASK-2507-sdd-doc-plumbing-hotfix-no-id.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2508",
@@ -139,7 +145,8 @@
       "assigned_to": null,
       "started_at": "2026-08-27T15:22:57+00:00",
       "completed_at": "2026-08-27T16:10:25+00:00",
-      "file": "sdd/tasks/completed/TASK-2508-console-base-branch-override.md"
+      "file": "sdd/tasks/completed/TASK-2508-console-base-branch-override.md",
+      "verification": "verified"
     }
   ]
 }

--- a/sdd/tasks/index/dev-loop-run-fidelity.json
+++ b/sdd/tasks/index/dev-loop-run-fidelity.json
@@ -90,7 +90,7 @@
       "feature_id": "FEAT-466",
       "feature": "dev-loop-run-fidelity",
       "spec": "sdd/specs/dev-loop-run-fidelity.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [],
@@ -98,8 +98,8 @@
       "parallelism_notes": "Problem B — fully independent of the base-branch chain. Only shares development.py with 2503's one-line _find_feature_slug guard. Safe to run first or concurrently.",
       "assigned_to": null,
       "started_at": "2026-08-27T15:22:57+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2506-single-agent-honours-dev-agent.md"
+      "completed_at": "2026-08-27T15:39:52+00:00",
+      "file": "sdd/tasks/completed/TASK-2506-single-agent-honours-dev-agent.md"
     },
     {
       "id": "TASK-2507",

--- a/sdd/tasks/index/dev-loop-run-fidelity.json
+++ b/sdd/tasks/index/dev-loop-run-fidelity.json
@@ -108,7 +108,7 @@
       "feature_id": "FEAT-466",
       "feature": "dev-loop-run-fidelity",
       "spec": "sdd/specs/dev-loop-run-fidelity.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "M",
       "depends_on": [
@@ -118,8 +118,8 @@
       "parallelism_notes": "Markdown only (.claude/commands/*, .claude/agents/*, _subagent_data/*, CLAUDE.md) so it conflicts with no Python task — but it must follow 2502 because it documents calling resolve_flow(), and it should follow 2503 because it starts PRODUCING feat_id == \"\" runs that 2503 makes safe.",
       "assigned_to": null,
       "started_at": "2026-08-27T15:22:57+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2507-sdd-doc-plumbing-hotfix-no-id.md"
+      "completed_at": "2026-08-27T15:53:51+00:00",
+      "file": "sdd/tasks/completed/TASK-2507-sdd-doc-plumbing-hotfix-no-id.md"
     },
     {
       "id": "TASK-2508",

--- a/sdd/tasks/index/dev-loop-run-fidelity.json
+++ b/sdd/tasks/index/dev-loop-run-fidelity.json
@@ -70,7 +70,7 @@
       "feature_id": "FEAT-466",
       "feature": "dev-loop-run-fidelity",
       "spec": "sdd/specs/dev-loop-run-fidelity.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "depends_on": [
@@ -80,8 +80,8 @@
       "parallelism_notes": "Reads ResearchOutput.base_branch from 2504. Also edits nodes/base.py, which 2503 touches — sequence after 2503 when both are in flight.",
       "assigned_to": null,
       "started_at": "2026-08-27T15:22:57+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2505-sibling-overlap-guard.md"
+      "completed_at": "2026-08-27T16:37:20+00:00",
+      "file": "sdd/tasks/completed/TASK-2505-sibling-overlap-guard.md"
     },
     {
       "id": "TASK-2506",

--- a/tests/sdd_scripts/test_sdd_meta_resolve_flow.py
+++ b/tests/sdd_scripts/test_sdd_meta_resolve_flow.py
@@ -1,0 +1,73 @@
+"""Unit tests for ``scripts.sdd.sdd_meta.resolve_flow`` — FEAT-466 / TASK-2502."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.sdd.sdd_meta import WORK_KIND_FLOW, resolve_flow
+
+
+class TestResolveFlowKindMapping:
+    def test_bug_is_a_hotfix_on_main(self):
+        meta = resolve_flow(kind="bug")
+        assert (meta.type, meta.base_branch) == ("hotfix", "main")
+
+    @pytest.mark.parametrize("kind", ["enhancement", "new_feature"])
+    def test_non_bug_kinds_are_features_on_dev(self, kind):
+        meta = resolve_flow(kind=kind)
+        assert (meta.type, meta.base_branch) == ("feature", "dev")
+
+    def test_no_arguments_returns_default(self):
+        meta = resolve_flow()
+        assert (meta.type, meta.base_branch) == ("feature", "dev")
+
+    def test_unknown_kind_falls_through_to_default(self):
+        meta = resolve_flow(kind="not-a-kind")
+        assert (meta.type, meta.base_branch) == ("feature", "dev")
+
+    def test_mapping_constant_is_exhaustive(self):
+        assert set(WORK_KIND_FLOW) == {"bug", "enhancement", "new_feature"}
+
+
+class TestResolveFlowMissingDocument:
+    def test_missing_doc_path_is_not_an_error(self, tmp_path):
+        """THE regression this task exists for: parse() raises
+        FileNotFoundError on a missing path, which is exactly the dev-loop
+        bug path's situation."""
+        meta = resolve_flow(kind="bug", doc_path=tmp_path / "nope.brainstorm.md")
+        assert (meta.type, meta.base_branch) == ("hotfix", "main")
+
+    def test_none_doc_path_is_not_an_error(self):
+        assert resolve_flow(kind="bug", doc_path=None).type == "hotfix"
+
+
+class TestResolveFlowPrecedence:
+    def test_existing_doc_frontmatter_beats_kind(self, tmp_path):
+        doc = tmp_path / "x.brainstorm.md"
+        doc.write_text("---\ntype: feature\nbase_branch: dev\n---\n# body\n")
+        meta = resolve_flow(kind="bug", doc_path=doc)
+        assert (meta.type, meta.base_branch) == ("feature", "dev")
+
+    def test_overrides_beat_document(self, tmp_path):
+        doc = tmp_path / "x.brainstorm.md"
+        doc.write_text("---\ntype: feature\nbase_branch: dev\n---\n")
+        meta = resolve_flow(
+            doc_path=doc, type_override="hotfix", base_branch_override="main"
+        )
+        assert (meta.type, meta.base_branch) == ("hotfix", "main")
+
+    def test_overrides_compose_field_wise(self):
+        """Only base_branch overridden -> the kind-derived type survives.
+        This is what lets the console override just the base branch."""
+        meta = resolve_flow(kind="enhancement", base_branch_override="staging")
+        assert (meta.type, meta.base_branch) == ("feature", "staging")
+
+
+class TestResolveFlowValidation:
+    def test_hotfix_off_main_is_rejected(self):
+        with pytest.raises(ValueError, match="hotfix"):
+            resolve_flow(type_override="hotfix", base_branch_override="dev")
+
+    def test_unknown_branch_warns_but_succeeds(self, caplog):
+        meta = resolve_flow(base_branch_override="feat/parent-branch")
+        assert meta.base_branch == "feat/parent-branch"

--- a/tests/sdd_scripts/test_sdd_meta_resolve_flow.py
+++ b/tests/sdd_scripts/test_sdd_meta_resolve_flow.py
@@ -51,9 +51,7 @@ class TestResolveFlowPrecedence:
     def test_overrides_beat_document(self, tmp_path):
         doc = tmp_path / "x.brainstorm.md"
         doc.write_text("---\ntype: feature\nbase_branch: dev\n---\n")
-        meta = resolve_flow(
-            doc_path=doc, type_override="hotfix", base_branch_override="main"
-        )
+        meta = resolve_flow(doc_path=doc, type_override="hotfix", base_branch_override="main")
         assert (meta.type, meta.base_branch) == ("hotfix", "main")
 
     def test_overrides_compose_field_wise(self):


### PR DESCRIPTION
## Summary

FEAT-466 fixes two independent bugs in the dev-loop flow's run fidelity:

**Problem A — the declared base branch is never applied.** A `kind="bug"` run
was supposed to flow as a hotfix from `main`, but the branch was cut from `dev`
while the PR still targeted `main` (the real incident: PR #1250, 93 commits of
`dev` merged into `main`). Fixed by making the `WorkKind → (flow type, base
branch)` mapping executable code (`resolve_flow()`), recording the resolved
base branch on `ResearchOutput` (read back from the committed spec frontmatter,
never trusting the subagent's self-report), and adding a sibling-overlap guard
that blocks the PR before it's opened when the branch carries commits that
already live on a sibling long-lived branch — deliberately NOT an ancestry
check, which is provably blind to the #1250 shape.

**Problem B — the declared dev agent is silently replaced by the server's env
default.** `DevelopmentNode._execute_single()` now honours the operator's
declared dev agent (from the resolved pool config) instead of silently falling
back to the env-configured dispatcher when no per-spec task index is readable
— the normal case for a hotfix, which (per this feature) reserves no id.

A bugfix/hotfix now reserves **no** `FEAT`/`TASK` id at all — it's identified
by its Jira issue key instead (`hotfix-<JIRA-KEY>-<slug>` branch naming), and
every run-labelling consumer falls back to `jira_issue_key` when `feat_id` is
`""`. The console also exposes an explicit flow-type/base-branch override so
an operator can decide a `kind="bug"` run doesn't need to be a hotfix (the
motivating case: PR #1250 was a hardening fix with no live incident behind it).

## Tasks

7/7 tasks verified:
- TASK-2502 — Executable WorkKind → (flow type, base branch) mapping
- TASK-2503 — Honour `feat_id == ""` across every run-labelling consumer
- TASK-2504 — Record the resolved base branch on `ResearchOutput`
- TASK-2505 — Sibling-overlap guard + handoff nodes consume the recorded base
- TASK-2506 — Single-agent path must honour the operator's declared dev agent
- TASK-2507 — SDD doc plumbing: flow-type flags and "a hotfix reserves no id"
- TASK-2508 — Console flow-type / base-branch override

## Verification

- Full suite: `pytest packages/ai-parrot/tests/flows/dev_loop/ packages/ai-parrot/tests/flows/dev_flow/` → 1302 passed, 6 skipped, 3 pre-existing unrelated failures (confirmed on `dev` baseline, not touched by this PR).
- `ruff check`: no new findings beyond pre-existing file-wide style debt.
- `scripts/sdd/reserve_ids.py` confirmed byte-for-byte unmodified.
- Adversarial code review completed (code-reviewer agent): 0 critical, 3 important findings all addressed (console flow_type override now reaches the subagent; sibling-overlap guard's fetch-failure handling hardened with 3 new tests; defensive-only branches documented), 3 suggestions addressed (credential scrubbing on PR-creation error paths; docstring corrections).

---
_Closed by /sdd-done_