### PR TITLE
feat(dev_loop): wire FEAT-484/485/486 into the example consoles

### DIFF
--- a/examples/dev_loop/GUIA.md
+++ b/examples/dev_loop/GUIA.md
@@ -460,11 +460,13 @@ Dos comportamientos que conviene saber:
 >    se devuelve en la respuesta, y cualquier diferencia con el plan del
 >    servidor se registra como warning — pero el run usa el plan del
 >    **servidor**. Reinicia la consola con las `DEV_FLOW_*` que quieras.
-> 2. Esta consola usa el **judge panel** de FEAT-378 como revisor de QA, y
->    un revisor explícito gana al plan por diseño. La pareja de revisión
->    queda configurada y validada pero no es el revisor activo aquí:
->    `defaults.model_plan.review_pair_active` lo reporta como `false` y la
->    UI lo dice.
+> 2. Por defecto esta consola usa el **judge panel** de FEAT-378 como
+>    revisor de QA, y un revisor explícito gana al plan por diseño. La
+>    pareja de revisión queda configurada y validada pero no es el revisor
+>    activo: `defaults.model_plan.review_pair_active` lo reporta como
+>    `false` y la UI lo dice. Con `DEV_FLOW_USE_REVIEW_PAIR=true` la
+>    consola suelta el judge panel y deja que el plan monte su pareja de
+>    revisión (primario + contra-revisor Mantle) como revisor activo.
 
 Referencia completa: `docs/dev_loop/dev-flow-model-plan.md`.
 
@@ -479,11 +481,55 @@ Referencia completa: `docs/dev_loop/dev-flow-model-plan.md`.
 | `DEV_FLOW_RESEARCH_PARTNER_ENABLED` / `_BACKEND` / `_MODEL` | `false` / `gpt` / `gpt-5.6-sol` | Passthrough del research partner (FEAT-482) |
 | `DEV_FLOW_REVIEW_PRIMARY_BACKEND` / `_MODEL` | `claude-code` / `claude-opus-5` | Revisor primario (con permisos de escritura) |
 | `DEV_FLOW_REVIEW_COUNTER_MODEL` | `gpt-5.6-sol` | Contra-revisor de solo lectura, sobre Bedrock Mantle |
-| `DEV_LOOP_MANTLE_REVIEW_MODEL` | `gpt-5.6-sol` | Modelo propio del contra-revisor Mantle. Distinta de `DEV_LOOP_ADVERSARIAL_MODEL` (la del asiento codex) |
+| `DEV_LOOP_MANTLE_REVIEW_MODEL` | `gpt-5.6-sol` | Modelo propio del contra-revisor Mantle. Distinta de `DEV_LOOP_ADVERSARIAL_MODEL` (la del asiento codex). También la usa el revisor `mantle-adversarial` cuando `DEV_LOOP_ADVERSARIAL_BACKEND=mantle` |
+| `DEV_FLOW_USE_REVIEW_PAIR` | `false` | Solo consola dev: sustituye el judge panel por la pareja de revisión del plan como revisor de QA activo |
+| `DEV_LOOP_RESEARCH_MCP_ENABLED` | `true` | Interruptor del wiring MCP de los asientos de research (ambas consolas) — ver §9.9 |
+| `DEV_LOOP_RESEARCH_MCP_TOOLKITS` | `auto` | Secciones de `.parrot/mcp-toolkits.yaml` a servir a los asientos de research (`auto` = las declaradas en el archivo) |
+| `NOVA_CODE_MAX_CONCURRENT_DISPATCHES` | `CLAUDE_CODE_MAX_CONCURRENT_DISPATCHES` | Tope de concurrencia con `DEV_LOOP_DEVELOPMENT_AGENT=nova` |
 
 El resto se reutiliza tal cual de las `DEV_LOOP_*` que ya conoces
 (`DEV_LOOP_QA_MAX_RETRIES`, `DEV_LOOP_GATE_PARK`, `DEV_LOOP_JUDGE_PANEL`,
 `DEV_LOOP_DEV_AGENTS`, `FLOW_MAX_CONCURRENT_RUNS`…).
+
+### 9.9. Acceso MCP para los agentes de research (FEAT-484/485)
+
+Las dos consolas entregan a los **agentes de research** despachados una
+superficie MCP explícita (montada por el módulo hermano `mcp_wiring.py` al
+arrancar):
+
+* **Búsqueda en el grafo `wikitoolkit`** (FEAT-403) — el trío de solo
+  lectura `wiki_query` / `wiki_page` / `wiki_related`. En la consola ops
+  llega al dispatch `sdd-research` del `ResearchNode`; el `IdeationNode`
+  de la consola dev ya lo trae integrado.
+* **Servidores de toolkits locales FEAT-485** — cada sección declarada en
+  `<repo>/.parrot/mcp-toolkits.yaml` se sirve como `parrot mcp-local
+  <nombre>`. Copia `mcp-toolkits.example.yaml` para tener una sección
+  `repo` que expone el **`ReadOnlyRepoToolkit`** de FEAT-484 (acceso al
+  repositorio confinado y estrictamente de solo lectura: `search_code`,
+  `read_file`, `grep_files`, `git_log`/`git_show`/`git_blame`,
+  `web_search` opt-in).
+
+Como estos dispatches corren con `strict_mcp_config=True` (el CLI headless
+ignora el `.mcp.json` del sistema de archivos), los servidores se pasan
+explícitamente en el perfil de dispatch, y cada entrada lleva
+`--config <ruta absoluta>` para que `parrot mcp-local` encuentre el YAML
+aunque el cwd del dispatch sea `WORKTREE_BASE_PATH` y no la raíz del repo.
+Usa un `repo_root` **absoluto** en el YAML por la misma razón.
+
+Todo degrada con gracia: un binario `wikitoolkit` ausente, un YAML
+inválido o una sección desconocida solo generan un warning y se sirve el
+subconjunto que resuelva. `DEV_LOOP_RESEARCH_MCP_ENABLED=false` apaga el
+wiring completo; `DEV_LOOP_RESEARCH_MCP_TOOLKITS=repo,memory` fija una
+lista explícita (puede incluir los builtin `scraping`/`browsing`/`memory`
+— ojo con sus extras opcionales).
+
+Relacionado (FEAT-482/486): la consola ops ahora también honra
+`DEV_FLOW_RESEARCH_PARTNER_ENABLED` / `_BACKEND` / `_MODEL` para el
+research partner colaborativo del `ResearchNode` — el partner usa
+`ReadOnlyRepoToolkit` de forma nativa, sin MCP. Además, el pool de env
+(`DEV_LOOP_DEV_AGENTS`) llega ahora también a la topología **feature** de
+la consola ops, así que el `PlannerNode` sugiere los backends reales del
+operador también ahí.
 
 ---
 

--- a/examples/dev_loop/README.md
+++ b/examples/dev_loop/README.md
@@ -584,11 +584,13 @@ Two behaviours worth knowing:
 >    run response, and any difference from the server's plan is logged as
 >    a warning, but the run uses the **server's** plan. Restart the console
 >    with the desired `DEV_FLOW_*` keys to change seats.
-> 2. This console wires the FEAT-378 **judge panel** as its QA reviewer,
->    and an explicit reviewer wins over the plan by design. The review pair
->    is therefore configured and validated but not the active reviewer
->    here — `defaults.model_plan.review_pair_active` reports this as
->    `false`, and the UI says so.
+> 2. By default this console wires the FEAT-378 **judge panel** as its QA
+>    reviewer, and an explicit reviewer wins over the plan by design. The
+>    review pair is therefore configured and validated but not the active
+>    reviewer — `defaults.model_plan.review_pair_active` reports this as
+>    `false`, and the UI says so. Set `DEV_FLOW_USE_REVIEW_PAIR=true` to
+>    drop the judge panel and let the plan assemble its review pair
+>    (primary + Mantle counter-reviewer) as the active QA reviewer.
 
 See `docs/dev_loop/dev-flow-model-plan.md` for the full reference.
 
@@ -603,7 +605,11 @@ See `docs/dev_loop/dev-flow-model-plan.md` for the full reference.
 | `DEV_FLOW_RESEARCH_PARTNER_ENABLED` / `_BACKEND` / `_MODEL` | `false` / `gpt` / `gpt-5.6-sol` | Complementary research partner passthrough (FEAT-482). |
 | `DEV_FLOW_REVIEW_PRIMARY_BACKEND` / `_MODEL` | `claude-code` / `claude-opus-5` | Write-enabled primary reviewer. |
 | `DEV_FLOW_REVIEW_COUNTER_MODEL` | `gpt-5.6-sol` | Read-only counter-reviewer, over Bedrock Mantle. |
-| `DEV_LOOP_MANTLE_REVIEW_MODEL` | `gpt-5.6-sol` | The Mantle counter-reviewer's own model key. Distinct from `DEV_LOOP_ADVERSARIAL_MODEL` (the codex seat's). |
+| `DEV_LOOP_MANTLE_REVIEW_MODEL` | `gpt-5.6-sol` | The Mantle counter-reviewer's own model key. Distinct from `DEV_LOOP_ADVERSARIAL_MODEL` (the codex seat's). Also used when `DEV_LOOP_ADVERSARIAL_BACKEND=mantle` selects the `mantle-adversarial` reviewer in the ops console. |
+| `DEV_FLOW_USE_REVIEW_PAIR` | `false` | Dev console only: replace the judge panel with the model plan's review pair as the active QA reviewer. |
+| `DEV_LOOP_RESEARCH_MCP_ENABLED` | `true` | Kill switch for the research seats' MCP wiring (both consoles) — see the FEAT-484/485 section below. |
+| `DEV_LOOP_RESEARCH_MCP_TOOLKITS` | `auto` | Which `.parrot/mcp-toolkits.yaml` sections to serve to the research seats (`auto` = the sections declared in the file). |
+| `NOVA_CODE_MAX_CONCURRENT_DISPATCHES` | `CLAUDE_CODE_MAX_CONCURRENT_DISPATCHES` | Concurrency cap when `DEV_LOOP_DEVELOPMENT_AGENT=nova`. |
 
 Everything else is reused unchanged from the existing `DEV_LOOP_*` keys
 (`DEV_LOOP_QA_MAX_RETRIES`, `DEV_LOOP_GATE_PARK`, `DEV_LOOP_JUDGE_PANEL`,
@@ -617,6 +623,45 @@ per-run toggle overrides.
 
 Revision mode (`DevLoopRunner.run_revision`) is a library/`e2e_demo` feature
 and is not served by either console.
+
+## Research-seat MCP access (FEAT-484/485)
+
+Both consoles hand the dispatched **research agents** an explicit MCP
+surface (built by the sibling module `mcp_wiring.py` at startup):
+
+* **`wikitoolkit` graph search** (FEAT-403) — the read-only trio
+  `wiki_query` / `wiki_page` / `wiki_related`. In the ops console this
+  reaches `ResearchNode`'s `sdd-research` dispatch; the dev console's
+  `IdeationNode` already ships it built in.
+* **FEAT-485 local toolkit servers** — every section declared in
+  `<repo>/.parrot/mcp-toolkits.yaml` is served as `parrot mcp-local
+  <name>` and exposed to the research seats. Copy
+  `mcp-toolkits.example.yaml` to get a `repo` section exposing the
+  FEAT-484 **`ReadOnlyRepoToolkit`** (confined, strictly read-only
+  repository access: `search_code`, `read_file`, `grep_files`,
+  `git_log`/`git_show`/`git_blame`, opt-in `web_search`).
+
+Because these dispatches run with `strict_mcp_config=True` (the headless
+CLI ignores the filesystem `.mcp.json`), the servers are passed explicitly
+on the dispatch profile, and each server entry carries
+`--config <abs path>` so `parrot mcp-local` finds the YAML even though the
+research dispatch cwd is `WORKTREE_BASE_PATH`, not the repo root. Use an
+**absolute** `repo_root` in the YAML for the same reason.
+
+Everything degrades gracefully: a missing `wikitoolkit` binary, a missing
+or invalid YAML, or an unknown section name logs a warning and serves
+whatever subset resolves. `DEV_LOOP_RESEARCH_MCP_ENABLED=false` turns the
+whole wiring off; `DEV_LOOP_RESEARCH_MCP_TOOLKITS=repo,memory` pins an
+explicit section list (which may include the built-ins
+`scraping`/`browsing`/`memory` — mind their optional extras).
+
+Related (FEAT-482/486): the ops console now also honours
+`DEV_FLOW_RESEARCH_PARTNER_ENABLED` / `_BACKEND` / `_MODEL` for
+`ResearchNode`'s collaborative-research partner — the partner itself uses
+`ReadOnlyRepoToolkit` natively, no MCP required. The env pool
+(`DEV_LOOP_DEV_AGENTS`) now also reaches the ops console's **feature**
+topology, so `PlannerNode` suggests the operator's real backends there
+too.
 
 ## Stream layout (for reference)
 

--- a/examples/dev_loop/mcp-toolkits.example.yaml
+++ b/examples/dev_loop/mcp-toolkits.example.yaml
@@ -1,0 +1,33 @@
+# Example FEAT-485 local-MCP toolkit config for the dev-loop consoles.
+#
+# Copy this file to <repo-root>/.parrot/mcp-toolkits.yaml and adjust the
+# paths. Every enabled section becomes a `parrot mcp-local <name>` stdio
+# MCP server that the consoles (server.py / server_dev.py) expose to the
+# research seats (ResearchNode / IdeationNode dispatches) — see
+# mcp_wiring.build_research_mcp().
+#
+# Selection is controlled by DEV_LOOP_RESEARCH_MCP_TOOLKITS:
+#   auto (default)  → exactly the sections declared in this file
+#   repo,memory,... → an explicit comma list (may include the built-ins
+#                     scraping / browsing / memory)
+
+toolkits:
+  # FEAT-484: confined, strictly read-only repository access for research
+  # agents — search_code / related_code (wiki code graph), read_file /
+  # list_files / grep_files, git_log / git_show / git_blame.
+  #
+  # NOTE: the FEAT-482 collaborative-research partner already registers
+  # this toolkit natively (research_partner.py); this section is what
+  # ADDITIONALLY exposes it to the dispatched Claude Code research agents
+  # over MCP.
+  repo:
+    class: parrot.tools.repo.toolkit.ReadOnlyRepoToolkit
+    enabled: true
+    kwargs:
+      # IMPORTANT: use an ABSOLUTE path. dev-loop research dispatches run
+      # from WORKTREE_BASE_PATH (or a clone path), not the repo root, and
+      # the MCP server inherits that cwd — a relative path would resolve
+      # against the wrong directory. In DEV_LOOP_REPOS (clone) mode this
+      # still points at the base checkout, not the per-run clone.
+      repo_root: /abs/path/to/your/checkout
+      # enable_web_search: true   # opt-in DuckDuckGo web_search tool

--- a/examples/dev_loop/mcp_wiring.py
+++ b/examples/dev_loop/mcp_wiring.py
@@ -1,0 +1,160 @@
+"""Research-seat MCP wiring for the dev-loop example consoles (FEAT-484/485).
+
+Builds the ``(mcp_servers, mcp_tools)`` pair both consoles forward to the
+research seats — ``ResearchNode`` (ops console, ``server.py``) and
+``IdeationNode`` (dev console, ``server_dev.py``) — so the dispatched
+research agents can reach:
+
+* the **LLM-wiki graph-search** MCP server (``wikitoolkit mcp``, FEAT-403),
+  read-only: ``wiki_query`` / ``wiki_page`` / ``wiki_related``; and
+* the **FEAT-485 local toolkit servers** (``parrot mcp-local <name>``)
+  declared in ``<repo>/.parrot/mcp-toolkits.yaml`` — e.g. a ``repo``
+  section exposing the FEAT-484 :class:`~parrot.tools.repo.ReadOnlyRepoToolkit`
+  for confined repository access (see ``mcp-toolkits.example.yaml``).
+
+Everything degrades gracefully: a missing binary, a missing/invalid YAML,
+or an unknown section name logs a warning and yields whatever subset still
+resolves — MCP access is additive and never blocks server startup.
+
+Environment:
+    DEV_LOOP_RESEARCH_MCP_ENABLED: Kill switch (default ``true``).
+    DEV_LOOP_RESEARCH_MCP_TOOLKITS: Comma-separated section names from
+        ``.parrot/mcp-toolkits.yaml`` to serve, or ``auto`` (default) for
+        exactly the sections DECLARED IN THE FILE. ``auto`` deliberately
+        skips undeclared built-ins (``scraping``/``browsing``/``memory``):
+        those may need optional extras and must not be auto-spawned.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from parrot import conf
+from parrot.flows.dev_loop.mcp_profiles import WIKI_MCP_TOOLS
+from parrot.knowledge.wiki.claude_code.assets import (
+    resolve_wikitoolkit_bin,
+    toolkit_mcp_json_entry,
+)
+from parrot.mcp.toolkit_config import load_toolkits_config
+
+logger = logging.getLogger("dev_loop.mcp_wiring")
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _config_flag(key: str, default: bool) -> bool:
+    """Read a boolean config key via ``conf.config.get``.
+
+    Deliberately avoids ``getboolean``: the server-wiring tests stub
+    ``conf.config`` with a minimal ``get``/``getint`` mock.
+    """
+    raw = conf.config.get(key, fallback=str(default))
+    return str(raw).strip().lower() in _TRUTHY
+
+
+def _declared_section_names(config_path: Path) -> list[str]:
+    """Return the toolkit names DECLARED in the YAML file itself.
+
+    ``load_toolkits_config`` merges built-ins in, so ``auto`` mode reads the
+    raw file to know which sections the operator actually wrote down.
+
+    Args:
+        config_path: Path to ``.parrot/mcp-toolkits.yaml``.
+
+    Returns:
+        The file's ``toolkits:`` keys, or ``[]`` when the file is absent or
+        unreadable (the caller logs the loader's own error separately).
+    """
+    if not config_path.exists():
+        return []
+    try:
+        with open(config_path, encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    except yaml.YAMLError:
+        return []
+    toolkits = data.get("toolkits") if isinstance(data, dict) else None
+    return list(toolkits.keys()) if isinstance(toolkits, dict) else []
+
+
+def build_research_mcp(repo_root: Path) -> tuple[dict[str, Any], list[str]]:
+    """Build the research seats' MCP servers and their allow rules.
+
+    Args:
+        repo_root: The repository the console serves (normally
+            ``conf.PROJECT_ROOT``). Used to resolve the ``wikitoolkit`` /
+            ``parrot`` binaries and ``.parrot/mcp-toolkits.yaml``.
+
+    Returns:
+        ``(mcp_servers, mcp_tools)`` — the dict/list to pass as
+        ``research_mcp_servers`` / ``research_mcp_tools`` to
+        ``build_dev_loop_flow`` / ``build_dev_flow``. ``({}, [])`` when
+        nothing usable resolved (callers then pass ``None`` to keep the
+        dispatch profiles byte-identical).
+    """
+    enabled = _config_flag("DEV_LOOP_RESEARCH_MCP_ENABLED", True)
+    if not enabled:
+        logger.info("Research-seat MCP wiring disabled (DEV_LOOP_RESEARCH_MCP_ENABLED=false).")
+        return {}, []
+
+    repo_root = Path(repo_root).resolve()
+    servers: dict[str, Any] = {}
+    tools: list[str] = []
+
+    # 1. LLM-wiki graph search (FEAT-403). Read-only tool trio; skipped
+    # with a warning when the binary cannot be resolved, matching the
+    # consoles' existing missing-wikitoolkit warning for Bash triage.
+    wikitoolkit_cmd = resolve_wikitoolkit_bin(repo_root)
+    if Path(wikitoolkit_cmd).is_file() or shutil.which(wikitoolkit_cmd):
+        servers["wikitoolkit"] = {"command": wikitoolkit_cmd, "args": ["mcp"], "env": {}}
+        tools.extend(WIKI_MCP_TOOLS)
+    else:
+        logger.warning(
+            "wikitoolkit binary not found (looked at %r) — research agents "
+            "get no wiki graph-search MCP server.",
+            wikitoolkit_cmd,
+        )
+
+    # 2. FEAT-485 local toolkit servers from .parrot/mcp-toolkits.yaml.
+    config_path = repo_root / ".parrot" / "mcp-toolkits.yaml"
+    selection_raw = conf.config.get("DEV_LOOP_RESEARCH_MCP_TOOLKITS", fallback="auto").strip()
+    try:
+        cfg = load_toolkits_config(repo_root)
+    except ValueError as exc:
+        logger.warning("Ignoring invalid %s: %s", config_path, exc)
+        return servers, tools
+
+    if selection_raw.lower() == "auto":
+        selected = _declared_section_names(config_path)
+    else:
+        selected = [name.strip() for name in selection_raw.split(",") if name.strip()]
+
+    for name in selected:
+        section = cfg.toolkits.get(name)
+        if section is None:
+            logger.warning(
+                "DEV_LOOP_RESEARCH_MCP_TOOLKITS names unknown toolkit %r "
+                "(resolvable: %s) — skipped.",
+                name,
+                ", ".join(sorted(cfg.toolkits)),
+            )
+            continue
+        if not section.enabled:
+            logger.info("Toolkit %r is disabled in %s — skipped.", name, config_path)
+            continue
+        entry = toolkit_mcp_json_entry(repo_root, name, section)
+        if config_path.exists():
+            # The MCP host spawns `parrot mcp-local` with the DISPATCH cwd
+            # (dev-loop research runs from WORKTREE_BASE_PATH, not the repo
+            # root), so the server must be told where the config lives.
+            entry["args"] = [*entry["args"], "--config", str(config_path)]
+        servers[f"parrot-{name}"] = entry
+        # Server-level allow rule ("every tool of this server") — per-tool
+        # enumeration would require importing each toolkit class here.
+        tools.append(f"mcp__parrot-{name}")
+
+    return servers, tools

--- a/examples/dev_loop/server.py
+++ b/examples/dev_loop/server.py
@@ -85,6 +85,21 @@ Repository targeting (FEAT-253):
   Private SSH repos require an SSH key/agent on the host. For ``gh``-based
   auth set ``GITHUB_TOKEN``.
 
+FEAT-482/484/485/486 wiring (see ``README.md`` §"Research-seat MCP access"):
+
+- The ``sdd-research`` dispatch gets explicit MCP servers — wikitoolkit
+  graph search plus every ``.parrot/mcp-toolkits.yaml`` section served as
+  ``parrot mcp-local <name>`` (e.g. a ``repo`` section exposing the
+  read-only ``ReadOnlyRepoToolkit``). Built by the sibling
+  ``mcp_wiring.build_research_mcp``; ``DEV_LOOP_RESEARCH_MCP_ENABLED`` /
+  ``DEV_LOOP_RESEARCH_MCP_TOOLKITS`` control it.
+- ``DEV_FLOW_RESEARCH_PARTNER_ENABLED`` / ``_BACKEND`` / ``_MODEL`` select
+  the collaborative-research partner's secondary LLM for ``ResearchNode``.
+- ``DEV_LOOP_ADVERSARIAL_BACKEND`` accepts ``mantle`` (the
+  ``mantle-adversarial`` reviewer) in addition to ``codex``/``nova``.
+- The env dev-agent pool now also reaches the feature topology
+  (``build_dev_loop_feature_flow(development_pool_config=...)``).
+
 Boot::
 
     docker run --rm -p 6379:6379 redis:7    # if you don't have one
@@ -135,6 +150,12 @@ from parrot.flows.dev_loop import (
     flow_stream_ws,
     parse_repo_specs,
 )
+from parrot.flows.dev_flow.complementary_research import ComplementaryResearchCoordinator
+from parrot.flows.dev_flow.model_plan import (
+    DevFlowModelPlan,
+    resolve_model_plan,
+    supported_dev_pool_backends,
+)
 from parrot.flows.dev_loop.agent_builder import build_dispatcher, parse_pool_env, resolve_pool_max
 from parrot.flows.dev_loop.code_review import CodeReviewDispatcherFactory
 from parrot.flows.dev_loop.graph_memory import DevLoopGraphMemory
@@ -155,6 +176,7 @@ from parrot_tools.jiratoolkit import JiraToolkit
 # directory on sys.path) or imported from elsewhere.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import llm_catalog  # noqa: E402
+import mcp_wiring  # noqa: E402
 
 logger = logging.getLogger("dev_loop.server")
 STATIC_DIR = Path(__file__).parent / "static"
@@ -170,6 +192,7 @@ _DEVELOPMENT_AGENT_MAX_CONCURRENT_ENV = {
     "zai": "ZAI_CODE_MAX_CONCURRENT_DISPATCHES",
     "moonshot": "MOONSHOT_CODE_MAX_CONCURRENT_DISPATCHES",
     "google_coding": "GOOGLE_CODING_MAX_CONCURRENT_DISPATCHES",
+    "nova": "NOVA_CODE_MAX_CONCURRENT_DISPATCHES",
 }
 
 
@@ -213,6 +236,11 @@ def _log_development_agent_selection(backend: str, profile: Any) -> None:
         )
     elif backend == "google_coding":
         logger.info("Development node using google_coding CLI (model=%s)", profile.model)
+    elif backend == "nova":
+        logger.info(
+            "Development node using Nova code dispatcher (model=%s)",
+            getattr(profile, "model", ""),
+        )
 
 
 def _build_codex_adversarial_reviewer(codex_dispatcher: CodexCodeDispatcher) -> object:
@@ -309,17 +337,57 @@ def _build_nova_adversarial_reviewer() -> object:
     )
 
 
+def _build_mantle_adversarial_reviewer() -> object:
+    """Build the ``mantle-adversarial`` reviewer (FEAT-486).
+
+    Mirrors :func:`_build_nova_adversarial_reviewer`'s scope-misconfiguration
+    guards; ``MantleAdversarialReviewDispatcher`` drives the OpenAI-compatible
+    ``BedrockMantleClient`` directly, so it needs no underlying CLI
+    dispatcher either.
+
+    Returns:
+        The registered ``mantle-adversarial`` reviewer.
+
+    Raises:
+        RuntimeError: Same conditions as
+            :func:`_build_codex_adversarial_reviewer`.
+    """
+    scope = conf.DEV_LOOP_ADVERSARIAL_SCOPE.strip().lower()
+    if scope == "commit":
+        raise RuntimeError(
+            "DEV_LOOP_ADVERSARIAL_SCOPE='commit' is not supported by this "
+            "server's static reviewer wiring — a commit SHA is inherently "
+            "per-run, not a persistent setting. Use 'uncommitted' (default) "
+            "or 'base' with DEV_LOOP_ADVERSARIAL_BASE_REF set, or drive "
+            "'commit' scope via a programmatic "
+            "MantleAdversarialReviewDispatcher(review_scope='commit', "
+            "review_commit=<sha>) construction outside this bootstrap."
+        )
+    if scope == "base" and not conf.DEV_LOOP_ADVERSARIAL_BASE_REF:
+        raise RuntimeError(
+            "DEV_LOOP_ADVERSARIAL_SCOPE='base' requires "
+            "DEV_LOOP_ADVERSARIAL_BASE_REF to be set (e.g. 'dev' or "
+            "'origin/main') — otherwise every adversarial review would "
+            "silently degrade to an unreviewed pass."
+        )
+    return CodeReviewDispatcherFactory.create(
+        "mantle-adversarial",
+        model=conf.DEV_LOOP_MANTLE_REVIEW_MODEL,
+        review_scope=conf.DEV_LOOP_ADVERSARIAL_SCOPE,
+        review_base=conf.DEV_LOOP_ADVERSARIAL_BASE_REF if scope == "base" else "",
+    )
+
+
 def _build_adversarial_reviewer(
     codex_dispatcher: CodexCodeDispatcher,
 ) -> tuple[object, str]:
     """Build the adversarial reviewer for whichever backend is configured.
 
-    FEAT-405 Module 5: ``DEV_LOOP_ADVERSARIAL_BACKEND`` (resolved via
-    :func:`llm_catalog.resolve_adversarial_backend`) selects ``codex``
-    (default — [R3]: unset config is byte-identical to before FEAT-405) or
-    ``nova``. Renamed/generalized from the FEAT-375 codex-only adversarial
-    builder to make the backend selectable, per spec §5 "The adversarial
-    reviewer is selectable over {codex, nova}".
+    FEAT-405 Module 5 / FEAT-486: ``DEV_LOOP_ADVERSARIAL_BACKEND`` (resolved
+    via :func:`llm_catalog.resolve_adversarial_backend`) selects ``codex``
+    (default — [R3]: unset config is byte-identical to before FEAT-405),
+    ``nova``, or ``mantle``. Previously ``mantle`` passed the catalog's
+    validation and then silently built the Codex reviewer here.
 
     Args:
         codex_dispatcher: The (possibly shared) ``CodexCodeDispatcher`` —
@@ -328,11 +396,14 @@ def _build_adversarial_reviewer(
     Returns:
         A ``(reviewer, agent_key)`` pair; ``agent_key`` is the
         ``CodeReviewDispatcherFactory`` registration name of whichever
-        reviewer was actually built (``"codex-adversarial"`` or
-        ``"nova-adversarial"``).
+        reviewer was actually built (``"codex-adversarial"``,
+        ``"nova-adversarial"``, or ``"mantle-adversarial"``).
     """
-    if llm_catalog.resolve_adversarial_backend() == "nova":
+    backend = llm_catalog.resolve_adversarial_backend()
+    if backend == "nova":
         return _build_nova_adversarial_reviewer(), "nova-adversarial"
+    if backend == "mantle":
+        return _build_mantle_adversarial_reviewer(), "mantle-adversarial"
     return _build_codex_adversarial_reviewer(codex_dispatcher), "codex-adversarial"
 
 
@@ -451,8 +522,9 @@ def _build_primary_reviewer(
         )
         return CodeReviewDispatcherFactory.create("google_coding", dispatcher=underlying)
     raise RuntimeError(
-        "DEV_LOOP_CODEREVIEW_AGENT must be 'claude-code', 'codex', 'gemini', "
-        f"'google_coding', 'codex-adversarial', or 'parallel', got {agent!r}"
+        f"DEV_LOOP_CODEREVIEW_AGENT must be one of "
+        f"{', '.join(repr(b) for b in llm_catalog.PRIMARY_REVIEW_BACKENDS)}, "
+        f"'codex-adversarial', or 'parallel', got {agent!r}"
     )
 
 
@@ -1052,6 +1124,15 @@ def _parse_dev_agents(raw: Any) -> Optional[list[DevAgentSpec]]:
             raise ValueError(
                 f"unknown dev agent backend {agent!r} — supported: " f"{', '.join(b.id for b in llm_catalog.BACKENDS)}"
             )
+        # The catalog also lists non-development backends (e.g. the
+        # research-partner-only "gpt" entry), which DevAgentSpec's
+        # DevAgentBackend Literal would reject with a raw pydantic error —
+        # pre-validate for a clean 400 instead.
+        if agent not in supported_dev_pool_backends():
+            raise ValueError(
+                f"backend {agent!r} is not a development backend — "
+                f"supported: {', '.join(supported_dev_pool_backends())}"
+            )
         specs.append(
             DevAgentSpec(
                 agent=agent,
@@ -1462,9 +1543,9 @@ async def _on_startup(app: web.Application) -> None:
         _log_development_agent_selection(backend, development_profile)
     else:
         raise RuntimeError(
-            "DEV_LOOP_DEVELOPMENT_AGENT must be 'claude-code', 'codex', "
-            "'gemini', 'nvidia', 'grok', 'zai', or 'moonshot', "
-            f"got {development_agent!r}"
+            f"DEV_LOOP_DEVELOPMENT_AGENT must be one of "
+            f"{', '.join(supported_dev_pool_backends())} "
+            f"(or the legacy alias 'llm'), got {development_agent!r}"
         )
 
     codereview_dispatcher, codereview_agent_key = _resolve_codereview_dispatcher(
@@ -1554,6 +1635,38 @@ async def _on_startup(app: web.Application) -> None:
     require_plan_approval = bool(getattr(conf, "DEV_LOOP_REQUIRE_PLAN_APPROVAL", False))
     skip_qa = bool(getattr(conf, "DEV_LOOP_SKIP_QA", False))
 
+    # FEAT-484/485: explicit MCP access for the research seat. The
+    # sdd-research dispatch runs with strict_mcp_config=True, so the
+    # wikitoolkit graph-search server and the `.parrot/mcp-toolkits.yaml`
+    # toolkit servers (e.g. the ReadOnlyRepoToolkit `repo` section) must be
+    # declared on the dispatch profile — see mcp_wiring.build_research_mcp.
+    research_mcp_servers, research_mcp_tools = mcp_wiring.build_research_mcp(Path(conf.PROJECT_ROOT))
+    if research_mcp_servers:
+        logger.info(
+            "Research-seat MCP servers: %s",
+            ", ".join(sorted(research_mcp_servers)),
+        )
+    else:
+        logger.info("Research seat runs without MCP servers (none resolved or disabled).")
+
+    # FEAT-482/486: collaborative-research partner for ResearchNode. The
+    # FEAT-486 keys (DEV_FLOW_RESEARCH_PARTNER_ENABLED/_BACKEND/_MODEL)
+    # select the secondary research LLM explicitly; when the seat is not
+    # enabled, None lets the library build its conf-driven default (the
+    # legacy DEV_FLOW_RESEARCH_PARTNER env path keeps working untouched).
+    partner_plan = resolve_model_plan(DevFlowModelPlan()).research_partner
+    research_coordinator: ComplementaryResearchCoordinator | None = None
+    if partner_plan.enabled:
+        research_coordinator = ComplementaryResearchCoordinator(
+            backend=partner_plan.backend or None,
+            model=partner_plan.model or None,
+        )
+        logger.info(
+            "Collaborative research partner enabled (backend=%s, model=%s)",
+            partner_plan.backend,
+            partner_plan.model,
+        )
+
     jira_toolkit = _build_jira_toolkit()
     git_toolkit = _build_git_toolkit()
     # FEAT-480 (TASK-2628): captured once as the exact kwargs `build_dev_loop_flow`
@@ -1580,6 +1693,12 @@ async def _on_startup(app: web.Application) -> None:
         "graph_memory": graph_memory,
         "require_plan_approval": require_plan_approval,
         "skip_qa": skip_qa,
+        # FEAT-482/484/485/486: research-seat MCP access + explicit
+        # collaborative-research coordinator. None values keep the
+        # library defaults byte-identical.
+        "research_coordinator": research_coordinator,
+        "research_mcp_servers": research_mcp_servers or None,
+        "research_mcp_tools": research_mcp_tools or None,
     }
     app["flow"] = build_dev_loop_flow(**dev_loop_flow_kwargs)
     # Orchestrator-side run cap (FLOW_MAX_CONCURRENT_RUNS) — spec G5.
@@ -1633,6 +1752,11 @@ async def _on_startup(app: web.Application) -> None:
                 max_concurrent=conf.CLAUDE_CODE_MAX_CONCURRENT_DISPATCHES,
                 stream_ttl_seconds=conf.FLOW_STREAM_TTL_SECONDS,
             ),
+            # FEAT-486 (D3): the env pool now also reaches feature mode, so
+            # PlannerNode's suggested_pool names the operator's real
+            # backends and DevelopmentNode has a default pool when the
+            # brief carries no dev_agents.
+            development_pool_config=development_pool_config,
             development_pool_max=development_pool_max,
             # FEAT-377 TASK-1914/1915/1916: same graph_memory/
             # require_plan_approval already computed above for the

--- a/examples/dev_loop/server_dev.py
+++ b/examples/dev_loop/server_dev.py
@@ -31,6 +31,13 @@ from** ``server.py`` rather than copied, so the two consoles cannot drift.
 Deliberately NOT imported: ``_build_log_toolkits`` (CloudWatch) and
 ``_build_brief_from_form`` (bug intake).
 
+FEAT-484/485/486 wiring (see ``README.md`` §"Research-seat MCP access"):
+the ideation (research) seat gets the ``.parrot/mcp-toolkits.yaml`` toolkit
+servers as extra MCP servers (its wikitoolkit server is built in), via the
+sibling ``mcp_wiring.build_research_mcp``; ``DEV_FLOW_USE_REVIEW_PAIR=true``
+swaps the judge panel for the model plan's review pair as the active QA
+reviewer.
+
 Run it with::
 
     PORT=8081 python examples/dev_loop/server_dev.py
@@ -81,6 +88,7 @@ from parrot.flows.dev_loop.wiki_search import DevLoopWikiSearch
 # ``llm_catalog``.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import llm_catalog
+import mcp_wiring
 import server as ops_server
 
 logger = logging.getLogger("dev_flow.server")
@@ -336,7 +344,9 @@ def _model_plan_payload(plan: DevFlowModelPlan, *, review_pair_active: bool = Tr
         },
         "pool_backends": list(supported_dev_pool_backends()),
         "review_primary_backends": list(llm_catalog.PRIMARY_REVIEW_BACKENDS),
-        "partner_backends": ["gpt", "nova"],
+        # Derived from the catalog's role lists rather than a hardcoded
+        # literal, so a new partner backend shows up here automatically.
+        "partner_backends": [b.id for b in llm_catalog.backends_for_role("research_partner")],
     }
 
 
@@ -630,9 +640,9 @@ async def _on_startup(app: web.Application) -> None:
         )
     else:
         raise RuntimeError(
-            "DEV_LOOP_DEVELOPMENT_AGENT must be 'claude-code', 'codex', "
-            "'gemini', 'nvidia', 'grok', 'zai', or 'moonshot', "
-            f"got {development_agent!r}"
+            f"DEV_LOOP_DEVELOPMENT_AGENT must be one of "
+            f"{', '.join(supported_dev_pool_backends())} "
+            f"(or the legacy alias 'llm'), got {development_agent!r}"
         )
 
     # -- QA review: the judge panel is dev-flow's default review gate ----
@@ -641,7 +651,20 @@ async def _on_startup(app: web.Application) -> None:
         development_dispatcher=development_dispatcher,
         redis_url=redis_url,
     )
-    judge_panel_dispatcher = ops_server._build_judge_panel_dispatcher(redis_url=redis_url)
+    # FEAT-486: opt-in switch to the model plan's review PAIR (primary +
+    # mantle counter-reviewer). Default false keeps the FEAT-378 judge
+    # panel byte-identical. An explicit dispatcher wins over the plan by
+    # design (TASK-2655 precedence), so activating the pair means passing
+    # codereview_dispatcher=None and letting the factories assemble it.
+    use_review_pair = mcp_wiring._config_flag("DEV_FLOW_USE_REVIEW_PAIR", False)
+    qa_review_dispatcher = None
+    if use_review_pair:
+        logger.info(
+            "DEV_FLOW_USE_REVIEW_PAIR=true — QA uses the model plan's "
+            "review pair (primary + counter-model) instead of the judge panel."
+        )
+    else:
+        qa_review_dispatcher = ops_server._build_judge_panel_dispatcher(redis_url=redis_url)
 
     repos = parse_repo_specs(conf.DEV_LOOP_REPOS)
     if repos:
@@ -694,6 +717,20 @@ async def _on_startup(app: web.Application) -> None:
     wiki_search = DevLoopWikiSearch.from_project()
     app["wiki_search"] = wiki_search
 
+    # FEAT-484/485: extra MCP servers for the ideation (research) seat —
+    # the wikitoolkit graph-search server is BUILT IN to IdeationNode, so
+    # only the `.parrot/mcp-toolkits.yaml` toolkit servers (e.g. the
+    # ReadOnlyRepoToolkit `repo` section) are additive here; a duplicate
+    # wikitoolkit entry from the wiring is overridden by the node's own.
+    research_mcp_servers, research_mcp_tools = mcp_wiring.build_research_mcp(Path(conf.PROJECT_ROOT))
+    extra_mcp_servers = {k: v for k, v in research_mcp_servers.items() if k != "wikitoolkit"}
+    extra_mcp_tools = [t for t in research_mcp_tools if not t.startswith("mcp__wikitoolkit")]
+    if extra_mcp_servers:
+        logger.info(
+            "Ideation-seat extra MCP servers: %s",
+            ", ".join(sorted(extra_mcp_servers)),
+        )
+
     jira_toolkit = _build_optional_jira_toolkit()
     app["jira_toolkit"] = jira_toolkit
     git_toolkit = ops_server._build_git_toolkit()
@@ -714,7 +751,7 @@ async def _on_startup(app: web.Application) -> None:
         "jira_toolkit": jira_toolkit,
         "git_toolkit": git_toolkit,
         "wiki_toolkit": wiki_toolkit,
-        "codereview_dispatcher": judge_panel_dispatcher,
+        "codereview_dispatcher": qa_review_dispatcher,
         "development_dispatcher_builder": development_dispatcher_builder,
         "development_pool_max": development_pool_max,
         "graph_memory": graph_memory,
@@ -723,10 +760,16 @@ async def _on_startup(app: web.Application) -> None:
         "require_plan_approval": require_plan_approval,
         # FEAT-486: selects every LLM seat — the development pool (with
         # `agent_builder.build_dispatcher` as its worker builder), the
-        # ideation model, and QANode's review pair. Note this OVERRIDES the
-        # `codereview_dispatcher` above only when that is None; the console
-        # passes an explicit judge panel, which keeps precedence.
+        # ideation model, and QANode's review pair. The plan's review pair
+        # only activates when `codereview_dispatcher` is None
+        # (DEV_FLOW_USE_REVIEW_PAIR=true); the default judge panel keeps
+        # precedence otherwise.
         "model_plan": model_plan,
+        # FEAT-485: `.parrot/mcp-toolkits.yaml` servers for the ideation
+        # seat (its wikitoolkit server is built in). None keeps the
+        # dispatch byte-identical.
+        "research_mcp_servers": extra_mcp_servers or None,
+        "research_mcp_tools": extra_mcp_tools or None,
         "name": "dev-flow-console",
     }
     app["flow"] = build_dev_flow(**dev_loop_flow_kwargs)
@@ -737,7 +780,7 @@ async def _on_startup(app: web.Application) -> None:
         git_toolkit=git_toolkit,
         wiki_toolkit=wiki_toolkit,
         redis_url=redis_url,
-        codereview_dispatcher=judge_panel_dispatcher,
+        codereview_dispatcher=qa_review_dispatcher,
         graph_memory=graph_memory,
         # FEAT-480 (TASK-2628): see server.py's identical wiring note — each
         # `handle_run` request below mints its own stable per-job `run_id`
@@ -748,12 +791,13 @@ async def _on_startup(app: web.Application) -> None:
     )
 
     app["runner"] = runner
-    app["codereview_agent_key"] = codereview_agent_key
-    # FEAT-486: this console keeps the FEAT-378 judge panel as its QA
-    # reviewer (an explicit `codereview_dispatcher` wins over the plan by
-    # design), so the plan's review PAIR is configured but not the active
-    # reviewer here. Reported honestly to the UI rather than implied.
-    app["review_pair_active"] = False
+    app["codereview_agent_key"] = "review-pair" if use_review_pair else codereview_agent_key
+    # FEAT-486: by default this console keeps the FEAT-378 judge panel as
+    # its QA reviewer (an explicit `codereview_dispatcher` wins over the
+    # plan by design), so the plan's review PAIR is configured but not the
+    # active reviewer. DEV_FLOW_USE_REVIEW_PAIR=true flips it. Reported
+    # honestly to the UI rather than implied.
+    app["review_pair_active"] = use_review_pair
     app["development_pool_max"] = development_pool_max
     app["require_plan_approval"] = require_plan_approval
     app["flow_tasks"] = {}  # run_id -> asyncio.Task

--- a/packages/ai-parrot/src/parrot/flows/dev_flow/factories.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_flow/factories.py
@@ -179,6 +179,8 @@ def build_dev_flow_node_factories(
     ideation_max_rounds: int | None = None,
     model_plan: DevFlowModelPlan | None = None,
     research_coordinator: ComplementaryResearchCoordinator | None = None,
+    research_mcp_servers: dict[str, Any] | None = None,
+    research_mcp_tools: list[str] | None = None,
 ) -> dict[str, NodeFactory]:
     """Return the ``{node type: factory}`` map for the dev-flow graph.
 
@@ -231,6 +233,16 @@ def build_dev_flow_node_factories(
             explicit value here still wins over ``model_plan``'s
             ``research_partner`` group; see
             :func:`_resolve_research_coordinator` for the full precedence.
+        research_mcp_servers: Optional EXTRA MCP server configs for
+            :class:`IdeationNode`'s dispatch (e.g. the FEAT-485 ``parrot
+            mcp-local <toolkit>`` servers), merged under the node's
+            built-in wikitoolkit entry. ``None`` (default) keeps the
+            ideation dispatch byte-identical. Mirrors
+            ``dev_loop.factories``' kwarg of the same name for
+            ``ResearchNode``.
+        research_mcp_tools: Optional explicit ``mcp__...`` allow rules for
+            those extra servers; ``None`` derives server-level
+            ``mcp__<name>`` rules.
 
     Returns:
         A factory map covering the two ``dev_flow.*`` types plus every
@@ -295,6 +307,8 @@ def build_dev_flow_node_factories(
                 # conf.DEV_FLOW_IDEATION_MODEL itself.
                 model=resolved_plan.research_primary if resolved_plan else None,
                 coordinator=coordinator,
+                extra_mcp_servers=research_mcp_servers,
+                extra_mcp_tools=research_mcp_tools,
                 name=nd.id,
             ),
             deps,

--- a/packages/ai-parrot/src/parrot/flows/dev_flow/flow.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_flow/flow.py
@@ -99,6 +99,9 @@ def build_dev_flow(
     require_plan_approval: bool = False,
     ideation_max_rounds: int | None = None,
     model_plan: DevFlowModelPlan | None = None,
+    research_coordinator: Any | None = None,
+    research_mcp_servers: dict[str, Any] | None = None,
+    research_mcp_tools: list[str] | None = None,
     name: str = "dev-flow",
     publish_flow_events: bool = True,
     lifecycle_events: bool = True,
@@ -142,6 +145,18 @@ def build_dev_flow(
             sub-agents through ``agent_builder.build_dispatcher``; an
             explicit ``development_dispatcher_builder`` still wins over
             the plan-derived one.
+        research_coordinator: Optional
+            ``ComplementaryResearchCoordinator`` (FEAT-482/486) for the
+            ideation seat; an explicit value wins over ``model_plan``'s
+            ``research_partner`` group. ``None`` (default) keeps the
+            factories' precedence untouched.
+        research_mcp_servers: Optional EXTRA MCP server configs for the
+            ideation dispatch (e.g. FEAT-485 ``parrot mcp-local``
+            toolkit servers), merged under the built-in wikitoolkit
+            entry. ``None`` (default) keeps the dispatch byte-identical.
+        research_mcp_tools: Optional explicit ``mcp__...`` allow rules for
+            those extra servers; ``None`` derives server-level
+            ``mcp__<name>`` rules.
         name: Flow name (default ``"dev-flow"``).
         publish_flow_events: When True (default), attach a
             :class:`FlowEventPublisher` to the engine's ``on_node_event`` hook.
@@ -179,6 +194,9 @@ def build_dev_flow(
         skip_qa=skip_qa,
         ideation_max_rounds=ideation_max_rounds,
         model_plan=model_plan,
+        research_coordinator=research_coordinator,
+        research_mcp_servers=research_mcp_servers,
+        research_mcp_tools=research_mcp_tools,
     )
     staged = AgentsFlow.from_definition(
         definition,

--- a/packages/ai-parrot/src/parrot/flows/dev_flow/nodes/ideation.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_flow/nodes/ideation.py
@@ -45,8 +45,6 @@ from __future__ import annotations
 
 import asyncio
 import re
-import shutil
-import sys
 from pathlib import Path
 from typing import Any, Literal
 
@@ -62,6 +60,12 @@ from parrot.flows.dev_flow.complementary_research import (
 from parrot.flows.dev_flow.models import DevRequestBrief, IdeationOutput
 from parrot.flows.dev_flow.research_partner import ComplementaryFindings
 from parrot.flows.dev_loop.dispatchers import ClaudeCodeDispatcher
+from parrot.flows.dev_loop.mcp_profiles import (
+    WIKI_MCP_TOOLS,
+    derive_mcp_tool_names,
+    resolve_wikitoolkit_command,
+    wikitoolkit_mcp_entry,
+)
 from parrot.flows.dev_loop.models import ClaudeCodeDispatchProfile, FeatureBrief
 from parrot.flows.dev_loop.nodes.base import DevLoopNode, register_dev_loop_node
 from parrot.flows.dev_loop.wiki_search import DevLoopWikiSearch
@@ -74,39 +78,11 @@ _MODE_FOR_KIND: dict[str, str] = {
 }
 
 
-#: FEAT-482 Module 6 (§8 Q11): read-only wiki graph-search tools exposed to
-#: the primary ideation seat. Deliberately excludes the write tools
-#: (`wiki_remember` / `wiki_note`) — the primary seat may read the graph,
-#: never mutate it via this seam.
-_WIKI_MCP_TOOLS: tuple[str, ...] = (
-    "mcp__wikitoolkit__wiki_query",
-    "mcp__wikitoolkit__wiki_page",
-    "mcp__wikitoolkit__wiki_related",
-)
-
-
-def _resolve_wikitoolkit_command() -> str:
-    """Resolve the ``wikitoolkit`` CLI path robustly.
-
-    The repo's own ``.mcp.json`` hardcodes an absolute venv path, which
-    would break in any other checkout/environment. Resolve it the same
-    way any other console-script installed into the running
-    interpreter's venv is found: ``PATH`` first (``shutil.which``), then
-    a same-directory-as-``sys.executable`` fallback (covers a venv whose
-    ``bin/`` is not on ``PATH`` but IS where the running Python lives).
-
-    Returns:
-        The resolved ``wikitoolkit`` command path, or the bare
-        ``"wikitoolkit"`` string as a last resort (lets the CLI's own
-        "not found" error surface instead of silently omitting the tool).
-    """
-    found = shutil.which("wikitoolkit")
-    if found:
-        return found
-    candidate = Path(sys.executable).parent / "wikitoolkit"
-    if candidate.is_file():
-        return str(candidate)
-    return "wikitoolkit"
+# Backward-compat aliases: these lived here (private) before moving to the
+# shared ``parrot.flows.dev_loop.mcp_profiles`` module so ``ResearchNode``
+# could reuse them. Kept so existing imports/monkeypatches keep working.
+_WIKI_MCP_TOOLS = WIKI_MCP_TOOLS
+_resolve_wikitoolkit_command = resolve_wikitoolkit_command
 
 
 def _slugify(title: str) -> str:
@@ -177,6 +153,17 @@ class IdeationNode(DevLoopNode):
             it is called on round 1 only; it never raises (it owns its own
             degradation), so a disabled/degraded/timed-out partner simply
             yields empty partner fields too.
+        extra_mcp_servers: Optional extra MCP server configs (same shape as
+            ``ClaudeCodeDispatchProfile.mcp_servers``) merged UNDER the
+            built-in ``wikitoolkit`` entry — on a key collision the
+            built-in wins (with a warning). Use this to expose the
+            FEAT-485 ``parrot mcp-local <toolkit>`` servers to the
+            research-primary seat. ``None`` (default) keeps the dispatch
+            profile byte-identical to pre-seam behavior.
+        extra_mcp_tools: Optional explicit ``mcp__...`` allow rules for the
+            extra servers, appended to ``allowed_tools``. ``None``
+            (default) derives one server-level ``mcp__<name>`` rule per
+            extra server. Ignored when ``extra_mcp_servers`` is unset.
         name: Node id, default ``"ideation"``.
     """
 
@@ -188,6 +175,8 @@ class IdeationNode(DevLoopNode):
         ideation_max_rounds: int | None = None,
         model: str | None = None,
         coordinator: ComplementaryResearchCoordinator | None = None,
+        extra_mcp_servers: dict[str, Any] | None = None,
+        extra_mcp_tools: list[str] | None = None,
         name: str = "ideation",
     ) -> None:
         super().__init__(node_id=name)
@@ -201,6 +190,8 @@ class IdeationNode(DevLoopNode):
         # DEV_FLOW_IDEATION_MAX_ROUNDS.
         object.__setattr__(self, "_model", model)
         object.__setattr__(self, "_coordinator", coordinator)
+        object.__setattr__(self, "_extra_mcp_servers", extra_mcp_servers)
+        object.__setattr__(self, "_extra_mcp_tools", extra_mcp_tools)
 
     # ------------------------------------------------------------------
     # Execute
@@ -493,6 +484,23 @@ class IdeationNode(DevLoopNode):
             partner_findings=partner_findings,
             partner_findings_path=partner_findings_path,
         )
+        # Extra caller-supplied servers (e.g. FEAT-485 `parrot mcp-local`
+        # toolkits) merge UNDER the built-in wikitoolkit entry: with no
+        # extras the dict is exactly {"wikitoolkit": ...}, byte-identical
+        # to pre-seam behavior.
+        mcp_servers: dict[str, Any] = dict(self._extra_mcp_servers or {})
+        if "wikitoolkit" in mcp_servers:
+            self.logger.warning(
+                "extra_mcp_servers supplied a 'wikitoolkit' entry; the built-in one takes precedence."
+            )
+        mcp_servers["wikitoolkit"] = wikitoolkit_mcp_entry()
+        allowed_tools = ["Read", "Grep", "Glob", "Bash", "Write", "Edit", *WIKI_MCP_TOOLS]
+        if self._extra_mcp_servers:
+            allowed_tools.extend(
+                self._extra_mcp_tools
+                if self._extra_mcp_tools is not None
+                else derive_mcp_tool_names(self._extra_mcp_servers)
+            )
         profile = ClaudeCodeDispatchProfile(
             # NOT profile.subagent: that path resolves the prompt through
             # dev_loop's loader, which does not know the dev_flow-owned
@@ -506,7 +514,7 @@ class IdeationNode(DevLoopNode):
             # FEAT-482 Module 6 (§8 Q11): plus the three read-only wiki
             # graph-search tools — the primary seat does the deepest
             # research in the pipeline and benefits most from it.
-            allowed_tools=["Read", "Grep", "Glob", "Bash", "Write", "Edit", *_WIKI_MCP_TOOLS],
+            allowed_tools=allowed_tools,
             # The dispatch is write-capable AND runs at the base checkout
             # (see _dispatch_cwd), so it needs the dispatcher's narrow
             # PROJECT_ROOT waiver of the WORKTREE_BASE_PATH confinement —
@@ -520,15 +528,9 @@ class IdeationNode(DevLoopNode):
             # FEAT-482 Module 6: strict_mcp_config stays at its True
             # default (NOT overridden here) — the field's own docstring
             # records that flipping it makes non-interactive runs exit
-            # with an empty error result. Passing the server explicitly
-            # is the correct way to reach it under that isolation.
-            mcp_servers={
-                "wikitoolkit": {
-                    "command": _resolve_wikitoolkit_command(),
-                    "args": ["mcp"],
-                    "env": {},
-                }
-            },
+            # with an empty error result. Passing the servers explicitly
+            # is the correct way to reach them under that isolation.
+            mcp_servers=mcp_servers,
         )
         return await self._dispatcher.dispatch(
             brief=dispatch_brief,

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/factories.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/factories.py
@@ -66,6 +66,8 @@ def build_dev_loop_node_factories(
     require_plan_approval: bool = False,
     skip_qa: bool = False,
     research_coordinator: Optional[ComplementaryResearchCoordinator] = None,
+    research_mcp_servers: Optional[Dict[str, Any]] = None,
+    research_mcp_tools: Optional[List[str]] = None,
 ) -> Dict[str, NodeFactory]:
     """Return the ``{dev_loop.* type: factory}`` map binding live deps.
 
@@ -139,6 +141,13 @@ def build_dev_loop_node_factories(
             ``dev_flow.factories.build_dev_flow_node_factories``'s
             equivalent kwarg for ``IdeationNode`` (D1: one shared
             mechanism serves both seats).
+        research_mcp_servers: Optional explicit MCP server configs
+            forwarded to ``ResearchNode`` (wikitoolkit graph search,
+            FEAT-485 ``parrot mcp-local`` toolkit servers, ...). ``None``
+            (default) keeps the research dispatch profile byte-identical.
+        research_mcp_tools: Optional explicit ``mcp__...`` allow rules for
+            those servers; ``None`` derives server-level ``mcp__<name>``
+            rules. See :class:`ResearchNode`.
 
     Returns:
         A mapping suitable for ``node_factories=`` on
@@ -167,6 +176,8 @@ def build_dev_loop_node_factories(
                 graph_memory=graph_memory,
                 wiki_search=wiki_search,
                 coordinator=coordinator,
+                mcp_servers=research_mcp_servers,
+                mcp_tools=research_mcp_tools,
                 name=nd.id,
             ),
             deps,

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/flow.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/flow.py
@@ -352,6 +352,9 @@ def build_dev_loop_flow(
     graph_memory: Optional[Any] = None,
     require_plan_approval: bool = False,
     skip_qa: bool = False,
+    research_coordinator: Optional[Any] = None,
+    research_mcp_servers: Optional[Dict[str, Any]] = None,
+    research_mcp_tools: Optional[list[str]] = None,
     checkpoint: bool = False,
     checkpoint_required: bool = False,
     checkpoint_store: Optional[Union[str, CheckpointStore]] = None,
@@ -431,6 +434,21 @@ def build_dev_loop_flow(
         skip_qa: When ``True``, ``QANode`` returns a synthetic passing
             ``QAReport`` without running deterministic checks or code
             review. ``False`` (default) preserves the full QA gate.
+        research_coordinator: Optional
+            ``ComplementaryResearchCoordinator`` (FEAT-482/486) forwarded
+            to ``ResearchNode`` via ``build_dev_loop_node_factories``.
+            ``None`` (default) lets the factories build a fresh
+            conf-driven one (inert until ``DEV_FLOW_RESEARCH_PARTNER`` is
+            configured). Pass an explicitly configured coordinator
+            (``backend=``/``model=``) to select the collaborative-research
+            partner's LLM programmatically.
+        research_mcp_servers: Optional explicit MCP server configs
+            forwarded to ``ResearchNode``'s dispatch profile (wikitoolkit
+            graph search, FEAT-485 ``parrot mcp-local`` toolkit servers).
+            ``None`` (default) keeps the research dispatch byte-identical.
+        research_mcp_tools: Optional explicit ``mcp__...`` allow rules for
+            those servers; ``None`` derives server-level ``mcp__<name>``
+            rules. See :class:`ResearchNode`.
         checkpoint: FEAT-480 — enable AgentsFlow state checkpointing for
             the built flow. ``False`` (default) is byte-identical to the
             pre-FEAT-480 behavior — no checkpoint config is attached at
@@ -481,6 +499,9 @@ def build_dev_loop_flow(
         graph_memory=graph_memory,
         require_plan_approval=require_plan_approval,
         skip_qa=skip_qa,
+        research_coordinator=research_coordinator,
+        research_mcp_servers=research_mcp_servers,
+        research_mcp_tools=research_mcp_tools,
     )
     staged = AgentsFlow.from_definition(
         definition,

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/mcp_profiles.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/mcp_profiles.py
@@ -1,0 +1,89 @@
+"""Shared MCP helpers for dev-loop / dev-flow dispatch profiles.
+
+The research seats of both flows (``dev_loop.ResearchNode`` and
+``dev_flow.IdeationNode``) dispatch headless Claude Code sessions with
+``strict_mcp_config=True`` (see ``ClaudeCodeDispatchProfile``), which makes
+the dispatched CLI ignore any filesystem ``.mcp.json``. Reaching an MCP
+server from such a dispatch therefore requires BOTH the explicit server
+config on ``profile.mcp_servers`` AND the matching ``mcp__...`` allow rules
+on ``profile.allowed_tools``. This module centralizes the pieces both nodes
+need so they share one mechanism instead of forking it:
+
+* the read-only wikitoolkit graph-search server entry (FEAT-482 Module 6,
+  originally private to ``dev_flow/nodes/ideation.py``), and
+* the allow-rule derivation for arbitrary caller-supplied servers — e.g.
+  the FEAT-485 ``parrot mcp-local <toolkit>`` servers.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Mapping
+
+#: FEAT-482 Module 6 (§8 Q11): read-only wiki graph-search tools exposed to
+#: the research seats. Deliberately excludes the write tools
+#: (`wiki_remember` / `wiki_note`) — a research seat may read the graph,
+#: never mutate it via this seam.
+WIKI_MCP_TOOLS: tuple[str, ...] = (
+    "mcp__wikitoolkit__wiki_query",
+    "mcp__wikitoolkit__wiki_page",
+    "mcp__wikitoolkit__wiki_related",
+)
+
+
+def resolve_wikitoolkit_command() -> str:
+    """Resolve the ``wikitoolkit`` CLI path robustly.
+
+    The repo's own ``.mcp.json`` hardcodes an absolute venv path, which
+    would break in any other checkout/environment. Resolve it the same
+    way any other console-script installed into the running
+    interpreter's venv is found: ``PATH`` first (``shutil.which``), then
+    a same-directory-as-``sys.executable`` fallback (covers a venv whose
+    ``bin/`` is not on ``PATH`` but IS where the running Python lives).
+
+    Returns:
+        The resolved ``wikitoolkit`` command path, or the bare
+        ``"wikitoolkit"`` string as a last resort (lets the CLI's own
+        "not found" error surface instead of silently omitting the tool).
+    """
+    found = shutil.which("wikitoolkit")
+    if found:
+        return found
+    candidate = Path(sys.executable).parent / "wikitoolkit"
+    if candidate.is_file():
+        return str(candidate)
+    return "wikitoolkit"
+
+
+def wikitoolkit_mcp_entry() -> Dict[str, Any]:
+    """Build the stdio server config for the wikitoolkit MCP server.
+
+    Returns:
+        A Claude Code MCP server config dict suitable as the value of a
+        ``"wikitoolkit"`` key in ``ClaudeCodeDispatchProfile.mcp_servers``.
+    """
+    return {
+        "command": resolve_wikitoolkit_command(),
+        "args": ["mcp"],
+        "env": {},
+    }
+
+
+def derive_mcp_tool_names(mcp_servers: Mapping[str, Any]) -> List[str]:
+    """Derive server-level allow rules for a set of MCP servers.
+
+    Claude Code accepts a bare ``mcp__<serverName>`` allow rule meaning
+    "every tool of that server". Enumerating per-tool names would require
+    importing every toolkit class in the calling process, so this is the
+    default when the caller does not supply an explicit tool list.
+
+    Args:
+        mcp_servers: Mapping of server name → server config (the same
+            shape as ``ClaudeCodeDispatchProfile.mcp_servers``).
+
+    Returns:
+        Sorted ``["mcp__<name>", ...]`` rules, one per server.
+    """
+    return [f"mcp__{name}" for name in sorted(mcp_servers)]

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/research.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/nodes/research.py
@@ -39,6 +39,7 @@ from parrot.flows.dev_flow.complementary_research import (
 )
 from parrot.flows.dev_loop.dispatchers import ClaudeCodeDispatcher
 from parrot.flows.dev_loop.graph_memory import DevLoopGraphMemory
+from parrot.flows.dev_loop.mcp_profiles import derive_mcp_tool_names
 from parrot.flows.dev_loop.models import (
     BugBrief,
     ClaudeCodeDispatchProfile,
@@ -220,6 +221,19 @@ class ResearchNode(DevLoopNode):
             context, not a new field on the shared ``BugBrief``/
             ``WorkBrief`` model. Never raises — a disabled/degraded/timed-
             out partner simply contributes no extra section.
+        mcp_servers: Optional explicit MCP server configs (same shape as
+            ``ClaudeCodeDispatchProfile.mcp_servers``) forwarded on the
+            ``sdd-research`` dispatch profile — e.g. the wikitoolkit
+            graph-search server and FEAT-485 ``parrot mcp-local
+            <toolkit>`` servers. Required to reach ANY MCP server: the
+            dispatch keeps ``strict_mcp_config=True``, so the headless CLI
+            ignores the filesystem ``.mcp.json``. ``None`` (default)
+            keeps the dispatch profile byte-identical to pre-seam
+            behavior.
+        mcp_tools: Optional explicit ``mcp__...`` allow rules appended to
+            the profile's ``allowed_tools``. ``None`` (default) derives
+            one server-level ``mcp__<name>`` rule per server. Ignored
+            when ``mcp_servers`` is unset.
         name: Node id, default ``"research"``.
     """
 
@@ -237,6 +251,8 @@ class ResearchNode(DevLoopNode):
         graph_memory: Optional[DevLoopGraphMemory] = None,
         wiki_search: Optional[DevLoopWikiSearch] = None,
         coordinator: Optional[ComplementaryResearchCoordinator] = None,
+        mcp_servers: Optional[Dict[str, Any]] = None,
+        mcp_tools: Optional[List[str]] = None,
         name: str = "research",
     ) -> None:
         super().__init__(node_id=name)
@@ -267,6 +283,11 @@ class ResearchNode(DevLoopNode):
         # injection. None (default) is a strict no-op.
         object.__setattr__(self, "_graph_memory", graph_memory)
         object.__setattr__(self, "_wiki_search", wiki_search)
+        # Explicit MCP access for the sdd-research dispatch (wikitoolkit +
+        # FEAT-485 local toolkit servers). None (default) is a strict
+        # no-op: the dispatch profile stays byte-identical.
+        object.__setattr__(self, "_mcp_servers", mcp_servers)
+        object.__setattr__(self, "_mcp_tools", mcp_tools)
 
     # ------------------------------------------------------------------
     # Execute
@@ -388,21 +409,30 @@ class ResearchNode(DevLoopNode):
         )
 
         # 4. Dispatch the sdd-research subagent.
+        # SlashCommand: the subagent runs /sdd-spec and /sdd-task.
+        # Write: it scaffolds spec/task files under sdd/. Read/Grep/Glob
+        # for triage, Bash for git worktree plumbing.
+        allowed_tools = [
+            "Read",
+            "Grep",
+            "Glob",
+            "Bash",
+            "Write",
+            "SlashCommand",
+        ]
+        if self._mcp_servers:
+            # strict_mcp_config stays True (profile default): reaching an
+            # MCP server needs BOTH the server config on the profile AND
+            # the matching mcp__... allow rules.
+            allowed_tools.extend(
+                self._mcp_tools if self._mcp_tools is not None else derive_mcp_tool_names(self._mcp_servers)
+            )
         profile = ClaudeCodeDispatchProfile(
             subagent="sdd-research",
             permission_mode="acceptEdits",
-            # SlashCommand: the subagent runs /sdd-spec and /sdd-task.
-            # Write: it scaffolds spec/task files under sdd/. Read/Grep/Glob
-            # for triage, Bash for git worktree plumbing.
-            allowed_tools=[
-                "Read",
-                "Grep",
-                "Glob",
-                "Bash",
-                "Write",
-                "SlashCommand",
-            ],
+            allowed_tools=allowed_tools,
             model="claude-sonnet-4-6",
+            mcp_servers=dict(self._mcp_servers) if self._mcp_servers else None,
         )
         os.makedirs(dispatch_cwd, exist_ok=True)
         # Stash the excerpts on the brief so the subagent gets them.

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/runner.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/runner.py
@@ -221,6 +221,7 @@ def build_dev_loop_feature_flow(
     redis_url: str,
     codereview_dispatcher: Optional[Any] = None,
     development_dispatcher_builder: Optional[Any] = None,
+    development_pool_config: Optional[Any] = None,
     development_pool_max: int = 4,
     graph_memory: Optional[Any] = None,
     require_plan_approval: bool = False,
@@ -261,6 +262,14 @@ def build_dev_loop_feature_flow(
         development_dispatcher_builder: Optional ``(DevAgentSpec) ->
             (dispatcher, profile)`` callable (FEAT-323) for ``DevelopmentNode``
             pool-worker materialization.
+        development_pool_config: Optional :class:`DevAgentPoolConfig`
+            (FEAT-323/486) forwarded via ``build_dev_loop_node_factories``
+            to BOTH ``DevelopmentNode`` (default pool when the brief
+            carries no ``dev_agents``) and ``PlannerNode`` (so
+            ``suggested_pool`` names the operator's real backends instead
+            of the claude-code default). ``None`` (default) preserves the
+            single-agent behaviour exactly — same semantics as
+            ``build_dev_loop_flow``'s kwarg of the same name.
         development_pool_max: Hard cap on total pool workers (FEAT-323),
             also passed to ``PlannerNode`` for its own pool-sizing cap.
         graph_memory: FEAT-377 TASK-1914/1915 (G2) — an optional
@@ -296,6 +305,7 @@ def build_dev_loop_feature_flow(
         git_toolkit=git_toolkit,
         wiki_toolkit=wiki_toolkit,
         development_dispatcher_builder=development_dispatcher_builder,
+        development_pool_config=development_pool_config,
         development_pool_max=development_pool_max,
         codereview_dispatcher=codereview_dispatcher,
         graph_memory=graph_memory,

--- a/packages/ai-parrot/src/parrot/mcp/local_cli.py
+++ b/packages/ai-parrot/src/parrot/mcp/local_cli.py
@@ -31,7 +31,7 @@ def _configure_stderr_logging() -> None:
     root_logger.setLevel(logging.WARNING)
 
 
-def _print_toolkit_list(root: Path) -> None:
+def _print_toolkit_list(root: Path, config_path: Path | None = None) -> None:
     """Print resolvable toolkit names, enabled state, and class path.
 
     Deliberately does NOT import any toolkit class — only the config
@@ -40,10 +40,11 @@ def _print_toolkit_list(root: Path) -> None:
 
     Args:
         root: Project root to resolve ``.parrot/mcp-toolkits.yaml`` from.
+        config_path: Optional explicit config file (``--config`` override).
     """
     from parrot.mcp.toolkit_config import load_toolkits_config
 
-    cfg = load_toolkits_config(root)
+    cfg = load_toolkits_config(root, config_path=config_path)
     if not cfg.toolkits:
         click.echo("No toolkits resolvable.")
         return
@@ -104,7 +105,7 @@ def mcp_local(
     root = Path.cwd()
 
     if list_toolkits:
-        _print_toolkit_list(root)
+        _print_toolkit_list(root, config_path)
         return
 
     if not name:

--- a/packages/ai-parrot/src/parrot/mcp/toolkit_config.py
+++ b/packages/ai-parrot/src/parrot/mcp/toolkit_config.py
@@ -77,7 +77,7 @@ BUILTIN_TOOLKITS: dict[str, ToolkitSection] = {
 }
 
 
-def load_toolkits_config(root: Path) -> MCPToolkitsConfig:
+def load_toolkits_config(root: Path, config_path: Path | None = None) -> MCPToolkitsConfig:
     """Load and merge toolkit configuration.
 
     Reads `.parrot/mcp-toolkits.yaml` from the project root if present,
@@ -92,22 +92,36 @@ def load_toolkits_config(root: Path) -> MCPToolkitsConfig:
 
     Args:
         root: Project root directory.
+        config_path: Optional explicit config file path (the `parrot
+            mcp-local --config` override). When given it is used instead of
+            `<root>/.parrot/mcp-toolkits.yaml`, and — unlike the default
+            path, whose absence silently falls back to the built-ins — a
+            missing explicit file raises ValueError: an operator who named
+            a file expects it to be read.
 
     Returns:
         MCPToolkitsConfig with merged sections.
 
     Raises:
         ValueError: If the file exists but is malformed YAML, contains unknown
-            top-level keys, or has a non-mapping `toolkits:` value. Error message
-            names the file path and the offending section/key.
+            top-level keys, or has a non-mapping `toolkits:` value — or if an
+            explicit `config_path` does not exist. Error message names the
+            file path and the offending section/key.
     """
-    config_path = root / ".parrot" / "mcp-toolkits.yaml"
+    explicit = config_path is not None
+    if config_path is None:
+        config_path = root / ".parrot" / "mcp-toolkits.yaml"
+    else:
+        config_path = Path(config_path)
 
     # Start with built-in defaults (these will be overridden by file sections)
     merged: dict[str, ToolkitSection] = {name: section.model_copy() for name, section in BUILTIN_TOOLKITS.items()}
 
-    # If file does not exist, return builtins only
+    # If file does not exist: builtins only for the default path; an
+    # explicitly named file that is absent is operator error.
     if not config_path.exists():
+        if explicit:
+            raise ValueError(f"Toolkit config file not found: {config_path}")
         return MCPToolkitsConfig(toolkits=merged)
 
     # Load and parse YAML

--- a/packages/ai-parrot/src/parrot/mcp/toolkit_server.py
+++ b/packages/ai-parrot/src/parrot/mcp/toolkit_server.py
@@ -60,8 +60,12 @@ def create_toolkit_mcp_server(
     """
     root = Path(root)
 
-    # Load config
-    cfg = load_toolkits_config(root)
+    # Load config — honoring the documented `config_path` override (the
+    # `parrot mcp-local --config` flag). Needed because stdio MCP servers
+    # inherit the MCP host's cwd, which is not always the project root
+    # (e.g. dev-loop research dispatches run from WORKTREE_BASE_PATH).
+    config_path = overrides.get("config_path")
+    cfg = load_toolkits_config(root, config_path=Path(config_path) if config_path else None)
 
     # Check for unknown name
     if name not in cfg.toolkits:

--- a/packages/ai-parrot/tests/flows/dev_flow/test_flow_mcp_threading.py
+++ b/packages/ai-parrot/tests/flows/dev_flow/test_flow_mcp_threading.py
@@ -1,0 +1,45 @@
+"""Threading tests for dev-flow's research-seat extra-MCP seam (FEAT-485).
+
+``build_dev_flow(research_mcp_servers=..., research_mcp_tools=...)`` must
+reach the materialized ``IdeationNode``; unset kwargs must leave its
+dispatch byte-identical (the built-in wikitoolkit entry alone). Mirrors
+``test_plan_threading.py``'s style.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from parrot.flows.dev_flow.definition import IDEATION
+from parrot.flows.dev_flow.flow import build_dev_flow
+
+_SERVERS = {"parrot-repo": {"command": "/x/parrot", "args": ["mcp-local", "repo"], "env": {}}}
+
+
+def _flow(**kwargs: Any):
+    return build_dev_flow(
+        dispatcher=MagicMock(),
+        redis_url="redis://x",
+        publish_flow_events=False,
+        lifecycle_events=False,
+        **kwargs,
+    )
+
+
+class TestIdeationExtraMcpThreading:
+    def test_defaults_leave_ideation_unwired(self):
+        node = _flow()._nodes[IDEATION]
+        assert node._extra_mcp_servers is None
+        assert node._extra_mcp_tools is None
+
+    def test_extra_servers_and_tools_reach_ideation(self):
+        tools = ["mcp__parrot-repo"]
+        node = _flow(research_mcp_servers=_SERVERS, research_mcp_tools=tools)._nodes[IDEATION]
+        assert node._extra_mcp_servers == _SERVERS
+        assert node._extra_mcp_tools == tools
+
+    def test_explicit_coordinator_still_wins(self):
+        sentinel = MagicMock()
+        node = _flow(research_coordinator=sentinel)._nodes[IDEATION]
+        assert node._coordinator is sentinel

--- a/packages/ai-parrot/tests/flows/dev_flow/test_ideation_graph_search.py
+++ b/packages/ai-parrot/tests/flows/dev_flow/test_ideation_graph_search.py
@@ -172,3 +172,58 @@ class TestPrimarySeatGraphSearch:
 
         source = inspect.getsource(IdeationNode._dispatch)
         assert "claude-sonnet-4-6" not in source
+
+
+class TestPrimarySeatExtraMcpServers:
+    """FEAT-485: caller-supplied extra MCP servers merge UNDER wikitoolkit."""
+
+    _EXTRA = {"parrot-repo": {"command": "/x/parrot", "args": ["mcp-local", "repo"], "env": {}}}
+
+    async def test_no_extras_profile_unchanged(self, doc):
+        """GUARD: without extras the servers dict is exactly {wikitoolkit}."""
+        dispatcher = ScriptedDispatcher([_output()])
+        node = IdeationNode(dispatcher=dispatcher)
+
+        await node.execute({"run_id": RUN_ID, "dev_brief": _brief()})
+
+        assert list(dispatcher.calls[0]["profile"].mcp_servers) == ["wikitoolkit"]
+
+    async def test_extras_merged_with_derived_rules(self, doc):
+        dispatcher = ScriptedDispatcher([_output()])
+        node = IdeationNode(dispatcher=dispatcher, extra_mcp_servers=dict(self._EXTRA))
+
+        await node.execute({"run_id": RUN_ID, "dev_brief": _brief()})
+
+        profile = dispatcher.calls[0]["profile"]
+        assert set(profile.mcp_servers) == {"wikitoolkit", "parrot-repo"}
+        assert profile.mcp_servers["parrot-repo"] == self._EXTRA["parrot-repo"]
+        assert "mcp__parrot-repo" in profile.allowed_tools
+        # The built-in wiki trio is still enumerated.
+        assert "mcp__wikitoolkit__wiki_query" in profile.allowed_tools
+
+    async def test_builtin_wikitoolkit_wins_on_collision(self, doc):
+        dispatcher = ScriptedDispatcher([_output()])
+        node = IdeationNode(
+            dispatcher=dispatcher,
+            extra_mcp_servers={"wikitoolkit": {"command": "/evil/wikitoolkit", "args": [], "env": {}}},
+        )
+
+        await node.execute({"run_id": RUN_ID, "dev_brief": _brief()})
+
+        server = dispatcher.calls[0]["profile"].mcp_servers["wikitoolkit"]
+        assert server["command"] != "/evil/wikitoolkit"
+        assert server["args"] == ["mcp"]
+
+    async def test_explicit_extra_tools_win_over_derivation(self, doc):
+        dispatcher = ScriptedDispatcher([_output()])
+        node = IdeationNode(
+            dispatcher=dispatcher,
+            extra_mcp_servers=dict(self._EXTRA),
+            extra_mcp_tools=["mcp__parrot-repo__read_file"],
+        )
+
+        await node.execute({"run_id": RUN_ID, "dev_brief": _brief()})
+
+        allowed = dispatcher.calls[0]["profile"].allowed_tools
+        assert "mcp__parrot-repo__read_file" in allowed
+        assert "mcp__parrot-repo" not in allowed

--- a/packages/ai-parrot/tests/flows/dev_flow/test_server_dev_model_plan.py
+++ b/packages/ai-parrot/tests/flows/dev_flow/test_server_dev_model_plan.py
@@ -135,7 +135,10 @@ class TestConfigPayload:
         plan = (await (await client.get("/api/config")).json())["defaults"]["model_plan"]
         assert "nova" in plan["pool_backends"]
         assert "claude-code" in plan["review_primary_backends"]
-        assert plan["partner_backends"] == ["gpt", "nova"]
+        # Derived from llm_catalog.backends_for_role("research_partner")
+        # (catalog order) instead of a hardcoded literal — assert the
+        # membership, not the ordering.
+        assert set(plan["partner_backends"]) == {"gpt", "nova"}
 
     async def test_nim_listed_not_default(self, make_client):
         """NIM must remain selectable in the catalog but never preselected."""

--- a/packages/ai-parrot/tests/flows/dev_loop/test_adversarial_server_wiring.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_adversarial_server_wiring.py
@@ -117,6 +117,36 @@ def test_nova_adversarial_respects_scope_guards(monkeypatch):
         module._build_nova_adversarial_reviewer()
 
 
+# ---------------------------------------------------------------------------
+# FEAT-486: mantle joins the selectable adversarial backends. Previously
+# "mantle" passed the catalog's validation and silently built the CODEX
+# reviewer here — the mantle-adversarial dispatcher was unreachable from
+# this console.
+# ---------------------------------------------------------------------------
+
+
+def test_adversarial_backend_selects_mantle(monkeypatch):
+    from parrot.flows.dev_loop.dispatchers.mantle import (
+        MantleAdversarialReviewDispatcher,
+    )
+
+    monkeypatch.setattr(conf, "DEV_LOOP_ADVERSARIAL_SCOPE", "uncommitted")
+    monkeypatch.setattr(conf, "DEV_LOOP_ADVERSARIAL_BASE_REF", "")
+    monkeypatch.setenv("DEV_LOOP_ADVERSARIAL_BACKEND", "mantle")
+    module = _load_server_module()
+    reviewer, agent_key = module._build_adversarial_reviewer(MagicMock())
+    assert isinstance(reviewer, MantleAdversarialReviewDispatcher)
+    assert agent_key == "mantle-adversarial"
+
+
+def test_mantle_adversarial_respects_scope_guards(monkeypatch):
+    monkeypatch.setattr(conf, "DEV_LOOP_ADVERSARIAL_SCOPE", "base")
+    monkeypatch.setattr(conf, "DEV_LOOP_ADVERSARIAL_BASE_REF", "")
+    module = _load_server_module()
+    with pytest.raises(RuntimeError, match="DEV_LOOP_ADVERSARIAL_BASE_REF"):
+        module._build_mantle_adversarial_reviewer()
+
+
 def test_resolve_codereview_dispatcher_advisory_mode_uses_nova(monkeypatch):
     """End-to-end: DEV_LOOP_CODEREVIEW_AGENT=codex-adversarial + backend=nova
     returns the nova reviewer as the advisory-only dispatcher."""

--- a/packages/ai-parrot/tests/flows/dev_loop/test_examples_mcp_wiring.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_examples_mcp_wiring.py
@@ -1,0 +1,125 @@
+"""Tests for the example consoles' research-seat MCP wiring (FEAT-484/485).
+
+Loads ``examples/dev_loop/mcp_wiring.py`` (and ``server.py`` for the
+``_parse_dev_agents`` guard) via ``importlib.util.spec_from_file_location``
+— the same pattern as ``test_adversarial_server_wiring.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_EXAMPLES_DIR = Path(__file__).parents[5] / "examples" / "dev_loop"
+
+_REPO_YAML = """
+toolkits:
+  repo:
+    class: parrot.tools.repo.toolkit.ReadOnlyRepoToolkit
+    enabled: true
+    kwargs:
+      repo_root: /abs/checkout
+  disabled_one:
+    class: parrot.tools.working_memory.tool.WorkingMemoryToolkit
+    enabled: false
+"""
+
+
+def _load_example_module(basename: str, module_name: str):
+    path = _EXAMPLES_DIR / basename
+    if not path.exists():
+        pytest.skip(f"{basename} not found at {path}")
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def mcp_wiring():
+    return _load_example_module("mcp_wiring.py", "_dev_loop_mcp_wiring_under_test")
+
+
+@pytest.fixture
+def repo_root(tmp_path: Path) -> Path:
+    (tmp_path / ".parrot").mkdir()
+    (tmp_path / ".parrot" / "mcp-toolkits.yaml").write_text(_REPO_YAML, encoding="utf-8")
+    return tmp_path
+
+
+class TestBuildResearchMcp:
+    def test_kill_switch(self, mcp_wiring, repo_root, monkeypatch):
+        monkeypatch.setenv("DEV_LOOP_RESEARCH_MCP_ENABLED", "false")
+        servers, tools = mcp_wiring.build_research_mcp(repo_root)
+        assert servers == {} and tools == []
+
+    def test_auto_serves_declared_enabled_sections_only(self, mcp_wiring, repo_root, monkeypatch):
+        monkeypatch.delenv("DEV_LOOP_RESEARCH_MCP_ENABLED", raising=False)
+        monkeypatch.delenv("DEV_LOOP_RESEARCH_MCP_TOOLKITS", raising=False)
+        servers, tools = mcp_wiring.build_research_mcp(repo_root)
+        assert "parrot-repo" in servers
+        # Disabled sections and undeclared built-ins are never auto-spawned.
+        assert "parrot-disabled_one" not in servers
+        assert "parrot-memory" not in servers
+        assert "mcp__parrot-repo" in tools
+
+    def test_toolkit_entry_carries_config_override(self, mcp_wiring, repo_root, monkeypatch):
+        monkeypatch.delenv("DEV_LOOP_RESEARCH_MCP_TOOLKITS", raising=False)
+        servers, _tools = mcp_wiring.build_research_mcp(repo_root)
+        args = servers["parrot-repo"]["args"]
+        assert args[:2] == ["mcp-local", "repo"]
+        assert "--config" in args
+        assert args[args.index("--config") + 1] == str(repo_root / ".parrot" / "mcp-toolkits.yaml")
+
+    def test_explicit_selection_may_name_builtins(self, mcp_wiring, repo_root, monkeypatch):
+        monkeypatch.setenv("DEV_LOOP_RESEARCH_MCP_TOOLKITS", "memory")
+        servers, tools = mcp_wiring.build_research_mcp(repo_root)
+        assert "parrot-memory" in servers
+        assert "mcp__parrot-memory" in tools
+
+    def test_unknown_selection_warns_and_skips(self, mcp_wiring, repo_root, monkeypatch, caplog):
+        monkeypatch.setenv("DEV_LOOP_RESEARCH_MCP_TOOLKITS", "ghost")
+        with caplog.at_level("WARNING"):
+            servers, _tools = mcp_wiring.build_research_mcp(repo_root)
+        assert "parrot-ghost" not in servers
+        assert any("ghost" in rec.message for rec in caplog.records)
+
+    def test_no_yaml_yields_no_toolkit_servers(self, mcp_wiring, tmp_path, monkeypatch):
+        monkeypatch.delenv("DEV_LOOP_RESEARCH_MCP_TOOLKITS", raising=False)
+        servers, _tools = mcp_wiring.build_research_mcp(tmp_path)
+        assert not any(name.startswith("parrot-") for name in servers)
+
+    def test_invalid_yaml_degrades_with_warning(self, mcp_wiring, tmp_path, monkeypatch, caplog):
+        (tmp_path / ".parrot").mkdir()
+        (tmp_path / ".parrot" / "mcp-toolkits.yaml").write_text("unknown_key: 1\n", encoding="utf-8")
+        monkeypatch.delenv("DEV_LOOP_RESEARCH_MCP_TOOLKITS", raising=False)
+        with caplog.at_level("WARNING"):
+            servers, _tools = mcp_wiring.build_research_mcp(tmp_path)
+        assert not any(name.startswith("parrot-") for name in servers)
+        assert any("Ignoring invalid" in rec.message for rec in caplog.records)
+
+    def test_wikitoolkit_included_when_binary_resolves(self, mcp_wiring, repo_root, monkeypatch):
+        monkeypatch.setattr(
+            "_dev_loop_mcp_wiring_under_test.resolve_wikitoolkit_bin",
+            lambda _root: "/opt/bin/wikitoolkit",
+        )
+        monkeypatch.setattr("shutil.which", lambda _n: "/opt/bin/wikitoolkit")
+        servers, tools = mcp_wiring.build_research_mcp(repo_root)
+        assert servers["wikitoolkit"]["args"] == ["mcp"]
+        assert "mcp__wikitoolkit__wiki_query" in tools
+
+
+class TestParseDevAgentsGuard:
+    def test_gpt_rejected_cleanly(self):
+        """FEAT-486: 'gpt' is a research-partner-only catalog entry — the
+        parser must reject it with its own message, not a pydantic blow-up
+        from DevAgentSpec's Literal."""
+        server = _load_example_module("server.py", "_dev_loop_server_under_test_mcp")
+        with pytest.raises(ValueError, match="not a development backend"):
+            server._parse_dev_agents([{"agent": "gpt", "model": "gpt-5.6-sol", "count": 1}])

--- a/packages/ai-parrot/tests/flows/dev_loop/test_flow_mcp_threading.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_flow_mcp_threading.py
@@ -1,0 +1,78 @@
+"""Threading tests for the dev-loop build surface's research/pool seams.
+
+Covers ``build_dev_loop_flow``'s new ``research_coordinator`` /
+``research_mcp_servers`` / ``research_mcp_tools`` kwargs and
+``build_dev_loop_feature_flow``'s ``development_pool_config`` passthrough.
+Mirrors ``dev_flow/test_plan_threading.py``'s materialized-node assertion
+style (``publish_flow_events=False`` — no Redis in tests).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from parrot.flows.dev_loop.definition import DEVELOPMENT, PLANNER, RESEARCH
+from parrot.flows.dev_loop.flow import build_dev_loop_flow
+from parrot.flows.dev_loop.models.base import DevAgentPoolConfig, DevAgentSpec
+from parrot.flows.dev_loop.runner import build_dev_loop_feature_flow
+
+_SERVERS = {"parrot-repo": {"command": "/x/parrot", "args": ["mcp-local", "repo"], "env": {}}}
+
+
+def _flow(**kwargs: Any):
+    return build_dev_loop_flow(
+        dispatcher=MagicMock(),
+        jira_toolkit=MagicMock(),
+        log_toolkits={},
+        redis_url="redis://x",
+        publish_flow_events=False,
+        lifecycle_events=False,
+        **kwargs,
+    )
+
+
+def _feature_flow(**kwargs: Any):
+    return build_dev_loop_feature_flow(
+        dispatcher=MagicMock(),
+        redis_url="redis://x",
+        publish_flow_events=False,
+        lifecycle_events=False,
+        **kwargs,
+    )
+
+
+class TestResearchSeamThreading:
+    def test_defaults_leave_research_node_unwired(self):
+        node = _flow()._nodes[RESEARCH]
+        assert node._mcp_servers is None
+        assert node._mcp_tools is None
+        # The factories' None-default coordinator is a fresh conf-driven one.
+        assert node._coordinator is not None
+
+    def test_mcp_servers_and_tools_reach_research_node(self):
+        tools = ["mcp__parrot-repo__read_file"]
+        node = _flow(research_mcp_servers=_SERVERS, research_mcp_tools=tools)._nodes[RESEARCH]
+        assert node._mcp_servers == _SERVERS
+        assert node._mcp_tools == tools
+
+    def test_explicit_coordinator_reaches_research_node(self):
+        sentinel = MagicMock()
+        node = _flow(research_coordinator=sentinel)._nodes[RESEARCH]
+        assert node._coordinator is sentinel
+
+
+class TestFeatureFlowPoolThreading:
+    def test_default_leaves_pool_unwired(self):
+        flow = _feature_flow()
+        assert flow._nodes[DEVELOPMENT]._pool_config is None
+        assert flow._nodes[PLANNER]._pool_config is None
+
+    def test_pool_config_reaches_development_and_planner(self):
+        cfg = DevAgentPoolConfig(
+            agents=[DevAgentSpec(agent="nova", model="zai.glm-5")],
+            isolation_mode="shared",
+        )
+        flow = _feature_flow(development_pool_config=cfg)
+        assert flow._nodes[DEVELOPMENT]._pool_config is cfg
+        assert flow._nodes[PLANNER]._pool_config is cfg

--- a/packages/ai-parrot/tests/flows/dev_loop/test_mcp_profiles.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_mcp_profiles.py
@@ -1,0 +1,75 @@
+"""Unit tests for the shared MCP dispatch-profile helpers.
+
+Covers ``parrot.flows.dev_loop.mcp_profiles`` — the module the research
+seats (``ResearchNode`` / ``IdeationNode``) share for wikitoolkit MCP
+wiring and allow-rule derivation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from parrot.flows.dev_loop.mcp_profiles import (
+    WIKI_MCP_TOOLS,
+    derive_mcp_tool_names,
+    resolve_wikitoolkit_command,
+    wikitoolkit_mcp_entry,
+)
+
+
+class TestWikiMcpTools:
+    def test_readonly_trio_frozen(self):
+        """GUARD: exactly the three read-only tools — never the write ones."""
+        assert WIKI_MCP_TOOLS == (
+            "mcp__wikitoolkit__wiki_query",
+            "mcp__wikitoolkit__wiki_page",
+            "mcp__wikitoolkit__wiki_related",
+        )
+
+    def test_ideation_aliases_are_the_same_objects(self):
+        """The pre-move private names on ideation.py stay identical."""
+        from parrot.flows.dev_flow.nodes import ideation
+
+        assert ideation._WIKI_MCP_TOOLS is WIKI_MCP_TOOLS
+        assert ideation._resolve_wikitoolkit_command is resolve_wikitoolkit_command
+
+
+class TestResolveWikitoolkitCommand:
+    def test_path_hit_wins(self, monkeypatch):
+        monkeypatch.setattr("shutil.which", lambda _name: "/opt/bin/wikitoolkit")
+        assert resolve_wikitoolkit_command() == "/opt/bin/wikitoolkit"
+
+    def test_sys_executable_sibling_fallback(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("shutil.which", lambda _name: None)
+        candidate = tmp_path / "wikitoolkit"
+        candidate.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setattr("sys.executable", str(tmp_path / "python"))
+        assert resolve_wikitoolkit_command() == str(candidate)
+
+    def test_bare_fallback(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("shutil.which", lambda _name: None)
+        monkeypatch.setattr("sys.executable", str(tmp_path / "python"))
+        assert resolve_wikitoolkit_command() == "wikitoolkit"
+
+
+class TestWikitoolkitMcpEntry:
+    def test_shape(self, monkeypatch):
+        monkeypatch.setattr("shutil.which", lambda _name: "/opt/bin/wikitoolkit")
+        assert wikitoolkit_mcp_entry() == {
+            "command": "/opt/bin/wikitoolkit",
+            "args": ["mcp"],
+            "env": {},
+        }
+
+
+class TestDeriveMcpToolNames:
+    def test_one_server_level_rule_per_server_sorted(self):
+        servers = {"parrot-repo": {}, "wikitoolkit": {}, "parrot-memory": {}}
+        assert derive_mcp_tool_names(servers) == [
+            "mcp__parrot-memory",
+            "mcp__parrot-repo",
+            "mcp__wikitoolkit",
+        ]
+
+    def test_empty_mapping(self):
+        assert derive_mcp_tool_names({}) == []

--- a/packages/ai-parrot/tests/flows/dev_loop/test_research_mcp.py
+++ b/packages/ai-parrot/tests/flows/dev_loop/test_research_mcp.py
@@ -1,0 +1,148 @@
+"""Unit tests for ResearchNode's explicit-MCP seam (FEAT-484/485 wiring).
+
+Mirrors ``test_research_partner_seam.py``'s fixture shape (mocked Jira
+toolkit + mocked dispatcher). The seam contract: with ``mcp_servers`` unset
+the ``sdd-research`` dispatch profile is byte-identical to pre-seam
+behavior; with servers set, the profile carries them plus the matching
+``mcp__...`` allow rules (derived server-level, or the caller's explicit
+``mcp_tools``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from parrot.flows.dev_loop import (
+    BugBrief,
+    FlowtaskCriterion,
+    ResearchOutput,
+    ShellCriterion,
+)
+from parrot.flows.dev_loop.nodes.research import ResearchNode
+
+_SERVERS = {
+    "wikitoolkit": {"command": "/x/wikitoolkit", "args": ["mcp"], "env": {}},
+    "parrot-repo": {"command": "/x/parrot", "args": ["mcp-local", "repo"], "env": {}},
+}
+
+_LEGACY_ALLOWED = ["Read", "Grep", "Glob", "Bash", "Write", "SlashCommand"]
+
+
+@pytest.fixture
+def good_brief() -> BugBrief:
+    return BugBrief(
+        summary="customer sync drops the last row",
+        affected_component="etl/customers/sync.yaml",
+        log_sources=[],
+        acceptance_criteria=[
+            FlowtaskCriterion(name="run", task_path="etl/customers/sync.yaml"),
+            ShellCriterion(name="lint", command="ruff check ."),
+        ],
+        escalation_assignee="557058:abc",
+        reporter="557058:def",
+    )
+
+
+@pytest.fixture
+def research_out_fixture(tmp_path) -> ResearchOutput:
+    return ResearchOutput(
+        jira_issue_key="OPS-1",
+        spec_path="sdd/specs/x.spec.md",
+        feat_id="FEAT-130",
+        branch_name="feat-130-fix-customer-sync",
+        worktree_path=str(tmp_path / "feat-130-fix-customer-sync"),
+        log_excerpts=[],
+    )
+
+
+def _make_jira() -> MagicMock:
+    jira = MagicMock()
+    jira.jira_create_issue = AsyncMock(return_value={"key": "OPS-1"})
+    jira.jira_add_comment = AsyncMock(return_value={"id": "c1"})
+    jira.jira_search_issues = AsyncMock(return_value={"status": "empty"})
+    jira.jira_get_issue = AsyncMock(return_value={"status": "error"})
+    jira.jira_find_user = AsyncMock(
+        return_value={
+            "found": True,
+            "matches": [{"accountId": "557058:resolved", "emailAddress": "reporter@example.com"}],
+        }
+    )
+    return jira
+
+
+def _make_node(research_out_fixture, monkeypatch, tmp_path, **node_kwargs):
+    monkeypatch.setattr(
+        "parrot.flows.dev_loop.nodes.research.conf.WORKTREE_BASE_PATH",
+        str(tmp_path),
+    )
+    dispatcher = MagicMock()
+    dispatcher.dispatch = AsyncMock(return_value=research_out_fixture)
+    node = ResearchNode(
+        dispatcher=dispatcher,
+        jira_toolkit=_make_jira(),
+        log_toolkits={},
+        **node_kwargs,
+    )
+    return node, dispatcher
+
+
+class TestResearchMcpSeam:
+    async def test_default_profile_byte_identical(self, good_brief, research_out_fixture, monkeypatch, tmp_path):
+        """GUARD: no mcp kwargs => the exact legacy profile."""
+        node, dispatcher = _make_node(research_out_fixture, monkeypatch, tmp_path)
+
+        await node.execute(ctx={"run_id": "r1", "bug_brief": good_brief})
+
+        profile = dispatcher.dispatch.call_args.kwargs["profile"]
+        assert profile.mcp_servers is None
+        assert profile.allowed_tools == _LEGACY_ALLOWED
+        assert profile.strict_mcp_config is True
+
+    async def test_servers_reach_profile_with_derived_rules(
+        self, good_brief, research_out_fixture, monkeypatch, tmp_path
+    ):
+        node, dispatcher = _make_node(research_out_fixture, monkeypatch, tmp_path, mcp_servers=dict(_SERVERS))
+
+        await node.execute(ctx={"run_id": "r1", "bug_brief": good_brief})
+
+        profile = dispatcher.dispatch.call_args.kwargs["profile"]
+        assert profile.mcp_servers == _SERVERS
+        assert profile.allowed_tools == [
+            *_LEGACY_ALLOWED,
+            "mcp__parrot-repo",
+            "mcp__wikitoolkit",
+        ]
+        # Isolation guard holds: explicit servers, not inherited .mcp.json.
+        assert profile.strict_mcp_config is True
+
+    async def test_explicit_mcp_tools_win_over_derivation(
+        self, good_brief, research_out_fixture, monkeypatch, tmp_path
+    ):
+        explicit = ["mcp__wikitoolkit__wiki_query", "mcp__parrot-repo__read_file"]
+        node, dispatcher = _make_node(
+            research_out_fixture,
+            monkeypatch,
+            tmp_path,
+            mcp_servers=dict(_SERVERS),
+            mcp_tools=explicit,
+        )
+
+        await node.execute(ctx={"run_id": "r1", "bug_brief": good_brief})
+
+        profile = dispatcher.dispatch.call_args.kwargs["profile"]
+        assert profile.allowed_tools == [*_LEGACY_ALLOWED, *explicit]
+
+    async def test_mcp_tools_ignored_without_servers(self, good_brief, research_out_fixture, monkeypatch, tmp_path):
+        node, dispatcher = _make_node(
+            research_out_fixture,
+            monkeypatch,
+            tmp_path,
+            mcp_tools=["mcp__ghost"],
+        )
+
+        await node.execute(ctx={"run_id": "r1", "bug_brief": good_brief})
+
+        profile = dispatcher.dispatch.call_args.kwargs["profile"]
+        assert profile.mcp_servers is None
+        assert profile.allowed_tools == _LEGACY_ALLOWED

--- a/tests/mcp/test_toolkit_config.py
+++ b/tests/mcp/test_toolkit_config.py
@@ -145,3 +145,26 @@ def test_mcp_config_defaults(tmp_path):
     """MCPToolkitsConfig defaults to empty toolkits dict."""
     cfg = MCPToolkitsConfig()
     assert cfg.toolkits == {}
+
+
+def test_explicit_config_path_override(tmp_path):
+    """FEAT-485 fix: an explicit config_path is read INSTEAD of
+    <root>/.parrot/mcp-toolkits.yaml (previously a documented no-op)."""
+    elsewhere = tmp_path / "custom-toolkits.yaml"
+    elsewhere.write_text("toolkits:\n" "  custom:\n" "    class: test.CustomToolkit\n")
+    # A decoy default-path file proves the override actually wins.
+    parrot_dir = tmp_path / ".parrot"
+    parrot_dir.mkdir()
+    (parrot_dir / "mcp-toolkits.yaml").write_text("toolkits:\n" "  decoy:\n" "    class: test.Decoy\n")
+
+    cfg = load_toolkits_config(tmp_path, config_path=elsewhere)
+
+    assert "custom" in cfg.toolkits
+    assert "decoy" not in cfg.toolkits
+
+
+def test_explicit_config_path_missing_raises(tmp_path):
+    """An explicitly named file that is absent is operator error — unlike
+    the default path, whose absence silently falls back to built-ins."""
+    with pytest.raises(ValueError, match="not found"):
+        load_toolkits_config(tmp_path, config_path=tmp_path / "nope.yaml")

--- a/tests/mcp/test_toolkit_server.py
+++ b/tests/mcp/test_toolkit_server.py
@@ -219,3 +219,20 @@ def test_toolkit_instantiation_error(stub_config, monkeypatch):
 
     with pytest.raises(ValueError, match="Failed to instantiate toolkit"):
         create_toolkit_mcp_server("stub", stub_config)
+
+
+def test_config_path_override_honored(tmp_path, monkeypatch):
+    """FEAT-485 fix: the documented `config_path` override (the
+    `parrot mcp-local --config` flag) must actually be used — it was a
+    silent no-op before."""
+    monkeypatch.setattr("parrot.mcp.toolkit_server.importlib.import_module", mock_import_module)
+    elsewhere = tmp_path / "custom-toolkits.yaml"
+    elsewhere.write_text(
+        "toolkits:\n" "  stub:\n" "    class: tests.mcp.stub_toolkit.StubToolkit\n" "    kwargs: {}\n"
+    )
+
+    # No .parrot/ under tmp_path at all — only the override can resolve "stub".
+    server = create_toolkit_mcp_server("stub", tmp_path, config_path=str(elsewhere))
+
+    assert server.config.name == "parrot-stub"
+    assert "plain" in server.tools


### PR DESCRIPTION
Examples (server.py / server_dev.py):
- Research seats get explicit MCP access (wikitoolkit graph search + every .parrot/mcp-toolkits.yaml section served via `parrot mcp-local`, e.g. a `repo` section exposing FEAT-484's ReadOnlyRepoToolkit). New sibling module mcp_wiring.py + mcp-toolkits.example.yaml; controlled by DEV_LOOP_RESEARCH_MCP_ENABLED / DEV_LOOP_RESEARCH_MCP_TOOLKITS.
- Ops console honours DEV_FLOW_RESEARCH_PARTNER_ENABLED/_BACKEND/_MODEL to select the collaborative-research partner's secondary LLM for ResearchNode, and forwards the env dev-agent pool to the feature topology (PlannerNode's suggested_pool now reflects real backends).
- Dev console: DEV_FLOW_USE_REVIEW_PAIR=true activates the model plan's review pair instead of the judge panel; partner_backends derived from the catalog role list; backend error strings derived from supported_dev_pool_backends().
- mantle-adversarial reviewer now reachable via DEV_LOOP_ADVERSARIAL_BACKEND=mantle (was silently falling back to codex); nova added to the max-concurrent env map; _parse_dev_agents rejects research-partner-only backends (e.g. "gpt") with a clean 400.

Library seams (None-default, byte-identical when unset):
- New shared parrot/flows/dev_loop/mcp_profiles.py (WIKI_MCP_TOOLS, resolve_wikitoolkit_command, wikitoolkit_mcp_entry, derive_mcp_tool_names); ideation.py keeps compat aliases.
- ResearchNode(mcp_servers=, mcp_tools=) and IdeationNode( extra_mcp_servers=, extra_mcp_tools=) with threading through build_dev_loop_node_factories/build_dev_loop_flow and build_dev_flow_node_factories/build_dev_flow; build_dev_loop_flow also exposes research_coordinator.
- build_dev_loop_feature_flow gains development_pool_config passthrough.
- FEAT-485 fix: the documented `parrot mcp-local --config` override was a silent no-op — load_toolkits_config/create_toolkit_mcp_server now honour config_path (needed because stdio MCP servers inherit the dispatch cwd, not the repo root).

Docs: README.md / GUIA.md research-seat MCP sections + new env keys.


Claude-Session: https://claude.ai/code/session_01LXAinFCFPYU3k5JsiNVtbK