### PR TITLE
mcp: Streamable HTTP transport (Claude.ai-compatible) + protocol negotiation

### DIFF
--- a/packages/ai-parrot-server/pyproject.toml
+++ b/packages/ai-parrot-server/pyproject.toml
@@ -116,6 +116,7 @@ markers = [
     "wheel_build: requires building the wheel (slow, needs uv)",
     "requires_apscheduler: requires the scheduler extra (apscheduler)",
     "requires_aioquic: requires the mcp extra (aioquic)",
+    "requires_mcp_sdk: requires the official mcp SDK (mcp extra)",
     "live: hits live external services; opt-in, deselect with -m 'not live'",
 ]
 

--- a/packages/ai-parrot-server/src/parrot/mcp/config.py
+++ b/packages/ai-parrot-server/src/parrot/mcp/config.py
@@ -63,13 +63,25 @@ class MCPServerConfig:
     events_path: Optional[str] = None
 
     # Streamable HTTP transport settings
-    # Origins allowed on the /mcp endpoint (DNS-rebinding protection).
-    # None = allow any origin; localhost is always allowed.
+    # Browser origins allowed on the /mcp endpoint (DNS-rebinding
+    # protection, mandatory per the MCP spec). Localhost is always allowed
+    # and requests without an Origin header (server-to-server clients such
+    # as Claude.ai) are unaffected; any other origin must be listed here.
     allowed_origins: Optional[List[str]] = None
+    # Escape hatch: skip Origin validation entirely. Only for deployments
+    # already fronted by a proxy that performs the same check.
+    allow_any_origin: bool = False
     # Idle seconds before an Mcp-Session-Id session expires.
     session_ttl: int = 3600
-    # Max buffered SSE events per session (Last-Event-ID resumability window).
+    # Max buffered SSE events per stream (Last-Event-ID resumability window).
     event_buffer_size: int = 1000
+    # Max concurrent sessions; further initialize calls are refused with 503
+    # rather than growing memory without bound.
+    max_sessions: int = 1000
+    # Max SSE streams retained per session. Each request-bearing SSE POST
+    # opens one; beyond the cap the least useful are evicted so a busy
+    # session cannot accumulate buffers for the whole of its TTL.
+    max_streams_per_session: int = 64
     
     # For Future gRPC implementation (expected)
     grpc_host: Optional[str] = None
@@ -97,10 +109,14 @@ class MCPServerConfig:
 class TransportConfig:
     """Configuration for a single MCP transport (used by ParrotMCPServer)."""
 
-    transport: str  # "stdio" or "http" or "sse" or "unix"
+    transport: str  # "stdio", "http", "streamable-http", "sse", "unix", "quic"
     enabled: bool = True
     host: Optional[str] = None  # Only for HTTP
     port: Optional[int] = None  # Only for HTTP
     url: Optional[str] = None  # Only for HTTP/SSE transport
     name_suffix: Optional[str] = None  # e.g., "local" or "remote"
     socket_path: Optional[str] = None  # Only for UNIX socket transport
+    # Route prefix for HTTP-like transports on a shared app. Two HTTP-like
+    # transports cannot share one; set distinct paths to run e.g. http and
+    # streamable-http side by side. None = MCPServerConfig.base_path.
+    base_path: Optional[str] = None

--- a/packages/ai-parrot-server/src/parrot/mcp/config.py
+++ b/packages/ai-parrot-server/src/parrot/mcp/config.py
@@ -20,7 +20,10 @@ class MCPServerConfig:
     description: str = "AI-Parrot Tools via MCP Protocol"
 
     # Server settings
-    transport: str = "stdio"  # "stdio" or "http" or "unix"
+    # "stdio", "http", "streamable-http", "sse", "unix" or "quic".
+    # Use "streamable-http" for MCP Streamable HTTP (2025-03-26) clients
+    # such as Claude.ai custom connectors.
+    transport: str = "stdio"
     host: str = "localhost"
     port: int = 8080
     socket_path: Optional[str] = None  # For UNIX socket transport
@@ -58,6 +61,15 @@ class MCPServerConfig:
     base_path: str = "/mcp"
     # custom events path for SSE (optional)
     events_path: Optional[str] = None
+
+    # Streamable HTTP transport settings
+    # Origins allowed on the /mcp endpoint (DNS-rebinding protection).
+    # None = allow any origin; localhost is always allowed.
+    allowed_origins: Optional[List[str]] = None
+    # Idle seconds before an Mcp-Session-Id session expires.
+    session_ttl: int = 3600
+    # Max buffered SSE events per session (Last-Event-ID resumability window).
+    event_buffer_size: int = 1000
     
     # For Future gRPC implementation (expected)
     grpc_host: Optional[str] = None

--- a/packages/ai-parrot-server/src/parrot/mcp/parrot_server.py
+++ b/packages/ai-parrot-server/src/parrot/mcp/parrot_server.py
@@ -16,7 +16,13 @@ from parrot.conf import (
     MCP_SERVER_TRANSPORT,
     MCP_STARTED_TOOLS,
 )
-from parrot.mcp.server import MCPServer, MCPServerConfig, HttpMCPServer, SseMCPServer
+from parrot.mcp.server import (
+    MCPServer,
+    MCPServerConfig,
+    HttpMCPServer,
+    SseMCPServer,
+    StreamableHttpMCPServer,
+)
 from parrot.tools.abstract import AbstractTool
 from parrot.tools.toolkit import AbstractToolkit
 from parrot.mcp.config import TransportConfig
@@ -70,11 +76,13 @@ class ParrotMCPServer:
 
         configs = {}
 
+        http_like = {"http", "streamable-http", "streamable_http", "sse"}
+
         if isinstance(transports, str):
-            # Single transport string: "stdio" or "http"
+            # Single transport string: "stdio", "http", "streamable-http", ...
             transport = transports.lower()
-            host = default_host or MCP_SERVER_HOST if transport in {"http", "sse"} else None
-            port = default_port or MCP_SERVER_PORT if transport in {"http", "sse"} else None
+            host = default_host or MCP_SERVER_HOST if transport in http_like else None
+            port = default_port or MCP_SERVER_PORT if transport in http_like else None
             configs[transport] = TransportConfig(
                 transport=transport,
                 host=host,
@@ -85,7 +93,7 @@ class ParrotMCPServer:
             # List of transport names: ["stdio", "http"]
             for i, transport in enumerate(transports):
                 transport = transport.lower()
-                is_http_like = transport in {"http", "sse"}
+                is_http_like = transport in http_like
                 port = ((default_port or MCP_SERVER_PORT) + i) if is_http_like else None
                 configs[transport] = TransportConfig(
                     transport=transport,
@@ -156,12 +164,37 @@ class ParrotMCPServer:
                 self._server_tasks[transport_key] = asyncio.create_task(start_coro)
                 self.logger.info("Spawned stdio MCP server task: %s", server_name)
 
-            elif config.transport in {"http", "sse"}:
-                # Launch HTTP/SSE MCP server using existing aiohttp app
+            elif config.transport in {
+                "http", "streamable-http", "streamable_http", "sse"
+            }:
+                # Launch HTTP-like MCP server using existing aiohttp app
                 if config.transport == "sse":
                     server = SseMCPServer(mcp_config, parent_app=app)
+                elif config.transport in {"streamable-http", "streamable_http"}:
+                    server = StreamableHttpMCPServer(mcp_config, parent_app=app)
                 else:
                     server = HttpMCPServer(mcp_config, parent_app=app)
+
+                # http and streamable-http both claim POST {base_path}; two
+                # servers on one shared app would crash aiohttp with a
+                # duplicate-route error.
+                base_path = mcp_config.base_path
+                if any(
+                    getattr(existing, "config", None)
+                    and getattr(existing.config, "base_path", None) == base_path
+                    and existing.config.transport in {
+                        "http", "streamable-http", "streamable_http", "sse"
+                    }
+                    for existing in self.servers.values()
+                ):
+                    self.logger.error(
+                        "Skipping MCP transport %r: base_path %r already "
+                        "claimed by another HTTP-like transport",
+                        config.transport,
+                        base_path,
+                    )
+                    continue
+
                 server.register_tools(tools)
                 self.servers[transport_key] = server
 

--- a/packages/ai-parrot-server/src/parrot/mcp/parrot_server.py
+++ b/packages/ai-parrot-server/src/parrot/mcp/parrot_server.py
@@ -27,6 +27,16 @@ from parrot.tools.abstract import AbstractTool
 from parrot.tools.toolkit import AbstractToolkit
 from parrot.mcp.config import TransportConfig
 
+#: Transport names that speak Streamable HTTP (2025-03-26).
+STREAMABLE_TRANSPORTS: frozenset[str] = frozenset(
+    {"streamable-http", "streamable_http"}
+)
+#: Transports served over the shared aiohttp application. They all claim
+#: ``POST {base_path}``, so no two of them may share a base_path.
+HTTP_LIKE_TRANSPORTS: frozenset[str] = frozenset(
+    {"http", "sse"} | STREAMABLE_TRANSPORTS
+)
+
 
 class ParrotMCPServer:
     """Manage lifecycle of multiple MCP servers (multi-transport) attached to an aiohttp app."""
@@ -76,7 +86,7 @@ class ParrotMCPServer:
 
         configs = {}
 
-        http_like = {"http", "streamable-http", "streamable_http", "sse"}
+        http_like = HTTP_LIKE_TRANSPORTS
 
         if isinstance(transports, str):
             # Single transport string: "stdio", "http", "streamable-http", ...
@@ -108,6 +118,34 @@ class ParrotMCPServer:
 
         return configs
 
+    def _check_base_path_conflicts(self) -> None:
+        """Refuse two HTTP-like transports that would claim the same path.
+
+        They all register ``POST {base_path}``. aiohttp accepts the duplicate
+        silently and routes it to whichever was registered first, so the
+        second transport's semantics (session ids, SSE, DELETE) would vanish
+        without a trace. Checked up front, before any server is constructed —
+        ``SseMCPServer`` registers its routes in ``__init__``, so a check
+        made while starting would already be too late.
+
+        Raises:
+            ValueError: If two enabled HTTP-like transports share a path.
+        """
+        claimed: Dict[str, str] = {}
+        default_base_path = MCPServerConfig().base_path
+        for transport_key, config in self.transport_configs.items():
+            if not config.enabled or config.transport not in HTTP_LIKE_TRANSPORTS:
+                continue
+            base_path = config.base_path or default_base_path
+            owner = claimed.get(base_path)
+            if owner is not None:
+                raise ValueError(
+                    f"MCP transport {transport_key!r} cannot share base_path "
+                    f"{base_path!r} with transport {owner!r}. Give one of them "
+                    f"a distinct path via TransportConfig(base_path=...)."
+                )
+            claimed[base_path] = transport_key
+
     def setup(self, app: web.Application) -> None:
         """Register lifecycle hooks inside the aiohttp application."""
         self.app = app
@@ -120,6 +158,11 @@ class ParrotMCPServer:
 
     async def on_startup(self, app: web.Application) -> None:  # pylint: disable=unused-argument
         """Start the MCP server once aiohttp finishes bootstrapping."""
+        # Validate the whole transport set before starting anything, so a
+        # misconfiguration cannot leave half the transports mounted with
+        # background tasks running.
+        self._check_base_path_conflicts()
+
         tools = await self._load_configured_tools()
         if not tools:
             self.logger.info("No MCP tools configured to start")
@@ -141,6 +184,7 @@ class ParrotMCPServer:
                 host=config.host,
                 port=config.port,
                 log_level=self.log_level,
+                **({"base_path": config.base_path} if config.base_path else {}),
             )
 
             # Ensure MCP endpoints bypass the auth middleware (uses AuthHandler.exclude_list)
@@ -164,36 +208,14 @@ class ParrotMCPServer:
                 self._server_tasks[transport_key] = asyncio.create_task(start_coro)
                 self.logger.info("Spawned stdio MCP server task: %s", server_name)
 
-            elif config.transport in {
-                "http", "streamable-http", "streamable_http", "sse"
-            }:
+            elif config.transport in HTTP_LIKE_TRANSPORTS:
                 # Launch HTTP-like MCP server using existing aiohttp app
                 if config.transport == "sse":
                     server = SseMCPServer(mcp_config, parent_app=app)
-                elif config.transport in {"streamable-http", "streamable_http"}:
+                elif config.transport in STREAMABLE_TRANSPORTS:
                     server = StreamableHttpMCPServer(mcp_config, parent_app=app)
                 else:
                     server = HttpMCPServer(mcp_config, parent_app=app)
-
-                # http and streamable-http both claim POST {base_path}; two
-                # servers on one shared app would crash aiohttp with a
-                # duplicate-route error.
-                base_path = mcp_config.base_path
-                if any(
-                    getattr(existing, "config", None)
-                    and getattr(existing.config, "base_path", None) == base_path
-                    and existing.config.transport in {
-                        "http", "streamable-http", "streamable_http", "sse"
-                    }
-                    for existing in self.servers.values()
-                ):
-                    self.logger.error(
-                        "Skipping MCP transport %r: base_path %r already "
-                        "claimed by another HTTP-like transport",
-                        config.transport,
-                        base_path,
-                    )
-                    continue
 
                 server.register_tools(tools)
                 self.servers[transport_key] = server

--- a/packages/ai-parrot-server/src/parrot/mcp/server.py
+++ b/packages/ai-parrot-server/src/parrot/mcp/server.py
@@ -20,6 +20,7 @@ from parrot.mcp.config import MCPServerConfig
 from parrot.mcp.transports.stdio import StdioMCPServer
 from parrot.mcp.transports.http import HttpMCPServer
 from parrot.mcp.transports.sse import SseMCPServer
+from parrot.mcp.transports.streamable_http import StreamableHttpMCPServer
 from parrot.mcp.transports.unix import UnixMCPServer
 # QUIC lives behind the optional `ai-parrot-server[mcp]` extra (aioquic);
 # resolved lazily so a bare install can still use the other transports.
@@ -42,6 +43,8 @@ class MCPServer:
             self.server = StdioMCPServer(config)
         elif config.transport == "http":
             self.server = HttpMCPServer(config, parent_app=parent_app)
+        elif config.transport in {"streamable-http", "streamable_http"}:
+            self.server = StreamableHttpMCPServer(config, parent_app=parent_app)
         elif config.transport == "sse":
             self.server = SseMCPServer(config, parent_app=parent_app)
         elif config.transport == "unix":
@@ -127,6 +130,30 @@ def create_http_mcp_server(
 
     return server
 
+def create_streamable_http_mcp_server(
+    name: str = "ai-parrot-tools",
+    host: str = "localhost",
+    port: int = 8080,
+    tools: Optional[List[AbstractTool]] = None,
+    parent_app: Optional[web.Application] = None,
+    **kwargs,
+) -> MCPServer:
+    """Create a Streamable HTTP MCP server (Claude.ai-compatible)."""
+    config = MCPServerConfig(
+        name=name,
+        transport="streamable-http",
+        host=host,
+        port=port,
+        **kwargs,
+    )
+
+    server = MCPServer(config, parent_app=parent_app)
+    if tools:
+        server.register_tools(tools)
+
+    return server
+
+
 def create_sse_mcp_server(
     name: str = "ai-parrot-tools",
     host: str = "localhost",
@@ -176,7 +203,9 @@ async def main():
     parser = argparse.ArgumentParser(
         description="AI-Parrot MCP Server"
     )
-    parser.add_argument("--transport", choices=["stdio", "http", "sse"], default="stdio",
+    parser.add_argument("--transport",
+                        choices=["stdio", "http", "streamable-http", "sse"],
+                        default="stdio",
                         help="Transport type")
     parser.add_argument("--host", default="localhost",
                         help="Host for HTTP server")
@@ -206,7 +235,7 @@ async def main():
     # server.register_tool(YourDatabaseQueryTool())
 
     try:
-        if args.transport in {"http", "sse"}:
+        if args.transport in {"http", "streamable-http", "sse"}:
             await server.start()
             print(f"Server running at http://{args.host}:{args.port}")
             print("Press Ctrl+C to stop")

--- a/packages/ai-parrot-server/src/parrot/mcp/transports/base.py
+++ b/packages/ai-parrot-server/src/parrot/mcp/transports/base.py
@@ -146,7 +146,9 @@ class RemoteMCPServerBase(_CoreMCPServerBase):
 
         elif auth_method == AuthMethod.OAUTH2_INTERNAL:
             self.oauth_server = OAuthAuthorizationServer(
-                default_scopes=self.config.oauth_scopes,
+                # MCPServerConfig spells this `oauth_scope`; the plural
+                # raised AttributeError, making OAUTH2_INTERNAL unusable.
+                default_scopes=self.config.oauth_scope,
                 allow_dynamic_registration=self.config.oauth_allow_dynamic_registration,
                 token_ttl=self.config.oauth_token_ttl,
                 code_ttl=self.config.oauth_code_ttl,

--- a/packages/ai-parrot-server/src/parrot/mcp/transports/http.py
+++ b/packages/ai-parrot-server/src/parrot/mcp/transports/http.py
@@ -48,9 +48,8 @@ class HttpMCPServer(OAuthRoutesMixin, RemoteMCPServerBase):
         base_route = self.config.base_path
         if not base_route or base_route == "/":
             base_route = "/"
-            
-        target_router.add_post(base_route, self._handle_http_request)
-        target_router.add_get(f"{base_route.rstrip('/')}/info", self._handle_info)
+
+        self._register_routes(target_router, base_route)
 
         if self.config.enable_oauth:
             self._add_oauth_routes(target_router)
@@ -87,6 +86,19 @@ class HttpMCPServer(OAuthRoutesMixin, RemoteMCPServerBase):
                 ssl_context=ssl_context
             )
             await self.site.start()
+
+    def _register_routes(self, router, base_route: str) -> None:
+        """Register the transport's HTTP routes.
+
+        Subclasses override this to change the route set without duplicating
+        the parent-app/sub-app/standalone mounting logic in ``start()``.
+
+        Args:
+            router: The aiohttp router to register routes on.
+            base_route: Normalized base path (never empty; ``/`` for root).
+        """
+        router.add_post(base_route, self._handle_http_request)
+        router.add_get(f"{base_route.rstrip('/')}/info", self._handle_info)
 
     async def stop(self):
         """Stop the HTTP server."""
@@ -197,6 +209,10 @@ class HttpMCPSession:
         self._base_headers = {}
         # OAuth2 provider (set when config.oauth2 is configured)
         self._oauth2_provider = None
+        # Streamable HTTP session state (captured from the initialize
+        # response when the server issues them)
+        self._mcp_session_id: Optional[str] = None
+        self._protocol_version: Optional[str] = None
 
     async def _setup_oauth2(self) -> None:
         """Set up MCP SDK OAuth2 provider when config.oauth2 is configured.
@@ -357,6 +373,9 @@ class HttpMCPSession:
                 "capabilities": {"tools": {}},
                 "clientInfo": {"name": "ai-parrot-mcp-client", "version": "1.0.0"}
             })
+            negotiated = (init_result or {}).get("protocolVersion")
+            if negotiated:
+                self._protocol_version = negotiated
 
             # Send initialized notification
             await self._send_notification("notifications/initialized")
@@ -377,11 +396,18 @@ class HttpMCPSession:
         try:
             self.logger.debug("HTTP sending: %s", json.dumps(request))
 
-            # Build per-request headers, injecting OAuth2 token when available
+            # Build per-request headers, injecting OAuth2 token when available.
+            # Accept advertises text/event-stream too — Streamable HTTP
+            # servers (e.g. Fireflies) return 406 without it. SSE response
+            # bodies are not parsed yet (see _read_json_response).
             req_headers: Dict[str, str] = {
                 "Content-Type": "application/json",
-                "Accept": "application/json",
+                "Accept": "application/json, text/event-stream",
             }
+            if self._mcp_session_id:
+                req_headers["Mcp-Session-Id"] = self._mcp_session_id
+            if self._protocol_version:
+                req_headers["MCP-Protocol-Version"] = self._protocol_version
             if self._oauth2_provider is not None:
                 token = await self._get_oauth2_token()
                 if token:
@@ -410,6 +436,21 @@ class HttpMCPSession:
                 if response.status != 200:
                     raise MCPConnectionError(f"HTTP error: {response.status}")
 
+                # Capture the Streamable HTTP session id issued on initialize
+                # and echo it on subsequent requests.
+                issued_session = response.headers.get("Mcp-Session-Id")
+                if issued_session:
+                    self._mcp_session_id = issued_session
+
+                content_type = response.headers.get("Content-Type", "")
+                if "text/event-stream" in content_type:
+                    # Parsing SSE POST responses is not implemented yet
+                    # (tracked in sdd/specs/netsuite-mcp-integration.spec.md).
+                    raise MCPConnectionError(
+                        "Server answered with an SSE stream; this client "
+                        "only supports application/json responses"
+                    )
+
                 response_data = await response.json()
                 self.logger.debug("HTTP received: %s", json.dumps(response_data))
 
@@ -434,14 +475,20 @@ class HttpMCPSession:
         try:
             self.logger.debug("HTTP notification: %s", json.dumps(notification))
 
+            notif_headers = {
+                "Content-Type": "application/json",
+                "Accept": "application/json, text/event-stream",
+            }
+            if self._mcp_session_id:
+                notif_headers["Mcp-Session-Id"] = self._mcp_session_id
+            if self._protocol_version:
+                notif_headers["MCP-Protocol-Version"] = self._protocol_version
+
             async with self._session.post(
                 self.config.url,
                 json=notification,
-                headers={
-                    "Content-Type": "application/json",
-                    "Accept": "application/json"
-                }
-            ) as response:
+                headers=notif_headers,
+            ):
                 # Notifications don't expect responses
                 pass
 
@@ -496,3 +543,5 @@ class HttpMCPSession:
 
         self._auth_handler = None
         self._base_headers.clear()
+        self._mcp_session_id = None
+        self._protocol_version = None

--- a/packages/ai-parrot-server/src/parrot/mcp/transports/http.py
+++ b/packages/ai-parrot-server/src/parrot/mcp/transports/http.py
@@ -28,21 +28,30 @@ class HttpMCPServer(OAuthRoutesMixin, RemoteMCPServerBase):
         self.runner = None
         self.site = None
         self.parent_app = parent_app
+        # Route prefix this server answers on. OAuthRoutesMixin._oauth_paths()
+        # reads it, so it must exist before any route registration.
+        self.base_path = config.base_path or "/"
 
         if config.enable_oauth:
             self._init_oauth_support()
 
     async def start(self):
-        """Start the HTTP server."""
-        # Determine strict router target
-        # If we have a parent app and base_path is root (empty or /), we attach directly
-        target_router = self.app.router
-        use_direct_attach = False
-        
-        if self.parent_app:
-            if not self.config.base_path or self.config.base_path == "/":
-                target_router = self.parent_app.router
-                use_direct_attach = True
+        """Start the HTTP server.
+
+        On a shared (parent) application the routes are registered directly on
+        the parent's router at ``base_path``. They used to be registered on
+        this server's own router at ``base_path`` *and* then mounted as a
+        sub-app at ``base_path`` too, which applied the prefix twice and
+        served the endpoint at ``/mcp/mcp`` — inconsistent with
+        ``SseMCPServer`` (which always attached directly) and outside the
+        auth-middleware exclusion list ``ParrotMCPServer`` registers.
+        """
+        # On a shared app, attach to the parent's router; standalone servers
+        # own self.app. Either way the routes carry the full base_path, so the
+        # endpoint is always reachable at exactly base_path.
+        target_router = (
+            self.parent_app.router if self.parent_app else self.app.router
+        )
 
         # Setup routes
         base_route = self.config.base_path
@@ -59,12 +68,7 @@ class HttpMCPServer(OAuthRoutesMixin, RemoteMCPServerBase):
         )
 
         if self.parent_app:
-            if not use_direct_attach:
-                # If running as sub-app with prefix, register the sub-app
-                self.parent_app.add_subapp(self.config.base_path, self.app)
-                self.logger.info("Mounted at %s", self.config.base_path)
-            else:
-                self.logger.info("Mounted at / (merged)")
+            self.logger.info("Mounted on the shared application at %s", base_route)
         else:
             # Run standalone
             self.runner = web.AppRunner(self.app)
@@ -398,8 +402,8 @@ class HttpMCPSession:
 
             # Build per-request headers, injecting OAuth2 token when available.
             # Accept advertises text/event-stream too — Streamable HTTP
-            # servers (e.g. Fireflies) return 406 without it. SSE response
-            # bodies are not parsed yet (see _read_json_response).
+            # servers (e.g. Fireflies) return 406 without it, and both formats
+            # are read back (see _read_sse_response).
             req_headers: Dict[str, str] = {
                 "Content-Type": "application/json",
                 "Accept": "application/json, text/event-stream",
@@ -444,14 +448,14 @@ class HttpMCPSession:
 
                 content_type = response.headers.get("Content-Type", "")
                 if "text/event-stream" in content_type:
-                    # Parsing SSE POST responses is not implemented yet
-                    # (tracked in sdd/specs/netsuite-mcp-integration.spec.md).
-                    raise MCPConnectionError(
-                        "Server answered with an SSE stream; this client "
-                        "only supports application/json responses"
+                    # Streamable HTTP servers may answer a POST with an SSE
+                    # stream instead of a JSON body; read it until our own
+                    # request id comes back.
+                    response_data = await self._read_sse_response(
+                        response, request_id
                     )
-
-                response_data = await response.json()
+                else:
+                    response_data = await response.json()
                 self.logger.debug("HTTP received: %s", json.dumps(response_data))
 
                 if "error" in response_data:
@@ -465,6 +469,65 @@ class HttpMCPSession:
             if isinstance(e, MCPConnectionError):
                 raise
             raise MCPConnectionError(f"HTTP request failed: {e}") from e
+
+    async def _read_sse_response(
+        self, response: aiohttp.ClientResponse, request_id: int
+    ) -> Dict[str, Any]:
+        """Read a JSON-RPC response out of an SSE POST body.
+
+        Streamable HTTP servers may answer a request-bearing POST with a
+        ``text/event-stream`` body instead of ``application/json``. The stream
+        carries a JSON-RPC message — or a batch of them — per ``data:``
+        field; anything that is not the answer to ``request_id``
+        (server-initiated notifications, replies to other requests) is
+        skipped.
+
+        Args:
+            response: The open aiohttp response with an SSE body.
+            request_id: The JSON-RPC id whose response we are waiting for.
+
+        Returns:
+            The matching JSON-RPC response object.
+
+        Raises:
+            MCPConnectionError: If the stream ends without that response.
+        """
+        data_lines: list[str] = []
+
+        async for raw_line in response.content:
+            line = raw_line.decode("utf-8").rstrip("\r\n")
+
+            if line:
+                if line.startswith(":"):
+                    continue  # keep-alive comment
+                field, _, value = line.partition(":")
+                if field == "data":
+                    data_lines.append(value[1:] if value.startswith(" ") else value)
+                continue
+
+            # Blank line terminates the event — dispatch what we collected.
+            if not data_lines:
+                continue
+            payload = "\n".join(data_lines)
+            data_lines = []
+            try:
+                message = json.loads(payload)
+            except json.JSONDecodeError:
+                self.logger.debug("Skipping non-JSON SSE payload: %s", payload)
+                continue
+            self.logger.debug("HTTP received (SSE): %s", payload)
+            # A single data: field may carry one message or a batch.
+            candidates = message if isinstance(message, list) else [message]
+            for candidate in candidates:
+                if (
+                    isinstance(candidate, dict)
+                    and candidate.get("id") == request_id
+                ):
+                    return candidate
+
+        raise MCPConnectionError(
+            f"SSE stream ended without a response to request {request_id}"
+        )
 
     async def _send_notification(self, method: str, params: dict = None):
         """Send JSON-RPC notification via HTTP."""

--- a/packages/ai-parrot-server/src/parrot/mcp/transports/streamable_http.py
+++ b/packages/ai-parrot-server/src/parrot/mcp/transports/streamable_http.py
@@ -16,8 +16,20 @@ Claude.ai custom connectors and the official MCP SDK client:
 
 Sessions are identified by the ``Mcp-Session-Id`` header minted on
 ``initialize``. Request dispatch in SSE mode runs as asyncio tasks that
-record their responses in a per-session event store regardless of
+record their responses in a per-*stream* event buffer regardless of
 connection state, which is what makes disconnect-and-resume possible.
+
+Streams, not sessions, own their events. Each request-bearing POST opens
+its own stream and only that stream's SSE response writes its events, so
+a concurrently open ``GET`` stream can never consume a response the POST
+still owes its client (the spec requires the response to travel on the
+stream that carried the request). Event ids are
+``{stream_id}:{sequence}``, so a client that reconnects with
+``Last-Event-ID`` names the stream it was cut off from and receives that
+stream and nothing else. A plain ``GET`` is the session's
+server-to-client stream; it additionally *adopts* streams orphaned by a
+disconnected client, which is what lets a client collect a long tool
+call's result after a drop without having kept the event id.
 
 The event store is in-memory and per-process, matching how the rest of
 the MCP server stack keeps state; a shared (e.g. Redis-backed) store for
@@ -25,31 +37,61 @@ multi-worker deployments is a documented follow-up.
 """
 import asyncio
 import contextlib
+import hashlib
 import json
 import secrets
 import time
 from collections import deque
 from dataclasses import dataclass, field
-from typing import Any, Deque, Dict, List, Optional, Set
+from typing import Any
 from urllib.parse import urlparse
 
 from aiohttp import web
-
-from parrot.mcp.config import MCPServerConfig
 from parrot.mcp.server_base import SUPPORTED_PROTOCOL_VERSIONS
+
+from parrot.mcp.config import AuthMethod, MCPServerConfig
 from parrot.mcp.transports.http import HttpMCPServer
 
 #: Seconds between SSE keep-alive comments on an idle stream.
 KEEP_ALIVE_INTERVAL: float = 15.0
 
+#: Seconds between background sweeps for idle sessions. Pruning also runs
+#: lazily on session lookup; the sweep is what reclaims sessions on a
+#: server that stops receiving requests entirely.
+PRUNE_INTERVAL: float = 60.0
+
 #: Version assumed when a request carries no ``MCP-Protocol-Version``
 #: header, per the 2025-06-18 spec's backwards-compatibility rule.
 ASSUMED_HEADER_VERSION: str = "2025-03-26"
 
+#: Origins always accepted regardless of configuration — a loopback origin
+#: cannot be produced by the DNS-rebinding attack Origin checking exists
+#: to stop.
+LOCALHOST_HOSTS: frozenset[str] = frozenset({"localhost", "127.0.0.1", "::1"})
+
+#: Seconds to wait for cancelled dispatch tasks before abandoning them,
+#: so a tool that swallows cancellation cannot hang DELETE or shutdown.
+TEARDOWN_TIMEOUT: float = 5.0
+
+#: Stream id of the session's dedicated server-to-client stream.
+SERVER_STREAM: str = "server"
+
+
+def _cancelled_by_caller() -> bool:
+    """True when the *current* task is the one being cancelled.
+
+    ``await``ing a child task that gets cancelled also raises
+    ``CancelledError`` here, and that case must not be confused with aiohttp
+    tearing the request handler down — swallowing the latter would keep a
+    dead handler alive.
+    """
+    task = asyncio.current_task()
+    return bool(task is not None and task.cancelling())
+
 
 def _jsonrpc_error(
     code: int, message: str, request_id: Any = None
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Build a JSON-RPC error object."""
     return {
         "jsonrpc": "2.0",
@@ -62,47 +104,78 @@ def _jsonrpc_error(
 class StreamEvent:
     """One buffered outbound JSON-RPC message with its SSE event id."""
 
-    event_id: int
-    message: Dict[str, Any]
+    stream_id: str
+    sequence: int
+    message: dict[str, Any]
     delivered: bool = False
+
+    @property
+    def event_id(self) -> str:
+        """SSE ``id:`` value — scoped to the stream that produced it."""
+        return f"{self.stream_id}:{self.sequence}"
 
     def to_sse(self) -> bytes:
         """Serialize as an SSE ``message`` event carrying the event id."""
         data = json.dumps(self.message)
-        return f"id: {self.event_id}\nevent: message\ndata: {data}\n\n".encode(
-            "utf-8"
-        )
+        return (
+            f"id: {self.event_id}\nevent: message\ndata: {data}\n\n"
+        ).encode()
 
 
-class SessionEventStore:
-    """Ordered, bounded buffer of outbound messages for one session.
+def parse_event_id(raw: str) -> tuple[str, int] | None:
+    """Split a ``Last-Event-ID`` into its ``(stream_id, sequence)`` parts.
 
-    Event ids increase monotonically per session and become the SSE ``id:``
-    field, so a client can resume with ``Last-Event-ID`` after a disconnect.
-    The buffer is a ring: once ``max_events`` is exceeded the oldest events
-    are dropped (no longer replayable).
+    Args:
+        raw: The header value sent by the client.
+
+    Returns:
+        The parsed pair, or ``None`` when the value is not a well-formed
+        event id this server could have issued.
+    """
+    stream_id, sep, sequence = raw.rpartition(":")
+    if not sep or not stream_id:
+        return None
+    try:
+        return stream_id, int(sequence)
+    except ValueError:
+        return None
+
+
+class StreamBuffer:
+    """Ordered, bounded buffer of outbound messages for one SSE stream.
+
+    Sequence numbers increase monotonically per stream and combine with the
+    stream id to form the SSE ``id:`` field, so a client can resume with
+    ``Last-Event-ID`` after a disconnect. The buffer is a ring: once
+    ``max_events`` is exceeded the oldest events are dropped (no longer
+    replayable).
     """
 
-    def __init__(self, max_events: int = 1000):
-        self._events: Deque[StreamEvent] = deque(maxlen=max_events)
+    def __init__(self, stream_id: str, max_events: int = 1000):
+        self.stream_id = stream_id
+        self._events: deque[StreamEvent] = deque(maxlen=max_events)
         self._counter = 0
-        #: Set whenever a new event is appended; the live GET stream waits
-        #: on it and clears it after draining.
-        self.new_event: asyncio.Event = asyncio.Event()
+        #: True while an SSE response is actively writing this stream. An
+        #: unattached stream with undelivered events is orphaned, and the
+        #: session's GET stream may adopt it.
+        self.attached: bool = False
 
-    def append(self, message: Dict[str, Any]) -> StreamEvent:
-        """Buffer an outbound message and wake any live stream."""
+    def append(self, message: dict[str, Any]) -> StreamEvent:
+        """Buffer an outbound message."""
         self._counter += 1
-        event = StreamEvent(event_id=self._counter, message=message)
+        event = StreamEvent(
+            stream_id=self.stream_id,
+            sequence=self._counter,
+            message=message,
+        )
         self._events.append(event)
-        self.new_event.set()
         return event
 
-    def events_after(self, last_event_id: int) -> List[StreamEvent]:
-        """Return buffered events with an id greater than ``last_event_id``."""
-        return [e for e in self._events if e.event_id > last_event_id]
+    def events_after(self, sequence: int) -> list[StreamEvent]:
+        """Return buffered events with a sequence greater than ``sequence``."""
+        return [e for e in self._events if e.sequence > sequence]
 
-    def undelivered(self) -> List[StreamEvent]:
+    def undelivered(self) -> list[StreamEvent]:
         """Return buffered events not yet written to any stream."""
         return [e for e in self._events if not e.delivered]
 
@@ -115,11 +188,63 @@ class McpStreamSession:
     protocol_version: str
     created_at: float
     last_seen: float
-    user: Optional[Any] = None
-    events: SessionEventStore = field(default_factory=SessionEventStore)
-    tasks: Set[asyncio.Task] = field(default_factory=set)
+    #: Stable identifier of the authenticated principal that opened the
+    #: session, or ``None`` when the auth method establishes no identity.
+    principal: Any = None
+    streams: dict[str, StreamBuffer] = field(default_factory=dict)
+    #: In-flight dispatch tasks keyed by their JSON-RPC request id, so
+    #: ``notifications/cancelled`` and DELETE can reach them.
+    tasks: dict[Any, asyncio.Task] = field(default_factory=dict)
+    #: Set whenever a new event is appended anywhere in the session; the
+    #: live GET stream waits on it and clears it after draining.
+    wakeup: asyncio.Event = field(default_factory=asyncio.Event)
     #: True while a GET SSE stream is attached (one per session).
     live_stream: bool = False
+
+    def open_stream(
+        self,
+        max_events: int,
+        stream_id: str | None = None,
+        max_streams: int = 64,
+    ) -> StreamBuffer:
+        """Create (or fetch) a buffer for one outbound stream.
+
+        Opening a stream first reclaims spent ones, so a session that issues
+        many SSE POSTs does not accumulate buffers for the whole of its TTL.
+        """
+        self.prune_streams(max_streams)
+        stream_id = stream_id or secrets.token_urlsafe(6)
+        buffer = self.streams.get(stream_id)
+        if buffer is None:
+            buffer = StreamBuffer(stream_id, max_events=max_events)
+            self.streams[stream_id] = buffer
+        return buffer
+
+    def prune_streams(self, max_streams: int) -> None:
+        """Keep at most ``max_streams`` streams, evicting the least useful.
+
+        Streams are not dropped merely because their events were delivered —
+        a client may still resume one from an earlier ``Last-Event-ID``. They
+        are dropped only to stay under the cap, and then spent streams (no
+        attached response, nothing undelivered) go first, oldest to newest,
+        before any stream that still owes someone data. The server stream is
+        permanent.
+        """
+        evictable = [
+            stream_id
+            for stream_id, buffer in self.streams.items()
+            if stream_id != SERVER_STREAM and not buffer.attached
+        ]
+        # Spent streams first (insertion order preserved within each group).
+        evictable.sort(key=lambda sid: bool(self.streams[sid].undelivered()))
+        while len(self.streams) > max_streams and evictable:
+            del self.streams[evictable.pop(0)]
+
+    def is_busy(self) -> bool:
+        """True when the session has a live stream or unfinished work."""
+        return self.live_stream or any(
+            not task.done() for task in self.tasks.values()
+        )
 
 
 class StreamableHttpMCPServer(HttpMCPServer):
@@ -134,19 +259,29 @@ class StreamableHttpMCPServer(HttpMCPServer):
     def __init__(
         self,
         config: MCPServerConfig,
-        parent_app: Optional[web.Application] = None,
+        parent_app: web.Application | None = None,
     ):
         super().__init__(config, parent_app=parent_app)
-        self._sessions: Dict[str, McpStreamSession] = {}
+        self._sessions: dict[str, McpStreamSession] = {}
         self._session_ttl: float = float(
             getattr(config, "session_ttl", 3600) or 3600
         )
         self._event_buffer_size: int = int(
             getattr(config, "event_buffer_size", 1000) or 1000
         )
-        self._allowed_origins: Optional[List[str]] = getattr(
+        self._max_sessions: int = int(
+            getattr(config, "max_sessions", 1000) or 1000
+        )
+        self._max_streams: int = int(
+            getattr(config, "max_streams_per_session", 64) or 64
+        )
+        self._allowed_origins: list[str] | None = getattr(
             config, "allowed_origins", None
         )
+        self._allow_any_origin: bool = bool(
+            getattr(config, "allow_any_origin", False)
+        )
+        self._prune_task: asyncio.Task | None = None
 
     def _register_routes(self, router, base_route: str) -> None:
         """Register POST/GET/DELETE on the single MCP endpoint."""
@@ -155,10 +290,21 @@ class StreamableHttpMCPServer(HttpMCPServer):
         router.add_delete(base_route, self._handle_streamable_delete)
         router.add_get(f"{base_route.rstrip('/')}/info", self._handle_info)
 
+    async def start(self):
+        """Start the server and its background session sweeper."""
+        await super().start()
+        if self._prune_task is None:
+            self._prune_task = asyncio.create_task(self._prune_loop())
+
     async def stop(self):
         """Stop the server, cancelling pending dispatch tasks."""
+        if self._prune_task is not None:
+            self._prune_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._prune_task
+            self._prune_task = None
         for session in list(self._sessions.values()):
-            self._teardown_session(session)
+            await self._teardown_session(session)
         self._sessions.clear()
         await super().stop()
 
@@ -178,75 +324,187 @@ class StreamableHttpMCPServer(HttpMCPServer):
     # Session management
     # ------------------------------------------------------------------
 
-    def _create_session(
-        self, protocol_version: str, user: Optional[Any] = None
-    ) -> McpStreamSession:
-        """Mint a new session with a cryptographically secure id."""
+    def _principal(self, request: web.Request) -> Any:
+        """Return a stable identifier for the request's authenticated caller.
+
+        Prefers the authenticated user id. Auth methods that validate a
+        credential without attributing it to a user (internal OAuth) — or
+        that hand back a principal with no recognisable id (navigator-auth
+        session data) — fall back to a digest of the presented credential,
+        so the session is at least bound to the token that opened it rather
+        than shared across everyone the same method authenticates.
+
+        ``None`` only when no authentication is configured at all, where
+        there is no identity to bind to and ownership is not enforced.
+        """
+        user = request.get("mcp_user")
+        if isinstance(user, dict):
+            for key in ("user_id", "id", "sub", "username", "email"):
+                value = user.get(key)
+                if value:
+                    return value
+        elif user:
+            return user
+
+        if self.config.auth_method == AuthMethod.NONE:
+            return None
+        return self._credential_digest(request)
+
+    def _credential_digest(self, request: web.Request) -> str | None:
+        """Hash the presented credential, for binding without storing it."""
+        credential = request.headers.get(
+            self.config.api_key_header
+        ) or request.headers.get("Authorization")
+        if not credential:
+            return None
+        return hashlib.sha256(credential.encode("utf-8")).hexdigest()
+
+    async def _create_session(
+        self, protocol_version: str, principal: Any = None
+    ) -> McpStreamSession | None:
+        """Mint a new session with a cryptographically secure id.
+
+        Returns ``None`` when the server is already holding its configured
+        maximum number of sessions, so the caller can answer 503 instead of
+        growing memory without bound.
+        """
+        await self._prune_sessions()
+        if len(self._sessions) >= self._max_sessions:
+            self.logger.warning(
+                "Refusing new MCP session: %s sessions already open (max_sessions)",
+                len(self._sessions),
+            )
+            return None
         now = time.monotonic()
         session = McpStreamSession(
             session_id=secrets.token_urlsafe(32),
             protocol_version=protocol_version,
             created_at=now,
             last_seen=now,
-            user=user,
-            events=SessionEventStore(max_events=self._event_buffer_size),
+            principal=principal,
         )
         self._sessions[session.session_id] = session
-        self._prune_sessions()
         return session
 
-    def _get_session(self, session_id: str) -> Optional[McpStreamSession]:
-        """Look up a session, expiring it when past its TTL."""
-        self._prune_sessions()
+    async def _get_session(
+        self, session_id: str, request: web.Request
+    ) -> McpStreamSession | None:
+        """Look up a session, expiring it when past its TTL.
+
+        A session is only returned to the principal that created it, so a
+        leaked ``Mcp-Session-Id`` cannot be replayed under another identity.
+        """
+        await self._prune_sessions()
         session = self._sessions.get(session_id)
         if session is None:
+            return None
+        if session.principal != self._principal(request):
+            self.logger.warning(
+                "Rejecting MCP session %s: principal mismatch", session_id
+            )
             return None
         session.last_seen = time.monotonic()
         return session
 
-    def _prune_sessions(self) -> None:
-        """Drop sessions idle beyond the TTL (lazy, no background task)."""
+    async def _prune_loop(self) -> None:
+        """Sweep idle sessions periodically, independent of traffic."""
+        try:
+            while True:
+                await asyncio.sleep(PRUNE_INTERVAL)
+                await self._prune_sessions()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - the sweeper must never die
+            self.logger.error("MCP session sweeper failed: %s", exc)
+
+    async def _prune_sessions(self) -> None:
+        """Drop sessions idle beyond the TTL.
+
+        Sessions with an attached stream or unfinished dispatch work are
+        never pruned — a long-running tool call must not have its session
+        expire out from under it.
+        """
         now = time.monotonic()
         expired = [
             sid
             for sid, session in self._sessions.items()
             if now - session.last_seen > self._session_ttl
+            and not session.is_busy()
         ]
         for sid in expired:
             session = self._sessions.pop(sid, None)
             if session:
-                self._teardown_session(session)
+                await self._teardown_session(session)
                 self.logger.info("Expired MCP session: %s", sid)
 
-    def _teardown_session(self, session: McpStreamSession) -> None:
-        """Cancel a session's pending dispatch tasks and wake its stream."""
-        for task in list(session.tasks):
-            if not task.done():
-                task.cancel()
+    async def _teardown_session(self, session: McpStreamSession) -> None:
+        """Cancel a session's pending dispatch tasks and wake its stream.
+
+        Waits for the cancellations to land so a 204 from DELETE means the
+        work has actually stopped — but only up to ``TEARDOWN_TIMEOUT``, so a
+        tool that swallows cancellation cannot hang session deletion or
+        server shutdown.
+        """
+        tasks = [task for task in session.tasks.values() if not task.done()]
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            _, pending = await asyncio.wait(
+                tasks, timeout=TEARDOWN_TIMEOUT
+            )
+            if pending:
+                self.logger.warning(
+                    "%s task(s) on session %s ignored cancellation after %ss; "
+                    "abandoning them",
+                    len(pending),
+                    session.session_id,
+                    TEARDOWN_TIMEOUT,
+                )
         session.tasks.clear()
-        session.events.new_event.set()
+        session.wakeup.set()
+
+    def _track(
+        self, session: McpStreamSession | None, message: dict[str, Any], coro
+    ) -> asyncio.Task:
+        """Run a dispatch coroutine as a task the session can cancel."""
+        task = asyncio.create_task(coro)
+        if session is not None:
+            key = message.get("id")
+            session.tasks[key] = task
+            task.add_done_callback(
+                lambda finished, s=session, k=key: (
+                    # Only drop our own entry: a batch may repeat an id, and
+                    # the later task then owns the slot.
+                    s.tasks.pop(k, None) if s.tasks.get(k) is finished else None
+                )
+            )
+        return task
 
     # ------------------------------------------------------------------
     # Request validation helpers
     # ------------------------------------------------------------------
 
-    def _check_origin(self, request: web.Request) -> Optional[web.Response]:
+    def _check_origin(self, request: web.Request) -> web.Response | None:
         """Validate the Origin header (DNS-rebinding protection).
 
         Requests without an ``Origin`` header (server-to-server clients such
-        as Claude.ai) are always allowed. Localhost origins are always
-        allowed. When ``config.allowed_origins`` is unset, any origin is
-        allowed for backward compatibility.
+        as Claude.ai) are always allowed — the header is browser-supplied and
+        its absence means no browser is involved. Localhost origins are
+        always allowed. Any other origin must appear in
+        ``config.allowed_origins``; with no allowlist configured only
+        localhost passes, unless ``config.allow_any_origin`` is set.
         """
         origin = request.headers.get("Origin")
         if not origin:
             return None
+        if self._allow_any_origin:
+            return None
         hostname = urlparse(origin).hostname or ""
-        if hostname in {"localhost", "127.0.0.1", "::1"}:
+        if hostname in LOCALHOST_HOSTS:
             return None
-        if self._allowed_origins is None:
-            return None
-        if origin.rstrip("/") in {o.rstrip("/") for o in self._allowed_origins}:
+        if self._allowed_origins and origin.rstrip("/") in {
+            o.rstrip("/") for o in self._allowed_origins
+        }:
             return None
         return web.json_response(
             _jsonrpc_error(-32600, f"Origin not allowed: {origin}"),
@@ -255,7 +513,7 @@ class StreamableHttpMCPServer(HttpMCPServer):
 
     def _check_protocol_header(
         self, request: web.Request
-    ) -> Optional[web.Response]:
+    ) -> web.Response | None:
         """Reject requests carrying an unsupported protocol-version header."""
         header = request.headers.get("MCP-Protocol-Version")
         if header and header not in SUPPORTED_PROTOCOL_VERSIONS:
@@ -269,19 +527,53 @@ class StreamableHttpMCPServer(HttpMCPServer):
             )
         return None
 
+    async def _guard(self, request: web.Request) -> web.Response | None:
+        """Run auth plus the transport checks every verb shares."""
+        auth_response = await self._authenticate_request(request)
+        if auth_response:
+            return auth_response
+        for check in (self._check_origin, self._check_protocol_header):
+            error = check(request)
+            if error:
+                return error
+        return None
+
     @staticmethod
     def _wants_sse(request: web.Request) -> bool:
         """True when the client accepts SSE responses to POST."""
         return "text/event-stream" in request.headers.get("Accept", "")
 
     @staticmethod
+    def _wants_json(request: web.Request) -> bool:
+        """True when the client accepts a plain JSON response body."""
+        accept = request.headers.get("Accept", "")
+        if not accept:
+            return True  # unset Accept means "anything"
+        return "application/json" in accept or "*/*" in accept
+
+    @staticmethod
     def _is_request(message: Any) -> bool:
-        """True for a JSON-RPC request (has method AND id)."""
+        """True for a JSON-RPC request (has method AND id).
+
+        Notifications are excluded even when a client mistakenly gives them
+        an ``id``: they produce no response, and treating them as requests
+        leaves the caller waiting for an answer that never comes.
+        """
         return (
             isinstance(message, dict)
             and "method" in message
             and "id" in message
+            and not str(message.get("method", "")).startswith("notifications/")
         )
+
+    def _session_headers(
+        self, session: McpStreamSession | None, **extra: str
+    ) -> dict[str, str]:
+        """Response headers echoing the session id when one is in play."""
+        headers = dict(extra)
+        if session is not None:
+            headers["Mcp-Session-Id"] = session.session_id
+        return headers
 
     # ------------------------------------------------------------------
     # POST — client-to-server messages
@@ -291,13 +583,18 @@ class StreamableHttpMCPServer(HttpMCPServer):
         self, request: web.Request
     ) -> web.StreamResponse:
         """Handle POST: JSON-RPC single messages or batches."""
-        auth_response = await self._authenticate_request(request)
-        if auth_response:
-            return auth_response
-        for check in (self._check_origin, self._check_protocol_header):
-            error = check(request)
-            if error:
-                return error
+        error = await self._guard(request)
+        if error:
+            return error
+
+        if not self._wants_sse(request) and not self._wants_json(request):
+            return web.json_response(
+                _jsonrpc_error(
+                    -32600,
+                    "Accept must include application/json or text/event-stream",
+                ),
+                status=406,
+            )
 
         try:
             data = await request.json()
@@ -307,20 +604,26 @@ class StreamableHttpMCPServer(HttpMCPServer):
             )
 
         is_batch = isinstance(data, list)
-        messages: List[Any] = data if is_batch else [data]
+        messages: list[Any] = data if is_batch else [data]
         if not messages or not all(isinstance(m, dict) for m in messages):
             return web.json_response(
                 _jsonrpc_error(-32600, "Invalid Request"), status=400
             )
 
-        is_initialize = any(
-            m.get("method") == "initialize" for m in messages
-        )
-        session: Optional[McpStreamSession] = None
+        is_initialize = any(m.get("method") == "initialize" for m in messages)
+        if is_initialize and len(messages) > 1:
+            # The MCP lifecycle forbids batching initialize; refusing keeps a
+            # malformed body from being the one path that creates state.
+            return web.json_response(
+                _jsonrpc_error(-32600, "initialize must not be batched"),
+                status=400,
+            )
+
+        session: McpStreamSession | None = None
         if not is_initialize:
             session_id = request.headers.get("Mcp-Session-Id")
             if session_id:
-                session = self._get_session(session_id)
+                session = await self._get_session(session_id, request)
                 if session is None:
                     return web.json_response(
                         _jsonrpc_error(-32001, "Session not found"),
@@ -336,104 +639,190 @@ class StreamableHttpMCPServer(HttpMCPServer):
             # Only notifications and/or responses: run them for their side
             # effects and acknowledge with 202 (spec requirement).
             for message in messages:
-                await self._handle_request(message)
-            return web.Response(status=202)
-
-        if is_initialize:
-            return await self._respond_initialize(
-                request, messages, is_batch
+                await self._handle_notification(session, message)
+            return web.Response(
+                status=202, headers=self._session_headers(session)
             )
 
-        if self._wants_sse(request) and session is not None:
-            return await self._respond_sse(request, session, messages)
+        if is_initialize:
+            return await self._respond_initialize(request, messages[0])
 
-        return await self._respond_json(request, messages, is_batch)
+        if self._wants_sse(request):
+            if session is not None:
+                return await self._respond_sse(request, session, messages)
+            if not self._wants_json(request):
+                return web.json_response(
+                    _jsonrpc_error(
+                        -32600,
+                        "Mcp-Session-Id is required for text/event-stream "
+                        "responses; call initialize first",
+                    ),
+                    status=400,
+                )
+
+        return await self._respond_json(request, session, messages, is_batch)
+
+    async def _handle_notification(
+        self, session: McpStreamSession | None, message: dict[str, Any]
+    ) -> None:
+        """Run one notification for its side effects."""
+        if message.get("method") == "notifications/cancelled":
+            self._cancel_request(session, message)
+            return
+        await self._handle_request(message)
+
+    def _cancel_request(
+        self, session: McpStreamSession | None, message: dict[str, Any]
+    ) -> None:
+        """Cancel the in-flight dispatch named by ``notifications/cancelled``."""
+        if session is None:
+            return
+        request_id = (message.get("params") or {}).get("requestId")
+        task = session.tasks.get(request_id)
+        if task is not None and not task.done():
+            task.cancel()
+            self.logger.info(
+                "Cancelled MCP request %s on session %s",
+                request_id,
+                session.session_id,
+            )
 
     async def _respond_initialize(
-        self,
-        request: web.Request,
-        messages: List[Dict[str, Any]],
-        is_batch: bool,
-    ) -> web.Response:
-        """Dispatch an initialize body, minting a new session."""
-        responses = []
-        negotiated: Optional[str] = None
-        for message in messages:
-            response = await self._handle_request(message)
-            if response is not None:
-                responses.append(response)
-                if message.get("method") == "initialize":
-                    negotiated = response.get("result", {}).get(
-                        "protocolVersion"
-                    )
+        self, request: web.Request, message: dict[str, Any]
+    ) -> web.StreamResponse:
+        """Dispatch an initialize request, minting a new session."""
+        response = await self._handle_request(message)
+        if response is None:  # pragma: no cover - initialize always answers
+            return web.Response(status=202)
 
-        session = self._create_session(
+        negotiated = response.get("result", {}).get("protocolVersion")
+        session = await self._create_session(
             protocol_version=negotiated or ASSUMED_HEADER_VERSION,
-            user=request.get("mcp_user"),
+            principal=self._principal(request),
         )
-        payload: Any = responses if is_batch else responses[0]
+        if session is None:
+            return web.json_response(
+                _jsonrpc_error(-32000, "Server session capacity reached"),
+                status=503,
+            )
+
+        if self._wants_sse(request) and not self._wants_json(request):
+            # SSE-only client: answer on a stream rather than forcing JSON.
+            buffer = session.open_stream(
+            self._event_buffer_size, max_streams=self._max_streams
+        )
+            event = buffer.append(response)
+            return await self._write_events(request, session, buffer, [event])
+
         return web.json_response(
-            payload, headers={"Mcp-Session-Id": session.session_id}
+            response, headers=self._session_headers(session)
         )
 
     async def _respond_json(
         self,
         request: web.Request,
-        messages: List[Dict[str, Any]],
+        session: McpStreamSession | None,
+        messages: list[dict[str, Any]],
         is_batch: bool,
     ) -> web.Response:
         """Answer a request-bearing body with a plain JSON response."""
         responses = []
         for message in messages:
-            response = await self._handle_request(message)
+            if not self._is_request(message):
+                await self._handle_notification(session, message)
+                continue
+            # Dispatch through a tracked task so DELETE and
+            # notifications/cancelled can reach the work.
+            task = self._track(session, message, self._handle_request(message))
+            try:
+                response = await task
+            except asyncio.CancelledError:
+                if not task.cancelled():
+                    raise  # this handler is being cancelled, not the task
+                response = _jsonrpc_error(
+                    -32800, "Request cancelled", message.get("id")
+                )
             if response is None:
                 continue
-            if "result" in response and "tools" in response.get("result", {}):
-                if "Anthropic" in request.headers.get("User-Agent", ""):
-                    response["result"] = self._convert_tools_to_anthropic(
-                        response["result"]
-                    )
+            if (
+                "tools" in response.get("result", {})
+                and "Anthropic" in request.headers.get("User-Agent", "")
+            ):
+                response["result"] = self._convert_tools_to_anthropic(
+                    response["result"]
+                )
             responses.append(response)
+
+        headers = self._session_headers(session)
+        if not responses:
+            # Every message turned out to be a notification (a client may
+            # give one an id); there is nothing to answer with.
+            return web.Response(status=202, headers=headers)
         payload: Any = responses if is_batch else responses[0]
-        return web.json_response(payload)
+        return web.json_response(payload, headers=headers)
 
     async def _respond_sse(
         self,
         request: web.Request,
         session: McpStreamSession,
-        messages: List[Dict[str, Any]],
+        messages: list[dict[str, Any]],
     ) -> web.StreamResponse:
         """Answer a request-bearing body with an SSE stream.
 
-        Each request is dispatched as an independent asyncio task that
-        records its response in the session's event store even if the
-        client disconnects — the client can then resume via
-        ``GET + Last-Event-ID`` and still collect the results.
+        The POST opens its own stream. Each request is dispatched as an
+        independent asyncio task that records its response in that stream's
+        buffer even if the client disconnects — the client can then resume
+        via ``GET`` (optionally with ``Last-Event-ID``) and still collect the
+        results. Because the buffer belongs to this stream alone, a
+        concurrently open GET stream cannot consume these responses while
+        this response is still writing them.
         """
-        tasks: List[asyncio.Task] = []
+        buffer = session.open_stream(
+            self._event_buffer_size, max_streams=self._max_streams
+        )
+        tasks: list[asyncio.Task] = []
         for message in messages:
             if self._is_request(message):
-                task = asyncio.create_task(
-                    self._dispatch_to_store(session, message)
+                tasks.append(
+                    self._track(
+                        session,
+                        message,
+                        self._dispatch_to_stream(session, buffer, message),
+                    )
                 )
-                session.tasks.add(task)
-                task.add_done_callback(session.tasks.discard)
-                tasks.append(task)
             else:
                 # Notifications inside a mixed body: side effects only.
-                await self._handle_request(message)
+                await self._handle_notification(session, message)
 
+        return await self._write_events(request, session, buffer, tasks=tasks)
+
+    async def _write_events(
+        self,
+        request: web.Request,
+        session: McpStreamSession,
+        buffer: StreamBuffer,
+        events: list[StreamEvent] | None = None,
+        tasks: list[asyncio.Task] | None = None,
+    ) -> web.StreamResponse:
+        """Stream a set of already-known or still-pending events to a client."""
         response = web.StreamResponse(
             status=200,
-            headers={
-                "Content-Type": "text/event-stream",
-                "Cache-Control": "no-cache",
-                "Connection": "keep-alive",
-            },
+            headers=self._session_headers(
+                session,
+                **{
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    "Connection": "keep-alive",
+                },
+            ),
         )
-        await response.prepare(request)
+        buffer.attached = True
         try:
-            for finished in asyncio.as_completed(tasks):
+            await response.prepare(request)
+            for event in events or []:
+                await response.write(event.to_sse())
+                event.delivered = True
+            for finished in asyncio.as_completed(tasks or []):
                 event = await finished
                 if event is None or event.delivered:
                     continue
@@ -441,8 +830,18 @@ class StreamableHttpMCPServer(HttpMCPServer):
                 event.delivered = True
             with contextlib.suppress(Exception):
                 await response.write_eof()
+        except asyncio.CancelledError:
+            if _cancelled_by_caller():
+                # aiohttp is tearing this handler down — do not swallow it.
+                raise
+            # A dispatch task was cancelled (session teardown): its response
+            # stays buffered and the stream is orphaned below.
+            self.logger.info(
+                "SSE POST dispatch cancelled for session %s (stream %s)",
+                session.session_id,
+                buffer.stream_id,
+            )
         except (
-            asyncio.CancelledError,
             ConnectionResetError,
             ConnectionError,
             OSError,
@@ -451,20 +850,40 @@ class StreamableHttpMCPServer(HttpMCPServer):
             # their responses stay buffered (undelivered) for resumption.
             self.logger.info(
                 "SSE POST client disconnected; %s call(s) continue for "
-                "session %s",
-                sum(1 for t in tasks if not t.done()),
+                "session %s (stream %s)",
+                sum(1 for t in (tasks or []) if not t.done()),
                 session.session_id,
+                buffer.stream_id,
             )
+        finally:
+            # Orphan the stream so the session's GET stream may adopt any
+            # events this response did not manage to deliver.
+            buffer.attached = False
+            session.wakeup.set()
         return response
 
-    async def _dispatch_to_store(
-        self, session: McpStreamSession, message: Dict[str, Any]
-    ) -> Optional[StreamEvent]:
+    async def _dispatch_to_stream(
+        self,
+        session: McpStreamSession,
+        buffer: StreamBuffer,
+        message: dict[str, Any],
+    ) -> StreamEvent | None:
         """Run one JSON-RPC request and buffer its response as an event."""
-        response = await self._handle_request(message)
+        try:
+            response = await self._handle_request(message)
+        except asyncio.CancelledError:
+            # Record the cancellation for anyone resuming the stream, then
+            # let the cancellation propagate.
+            buffer.append(
+                _jsonrpc_error(-32800, "Request cancelled", message.get("id"))
+            )
+            session.wakeup.set()
+            raise
         if response is None:
             return None
-        return session.events.append(response)
+        event = buffer.append(response)
+        session.wakeup.set()
+        return event
 
     # ------------------------------------------------------------------
     # GET — server-to-client stream (resumable)
@@ -474,10 +893,7 @@ class StreamableHttpMCPServer(HttpMCPServer):
         self, request: web.Request
     ) -> web.StreamResponse:
         """Open the session's SSE stream, replaying from Last-Event-ID."""
-        auth_response = await self._authenticate_request(request)
-        if auth_response:
-            return auth_response
-        error = self._check_origin(request)
+        error = await self._guard(request)
         if error:
             return error
 
@@ -492,7 +908,7 @@ class StreamableHttpMCPServer(HttpMCPServer):
                 _jsonrpc_error(-32600, "Missing Mcp-Session-Id header"),
                 status=400,
             )
-        session = self._get_session(session_id)
+        session = await self._get_session(session_id, request)
         if session is None:
             return web.json_response(
                 _jsonrpc_error(-32001, "Session not found"), status=404
@@ -505,51 +921,100 @@ class StreamableHttpMCPServer(HttpMCPServer):
                 status=409,
             )
 
-        last_event_id: Optional[int] = None
+        resumed: StreamBuffer | None = None
+        replay: list[StreamEvent] = []
         raw_last_id = request.headers.get("Last-Event-ID")
         if raw_last_id:
-            with contextlib.suppress(ValueError):
-                last_event_id = int(raw_last_id)
+            parsed = parse_event_id(raw_last_id)
+            if parsed is None:
+                return web.json_response(
+                    _jsonrpc_error(
+                        -32600, f"Malformed Last-Event-ID: {raw_last_id}"
+                    ),
+                    status=400,
+                )
+            stream_id, sequence = parsed
+            resumed = session.streams.get(stream_id)
+            if resumed is None:
+                return web.json_response(
+                    _jsonrpc_error(
+                        -32001, f"Unknown stream in Last-Event-ID: {stream_id}"
+                    ),
+                    status=404,
+                )
+            # Replay from where the client says it stopped, delivered or not.
+            replay = resumed.events_after(sequence)
 
         session.live_stream = True
         response = web.StreamResponse(
             status=200,
-            headers={
-                "Content-Type": "text/event-stream",
-                "Cache-Control": "no-cache",
-                "Connection": "keep-alive",
-                "Mcp-Session-Id": session.session_id,
-            },
+            headers=self._session_headers(
+                session,
+                **{
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    "Connection": "keep-alive",
+                },
+            ),
         )
         try:
             await response.prepare(request)
-            store = session.events
-
-            # Resume: replay buffered events after the client's last id
-            # (delivered or not — the client told us where it stopped).
-            replay = (
-                store.events_after(last_event_id)
-                if last_event_id is not None
-                else store.undelivered()
-            )
             for event in replay:
                 await response.write(event.to_sse())
                 event.delivered = True
 
-            # Live phase: deliver new events as dispatch tasks complete.
+            # Live phase.
+            #
+            # Resuming (``Last-Event-ID``) delivers that stream and nothing
+            # else: the spec forbids a resumed stream from replaying
+            # messages that belong to a different one.
+            #
+            # A plain GET is the session's server-to-client stream. It
+            # carries server-initiated messages, and — as a deliberate
+            # extension — adopts streams orphaned by a disconnected client,
+            # which is what lets "POST a long tool call, drop, reconnect,
+            # collect the result" work without the client having kept the
+            # event id. A stream still attached to its own SSE response is
+            # never drained here: that response owes those events to its
+            # own client.
+            server_stream = session.open_stream(
+                self._event_buffer_size,
+                stream_id=SERVER_STREAM,
+                max_streams=self._max_streams,
+            )
             while session.session_id in self._sessions:
-                store.new_event.clear()
-                for event in store.undelivered():
-                    await response.write(event.to_sse())
-                    event.delivered = True
+                session.wakeup.clear()
+                if resumed is not None:
+                    sources = [resumed]
+                else:
+                    sources = [
+                        buffer
+                        for buffer in session.streams.values()
+                        if not buffer.attached or buffer is server_stream
+                    ]
+                for buffer in list(sources):
+                    if buffer.attached and buffer is not server_stream:
+                        continue
+                    for event in buffer.undelivered():
+                        await response.write(event.to_sse())
+                        event.delivered = True
                 try:
                     await asyncio.wait_for(
-                        store.new_event.wait(), timeout=KEEP_ALIVE_INTERVAL
+                        session.wakeup.wait(), timeout=KEEP_ALIVE_INTERVAL
                     )
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     await response.write(b": keep-alive\n\n")
+                # An attached stream is proof of life: keep the session from
+                # expiring under a client that is connected but idle.
+                session.last_seen = time.monotonic()
+        except asyncio.CancelledError:
+            session.live_stream = False
+            if _cancelled_by_caller():
+                raise
+            self.logger.info(
+                "SSE GET stream cancelled: %s", session.session_id
+            )
         except (
-            asyncio.CancelledError,
             ConnectionResetError,
             ConnectionError,
             OSError,
@@ -571,9 +1036,9 @@ class StreamableHttpMCPServer(HttpMCPServer):
         self, request: web.Request
     ) -> web.Response:
         """Terminate a session, cancelling its pending dispatch tasks."""
-        auth_response = await self._authenticate_request(request)
-        if auth_response:
-            return auth_response
+        error = await self._guard(request)
+        if error:
+            return error
 
         session_id = request.headers.get("Mcp-Session-Id")
         if not session_id:
@@ -581,11 +1046,14 @@ class StreamableHttpMCPServer(HttpMCPServer):
                 _jsonrpc_error(-32600, "Missing Mcp-Session-Id header"),
                 status=400,
             )
-        session = self._sessions.pop(session_id, None)
+        # Look up before removing so ownership is enforced on DELETE too.
+        session = await self._get_session(session_id, request)
         if session is None:
             return web.json_response(
                 _jsonrpc_error(-32001, "Session not found"), status=404
             )
-        self._teardown_session(session)
+        self._sessions.pop(session_id, None)
+        # Awaits cancellation, so 204 means the work has actually stopped.
+        await self._teardown_session(session)
         self.logger.info("Terminated MCP session: %s", session_id)
         return web.Response(status=204)

--- a/packages/ai-parrot-server/src/parrot/mcp/transports/streamable_http.py
+++ b/packages/ai-parrot-server/src/parrot/mcp/transports/streamable_http.py
@@ -1,0 +1,591 @@
+"""MCP Streamable HTTP transport (spec revision 2025-03-26).
+
+Implements the single-endpoint Streamable HTTP transport required by
+Claude.ai custom connectors and the official MCP SDK client:
+
+- ``POST {base_path}``: JSON-RPC messages (single or batch). Bodies with
+  only notifications/responses are acknowledged with ``202``. Bodies with
+  requests are answered as ``application/json``, or as an SSE stream when
+  the client's ``Accept`` header includes ``text/event-stream``.
+- ``GET {base_path}``: opens the session's server-to-client SSE stream.
+  Supports resumability via ``Last-Event-ID``: buffered events after that
+  id are replayed in order, so a client that disconnected during a
+  long-running ``tools/call`` (e.g. launching an agent flow) can reconnect
+  and still collect the result.
+- ``DELETE {base_path}``: terminates the session.
+
+Sessions are identified by the ``Mcp-Session-Id`` header minted on
+``initialize``. Request dispatch in SSE mode runs as asyncio tasks that
+record their responses in a per-session event store regardless of
+connection state, which is what makes disconnect-and-resume possible.
+
+The event store is in-memory and per-process, matching how the rest of
+the MCP server stack keeps state; a shared (e.g. Redis-backed) store for
+multi-worker deployments is a documented follow-up.
+"""
+import asyncio
+import contextlib
+import json
+import secrets
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Deque, Dict, List, Optional, Set
+from urllib.parse import urlparse
+
+from aiohttp import web
+
+from parrot.mcp.config import MCPServerConfig
+from parrot.mcp.server_base import SUPPORTED_PROTOCOL_VERSIONS
+from parrot.mcp.transports.http import HttpMCPServer
+
+#: Seconds between SSE keep-alive comments on an idle stream.
+KEEP_ALIVE_INTERVAL: float = 15.0
+
+#: Version assumed when a request carries no ``MCP-Protocol-Version``
+#: header, per the 2025-06-18 spec's backwards-compatibility rule.
+ASSUMED_HEADER_VERSION: str = "2025-03-26"
+
+
+def _jsonrpc_error(
+    code: int, message: str, request_id: Any = None
+) -> Dict[str, Any]:
+    """Build a JSON-RPC error object."""
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": {"code": code, "message": message},
+    }
+
+
+@dataclass
+class StreamEvent:
+    """One buffered outbound JSON-RPC message with its SSE event id."""
+
+    event_id: int
+    message: Dict[str, Any]
+    delivered: bool = False
+
+    def to_sse(self) -> bytes:
+        """Serialize as an SSE ``message`` event carrying the event id."""
+        data = json.dumps(self.message)
+        return f"id: {self.event_id}\nevent: message\ndata: {data}\n\n".encode(
+            "utf-8"
+        )
+
+
+class SessionEventStore:
+    """Ordered, bounded buffer of outbound messages for one session.
+
+    Event ids increase monotonically per session and become the SSE ``id:``
+    field, so a client can resume with ``Last-Event-ID`` after a disconnect.
+    The buffer is a ring: once ``max_events`` is exceeded the oldest events
+    are dropped (no longer replayable).
+    """
+
+    def __init__(self, max_events: int = 1000):
+        self._events: Deque[StreamEvent] = deque(maxlen=max_events)
+        self._counter = 0
+        #: Set whenever a new event is appended; the live GET stream waits
+        #: on it and clears it after draining.
+        self.new_event: asyncio.Event = asyncio.Event()
+
+    def append(self, message: Dict[str, Any]) -> StreamEvent:
+        """Buffer an outbound message and wake any live stream."""
+        self._counter += 1
+        event = StreamEvent(event_id=self._counter, message=message)
+        self._events.append(event)
+        self.new_event.set()
+        return event
+
+    def events_after(self, last_event_id: int) -> List[StreamEvent]:
+        """Return buffered events with an id greater than ``last_event_id``."""
+        return [e for e in self._events if e.event_id > last_event_id]
+
+    def undelivered(self) -> List[StreamEvent]:
+        """Return buffered events not yet written to any stream."""
+        return [e for e in self._events if not e.delivered]
+
+
+@dataclass
+class McpStreamSession:
+    """State for one Streamable HTTP session."""
+
+    session_id: str
+    protocol_version: str
+    created_at: float
+    last_seen: float
+    user: Optional[Any] = None
+    events: SessionEventStore = field(default_factory=SessionEventStore)
+    tasks: Set[asyncio.Task] = field(default_factory=set)
+    #: True while a GET SSE stream is attached (one per session).
+    live_stream: bool = False
+
+
+class StreamableHttpMCPServer(HttpMCPServer):
+    """MCP server speaking the Streamable HTTP transport on aiohttp.
+
+    Extends :class:`HttpMCPServer` (reusing auth, OAuth routes, and the
+    parent-app/standalone mounting logic) with the 2025-03-26 transport
+    semantics: session ids, ``Accept`` negotiation, SSE responses, a
+    resumable GET stream, and DELETE session termination.
+    """
+
+    def __init__(
+        self,
+        config: MCPServerConfig,
+        parent_app: Optional[web.Application] = None,
+    ):
+        super().__init__(config, parent_app=parent_app)
+        self._sessions: Dict[str, McpStreamSession] = {}
+        self._session_ttl: float = float(
+            getattr(config, "session_ttl", 3600) or 3600
+        )
+        self._event_buffer_size: int = int(
+            getattr(config, "event_buffer_size", 1000) or 1000
+        )
+        self._allowed_origins: Optional[List[str]] = getattr(
+            config, "allowed_origins", None
+        )
+
+    def _register_routes(self, router, base_route: str) -> None:
+        """Register POST/GET/DELETE on the single MCP endpoint."""
+        router.add_post(base_route, self._handle_streamable_post)
+        router.add_get(base_route, self._handle_streamable_get)
+        router.add_delete(base_route, self._handle_streamable_delete)
+        router.add_get(f"{base_route.rstrip('/')}/info", self._handle_info)
+
+    async def stop(self):
+        """Stop the server, cancelling pending dispatch tasks."""
+        for session in list(self._sessions.values()):
+            self._teardown_session(session)
+        self._sessions.clear()
+        await super().stop()
+
+    async def _handle_info(self, request: web.Request) -> web.Response:
+        """Return server info."""
+        return web.json_response(
+            {
+                "name": self.config.name,
+                "version": self.config.version,
+                "transport": "streamable-http",
+                "protocol_versions": list(SUPPORTED_PROTOCOL_VERSIONS),
+                "tools_count": len(self.tools),
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # Session management
+    # ------------------------------------------------------------------
+
+    def _create_session(
+        self, protocol_version: str, user: Optional[Any] = None
+    ) -> McpStreamSession:
+        """Mint a new session with a cryptographically secure id."""
+        now = time.monotonic()
+        session = McpStreamSession(
+            session_id=secrets.token_urlsafe(32),
+            protocol_version=protocol_version,
+            created_at=now,
+            last_seen=now,
+            user=user,
+            events=SessionEventStore(max_events=self._event_buffer_size),
+        )
+        self._sessions[session.session_id] = session
+        self._prune_sessions()
+        return session
+
+    def _get_session(self, session_id: str) -> Optional[McpStreamSession]:
+        """Look up a session, expiring it when past its TTL."""
+        self._prune_sessions()
+        session = self._sessions.get(session_id)
+        if session is None:
+            return None
+        session.last_seen = time.monotonic()
+        return session
+
+    def _prune_sessions(self) -> None:
+        """Drop sessions idle beyond the TTL (lazy, no background task)."""
+        now = time.monotonic()
+        expired = [
+            sid
+            for sid, session in self._sessions.items()
+            if now - session.last_seen > self._session_ttl
+        ]
+        for sid in expired:
+            session = self._sessions.pop(sid, None)
+            if session:
+                self._teardown_session(session)
+                self.logger.info("Expired MCP session: %s", sid)
+
+    def _teardown_session(self, session: McpStreamSession) -> None:
+        """Cancel a session's pending dispatch tasks and wake its stream."""
+        for task in list(session.tasks):
+            if not task.done():
+                task.cancel()
+        session.tasks.clear()
+        session.events.new_event.set()
+
+    # ------------------------------------------------------------------
+    # Request validation helpers
+    # ------------------------------------------------------------------
+
+    def _check_origin(self, request: web.Request) -> Optional[web.Response]:
+        """Validate the Origin header (DNS-rebinding protection).
+
+        Requests without an ``Origin`` header (server-to-server clients such
+        as Claude.ai) are always allowed. Localhost origins are always
+        allowed. When ``config.allowed_origins`` is unset, any origin is
+        allowed for backward compatibility.
+        """
+        origin = request.headers.get("Origin")
+        if not origin:
+            return None
+        hostname = urlparse(origin).hostname or ""
+        if hostname in {"localhost", "127.0.0.1", "::1"}:
+            return None
+        if self._allowed_origins is None:
+            return None
+        if origin.rstrip("/") in {o.rstrip("/") for o in self._allowed_origins}:
+            return None
+        return web.json_response(
+            _jsonrpc_error(-32600, f"Origin not allowed: {origin}"),
+            status=403,
+        )
+
+    def _check_protocol_header(
+        self, request: web.Request
+    ) -> Optional[web.Response]:
+        """Reject requests carrying an unsupported protocol-version header."""
+        header = request.headers.get("MCP-Protocol-Version")
+        if header and header not in SUPPORTED_PROTOCOL_VERSIONS:
+            return web.json_response(
+                _jsonrpc_error(
+                    -32600,
+                    f"Unsupported MCP protocol version: {header}. "
+                    f"Supported: {', '.join(SUPPORTED_PROTOCOL_VERSIONS)}",
+                ),
+                status=400,
+            )
+        return None
+
+    @staticmethod
+    def _wants_sse(request: web.Request) -> bool:
+        """True when the client accepts SSE responses to POST."""
+        return "text/event-stream" in request.headers.get("Accept", "")
+
+    @staticmethod
+    def _is_request(message: Any) -> bool:
+        """True for a JSON-RPC request (has method AND id)."""
+        return (
+            isinstance(message, dict)
+            and "method" in message
+            and "id" in message
+        )
+
+    # ------------------------------------------------------------------
+    # POST — client-to-server messages
+    # ------------------------------------------------------------------
+
+    async def _handle_streamable_post(
+        self, request: web.Request
+    ) -> web.StreamResponse:
+        """Handle POST: JSON-RPC single messages or batches."""
+        auth_response = await self._authenticate_request(request)
+        if auth_response:
+            return auth_response
+        for check in (self._check_origin, self._check_protocol_header):
+            error = check(request)
+            if error:
+                return error
+
+        try:
+            data = await request.json()
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return web.json_response(
+                _jsonrpc_error(-32700, "Parse error"), status=400
+            )
+
+        is_batch = isinstance(data, list)
+        messages: List[Any] = data if is_batch else [data]
+        if not messages or not all(isinstance(m, dict) for m in messages):
+            return web.json_response(
+                _jsonrpc_error(-32600, "Invalid Request"), status=400
+            )
+
+        is_initialize = any(
+            m.get("method") == "initialize" for m in messages
+        )
+        session: Optional[McpStreamSession] = None
+        if not is_initialize:
+            session_id = request.headers.get("Mcp-Session-Id")
+            if session_id:
+                session = self._get_session(session_id)
+                if session is None:
+                    return web.json_response(
+                        _jsonrpc_error(-32001, "Session not found"),
+                        status=404,
+                    )
+            # Missing session id is tolerated (lenient stateless mode) —
+            # the spec says SHOULD 400; we accept for pragmatic interop
+            # with hand-rolled clients.
+
+        requests_ = [m for m in messages if self._is_request(m)]
+
+        if not requests_:
+            # Only notifications and/or responses: run them for their side
+            # effects and acknowledge with 202 (spec requirement).
+            for message in messages:
+                await self._handle_request(message)
+            return web.Response(status=202)
+
+        if is_initialize:
+            return await self._respond_initialize(
+                request, messages, is_batch
+            )
+
+        if self._wants_sse(request) and session is not None:
+            return await self._respond_sse(request, session, messages)
+
+        return await self._respond_json(request, messages, is_batch)
+
+    async def _respond_initialize(
+        self,
+        request: web.Request,
+        messages: List[Dict[str, Any]],
+        is_batch: bool,
+    ) -> web.Response:
+        """Dispatch an initialize body, minting a new session."""
+        responses = []
+        negotiated: Optional[str] = None
+        for message in messages:
+            response = await self._handle_request(message)
+            if response is not None:
+                responses.append(response)
+                if message.get("method") == "initialize":
+                    negotiated = response.get("result", {}).get(
+                        "protocolVersion"
+                    )
+
+        session = self._create_session(
+            protocol_version=negotiated or ASSUMED_HEADER_VERSION,
+            user=request.get("mcp_user"),
+        )
+        payload: Any = responses if is_batch else responses[0]
+        return web.json_response(
+            payload, headers={"Mcp-Session-Id": session.session_id}
+        )
+
+    async def _respond_json(
+        self,
+        request: web.Request,
+        messages: List[Dict[str, Any]],
+        is_batch: bool,
+    ) -> web.Response:
+        """Answer a request-bearing body with a plain JSON response."""
+        responses = []
+        for message in messages:
+            response = await self._handle_request(message)
+            if response is None:
+                continue
+            if "result" in response and "tools" in response.get("result", {}):
+                if "Anthropic" in request.headers.get("User-Agent", ""):
+                    response["result"] = self._convert_tools_to_anthropic(
+                        response["result"]
+                    )
+            responses.append(response)
+        payload: Any = responses if is_batch else responses[0]
+        return web.json_response(payload)
+
+    async def _respond_sse(
+        self,
+        request: web.Request,
+        session: McpStreamSession,
+        messages: List[Dict[str, Any]],
+    ) -> web.StreamResponse:
+        """Answer a request-bearing body with an SSE stream.
+
+        Each request is dispatched as an independent asyncio task that
+        records its response in the session's event store even if the
+        client disconnects — the client can then resume via
+        ``GET + Last-Event-ID`` and still collect the results.
+        """
+        tasks: List[asyncio.Task] = []
+        for message in messages:
+            if self._is_request(message):
+                task = asyncio.create_task(
+                    self._dispatch_to_store(session, message)
+                )
+                session.tasks.add(task)
+                task.add_done_callback(session.tasks.discard)
+                tasks.append(task)
+            else:
+                # Notifications inside a mixed body: side effects only.
+                await self._handle_request(message)
+
+        response = web.StreamResponse(
+            status=200,
+            headers={
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+            },
+        )
+        await response.prepare(request)
+        try:
+            for finished in asyncio.as_completed(tasks):
+                event = await finished
+                if event is None or event.delivered:
+                    continue
+                await response.write(event.to_sse())
+                event.delivered = True
+            with contextlib.suppress(Exception):
+                await response.write_eof()
+        except (
+            asyncio.CancelledError,
+            ConnectionResetError,
+            ConnectionError,
+            OSError,
+        ):
+            # Client went away mid-call: dispatch tasks keep running and
+            # their responses stay buffered (undelivered) for resumption.
+            self.logger.info(
+                "SSE POST client disconnected; %s call(s) continue for "
+                "session %s",
+                sum(1 for t in tasks if not t.done()),
+                session.session_id,
+            )
+        return response
+
+    async def _dispatch_to_store(
+        self, session: McpStreamSession, message: Dict[str, Any]
+    ) -> Optional[StreamEvent]:
+        """Run one JSON-RPC request and buffer its response as an event."""
+        response = await self._handle_request(message)
+        if response is None:
+            return None
+        return session.events.append(response)
+
+    # ------------------------------------------------------------------
+    # GET — server-to-client stream (resumable)
+    # ------------------------------------------------------------------
+
+    async def _handle_streamable_get(
+        self, request: web.Request
+    ) -> web.StreamResponse:
+        """Open the session's SSE stream, replaying from Last-Event-ID."""
+        auth_response = await self._authenticate_request(request)
+        if auth_response:
+            return auth_response
+        error = self._check_origin(request)
+        if error:
+            return error
+
+        if not self._wants_sse(request):
+            return web.Response(
+                status=405, headers={"Allow": "POST, DELETE"}
+            )
+
+        session_id = request.headers.get("Mcp-Session-Id")
+        if not session_id:
+            return web.json_response(
+                _jsonrpc_error(-32600, "Missing Mcp-Session-Id header"),
+                status=400,
+            )
+        session = self._get_session(session_id)
+        if session is None:
+            return web.json_response(
+                _jsonrpc_error(-32001, "Session not found"), status=404
+            )
+        if session.live_stream:
+            return web.json_response(
+                _jsonrpc_error(
+                    -32600, "A stream is already open for this session"
+                ),
+                status=409,
+            )
+
+        last_event_id: Optional[int] = None
+        raw_last_id = request.headers.get("Last-Event-ID")
+        if raw_last_id:
+            with contextlib.suppress(ValueError):
+                last_event_id = int(raw_last_id)
+
+        session.live_stream = True
+        response = web.StreamResponse(
+            status=200,
+            headers={
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "Mcp-Session-Id": session.session_id,
+            },
+        )
+        try:
+            await response.prepare(request)
+            store = session.events
+
+            # Resume: replay buffered events after the client's last id
+            # (delivered or not — the client told us where it stopped).
+            replay = (
+                store.events_after(last_event_id)
+                if last_event_id is not None
+                else store.undelivered()
+            )
+            for event in replay:
+                await response.write(event.to_sse())
+                event.delivered = True
+
+            # Live phase: deliver new events as dispatch tasks complete.
+            while session.session_id in self._sessions:
+                store.new_event.clear()
+                for event in store.undelivered():
+                    await response.write(event.to_sse())
+                    event.delivered = True
+                try:
+                    await asyncio.wait_for(
+                        store.new_event.wait(), timeout=KEEP_ALIVE_INTERVAL
+                    )
+                except asyncio.TimeoutError:
+                    await response.write(b": keep-alive\n\n")
+        except (
+            asyncio.CancelledError,
+            ConnectionResetError,
+            ConnectionError,
+            OSError,
+        ):
+            self.logger.info(
+                "SSE GET client disconnected: %s", session.session_id
+            )
+        finally:
+            session.live_stream = False
+            with contextlib.suppress(Exception):
+                await response.write_eof()
+        return response
+
+    # ------------------------------------------------------------------
+    # DELETE — session termination
+    # ------------------------------------------------------------------
+
+    async def _handle_streamable_delete(
+        self, request: web.Request
+    ) -> web.Response:
+        """Terminate a session, cancelling its pending dispatch tasks."""
+        auth_response = await self._authenticate_request(request)
+        if auth_response:
+            return auth_response
+
+        session_id = request.headers.get("Mcp-Session-Id")
+        if not session_id:
+            return web.json_response(
+                _jsonrpc_error(-32600, "Missing Mcp-Session-Id header"),
+                status=400,
+            )
+        session = self._sessions.pop(session_id, None)
+        if session is None:
+            return web.json_response(
+                _jsonrpc_error(-32001, "Session not found"), status=404
+            )
+        self._teardown_session(session)
+        self.logger.info("Terminated MCP session: %s", session_id)
+        return web.Response(status=204)

--- a/packages/ai-parrot-server/tests/mcp/test_streamable_http.py
+++ b/packages/ai-parrot-server/tests/mcp/test_streamable_http.py
@@ -1,0 +1,499 @@
+"""Tests for the MCP Streamable HTTP transport (spec rev 2025-03-26).
+
+Covers the Claude.ai-compatibility surface (POST JSON mode, 202 for
+notifications, Mcp-Session-Id lifecycle, protocol version negotiation,
+Origin validation) and the resumability path: SSE POST responses with
+event ids, and GET + Last-Event-ID resume after a client disconnect
+mid-call — the "launch an agent flow, reconnect, collect the result"
+scenario.
+
+Manual smoke test against a running server (needs the ``mcp`` extra)::
+
+    uv run --extra mcp python - <<'EOF'
+    import asyncio
+    from mcp.client.streamable_http import streamablehttp_client
+    from mcp import ClientSession
+
+    async def main():
+        async with streamablehttp_client("http://127.0.0.1:9090/mcp") as (r, w, _):
+            async with ClientSession(r, w) as session:
+                await session.initialize()
+                print(await session.list_tools())
+
+    asyncio.run(main())
+    EOF
+"""
+import asyncio
+import json
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from pydantic import BaseModel, Field
+
+from parrot.mcp.config import AuthMethod, MCPServerConfig
+from parrot.mcp.server_base import LATEST_PROTOCOL_VERSION, SUPPORTED_PROTOCOL_VERSIONS
+from parrot.mcp.transports.streamable_http import StreamableHttpMCPServer
+from parrot.tools.abstract import AbstractTool
+
+
+class EchoInput(BaseModel):
+    text: str = Field(..., description="Text to echo")
+
+
+class EchoTool(AbstractTool):
+    """Echo input back"""
+    name = "echo"
+    description = "Echo input back"
+    args_schema = EchoInput
+
+    async def _execute(self, text: str) -> str:
+        return text
+
+
+class SlowInput(BaseModel):
+    text: str = Field(..., description="Text to echo after a delay")
+
+
+class SlowTool(AbstractTool):
+    """Echo input back after a short delay (simulates a long agent flow)."""
+    name = "slow_echo"
+    description = "Echo input back after a delay"
+    args_schema = SlowInput
+
+    async def _execute(self, text: str) -> str:
+        await asyncio.sleep(0.3)
+        return text
+
+
+def make_server(**overrides) -> StreamableHttpMCPServer:
+    config = MCPServerConfig(
+        name="test-streamable",
+        transport="streamable-http",
+        **overrides,
+    )
+    server = StreamableHttpMCPServer(config)
+    server.register_tool(EchoTool())
+    server.register_tool(SlowTool())
+    server._register_routes(server.app.router, config.base_path)
+    return server
+
+
+@pytest.fixture
+async def client():
+    server = make_server()
+    test_client = TestClient(TestServer(server.app))
+    await test_client.start_server()
+    yield test_client
+    await server.stop()
+    await test_client.close()
+
+
+def initialize_body(version: str = "2025-03-26") -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": version,
+            "capabilities": {},
+            "clientInfo": {"name": "pytest", "version": "0"},
+        },
+    }
+
+
+async def do_initialize(client: TestClient, version: str = "2025-03-26"):
+    resp = await client.post("/mcp", json=initialize_body(version))
+    assert resp.status == 200
+    session_id = resp.headers.get("Mcp-Session-Id")
+    data = await resp.json()
+    return session_id, data
+
+
+async def read_sse_events(resp, count: int, timeout: float = 5.0):
+    """Read `count` SSE message events (id + data) from a response."""
+    events = []
+    current_id = None
+
+    async def _read():
+        nonlocal current_id
+        while len(events) < count:
+            line = (await resp.content.readline()).decode().rstrip("\n")
+            if line.startswith("id: "):
+                current_id = int(line[4:])
+            elif line.startswith("data: "):
+                events.append((current_id, json.loads(line[6:])))
+
+    await asyncio.wait_for(_read(), timeout)
+    return events
+
+
+class TestInitializeAndVersions:
+    @pytest.mark.parametrize("version", SUPPORTED_PROTOCOL_VERSIONS)
+    async def test_initialize_echoes_supported_version(self, client, version):
+        session_id, data = await do_initialize(client, version)
+        assert session_id, "Mcp-Session-Id header must be issued on initialize"
+        assert data["result"]["protocolVersion"] == version
+
+    async def test_initialize_unknown_version_gets_latest(self, client):
+        _, data = await do_initialize(client, "1999-01-01")
+        assert data["result"]["protocolVersion"] == LATEST_PROTOCOL_VERSION
+
+    async def test_bad_protocol_version_header_rejected(self, client):
+        resp = await client.post(
+            "/mcp",
+            json=initialize_body(),
+            headers={"MCP-Protocol-Version": "1999-01-01"},
+        )
+        assert resp.status == 400
+
+    async def test_info_reports_transport(self, client):
+        resp = await client.get("/mcp/info")
+        data = await resp.json()
+        assert data["transport"] == "streamable-http"
+
+
+class TestPostSemantics:
+    async def test_notification_returns_202(self, client):
+        resp = await client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        )
+        assert resp.status == 202
+        assert await resp.read() == b""
+
+    async def test_tools_roundtrip_json_mode(self, client):
+        session_id, _ = await do_initialize(client)
+        headers = {"Mcp-Session-Id": session_id}
+
+        resp = await client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+            headers=headers,
+        )
+        assert resp.status == 200
+        tools = (await resp.json())["result"]["tools"]
+        assert {t["name"] for t in tools} == {"echo", "slow_echo"}
+
+        resp = await client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {"name": "echo", "arguments": {"text": "hi"}},
+            },
+            headers=headers,
+        )
+        result = (await resp.json())["result"]
+        assert result["isError"] is False
+        assert any("hi" in c["text"] for c in result["content"])
+
+    async def test_batch_post_returns_array(self, client):
+        session_id, _ = await do_initialize(client)
+        resp = await client.post(
+            "/mcp",
+            json=[
+                {"jsonrpc": "2.0", "id": 10, "method": "tools/list"},
+                {"jsonrpc": "2.0", "id": 11, "method": "tools/list"},
+            ],
+            headers={"Mcp-Session-Id": session_id},
+        )
+        data = await resp.json()
+        assert isinstance(data, list)
+        assert {r["id"] for r in data} == {10, 11}
+
+    async def test_unknown_session_returns_404(self, client):
+        resp = await client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+            headers={"Mcp-Session-Id": "no-such-session"},
+        )
+        assert resp.status == 404
+
+    async def test_missing_session_is_tolerated(self, client):
+        # Lenient stateless mode: hand-rolled clients without session ids
+        # still get JSON answers.
+        resp = await client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+        )
+        assert resp.status == 200
+
+    async def test_parse_error_returns_400(self, client):
+        resp = await client.post(
+            "/mcp",
+            data=b"{not json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status == 400
+        assert (await resp.json())["error"]["code"] == -32700
+
+
+class TestSessionLifecycle:
+    async def test_delete_terminates_session(self, client):
+        session_id, _ = await do_initialize(client)
+        resp = await client.delete(
+            "/mcp", headers={"Mcp-Session-Id": session_id}
+        )
+        assert resp.status == 204
+
+        # Session is gone afterwards
+        resp = await client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+            headers={"Mcp-Session-Id": session_id},
+        )
+        assert resp.status == 404
+
+    async def test_delete_without_header_returns_400(self, client):
+        resp = await client.delete("/mcp")
+        assert resp.status == 400
+
+    async def test_delete_unknown_session_returns_404(self, client):
+        resp = await client.delete(
+            "/mcp", headers={"Mcp-Session-Id": "no-such-session"}
+        )
+        assert resp.status == 404
+
+
+class TestGetStream:
+    async def test_get_without_sse_accept_returns_405(self, client):
+        resp = await client.get("/mcp", headers={"Accept": "application/json"})
+        assert resp.status == 405
+        assert "POST" in resp.headers.get("Allow", "")
+
+    async def test_get_without_session_returns_400(self, client):
+        resp = await client.get(
+            "/mcp", headers={"Accept": "text/event-stream"}
+        )
+        assert resp.status == 400
+
+    async def test_get_unknown_session_returns_404(self, client):
+        resp = await client.get(
+            "/mcp",
+            headers={
+                "Accept": "text/event-stream",
+                "Mcp-Session-Id": "no-such-session",
+            },
+        )
+        assert resp.status == 404
+
+    async def test_second_concurrent_get_returns_409(self, client):
+        session_id, _ = await do_initialize(client)
+        headers = {
+            "Accept": "text/event-stream",
+            "Mcp-Session-Id": session_id,
+        }
+        first = await client.get("/mcp", headers=headers, timeout=None)
+        assert first.status == 200
+        second = await client.get("/mcp", headers=headers)
+        assert second.status == 409
+        first.close()
+
+
+class TestSsePostResponses:
+    async def test_post_with_sse_accept_streams_response(self, client):
+        session_id, _ = await do_initialize(client)
+        resp = await client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 5,
+                "method": "tools/call",
+                "params": {"name": "echo", "arguments": {"text": "sse"}},
+            },
+            headers={
+                "Accept": "application/json, text/event-stream",
+                "Mcp-Session-Id": session_id,
+            },
+        )
+        assert resp.status == 200
+        assert "text/event-stream" in resp.headers["Content-Type"]
+        events = await read_sse_events(resp, 1)
+        event_id, message = events[0]
+        assert event_id == 1
+        assert message["id"] == 5
+        assert message["result"]["isError"] is False
+
+    async def test_sse_event_ids_increment(self, client):
+        session_id, _ = await do_initialize(client)
+        headers = {
+            "Accept": "text/event-stream",
+            "Mcp-Session-Id": session_id,
+        }
+        for expected_id, request_id in ((1, 21), (2, 22)):
+            resp = await client.post(
+                "/mcp",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "method": "tools/list",
+                },
+                headers=headers,
+            )
+            events = await read_sse_events(resp, 1)
+            assert events[0][0] == expected_id
+            assert events[0][1]["id"] == request_id
+
+
+class TestResumability:
+    async def test_disconnect_and_resume_collects_result(self, client):
+        """Launch a slow call over SSE, drop the connection mid-call, then
+        resume via GET + Last-Event-ID and still receive the result."""
+        session_id, _ = await do_initialize(client)
+
+        resp = await client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 42,
+                "method": "tools/call",
+                "params": {"name": "slow_echo", "arguments": {"text": "flow"}},
+            },
+            headers={
+                "Accept": "text/event-stream",
+                "Mcp-Session-Id": session_id,
+            },
+        )
+        assert resp.status == 200
+        # Disconnect before the slow tool (0.3s) finishes.
+        resp.close()
+
+        # Reconnect and resume from the beginning of the stream.
+        get_resp = await client.get(
+            "/mcp",
+            headers={
+                "Accept": "text/event-stream",
+                "Mcp-Session-Id": session_id,
+                "Last-Event-ID": "0",
+            },
+            timeout=None,
+        )
+        assert get_resp.status == 200
+        events = await read_sse_events(get_resp, 1)
+        event_id, message = events[0]
+        assert event_id == 1
+        assert message["id"] == 42
+        assert any(
+            "flow" in c["text"] for c in message["result"]["content"]
+        )
+        get_resp.close()
+
+    async def test_last_event_id_replays_only_later_events(self, client):
+        session_id, _ = await do_initialize(client)
+        headers = {
+            "Accept": "text/event-stream",
+            "Mcp-Session-Id": session_id,
+        }
+        # Produce two buffered events (ids 1 and 2).
+        for request_id in (31, 32):
+            resp = await client.post(
+                "/mcp",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "method": "tools/list",
+                },
+                headers=headers,
+            )
+            await read_sse_events(resp, 1)
+
+        get_resp = await client.get(
+            "/mcp",
+            headers={**headers, "Last-Event-ID": "1"},
+            timeout=None,
+        )
+        events = await read_sse_events(get_resp, 1)
+        assert events[0][0] == 2
+        assert events[0][1]["id"] == 32
+        get_resp.close()
+
+    async def test_event_buffer_is_bounded(self):
+        server = make_server(event_buffer_size=2)
+        test_client = TestClient(TestServer(server.app))
+        await test_client.start_server()
+        try:
+            session_id, _ = await do_initialize(test_client)
+            headers = {
+                "Accept": "text/event-stream",
+                "Mcp-Session-Id": session_id,
+            }
+            for request_id in (51, 52, 53):
+                resp = await test_client.post(
+                    "/mcp",
+                    json={
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "method": "tools/list",
+                    },
+                    headers=headers,
+                )
+                await read_sse_events(resp, 1)
+
+            session = server._sessions[session_id]
+            replay = session.events.events_after(0)
+            # Ring buffer of 2: event 1 was evicted.
+            assert [e.event_id for e in replay] == [2, 3]
+        finally:
+            await server.stop()
+            await test_client.close()
+
+
+class TestOriginValidation:
+    async def make_client(self, **overrides):
+        server = make_server(**overrides)
+        test_client = TestClient(TestServer(server.app))
+        await test_client.start_server()
+        return server, test_client
+
+    async def test_disallowed_origin_rejected(self):
+        server, test_client = await self.make_client(
+            allowed_origins=["https://claude.ai"]
+        )
+        try:
+            resp = await test_client.post(
+                "/mcp",
+                json=initialize_body(),
+                headers={"Origin": "https://evil.example"},
+            )
+            assert resp.status == 403
+        finally:
+            await server.stop()
+            await test_client.close()
+
+    async def test_allowed_origin_accepted(self):
+        server, test_client = await self.make_client(
+            allowed_origins=["https://claude.ai"]
+        )
+        try:
+            resp = await test_client.post(
+                "/mcp",
+                json=initialize_body(),
+                headers={"Origin": "https://claude.ai"},
+            )
+            assert resp.status == 200
+        finally:
+            await server.stop()
+            await test_client.close()
+
+    async def test_any_origin_allowed_without_allowlist(self, client):
+        resp = await client.post(
+            "/mcp",
+            json=initialize_body(),
+            headers={"Origin": "https://anywhere.example"},
+        )
+        assert resp.status == 200
+
+
+class TestAuth:
+    async def test_api_key_required_when_configured(self):
+        server = make_server(auth_method=AuthMethod.API_KEY)
+        test_client = TestClient(TestServer(server.app))
+        await test_client.start_server()
+        try:
+            resp = await test_client.post("/mcp", json=initialize_body())
+            assert resp.status == 401
+        finally:
+            await server.stop()
+            await test_client.close()

--- a/packages/ai-parrot-server/tests/mcp/test_streamable_http.py
+++ b/packages/ai-parrot-server/tests/mcp/test_streamable_http.py
@@ -3,7 +3,7 @@
 Covers the Claude.ai-compatibility surface (POST JSON mode, 202 for
 notifications, Mcp-Session-Id lifecycle, protocol version negotiation,
 Origin validation) and the resumability path: SSE POST responses with
-event ids, and GET + Last-Event-ID resume after a client disconnect
+stream-scoped event ids, and GET resume after a client disconnect
 mid-call — the "launch an agent flow, reconnect, collect the result"
 scenario.
 
@@ -24,17 +24,23 @@ Manual smoke test against a running server (needs the ``mcp`` extra)::
     EOF
 """
 import asyncio
+import contextlib
 import json
 
 import pytest
 from aiohttp import web
-from aiohttp.test_utils import TestClient, TestServer
+from aiohttp.test_utils import TestClient, TestServer, make_mocked_request
+from multidict import CIMultiDict
+from parrot.mcp.server_base import LATEST_PROTOCOL_VERSION, SUPPORTED_PROTOCOL_VERSIONS
+from parrot.tools.abstract import AbstractTool
 from pydantic import BaseModel, Field
 
 from parrot.mcp.config import AuthMethod, MCPServerConfig
-from parrot.mcp.server_base import LATEST_PROTOCOL_VERSION, SUPPORTED_PROTOCOL_VERSIONS
-from parrot.mcp.transports.streamable_http import StreamableHttpMCPServer
-from parrot.tools.abstract import AbstractTool
+from parrot.mcp.oauth_server import APIKeyStore
+from parrot.mcp.transports.streamable_http import (
+    StreamableHttpMCPServer,
+    parse_event_id,
+)
 
 
 class EchoInput(BaseModel):
@@ -89,6 +95,17 @@ async def client():
     await test_client.close()
 
 
+@pytest.fixture
+async def server_and_client():
+    """Both halves, for tests that inspect server state directly."""
+    server = make_server()
+    test_client = TestClient(TestServer(server.app))
+    await test_client.start_server()
+    yield server, test_client
+    await server.stop()
+    await test_client.close()
+
+
 def initialize_body(version: str = "2025-03-26") -> dict:
     return {
         "jsonrpc": "2.0",
@@ -102,8 +119,8 @@ def initialize_body(version: str = "2025-03-26") -> dict:
     }
 
 
-async def do_initialize(client: TestClient, version: str = "2025-03-26"):
-    resp = await client.post("/mcp", json=initialize_body(version))
+async def do_initialize(client: TestClient, version: str = "2025-03-26", **kwargs):
+    resp = await client.post("/mcp", json=initialize_body(version), **kwargs)
     assert resp.status == 200
     session_id = resp.headers.get("Mcp-Session-Id")
     data = await resp.json()
@@ -111,7 +128,11 @@ async def do_initialize(client: TestClient, version: str = "2025-03-26"):
 
 
 async def read_sse_events(resp, count: int, timeout: float = 5.0):
-    """Read `count` SSE message events (id + data) from a response."""
+    """Read `count` SSE message events (id + data) from a response.
+
+    Event ids are stream-scoped strings (``{stream_id}:{sequence}``), not
+    plain integers.
+    """
     events = []
     current_id = None
 
@@ -120,7 +141,7 @@ async def read_sse_events(resp, count: int, timeout: float = 5.0):
         while len(events) < count:
             line = (await resp.content.readline()).decode().rstrip("\n")
             if line.startswith("id: "):
-                current_id = int(line[4:])
+                current_id = line[4:]
             elif line.startswith("data: "):
                 events.append((current_id, json.loads(line[6:])))
 
@@ -152,6 +173,39 @@ class TestInitializeAndVersions:
         data = await resp.json()
         assert data["transport"] == "streamable-http"
 
+    async def test_batched_initialize_rejected(self, client):
+        """The MCP lifecycle forbids batching initialize."""
+        resp = await client.post(
+            "/mcp",
+            json=[
+                initialize_body(),
+                {"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+            ],
+        )
+        assert resp.status == 400
+        assert "batched" in (await resp.json())["error"]["message"]
+
+    async def test_sse_only_client_gets_initialize_over_sse(self, client):
+        """A client that accepts only SSE is answered on a stream."""
+        resp = await client.post(
+            "/mcp",
+            json=initialize_body(),
+            headers={"Accept": "text/event-stream"},
+        )
+        assert resp.status == 200
+        assert "text/event-stream" in resp.headers["Content-Type"]
+        assert resp.headers.get("Mcp-Session-Id")
+        events = await read_sse_events(resp, 1)
+        assert events[0][1]["result"]["protocolVersion"] == "2025-03-26"
+
+    async def test_unacceptable_accept_returns_406(self, client):
+        resp = await client.post(
+            "/mcp",
+            json=initialize_body(),
+            headers={"Accept": "application/xml"},
+        )
+        assert resp.status == 406
+
 
 class TestPostSemantics:
     async def test_notification_returns_202(self, client):
@@ -161,6 +215,24 @@ class TestPostSemantics:
         )
         assert resp.status == 202
         assert await resp.read() == b""
+
+    async def test_notification_with_an_id_is_still_a_notification(self, client):
+        """A notification carrying an id must not 500 the endpoint.
+
+        ``notifications/initialized`` produces no response, so treating it as
+        a request left nothing to answer with and raised IndexError.
+        """
+        session_id, _ = await do_initialize(client)
+        resp = await client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": "notifications/initialized",
+            },
+            headers={"Mcp-Session-Id": session_id},
+        )
+        assert resp.status == 202
 
     async def test_tools_roundtrip_json_mode(self, client):
         session_id, _ = await do_initialize(client)
@@ -188,6 +260,16 @@ class TestPostSemantics:
         result = (await resp.json())["result"]
         assert result["isError"] is False
         assert any("hi" in c["text"] for c in result["content"])
+
+    async def test_session_id_echoed_on_later_responses(self, client):
+        """Clients that re-read the header per response must keep the session."""
+        session_id, _ = await do_initialize(client)
+        resp = await client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+            headers={"Mcp-Session-Id": session_id},
+        )
+        assert resp.headers.get("Mcp-Session-Id") == session_id
 
     async def test_batch_post_returns_array(self, client):
         session_id, _ = await do_initialize(client)
@@ -219,6 +301,15 @@ class TestPostSemantics:
             json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
         )
         assert resp.status == 200
+
+    async def test_sse_without_session_is_refused(self, client):
+        """An SSE-only client cannot stream without first initializing."""
+        resp = await client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+            headers={"Accept": "text/event-stream"},
+        )
+        assert resp.status == 400
 
     async def test_parse_error_returns_400(self, client):
         resp = await client.post(
@@ -256,6 +347,106 @@ class TestSessionLifecycle:
         )
         assert resp.status == 404
 
+    async def test_delete_awaits_cancellation(self, server_and_client):
+        """204 must mean the in-flight work has actually stopped."""
+        server, test_client = server_and_client
+        session_id, _ = await do_initialize(test_client)
+        headers = {
+            "Accept": "text/event-stream",
+            "Mcp-Session-Id": session_id,
+        }
+        resp = await test_client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 60,
+                "method": "tools/call",
+                "params": {"name": "slow_echo", "arguments": {"text": "x"}},
+            },
+            headers=headers,
+        )
+        assert resp.status == 200
+        session = server._sessions[session_id]
+        await asyncio.sleep(0.05)
+        assert session.tasks, "dispatch task should be tracked"
+        tasks = list(session.tasks.values())
+
+        del_resp = await test_client.delete(
+            "/mcp", headers={"Mcp-Session-Id": session_id}
+        )
+        assert del_resp.status == 204
+        assert all(t.done() for t in tasks), "204 returned with work still running"
+        resp.close()
+
+    async def test_max_sessions_returns_503(self):
+        server = make_server(max_sessions=2)
+        test_client = TestClient(TestServer(server.app))
+        await test_client.start_server()
+        try:
+            await do_initialize(test_client)
+            await do_initialize(test_client)
+            resp = await test_client.post("/mcp", json=initialize_body())
+            assert resp.status == 503
+            assert len(server._sessions) == 2
+        finally:
+            await server.stop()
+            await test_client.close()
+
+    async def test_busy_sessions_are_not_pruned(self, server_and_client):
+        """A session with unfinished work must survive its idle TTL."""
+        server, test_client = server_and_client
+        session_id, _ = await do_initialize(test_client)
+        session = server._sessions[session_id]
+
+        never = asyncio.Event()
+        task = asyncio.create_task(never.wait())
+        session.tasks[99] = task
+        session.last_seen -= server._session_ttl * 10  # long past the TTL
+
+        await server._prune_sessions()
+        assert session_id in server._sessions
+
+        never.set()
+        await task
+        session.tasks.pop(99, None)
+        await server._prune_sessions()
+        assert session_id not in server._sessions
+
+    async def test_cancelled_notification_stops_the_call(self, server_and_client):
+        server, test_client = server_and_client
+        session_id, _ = await do_initialize(test_client)
+        headers = {
+            "Accept": "text/event-stream",
+            "Mcp-Session-Id": session_id,
+        }
+        resp = await test_client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 61,
+                "method": "tools/call",
+                "params": {"name": "slow_echo", "arguments": {"text": "x"}},
+            },
+            headers=headers,
+        )
+        assert resp.status == 200
+        await asyncio.sleep(0.05)
+        task = server._sessions[session_id].tasks[61]
+
+        cancel = await test_client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "method": "notifications/cancelled",
+                "params": {"requestId": 61},
+            },
+            headers={"Mcp-Session-Id": session_id},
+        )
+        assert cancel.status == 202
+        await asyncio.sleep(0.05)
+        assert task.cancelled() or task.done()
+        resp.close()
+
 
 class TestGetStream:
     async def test_get_without_sse_accept_returns_405(self, client):
@@ -291,6 +482,30 @@ class TestGetStream:
         assert second.status == 409
         first.close()
 
+    async def test_malformed_last_event_id_returns_400(self, client):
+        session_id, _ = await do_initialize(client)
+        resp = await client.get(
+            "/mcp",
+            headers={
+                "Accept": "text/event-stream",
+                "Mcp-Session-Id": session_id,
+                "Last-Event-ID": "0",
+            },
+        )
+        assert resp.status == 400
+
+    async def test_unknown_stream_in_last_event_id_returns_404(self, client):
+        session_id, _ = await do_initialize(client)
+        resp = await client.get(
+            "/mcp",
+            headers={
+                "Accept": "text/event-stream",
+                "Mcp-Session-Id": session_id,
+                "Last-Event-ID": "no-such-stream:1",
+            },
+        )
+        assert resp.status == 404
+
 
 class TestSsePostResponses:
     async def test_post_with_sse_accept_streams_response(self, client):
@@ -312,17 +527,20 @@ class TestSsePostResponses:
         assert "text/event-stream" in resp.headers["Content-Type"]
         events = await read_sse_events(resp, 1)
         event_id, message = events[0]
-        assert event_id == 1
+        stream_id, sequence = parse_event_id(event_id)
+        assert stream_id and sequence == 1
         assert message["id"] == 5
         assert message["result"]["isError"] is False
 
-    async def test_sse_event_ids_increment(self, client):
+    async def test_each_post_gets_its_own_stream(self, client):
+        """Event ids are scoped per stream, so each POST restarts at 1."""
         session_id, _ = await do_initialize(client)
         headers = {
             "Accept": "text/event-stream",
             "Mcp-Session-Id": session_id,
         }
-        for expected_id, request_id in ((1, 21), (2, 22)):
+        stream_ids = set()
+        for request_id in (21, 22):
             resp = await client.post(
                 "/mcp",
                 json={
@@ -333,14 +551,69 @@ class TestSsePostResponses:
                 headers=headers,
             )
             events = await read_sse_events(resp, 1)
-            assert events[0][0] == expected_id
+            stream_id, sequence = parse_event_id(events[0][0])
+            assert sequence == 1
             assert events[0][1]["id"] == request_id
+            stream_ids.add(stream_id)
+        assert len(stream_ids) == 2, "each POST must open a distinct stream"
+
+    async def test_batch_over_sse_shares_one_stream(self, client):
+        session_id, _ = await do_initialize(client)
+        resp = await client.post(
+            "/mcp",
+            json=[
+                {"jsonrpc": "2.0", "id": 71, "method": "tools/list"},
+                {"jsonrpc": "2.0", "id": 72, "method": "tools/list"},
+            ],
+            headers={
+                "Accept": "text/event-stream",
+                "Mcp-Session-Id": session_id,
+            },
+        )
+        events = await read_sse_events(resp, 2)
+        streams = {parse_event_id(eid)[0] for eid, _ in events}
+        assert len(streams) == 1
+        assert {parse_event_id(eid)[1] for eid, _ in events} == {1, 2}
+
+    async def test_open_get_stream_does_not_steal_post_response(self, client):
+        """The response must travel on the stream that carried the request.
+
+        The official SDK opens a GET stream right after initialize, so this
+        is the ordinary state, not an edge case.
+        """
+        session_id, _ = await do_initialize(client)
+        headers = {
+            "Accept": "text/event-stream",
+            "Mcp-Session-Id": session_id,
+        }
+        get_resp = await client.get("/mcp", headers=headers, timeout=None)
+        assert get_resp.status == 200
+        await asyncio.sleep(0.1)  # let the GET stream settle into its wait
+
+        post = await client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 99,
+                "method": "tools/call",
+                "params": {"name": "echo", "arguments": {"text": "mine"}},
+            },
+            headers=headers,
+        )
+        assert post.status == 200
+        events = await read_sse_events(post, 1)
+        assert events[0][1]["id"] == 99
+        get_resp.close()
 
 
 class TestResumability:
     async def test_disconnect_and_resume_collects_result(self, client):
         """Launch a slow call over SSE, drop the connection mid-call, then
-        resume via GET + Last-Event-ID and still receive the result."""
+        reconnect with GET and still receive the result.
+
+        The abandoned POST stream is orphaned when its response unwinds, and
+        an orphaned stream is exactly what the session's GET stream adopts.
+        """
         session_id, _ = await do_initialize(client)
 
         resp = await client.post(
@@ -360,20 +633,18 @@ class TestResumability:
         # Disconnect before the slow tool (0.3s) finishes.
         resp.close()
 
-        # Reconnect and resume from the beginning of the stream.
         get_resp = await client.get(
             "/mcp",
             headers={
                 "Accept": "text/event-stream",
                 "Mcp-Session-Id": session_id,
-                "Last-Event-ID": "0",
             },
             timeout=None,
         )
         assert get_resp.status == 200
         events = await read_sse_events(get_resp, 1)
         event_id, message = events[0]
-        assert event_id == 1
+        assert parse_event_id(event_id)[1] == 1
         assert message["id"] == 42
         assert any(
             "flow" in c["text"] for c in message["result"]["content"]
@@ -381,32 +652,40 @@ class TestResumability:
         get_resp.close()
 
     async def test_last_event_id_replays_only_later_events(self, client):
+        """Resuming a stream replays that stream's events after the id."""
         session_id, _ = await do_initialize(client)
         headers = {
             "Accept": "text/event-stream",
             "Mcp-Session-Id": session_id,
         }
-        # Produce two buffered events (ids 1 and 2).
-        for request_id in (31, 32):
-            resp = await client.post(
-                "/mcp",
-                json={
-                    "jsonrpc": "2.0",
-                    "id": request_id,
-                    "method": "tools/list",
-                },
-                headers=headers,
-            )
-            await read_sse_events(resp, 1)
+        # One POST carrying two requests -> one stream, sequences 1 and 2.
+        resp = await client.post(
+            "/mcp",
+            json=[
+                {"jsonrpc": "2.0", "id": 31, "method": "tools/list"},
+                {"jsonrpc": "2.0", "id": 32, "method": "tools/list"},
+            ],
+            headers=headers,
+        )
+        events = await read_sse_events(resp, 2)
+        stream_id = parse_event_id(events[0][0])[0]
+        first_id = next(
+            eid for eid, msg in events if parse_event_id(eid)[1] == 1
+        )
+        second_msg_id = next(
+            msg["id"] for eid, msg in events if parse_event_id(eid)[1] == 2
+        )
+        resp.close()
+        await asyncio.sleep(0.05)
 
         get_resp = await client.get(
             "/mcp",
-            headers={**headers, "Last-Event-ID": "1"},
+            headers={**headers, "Last-Event-ID": first_id},
             timeout=None,
         )
-        events = await read_sse_events(get_resp, 1)
-        assert events[0][0] == 2
-        assert events[0][1]["id"] == 32
+        replayed = await read_sse_events(get_resp, 1)
+        assert parse_event_id(replayed[0][0]) == (stream_id, 2)
+        assert replayed[0][1]["id"] == second_msg_id
         get_resp.close()
 
     async def test_event_buffer_is_bounded(self):
@@ -419,22 +698,21 @@ class TestResumability:
                 "Accept": "text/event-stream",
                 "Mcp-Session-Id": session_id,
             }
-            for request_id in (51, 52, 53):
-                resp = await test_client.post(
-                    "/mcp",
-                    json={
-                        "jsonrpc": "2.0",
-                        "id": request_id,
-                        "method": "tools/list",
-                    },
-                    headers=headers,
-                )
-                await read_sse_events(resp, 1)
+            # One stream carrying three requests: the ring drops the oldest.
+            resp = await test_client.post(
+                "/mcp",
+                json=[
+                    {"jsonrpc": "2.0", "id": 51, "method": "tools/list"},
+                    {"jsonrpc": "2.0", "id": 52, "method": "tools/list"},
+                    {"jsonrpc": "2.0", "id": 53, "method": "tools/list"},
+                ],
+                headers=headers,
+            )
+            events = await read_sse_events(resp, 3)
+            stream_id = parse_event_id(events[0][0])[0]
 
-            session = server._sessions[session_id]
-            replay = session.events.events_after(0)
-            # Ring buffer of 2: event 1 was evicted.
-            assert [e.event_id for e in replay] == [2, 3]
+            buffer = server._sessions[session_id].streams[stream_id]
+            assert [e.sequence for e in buffer.events_after(0)] == [2, 3]
         finally:
             await server.stop()
             await test_client.close()
@@ -477,13 +755,72 @@ class TestOriginValidation:
             await server.stop()
             await test_client.close()
 
-    async def test_any_origin_allowed_without_allowlist(self, client):
+    async def test_unlisted_origin_rejected_by_default(self, client):
+        """No allowlist means localhost only — the spec's mandatory default."""
         resp = await client.post(
             "/mcp",
             json=initialize_body(),
             headers={"Origin": "https://anywhere.example"},
         )
+        assert resp.status == 403
+
+    async def test_localhost_origin_always_allowed(self, client):
+        resp = await client.post(
+            "/mcp",
+            json=initialize_body(),
+            headers={"Origin": "http://localhost:3000"},
+        )
         assert resp.status == 200
+
+    async def test_no_origin_header_allowed(self, client):
+        """Server-to-server clients (Claude.ai) send no Origin."""
+        resp = await client.post("/mcp", json=initialize_body())
+        assert resp.status == 200
+
+    async def test_allow_any_origin_escape_hatch(self):
+        server, test_client = await self.make_client(allow_any_origin=True)
+        try:
+            resp = await test_client.post(
+                "/mcp",
+                json=initialize_body(),
+                headers={"Origin": "https://anywhere.example"},
+            )
+            assert resp.status == 200
+        finally:
+            await server.stop()
+            await test_client.close()
+
+    async def test_origin_checked_on_get_and_delete(self):
+        server, test_client = await self.make_client(
+            allowed_origins=["https://claude.ai"]
+        )
+        try:
+            session_id, _ = await do_initialize(
+                test_client, headers={"Origin": "https://claude.ai"}
+            )
+            bad = {"Origin": "https://evil.example", "Mcp-Session-Id": session_id}
+            get_resp = await test_client.get(
+                "/mcp", headers={**bad, "Accept": "text/event-stream"}
+            )
+            assert get_resp.status == 403
+            del_resp = await test_client.delete("/mcp", headers=bad)
+            assert del_resp.status == 403
+        finally:
+            await server.stop()
+            await test_client.close()
+
+    async def test_protocol_header_checked_on_get_and_delete(self, client):
+        session_id, _ = await do_initialize(client)
+        bad = {
+            "MCP-Protocol-Version": "1999-01-01",
+            "Mcp-Session-Id": session_id,
+        }
+        get_resp = await client.get(
+            "/mcp", headers={**bad, "Accept": "text/event-stream"}
+        )
+        assert get_resp.status == 400
+        del_resp = await client.delete("/mcp", headers=bad)
+        assert del_resp.status == 400
 
 
 class TestAuth:
@@ -497,3 +834,255 @@ class TestAuth:
         finally:
             await server.stop()
             await test_client.close()
+
+    async def test_session_is_bound_to_its_owner(self):
+        """A leaked Mcp-Session-Id must not be usable by another principal."""
+        store = APIKeyStore()
+        alice = store.issue_key("alice").key
+        mallory = store.issue_key("mallory").key
+        server = make_server(
+            auth_method=AuthMethod.API_KEY, api_key_store=store
+        )
+        test_client = TestClient(TestServer(server.app))
+        await test_client.start_server()
+        try:
+            session_id, _ = await do_initialize(
+                test_client, headers={"X-API-Key": alice}
+            )
+            call = {"jsonrpc": "2.0", "id": 2, "method": "tools/list"}
+
+            mine = await test_client.post(
+                "/mcp",
+                json=call,
+                headers={"X-API-Key": alice, "Mcp-Session-Id": session_id},
+            )
+            assert mine.status == 200
+
+            theirs = await test_client.post(
+                "/mcp",
+                json=call,
+                headers={"X-API-Key": mallory, "Mcp-Session-Id": session_id},
+            )
+            assert theirs.status == 404
+
+            stolen_delete = await test_client.delete(
+                "/mcp",
+                headers={"X-API-Key": mallory, "Mcp-Session-Id": session_id},
+            )
+            assert stolen_delete.status == 404
+            assert session_id in server._sessions
+        finally:
+            await server.stop()
+            await test_client.close()
+
+
+class TestSharedAppMounting:
+    """The route set as ``start()`` actually mounts it.
+
+    The other suites register routes directly, which skips exactly the step
+    that used to serve the endpoint at ``/mcp/mcp``.
+    """
+
+    async def test_mounted_on_parent_app_at_base_path(self):
+        parent = web.Application()
+        config = MCPServerConfig(
+            name="mounted", transport="streamable-http"
+        )
+        server = StreamableHttpMCPServer(config, parent_app=parent)
+        server.register_tool(EchoTool())
+        await server.start()
+
+        test_client = TestClient(TestServer(parent))
+        await test_client.start_server()
+        try:
+            resp = await test_client.post("/mcp", json=initialize_body())
+            assert resp.status == 200, "endpoint must answer at base_path"
+            assert resp.headers.get("Mcp-Session-Id")
+
+            info = await test_client.get("/mcp/info")
+            assert info.status == 200
+
+            doubled = await test_client.post("/mcp/mcp", json=initialize_body())
+            assert doubled.status == 404, "base_path must not be applied twice"
+        finally:
+            await server.stop()
+            await test_client.close()
+
+    async def test_custom_base_path_is_honoured(self):
+        parent = web.Application()
+        config = MCPServerConfig(
+            name="mounted", transport="streamable-http", base_path="/tools/mcp"
+        )
+        server = StreamableHttpMCPServer(config, parent_app=parent)
+        server.register_tool(EchoTool())
+        await server.start()
+
+        test_client = TestClient(TestServer(parent))
+        await test_client.start_server()
+        try:
+            resp = await test_client.post("/tools/mcp", json=initialize_body())
+            assert resp.status == 200
+        finally:
+            await server.stop()
+            await test_client.close()
+
+
+class TestStreamIsolationAndBounds:
+    """Follow-ups from the adversarial review of the fixes."""
+
+    async def test_resumed_stream_does_not_replay_other_streams(self, client):
+        """A resumed GET carries its own stream and nothing else.
+
+        The spec forbids a resumed stream from replaying messages that
+        belong to a different one.
+        """
+        session_id, _ = await do_initialize(client)
+        headers = {
+            "Accept": "text/event-stream",
+            "Mcp-Session-Id": session_id,
+        }
+        # Stream A: read its event, then abandon the connection.
+        resp_a = await client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 81, "method": "tools/list"},
+            headers=headers,
+        )
+        events_a = await read_sse_events(resp_a, 1)
+        stream_a, _seq = parse_event_id(events_a[0][0])
+        resp_a.close()
+
+        # Stream B: launch a slow call and drop it, leaving an undelivered
+        # event behind on a *different* stream.
+        resp_b = await client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 82,
+                "method": "tools/call",
+                "params": {"name": "slow_echo", "arguments": {"text": "b"}},
+            },
+            headers=headers,
+        )
+        assert resp_b.status == 200
+        resp_b.close()
+        await asyncio.sleep(0.5)  # let the slow call finish and buffer
+
+        # Resume stream A from before its only event.
+        get_resp = await client.get(
+            "/mcp",
+            headers={**headers, "Last-Event-ID": f"{stream_a}:0"},
+            timeout=None,
+        )
+        assert get_resp.status == 200
+        events = await read_sse_events(get_resp, 1)
+        assert {parse_event_id(eid)[0] for eid, _ in events} == {stream_a}
+        assert events[0][1]["id"] == 81, "stream B's response must not appear"
+        get_resp.close()
+
+    async def test_streams_are_bounded_per_session(self):
+        """A session issuing many SSE POSTs must not accumulate buffers."""
+        server = make_server(max_streams_per_session=4)
+        test_client = TestClient(TestServer(server.app))
+        await test_client.start_server()
+        try:
+            session_id, _ = await do_initialize(test_client)
+            headers = {
+                "Accept": "text/event-stream",
+                "Mcp-Session-Id": session_id,
+            }
+            for request_id in range(90, 105):
+                resp = await test_client.post(
+                    "/mcp",
+                    json={
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "method": "tools/list",
+                    },
+                    headers=headers,
+                )
+                await read_sse_events(resp, 1)
+
+            streams = server._sessions[session_id].streams
+            assert len(streams) <= 5, (
+                f"expected the cap to hold, got {len(streams)} streams"
+            )
+        finally:
+            await server.stop()
+            await test_client.close()
+
+    async def test_teardown_abandons_tasks_that_ignore_cancellation(
+        self, server_and_client, monkeypatch
+    ):
+        """DELETE must not hang on a tool that swallows cancellation."""
+        import parrot.mcp.transports.streamable_http as module
+
+        monkeypatch.setattr(module, "TEARDOWN_TIMEOUT", 0.2)
+        server, test_client = server_and_client
+        session_id, _ = await do_initialize(test_client)
+        session = server._sessions[session_id]
+
+        release = asyncio.Event()
+
+        async def stubborn():
+            # Ignores cancellation until the test lets it go, so the run
+            # cannot be left with an uncollectable task.
+            while not release.is_set():
+                with contextlib.suppress(
+                    asyncio.TimeoutError, asyncio.CancelledError
+                ):
+                    await asyncio.wait_for(release.wait(), timeout=0.05)
+
+        task = asyncio.create_task(stubborn())
+        session.tasks[77] = task
+        try:
+            resp = await asyncio.wait_for(
+                test_client.delete(
+                    "/mcp", headers={"Mcp-Session-Id": session_id}
+                ),
+                timeout=5,
+            )
+            assert resp.status == 204, "DELETE must not hang on a stuck task"
+            assert not task.done(), "the task really did ignore cancellation"
+        finally:
+            release.set()
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(task, timeout=2)
+
+
+class TestPrincipalBinding:
+    """`_principal` must not collapse every caller onto None."""
+
+    def _request(self, server, **headers):
+        return make_mocked_request(
+            "POST", "/mcp", headers=CIMultiDict(headers), app=server.app
+        )
+
+    def test_no_auth_has_no_principal(self):
+        server = make_server()
+        assert server._principal(self._request(server)) is None
+
+    def test_credential_digest_binds_when_auth_attributes_nobody(self):
+        """Internal OAuth validates a token but names no user."""
+        server = make_server(auth_method=AuthMethod.OAUTH2_INTERNAL)
+        alice = server._principal(
+            self._request(server, Authorization="Bearer alice-token")
+        )
+        mallory = server._principal(
+            self._request(server, Authorization="Bearer mallory-token")
+        )
+        assert alice and mallory
+        assert alice != mallory, "different tokens must not share a session"
+        assert "alice-token" not in alice, "the credential must not be stored"
+
+    def test_user_id_preferred_over_digest(self):
+        server = make_server(auth_method=AuthMethod.API_KEY)
+        request = self._request(server, **{"X-API-Key": "k"})
+        request["mcp_user"] = {"user_id": "alice", "scopes": []}
+        assert server._principal(request) == "alice"
+
+    def test_falls_back_through_common_identity_keys(self):
+        """navigator-auth session data may not use `user_id`."""
+        server = make_server(auth_method=AuthMethod.BEARER)
+        request = self._request(server, Authorization="Bearer x")
+        request["mcp_user"] = {"email": "alice@example.com"}
+        assert server._principal(request) == "alice@example.com"

--- a/packages/ai-parrot-server/tests/mcp/test_streamable_http_interop.py
+++ b/packages/ai-parrot-server/tests/mcp/test_streamable_http_interop.py
@@ -13,13 +13,13 @@ import asyncio
 
 import pytest
 from aiohttp import web
+from parrot.tools.abstract import AbstractTool
 from pydantic import BaseModel, Field
 
 from parrot.mcp.config import MCPServerConfig
 from parrot.mcp.transports.streamable_http import StreamableHttpMCPServer
-from parrot.tools.abstract import AbstractTool
 
-mcp_sdk = pytest.importorskip("mcp", reason="requires the mcp extra")
+pytest.importorskip("mcp", reason="requires the mcp extra")
 pytestmark = pytest.mark.requires_mcp_sdk
 
 from mcp import ClientSession  # noqa: E402
@@ -48,11 +48,14 @@ async def server_url():
         host="127.0.0.1",
         port=0,
     )
-    server = StreamableHttpMCPServer(config)
+    # Mount through start() on a shared app, the way ParrotMCPServer does,
+    # so the interop check covers the real route-mounting path too.
+    app = web.Application()
+    server = StreamableHttpMCPServer(config, parent_app=app)
     server.register_tool(EchoTool())
-    server._register_routes(server.app.router, config.base_path)
+    await server.start()
 
-    runner = web.AppRunner(server.app)
+    runner = web.AppRunner(app)
     await runner.setup()
     site = web.TCPSite(runner, "127.0.0.1", 0)
     await site.start()
@@ -63,15 +66,17 @@ async def server_url():
 
 
 async def test_official_sdk_client_roundtrip(server_url):
-    async with streamablehttp_client(server_url) as (read, write, _):
-        async with ClientSession(read, write) as session:
-            init = await asyncio.wait_for(session.initialize(), timeout=10)
-            assert init.serverInfo.name == "interop-streamable"
+    async with (
+        streamablehttp_client(server_url) as (read, write, _),
+        ClientSession(read, write) as session,
+    ):
+        init = await asyncio.wait_for(session.initialize(), timeout=10)
+        assert init.serverInfo.name == "interop-streamable"
 
-            tools = await asyncio.wait_for(session.list_tools(), timeout=10)
-            assert any(t.name == "echo" for t in tools.tools)
+        tools = await asyncio.wait_for(session.list_tools(), timeout=10)
+        assert any(t.name == "echo" for t in tools.tools)
 
-            result = await asyncio.wait_for(
-                session.call_tool("echo", {"text": "interop"}), timeout=10
-            )
-            assert any("interop" in c.text for c in result.content)
+        result = await asyncio.wait_for(
+            session.call_tool("echo", {"text": "interop"}), timeout=10
+        )
+        assert any("interop" in c.text for c in result.content)

--- a/packages/ai-parrot-server/tests/mcp/test_streamable_http_interop.py
+++ b/packages/ai-parrot-server/tests/mcp/test_streamable_http_interop.py
@@ -1,0 +1,77 @@
+"""Interop test: official MCP SDK Streamable HTTP client vs our server.
+
+This is the definitive Claude.ai-compatibility check — the SDK client
+(`mcp.client.streamable_http.streamablehttp_client`) speaks the same
+transport family Claude Web custom connectors use: it sends
+``Accept: application/json, text/event-stream``, echoes ``Mcp-Session-Id``
+and ``MCP-Protocol-Version``, and negotiates the protocol revision.
+
+Gated behind the ``mcp`` extra (mirrors the ``requires_aioquic`` pattern):
+run with ``uv run --extra mcp pytest ...`` or after ``uv pip install mcp``.
+"""
+import asyncio
+
+import pytest
+from aiohttp import web
+from pydantic import BaseModel, Field
+
+from parrot.mcp.config import MCPServerConfig
+from parrot.mcp.transports.streamable_http import StreamableHttpMCPServer
+from parrot.tools.abstract import AbstractTool
+
+mcp_sdk = pytest.importorskip("mcp", reason="requires the mcp extra")
+pytestmark = pytest.mark.requires_mcp_sdk
+
+from mcp import ClientSession  # noqa: E402
+from mcp.client.streamable_http import streamablehttp_client  # noqa: E402
+
+
+class EchoInput(BaseModel):
+    text: str = Field(..., description="Text to echo")
+
+
+class EchoTool(AbstractTool):
+    """Echo input back"""
+    name = "echo"
+    description = "Echo input back"
+    args_schema = EchoInput
+
+    async def _execute(self, text: str) -> str:
+        return text
+
+
+@pytest.fixture
+async def server_url():
+    config = MCPServerConfig(
+        name="interop-streamable",
+        transport="streamable-http",
+        host="127.0.0.1",
+        port=0,
+    )
+    server = StreamableHttpMCPServer(config)
+    server.register_tool(EchoTool())
+    server._register_routes(server.app.router, config.base_path)
+
+    runner = web.AppRunner(server.app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = runner.addresses[0][1]
+    yield f"http://127.0.0.1:{port}/mcp"
+    await server.stop()
+    await runner.cleanup()
+
+
+async def test_official_sdk_client_roundtrip(server_url):
+    async with streamablehttp_client(server_url) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            init = await asyncio.wait_for(session.initialize(), timeout=10)
+            assert init.serverInfo.name == "interop-streamable"
+
+            tools = await asyncio.wait_for(session.list_tools(), timeout=10)
+            assert any(t.name == "echo" for t in tools.tools)
+
+            result = await asyncio.wait_for(
+                session.call_tool("echo", {"text": "interop"}), timeout=10
+            )
+            assert any("interop" in c.text for c in result.content)

--- a/packages/ai-parrot-server/tests/mcp/test_transport_integration.py
+++ b/packages/ai-parrot-server/tests/mcp/test_transport_integration.py
@@ -1,0 +1,263 @@
+"""Integration between the MCP transports and the clients that consume them.
+
+Two seams the per-transport suites do not cover:
+
+- ai-parrot's own ``HttpMCPSession`` against ai-parrot's own Streamable
+  HTTP server. The client advertises ``text/event-stream`` in ``Accept``,
+  so the server answers request-bearing POSTs with SSE — the client has to
+  read that back rather than treat it as an error.
+- ``ParrotMCPServer`` mounting several HTTP-like transports on one shared
+  aiohttp application. They all claim ``POST {base_path}``, and aiohttp
+  routes a duplicate to whichever was registered first instead of
+  complaining, so the collision has to be caught in configuration.
+"""
+import logging
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+from parrot.mcp.client import MCPClientConfig
+from parrot.tools.abstract import AbstractTool
+from pydantic import BaseModel, Field
+
+from parrot.mcp.config import MCPServerConfig, TransportConfig
+from parrot.mcp.parrot_server import ParrotMCPServer
+from parrot.mcp.transports.http import HttpMCPSession
+from parrot.mcp.transports.streamable_http import StreamableHttpMCPServer
+
+
+class EchoInput(BaseModel):
+    text: str = Field(..., description="Text to echo")
+
+
+class EchoTool(AbstractTool):
+    """Echo input back"""
+    name = "echo"
+    description = "Echo input back"
+    args_schema = EchoInput
+
+    async def _execute(self, text: str) -> str:
+        return text
+
+
+@pytest.fixture
+async def streamable_url():
+    """A running Streamable HTTP server; yields its endpoint URL."""
+    config = MCPServerConfig(
+        name="integration",
+        transport="streamable-http",
+        host="127.0.0.1",
+        port=0,
+    )
+    server = StreamableHttpMCPServer(config)
+    server.register_tool(EchoTool())
+    server._register_routes(server.app.router, config.base_path)
+
+    runner = web.AppRunner(server.app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = runner.addresses[0][1]
+    yield f"http://127.0.0.1:{port}/mcp"
+    await server.stop()
+    await runner.cleanup()
+
+
+class TestOwnClientAgainstStreamableServer:
+    async def test_client_reads_sse_post_responses(self, streamable_url):
+        """list_tools/call_tool must work, not raise on the SSE body.
+
+        The client sends ``Accept: application/json, text/event-stream``, so
+        a Streamable HTTP server is entitled to answer with a stream.
+        """
+        session = HttpMCPSession(
+            MCPClientConfig(name="c", url=streamable_url, transport="http"),
+            logging.getLogger("test-mcp-client"),
+        )
+        try:
+            await session.connect()
+            tools = await session.list_tools()
+            assert any(getattr(t, "name", None) == "echo" for t in tools)
+
+            result = await session.call_tool("echo", {"text": "roundtrip"})
+            assert any(
+                "roundtrip" in getattr(item, "text", "")
+                for item in result.content
+            )
+        finally:
+            await session.disconnect()
+
+    async def test_client_captures_and_echoes_the_session_id(
+        self, streamable_url
+    ):
+        session = HttpMCPSession(
+            MCPClientConfig(name="c", url=streamable_url, transport="http"),
+            logging.getLogger("test-mcp-client"),
+        )
+        try:
+            await session.connect()
+            assert session._mcp_session_id, "session id must be captured"
+            assert session._protocol_version == "2024-11-05"
+        finally:
+            await session.disconnect()
+        assert session._mcp_session_id is None, "disconnect must clear it"
+
+
+def make_parrot_server(transports) -> ParrotMCPServer:
+    server = ParrotMCPServer(transports=transports, host="127.0.0.1", port=0)
+
+    async def _tools():
+        return [EchoTool()]
+
+    server._load_configured_tools = _tools
+    server._add_auth_exclusions = lambda paths: None
+    return server
+
+
+class TestParrotMCPServerMounting:
+    async def test_colliding_base_paths_are_refused(self):
+        """Two HTTP-like transports on one path would silently shadow."""
+        app = web.Application()
+        mcp = make_parrot_server(["http", "sse"])
+        with pytest.raises(ValueError, match="base_path"):
+            await mcp.on_startup(app)
+        await mcp.on_shutdown(app)
+
+    async def test_streamable_and_http_collide_too(self):
+        app = web.Application()
+        mcp = make_parrot_server(["http", "streamable-http"])
+        with pytest.raises(ValueError, match="TransportConfig"):
+            await mcp.on_startup(app)
+        await mcp.on_shutdown(app)
+
+    async def test_distinct_base_paths_mount_side_by_side(self):
+        app = web.Application()
+        mcp = make_parrot_server(
+            {
+                "http": TransportConfig(
+                    transport="http", host="127.0.0.1", port=0
+                ),
+                "streamable-http": TransportConfig(
+                    transport="streamable-http",
+                    host="127.0.0.1",
+                    port=0,
+                    base_path="/mcp/stream",
+                ),
+            }
+        )
+        await mcp.on_startup(app)
+        try:
+            assert set(mcp.servers) == {"http", "streamable-http"}
+            test_server = TestServer(app)
+            await test_server.start_server()
+            client = test_server.make_url("")
+            assert client is not None
+
+            body = {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "pytest", "version": "0"},
+                },
+            }
+            import aiohttp
+
+            async with aiohttp.ClientSession() as http:
+                async with http.post(
+                    str(test_server.make_url("/mcp")), json=body
+                ) as plain:
+                    assert plain.status == 200
+                    # The plain http transport mints no session id.
+                    assert plain.headers.get("Mcp-Session-Id") is None
+
+                async with http.post(
+                    str(test_server.make_url("/mcp/stream")), json=body
+                ) as stream:
+                    assert stream.status == 200
+                    assert stream.headers.get("Mcp-Session-Id")
+
+            await test_server.close()
+        finally:
+            await mcp.on_shutdown(app)
+
+
+class FakeSseResponse:
+    """Minimal stand-in for an aiohttp response carrying an SSE body."""
+
+    def __init__(self, body: str):
+        self._lines = [
+            (line + "\n").encode("utf-8") for line in body.split("\n")
+        ]
+
+    @property
+    def content(self):
+        async def _iter():
+            for line in self._lines:
+                yield line
+
+        return _iter()
+
+
+class TestClientSseParsing:
+    def make_session(self):
+        return HttpMCPSession(
+            MCPClientConfig(name="c", url="http://x/mcp", transport="http"),
+            logging.getLogger("test-mcp-client"),
+        )
+
+    async def test_reads_a_batched_sse_payload(self):
+        """One `data:` field may carry a batch of JSON-RPC responses."""
+        session = self.make_session()
+        body = (
+            'id: s:1\n'
+            'event: message\n'
+            'data: [{"jsonrpc":"2.0","id":1,"result":{"a":1}},'
+            '{"jsonrpc":"2.0","id":2,"result":{"b":2}}]\n'
+            '\n'
+        )
+        message = await session._read_sse_response(FakeSseResponse(body), 2)
+        assert message["result"] == {"b": 2}
+
+    async def test_skips_comments_and_unrelated_messages(self):
+        session = self.make_session()
+        body = (
+            ': keep-alive\n'
+            '\n'
+            'id: s:1\n'
+            'event: message\n'
+            'data: {"jsonrpc":"2.0","method":"notifications/progress"}\n'
+            '\n'
+            'id: s:2\n'
+            'event: message\n'
+            'data: {"jsonrpc":"2.0","id":9,"result":{"ok":true}}\n'
+            '\n'
+        )
+        message = await session._read_sse_response(FakeSseResponse(body), 9)
+        assert message["result"] == {"ok": True}
+
+    async def test_stream_ending_without_the_response_raises(self):
+        from parrot.mcp.client import MCPConnectionError
+
+        session = self.make_session()
+        body = (
+            'id: s:1\n'
+            'event: message\n'
+            'data: {"jsonrpc":"2.0","id":1,"result":{}}\n'
+            '\n'
+        )
+        with pytest.raises(MCPConnectionError, match="ended without"):
+            await session._read_sse_response(FakeSseResponse(body), 42)
+
+
+class TestStartupValidation:
+    async def test_conflict_is_caught_before_anything_starts(self):
+        """A misconfiguration must not leave half the transports mounted."""
+        app = web.Application()
+        mcp = make_parrot_server(["http", "sse"])
+        with pytest.raises(ValueError, match="base_path"):
+            await mcp.on_startup(app)
+        assert mcp.servers == {}, "no transport may be left running"
+        assert not [r for r in app.router.routes()], "no routes registered"

--- a/packages/ai-parrot-server/tests/mcp/test_transports_base.py
+++ b/packages/ai-parrot-server/tests/mcp/test_transports_base.py
@@ -17,6 +17,7 @@ from parrot.mcp.transports.base import MCPServerBase, RemoteMCPServerBase
 from parrot.mcp.transports.http import HttpMCPServer
 from parrot.mcp.transports.sse import SseMCPServer
 from parrot.mcp.transports.stdio import StdioMCPServer
+from parrot.mcp.transports.streamable_http import StreamableHttpMCPServer
 from parrot.mcp.transports.unix import UnixMCPServer
 from parrot.mcp.transports.websocket import WebSocketMCPServer
 from parrot.tools.abstract import AbstractTool
@@ -60,7 +61,7 @@ class TestRemoteTransportsReparenting:
     server's old standalone MCPServerBase."""
 
     @pytest.mark.parametrize("transport_cls", [
-        HttpMCPServer, SseMCPServer, UnixMCPServer,
+        HttpMCPServer, SseMCPServer, StreamableHttpMCPServer, UnixMCPServer,
         pytest.param(QuicMCPServer, marks=pytest.mark.requires_aioquic),
         WebSocketMCPServer,
     ])

--- a/packages/ai-parrot/src/parrot/mcp/server_base.py
+++ b/packages/ai-parrot/src/parrot/mcp/server_base.py
@@ -13,6 +13,36 @@ from typing import Any
 from parrot.mcp.adapter import MCPToolAdapter
 from parrot.tools.abstract import AbstractTool
 
+#: MCP protocol revisions this server can speak, oldest first.
+SUPPORTED_PROTOCOL_VERSIONS: tuple[str, ...] = (
+    "2024-11-05",
+    "2025-03-26",
+    "2025-06-18",
+)
+#: Newest revision we support — offered when the client requests an unknown one.
+LATEST_PROTOCOL_VERSION: str = SUPPORTED_PROTOCOL_VERSIONS[-1]
+#: Revision assumed when the client does not send ``protocolVersion`` at all
+#: (legacy hand-rolled clients); keeps historical behavior unchanged.
+DEFAULT_PROTOCOL_VERSION: str = SUPPORTED_PROTOCOL_VERSIONS[0]
+
+
+def negotiate_protocol_version(requested: str | None) -> str:
+    """Negotiate the MCP protocol revision for an ``initialize`` request.
+
+    Args:
+        requested: The ``protocolVersion`` sent by the client, if any.
+
+    Returns:
+        The requested version when supported; the latest supported version
+        when the client asked for an unknown one; the legacy default when
+        the client sent no version at all.
+    """
+    if requested is None:
+        return DEFAULT_PROTOCOL_VERSION
+    if requested in SUPPORTED_PROTOCOL_VERSIONS:
+        return requested
+    return LATEST_PROTOCOL_VERSION
+
 
 @dataclass
 class LocalServerConfig:
@@ -52,7 +82,9 @@ class MCPServerBase(ABC):
         self.logger.info("Initializing MCP server...")
 
         return {
-            "protocolVersion": "2024-11-05",
+            "protocolVersion": negotiate_protocol_version(
+                params.get("protocolVersion")
+            ),
             "capabilities": {
                 "tools": {
                     "listChanged": False

--- a/packages/ai-parrot/tests/mcp/test_server_base.py
+++ b/packages/ai-parrot/tests/mcp/test_server_base.py
@@ -2,7 +2,13 @@ import pytest
 from pydantic import BaseModel, Field
 
 from parrot.tools.abstract import AbstractTool
-from parrot.mcp.server_base import MCPServerBase, LocalServerConfig
+from parrot.mcp.server_base import (
+    LATEST_PROTOCOL_VERSION,
+    MCPServerBase,
+    LocalServerConfig,
+    SUPPORTED_PROTOCOL_VERSIONS,
+    negotiate_protocol_version,
+)
 
 
 class EchoInput(BaseModel):
@@ -35,6 +41,22 @@ class TestMCPServerBase:
         result = await server.handle_initialize({})
         assert result["protocolVersion"] == "2024-11-05"
         assert result["serverInfo"]["name"] == "test"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("requested", SUPPORTED_PROTOCOL_VERSIONS)
+    async def test_handle_initialize_echoes_supported_version(self, requested):
+        server = ConcreteMCPServer(LocalServerConfig(name="test"))
+        result = await server.handle_initialize({"protocolVersion": requested})
+        assert result["protocolVersion"] == requested
+
+    @pytest.mark.asyncio
+    async def test_handle_initialize_unknown_version_falls_back_to_latest(self):
+        server = ConcreteMCPServer(LocalServerConfig(name="test"))
+        result = await server.handle_initialize({"protocolVersion": "1999-01-01"})
+        assert result["protocolVersion"] == LATEST_PROTOCOL_VERSION
+
+    def test_negotiate_protocol_version_no_version_keeps_legacy_default(self):
+        assert negotiate_protocol_version(None) == "2024-11-05"
 
     @pytest.mark.asyncio
     async def test_handle_tools_list(self):


### PR DESCRIPTION
## What this adds

An MCP **Streamable HTTP** server transport (spec rev 2025-03-26), selectable as
`transport="streamable-http"`, so ai-parrot tools can be consumed by Claude.ai
custom connectors and official-SDK clients. Plus protocol-version negotiation
shared by every transport.

- **Single `/mcp` endpoint** — `POST` (single or batch JSON-RPC; `202` for
  notification-only bodies; JSON or SSE by `Accept` negotiation), `GET`
  (server-to-client SSE stream), `DELETE` (session termination).
- **Sessions** — `Mcp-Session-Id` minted on `initialize`, bound to the
  authenticated principal, TTL-expired, capped.
- **Resumability** — SSE responses carry event ids from a bounded per-stream
  buffer. Dispatch runs as asyncio tasks that survive client disconnects, so a
  long-running `tools/call` (launching an agent flow) can be reconnected to and
  its result collected.
- **Protocol negotiation** — `2024-11-05`, `2025-03-26`, `2025-06-18`. Clients
  that send no `protocolVersion` still get `2024-11-05`, so stdio/http/sse/unix/quic
  see no behaviour change.

## Review and fixes

The first two commits were reviewed before this PR; `d7434be` fixes all 15
findings. Four of them broke the transport in the configuration ai-parrot
actually ships in, and all four escaped the original suite because it bypassed
`start()` and never opened two streams at once:

| | Finding |
|---|---|
| **S-01** | `HttpMCPServer.start()` registered routes at `base_path` *and* mounted the app as a sub-app at `base_path`, serving the endpoint at `/mcp/mcp` — outside the auth-middleware exclusion list, and inconsistent with `SseMCPServer` |
| **S-02** | ai-parrot's own `HttpMCPSession` advertised `text/event-stream` but hard-failed on SSE bodies, so it could not call tools on this server past `initialize` |
| **S-03** | One session-wide event store let a concurrently open `GET` consume a response the `POST` still owed its client (the official SDK opens a GET right after `initialize`, so this was the normal state) |
| **S-04** | A notification carrying an `id` produced no response, and `responses[0]` raised `IndexError` → HTTP 500 |

Plus session/principal binding, session and stream caps, a background sweeper,
spec-mandated Origin defaults, `Origin`/`MCP-Protocol-Version` checks on all
verbs, bounded teardown, `notifications/cancelled`, and the spec nits.

A second independent review of the fixes raised seven more findings; six were
confirmed and fixed, one partially rejected (the claim that `await task` cancels
the task when the awaiter is cancelled — it does not, which is why the
`task.cancelled()` discriminator is correct).

## Behaviour changes — please read before merging

1. **The `http` transport's URL moves from `/mcp/mcp` to `/mcp`** on a shared
   app. This is the S-01 fix applied at the source rather than only in the new
   subclass. Any deployment addressing the doubled path must be updated.
2. **`allowed_origins=None` now means localhost-only**, not allow-any, per the
   spec's mandatory DNS-rebinding protection. Set `allowed_origins=[...]` for
   browser origins, or `allow_any_origin=True` to opt out. Requests with no
   `Origin` header (server-to-server clients such as Claude.ai) are unaffected.
3. **Two HTTP-like transports sharing a `base_path` now raise at startup**
   instead of being silently shadowed. `TransportConfig` gains `base_path` so
   they can run side by side. The previous guard skipped the second transport
   entirely, which silently removed `/mcp/events` from an `["http", "sse"]`
   setup.

## Incidental fixes

- `HttpMCPServer` never set `self.base_path`, which `OAuthRoutesMixin._oauth_paths()`
  reads — `enable_oauth=True` raised `AttributeError`.
- `transports/base.py` read `config.oauth_scopes` where the field is
  `oauth_scope`, making `AuthMethod.OAUTH2_INTERNAL` unconstructible.

## Verification

- **81 mcp tests passing** (was 39), stable across 10 consecutive runs. Every
  blocker has a regression test that fails without its fix.
- **Official-SDK interop test** (`mcp.client.streamable_http`) drives
  initialize / list_tools / call_tool through the real shared-app mount, so it
  covers S-01 rather than bypassing it. Gated behind the `mcp` extra.
- **Full `ai-parrot-server` suite: 1324 passed**, with a failure set
  byte-identical to the untouched branch tip — the same 27 pre-existing
  failures, zero new.
- `ruff` clean on every file added or rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnCMaQ6d8WGCqU44NR16n9
