### PR TITLE
feat(dev-flow-partner-env-key-dedup): FEAT-487 — collapse the duplicate research-partner env keys

### DIFF
--- a/docs/dev_loop/dev-flow-model-plan.md
+++ b/docs/dev_loop/dev-flow-model-plan.md
@@ -46,9 +46,9 @@ config, while an unset one falls through.
 | Key | Seat | Default |
 |---|---|---|
 | `DEV_FLOW_IDEATION_MODEL` | research primary | `claude-opus-5` |
-| `DEV_FLOW_RESEARCH_PARTNER_ENABLED` | partner on/off | `false` |
-| `DEV_FLOW_RESEARCH_PARTNER_BACKEND` | partner selector (`gpt` \| `nova`) | `gpt` |
-| `DEV_FLOW_RESEARCH_PARTNER_MODEL` | partner model | `gpt-5.6-sol` |
+| `DEV_FLOW_RESEARCH_PARTNER` | partner on/off **and** backend in one key — `""` = disabled, else `gpt` \| `nova` | `""` (disabled) |
+| `DEV_FLOW_RESEARCH_PARTNER_GPT_MODEL` | partner model for the `gpt` backend | `gpt-5.6-sol` |
+| `DEV_FLOW_RESEARCH_PARTNER_NOVA_MODEL` | partner model for the `nova` backend | `us.amazon.nova-2-lite-v1:0` |
 | `DEV_FLOW_DEV_POOL` | dev pool (JSON array of `{agent, model, count}`) | *(unset)* |
 | `DEV_FLOW_REVIEW_PRIMARY_BACKEND` | review primary backend | `claude-code` |
 | `DEV_FLOW_REVIEW_PRIMARY_MODEL` | review primary model | `claude-opus-5` |
@@ -57,6 +57,22 @@ config, while an unset one falls through.
 
 `DEV_FLOW_IDEATION_MODEL` is deliberately **shared** with FEAT-482 rather
 than duplicated.
+
+The research-partner keys are **FEAT-482's, not this feature's** (FEAT-487).
+FEAT-486 briefly shipped its own `DEV_FLOW_RESEARCH_PARTNER_ENABLED` /
+`_BACKEND` / `_MODEL`; those are **retired and inert** — setting them does
+nothing. Two properties of FEAT-482's shape are worth knowing:
+
+* **One key carries both enable and backend.** `DEV_FLOW_RESEARCH_PARTNER=""`
+  (the default) disables the seat; any other value is the backend. The two
+  cannot disagree because there is only one of them.
+* **The model key is per backend.** The plan resolves the backend first and
+  then that backend's model key, so a `nova` partner gets a Nova model
+  rather than inheriting a `gpt-*` default.
+
+`DevFlowModelPlan.research_partner` keeps its `enabled` / `backend` / `model`
+*fields* — a plan names exactly one backend, so one `model` field is enough.
+An explicit plan value still beats config.
 
 > **Env keys only apply when a plan is supplied.** An omitted `model_plan`
 > ignores `DEV_FLOW_DEV_POOL` entirely, so a stray env var can never turn

--- a/examples/dev_loop/GUIA.md
+++ b/examples/dev_loop/GUIA.md
@@ -476,7 +476,8 @@ Referencia completa: `docs/dev_loop/dev-flow-model-plan.md`.
 | `DEV_FLOW_GATE_TTL_QUESTIONS` | `86400` (24 h) | TTL del gate `open_questions`; al expirar el run **falla** |
 | `DEV_FLOW_IDEATION_MODEL` | `claude-opus-5` | Modelo del asiento de research primario (compartida con FEAT-482) |
 | `DEV_FLOW_DEV_POOL` | *(sin valor)* | Pool como array JSON de `{agent, model, count}`. Solo se lee si hay `model_plan` |
-| `DEV_FLOW_RESEARCH_PARTNER_ENABLED` / `_BACKEND` / `_MODEL` | `false` / `gpt` / `gpt-5.6-sol` | Passthrough del research partner (FEAT-482) |
+| `DEV_FLOW_RESEARCH_PARTNER` | `""` (apagado) | Research partner (FEAT-482): `""` apaga el asiento, cualquier otro valor es el backend (`gpt` o `nova`). Activación **y** backend en una sola variable |
+| `DEV_FLOW_RESEARCH_PARTNER_GPT_MODEL` / `_NOVA_MODEL` | `gpt-5.6-sol` / `us.amazon.nova-2-lite-v1:0` | Modelo del partner, **por backend**. Las variables `_ENABLED`/`_BACKEND`/`_MODEL` de FEAT-486 quedaron retiradas por FEAT-487 y ya no hacen nada |
 | `DEV_FLOW_REVIEW_PRIMARY_BACKEND` / `_MODEL` | `claude-code` / `claude-opus-5` | Revisor primario (con permisos de escritura) |
 | `DEV_FLOW_REVIEW_COUNTER_MODEL` | `gpt-5.6-sol` | Contra-revisor de solo lectura, sobre Bedrock Mantle |
 | `DEV_LOOP_MANTLE_REVIEW_MODEL` | `gpt-5.6-sol` | Modelo propio del contra-revisor Mantle. Distinta de `DEV_LOOP_ADVERSARIAL_MODEL` (la del asiento codex) |

--- a/examples/dev_loop/README.md
+++ b/examples/dev_loop/README.md
@@ -600,7 +600,8 @@ See `docs/dev_loop/dev-flow-model-plan.md` for the full reference.
 | `DEV_FLOW_GATE_TTL_QUESTIONS` | `86400` (24 h) | TTL for an `open_questions` gate. **Fail-closed** — expiry routes the run to `failure_handler`. |
 | `DEV_FLOW_IDEATION_MODEL` | `claude-opus-5` | Research-primary seat model (FEAT-486; shared with FEAT-482). |
 | `DEV_FLOW_DEV_POOL` | *(unset)* | Dev pool as a JSON array of `{agent, model, count}`. Only read when a `model_plan` is supplied. |
-| `DEV_FLOW_RESEARCH_PARTNER_ENABLED` / `_BACKEND` / `_MODEL` | `false` / `gpt` / `gpt-5.6-sol` | Complementary research partner passthrough (FEAT-482). |
+| `DEV_FLOW_RESEARCH_PARTNER` | `""` (disabled) | Complementary research partner (FEAT-482): `""` disables the seat, otherwise the backend — `gpt` or `nova`. Enable **and** backend in one key. |
+| `DEV_FLOW_RESEARCH_PARTNER_GPT_MODEL` / `_NOVA_MODEL` | `gpt-5.6-sol` / `us.amazon.nova-2-lite-v1:0` | Partner model, **per backend**. FEAT-486's `_ENABLED`/`_BACKEND`/`_MODEL` keys were retired by FEAT-487 and are inert. |
 | `DEV_FLOW_REVIEW_PRIMARY_BACKEND` / `_MODEL` | `claude-code` / `claude-opus-5` | Write-enabled primary reviewer. |
 | `DEV_FLOW_REVIEW_COUNTER_MODEL` | `gpt-5.6-sol` | Read-only counter-reviewer, over Bedrock Mantle. |
 | `DEV_LOOP_MANTLE_REVIEW_MODEL` | `gpt-5.6-sol` | The Mantle counter-reviewer's own model key. Distinct from `DEV_LOOP_ADVERSARIAL_MODEL` (the codex seat's). |

--- a/packages/ai-parrot/src/parrot/flows/dev_flow/model_plan.py
+++ b/packages/ai-parrot/src/parrot/flows/dev_flow/model_plan.py
@@ -38,6 +38,7 @@ from typing import Any, get_args
 from pydantic import BaseModel, Field, field_validator
 
 from parrot import conf
+from parrot.flows.dev_loop.catalog import resolve_research_partner_backend
 from parrot.flows.dev_loop.models.base import (
     DevAgentBackend,
     DevAgentPoolConfig,
@@ -64,7 +65,11 @@ DEFAULT_RESEARCH_PRIMARY: str = "claude-opus-5"
 #: Bedrock Nova). Validated by FEAT-482's own
 #: ``resolve_research_partner_backend()``, never here.
 DEFAULT_PARTNER_BACKEND: str = "gpt"
+#: Default model for the ``"gpt"`` backend. FEAT-487: the model default is
+#: now chosen AFTER the backend is known, so a ``"nova"`` partner no longer
+#: inherits a ``gpt-*`` default (the latent mismatch FEAT-486 shipped).
 DEFAULT_PARTNER_MODEL: str = "gpt-5.6-sol"
+DEFAULT_PARTNER_NOVA_MODEL: str = "us.amazon.nova-2-lite-v1:0"
 
 #: Adversarial review pair (spec G5): Claude Opus 5 primary + Bedrock
 #: Mantle ``gpt-5.6-sol`` read-only counter-reviewer.
@@ -78,9 +83,17 @@ DEFAULT_REVIEW_COUNTER_MODEL: str = "gpt-5.6-sol"
 
 #: Shared with FEAT-482 — the ideation primary seat's model.
 ENV_RESEARCH_PRIMARY: str = "DEV_FLOW_IDEATION_MODEL"
-ENV_PARTNER_ENABLED: str = "DEV_FLOW_RESEARCH_PARTNER_ENABLED"
-ENV_PARTNER_BACKEND: str = "DEV_FLOW_RESEARCH_PARTNER_BACKEND"
-ENV_PARTNER_MODEL: str = "DEV_FLOW_RESEARCH_PARTNER_MODEL"
+#: FEAT-487: the research-partner seat has NO enable/backend key of its
+#: own. FEAT-486 originally invented ``DEV_FLOW_RESEARCH_PARTNER_ENABLED``
+#: / ``_BACKEND`` / ``_MODEL`` here, written against a predicted FEAT-482
+#: API before that feature merged. FEAT-482 shipped a different, better
+#: shape — ``DEV_FLOW_RESEARCH_PARTNER`` ("" = disabled, else the backend
+#: id) plus a PER-BACKEND model key — so the duplicates were retired and
+#: this resolver now reads FEAT-482's keys through
+#: ``catalog.resolve_research_partner_backend()``: one key set, one parse,
+#: one place where the Anthropic family guard lives.
+ENV_PARTNER_GPT_MODEL: str = "DEV_FLOW_RESEARCH_PARTNER_GPT_MODEL"
+ENV_PARTNER_NOVA_MODEL: str = "DEV_FLOW_RESEARCH_PARTNER_NOVA_MODEL"
 #: JSON list of ``{"agent": ..., "model": ..., "count": ...}`` rows.
 ENV_DEV_POOL: str = "DEV_FLOW_DEV_POOL"
 ENV_REVIEW_PRIMARY_BACKEND: str = "DEV_FLOW_REVIEW_PRIMARY_BACKEND"
@@ -254,6 +267,32 @@ def _as_bool(value: Any, fallback: bool) -> bool:
     return fallback
 
 
+def _partner_model_default(backend: str, getter: ConfigGetter) -> str:
+    """Return the configured default model for the partner ``backend``.
+
+    FEAT-487: mirrors FEAT-482's per-backend mapping
+    (``research_partner.resolve_backend_model``) but reads through the
+    injected ``getter``, with the built-in as fallback — the shape every
+    other default in this module uses, and what keeps tests hermetic.
+    Deliberately NOT an import of ``resolve_backend_model``: that reads
+    ``conf.*`` module attributes directly and would ignore ``getter``.
+
+    Args:
+        backend: ``"gpt"`` or ``"nova"``. Anything else falls back to the
+            gpt key — an invalid backend has already raised by this point,
+            inside ``resolve_research_partner_backend``.
+        getter: ``(key, fallback=...) -> Any`` config accessor.
+
+    Returns:
+        The model id for that backend.
+    """
+    if backend == "nova":
+        key, fallback = ENV_PARTNER_NOVA_MODEL, DEFAULT_PARTNER_NOVA_MODEL
+    else:
+        key, fallback = ENV_PARTNER_GPT_MODEL, DEFAULT_PARTNER_MODEL
+    return str(getter(key, fallback=fallback) or "").strip() or fallback
+
+
 def _pool_from_env(raw: Any) -> list[dict[str, Any]] | None:
     """Parse the ``DEV_FLOW_DEV_POOL`` JSON list into raw spec rows.
 
@@ -335,22 +374,27 @@ def resolve_model_plan(
     partner_explicit = base.research_partner.model_fields_set if "research_partner" in explicit else frozenset()
     partner = base.research_partner
     partner_kwargs: dict[str, Any] = {}
+    # FEAT-487: `enabled` and `backend` come from ONE key,
+    # `DEV_FLOW_RESEARCH_PARTNER` ("" = disabled, else the backend id),
+    # resolved through FEAT-482's own `resolve_research_partner_backend()`.
+    # Delegating rather than re-parsing keeps the enable/backend semantics
+    # AND the Anthropic family guard in a single place — with two separate
+    # key sets the two could disagree.
+    configured_backend = resolve_research_partner_backend(getter)
     if "enabled" in partner_explicit:
         partner_kwargs["enabled"] = partner.enabled
     else:
-        partner_kwargs["enabled"] = _as_bool(getter(ENV_PARTNER_ENABLED, fallback=None), False)
+        partner_kwargs["enabled"] = bool(configured_backend)
     if "backend" in partner_explicit:
         partner_kwargs["backend"] = partner.backend
     else:
-        partner_kwargs["backend"] = (
-            str(getter(ENV_PARTNER_BACKEND, fallback=DEFAULT_PARTNER_BACKEND) or "").strip() or DEFAULT_PARTNER_BACKEND
-        )
+        partner_kwargs["backend"] = configured_backend or DEFAULT_PARTNER_BACKEND
     if "model" in partner_explicit:
         partner_kwargs["model"] = partner.model
     else:
-        partner_kwargs["model"] = (
-            str(getter(ENV_PARTNER_MODEL, fallback=DEFAULT_PARTNER_MODEL) or "").strip() or DEFAULT_PARTNER_MODEL
-        )
+        # Resolved AFTER the backend, from that backend's own key — the
+        # whole point of the FEAT-487 dedup.
+        partner_kwargs["model"] = _partner_model_default(partner_kwargs["backend"], getter)
 
     # ── development pool ────────────────────────────────────────────
     dev_pool: list[Any] = list(base.dev_pool)

--- a/packages/ai-parrot/tests/flows/dev_flow/test_model_plan.py
+++ b/packages/ai-parrot/tests/flows/dev_flow/test_model_plan.py
@@ -14,9 +14,8 @@ import pytest
 from parrot.flows.dev_flow.model_plan import (
     DEFAULT_RESEARCH_PRIMARY,
     ENV_DEV_POOL,
-    ENV_PARTNER_BACKEND,
-    ENV_PARTNER_ENABLED,
-    ENV_PARTNER_MODEL,
+    ENV_PARTNER_GPT_MODEL,
+    ENV_PARTNER_NOVA_MODEL,
     ENV_RESEARCH_PRIMARY,
     ENV_REVIEW_COUNTER_MODEL,
     ENV_REVIEW_PRIMARY_MODEL,
@@ -27,6 +26,10 @@ from parrot.flows.dev_flow.model_plan import (
     supported_dev_pool_backends,
 )
 from parrot.flows.dev_loop.models.base import DevAgentPoolConfig, DevAgentSpec
+
+#: FEAT-482's authoritative key. Not re-exported by model_plan (which no
+#: longer owns any partner enable/backend key), so named here.
+ENV_RESEARCH_PARTNER = "DEV_FLOW_RESEARCH_PARTNER"
 
 
 def _getter(values: dict[str, Any]):
@@ -157,25 +160,29 @@ class TestResolveModelPlan:
         assert resolved.research_primary == "claude-opus-5"
 
     def test_explicit_nested_field_beats_env_sibling_still_resolves(self):
-        """Setting one partner field must not freeze the others."""
+        """Setting one partner field must not freeze the others.
+
+        FEAT-487: the sibling now resolves from FEAT-482's per-backend
+        model key rather than a partner-specific ``_MODEL`` key.
+        """
         resolved = resolve_model_plan(
             DevFlowModelPlan(research_partner=ResearchPartnerPlan(enabled=True)),
-            config_getter=_getter({ENV_PARTNER_ENABLED: "false", ENV_PARTNER_MODEL: "nova-2-lite"}),
+            config_getter=_getter(
+                {ENV_RESEARCH_PARTNER: "", ENV_PARTNER_GPT_MODEL: "openai.gpt-oss-120b"}
+            ),
         )
+        # `enabled` was explicit, so the (disabled) config must not win...
         assert resolved.research_partner.enabled is True
-        assert resolved.research_partner.model == "nova-2-lite"
-
-    @pytest.mark.parametrize(
-        "raw,expected",
-        [("1", True), ("true", True), ("yes", True), ("0", False), ("false", False), ("", False)],
-    )
-    def test_partner_enabled_env_coercion(self, raw: str, expected: bool):
-        resolved = resolve_model_plan(None, config_getter=_getter({ENV_PARTNER_ENABLED: raw}))
-        assert resolved.research_partner.enabled is expected
+        # ...while `model` still resolves from config.
+        assert resolved.research_partner.model == "openai.gpt-oss-120b"
 
     def test_partner_backend_from_env(self):
-        resolved = resolve_model_plan(None, config_getter=_getter({ENV_PARTNER_BACKEND: "nova"}))
+        """FEAT-487: one key carries enable AND backend."""
+        resolved = resolve_model_plan(
+            None, config_getter=_getter({ENV_RESEARCH_PARTNER: "nova"})
+        )
         assert resolved.research_partner.backend == "nova"
+        assert resolved.research_partner.enabled is True
 
     def test_dev_pool_from_env_json(self):
         resolved = resolve_model_plan(
@@ -249,3 +256,110 @@ class TestExports:
 
         assert pkg.DevFlowModelPlan is DevFlowModelPlan
         assert "DevFlowModelPlan" in pkg.__all__
+
+
+class TestPartnerKeyDedup:
+    """FEAT-487 — one key set for the research-partner seat.
+
+    FEAT-486 shipped `DEV_FLOW_RESEARCH_PARTNER_ENABLED`/`_BACKEND`/`_MODEL`
+    alongside FEAT-482's `DEV_FLOW_RESEARCH_PARTNER` + per-backend model
+    keys. These pin the retired keys dead and the survivors live.
+    """
+
+    def test_partner_enabled_from_feat482_key(self):
+        resolved = resolve_model_plan(
+            None, config_getter=_getter({ENV_RESEARCH_PARTNER: "gpt"})
+        )
+        assert resolved.research_partner.enabled is True
+        assert resolved.research_partner.backend == "gpt"
+
+    def test_partner_disabled_when_key_unset(self):
+        """The pure-addition guarantee: unset ⇒ the seat does not run."""
+        resolved = resolve_model_plan(None, config_getter=_getter({}))
+        assert resolved.research_partner.enabled is False
+
+    def test_partner_disabled_when_key_blank(self):
+        resolved = resolve_model_plan(
+            None, config_getter=_getter({ENV_RESEARCH_PARTNER: ""})
+        )
+        assert resolved.research_partner.enabled is False
+
+    def test_partner_model_follows_backend_nova(self):
+        """THE bug FEAT-487 fixes: a nova partner must not default to gpt-*."""
+        resolved = resolve_model_plan(
+            None, config_getter=_getter({ENV_RESEARCH_PARTNER: "nova"})
+        )
+        assert resolved.research_partner.model == "us.amazon.nova-2-lite-v1:0"
+        assert not resolved.research_partner.model.startswith("gpt-")
+
+    def test_partner_model_follows_backend_gpt(self):
+        resolved = resolve_model_plan(
+            None, config_getter=_getter({ENV_RESEARCH_PARTNER: "gpt"})
+        )
+        assert resolved.research_partner.model == "gpt-5.6-sol"
+
+    def test_per_backend_model_keys_are_honoured(self):
+        for backend, key, value in (
+            ("gpt", ENV_PARTNER_GPT_MODEL, "openai.gpt-oss-120b"),
+            ("nova", ENV_PARTNER_NOVA_MODEL, "us.amazon.nova-pro-v1:0"),
+        ):
+            resolved = resolve_model_plan(
+                None,
+                config_getter=_getter({ENV_RESEARCH_PARTNER: backend, key: value}),
+            )
+            assert resolved.research_partner.model == value
+
+    def test_explicit_plan_still_beats_config(self):
+        resolved = resolve_model_plan(
+            DevFlowModelPlan(
+                research_partner=ResearchPartnerPlan(
+                    enabled=True, backend="nova", model="pinned-model"
+                )
+            ),
+            config_getter=_getter({ENV_RESEARCH_PARTNER: "gpt"}),
+        )
+        assert resolved.research_partner.backend == "nova"
+        assert resolved.research_partner.model == "pinned-model"
+
+    def test_retired_keys_are_ignored(self):
+        """The FEAT-486 keys must be inert — they no longer enable the seat."""
+        resolved = resolve_model_plan(
+            None,
+            config_getter=_getter(
+                {
+                    "DEV_FLOW_RESEARCH_PARTNER_ENABLED": "1",
+                    "DEV_FLOW_RESEARCH_PARTNER_BACKEND": "nova",
+                    "DEV_FLOW_RESEARCH_PARTNER_MODEL": "ignored-model",
+                }
+            ),
+        )
+        assert resolved.research_partner.enabled is False
+        assert resolved.research_partner.backend == "gpt"
+        assert resolved.research_partner.model == "gpt-5.6-sol"
+
+    def test_retired_constants_are_gone(self):
+        """Guard against a well-meaning re-introduction."""
+        from parrot.flows.dev_flow import model_plan
+
+        for name in ("ENV_PARTNER_ENABLED", "ENV_PARTNER_BACKEND", "ENV_PARTNER_MODEL"):
+            assert not hasattr(model_plan, name), f"{name} was re-added"
+
+    def test_invalid_backend_surfaces_feat482_error(self):
+        """Delegation means FEAT-482's own error text, not a second dialect."""
+        with pytest.raises(ValueError, match="gpt, nova"):
+            resolve_model_plan(
+                None, config_getter=_getter({ENV_RESEARCH_PARTNER: "bogus"})
+            )
+
+    def test_anthropic_partner_model_rejected(self):
+        """The family guard now reaches the plan resolver via delegation."""
+        with pytest.raises(ValueError, match="research-partner seat"):
+            resolve_model_plan(
+                None,
+                config_getter=_getter(
+                    {
+                        ENV_RESEARCH_PARTNER: "nova",
+                        ENV_PARTNER_NOVA_MODEL: "us.anthropic.claude-opus-5",
+                    }
+                ),
+            )

--- a/packages/ai-parrot/tests/flows/dev_flow/test_model_plan.py
+++ b/packages/ai-parrot/tests/flows/dev_flow/test_model_plan.py
@@ -167,9 +167,7 @@ class TestResolveModelPlan:
         """
         resolved = resolve_model_plan(
             DevFlowModelPlan(research_partner=ResearchPartnerPlan(enabled=True)),
-            config_getter=_getter(
-                {ENV_RESEARCH_PARTNER: "", ENV_PARTNER_GPT_MODEL: "openai.gpt-oss-120b"}
-            ),
+            config_getter=_getter({ENV_RESEARCH_PARTNER: "", ENV_PARTNER_GPT_MODEL: "openai.gpt-oss-120b"}),
         )
         # `enabled` was explicit, so the (disabled) config must not win...
         assert resolved.research_partner.enabled is True
@@ -178,9 +176,7 @@ class TestResolveModelPlan:
 
     def test_partner_backend_from_env(self):
         """FEAT-487: one key carries enable AND backend."""
-        resolved = resolve_model_plan(
-            None, config_getter=_getter({ENV_RESEARCH_PARTNER: "nova"})
-        )
+        resolved = resolve_model_plan(None, config_getter=_getter({ENV_RESEARCH_PARTNER: "nova"}))
         assert resolved.research_partner.backend == "nova"
         assert resolved.research_partner.enabled is True
 
@@ -267,9 +263,7 @@ class TestPartnerKeyDedup:
     """
 
     def test_partner_enabled_from_feat482_key(self):
-        resolved = resolve_model_plan(
-            None, config_getter=_getter({ENV_RESEARCH_PARTNER: "gpt"})
-        )
+        resolved = resolve_model_plan(None, config_getter=_getter({ENV_RESEARCH_PARTNER: "gpt"}))
         assert resolved.research_partner.enabled is True
         assert resolved.research_partner.backend == "gpt"
 
@@ -279,23 +273,17 @@ class TestPartnerKeyDedup:
         assert resolved.research_partner.enabled is False
 
     def test_partner_disabled_when_key_blank(self):
-        resolved = resolve_model_plan(
-            None, config_getter=_getter({ENV_RESEARCH_PARTNER: ""})
-        )
+        resolved = resolve_model_plan(None, config_getter=_getter({ENV_RESEARCH_PARTNER: ""}))
         assert resolved.research_partner.enabled is False
 
     def test_partner_model_follows_backend_nova(self):
         """THE bug FEAT-487 fixes: a nova partner must not default to gpt-*."""
-        resolved = resolve_model_plan(
-            None, config_getter=_getter({ENV_RESEARCH_PARTNER: "nova"})
-        )
+        resolved = resolve_model_plan(None, config_getter=_getter({ENV_RESEARCH_PARTNER: "nova"}))
         assert resolved.research_partner.model == "us.amazon.nova-2-lite-v1:0"
         assert not resolved.research_partner.model.startswith("gpt-")
 
     def test_partner_model_follows_backend_gpt(self):
-        resolved = resolve_model_plan(
-            None, config_getter=_getter({ENV_RESEARCH_PARTNER: "gpt"})
-        )
+        resolved = resolve_model_plan(None, config_getter=_getter({ENV_RESEARCH_PARTNER: "gpt"}))
         assert resolved.research_partner.model == "gpt-5.6-sol"
 
     def test_per_backend_model_keys_are_honoured(self):
@@ -311,11 +299,7 @@ class TestPartnerKeyDedup:
 
     def test_explicit_plan_still_beats_config(self):
         resolved = resolve_model_plan(
-            DevFlowModelPlan(
-                research_partner=ResearchPartnerPlan(
-                    enabled=True, backend="nova", model="pinned-model"
-                )
-            ),
+            DevFlowModelPlan(research_partner=ResearchPartnerPlan(enabled=True, backend="nova", model="pinned-model")),
             config_getter=_getter({ENV_RESEARCH_PARTNER: "gpt"}),
         )
         assert resolved.research_partner.backend == "nova"
@@ -347,9 +331,7 @@ class TestPartnerKeyDedup:
     def test_invalid_backend_surfaces_feat482_error(self):
         """Delegation means FEAT-482's own error text, not a second dialect."""
         with pytest.raises(ValueError, match="gpt, nova"):
-            resolve_model_plan(
-                None, config_getter=_getter({ENV_RESEARCH_PARTNER: "bogus"})
-            )
+            resolve_model_plan(None, config_getter=_getter({ENV_RESEARCH_PARTNER: "bogus"}))
 
     def test_anthropic_partner_model_rejected(self):
         """The family guard now reaches the plan resolver via delegation."""

--- a/sdd/specs/dev-flow-partner-env-key-dedup.spec.md
+++ b/sdd/specs/dev-flow-partner-env-key-dedup.spec.md
@@ -1,0 +1,230 @@
+---
+# SDD flow type and base branch (FEAT-145).
+type: feature
+base_branch: dev
+---
+
+# Feature Specification: Collapse the duplicate research-partner env keys
+
+**Feature ID**: FEAT-487
+**Date**: 2026-09-01
+**Author**: Jesus Lara
+**Status**: approved
+**Target version**: 0.29.0
+**Origin**: FEAT-486 TASK-2657 Completion Note ("Open follow-up")
+
+---
+
+## 1. Motivation & Business Requirements
+
+### Problem Statement
+
+The dev-flow research-partner seat is now configurable through **two
+competing sets of environment keys**, because FEAT-482 and FEAT-486 were
+developed in parallel and each invented its own:
+
+| Owner | Keys | Semantics |
+|---|---|---|
+| **FEAT-482** (shipped, authoritative) | `DEV_FLOW_RESEARCH_PARTNER` | `""` = disabled, `"gpt"`, `"nova"` — enable flag AND backend in one key |
+| | `DEV_FLOW_RESEARCH_PARTNER_GPT_MODEL` | model, per backend (`gpt-5.6-sol`) |
+| | `DEV_FLOW_RESEARCH_PARTNER_NOVA_MODEL` | model, per backend (`us.amazon.nova-2-lite-v1:0`) |
+| **FEAT-486** (invented, redundant) | `DEV_FLOW_RESEARCH_PARTNER_ENABLED` | separate boolean (`model_plan.py:81`) |
+| | `DEV_FLOW_RESEARCH_PARTNER_BACKEND` | separate backend (`model_plan.py:82`) |
+| | `DEV_FLOW_RESEARCH_PARTNER_MODEL` | single model, backend-agnostic (`model_plan.py:83`) |
+
+FEAT-486's keys were written before FEAT-482 merged, against a *predicted*
+API (see FEAT-486 TASK-2657's contract-corrections table). They are read
+only by `resolve_model_plan()` (`model_plan.py:341,346,352`), and FEAT-482's
+are read by `resolve_research_partner_backend()`
+(`dev_loop/catalog.py:157`) and `resolve_backend_model()`
+(`dev_flow/research_partner.py:171`).
+
+Concrete harm:
+
+- **Two ways to say the same thing, with different shapes.** An operator
+  who sets `DEV_FLOW_RESEARCH_PARTNER=nova` (FEAT-482's documented key)
+  does NOT enable the seat through a `DevFlowModelPlan`, because the plan
+  reads `_ENABLED`/`_BACKEND` instead — and vice versa.
+- **A backend-agnostic model key cannot express FEAT-482's model space.**
+  FEAT-486's single `_MODEL` has no per-backend dimension, so it silently
+  cannot represent "gpt→X, nova→Y".
+- **The docs are now wrong in three places** — `docs/dev_loop/dev-flow-model-plan.md`,
+  `examples/dev_loop/README.md`, `examples/dev_loop/GUIA.md` all publish
+  FEAT-486's key names as the way to configure this seat.
+
+### Goals
+
+- **G1** — One key set for the research-partner seat: FEAT-482's, since it
+  shipped first, is referenced by its own spec/docs, and carries the
+  per-backend model dimension.
+- **G2** — `DevFlowModelPlan.research_partner` keeps its current *field*
+  shape (`enabled`/`backend`/`model`) — it is a plan object, not an env
+  mirror, and `factories._resolve_research_coordinator()` plus the console
+  payload already depend on those field names. Only where the resolver
+  reads its **defaults from config** changes.
+- **G3** — Explicit-argument precedence is unchanged: an explicit plan
+  value still beats config, which still beats the built-in default.
+- **G4** — Docs corrected wherever the retired keys appear.
+- **G5** — No behaviour change for a deployment that configures nothing.
+
+### Non-Goals
+
+- Changing FEAT-482's keys, resolver or coordinator in any way.
+- Changing `ResearchPartnerPlan`'s field names or the console payload shape.
+- Adding a per-backend model dimension to the plan object (the plan's single
+  `model` applies to whichever backend the plan selects — that is
+  sufficient, since a plan names exactly one backend).
+- Touching any other seat group (`research_primary`, `dev_pool`, `review`).
+
+---
+
+## 2. Architectural Design
+
+Retire the three FEAT-486 key constants and repoint
+`resolve_model_plan()`'s partner block at FEAT-482's keys:
+
+```
+research_partner.enabled  <- bool(DEV_FLOW_RESEARCH_PARTNER != "")
+research_partner.backend  <- DEV_FLOW_RESEARCH_PARTNER or "gpt"
+research_partner.model    <- DEV_FLOW_RESEARCH_PARTNER_{GPT,NOVA}_MODEL,
+                             chosen by the resolved backend
+```
+
+`enabled` and `backend` collapsing onto one source is the point: FEAT-482
+deliberately encodes both in a single key (`""` = disabled), and mirroring
+that removes the possibility of the two disagreeing.
+
+The model default becomes **backend-dependent**, which is what makes the
+plan's default correct for a `nova` partner — today an unset plan on a
+`nova` backend still defaults `model` to `gpt-5.6-sol`, a latent
+mismatch that only avoids being a bug because `_resolve_research_coordinator`
+passes `model or None` and FEAT-482 then re-resolves per backend.
+
+### Integration Points
+
+| Component | Type | Note |
+|---|---|---|
+| `resolve_model_plan()` (`model_plan.py:330-360`) | modifies | partner block reads FEAT-482's keys |
+| `ENV_PARTNER_*` constants (`model_plan.py:81-83`) | removes | no external importer outside `test_model_plan.py` |
+| `catalog.resolve_research_partner_backend()` | reuses | may be called with the same injectable `config_getter`, keeping one parse of `DEV_FLOW_RESEARCH_PARTNER` |
+| `factories._resolve_research_coordinator()` (`factories.py:52`) | unchanged | consumes plan *fields*, not keys |
+| console `/api/config` + `_parse_model_plan` | unchanged | payload shape is field-based |
+
+---
+
+## 3. Module Breakdown
+
+### Module 1: Resolver repoint + docs
+- **Path**: `dev_flow/model_plan.py`, `tests/flows/dev_flow/test_model_plan.py`,
+  `docs/dev_loop/dev-flow-model-plan.md`, `examples/dev_loop/README.md`,
+  `examples/dev_loop/GUIA.md`
+- **Responsibility**: everything above. Single task — the change is one
+  cohesive edit and splitting it would leave the tree inconsistent.
+
+---
+
+## 4. Test Specification
+
+| Test | Description |
+|---|---|
+| `test_partner_enabled_from_feat482_key` | `DEV_FLOW_RESEARCH_PARTNER=gpt` ⇒ `enabled=True`, `backend="gpt"` |
+| `test_partner_disabled_when_key_unset` | unset ⇒ `enabled=False` (pure-addition guarantee) |
+| `test_partner_model_follows_backend` | `=nova` ⇒ model from `_NOVA_MODEL`; `=gpt` ⇒ from `_GPT_MODEL` |
+| `test_explicit_plan_still_beats_config` | explicit `ResearchPartnerPlan(...)` unchanged by config |
+| `test_retired_keys_are_ignored` | `DEV_FLOW_RESEARCH_PARTNER_ENABLED=1` alone does NOT enable the seat |
+| `test_invalid_backend_surfaces_feat482_error` | `=bogus` raises naming `gpt, nova` |
+
+---
+
+## 5. Acceptance Criteria
+
+- [ ] `ENV_PARTNER_ENABLED` / `_BACKEND` / `_MODEL` are gone from `model_plan.py`
+- [ ] `resolve_model_plan()` derives the partner group from
+  `DEV_FLOW_RESEARCH_PARTNER` + `_GPT_MODEL`/`_NOVA_MODEL`
+- [ ] `ResearchPartnerPlan` field names and the console payload are unchanged
+- [ ] Explicit plan values still beat config (precedence test)
+- [ ] Unconfigured deployment behaves identically (partner disabled)
+- [ ] `grep -rn DEV_FLOW_RESEARCH_PARTNER_ENABLED` returns nothing outside history
+- [ ] The three docs publish only FEAT-482's key names
+- [ ] Full `packages/ai-parrot/tests/flows/dev_flow/` green; `ruff check` clean
+
+---
+
+## 6. Codebase Contract
+
+> Verified against `dev` at `95957471a` (post-FEAT-486 merge), 2026-09-01.
+
+```python
+# packages/ai-parrot/src/parrot/flows/dev_flow/model_plan.py
+DEFAULT_PARTNER_BACKEND: str = "gpt"                  # :66  (KEEP)
+DEFAULT_PARTNER_MODEL: str = "gpt-5.6-sol"            # :67  (KEEP as gpt fallback)
+ENV_PARTNER_ENABLED = "DEV_FLOW_RESEARCH_PARTNER_ENABLED"   # :81 (REMOVE)
+ENV_PARTNER_BACKEND = "DEV_FLOW_RESEARCH_PARTNER_BACKEND"   # :82 (REMOVE)
+ENV_PARTNER_MODEL   = "DEV_FLOW_RESEARCH_PARTNER_MODEL"     # :83 (REMOVE)
+class ResearchPartnerPlan(BaseModel):                 # :109 — fields UNCHANGED
+def resolve_model_plan(plan=None, *, config_getter=None) -> DevFlowModelPlan
+#   partner block at :335-353 — the only reader of the three constants
+
+# packages/ai-parrot/src/parrot/conf.py — FEAT-482's shipped keys (authoritative)
+DEV_FLOW_RESEARCH_PARTNER            = config.get(..., fallback="")        # :1131
+DEV_FLOW_RESEARCH_PARTNER_GPT_MODEL  = config.get(..., "gpt-5.6-sol")      # :1137
+DEV_FLOW_RESEARCH_PARTNER_NOVA_MODEL = config.get(..., "us.amazon.nova-2-lite-v1:0")  # :1141
+
+# packages/ai-parrot/src/parrot/flows/dev_loop/catalog.py
+def resolve_research_partner_backend(config_getter=None) -> str  # :157
+#   "" | "gpt" | "nova"; ALSO validates the resolved model against the
+#   Anthropic family guard, and raises ValueError naming (gpt, nova).
+
+# packages/ai-parrot/src/parrot/flows/dev_flow/factories.py
+def _resolve_research_coordinator(explicit, plan)      # :52 — consumes plan
+#   FIELDS only; requires NO change.
+```
+
+### Does NOT Exist
+- Any importer of `ENV_PARTNER_*` outside `model_plan.py` and
+  `tests/flows/dev_flow/test_model_plan.py` (verified by grep).
+- A per-backend model field on `ResearchPartnerPlan` — deliberately not added.
+
+---
+
+## 7. Implementation Notes & Constraints
+
+- Prefer calling `resolve_research_partner_backend(config_getter)` over
+  re-parsing `DEV_FLOW_RESEARCH_PARTNER` locally, so the enable/backend
+  semantics AND the Anthropic family guard stay in one place. Note it
+  RAISES on an invalid value — `resolve_model_plan` currently raises on a
+  bad `dev_pool` backend too, so that is consistent.
+- `resolve_model_plan` reads config through an injectable `config_getter`
+  (tests pass a dict-backed lambda); keep that, and pass it through.
+- The model default must be chosen AFTER the backend is known.
+
+---
+
+## 8. Open Questions
+
+- [x] Which key set wins? — *Resolved*: FEAT-482's. It shipped first, owns
+  the seat's implementation, and carries the per-backend model dimension.
+- [x] Should `ResearchPartnerPlan` gain per-backend model fields? — *Resolved*:
+  no. A plan names exactly one backend, so one `model` is sufficient.
+- [ ] Should the retired keys emit a deprecation warning for one release
+  instead of vanishing? They shipped only in FEAT-486 (same day, unreleased),
+  so almost certainly not — confirm at implementation time.
+
+---
+
+## Worktree Strategy
+
+- **Isolation unit**: single task, single worktree
+  (`.claude/worktrees/feat-487-dev-flow-partner-env-key-dedup`, from `dev`).
+- **Cross-feature dependencies**: none — FEAT-482 and FEAT-486 are both
+  merged to `dev` (`95957471a`). **This spec exists precisely because
+  FEAT-486 was decomposed before FEAT-482 merged**; do not repeat that —
+  branch from a `dev` that already contains both.
+
+---
+
+## Revision History
+
+| Version | Date | Author | Change |
+|---|---|---|---|
+| 0.1 | 2026-09-01 | Jesus Lara (with Claude) | Initial — carved out of FEAT-486 TASK-2657's open follow-up |

--- a/sdd/tasks/active/TASK-2676-partner-env-key-dedup.md
+++ b/sdd/tasks/active/TASK-2676-partner-env-key-dedup.md
@@ -1,0 +1,188 @@
+# TASK-2676: Collapse the duplicate research-partner env keys onto FEAT-482's
+
+**Feature**: FEAT-487 — Collapse the duplicate research-partner env keys
+**Spec**: `sdd/specs/dev-flow-partner-env-key-dedup.spec.md`
+**Status**: pending
+**Priority**: medium
+**Estimated effort**: S (< 2h)
+**Depends-on**: none
+**Assigned-to**: unassigned
+
+---
+
+## Context
+
+Carved out of FEAT-486 TASK-2657's Completion Note. FEAT-482 and FEAT-486
+each invented env keys for the same research-partner seat because FEAT-486
+was decomposed before FEAT-482 merged. FEAT-482's set shipped first, owns
+the seat's implementation and carries a per-backend model dimension, so it
+wins; FEAT-486's three keys are retired.
+
+Full rationale, harm analysis and the key comparison table: spec §1.
+
+---
+
+## Scope
+
+- Delete `ENV_PARTNER_ENABLED` / `ENV_PARTNER_BACKEND` / `ENV_PARTNER_MODEL`
+  from `dev_flow/model_plan.py` (`:81-83`).
+- Repoint `resolve_model_plan()`'s partner block (`:335-353`) at FEAT-482's
+  keys:
+  - `enabled` ← `DEV_FLOW_RESEARCH_PARTNER != ""`
+  - `backend` ← `DEV_FLOW_RESEARCH_PARTNER` (falling back to
+    `DEFAULT_PARTNER_BACKEND`)
+  - `model` ← `DEV_FLOW_RESEARCH_PARTNER_GPT_MODEL` or
+    `_NOVA_MODEL`, **selected by the resolved backend** (this is the latent
+    bug the dedup also fixes: today a `nova` partner defaults its model to
+    `gpt-5.6-sol`)
+  Prefer delegating to `catalog.resolve_research_partner_backend(config_getter)`
+  over re-parsing the key locally, so enable/backend semantics AND the
+  Anthropic family guard stay in one place.
+- Keep `ResearchPartnerPlan`'s field names (`enabled`/`backend`/`model`)
+  and the console payload shape EXACTLY as they are — `factories.
+  _resolve_research_coordinator()` and `/api/config` consume fields, not keys.
+- Preserve precedence: explicit plan value > config > built-in default.
+- Update the three docs that publish the retired key names.
+- Update `tests/flows/dev_flow/test_model_plan.py` (the only other importer
+  of the constants) and add the spec §4 tests.
+
+**NOT in scope**: any change to FEAT-482's keys, resolver or coordinator;
+`ResearchPartnerPlan` field renames; per-backend model fields on the plan;
+the other three seat groups.
+
+---
+
+## Files to Create / Modify
+
+| File | Action | Description |
+|---|---|---|
+| `packages/ai-parrot/src/parrot/flows/dev_flow/model_plan.py` | MODIFY | Remove 3 constants; repoint the partner block |
+| `packages/ai-parrot/tests/flows/dev_flow/test_model_plan.py` | MODIFY | Retire constant imports; add spec §4 tests |
+| `docs/dev_loop/dev-flow-model-plan.md` | MODIFY | Key table → FEAT-482's names |
+| `examples/dev_loop/README.md` | MODIFY | Key table → FEAT-482's names |
+| `examples/dev_loop/GUIA.md` | MODIFY | Key table → FEAT-482's names (Spanish) |
+
+---
+
+## Codebase Contract (Anti-Hallucination)
+
+> Verified against `dev` at `95957471a` (post-FEAT-486 merge), 2026-09-01.
+> Re-verify before starting: `dev` moves.
+
+### Verified Imports
+```python
+from parrot import conf
+from parrot.flows.dev_loop.catalog import resolve_research_partner_backend
+```
+
+### Existing Signatures to Use
+```python
+# packages/ai-parrot/src/parrot/flows/dev_flow/model_plan.py
+DEFAULT_PARTNER_BACKEND: str = "gpt"                        # :66  KEEP
+DEFAULT_PARTNER_MODEL: str = "gpt-5.6-sol"                  # :67  KEEP (gpt fallback)
+ENV_PARTNER_ENABLED = "DEV_FLOW_RESEARCH_PARTNER_ENABLED"   # :81  REMOVE
+ENV_PARTNER_BACKEND = "DEV_FLOW_RESEARCH_PARTNER_BACKEND"   # :82  REMOVE
+ENV_PARTNER_MODEL   = "DEV_FLOW_RESEARCH_PARTNER_MODEL"     # :83  REMOVE
+class ResearchPartnerPlan(BaseModel):                       # :109 fields UNCHANGED
+    enabled: bool = False; backend: str = ...; model: str = ...
+def resolve_model_plan(plan=None, *, config_getter=None) -> DevFlowModelPlan
+#   partner block :335-353 — sole reader of the three constants.
+#   `config_getter` signature is (key, fallback=...) -> Any; tests inject a
+#   dict-backed lambda. Keep it and pass it through.
+
+# packages/ai-parrot/src/parrot/conf.py — FEAT-482, authoritative
+DEV_FLOW_RESEARCH_PARTNER            fallback ""                             # :1131
+DEV_FLOW_RESEARCH_PARTNER_GPT_MODEL  fallback "gpt-5.6-sol"                  # :1137
+DEV_FLOW_RESEARCH_PARTNER_NOVA_MODEL fallback "us.amazon.nova-2-lite-v1:0"   # :1141
+
+# packages/ai-parrot/src/parrot/flows/dev_loop/catalog.py
+def resolve_research_partner_backend(config_getter=None) -> str              # :157
+#   returns "" | "gpt" | "nova"; RAISES ValueError naming (gpt, nova) on a
+#   bad value, and also validates the resolved model against the Anthropic
+#   family guard (validate_research_partner_model, :124).
+
+# packages/ai-parrot/src/parrot/flows/dev_flow/factories.py
+def _resolve_research_coordinator(explicit, plan)                            # :52
+#   reads plan.research_partner.{enabled,backend,model} — NO change needed.
+```
+
+### Does NOT Exist
+- Any importer of `ENV_PARTNER_*` beyond `model_plan.py` and
+  `tests/flows/dev_flow/test_model_plan.py` — confirm with
+  `grep -rn ENV_PARTNER packages/ examples/` before deleting.
+- A per-backend model field on `ResearchPartnerPlan` — deliberately NOT added.
+- A deprecation shim for the retired keys — see the open question below.
+
+---
+
+## Implementation Notes
+
+- `resolve_research_partner_backend()` RAISES on an invalid value. That is
+  consistent with `resolve_model_plan` already raising on an unknown
+  `dev_pool` backend, so let it propagate rather than swallowing it.
+- Resolve the backend FIRST, then pick the model default from it — the
+  ordering is what fixes the `nova`-defaults-to-`gpt-5.6-sol` mismatch.
+- `conf` module attributes vs `config_getter`: FEAT-482's resolver reads
+  through the getter, but `resolve_backend_model()` reads `conf.*` module
+  attributes directly. For the model default, read via the injected getter
+  with the `conf.*` value as the fallback — that is the pattern the rest of
+  `resolve_model_plan` already uses, and it keeps tests injectable.
+
+## Reference Code
+- `model_plan.py:355-375` — the review-pair block, same explicit>env>default
+  shape to mirror for the partner block.
+- `tests/flows/dev_flow/test_model_plan.py:33-40` — the `_getter` dict-lambda
+  fixture to reuse for the new tests.
+
+---
+
+## Acceptance Criteria
+
+- [ ] The three `ENV_PARTNER_*` constants are gone
+- [ ] `grep -rn "DEV_FLOW_RESEARCH_PARTNER_ENABLED\|_PARTNER_BACKEND\|DEV_FLOW_RESEARCH_PARTNER_MODEL" packages/ examples/ docs/` returns nothing
+- [ ] `DEV_FLOW_RESEARCH_PARTNER=nova` ⇒ plan `enabled=True, backend="nova"`, model from `_NOVA_MODEL`
+- [ ] Unset key ⇒ `enabled=False` (unconfigured deployment unchanged)
+- [ ] Explicit plan values still beat config
+- [ ] `ResearchPartnerPlan` fields and `/api/config` payload unchanged
+- [ ] All tests pass: `pytest packages/ai-parrot/tests/flows/dev_flow/ -v`; `ruff check` clean
+- [ ] The three docs publish only FEAT-482's key names
+
+---
+
+## Test Specification
+
+```python
+# packages/ai-parrot/tests/flows/dev_flow/test_model_plan.py (extend)
+class TestPartnerKeyDedup:
+    def test_partner_enabled_from_feat482_key(self): ...
+    def test_partner_disabled_when_key_unset(self): ...
+    def test_partner_model_follows_backend(self): ...       # nova -> _NOVA_MODEL
+    def test_explicit_plan_still_beats_config(self): ...
+    def test_retired_keys_are_ignored(self): ...            # _ENABLED alone: no-op
+    def test_invalid_backend_surfaces_feat482_error(self): ...  # match "gpt, nova"
+```
+
+---
+
+## Agent Instructions
+
+1. **Read the spec** at the path in the header
+2. **Check dependencies** — none
+3. **Verify the Codebase Contract** — `dev` moves; re-anchor the line numbers
+   and re-run the `ENV_PARTNER` grep before deleting anything
+4. **Update status** in `sdd/tasks/index/dev-flow-partner-env-key-dedup.json` → `"in-progress"`
+5. **Implement**; 6. **Verify**; 7. **Move this file** to `sdd/tasks/completed/`
+   via `scripts/sdd/close_task.sh`; 8. **Update index** → `"done"`;
+9. **Fill in the Completion Note**
+
+---
+
+## Completion Note
+
+*(Agent fills this in when done)*
+
+**Completed by**:
+**Date**:
+**Notes**:
+
+**Deviations from spec**: none

--- a/sdd/tasks/completed/TASK-2676-partner-env-key-dedup.md
+++ b/sdd/tasks/completed/TASK-2676-partner-env-key-dedup.md
@@ -2,7 +2,7 @@
 
 **Feature**: FEAT-487 — Collapse the duplicate research-partner env keys
 **Spec**: `sdd/specs/dev-flow-partner-env-key-dedup.spec.md`
-**Status**: pending
+**Status**: done
 **Priority**: medium
 **Estimated effort**: S (< 2h)
 **Depends-on**: none
@@ -181,8 +181,67 @@ class TestPartnerKeyDedup:
 
 *(Agent fills this in when done)*
 
-**Completed by**:
-**Date**:
+**Completed by**: sdd-worker (Claude Opus 5)
+**Date**: 2026-09-01
 **Notes**:
+- Contract verified before any edit: every declared anchor
+  (`model_plan.py:66,67,81-83,109`, `catalog.py:124,157`,
+  `conf.py:1131,1137,1141`) matched exactly, and the `ENV_PARTNER` grep
+  confirmed the only importers were `model_plan.py` and
+  `test_model_plan.py` — so the constants were safe to delete.
+- **A stale anchor did bite once, harmlessly**: my first edit script
+  targeted `_pool_from_env(raw: Any) -> Optional[...]`, but FEAT-486's
+  post-merge `black` pass had modernized it to `list[dict[str, Any]] | None`.
+  The assertion failed and — because the file write is the last statement —
+  nothing was written. Re-anchored and re-applied atomically.
+- `resolve_model_plan()`'s partner block now calls
+  `catalog.resolve_research_partner_backend(getter)` for enable+backend.
+  Delegating rather than re-parsing buys three things: one parse of one key;
+  the Anthropic family guard now fires at plan-resolution time (before, an
+  Anthropic partner model passed the plan resolver silently and only failed
+  later inside the partner); and FEAT-482's own error text
+  ("must be one of ('gpt','nova')") instead of a second dialect.
+- **The latent mismatch is fixed.** FEAT-486's single backend-agnostic
+  `_MODEL` meant a `nova` partner defaulted to `gpt-5.6-sol`. The backend is
+  resolved FIRST, then the model default from that backend's key, so `nova`
+  now yields `us.amazon.nova-2-lite-v1:0`. It was never a live bug only
+  because `_resolve_research_coordinator` passes `model or None` and
+  FEAT-482 re-resolves per backend downstream — but the plan was reporting a
+  model it would not use.
+- `_partner_model_default()` deliberately does NOT import FEAT-482's
+  `resolve_backend_model()`: that reads `conf.*` module attributes directly
+  and would ignore the injected `config_getter`, breaking the hermetic
+  dict-lambda pattern every other default in this module uses. The
+  duplication is one two-branch `if`, documented as such.
+- **Nothing downstream changed**, as the spec required:
+  `ResearchPartnerPlan`'s `enabled`/`backend`/`model` fields,
+  `factories._resolve_research_coordinator()` and the console
+  `/api/config` payload all consume FIELDS, not keys — neither
+  `factories.py` nor `server_dev.py` was touched, and their 50 tests pass.
+- No import cycle introduced: `dev_loop.catalog` imports only `parrot.conf`.
+- 11 new tests (`TestPartnerKeyDedup`), notably
+  `test_retired_keys_are_ignored` (old keys inert),
+  `test_retired_constants_are_gone` (guards a well-meaning
+  re-introduction), `test_partner_model_follows_backend_nova` (the mismatch
+  fix) and `test_anthropic_partner_model_rejected`.
+  `test_partner_enabled_env_coercion` was DELETED along with the boolean key
+  it existed to test — the new key has no boolean form.
+- `test_model_plan.py`: 41 passed. Full
+  `packages/ai-parrot/tests/flows/`: 1825 passed, 15 skipped, 4 failed —
+  the four pre-existing `dev` failures (`test_qa_codereview`,
+  `test_secondopinion_brief`, `test_subagent_parity[sdd-secondopinion]`,
+  `test_dev_recovery_integration`). ruff clean on both code files.
 
-**Deviations from spec**: none
+**Deviations from spec**: none in scope — exactly the 5 declared files.
+
+Two notes on acceptance criteria:
+1. The AC "`grep -rn DEV_FLOW_RESEARCH_PARTNER_ENABLED` returns nothing"
+   still matches ONE line: `docs/dev_loop/dev-flow-model-plan.md:62`, which
+   is the deliberate "FEAT-486 briefly shipped its own ... those are retired
+   and inert" note. Documenting the retirement is more useful to an operator
+   who has the old key in an `.env` than silence would be, so it was kept.
+2. Spec §8's open question — whether to emit a deprecation warning for the
+   retired keys for one release — was resolved as **no**. They shipped only
+   in FEAT-486, unreleased, on the same day; a warning path would outlive
+   its own audience. `test_retired_keys_are_ignored` pins the silent-inert
+   behaviour instead.

--- a/sdd/tasks/index/dev-flow-partner-env-key-dedup.json
+++ b/sdd/tasks/index/dev-flow-partner-env-key-dedup.json
@@ -5,7 +5,7 @@
   "type": "feature",
   "base_branch": "dev",
   "created_at": "2026-09-01T10:29:38Z",
-  "completed_at": null,
+  "completed_at": "2026-09-01T10:53:28+00:00",
   "tasks": [
     {
       "id": "TASK-2676",
@@ -14,7 +14,7 @@
       "feature_id": "FEAT-487",
       "feature": "dev-flow-partner-env-key-dedup",
       "spec": "sdd/specs/dev-flow-partner-env-key-dedup.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "S",
       "depends_on": [],
@@ -22,8 +22,9 @@
       "parallelism_notes": "Single task — one cohesive edit; splitting would leave the tree inconsistent.",
       "assigned_to": null,
       "started_at": "2026-09-01T10:47:38+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2676-partner-env-key-dedup.md"
+      "completed_at": "2026-09-01T10:53:28+00:00",
+      "file": "sdd/tasks/completed/TASK-2676-partner-env-key-dedup.md",
+      "verification": "verified"
     }
   ]
 }

--- a/sdd/tasks/index/dev-flow-partner-env-key-dedup.json
+++ b/sdd/tasks/index/dev-flow-partner-env-key-dedup.json
@@ -1,0 +1,29 @@
+{
+  "feature": "dev-flow-partner-env-key-dedup",
+  "feature_id": "FEAT-487",
+  "spec": "sdd/specs/dev-flow-partner-env-key-dedup.spec.md",
+  "type": "feature",
+  "base_branch": "dev",
+  "created_at": "2026-09-01T10:29:38Z",
+  "completed_at": null,
+  "tasks": [
+    {
+      "id": "TASK-2676",
+      "slug": "partner-env-key-dedup",
+      "title": "Collapse the duplicate research-partner env keys onto FEAT-482's",
+      "feature_id": "FEAT-487",
+      "feature": "dev-flow-partner-env-key-dedup",
+      "spec": "sdd/specs/dev-flow-partner-env-key-dedup.spec.md",
+      "status": "pending",
+      "priority": "medium",
+      "effort": "S",
+      "depends_on": [],
+      "parallel": false,
+      "parallelism_notes": "Single task — one cohesive edit; splitting would leave the tree inconsistent.",
+      "assigned_to": null,
+      "started_at": null,
+      "completed_at": null,
+      "file": "sdd/tasks/active/TASK-2676-partner-env-key-dedup.md"
+    }
+  ]
+}

--- a/sdd/tasks/index/dev-flow-partner-env-key-dedup.json
+++ b/sdd/tasks/index/dev-flow-partner-env-key-dedup.json
@@ -14,14 +14,14 @@
       "feature_id": "FEAT-487",
       "feature": "dev-flow-partner-env-key-dedup",
       "spec": "sdd/specs/dev-flow-partner-env-key-dedup.spec.md",
-      "status": "pending",
+      "status": "in-progress",
       "priority": "medium",
       "effort": "S",
       "depends_on": [],
       "parallel": false,
       "parallelism_notes": "Single task — one cohesive edit; splitting would leave the tree inconsistent.",
       "assigned_to": null,
-      "started_at": null,
+      "started_at": "2026-09-01T10:47:38+00:00",
       "completed_at": null,
       "file": "sdd/tasks/active/TASK-2676-partner-env-key-dedup.md"
     }


### PR DESCRIPTION
## Summary

The dev-flow research-partner seat was configurable through **two competing
env key sets**, because FEAT-486 was decomposed before FEAT-482 merged and
each invented its own. FEAT-482's set wins; FEAT-486's three keys are
retired.

| Owner | Keys | Fate |
|---|---|---|
| FEAT-482 | `DEV_FLOW_RESEARCH_PARTNER` (`""`=disabled, else backend) + `_GPT_MODEL` / `_NOVA_MODEL` | **authoritative** |
| FEAT-486 | `DEV_FLOW_RESEARCH_PARTNER_ENABLED` / `_BACKEND` / `_MODEL` | **retired, inert** |

`resolve_model_plan()`'s partner block now delegates enable+backend to
`catalog.resolve_research_partner_backend(getter)`.

## Why delegate rather than re-parse

Three concrete gains beyond removing the duplication:

1. **One parse of one key**, so the two sources can no longer disagree —
   previously `DEV_FLOW_RESEARCH_PARTNER=nova` did *not* enable the seat via
   a `DevFlowModelPlan`, because the plan read `_ENABLED`/`_BACKEND` instead.
2. **The Anthropic family guard now fires at plan-resolution time.** Before,
   a plan configured with `us.anthropic.*`/`claude-*` passed the plan
   resolver silently and only failed later inside the partner. That seat
   exists to *decorrelate* from the primary Claude seat, so failing early
   matters.
3. FEAT-482's own error text, not a second dialect.

## A real bug fixed, not just tidying

FEAT-486's single backend-agnostic `_MODEL` meant a **`nova` partner
defaulted its model to `gpt-5.6-sol`**. The backend is now resolved *first*
and the model default taken from that backend's own key, so `nova` yields
`us.amazon.nova-2-lite-v1:0`.

It was never a live failure only because `_resolve_research_coordinator`
passes `model or None` and FEAT-482 re-resolves per backend downstream — but
the plan was *reporting* a model it would never use.

## Deliberately unchanged

`ResearchPartnerPlan`'s `enabled`/`backend`/`model` **fields**,
`factories._resolve_research_coordinator()` and the console `/api/config`
payload all consume fields, not keys — so **neither `factories.py` nor
`server_dev.py` was touched**, and their 50 tests pass untouched. A plan
names exactly one backend, so one `model` field remains sufficient.

## Tests

- `test_model_plan.py`: **41 passed** (11 new in `TestPartnerKeyDedup`)
- Full `packages/ai-parrot/tests/flows/`: **1825 passed**, 15 skipped, 4
  failed — all 4 pre-existing on `dev` and unrelated
  (`test_qa_codereview`, `test_secondopinion_brief`,
  `test_subagent_parity[sdd-secondopinion]`, `test_dev_recovery_integration`)
- `ruff` clean; no import cycle (`dev_loop.catalog` imports only `parrot.conf`)

Notable tests: `test_retired_keys_are_ignored` (old keys inert),
`test_retired_constants_are_gone` (guards a well-meaning re-introduction),
`test_partner_model_follows_backend_nova` (the mismatch fix),
`test_anthropic_partner_model_rejected`.
`test_partner_enabled_env_coercion` was **deleted** along with the boolean
key it existed to test.

## Reviewer notes

1. **One AC is intentionally unmet.** The spec asked that
   `grep DEV_FLOW_RESEARCH_PARTNER_ENABLED` return nothing; it still matches
   one line — the deliberate *"FEAT-486 briefly shipped its own … retired and
   inert"* note in `docs/dev_loop/dev-flow-model-plan.md`. An operator with
   the old key in their `.env` is better served by that sentence than by
   silence.
2. **No deprecation shim** (spec §8 open question, resolved *no*): the keys
   shipped unreleased, same day. `test_retired_keys_are_ignored` pins
   silent-inert behaviour instead.
3. `_partner_model_default()` duplicates FEAT-482's two-branch mapping rather
   than importing `resolve_backend_model()`, because that reads `conf.*`
   module attributes directly and would ignore the injected `config_getter`,
   breaking test hermeticity. Documented at the definition.

## Note on the diff

This PR also carries `3bf330e90` (FEAT-487's own spec + task artifacts),
which was committed to local `dev` but not yet pushed — it belongs to this
feature and is self-contained.

---
_Closed by /sdd-done_