### PR TITLE
fix(sdd): reserve_ids must not destroy or publish local commits

### DIFF
--- a/.claude/commands/remove-worktree.md
+++ b/.claude/commands/remove-worktree.md
@@ -47,7 +47,9 @@ State flags:
 - `unpushed:n` — commits origin does not have. Per this repo's history, a
   concurrent SDD process can `reset --hard` a shared branch and eat local
   commits, so unpushed work in a worktree is genuinely at risk — push it
-  rather than discarding it.
+  rather than discarding it. (The worst offender, `reserve_ids.py`'s retry
+  path, no longer resets anything — but `/sdd-done` merges and release
+  tooling still move shared branches under you.)
 
 Add `--check-pr` to also resolve PR state via `gh` (slower).
 

--- a/.claude/commands/sdd-spec.md
+++ b/.claude/commands/sdd-spec.md
@@ -276,7 +276,8 @@ This step prevents AI hallucinations during implementation. You MUST:
      document's identity line (`**Jira**: <KEY>` in place of `**Feature
      ID**: FEAT-<NNN>`). This is not an oversight to fix later: it is the
      whole point — the allocator's "current branch must equal
-     `--base-branch`" precondition (`reserve_ids.py:140`) would otherwise be
+     `--base-branch`" precondition (`reserve_ids.py`, `_assert_safe_to_reserve`)
+     would otherwise be
      unreachable for a hotfix that has to reserve on `main` while another
      worktree already has `main` checked out. Skipping reservation removes
      the problem rather than solving it.
@@ -289,11 +290,12 @@ This step prevents AI hallucinations during implementation. You MUST:
        --base-branch "$BASE_BRANCH" --label <feature-name>)
      ```
      On success this prints exactly one `FEAT-<NNN>` line; use it verbatim
-     as this spec's Feature ID. `reserve_ids.py` commits and pushes its own
-     ledger-only update to `origin/$BASE_BRANCH` as part of this call
-     (retrying internally on a non-fast-forward rejection) and refuses to
-     run if the working tree has uncommitted changes besides the ledger
-     file. If the command exits non-zero, **STOP** and report the error —
+     as this spec's Feature ID. `reserve_ids.py` pushes its own ledger-only
+     commit to `origin/$BASE_BRANCH` as part of this call (retrying
+     internally on a non-fast-forward rejection) and refuses to run if
+     tracked files have uncommitted changes besides the ledger file. It
+     builds that commit on `origin/$BASE_BRANCH` with git plumbing, so it
+     never publishes or discards local-only commits on your branch. If the command exits non-zero, **STOP** and report the error —
      do NOT fall back to hand-computing a number.
 
      **Escape hatch — intentional FEAT-ID reuse**: if this spec is a

--- a/.claude/commands/sdd-task.md
+++ b/.claude/commands/sdd-task.md
@@ -131,10 +131,12 @@ explicit, verified code anchors.
    TASK-1969
    TASK-1970
    ```
-   `reserve_ids.py` commits and pushes its own ledger-only update to
-   `origin/<BASE>` as part of this call (retrying internally on a
-   non-fast-forward rejection); it refuses to run if the working tree has
-   any uncommitted changes besides the ledger file. If the command exits
+   `reserve_ids.py` pushes its own ledger-only commit to `origin/<BASE>` as
+   part of this call (retrying internally on a non-fast-forward rejection);
+   it refuses to run if tracked files have any uncommitted changes besides
+   the ledger file. The commit is built on `origin/<BASE>` with git
+   plumbing and pushed by sha, so local-only commits on `<BASE>` are
+   neither published nor discarded by a lost race. If the command exits
    non-zero (retries exhausted, or the working tree wasn't clean), **STOP**
    and report the error to the user — do NOT fall back to hand-computing a
    number.

--- a/scripts/sdd/reserve_ids.py
+++ b/scripts/sdd/reserve_ids.py
@@ -3,11 +3,20 @@
 Replaces the "scan existing files, take the max, +1" numbering used by
 ``/sdd-task``/``/sdd-spec`` with an optimistic-concurrency-with-retry
 allocator (FEAT-387): read ``sdd/tasks/.id_ledger.json`` (TASK-1963),
-compute the requested reservation, commit a *ledger-only* update, and push
-to ``origin/<base_branch>``. A non-fast-forward push rejection means
-another allocation landed first — fetch, re-read the now-current ledger,
-recompute, and retry (bounded, with jittered backoff), instead of silently
-succeeding with a stale, already-claimed number.
+compute the requested reservation, build a *ledger-only* commit on top of
+``origin/<base_branch>``, and push it. A non-fast-forward push rejection
+means another allocation landed first — fetch, re-read the now-current
+ledger, recompute, and retry (bounded, with jittered backoff), instead of
+silently succeeding with a stale, already-claimed number.
+
+The reservation is a compare-and-swap against ``origin/<base_branch>``
+**alone**. The candidate commit is assembled with git plumbing
+(``hash-object`` / ``read-tree`` / ``write-tree`` / ``commit-tree``) in a
+throwaway index, so the local branch, the local index and the working tree
+are never mutated by an attempt — a lost race costs one dangling commit
+object and nothing else. In particular this allocator never runs ``git
+reset --hard`` and never pushes ``HEAD``, so it can neither destroy nor
+publish local-only commits on the base branch.
 
 Usage:
     python -m scripts.sdd.reserve_ids --kind task --count 8 --base-branch dev --label sandbox-hardening
@@ -20,6 +29,7 @@ import os
 import random
 import subprocess
 import sys
+import tempfile
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -27,13 +37,16 @@ from typing import Callable, Literal
 
 from pydantic import BaseModel, Field
 
-from scripts.sdd.id_ledger import LEDGER_PATH, load_ledger, save_ledger
+from scripts.sdd.id_ledger import LEDGER_PATH, IdLedger, save_ledger
 
 #: Timeout (seconds) for every individual git subprocess call. This script
 #: is meant to serve concurrent, automated dev-loop dispatches — an
 #: indefinite hang (stalled network, interactive credential prompt) in one
 #: allocator instance must not block forever.
 _GIT_TIMEOUT_SECONDS = 30.0
+
+#: The ledger's path as git spells it (forward slashes on every platform).
+_LEDGER_GIT_PATH = LEDGER_PATH.as_posix()
 
 
 class IdReservationError(RuntimeError):
@@ -57,6 +70,8 @@ def _run_git(
     repo_root: Path,
     *,
     check: bool = True,
+    env_extra: dict[str, str] | None = None,
+    stdin: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run a git subcommand rooted at ``repo_root``.
 
@@ -66,6 +81,11 @@ def _run_git(
         check: When ``True`` (default), raise ``CalledProcessError`` on a
             non-zero exit code. Set to ``False`` for calls (like ``push``)
             whose failure is expected and handled explicitly by the caller.
+        env_extra: Extra environment variables for this call — used to
+            point ``GIT_INDEX_FILE`` at a throwaway index so the plumbing
+            that builds the ledger commit never touches the real one.
+        stdin: Text piped to the command's standard input (used by
+            ``git hash-object --stdin``).
 
     Returns:
         The completed subprocess result.
@@ -80,6 +100,8 @@ def _run_git(
     # Never let git block on an interactive credential prompt — fail fast
     # instead of hanging indefinitely.
     env["GIT_TERMINAL_PROMPT"] = "0"
+    if env_extra:
+        env.update(env_extra)
     return subprocess.run(
         ["git", *args],
         cwd=repo_root,
@@ -87,6 +109,7 @@ def _run_git(
         capture_output=True,
         text=True,
         env=env,
+        input=stdin,
         timeout=_GIT_TIMEOUT_SECONDS,
     )
 
@@ -104,22 +127,25 @@ def _porcelain_path(line: str) -> str:
 
 
 def _assert_safe_to_reserve(root: Path, base_branch: str) -> None:
-    """Verify it is safe to run the destructive retry sequence in ``root``.
+    """Verify ``root`` is in the state this allocator is contracted to run in.
 
-    ``reserve_ids()``'s retry path runs ``git reset --hard
-    origin/<base_branch>`` after a rejected push — that is only safe when
-    (a) the working tree has no changes besides the ledger file, and (b)
-    the current branch actually IS ``base_branch``. Enforced here (not just
-    in the CLI) so any caller of the library function — including a future
-    dev-loop subagent invoking ``reserve_ids()`` directly — inherits the
-    same guard rather than a footgun.
+    Neither check is load-bearing for *safety* any more — the reservation
+    is built with plumbing against ``origin/<base_branch>`` and never
+    rewrites local history (see the module docstring). They are kept as a
+    contract check: ``/sdd-task`` and ``/sdd-spec`` are documented to run
+    on the base branch with a clean tree, and the post-reservation
+    fast-forward of the local branch only lands cleanly under those
+    conditions. Failing loudly here beats silently leaving the caller's
+    branch behind ``origin/<base_branch>``.
+
+    Untracked files are ignored: nothing in this module can clobber them.
 
     Args:
         root: Repository working directory to check.
         base_branch: The branch this reservation is expected to push to.
 
     Raises:
-        IdReservationError: If the working tree has uncommitted changes
+        IdReservationError: If tracked files have uncommitted changes
             besides the ledger file, or the current branch is not
             ``base_branch``.
     """
@@ -129,7 +155,7 @@ def _assert_safe_to_reserve(root: Path, base_branch: str) -> None:
         for line in status.stdout.splitlines()
         if line.strip()
         and not line.startswith("?? ")
-        and _porcelain_path(line) != str(LEDGER_PATH)
+        and _porcelain_path(line) != _LEDGER_GIT_PATH
     ]
     if dirty:
         raise IdReservationError(
@@ -162,6 +188,155 @@ def _is_non_fast_forward_rejection(stderr: str) -> bool:
     )
 
 
+def _resolve_base_sha(root: Path, base_branch: str, *, fetch: bool) -> str:
+    """Return the commit sha the next reservation attempt must build on.
+
+    Args:
+        root: Repository working directory.
+        base_branch: Branch being reserved against.
+        fetch: When ``True``, refresh from the remote first and use the
+            fetched tip. Retries always fetch — a retry only happens
+            because the remote moved. The first attempt reads the existing
+            ``origin/<base_branch>`` remote-tracking ref (falling back to a
+            fetch if it does not exist yet): if that ref is stale, the
+            attempt simply loses the race and the retry corrects it.
+
+    Returns:
+        The 40-character sha of the base commit.
+
+    Raises:
+        IdReservationError: If the base tip cannot be resolved.
+    """
+    if not fetch:
+        probe = _run_git(
+            ["rev-parse", "--verify", "--quiet", f"origin/{base_branch}^{{commit}}"],
+            root,
+            check=False,
+        )
+        if probe.returncode == 0 and probe.stdout.strip():
+            return probe.stdout.strip()
+
+    try:
+        _run_git(["fetch", "origin", base_branch], root)
+        result = _run_git(["rev-parse", "--verify", "FETCH_HEAD^{commit}"], root)
+    except subprocess.CalledProcessError as exc:
+        raise IdReservationError(
+            f"could not resolve origin/{base_branch}: {exc.stderr or exc}"
+        ) from exc
+    return result.stdout.strip()
+
+
+def _read_ledger_at(root: Path, base_sha: str) -> IdLedger:
+    """Read the ledger exactly as it exists in commit ``base_sha``.
+
+    The remote's copy — not the working tree's — is the compare-and-swap's
+    input: a local edit or a stale checkout must never be able to hand out
+    a number the remote already issued.
+
+    Args:
+        root: Repository working directory.
+        base_sha: Commit to read ``sdd/tasks/.id_ledger.json`` out of.
+
+    Returns:
+        The parsed ``IdLedger``.
+
+    Raises:
+        IdReservationError: If the ledger is missing from that commit.
+    """
+    try:
+        result = _run_git(["show", f"{base_sha}:{_LEDGER_GIT_PATH}"], root)
+    except subprocess.CalledProcessError as exc:
+        raise IdReservationError(
+            f"{LEDGER_PATH} not found in {base_sha}: {exc.stderr or exc}"
+        ) from exc
+    return IdLedger.model_validate_json(result.stdout)
+
+
+def _build_ledger_commit(
+    root: Path, base_sha: str, ledger: IdLedger, message: str
+) -> str:
+    """Create a commit on top of ``base_sha`` changing only the ledger.
+
+    Built entirely with plumbing against a throwaway index
+    (``GIT_INDEX_FILE``), so the caller's branch, index and working tree
+    are untouched. The commit is a loose object until the push succeeds; a
+    lost race leaves it dangling, to be reclaimed by ``git gc``.
+
+    Args:
+        root: Repository working directory.
+        base_sha: Parent commit for the new commit.
+        ledger: The updated ledger to serialize into the commit.
+        message: Commit message.
+
+    Returns:
+        The sha of the newly created commit object.
+
+    Raises:
+        IdReservationError: If any plumbing step fails.
+    """
+    with tempfile.TemporaryDirectory(prefix="reserve-ids-") as tmpdir:
+        index_env = {"GIT_INDEX_FILE": str(Path(tmpdir) / "index")}
+        ledger_json = Path(tmpdir) / "ledger.json"
+        save_ledger(ledger_json, ledger)
+
+        try:
+            blob = _run_git(
+                ["hash-object", "-w", "--stdin"],
+                root,
+                stdin=ledger_json.read_text(encoding="utf-8"),
+            ).stdout.strip()
+            _run_git(["read-tree", base_sha], root, env_extra=index_env)
+            _run_git(
+                [
+                    "update-index",
+                    "--add",
+                    "--cacheinfo",
+                    f"100644,{blob},{_LEDGER_GIT_PATH}",
+                ],
+                root,
+                env_extra=index_env,
+            )
+            tree = _run_git(["write-tree"], root, env_extra=index_env).stdout.strip()
+            commit = _run_git(
+                ["commit-tree", tree, "-p", base_sha, "-m", message], root
+            ).stdout.strip()
+        except subprocess.CalledProcessError as exc:
+            raise IdReservationError(
+                f"could not build the ledger commit: {exc.stderr or exc}"
+            ) from exc
+
+    return commit
+
+
+def _sync_local_branch(root: Path, base_branch: str, commit_sha: str) -> None:
+    """Fast-forward the checked-out base branch onto the reserved commit.
+
+    Best-effort and strictly non-destructive: ``--ff-only`` refuses rather
+    than rewrites, so a base branch carrying unpushed local commits (or a
+    locally modified ledger) is left exactly as it was, with a warning
+    telling the caller how to reconcile. The reservation has already
+    landed on the remote at this point — failing the call over a local
+    bookkeeping step would strand IDs that are now permanently issued.
+
+    Args:
+        root: Repository working directory.
+        base_branch: Branch expected to be checked out.
+        commit_sha: The ledger commit that was just pushed.
+    """
+    merge = _run_git(["merge", "--ff-only", commit_sha], root, check=False)
+    if merge.returncode == 0:
+        return
+
+    print(
+        f"reserve_ids: WARNING — the reservation is pushed to origin/{base_branch}, "
+        f"but the local {base_branch} could not be fast-forwarded onto it "
+        f"({merge.stderr.strip() or 'not a fast-forward'}).\n"
+        f"reserve_ids: your local commits are intact and were NOT pushed. "
+        f"Reconcile before pushing, e.g. `git pull --no-rebase origin {base_branch}`.",
+        file=sys.stderr,
+    )
+
+
 def reserve_ids(
     kind: Literal["task", "feature"],
     count: int,
@@ -174,31 +349,30 @@ def reserve_ids(
 ) -> IdReservation:
     """Atomically reserve ``count`` sequential TASK or FEAT numbers.
 
-    Reads ``sdd/tasks/.id_ledger.json``, computes the next ``count``
-    numbers of the given ``kind``, commits the incremented ledger, and
-    pushes to ``origin/<base_branch>``. On a non-fast-forward push
-    rejection, fetches the current remote state, re-reads the ledger,
-    recomputes the reservation, and retries up to ``max_retries`` times
-    (with jittered backoff). Raises ``IdReservationError`` if retries are
-    exhausted, or if the push fails for a reason OTHER than a
-    non-fast-forward rejection (e.g. auth/network failure), since those
-    are not safe to retry the same way.
+    Reads ``sdd/tasks/.id_ledger.json`` **as of ``origin/<base_branch>``**,
+    computes the next ``count`` numbers of the given ``kind``, builds a
+    ledger-only commit on that tip with git plumbing, and pushes it to
+    ``refs/heads/<base_branch>``. The push IS the compare-and-swap: on a
+    non-fast-forward rejection the remote moved first, so the allocator
+    fetches, re-reads the now-current ledger, recomputes, and retries up
+    to ``max_retries`` times (with jittered backoff). It raises
+    ``IdReservationError`` if retries are exhausted, or if the push fails
+    for a reason OTHER than a non-fast-forward rejection (e.g.
+    auth/network failure), since those are not safe to retry the same way.
 
-    This function's own commit touches ONLY ``sdd/tasks/.id_ledger.json``
-    — it never bundles in the task/spec files themselves, so the
-    reservation race is decided by a single-line JSON diff, not by
-    whatever else the calling command is about to commit.
+    The pushed commit touches ONLY ``sdd/tasks/.id_ledger.json`` and has
+    ``origin/<base_branch>`` as its parent, so the reservation race is
+    decided by a single-line JSON diff — never by whatever else the caller
+    happens to have committed locally.
 
-    **Precondition**: at the moment this function is called, this
-    function's own ledger-only commit must be the ONLY local commit ahead
-    of ``origin/<base_branch>`` — the retry path runs `git reset --hard
-    origin/<base_branch>` after a rejected push, which would silently
-    discard ANY other local, unpushed commits or uncommitted changes. This
-    is now enforced by ``reserve_ids()`` itself (not just the CLI): it
-    refuses to run if the working tree is dirty with anything besides the
-    ledger file, OR if the current branch does not match ``base_branch``
-    (guards against being invoked from the wrong context, e.g. accidentally
-    inside a feature worktree).
+    **Local commits on the base branch are never published and never
+    destroyed.** Attempts run entirely in the object database plus a
+    throwaway index; no attempt mutates the local branch, the index or the
+    working tree, and no code path here runs ``git reset``. After a
+    successful push the local branch is fast-forwarded onto the
+    reservation as a convenience; if it cannot be (because it carries
+    unpushed commits), it is left untouched and a warning explains how to
+    reconcile.
 
     Args:
         kind: ``"task"`` or ``"feature"``.
@@ -212,7 +386,7 @@ def reserve_ids(
         label: Free-text origin of this reservation (feature slug or
             session id) — diagnostic only, stored in the ledger's
             ``updated_by`` field.
-        max_retries: Maximum number of read-commit-push attempts before
+        max_retries: Maximum number of read-build-push attempts before
             raising ``IdReservationError``.
         repo_root: Directory to run all git operations in. Defaults to the
             current working directory. Tests pass a throwaway clone here
@@ -229,19 +403,18 @@ def reserve_ids(
         ValueError: If ``count < 1``.
         IdReservationError: When every attempt is rejected up to
             ``max_retries``, when a push fails for a non-retryable reason,
-            or when the safety precondition (clean tree, correct branch)
-            is violated.
+            or when the contract check (clean tree, correct branch) fails.
     """
     if count < 1:
         raise ValueError(f"count must be >= 1, got {count!r}")
 
     root = repo_root if repo_root is not None else Path.cwd()
     _assert_safe_to_reserve(root, base_branch)
-    ledger_path = root / LEDGER_PATH
     prefix = "TASK" if kind == "task" else "FEAT"
 
     for attempt in range(max_retries):
-        ledger = load_ledger(ledger_path)
+        base_sha = _resolve_base_sha(root, base_branch, fetch=attempt > 0)
+        ledger = _read_ledger_at(root, base_sha)
         first = ledger.next_task_id if kind == "task" else ledger.next_feature_id
         ids = [f"{prefix}-{first + i}" for i in range(count)]
 
@@ -251,35 +424,35 @@ def reserve_ids(
             ledger.next_feature_id = first + count
         ledger.updated_by = label
         ledger.updated_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+00:00")
-        save_ledger(ledger_path, ledger)
 
-        _run_git(["add", str(LEDGER_PATH)], root)
-        _run_git(
-            ["commit", "-m", f"sdd: reserve {count} {kind} id(s) for {label}"],
+        commit_sha = _build_ledger_commit(
             root,
+            base_sha,
+            ledger,
+            f"sdd: reserve {count} {kind} id(s) for {label}",
         )
 
         push_result = _run_git(
-            ["push", "origin", f"HEAD:{base_branch}"], root, check=False
+            ["push", "origin", f"{commit_sha}:refs/heads/{base_branch}"],
+            root,
+            check=False,
         )
         if push_result.returncode == 0:
+            _sync_local_branch(root, base_branch, commit_sha)
             return IdReservation(kind=kind, first_id=first, count=count, ids=ids)
 
         if not _is_non_fast_forward_rejection(push_result.stderr):
             # Not a rejection we know how to retry (auth/network failure,
-            # etc.) — undo this attempt's local commit and fail loudly
-            # instead of retrying the same way as a lost race.
-            _run_git(["reset", "--hard", "HEAD~1"], root)
+            # etc.) — fail loudly instead of retrying as a lost race.
+            # Nothing to undo: the attempt never left the object database.
             raise IdReservationError(
                 "git push failed for a reason other than a non-fast-forward "
                 f"rejection: {push_result.stderr}"
             )
 
-        # Rejected — someone else advanced the ledger first. Undo this
-        # attempt's local commit, sync to the new remote state, and retry.
-        _run_git(["reset", "--hard", "HEAD~1"], root)
-        _run_git(["fetch", "origin", base_branch], root)
-        _run_git(["reset", "--hard", f"origin/{base_branch}"], root)
+        # Rejected — someone else advanced the ledger first. Retry against
+        # the new remote tip; the candidate commit just built is abandoned
+        # as an unreferenced object.
         sleep_fn(random.uniform(0.1, 0.5) * (attempt + 1))
 
     raise IdReservationError(
@@ -292,11 +465,10 @@ def main(argv: list[str] | None = None) -> int:
 
     Prints the reserved IDs one per line on success (exit 0); prints an
     error to stderr and exits 1 on failure. ``reserve_ids()`` itself
-    refuses to run (see its docstring precondition) if the working tree
-    has uncommitted changes besides the ledger file, if the current branch
-    does not match ``--base-branch``, or if ``--count`` is not positive —
-    this CLI surfaces all three as a clean error message rather than a
-    traceback.
+    refuses to run (see its docstring) if tracked files have uncommitted
+    changes besides the ledger file, if the current branch does not match
+    ``--base-branch``, or if ``--count`` is not positive — this CLI
+    surfaces all three as a clean error message rather than a traceback.
     """
     parser = argparse.ArgumentParser(
         description="Reserve sequential TASK/FEAT IDs via a git-native compare-and-swap ledger (FEAT-387).",
@@ -318,6 +490,9 @@ def main(argv: list[str] | None = None) -> int:
         )
     except (IdReservationError, ValueError) as exc:
         print(f"reserve_ids: {exc}", file=sys.stderr)
+        return 1
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        print(f"reserve_ids: git command failed: {exc}", file=sys.stderr)
         return 1
 
     for reserved_id in reservation.ids:

--- a/scripts/sdd/reserve_ids.py
+++ b/scripts/sdd/reserve_ids.py
@@ -35,7 +35,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from scripts.sdd.id_ledger import LEDGER_PATH, IdLedger, save_ledger
 
@@ -91,27 +91,46 @@ def _run_git(
         The completed subprocess result.
 
     Raises:
-        subprocess.TimeoutExpired: If the git command does not complete
-            within ``_GIT_TIMEOUT_SECONDS`` (e.g. a stalled network or an
-            interactive credential prompt) — bounded so a single allocator
-            instance can never hang forever.
+        IdReservationError: If the git command does not complete within
+            ``_GIT_TIMEOUT_SECONDS`` (e.g. a stalled network or an
+            interactive credential prompt). Bounded so a single allocator
+            instance can never hang forever — and surfaced as this
+            module's own error type so ``reserve_ids()`` keeps its
+            contract that every failure mode is an ``IdReservationError``.
+        subprocess.CalledProcessError: If ``check`` is ``True`` and git
+            exits non-zero; callers translate this into an
+            ``IdReservationError`` with context.
     """
     env = dict(os.environ)
     # Never let git block on an interactive credential prompt — fail fast
     # instead of hanging indefinitely.
     env["GIT_TERMINAL_PROMPT"] = "0"
+    # Two of this module's decisions read git's output (the porcelain
+    # status codes and the push ref-status line). Neither is translated by
+    # the git version in use — verified empirically under a fully
+    # installed es_ES.UTF-8 with LANGUAGE=es, where the surrounding advice
+    # text IS translated ("ayuda:") but `! [rejected] ... (fetch first)`
+    # stays English. Pinning the locale anyway costs nothing and removes
+    # the dependency on that observation holding in future git releases.
+    env["LC_ALL"] = "C"
     if env_extra:
         env.update(env_extra)
-    return subprocess.run(
-        ["git", *args],
-        cwd=repo_root,
-        check=check,
-        capture_output=True,
-        text=True,
-        env=env,
-        input=stdin,
-        timeout=_GIT_TIMEOUT_SECONDS,
-    )
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=repo_root,
+            check=check,
+            capture_output=True,
+            text=True,
+            env=env,
+            input=stdin,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise IdReservationError(
+            f"git {' '.join(args[:2])} timed out after "
+            f"{_GIT_TIMEOUT_SECONDS:.0f}s"
+        ) from exc
 
 
 def _porcelain_path(line: str) -> str:
@@ -216,9 +235,18 @@ def _resolve_base_sha(root: Path, base_branch: str, *, fetch: bool) -> str:
         if probe.returncode == 0 and probe.stdout.strip():
             return probe.stdout.strip()
 
+    # Fetch into the remote-tracking ref explicitly rather than reading
+    # FETCH_HEAD: FETCH_HEAD is a single per-worktree file, so a concurrent
+    # `git fetch` for a DIFFERENT branch in the same working directory (two
+    # SDD commands on one checkout is a documented hazard in this repo)
+    # could hand us an unrelated tip — which we would then push onto
+    # <base_branch>. The tracking ref is per-branch and cannot be confused.
+    tracking_ref = f"refs/remotes/origin/{base_branch}"
     try:
-        _run_git(["fetch", "origin", base_branch], root)
-        result = _run_git(["rev-parse", "--verify", "FETCH_HEAD^{commit}"], root)
+        _run_git(
+            ["fetch", "origin", f"+refs/heads/{base_branch}:{tracking_ref}"], root
+        )
+        result = _run_git(["rev-parse", "--verify", f"{tracking_ref}^{{commit}}"], root)
     except subprocess.CalledProcessError as exc:
         raise IdReservationError(
             f"could not resolve origin/{base_branch}: {exc.stderr or exc}"
@@ -249,7 +277,13 @@ def _read_ledger_at(root: Path, base_sha: str) -> IdLedger:
         raise IdReservationError(
             f"{LEDGER_PATH} not found in {base_sha}: {exc.stderr or exc}"
         ) from exc
-    return IdLedger.model_validate_json(result.stdout)
+
+    try:
+        return IdLedger.model_validate_json(result.stdout)
+    except ValidationError as exc:
+        raise IdReservationError(
+            f"{LEDGER_PATH} in {base_sha} is not a valid ledger: {exc}"
+        ) from exc
 
 
 def _build_ledger_commit(

--- a/sdd/WORKFLOW.md
+++ b/sdd/WORKFLOW.md
@@ -298,11 +298,24 @@ undetected until `/sdd-done`'s closeout tooling stumbled on them.
   python -m scripts.sdd.reserve_ids --kind task --count 8 \
     --base-branch dev --label <feature-slug>
   ```
-  Reads the ledger, commits a *ledger-only* update, and pushes to
-  `origin/<base_branch>`; on a rejected (non-fast-forward) push it fetches,
-  re-reads the now-current ledger, recomputes, and retries (bounded, with
-  jittered backoff) instead of silently succeeding with a stale, already-
-  claimed number. Prints the reserved IDs one per line.
+  Reads the ledger **as of `origin/<base_branch>`**, builds a *ledger-only*
+  commit on that tip, and pushes it; on a rejected (non-fast-forward) push
+  it fetches, re-reads the now-current ledger, recomputes, and retries
+  (bounded, with jittered backoff) instead of silently succeeding with a
+  stale, already-claimed number. Prints the reserved IDs one per line.
+
+  **The reservation never touches local history.** The candidate commit is
+  assembled with git plumbing in a throwaway index, so no attempt mutates
+  the local branch, index or working tree, and the push carries that one
+  commit (`<sha>:refs/heads/<base>`) rather than `HEAD` — local-only
+  commits on the base branch are therefore neither published nor
+  destroyed. This is a fix for a real incident: the original implementation
+  committed on top of `HEAD`, pushed the whole branch, and ran
+  `git reset --hard origin/<base_branch>` on a lost race, silently eating
+  two unpushed commits and still exiting 0. After a successful push the
+  local branch is fast-forwarded onto the reservation as a convenience; if
+  it carries unpushed commits the fast-forward is skipped and a warning
+  tells you to reconcile with `git pull --no-rebase`.
 - **`scripts/sdd/check_id_collisions.py`** — an independent, read-only
   defense-in-depth backstop (no dependency on the ledger/allocator): scans
   `sdd/tasks/index/*.json`, `sdd/tasks/active/*.md`, and

--- a/tests/sdd_scripts/test_reserve_ids.py
+++ b/tests/sdd_scripts/test_reserve_ids.py
@@ -13,6 +13,19 @@ def _git(args: list[str], cwd: Path) -> None:
     subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
 
 
+def _dirty_tracked_file(clone: Path, name: str) -> None:
+    """Commit ``name``, then modify it — an uncommitted change to a TRACKED
+    file, which is what the dirty-tree guard exists to catch. Untracked
+    files are deliberately ignored by it (see
+    ``test_reserve_ids_ignores_untracked_files``).
+    """
+    (clone / name).write_text("committed\n", encoding="utf-8")
+    _git(["add", name], clone)
+    _git(["commit", "-m", f"add {name}"], clone)
+    _git(["push", "origin", "dev"], clone)
+    (clone / name).write_text("dirty\n", encoding="utf-8")
+
+
 @pytest.fixture
 def bare_remote_and_clone(tmp_path: Path):
     """A throwaway bare git 'origin' plus one clone, standing in for the
@@ -169,13 +182,23 @@ class TestReserveIds:
     ) -> None:
         """The library function itself (not just the CLI) must refuse a dirty tree."""
         remote, clone = bare_remote_and_clone
-        (clone / "unrelated.txt").write_text("dirty\n", encoding="utf-8")
+        _dirty_tracked_file(clone, "unrelated.txt")
 
         with pytest.raises(IdReservationError, match="uncommitted changes"):
             reserve_ids("task", 1, "dev", "feature-f", repo_root=clone)
 
         ledger = load_ledger(clone / LEDGER_PATH)
         assert ledger.next_task_id == 1000
+
+    def test_reserve_ids_ignores_untracked_files(self, bare_remote_and_clone) -> None:
+        """Untracked files never block a reservation — nothing here can clobber them."""
+        remote, clone = bare_remote_and_clone
+        (clone / "scratch.txt").write_text("untracked\n", encoding="utf-8")
+
+        reservation = reserve_ids("task", 1, "dev", "feature-i", repo_root=clone)
+
+        assert reservation.ids == ["TASK-1000"]
+        assert (clone / "scratch.txt").read_text(encoding="utf-8") == "untracked\n"
 
     def test_reserve_ids_refuses_on_branch_mismatch(
         self, bare_remote_and_clone
@@ -206,10 +229,142 @@ class TestReserveIdsCli:
     ) -> None:
         remote, clone = bare_remote_and_clone
         monkeypatch.chdir(clone)
-        (clone / "unrelated.txt").write_text("dirty\n", encoding="utf-8")
+        _dirty_tracked_file(clone, "unrelated.txt")
 
         exit_code = main(["--kind", "task", "--count", "1", "--base-branch", "dev", "--label", "cli-test"])
 
         assert exit_code == 1
         err = capsys.readouterr().err
         assert "refusing to run" in err
+
+
+class TestReserveIdsNeverDestroysLocalWork:
+    """Regression tests for the FEAT-387 allocator's destructive retry path.
+
+    ``reserve_ids()`` used to commit on top of whatever local HEAD it found
+    and push the WHOLE branch (``HEAD:<base>``); on a lost race it ran
+    ``git reset --hard origin/<base>``, which silently discarded every
+    local-only commit on the base branch and still exited 0. The
+    reservation must be a compare-and-swap against ``origin/<base>``
+    alone — it must never publish, and never destroy, unrelated local
+    commits.
+    """
+
+    @staticmethod
+    def _add_local_commit(clone: Path, name: str) -> str:
+        """Commit an unpushed, unrelated change and return its sha."""
+        (clone / name).write_text("local work\n", encoding="utf-8")
+        _git(["add", name], clone)
+        _git(["commit", "-m", f"local work: {name}"], clone)
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=clone,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+
+    @staticmethod
+    def _remote_shas(remote: Path, branch: str = "dev") -> list[str]:
+        result = subprocess.run(
+            ["git", "rev-list", branch],
+            cwd=remote,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.split()
+
+    def test_losing_the_race_preserves_unpushed_local_commits(
+        self, bare_remote_and_clone, tmp_path: Path
+    ) -> None:
+        """A rejected push must not discard local-only commits on the base branch."""
+        remote, clone_a = bare_remote_and_clone
+        clone_b = tmp_path / "clone_b"
+        subprocess.run(
+            ["git", "clone", str(remote), str(clone_b)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        _git(["config", "user.email", "test-b@example.com"], clone_b)
+        _git(["config", "user.name", "Test B"], clone_b)
+
+        # clone_b carries two unpushed commits of real work on dev.
+        first_sha = self._add_local_commit(clone_b, "work_one.txt")
+        second_sha = self._add_local_commit(clone_b, "work_two.txt")
+
+        # clone_a wins the race, making clone_b's view of the ledger stale.
+        reserve_ids("task", 2, "dev", "feature-a", repo_root=clone_a)
+
+        sleeps: list[float] = []
+        reservation_b = reserve_ids(
+            "task",
+            2,
+            "dev",
+            "feature-b",
+            repo_root=clone_b,
+            sleep_fn=sleeps.append,
+        )
+
+        assert reservation_b.ids == ["TASK-1002", "TASK-1003"]
+        assert len(sleeps) >= 1, "expected the stale clone to lose a race first"
+
+        # Both local commits must still be reachable from clone_b's HEAD.
+        log = subprocess.run(
+            ["git", "rev-list", "HEAD"],
+            cwd=clone_b,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.split()
+        assert first_sha in log
+        assert second_sha in log
+        assert (clone_b / "work_one.txt").exists()
+        assert (clone_b / "work_two.txt").exists()
+
+    def test_reservation_does_not_publish_unpushed_local_commits(
+        self, bare_remote_and_clone
+    ) -> None:
+        """The ledger push must carry the ledger commit only, never local work."""
+        remote, clone = bare_remote_and_clone
+        local_sha = self._add_local_commit(clone, "unpublished.txt")
+
+        reservation = reserve_ids("task", 1, "dev", "feature-h", repo_root=clone)
+
+        assert reservation.ids == ["TASK-1000"]
+        assert local_sha not in self._remote_shas(remote), (
+            "reserve_ids published an unrelated local commit to origin/dev"
+        )
+        # …and the reservation itself still landed on the remote.
+        remote_ledger = subprocess.run(
+            ["git", "show", "dev:" + str(LEDGER_PATH)],
+            cwd=remote,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        assert '"next_task_id": 1001' in remote_ledger
+
+    def test_unpushable_local_branch_is_left_alone_with_a_warning(
+        self, bare_remote_and_clone, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Local commits block the courtesy fast-forward — warn, never rewrite."""
+        remote, clone = bare_remote_and_clone
+        local_sha = self._add_local_commit(clone, "in_progress.txt")
+
+        reserve_ids("task", 1, "dev", "feature-j", repo_root=clone)
+
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=clone,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        assert head == local_sha, "local branch was moved despite unpushed commits"
+
+        err = capsys.readouterr().err
+        assert "could not be fast-forwarded" in err
+        assert "your local commits are intact" in err.lower()

--- a/tests/sdd_scripts/test_reserve_ids.py
+++ b/tests/sdd_scripts/test_reserve_ids.py
@@ -78,6 +78,16 @@ class TestReserveIds:
         ledger = load_ledger(clone / LEDGER_PATH)
         assert ledger.next_task_id == 1003
 
+        # …and the reservation is only real if it landed on the remote.
+        remote_ledger = subprocess.run(
+            ["git", "show", "dev:" + str(LEDGER_PATH)],
+            cwd=remote,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        assert '"next_task_id": 1003' in remote_ledger
+
     def test_reserve_ids_retries_on_non_fast_forward(
         self, bare_remote_and_clone, tmp_path: Path
     ) -> None:
@@ -134,7 +144,8 @@ class TestReserveIds:
 
         monkeypatch.setattr(subprocess, "run", _fake_run)
 
-        with pytest.raises(IdReservationError):
+        sleeps: list[float] = []
+        with pytest.raises(IdReservationError, match="after 2 attempts"):
             reserve_ids(
                 "task",
                 1,
@@ -142,8 +153,12 @@ class TestReserveIds:
                 "feature-c",
                 repo_root=clone,
                 max_retries=2,
-                sleep_fn=lambda _seconds: None,
+                sleep_fn=sleeps.append,
             )
+        # Without the `match` and this assertion the test also passes when
+        # the rejection is misclassified as non-retryable and attempt 0
+        # raises immediately — i.e. when the retry loop is entirely broken.
+        assert len(sleeps) == 2
 
     def test_reserve_ids_commit_touches_only_ledger(
         self, bare_remote_and_clone
@@ -368,3 +383,162 @@ class TestReserveIdsNeverDestroysLocalWork:
         err = capsys.readouterr().err
         assert "could not be fast-forwarded" in err
         assert "your local commits are intact" in err.lower()
+
+    def test_reservation_works_without_a_remote_tracking_ref(
+        self, bare_remote_and_clone
+    ) -> None:
+        """A missing origin/<base> ref must be fetched, not guessed at."""
+        remote, clone = bare_remote_and_clone
+        _git(["update-ref", "-d", "refs/remotes/origin/dev"], clone)
+
+        reservation = reserve_ids("task", 1, "dev", "feature-k", repo_root=clone)
+
+        assert reservation.ids == ["TASK-1000"]
+        tracking = subprocess.run(
+            ["git", "rev-parse", "refs/remotes/origin/dev"],
+            cwd=clone,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        remote_tip = subprocess.run(
+            ["git", "rev-parse", "dev"],
+            cwd=remote,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        assert tracking == remote_tip
+
+
+class TestReserveIdsRobustness:
+    """Findings from an adversarial review of the plumbing rewrite."""
+
+    def test_second_allocation_in_same_clone_does_not_burn_a_retry(
+        self, bare_remote_and_clone
+    ) -> None:
+        """Back-to-back reservations must not each lose a race to themselves.
+
+        `git push <sha>:refs/heads/<base>` and `git merge --ff-only` leave
+        `refs/remotes/origin/<base>` where it was, so the next call's first
+        attempt would build on a tip the remote has already moved past —
+        wasting an attempt every time, and failing outright at
+        `max_retries=1`.
+        """
+        remote, clone = bare_remote_and_clone
+        reserve_ids("task", 1, "dev", "first", repo_root=clone)
+
+        sleeps: list[float] = []
+        second = reserve_ids(
+            "task", 1, "dev", "second", repo_root=clone, max_retries=1,
+            sleep_fn=sleeps.append,
+        )
+
+        assert second.ids == ["TASK-1001"]
+        assert sleeps == [], "the second allocation raced against its own push"
+
+    def test_non_retryable_push_failure_aborts_immediately(
+        self, bare_remote_and_clone, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An auth/hook failure must fail loudly, never burn the retry budget."""
+        remote, clone = bare_remote_and_clone
+        original_run = subprocess.run
+        pushes = 0
+
+        class _AuthFailure:
+            returncode = 128
+            stdout = ""
+            stderr = "remote: Permission to org/repo denied\nfatal: unable to access\n"
+
+        def _fake_run(args, *a, **kw):
+            nonlocal pushes
+            if args[:2] == ["git", "push"]:
+                pushes += 1
+                return _AuthFailure()
+            return original_run(args, *a, **kw)
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+
+        with pytest.raises(IdReservationError, match="other than a non-fast-forward"):
+            reserve_ids(
+                "task", 1, "dev", "feature-l", repo_root=clone,
+                max_retries=5, sleep_fn=lambda _s: None,
+            )
+
+        assert pushes == 1, "a non-retryable failure was retried"
+
+    def test_reservation_preserves_every_other_file_in_the_tree(
+        self, bare_remote_and_clone
+    ) -> None:
+        """The plumbing-built tree must carry the whole base tree, not just the ledger."""
+        remote, clone = bare_remote_and_clone
+        (clone / "keep_me.py").write_text("print('hi')\n", encoding="utf-8")
+        _git(["add", "keep_me.py"], clone)
+        _git(["commit", "-m", "add keep_me.py"], clone)
+        _git(["push", "origin", "dev"], clone)
+
+        reserve_ids("task", 1, "dev", "feature-m", repo_root=clone)
+
+        tree = subprocess.run(
+            ["git", "ls-tree", "-r", "--name-only", "dev"],
+            cwd=remote,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.split()
+        assert "keep_me.py" in tree
+        assert str(LEDGER_PATH) in tree
+
+    def test_lost_race_is_detected_under_a_non_english_locale(
+        self, bare_remote_and_clone, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Retry detection parses git's output, so it must not depend on LANG."""
+        remote, clone_a = bare_remote_and_clone
+        clone_b = tmp_path / "clone_b"
+        subprocess.run(
+            ["git", "clone", str(remote), str(clone_b)],
+            check=True, capture_output=True, text=True,
+        )
+        _git(["config", "user.email", "test-b@example.com"], clone_b)
+        _git(["config", "user.name", "Test B"], clone_b)
+
+        monkeypatch.setenv("LC_ALL", "es_ES.UTF-8")
+        monkeypatch.setenv("LANG", "es_ES.UTF-8")
+        monkeypatch.setenv("LANGUAGE", "es")
+
+        reserve_ids("task", 1, "dev", "feature-a", repo_root=clone_a)
+
+        sleeps: list[float] = []
+        reservation = reserve_ids(
+            "task", 1, "dev", "feature-b", repo_root=clone_b, sleep_fn=sleeps.append,
+        )
+
+        assert reservation.ids == ["TASK-1001"]
+        assert len(sleeps) >= 1
+
+    def test_corrupt_remote_ledger_raises_a_clean_error(
+        self, bare_remote_and_clone
+    ) -> None:
+        """A malformed ledger must not surface as a Pydantic traceback."""
+        remote, clone = bare_remote_and_clone
+        (clone / LEDGER_PATH).write_text('{"next_task_id": "boom"}\n', encoding="utf-8")
+        _git(["add", str(LEDGER_PATH)], clone)
+        _git(["commit", "-m", "corrupt the ledger"], clone)
+        _git(["push", "origin", "dev"], clone)
+
+        with pytest.raises(IdReservationError, match="not a valid ledger"):
+            reserve_ids("task", 1, "dev", "feature-n", repo_root=clone)
+
+    def test_git_timeout_surfaces_as_a_reservation_error(
+        self, bare_remote_and_clone, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A stalled git call must raise this module's error, not TimeoutExpired."""
+        remote, clone = bare_remote_and_clone
+
+        def _timeout(args, *a, **kw):
+            raise subprocess.TimeoutExpired(cmd=args, timeout=30.0)
+
+        monkeypatch.setattr(subprocess, "run", _timeout)
+
+        with pytest.raises(IdReservationError, match="timed out"):
+            reserve_ids("task", 1, "dev", "feature-o", repo_root=clone)


### PR DESCRIPTION
## The bug

`reserve_ids()` (FEAT-387, called by `/sdd-task` and `/sdd-spec`) committed its ledger update **on top of local HEAD** and pushed the **whole branch** (`HEAD:<base>`). On a lost race it ran:

```
git reset --hard HEAD~1
git reset --hard origin/<base_branch>
```

…which silently discarded **every local-only commit on the base branch** — and still exited 0.

Its docstring declared the precondition ("this function's own commit must be the ONLY local commit ahead of `origin/<base>`") but nothing enforced it: `_assert_safe_to_reserve()` only checked for a dirty tree and the branch name, and `/sdd-task`'s `git pull --ff-only` is a no-op when local is *ahead*. Two real commits were lost this way.

The same `HEAD:<base>` push also **published** local commits the user had not chosen to push.

## The fix

The reservation is now a compare-and-swap against `origin/<base>` **alone**:

- The candidate commit is assembled with git plumbing (`hash-object` / `read-tree` / `write-tree` / `commit-tree`) in a **throwaway index** (`GIT_INDEX_FILE`) and pushed **by sha** (`<sha>:refs/heads/<base>`).
- No attempt mutates the local branch, index or working tree. **No code path runs `git reset`.** A lost race now costs one dangling object.
- After a successful push the local branch is fast-forwarded as a convenience; when it can't be (unpushed local commits) it is left untouched with a warning pointing at `git pull --no-rebase`.

## Hardening (from an adversarial review pass)

- Base tip resolved from `refs/remotes/origin/<base>` via an explicit refspec instead of `FETCH_HEAD` — `FETCH_HEAD` is one per-worktree file, so a concurrent `git fetch` of another branch in the same checkout could hand the allocator an unrelated tip, which it would then push onto `<base>`.
- `subprocess.TimeoutExpired` → `IdReservationError` (contract said every failure is an `IdReservationError`).
- `ValidationError` on a malformed ledger → `IdReservationError` instead of a raw traceback.
- `LC_ALL=C` for git calls whose output is parsed. Not currently load-bearing — verified under a fully installed `es_ES.UTF-8` with `LANGUAGE=es` that git translates the advice text (`ayuda:`) but leaves `! [rejected] ... (fetch first)` English — but it removes the dependency on that holding in future git versions.

Findings deliberately **not** adopted: relaxing the branch guard for detached HEAD (CI never allocates IDs; the guard exists to stop worktree misuse), the `--cacheinfo` 3-arg form (no behavioral difference), and `core.quotePath` porcelain parsing (the ledger path is ASCII and never quoted — it can only affect error-message text).

## Tests

`tests/sdd_scripts/` — **88 passed**. New coverage: unpushed local commits survive a lost race; they are never pushed; the un-fast-forwardable branch is left alone with a warning; back-to-back allocations in one clone; a non-retryable push failure aborting without retries; whole-tree preservation by the plumbing-built commit; lost-race detection under a non-English locale; a missing remote-tracking ref; a corrupt ledger; a git timeout.

Also repairs three weak tests the review caught:
- `test_reserve_ids_raises_after_max_retries` passed even when the retry loop never ran (no `match=`, no sleep assertion).
- `test_reserve_ids_happy_path` never checked that the reservation reached the remote.
- Two dirty-tree tests asserted the pre-`01b8d7b53` behavior using an *untracked* file, which the guard deliberately ignores — they were failing on `dev` before this branch. Now they modify a tracked file, and a new test pins that untracked files are ignored.

Docs updated: `sdd/WORKFLOW.md`, `.claude/commands/sdd-task.md`, `.claude/commands/sdd-spec.md` (also fixes a stale `reserve_ids.py:140` line reference), `.claude/commands/remove-worktree.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)