### PR TITLE
feat(flex-agent-infographic-a2ui): FEAT-491 — Flex A2UI Dashboard Agent

### DIFF
--- a/agents/flex_dashboard.py
+++ b/agents/flex_dashboard.py
@@ -10,12 +10,42 @@ Sibling package ``agents/flex_dashboard/`` holds the pure normalization
 layer (:mod:`agents.flex_dashboard.normalize`), the registered
 ``@infographic_transformer`` functions (:mod:`agents.flex_dashboard.
 transformers`), the kb docs (``kb/*.md``), and the composite skills
-(``skills/``) — same file+package coexistence pattern as
-``agents/finance_reporter.py``::
+(``skills/``)::
 
     agent = FlexDashboard(name="flex-dashboard", recipe_store=store)
     await agent.configure()
     recipe = await agent.publish_dashboard_recipe(overwrite=True)
+
+.. warning::
+
+   **Known, confirmed limitation (external code review finding)**: because
+   ``agents/flex_dashboard/`` is a REGULAR package (has its own
+   ``__init__.py``), Python's ``FileFinder`` always resolves a plain
+   ``import agents.flex_dashboard`` — or ``from agents.flex_dashboard
+   import FlexDashboard`` — to that PACKAGE, never to THIS file, even
+   though ``FlexDashboard`` is only ever defined here. This is reproducible
+   directly (``python -c "from agents.flex_dashboard import
+   FlexDashboard"`` raises ``ImportError``). It does NOT affect the
+   application as actually deployed: ``parrot.registry.registry
+   .AgentRegistry._load_modules_from_directory`` — the real production
+   agent-discovery path — globs ``agents/*.py`` and loads each file via
+   ``importlib.util.spec_from_file_location`` under a synthetic name,
+   never a plain dotted import, so ``@register_agent(name="flex_dashboard")``
+   fires correctly at boot. Every test file and the example runner in this
+   feature load this module the SAME way for the same reason (see any
+   test file's ``_load_module``/``_load_package`` helpers). A caller that
+   writes the natural ``from agents.flex_dashboard import FlexDashboard``
+   in a notebook, script, or a future ``agents.yaml``-driven
+   ``config.module`` entry WILL hit this ``ImportError`` — there is no
+   compositional fix available from within this agent's own file(s) that
+   preserves both "the class is importable via the natural path" and "the
+   sibling package's submodules (``normalize``/``transformers``) are
+   importable" simultaneously with this exact file/directory naming.
+   Resolving it for real requires renaming the sibling package (e.g. to
+   ``agents/flex_dashboard_kit/``) and updating every internal reference —
+   out of scope for this feature to do unilaterally, since the spec's own
+   Module 3 architecture mandates the current name; flagged here for the
+   PR reviewer to decide.
 
 Prefer :meth:`FlexDashboard.publish_dashboard_recipe` over calling the
 inherited ``publish_recipe()`` directly for ``DASHBOARD_RECIPE_NAME`` — the

--- a/agents/flex_dashboard.py
+++ b/agents/flex_dashboard.py
@@ -15,6 +15,14 @@ transformers`), the kb docs (``kb/*.md``), and the composite skills
 
     agent = FlexDashboard(name="flex-dashboard", recipe_store=store)
     await agent.configure()
+    recipe = await agent.publish_dashboard_recipe(overwrite=True)
+
+Prefer :meth:`FlexDashboard.publish_dashboard_recipe` over calling the
+inherited ``publish_recipe()`` directly for ``DASHBOARD_RECIPE_NAME`` — the
+base mixin has no ``params=`` argument, so a bare ``publish_recipe()`` call
+leaves the recipe's declared ``RecipeParam`` overrides unset, which breaks
+even the unfiltered default replay (see ``publish_dashboard_recipe``'s own
+docstring for the full reasoning).
 
 See ``sdd/specs/flex-agent-infographic-a2ui.spec.md`` for the full design.
 """
@@ -35,7 +43,7 @@ from parrot.tools.abstract import (
     current_a2ui_surface_state,
 )
 from parrot.tools.infographic_recipes.runner import RecipeRunner
-from parrot.tools.infographic_sections import SectionDescriptor, SectionSpec
+from parrot.tools.infographic_sections import GapReport, SectionDescriptor, SectionSpec
 from parrot.tools.working_memory import WorkingMemoryToolkit
 from pydantic import Field
 
@@ -590,6 +598,41 @@ class FlexDashboard(NarrativeMixin, InfographicAuthoringMixin, PandasAgent):
             narrative=cls._narrative_spec(),
         )
 
+    async def publish_dashboard_recipe(self, *, overwrite: bool = False) -> Any:
+        """Publish the dashboard recipe AND persist its declared filter params.
+
+        Code-review finding (adopted): ``InfographicAuthoringMixin
+        .publish_recipe()`` has no ``params=`` argument — it never persists
+        ``RecipeParam`` declarations on its own. A caller that publishes via
+        the base ``publish_recipe()`` directly and forgets the follow-up
+        ``recipe.params = FlexDashboard.recipe_params(); await
+        recipe_store.save(recipe)`` step gets a recipe with `params=[]`,
+        which makes EVERY replay fail — even the unfiltered default one —
+        because ``dashboard_descriptor()``'s ``{month}``/etc. placeholders
+        have nothing to resolve against (``resolve_params`` raises). This
+        wraps both steps atomically so that footgun cannot happen; prefer
+        this over calling ``publish_recipe`` directly for
+        ``DASHBOARD_RECIPE_NAME``.
+
+        Args:
+            overwrite: Forwarded to ``publish_recipe`` — replace an
+                existing ``(name, owner)`` recipe when True.
+
+        Returns:
+            The saved :class:`~parrot.outputs.a2ui.recipes.models.InfographicRecipe`,
+            or a :class:`~parrot.tools.infographic_sections.GapReport` on
+            partial transformer coverage (nothing is saved in that case,
+            matching ``publish_recipe``'s own contract).
+        """
+        recipe = await self.publish_recipe(
+            self.DASHBOARD_RECIPE_NAME, self.dashboard_descriptor(), overwrite=overwrite
+        )
+        if isinstance(recipe, GapReport):
+            return recipe
+        recipe.params = self.recipe_params()
+        await self._require_recipe_store().save(recipe)
+        return recipe
+
     # ── Refresh lane (FEAT-469 pattern) ─────────────────────────────────
 
     def build_refresh_tool(self, pctx: Any) -> RefreshDashboardTool:
@@ -633,6 +676,18 @@ class RefreshDashboardTool(AbstractTool):
     (the renderer's inline filter widget) → the surface's last persisted
     ``dataModel.filters`` (read via ``current_a2ui_surface_state()``) →
     the recipe's own declared defaults (empty-string "no filter" / 50 / 3).
+
+    Permission-context precedence (code-review finding, adopted): the
+    PER-CALL ``PermissionContext`` — injected by ``AbstractTool.execute()``
+    onto ``self._current_pctx`` whenever the caller (e.g.
+    ``ToolManagerExecutor.call`` → ``ToolManager.execute_tool``) supplies
+    one via the ``_permission_context`` kwarg — always wins over the
+    ``pctx`` captured at construction time. On a shared/pooled agent
+    instance serving multiple callers, always using the CONSTRUCTION-time
+    ``pctx`` would let one user's DatasetManager PBAC/tenant scope leak
+    into another user's refresh. The constructor ``pctx`` is kept only as
+    the fallback for direct/demo calls that never go through
+    ``ToolManager.execute_tool`` (e.g. this feature's own example runner).
     """
 
     name = "refresh_dashboard"
@@ -683,7 +738,13 @@ class RefreshDashboardTool(AbstractTool):
             if value is not None:
                 params[key] = value
 
-        artifact = await self._runner.run(FlexDashboard.DASHBOARD_RECIPE_NAME, params=params, pctx=self._pctx)
+        # Per-call pctx (set by AbstractTool.execute() from the
+        # `_permission_context` kwarg) wins over the constructor-captured
+        # one — see the class docstring.
+        effective_pctx = getattr(self, "_current_pctx", None) or self._pctx
+        artifact = await self._runner.run(
+            FlexDashboard.DASHBOARD_RECIPE_NAME, params=params, pctx=effective_pctx
+        )
         return {
             "filters": params,
             "filter_source": (

--- a/agents/flex_dashboard.py
+++ b/agents/flex_dashboard.py
@@ -624,9 +624,7 @@ class FlexDashboard(NarrativeMixin, InfographicAuthoringMixin, PandasAgent):
             partial transformer coverage (nothing is saved in that case,
             matching ``publish_recipe``'s own contract).
         """
-        recipe = await self.publish_recipe(
-            self.DASHBOARD_RECIPE_NAME, self.dashboard_descriptor(), overwrite=overwrite
-        )
+        recipe = await self.publish_recipe(self.DASHBOARD_RECIPE_NAME, self.dashboard_descriptor(), overwrite=overwrite)
         if isinstance(recipe, GapReport):
             return recipe
         recipe.params = self.recipe_params()
@@ -742,9 +740,7 @@ class RefreshDashboardTool(AbstractTool):
         # `_permission_context` kwarg) wins over the constructor-captured
         # one — see the class docstring.
         effective_pctx = getattr(self, "_current_pctx", None) or self._pctx
-        artifact = await self._runner.run(
-            FlexDashboard.DASHBOARD_RECIPE_NAME, params=params, pctx=effective_pctx
-        )
+        artifact = await self._runner.run(FlexDashboard.DASHBOARD_RECIPE_NAME, params=params, pctx=effective_pctx)
         return {
             "filters": params,
             "filter_source": (

--- a/agents/flex_dashboard.py
+++ b/agents/flex_dashboard.py
@@ -1,0 +1,238 @@
+"""FlexDashboard — FEAT-491: A2UI dashboard agent for the Flex program.
+
+Composes :class:`NarrativeMixin` and :class:`InfographicAuthoringMixin` onto
+:class:`PandasAgent` (mirroring `agents/finance_reporter.py`, FEAT-420) and
+gives the agent's ``DatasetManager`` lazy access to the six Flex QuerySource
+slugs (spec §2): Master Store List, Finance results, Hours, Employees,
+Region utilization, and Rep utilization.
+
+Sibling package ``agents/flex_dashboard/`` holds the pure normalization
+layer (:mod:`agents.flex_dashboard.normalize`), the registered
+``@infographic_transformer`` functions (:mod:`agents.flex_dashboard.
+transformers`), the kb docs (``kb/*.md``), and the composite skills
+(``skills/``) — same file+package coexistence pattern as
+``agents/finance_reporter.py``::
+
+    agent = FlexDashboard(name="flex-dashboard", recipe_store=store)
+    await agent.configure()
+
+See ``sdd/specs/flex-agent-infographic-a2ui.spec.md`` for the full design.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, ClassVar
+
+from aiohttp import web
+from parrot.bots.data import PandasAgent
+from parrot.bots.mixins import InfographicAuthoringMixin, NarrativeMixin
+from parrot.registry import register_agent
+from parrot.tools.working_memory import WorkingMemoryToolkit
+
+# Import side effect ONLY: registers the Flex transformers (payroll_hero,
+# worked_hours_by_month, ..., flex_narrative_facts) on the shared
+# `transformer_registry` — see agents/flex_dashboard/transformers.py.
+import agents.flex_dashboard.transformers  # noqa: F401
+
+#: This file's own directory — skill_paths/kb glob MUST anchor here, never
+#: to process cwd (finance_reporter.py's FEAT-420 lesson, SKILLS_DIR note).
+_AGENT_DIR = Path(__file__).resolve().parent
+_PACKAGE_DIR = _AGENT_DIR / "flex_dashboard"
+SKILLS_DIR = _PACKAGE_DIR / "skills"
+KB_DIR = _PACKAGE_DIR / "kb"
+
+#: Frozen dataset aliases (spec §2) — every transformer hard-codes these as
+#: its input frame key. Changing one means changing both sides (spec §7
+#: Known Risks: "Alias ↔ transformer-key 1:1").
+DATASET_SLUGS: dict[str, str] = {
+    "msl": "flex_msl_brian_bi",
+    "finance": "Finance_results_bi",  # capital F — verbatim, spec §7 gotcha
+    "hours": "flex_hours_query_pbi",
+    "employees": "flex_empolyees_brian_bi",
+    "region_utilization": "fm_regions_avg_employees_html",
+    "rep_utilization": "fm_rep_utilization",
+}
+
+
+def _build_default_artifact_store() -> Any:
+    """Build an offline-safe default ``ArtifactStore`` (no network/DB).
+
+    Local SQLite conversation backend + local-filesystem overflow store —
+    the same offline primitives ``examples/agents/a2ui/
+    deterministic_refresh_dashboard.py`` uses for its synthetic-data demo.
+    Construction is cheap (no I/O): ``ConversationSQLiteBackend.__init__``
+    only stores the path; the schema is created lazily by its (async)
+    ``initialize()``, which callers invoke before first real use.
+
+    Returns:
+        A ready-to-use :class:`~parrot.storage.artifacts.ArtifactStore`.
+    """
+    from parrot.storage.artifacts import ArtifactStore
+    from parrot.storage.backends import build_overflow_store
+    from parrot.storage.backends.sqlite import ConversationSQLiteBackend
+
+    backend = ConversationSQLiteBackend(path=":memory:")
+    return ArtifactStore(backend, build_overflow_store())
+
+
+@register_agent(name="flex_dashboard")
+class FlexDashboard(NarrativeMixin, InfographicAuthoringMixin, PandasAgent):
+    """Flex program KPI + dashboard agent over six QuerySource datasets."""
+
+    agent_id: str = "flex_dashboard"
+    llm = "google:gemini-3.5-flash"
+    narrative_skill = "flex-narrative"
+
+    #: Directory-discovery opt-in (FEAT-420-derived pattern) — anchored to
+    #: this file's own location so `/widget`, `/infographic`, and
+    #: `flex-narrative` are found regardless of process cwd.
+    skill_paths: ClassVar[list[Path]] = [SKILLS_DIR]
+
+    DASHBOARD_RECIPE_NAME = "flex-program-dashboard"
+
+    def __init__(
+        self,
+        *args: Any,
+        tools: list[Any] | None = None,
+        artifact_store: Any | None = None,
+        recipe_store: Any | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Attach WorkingMemory + Infographic toolkits, enable kb + routing.
+
+        Args:
+            tools: Extra tools beyond the two attached here.
+            artifact_store: Optional pre-built ``ArtifactStore`` forwarded to
+                ``InfographicAuthoringMixin`` (which builds the
+                ``InfographicToolkit`` from it). Defaults to an offline-safe
+                local store (see :func:`_build_default_artifact_store`) so
+                the agent instantiates without network/DB.
+            recipe_store: Optional recipe store forwarded to
+                ``InfographicAuthoringMixin`` (enables ``publish_recipe``
+                tier-2 authoring and the toolkit's recipe tools).
+            **kwargs: Forwarded to the cooperative ``__init__`` chain.
+        """
+        tools = list(tools or [])
+        tools.append(WorkingMemoryToolkit())
+
+        super().__init__(
+            *args,
+            tools=tools,
+            artifact_store=artifact_store or _build_default_artifact_store(),
+            recipe_store=recipe_store,
+            output_routing=True,
+            use_kb=True,
+            llm=kwargs.pop("llm", None) or self.llm,
+            **kwargs,
+        )
+
+    async def register_datasets(self) -> None:
+        """Lazily register the six Flex QuerySource slugs (spec §2).
+
+        Uses ``DatasetManager.add_query`` — the genuinely lazy registration
+        path (registers a ``QuerySlugSource`` with NO fetch; data loads on
+        first ``fetch_dataset()``/REPL access). ``DatasetManager.add_dataset
+        (query_slug=...)`` is NOT used here: it fetches immediately (see the
+        Codebase Contract correction in this feature's TASK-2696), which
+        would violate "no eager fetch at construction/configure time".
+        """
+        self._dataset_manager.add_query(
+            name="msl",
+            query_slug=DATASET_SLUGS["msl"],
+            description=(
+                "Master Store List: district/region/market/account/store, "
+                "lat/lon, city, state. Used for Proximity Staffing."
+            ),
+            usage_guidance={"do": ["Proximity Staffing store-side geo lookups"]},
+        )
+        self._dataset_manager.add_query(
+            name="finance",
+            query_slug=DATASET_SLUGS["finance"],
+            description=(
+                "Monthly P&L per project: Revenue, PC Revenue, EBITDA, "
+                "Payroll, Travel and Expenses, Program Overhead Allocation, "
+                "Other Related Expenses, Total Hours, FTE, Visits. Currency "
+                "columns arrive as formatted strings."
+            ),
+            usage_guidance={
+                "do": [
+                    "Payroll / Revenue / Payroll % to Revenue by month",
+                    "FTE cross-check via Total Hours (never Worked Hours source)",
+                ],
+            },
+        )
+        self._dataset_manager.add_query(
+            name="hours",
+            query_slug=DATASET_SLUGS["hours"],
+            description=(
+                "Hours/wages by month, program, pay_code, cost_center."
+            ),
+            usage_guidance={
+                "do": [
+                    "Worked Hours by Month",
+                    "Pay Code Hours / Worked Hours by Pay Code Allocation",
+                ],
+            },
+        )
+        self._dataset_manager.add_query(
+            name="employees",
+            query_slug=DATASET_SLUGS["employees"],
+            description=(
+                "Employee roster with lat/lon, Flex Type, service tenure."
+            ),
+            usage_guidance={"do": ["Proximity Staffing employee-side geo lookups"]},
+        )
+        self._dataset_manager.add_query(
+            name="region_utilization",
+            query_slug=DATASET_SLUGS["region_utilization"],
+            description=(
+                "Regional monthly employee utilization (BOP/EOP dates); "
+                "precomputed Employee Utilization column."
+            ),
+            usage_guidance={
+                "do": ["Cross-check for recomputed Rep Utilization — never the source of truth"],
+            },
+        )
+        self._dataset_manager.add_query(
+            name="rep_utilization",
+            query_slug=DATASET_SLUGS["rep_utilization"],
+            description=(
+                "Rep utilization by region/state/category per month "
+                "(raw 'catagory' typo column)."
+            ),
+            usage_guidance={
+                "do": ["Rep Utilization = employees_worked / average_active, recomputed"],
+            },
+        )
+
+    async def _load_kb_docs(self) -> None:
+        """Load each ``agents/flex_dashboard/kb/*.md`` doc as one kb fact.
+
+        Requires ``self.kb_store`` to already exist (``use_kb=True`` in
+        ``__init__``). Called AFTER ``super().configure()`` so any facts
+        ``configure_kb()`` already added (from ``self._kb``, empty here)
+        are unaffected — this simply appends the file-based facts.
+        """
+        if not self.kb_store:
+            return
+        facts = []
+        for doc_path in sorted(KB_DIR.glob("*.md")):
+            facts.append(
+                {
+                    "content": doc_path.read_text(),
+                    "metadata": {"category": "kpi", "kpi": doc_path.stem},
+                }
+            )
+        if facts:
+            await self.kb_store.add_facts(facts)
+
+    async def configure(
+        self,
+        app: web.Application | None = None,
+        queries: list[str] | dict | None = None,
+    ) -> None:
+        """Register datasets, run base configuration, then load kb docs."""
+        await self.register_datasets()
+        await super().configure(app=app, queries=queries)
+        await self._load_kb_docs()

--- a/agents/flex_dashboard.py
+++ b/agents/flex_dashboard.py
@@ -174,9 +174,7 @@ class FlexDashboard(NarrativeMixin, InfographicAuthoringMixin, PandasAgent):
         self._dataset_manager.add_query(
             name="hours",
             query_slug=DATASET_SLUGS["hours"],
-            description=(
-                "Hours/wages by month, program, pay_code, cost_center."
-            ),
+            description=("Hours/wages by month, program, pay_code, cost_center."),
             usage_guidance={
                 "do": [
                     "Worked Hours by Month",
@@ -187,17 +185,14 @@ class FlexDashboard(NarrativeMixin, InfographicAuthoringMixin, PandasAgent):
         self._dataset_manager.add_query(
             name="employees",
             query_slug=DATASET_SLUGS["employees"],
-            description=(
-                "Employee roster with lat/lon, Flex Type, service tenure."
-            ),
+            description=("Employee roster with lat/lon, Flex Type, service tenure."),
             usage_guidance={"do": ["Proximity Staffing employee-side geo lookups"]},
         )
         self._dataset_manager.add_query(
             name="region_utilization",
             query_slug=DATASET_SLUGS["region_utilization"],
             description=(
-                "Regional monthly employee utilization (BOP/EOP dates); "
-                "precomputed Employee Utilization column."
+                "Regional monthly employee utilization (BOP/EOP dates); " "precomputed Employee Utilization column."
             ),
             usage_guidance={
                 "do": ["Cross-check for recomputed Rep Utilization — never the source of truth"],
@@ -206,10 +201,7 @@ class FlexDashboard(NarrativeMixin, InfographicAuthoringMixin, PandasAgent):
         self._dataset_manager.add_query(
             name="rep_utilization",
             query_slug=DATASET_SLUGS["rep_utilization"],
-            description=(
-                "Rep utilization by region/state/category per month "
-                "(raw 'catagory' typo column)."
-            ),
+            description=("Rep utilization by region/state/category per month " "(raw 'catagory' typo column)."),
             usage_guidance={
                 "do": ["Rep Utilization = employees_worked / average_active, recomputed"],
             },
@@ -355,13 +347,9 @@ class FlexDashboard(NarrativeMixin, InfographicAuthoringMixin, PandasAgent):
         """
         return [
             RecipeParam(name="month", default="", description="YYYY-MM filter."),
-            RecipeParam(
-                name="flex_type", default="", description="Employee Flex Type filter."
-            ),
+            RecipeParam(name="flex_type", default="", description="Employee Flex Type filter."),
             RecipeParam(name="pay_code", default="", description="Pay code filter."),
-            RecipeParam(
-                name="cost_center", default="", description="Cost center filter."
-            ),
+            RecipeParam(name="cost_center", default="", description="Cost center filter."),
             RecipeParam(
                 name="category",
                 default="",
@@ -575,9 +563,7 @@ class FlexDashboard(NarrativeMixin, InfographicAuthoringMixin, PandasAgent):
                                                 {"name": "latitude"},
                                                 {"name": "longitude"},
                                             ],
-                                            "data": {
-                                                "path": "/proximity_staffing/employee_layer"
-                                            },
+                                            "data": {"path": "/proximity_staffing/employee_layer"},
                                         },
                                     ],
                                 },
@@ -635,15 +621,9 @@ class RefreshDashboardArgs(AbstractToolArgsSchema):
     flex_type: str | None = Field(default=None, description="Employee Flex Type filter.")
     pay_code: str | None = Field(default=None, description="Pay code filter.")
     cost_center: str | None = Field(default=None, description="Cost center filter.")
-    category: str | None = Field(
-        default=None, description="Rep utilization category filter."
-    )
-    radius_miles: float | None = Field(
-        default=None, description="Proximity Staffing coverage radius, miles."
-    )
-    nearest_n: int | None = Field(
-        default=None, description="Proximity Staffing nearest-N count."
-    )
+    category: str | None = Field(default=None, description="Rep utilization category filter.")
+    radius_miles: float | None = Field(default=None, description="Proximity Staffing coverage radius, miles.")
+    nearest_n: int | None = Field(default=None, description="Proximity Staffing nearest-N count.")
 
 
 class RefreshDashboardTool(AbstractTool):
@@ -703,15 +683,16 @@ class RefreshDashboardTool(AbstractTool):
             if value is not None:
                 params[key] = value
 
-        artifact = await self._runner.run(
-            FlexDashboard.DASHBOARD_RECIPE_NAME, params=params, pctx=self._pctx
-        )
+        artifact = await self._runner.run(FlexDashboard.DASHBOARD_RECIPE_NAME, params=params, pctx=self._pctx)
         return {
             "filters": params,
-            "filter_source": "args" if any(
-                v is not None
-                for v in (month, flex_type, pay_code, cost_center, category, radius_miles, nearest_n)
-            ) else ("surface_state" if state_filters else "defaults"),
+            "filter_source": (
+                "args"
+                if any(
+                    v is not None for v in (month, flex_type, pay_code, cost_center, category, radius_miles, nearest_n)
+                )
+                else ("surface_state" if state_filters else "defaults")
+            ),
             "artifact_id": artifact.artifact_id,
             "bytes": len(artifact.content or b""),
         }

--- a/agents/flex_dashboard.py
+++ b/agents/flex_dashboard.py
@@ -27,8 +27,17 @@ from typing import Any, ClassVar
 from aiohttp import web
 from parrot.bots.data import PandasAgent
 from parrot.bots.mixins import InfographicAuthoringMixin, NarrativeMixin
+from parrot.outputs.a2ui.recipes.models import LayoutSpec, NarrativeSpec, RecipeParam
 from parrot.registry import register_agent
+from parrot.tools.abstract import (
+    AbstractTool,
+    AbstractToolArgsSchema,
+    current_a2ui_surface_state,
+)
+from parrot.tools.infographic_recipes.runner import RecipeRunner
+from parrot.tools.infographic_sections import SectionDescriptor, SectionSpec
 from parrot.tools.working_memory import WorkingMemoryToolkit
+from pydantic import Field
 
 # Import side effect ONLY: registers the Flex transformers (payroll_hero,
 # worked_hours_by_month, ..., flex_narrative_facts) on the shared
@@ -236,3 +245,444 @@ class FlexDashboard(NarrativeMixin, InfographicAuthoringMixin, PandasAgent):
         await self.register_datasets()
         await super().configure(app=app, queries=queries)
         await self._load_kb_docs()
+
+    # ── Dashboard recipe (TASK-2697, spec §3 Module 4) ──────────────────
+
+    @classmethod
+    def _transform_sections(cls) -> list[SectionSpec]:
+        """Sections whose NAMES are registered transformer names.
+
+        Order matters: ``publish_recipe`` preserves ``descriptor.sections``
+        order into ``TransformStep`` order, and ``flex_narrative_facts``
+        consumes the other steps' outputs — it must come last
+        (FinanceReporter pattern, ``agents/finance_reporter.py:189-223``).
+        """
+        return [
+            SectionSpec(
+                name="payroll_hero",
+                target="/payroll_hero",
+                datasets=["hours", "finance"],
+                shape="mapping",
+            ),
+            SectionSpec(
+                name="worked_hours_by_month",
+                target="/worked_hours_by_month",
+                datasets=["hours"],
+                shape="mapping",
+            ),
+            SectionSpec(
+                name="payroll_by_month",
+                target="/payroll_by_month",
+                datasets=["finance"],
+                shape="mapping",
+            ),
+            SectionSpec(
+                name="revenue_by_month",
+                target="/revenue_by_month",
+                datasets=["finance"],
+                shape="mapping",
+            ),
+            SectionSpec(
+                name="payroll_pct_by_month",
+                target="/payroll_pct_by_month",
+                datasets=["finance"],
+                shape="mapping",
+            ),
+            SectionSpec(
+                name="pay_code_hours",
+                target="/pay_code_hours",
+                datasets=["hours"],
+                shape="mapping",
+            ),
+            SectionSpec(
+                name="pay_code_allocation",
+                target="/pay_code_allocation",
+                datasets=["hours"],
+                shape="mapping",
+            ),
+            SectionSpec(
+                name="rep_utilization_by_region",
+                target="/rep_utilization_by_region",
+                datasets=["rep_utilization", "region_utilization"],
+                shape="mapping",
+            ),
+            SectionSpec(
+                name="proximity_staffing",
+                target="/proximity_staffing",
+                datasets=["msl", "employees"],
+                shape="mapping",
+            ),
+            SectionSpec(
+                name="flex_narrative_facts",
+                target="/flex_narrative_facts",
+                # Prior-step output_keys, NOT dataset aliases — the generic
+                # shape resolved in FEAT-420 Module 1 (spec §2 Overview).
+                datasets=["payroll_hero", "worked_hours_by_month", "rep_utilization_by_region"],
+                shape="mapping",
+            ),
+        ]
+
+    @classmethod
+    def _narrative_spec(cls) -> NarrativeSpec:
+        """Declarative narrative step — optional, replays with no narrator."""
+        return NarrativeSpec(skill=cls.narrative_skill, facts_key="flex_narrative_facts")
+
+    #: Descriptor-level ``{param}`` templates, applied IDENTICALLY to every
+    #: ``TransformStep`` by ``publish_recipe`` — each transformer only reads
+    #: the keys it declared support for (per-section filter rule, spec
+    #: proposal U1, enforced in ``agents/flex_dashboard/transformers.py``).
+    _RECIPE_PARAM_TEMPLATE: ClassVar[dict[str, str]] = {
+        "month": "{month}",
+        "flex_type": "{flex_type}",
+        "pay_code": "{pay_code}",
+        "cost_center": "{cost_center}",
+        "category": "{category}",
+        "radius_miles": "{radius_miles}",
+        "nearest_n": "{nearest_n}",
+    }
+
+    @classmethod
+    def recipe_params(cls) -> list[RecipeParam]:
+        """Declared, overridable filter params for the published recipe.
+
+        ``resolve_params`` (``parrot.outputs.a2ui.recipes.params``) raises
+        when a declared param has no default AND no override is supplied —
+        every param below therefore needs a concrete, non-``None`` default.
+        Optional filters default to ``""``, which
+        ``agents/flex_dashboard/transformers.py``'s ``_apply_filters``
+        treats the same as "unset" (falsy check) — the sentinel that makes
+        an unfiltered replay work with no caller-supplied overrides.
+        """
+        return [
+            RecipeParam(name="month", default="", description="YYYY-MM filter."),
+            RecipeParam(
+                name="flex_type", default="", description="Employee Flex Type filter."
+            ),
+            RecipeParam(name="pay_code", default="", description="Pay code filter."),
+            RecipeParam(
+                name="cost_center", default="", description="Cost center filter."
+            ),
+            RecipeParam(
+                name="category",
+                default="",
+                description="Rep utilization category filter.",
+            ),
+            RecipeParam(
+                name="radius_miles",
+                default="50",
+                description="Proximity Staffing coverage radius, miles.",
+            ),
+            RecipeParam(
+                name="nearest_n",
+                default="3",
+                description="Proximity Staffing nearest-N count.",
+            ),
+        ]
+
+    @classmethod
+    def dashboard_descriptor(cls) -> SectionDescriptor:
+        """Flex program dashboard: hero row + month series + pay-code +
+        utilization + proximity sections, LayoutSpec v2."""
+        return SectionDescriptor(
+            template="unused-with-layout",  # layout below is used verbatim
+            mode="data-splice",
+            sections=cls._transform_sections(),
+            params=dict(cls._RECIPE_PARAM_TEMPLATE),
+            # v2 LayoutSpec (FEAT-470 TASK-2542): props top-level, `{"path"}`
+            # bindings; nested Infographic section-component descriptors
+            # keep their OWN "properties" wrapper (the composite's own
+            # authored-descriptor shape, not the wire Component shape
+            # LayoutSpec mirrors — agents/finance_reporter.py:267-273
+            # comment); a binding's `optional` marker moves to the layout's
+            # own `metadata.extensions.parrot_optional`.
+            layout=LayoutSpec(
+                component="Infographic",
+                title="Flex Program Dashboard",
+                sections=[
+                    {
+                        "heading": "Payroll Contribution — Hero",
+                        "components": [
+                            {
+                                "component": "KPICard",
+                                "properties": {
+                                    "label": "Worked Hours",
+                                    "value": {"path": "/payroll_hero/worked_hours_total"},
+                                },
+                            },
+                            {
+                                "component": "KPICard",
+                                "properties": {
+                                    "label": "Payroll",
+                                    "value": {"path": "/payroll_hero/payroll_total"},
+                                },
+                            },
+                            {
+                                "component": "KPICard",
+                                "properties": {
+                                    "label": "P&L Revenue",
+                                    "value": {"path": "/payroll_hero/revenue_total"},
+                                },
+                            },
+                            {
+                                "component": "KPICard",
+                                "properties": {
+                                    "label": "Payroll % to Revenue",
+                                    "value": {"path": "/payroll_hero/payroll_pct"},
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        "heading": "Payroll Contribution — Month Series",
+                        "components": [
+                            {
+                                "component": "Chart",
+                                "properties": {
+                                    "title": "Worked Hours by Month",
+                                    "type": "line",
+                                    "x": "month",
+                                    "y": ["worked_hours"],
+                                    "data": {"path": "/worked_hours_by_month/series"},
+                                },
+                            },
+                            {
+                                "component": "Chart",
+                                "properties": {
+                                    "title": "Payroll by Month",
+                                    "type": "line",
+                                    "x": "month",
+                                    "y": ["payroll"],
+                                    "data": {"path": "/payroll_by_month/series"},
+                                },
+                            },
+                            {
+                                "component": "Chart",
+                                "properties": {
+                                    "title": "P&L Revenue by Month",
+                                    "type": "line",
+                                    "x": "month",
+                                    "y": ["revenue"],
+                                    "data": {"path": "/revenue_by_month/series"},
+                                },
+                            },
+                            {
+                                "component": "Chart",
+                                "properties": {
+                                    "title": "Payroll % to Revenue by Month",
+                                    "type": "line",
+                                    "x": "month",
+                                    "y": ["payroll_pct"],
+                                    "data": {"path": "/payroll_pct_by_month/series"},
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        "heading": "Pay Code",
+                        "components": [
+                            {
+                                "component": "DataTable",
+                                "properties": {
+                                    "columns": [{"name": "pay_code"}, {"name": "hours"}],
+                                    "data": {"path": "/pay_code_hours/records"},
+                                },
+                            },
+                            {
+                                "component": "DataTable",
+                                "properties": {
+                                    "columns": [
+                                        {"name": "pay_code"},
+                                        {"name": "hours"},
+                                        {"name": "share_pct"},
+                                    ],
+                                    "data": {"path": "/pay_code_allocation/records"},
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        "heading": "Rep Utilization",
+                        "components": [
+                            {
+                                "component": "DataTable",
+                                "properties": {
+                                    "columns": [
+                                        {"name": "region"},
+                                        {"name": "category"},
+                                        {"name": "month"},
+                                        {"name": "utilization"},
+                                        {"name": "cross_check_utilization"},
+                                    ],
+                                    "data": {"path": "/rep_utilization_by_region/records"},
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        "heading": "Proximity Staffing",
+                        "text": {"path": "/narrative"},
+                        "components": [
+                            {
+                                "component": "Map",
+                                "properties": {
+                                    "title": "Store & Employee Proximity",
+                                    "layers": [
+                                        {
+                                            "layer": "stores",
+                                            "labelField": "store_name",
+                                            "markerColor": "#1f77b4",
+                                            "dataShape": "rows",
+                                            "columns": [
+                                                {"name": "store_name"},
+                                                {"name": "latitude"},
+                                                {"name": "longitude"},
+                                            ],
+                                            "data": {"path": "/proximity_staffing/store_layer"},
+                                        },
+                                        {
+                                            "layer": "employees",
+                                            "labelField": "display_name",
+                                            "markerColor": "#ff7f0e",
+                                            "dataShape": "rows",
+                                            "columns": [
+                                                {"name": "display_name"},
+                                                {"name": "latitude"},
+                                                {"name": "longitude"},
+                                            ],
+                                            "data": {
+                                                "path": "/proximity_staffing/employee_layer"
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                            {
+                                "component": "DataTable",
+                                "properties": {
+                                    "columns": [
+                                        {"name": "store_name"},
+                                        {"name": "nearest_employees"},
+                                        {"name": "employees_within_radius"},
+                                    ],
+                                    "data": {"path": "/proximity_staffing/coverage"},
+                                },
+                            },
+                        ],
+                    },
+                ],
+                metadata={"extensions": {"parrot_optional": ["/narrative"]}},
+            ),
+            narrative=cls._narrative_spec(),
+        )
+
+    # ── Refresh lane (FEAT-469 pattern) ─────────────────────────────────
+
+    def build_refresh_tool(self, pctx: Any) -> RefreshDashboardTool:
+        """Build and register the ``refresh_dashboard`` tool.
+
+        Requires a recipe store to already be wired (``recipe_store=`` at
+        construction, or a toolkit configured with one) — raises via
+        ``_require_recipe_store()`` otherwise.
+
+        Args:
+            pctx: A real ``PermissionContext`` (e.g. from
+                ``build_principal_context``). ``RecipeRunner.run`` fails
+                OPEN on a falsy ``pctx`` (its own docstring warning) — never
+                pass ``None`` here.
+
+        Returns:
+            The registered :class:`RefreshDashboardTool` instance.
+        """
+        runner = RecipeRunner(self._require_recipe_store(), self._dataset_manager)
+        tool = RefreshDashboardTool(runner=runner, pctx=pctx)
+        self.tool_manager.add_tool(tool)
+        return tool
+
+
+class RefreshDashboardArgs(AbstractToolArgsSchema):
+    """Arguments the renderer may pass on ``callAgentFunction``."""
+
+    month: str | None = Field(default=None, description="YYYY-MM filter.")
+    flex_type: str | None = Field(default=None, description="Employee Flex Type filter.")
+    pay_code: str | None = Field(default=None, description="Pay code filter.")
+    cost_center: str | None = Field(default=None, description="Cost center filter.")
+    category: str | None = Field(
+        default=None, description="Rep utilization category filter."
+    )
+    radius_miles: float | None = Field(
+        default=None, description="Proximity Staffing coverage radius, miles."
+    )
+    nearest_n: int | None = Field(
+        default=None, description="Proximity Staffing nearest-N count."
+    )
+
+
+class RefreshDashboardTool(AbstractTool):
+    """Deterministically re-render the Flex dashboard, optionally filtered.
+
+    Filter precedence per call (FEAT-469 example pattern): explicit args
+    (the renderer's inline filter widget) → the surface's last persisted
+    ``dataModel.filters`` (read via ``current_a2ui_surface_state()``) →
+    the recipe's own declared defaults (empty-string "no filter" / 50 / 3).
+    """
+
+    name = "refresh_dashboard"
+    description = (
+        "Re-render the Flex program dashboard deterministically via its "
+        "published recipe. Optional filters: month, flex_type, pay_code, "
+        "cost_center, category, radius_miles, nearest_n."
+    )
+    args_schema = RefreshDashboardArgs
+
+    def __init__(self, runner: RecipeRunner, pctx: Any, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._runner = runner
+        self._pctx = pctx
+
+    async def _execute(
+        self,
+        month: str | None = None,
+        flex_type: str | None = None,
+        pay_code: str | None = None,
+        cost_center: str | None = None,
+        category: str | None = None,
+        radius_miles: float | None = None,
+        nearest_n: int | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        state = current_a2ui_surface_state()
+        state_filters: dict[str, Any] = {}
+        if state is not None:
+            state_filters = dict(state.data_model.get("filters") or {})
+
+        def _pick(arg: Any, key: str) -> Any:
+            if arg is not None:
+                return arg
+            return state_filters.get(key)
+
+        params: dict[str, Any] = {}
+        for key, arg in (
+            ("month", month),
+            ("flex_type", flex_type),
+            ("pay_code", pay_code),
+            ("cost_center", cost_center),
+            ("category", category),
+            ("radius_miles", radius_miles),
+            ("nearest_n", nearest_n),
+        ):
+            value = _pick(arg, key)
+            if value is not None:
+                params[key] = value
+
+        artifact = await self._runner.run(
+            FlexDashboard.DASHBOARD_RECIPE_NAME, params=params, pctx=self._pctx
+        )
+        return {
+            "filters": params,
+            "filter_source": "args" if any(
+                v is not None
+                for v in (month, flex_type, pay_code, cost_center, category, radius_miles, nearest_n)
+            ) else ("surface_state" if state_filters else "defaults"),
+            "artifact_id": artifact.artifact_id,
+            "bytes": len(artifact.content or b""),
+        }

--- a/agents/flex_dashboard.py
+++ b/agents/flex_dashboard.py
@@ -520,7 +520,33 @@ class FlexDashboard(NarrativeMixin, InfographicAuthoringMixin, PandasAgent):
                     },
                     {
                         "heading": "Proximity Staffing",
-                        "text": {"path": "/narrative"},
+                        # NOTE (TASK-2699 finding): NOT binding a "text":
+                        # {"path": "/narrative"} field here, unlike
+                        # FinanceReporter's identical-looking pattern
+                        # (finance_reporter.py's "Top Movers" section) —
+                        # `RecipeRunner._assemble_envelope_or_raise`'s
+                        # Infographic path (`build_infographic` ->
+                        # `build_surface`) never threads `layout.metadata`
+                        # (and therefore never `metadata.extensions.
+                        # parrot_optional`) onto the built wire `Component`,
+                        # so ANY layout-level binding to an absent
+                        # `/narrative` key raises `BakeError` unconditionally
+                        # at render time — regardless of the optional-paths
+                        # declared on `LayoutSpec.metadata`. This is a
+                        # pre-existing, cross-cutting core bug (confirmed
+                        # reproducible on `dev`, unrelated to FEAT-491):
+                        # FinanceReporter's OWN e2e tests for this exact
+                        # behavior — `test_dashboard_profile_replay` AND
+                        # `test_report_profile_replay_no_narrator` — are
+                        # BOTH independently broken by it too. Filing a fix
+                        # in core is out of this feature's scope (spec §1
+                        # Non-Goals: "No changes to core packages"); the
+                        # `narrative=` `NarrativeSpec` below is kept (a
+                        # narrator, if ever configured, still runs and
+                        # populates `/narrative` in the data model — it
+                        # just is not bound anywhere in this layout, so its
+                        # ABSENCE never triggers the runner's broken
+                        # optional-binding check in the first place).
                         "components": [
                             {
                                 "component": "Map",
@@ -570,7 +596,10 @@ class FlexDashboard(NarrativeMixin, InfographicAuthoringMixin, PandasAgent):
                         ],
                     },
                 ],
-                metadata={"extensions": {"parrot_optional": ["/narrative"]}},
+                # No `metadata.extensions.parrot_optional` entry: nothing in
+                # this layout binds `/narrative` (see the Proximity Staffing
+                # section's NOTE above) — there is no optional pointer to
+                # declare.
             ),
             narrative=cls._narrative_spec(),
         )

--- a/agents/flex_dashboard/__init__.py
+++ b/agents/flex_dashboard/__init__.py
@@ -1,0 +1,15 @@
+"""``agents/flex_dashboard`` — asset package for the Flex A2UI dashboard agent.
+
+Companion package to ``agents/flex_dashboard.py`` (FEAT-491), mirroring the
+file+directory coexistence pattern used by ``agents/porygon.py`` /
+``agents/finance_reporter.py``. Contains:
+
+- :mod:`agents.flex_dashboard.normalize` — pure input canonicalization
+  (currency parsing, month-grain alignment, column renames).
+- :mod:`agents.flex_dashboard.transformers` — registered
+  ``@infographic_transformer`` functions (TASK-2694).
+- ``skills/`` — composite skill definitions (TASK-2698).
+- ``kb/`` — knowledge-base markdown documents, one per KPI (TASK-2695).
+"""
+
+from __future__ import annotations

--- a/agents/flex_dashboard/__init__.py
+++ b/agents/flex_dashboard/__init__.py
@@ -1,8 +1,20 @@
 """``agents/flex_dashboard`` — asset package for the Flex A2UI dashboard agent.
 
-Companion package to ``agents/flex_dashboard.py`` (FEAT-491), mirroring the
-file+directory coexistence pattern used by ``agents/porygon.py`` /
-``agents/finance_reporter.py``. Contains:
+Companion package to ``agents/flex_dashboard.py`` (FEAT-491) — the two
+share the same name at the same level of ``agents/``. Two corrections to
+this package's original citation (external code-review findings, adopted;
+see ``agents/flex_dashboard.py``'s module docstring for the full
+consequence of this naming collision):
+
+- ``agents/finance_reporter.py`` has NO sibling ``agents/finance_reporter/``
+  directory — the spec's "same file+directory coexistence pattern" citation
+  of it is inaccurate; FinanceReporter is a single file.
+- ``agents/porygon.py`` + ``agents/porygon/`` are NOT tracked in git
+  (``/agents/`` is blanket-ignored and neither was ever force-added) — they
+  exist only in one developer's local working tree, so this precedent is
+  unverifiable from a fresh clone or in CI.
+
+Contains:
 
 - :mod:`agents.flex_dashboard.normalize` — pure input canonicalization
   (currency parsing, month-grain alignment, column renames).

--- a/agents/flex_dashboard/kb/datasets.md
+++ b/agents/flex_dashboard/kb/datasets.md
@@ -1,0 +1,88 @@
+# Flex Datasets Reference
+
+## Definition
+
+The six QuerySource slugs the `flex_dashboard` agent registers on its
+`DatasetManager`, their stable aliases, grains, and known data quirks. The
+aliases below are FROZEN (spec §2) — every transformer hard-codes its
+input frame key to these exact names.
+
+## Formula
+
+Alias resolution (slug -> alias -> content):
+
+| Alias | Slug | Content |
+|---|---|---|
+| `msl` | `flex_msl_brian_bi` | Master Store List (district/region/market/account/store, lat/lon) |
+| `finance` | `Finance_results_bi` | Monthly P&L per project (currency strings, `month` month-end) |
+| `hours` | `flex_hours_query_pbi` | Hours/wages by month, program, pay_code, cost_center |
+| `employees` | `flex_empolyees_brian_bi` | Employee roster with lat/lon, Flex Type, tenure |
+| `region_utilization` | `fm_regions_avg_employees_html` | Regional monthly employee utilization (BOP/EOP dates) |
+| `rep_utilization` | `fm_rep_utilization` | Rep utilization by region/state/category (has `catagory` typo column) |
+
+## Source columns
+
+See `payroll_contribution.md`, `pay_code_allocation.md`,
+`rep_utilization.md`, and `proximity_staffing.md` for the per-KPI column
+lists. In brief:
+
+- `msl`: `district_name`, `region_name`, `market_name`, `account_name`,
+  `store_name`, `latitude`, `longitude`, `city`, `state_code`.
+- `finance`: `project`, `month`, `Revenue`, `PC Revenue`, `EBITDA`,
+  `Payroll`, `Travel and Expenses`, `Program Overhead Allocation`,
+  `Other Related Expenses`, `Total Hours`, `FTE`, `Visits`.
+- `hours`: `month_start`, `month_end`, `program`, `pay_code`,
+  `cost_center`, `hours`, `wages`.
+- `employees`: `display_name`, `start_date`, `job_code_title`,
+  `legal_city`, `legal_state`, `zipcode`, `latitude`, `longitude`,
+  `Flex Employees`, `Flex Type`, tenure fields.
+- `region_utilization`: `BOP Date`, `EOP Date`, `FM Region`,
+  `State Code`, `State`, `Category`, `Employees Worked`,
+  `Average Active Employees`, `Flex Employees`, `Employee Utilization`.
+- `rep_utilization`: `bop_date`, `eop_date`, `region`, `state`,
+  `catagory`, `hours_worked`, `work_shifts`, `employees_worked`,
+  `average_active`.
+
+## Normalization rules
+
+Three quirks, ALL handled centrally by
+`agents/flex_dashboard/normalize.py` — never inline in a transformer:
+
+1. **Currency strings** — `finance`'s money columns arrive as formatted
+   strings (`"$137,456.85"`, negatives `"-$44,621.24"`), parsed by
+   `parse_currency` / `normalize_currency_columns`.
+2. **Three date-grain conventions** — `finance.month` (month-end date),
+   `hours.month_start` (month-start date), and the `fm_*` datasets'
+   `BOP Date`/`bop_date` (period-start date) — all resolved to one
+   canonical `"YYYY-MM"` `month` column via `month_period`.
+3. **Header casing / typos** — `fm_rep_utilization`'s `catagory` typo
+   column, and `fm_regions_avg_employees_html` / `flex_empolyees_brian_bi`'s
+   Title/Space-Case headers, are canonicalized to snake_case via
+   `canonicalize_columns`.
+
+## Filters
+
+Filters are **per-section** (proposal U1): a filter only applies to
+sections whose dataset actually carries that column.
+
+| Filter | Applies to (dataset) |
+|---|---|
+| `month` | `finance`, `hours`, `region_utilization`, `rep_utilization` (all, after `month_period`) |
+| `pay_code` | `hours` only |
+| `cost_center` | `hours` only |
+| `flex_type` | `employees` only |
+| `category` | `region_utilization`, `rep_utilization` only (after canonicalization) |
+| `radius_miles` / `nearest_n` | Proximity Staffing (`msl` + `employees`) only |
+
+A `flex_type` or `category` filter must never reach or alter a
+finance-only section (`payroll_by_month`, `revenue_by_month`,
+`payroll_pct_by_month`) — those transformers only ever read the `month`
+param.
+
+## Worked example
+
+Resolving `hours` end to end: slug `flex_hours_query_pbi` -> alias
+`hours` -> sample row `{"month_start": "2025-10-01", "pay_code": "Admin Time",
+"cost_center": "Flex", "hours": 30.199996}` -> after `month_period(source="hours")`
+the row carries `month="2025-10"`, ready for `worked_hours_by_month` /
+`pay_code_hours` / `pay_code_allocation` to group over.

--- a/agents/flex_dashboard/kb/pay_code_allocation.md
+++ b/agents/flex_dashboard/kb/pay_code_allocation.md
@@ -1,0 +1,54 @@
+# Pay Code Hours / Worked Hours by Pay Code Allocation
+
+## Definition
+
+Two related sections over the `hours` dataset (`flex_hours_query_pbi`):
+Pay Code Hours (a per-pay-code hours listing) and Worked Hours by Pay Code
+Allocation (each pay_code's share of total worked hours).
+
+## Formula
+
+- **Pay Code Hours** — for each `pay_code`, `sum(hours)` (optionally
+  narrowed by `month`/`cost_center`, or to a single `pay_code`).
+- **Worked Hours by Pay Code Allocation** — for each `pay_code`:
+  `share_pct = sum(hours for that pay_code) / sum(hours, all pay codes) * 100`
+  (optionally narrowed by `month`/`cost_center`; NOT by a single `pay_code`,
+  since allocation is inherently a breakdown ACROSS pay codes).
+
+## Source columns
+
+`hours` (`flex_hours_query_pbi`): `month_start`, `month_end`, `program`,
+`pay_code`, `cost_center`, `hours`, `wages`.
+
+## Normalization rules
+
+Month grain: `month_start` resolves to the canonical `"YYYY-MM"` period key
+via `normalize.month_period(source="hours")`. `hours`/`wages` are already
+numeric — no currency parsing needed for this dataset.
+
+## Filters
+
+Per-section filter rule:
+
+- Pay Code Hours: `month`, `pay_code`, `cost_center` — all supported by the
+  `hours` dataset.
+- Worked Hours by Pay Code Allocation: `month`, `cost_center` only (a
+  `pay_code` filter would make the "allocation across pay codes" question
+  meaningless).
+
+## Worked example
+
+From the sample row (`sdd/state/FEAT-517/source.md`):
+
+```json
+{"month_start": "2025-10-01", "pay_code": "Admin Time", "cost_center": "Flex", "hours": 30.199996}
+```
+
+Pay Code Hours (2025-10): `Admin Time` = `30.199996`.
+
+Worked Hours by Pay Code Allocation (2025-10): with only this one sample
+row available, `Admin Time` is the sole pay code present, so its share is
+`30.199996 / 30.199996 * 100 = 100.0%`. With additional pay codes present
+(e.g. a second `"Field Time"` row), each pay code's share is its own hours
+divided by the sum of ALL pay codes' hours in the filtered window,
+expressed as a percentage.

--- a/agents/flex_dashboard/kb/payroll_contribution.md
+++ b/agents/flex_dashboard/kb/payroll_contribution.md
@@ -1,0 +1,65 @@
+# Payroll Contribution
+
+## Definition
+
+KPIs describing the Flex program's monthly Payroll Contribution: Worked
+Hours, Payroll, P&L Revenue, and Payroll % to Revenue. Sourced from the
+`hours` (`flex_hours_query_pbi`) and `finance` (`Finance_results_bi`)
+datasets.
+
+## Formula
+
+- **Worked Hours** = `sum(hours.hours)`. Pay-code and cost-center
+  filterable. `finance.Total Hours` is a related field used ONLY as an
+  independent FTE cross-check — it is never the source of Worked Hours.
+- **Payroll** = `sum(finance.Payroll)`, by month.
+- **P&L Revenue** = `sum(finance.Revenue)`, by month.
+- **Payroll % to Revenue** = `sum(Payroll) / sum(Revenue)`. The denominator
+  is **Revenue ALONE** — never `Revenue + PC Revenue`. This is a resolved,
+  pinned formula (spec §2 Q&A); do not substitute a different denominator
+  even though `PC Revenue` is a sibling column in the same dataset.
+
+## Source columns
+
+- `hours` (`flex_hours_query_pbi`): `month_start`, `month_end`, `program`,
+  `pay_code`, `cost_center`, `hours`, `wages`.
+- `finance` (`Finance_results_bi`): `project`, `month` (month-end date),
+  `Revenue`, `PC Revenue`, `Payroll`, and other P&L columns (currency
+  strings).
+
+## Normalization rules
+
+- `finance`'s `Revenue`/`Payroll`/etc. arrive as formatted currency strings
+  (e.g. `"$137,456.85"`, negatives `"-$44,621.24"`) — parsed via
+  `agents/flex_dashboard/normalize.parse_currency` before any arithmetic.
+- Month grain: `finance.month` is a month-END date (e.g. `"2025-10-31"`);
+  `hours.month_start` is a month-START date (e.g. `"2025-10-01"`). Both
+  resolve to the same canonical `"2025-10"` period key via
+  `normalize.month_period`.
+
+## Filters
+
+Per-section filter rule: a filter only applies to sections whose dataset
+carries that column.
+
+- Worked Hours / Pay Code sections (`hours` dataset): `month`, `pay_code`,
+  `cost_center`.
+- Payroll / Revenue / Payroll % sections (`finance` dataset): `month` only
+  — `finance` has no `pay_code`/`cost_center` column, so those filters
+  never reach it.
+
+## Worked example
+
+From the sample rows (`sdd/state/FEAT-517/source.md`):
+
+- `finance` row: `month="2025-10-31"`, `Revenue="$137,456.85"`,
+  `Payroll="$20,682.27"`.
+- `hours` row: `month_start="2025-10-01"`, `hours=30.199996`.
+
+Computed:
+
+- Worked Hours (2025-10) = `30.199996`.
+- Payroll (2025-10) = `20682.27`.
+- P&L Revenue (2025-10) = `137456.85`.
+- Payroll % to Revenue (2025-10) = `20682.27 / 137456.85` = `0.15046372734425384`
+  (≈ 15.05%).

--- a/agents/flex_dashboard/kb/proximity_staffing.md
+++ b/agents/flex_dashboard/kb/proximity_staffing.md
@@ -1,0 +1,68 @@
+# Proximity Staffing
+
+## Definition
+
+Compares the Master Store List (`flex_msl_brian_bi`) against the Employee
+roster (`flex_empolyees_brian_bi`) by geographic proximity: for each store,
+the nearest-N employees and a coverage count within a radius threshold.
+
+## Formula
+
+For each store in `msl`:
+
+1. Compute the great-circle (haversine) distance in miles from the store's
+   `(latitude, longitude)` to every employee's `(latitude, longitude)`.
+2. **Nearest-N employees** = the `nearest_n` (default `3`) closest
+   employees by distance, regardless of the radius threshold.
+3. **Coverage count** = the number of employees whose distance to the
+   store is `<= radius_miles` (default `50`).
+
+Output shape: a store map layer, an employee map layer, and a per-store
+coverage table (`nearest_employees` + `employees_within_radius`).
+
+Haversine distance (miles), Earth radius `R = 3958.8`:
+
+```
+a = sin²(Δφ/2) + cos(φ1)·cos(φ2)·sin²(Δλ/2)
+c = 2·atan2(√a, √(1−a))
+distance = R · c
+```
+
+## Source columns
+
+- `msl` (`flex_msl_brian_bi`): `district_name`, `region_name`,
+  `market_name`, `account_name`, `store_name`, `latitude`, `longitude`,
+  `city`, `state_code`.
+- `employees` (`flex_empolyees_brian_bi`): `display_name`, `latitude`,
+  `longitude`, `Flex Type`, plus tenure fields.
+
+## Normalization rules
+
+`employees`' `Flex Type` (and other Title/Space-Case headers) are
+canonicalized to `flex_type` (snake_case) via
+`normalize.canonicalize_columns(source="employees")` before any
+`flex_type` filter is applied. Coordinates are used as-is (already
+numeric, no currency/date handling needed).
+
+## Filters
+
+- `radius_miles` (default `50`) — the coverage-count threshold.
+- `nearest_n` (default `3`) — how many nearest employees to list per store.
+- `flex_type` — narrows the employee layer (and therefore the coverage
+  computation) to a single Flex Type; never applies to the store layer,
+  which has no `flex_type` column.
+
+## Worked example
+
+From the sample rows (`sdd/state/FEAT-517/source.md`):
+
+- Store: `T-Mobile 3SFD Norridge IL`, `latitude=41.95535`,
+  `longitude=-87.80886` (Norridge, IL).
+- Employee: `Abby Halladay`, `latitude=39.9222285`, `longitude=-75.414058`
+  (Media, PA).
+
+Haversine distance between these two points ≈ `661.38` miles (computed via
+the formula above, `R = 3958.8`). With only this single employee sample
+row, that single-store, single-employee pair IS the entire nearest-N list
+for `T-Mobile 3SFD Norridge IL` when `nearest_n >= 1`, and — since
+`661.38 > 50` — `employees_within_radius = 0` for the default radius.

--- a/agents/flex_dashboard/kb/rep_utilization.md
+++ b/agents/flex_dashboard/kb/rep_utilization.md
@@ -1,0 +1,65 @@
+# Rep (Representative) Utilization
+
+## Definition
+
+Utilization of Flex representatives by region/category/month, RECOMPUTED
+from `fm_rep_utilization`. `fm_regions_avg_employees_html`'s precomputed
+`Employee Utilization` column is surfaced only as a cross-check, never as
+the source of truth (spec §2 resolved Q&A).
+
+## Formula
+
+**Rep Utilization** = `employees_worked / average_active`, recomputed per
+region/category/month from `rep_utilization` (`fm_rep_utilization`).
+
+The `region_utilization` (`fm_regions_avg_employees_html`) dataset's
+precomputed `Employee Utilization` column is attached alongside the
+recomputed value, when a matching (region, category, month) row exists, as
+`cross_check_utilization` — a validation signal, not the authoritative
+number. If the two diverge materially, trust the recomputed value and flag
+the discrepancy; never silently prefer the precomputed column.
+
+## Source columns
+
+- `rep_utilization` (`fm_rep_utilization`): `bop_date`, `eop_date`,
+  `region`, `state`, `catagory` (raw typo — see Normalization rules),
+  `hours_worked`, `work_shifts`, `employees_worked`, `average_active`.
+- `region_utilization` (`fm_regions_avg_employees_html`): `BOP Date`,
+  `EOP Date`, `FM Region`, `State Code`, `State`, `Category`,
+  `Employees Worked`, `Average Active Employees`, `Flex Employees`,
+  `Employee Utilization`.
+
+## Normalization rules
+
+- `fm_rep_utilization` ships a **`catagory`** typo column — canonicalized
+  to `category` via `normalize.canonicalize_columns(source="rep_utilization")`.
+  The raw column name is genuinely `catagory`; this is not a documentation
+  error.
+- `fm_regions_avg_employees_html` header variants (`FM Region`,
+  `State Code`, `Employees Worked`, `Average Active Employees`,
+  `Employee Utilization`, ...) are canonicalized to snake_case via
+  `normalize.canonicalize_columns(source="region_utilization")`.
+- Both datasets' `BOP Date`/`bop_date` columns resolve to the canonical
+  `"YYYY-MM"` period key via `normalize.month_period(source="fm")`.
+
+## Filters
+
+`month`, `category` — both datasets carry `region`/`category`/month
+columns after canonicalization, so these filters apply to both the
+recomputed and the cross-check side of this section.
+
+## Worked example
+
+From the sample rows (`sdd/state/FEAT-517/source.md`):
+
+- `rep_utilization` row: `region="CA"`, `catagory="Flex"`,
+  `employees_worked=12`, `average_active=63`, month `2026-05`.
+  Rep Utilization = `12 / 63 = 0.19047619047619047` (≈ 19.05%).
+- `region_utilization` row: `FM Region="CA"`, `Category="Flex"`,
+  `Employees Worked=11`, `Average Active Employees=75.5`, month `2026-03`.
+  Precomputed `Employee Utilization = 11 / 75.5 = 0.1456953642384106`
+  (matches the dataset's own stated value exactly), illustrating the
+  cross-check computation — note this sample row is a DIFFERENT month
+  (`2026-03` vs `2026-05`) than the `rep_utilization` sample, so in this
+  particular pair of samples there is no matching (region, category,
+  month) key and `cross_check_utilization` would be `None` for that row.

--- a/agents/flex_dashboard/normalize.py
+++ b/agents/flex_dashboard/normalize.py
@@ -169,9 +169,7 @@ def month_period(df: pd.DataFrame, *, source: str) -> pd.DataFrame:
 
     date_column = next((c for c in candidates if c in df.columns), None)
     if date_column is None:
-        raise KeyError(
-            f"No date column found for source={source!r}; expected one of {candidates}"
-        )
+        raise KeyError(f"No date column found for source={source!r}; expected one of {candidates}")
 
     result = df.copy()
     dates = pd.to_datetime(result[date_column])

--- a/agents/flex_dashboard/normalize.py
+++ b/agents/flex_dashboard/normalize.py
@@ -1,0 +1,209 @@
+"""Flex dashboard normalization layer (FEAT-491 TASK-2693, spec §3 Module 1).
+
+Pure, deterministic input canonicalization shared by every Flex transformer
+(:mod:`agents.flex_dashboard.transformers`, TASK-2694). The six Flex
+datasets arrive dirty:
+
+- ``Finance_results_bi`` currency columns are formatted strings
+  (``"$137,456.85"``, negatives ``"-$44,621.24"``).
+- Three date-grain conventions coexist: finance ``month`` (month-end date),
+  hours ``month_start``/``month_end``, and the ``fm_*`` datasets'
+  ``BOP Date``/``EOP Date`` (or lowercase ``bop_date``/``eop_date``).
+- ``fm_rep_utilization`` ships a ``catagory`` typo column, and header
+  casing differs from ``fm_regions_avg_employees_html``.
+
+ALL canonicalization for these datasets lives here — transformers never
+inline it (spec §7 Known Risks: "Dirty inputs ... ALL canonicalization goes
+through Module 1 — never inline in transformers").
+
+Every function here is a pure function over :class:`pandas.DataFrame`
+objects: no I/O, no logging, no mutation of the input frame (always returns
+a copy). Determinism matters — recipe replay (TASK-2697) depends on the
+same input frame always producing the same output frame.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+__all__ = [
+    "canonicalize_columns",
+    "month_period",
+    "normalize_currency_columns",
+    "parse_currency",
+]
+
+#: Matches the characters `parse_currency` strips before calling `float()`.
+_CURRENCY_STRIP_RE = re.compile(r"[,$]")
+
+#: Per-source candidate date columns consulted by `month_period`, in the
+#: order finance/hours/fm datasets are documented in spec §2.
+_MONTH_SOURCE_COLUMNS: dict[str, Sequence[str]] = {
+    "finance": ("month",),
+    "hours": ("month_start",),
+    "fm": ("BOP Date", "bop_date"),
+}
+
+#: Per-source rename maps consulted by `canonicalize_columns`. Only keys
+#: present in the input frame are ever renamed — declaring a header that
+#: happens to be absent from a given frame is a no-op, not an error.
+_COLUMN_RENAMES: dict[str, dict[str, str]] = {
+    "msl": {},
+    "finance": {},
+    "hours": {},
+    "employees": {
+        "Flex Employees": "flex_employees",
+        "Flex Type": "flex_type",
+        "Years of Service": "years_of_service",
+        "Months of Service": "months_of_service",
+        "Days of Service": "days_of_service",
+        "Days of Service Retention": "days_of_service_retention",
+    },
+    "region_utilization": {
+        "BOP Date": "bop_date",
+        "EOP Date": "eop_date",
+        "FM Region": "region",
+        "State Code": "state",
+        "State": "state_name",
+        "Category": "category",
+        "Employees Worked": "employees_worked",
+        "Average Active Employees": "average_active",
+        "Flex Employees": "flex_employees",
+        "Employee Utilization": "employee_utilization",
+    },
+    "rep_utilization": {
+        "catagory": "category",
+    },
+}
+
+
+def parse_currency(value: Any) -> float:
+    """Parse a Flex currency string (or passthrough numeric) into a float.
+
+    Handles the ``Finance_results_bi`` currency-string convention:
+    ``"$137,456.85"`` -> ``137456.85``, negatives ``"-$44,621.24"`` ->
+    ``-44621.24``, ``"$0.00"`` -> ``0.0``. Already-numeric values pass
+    through unchanged (as ``float``); missing/unparseable values return
+    ``float("nan")`` (NaN-safe).
+
+    Args:
+        value: A currency string, an already-numeric value (``int``/
+            ``float``), or a missing value (``None``/``NaN``).
+
+    Returns:
+        The parsed float value, or ``float("nan")`` when *value* is
+        missing or cannot be parsed.
+    """
+    if value is None:
+        return float("nan")
+    if isinstance(value, (int, float, np.integer, np.floating)):
+        return float(value)
+    try:
+        if pd.isna(value):
+            return float("nan")
+    except (TypeError, ValueError):
+        pass
+    text = str(value).strip()
+    if not text:
+        return float("nan")
+    cleaned = _CURRENCY_STRIP_RE.sub("", text)
+    try:
+        return float(cleaned)
+    except ValueError:
+        return float("nan")
+
+
+def normalize_currency_columns(df: pd.DataFrame, columns: Sequence[str]) -> pd.DataFrame:
+    """Apply :func:`parse_currency` to the given columns of *df*.
+
+    Args:
+        df: Input frame (never mutated).
+        columns: Column names to parse. Columns absent from *df* are
+            silently skipped.
+
+    Returns:
+        A copy of *df* with the requested columns converted to ``float``.
+    """
+    result = df.copy()
+    for column in columns:
+        if column in result.columns:
+            result[column] = result[column].map(parse_currency)
+    return result
+
+
+def month_period(df: pd.DataFrame, *, source: str) -> pd.DataFrame:
+    """Add a canonical ``month`` column (``"YYYY-MM"``) to *df*.
+
+    Resolves one of the three Flex date-grain conventions documented in
+    spec §3 Module 1:
+
+    - ``source="finance"`` — the month-end ``month`` column
+      (``Finance_results_bi``).
+    - ``source="hours"`` — the ``month_start`` column
+      (``flex_hours_query_pbi``).
+    - ``source="fm"`` — ``BOP Date`` or ``bop_date``
+      (``fm_regions_avg_employees_html`` / ``fm_rep_utilization``).
+
+    Args:
+        df: Input frame (never mutated).
+        source: One of ``"finance"``, ``"hours"``, ``"fm"``.
+
+    Returns:
+        A copy of *df* with an added ``month`` column of ``"YYYY-MM"``
+        strings.
+
+    Raises:
+        ValueError: If *source* is not a recognized convention.
+        KeyError: If none of the source's candidate date columns are
+            present in *df*.
+    """
+    try:
+        candidates = _MONTH_SOURCE_COLUMNS[source]
+    except KeyError as exc:
+        raise ValueError(f"Unknown month source: {source!r}") from exc
+
+    date_column = next((c for c in candidates if c in df.columns), None)
+    if date_column is None:
+        raise KeyError(
+            f"No date column found for source={source!r}; expected one of {candidates}"
+        )
+
+    result = df.copy()
+    dates = pd.to_datetime(result[date_column])
+    result["month"] = dates.dt.strftime("%Y-%m")
+    return result
+
+
+def canonicalize_columns(df: pd.DataFrame, *, source: str) -> pd.DataFrame:
+    """Rename dataset-specific dirty headers to a canonical snake_case form.
+
+    Covers the known Flex header variants (spec §3 Module 1): the
+    ``catagory`` -> ``category`` typo in ``fm_rep_utilization``, and the
+    Title/Space-Case headers of ``fm_regions_avg_employees_html`` and
+    ``flex_empolyees_brian_bi``.
+
+    Args:
+        df: Input frame (never mutated).
+        source: One of the six Flex aliases (spec §2): ``"msl"``,
+            ``"finance"``, ``"hours"``, ``"employees"``,
+            ``"region_utilization"``, ``"rep_utilization"``.
+
+    Returns:
+        A copy of *df* with recognized headers renamed. Headers not in the
+        rename map for *source* are left unchanged.
+
+    Raises:
+        ValueError: If *source* is not one of the six known aliases.
+    """
+    try:
+        rename_map = _COLUMN_RENAMES[source]
+    except KeyError as exc:
+        raise ValueError(f"Unknown canonicalization source: {source!r}") from exc
+
+    applicable = {k: v for k, v in rename_map.items() if k in df.columns}
+    return df.rename(columns=applicable)

--- a/agents/flex_dashboard/skills/flex-narrative/SKILL.md
+++ b/agents/flex_dashboard/skills/flex-narrative/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: flex-narrative
+description: >
+  Render deterministic Flex dashboard facts (the flex_narrative_facts
+  transformer output) as short executive-summary prose. Quote only
+  figures present in the facts; never invent a number.
+triggers: []
+category: domain
+version: "1.0"
+---
+
+# Flex Program Narrative
+
+You are given a `flex_narrative_facts` object — a structured, deterministic
+summary of the Flex program dashboard. Turn it into a short executive
+narrative. You are the ONLY non-deterministic step in this pipeline; the
+numbers are already computed and verified (`agents/flex_dashboard/
+transformers.py`). Your job is prose, not analysis.
+
+## Fields you receive
+
+- `worked_hours_total` — total worked hours (sum of `hours.hours`).
+- `payroll_total` — total payroll (sum of `finance.Payroll`).
+- `revenue_total` — total P&L revenue (sum of `finance.Revenue`).
+- `payroll_pct` — `payroll_total / revenue_total` (Revenue ALONE as the
+  denominator).
+- `worked_hours_trend` — `"increasing"`, `"decreasing"`, or `"flat"`,
+  comparing the first and last month of the Worked Hours by Month series.
+- `regions_tracked` — sorted list of region names covered by the Rep
+  Utilization section.
+
+## Hard rules
+
+1. **Never write a number that is not in the facts.** Every figure you
+   write is checked mechanically after the fact — one invented figure
+   discards your ENTIRE output, not just the offending sentence. When in
+   doubt, name the direction (`worked_hours_trend`) or the entity
+   (a region name from `regions_tracked`) instead of a figure.
+2. **State direction; do not infer causes.** Say *what* the trend is; do
+   not speculate about *why* the hours are increasing/decreasing/flat
+   beyond what the facts carry.
+3. **Format money and percentages using the house style**: `$1.23M` /
+   `$45.6K` for dollars, `12.3%` for percentages (`payroll_pct` is a
+   ratio — multiply by 100 for display, never invent extra precision).
+4. **If `regions_tracked` is empty**, omit any sentence naming regions
+   rather than padding with a placeholder.
+
+## What to produce
+
+Write two short sections, matching what the layout binds to:
+
+1. **Headline** (1-2 sentences): worked hours, payroll, and revenue
+   totals, and the payroll % to revenue figure.
+2. **Trend** (1 sentence): the `worked_hours_trend` direction, naming
+   the tracked regions (`regions_tracked`) if any.
+
+If a section's driving field is absent or empty, omit that section
+entirely rather than padding it with a placeholder sentence.

--- a/agents/flex_dashboard/skills/infographic/SKILL.md
+++ b/agents/flex_dashboard/skills/infographic/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: infographic
+description: >
+  Compose a user-requested descriptive infographic from the currently
+  registered Flex datasets using InfographicToolkit's render tools,
+  quoting only figures actually computed from the data.
+triggers: ["/infographic"]
+category: domain
+version: "1.0"
+---
+
+# /infographic — Descriptive Flex Infographic
+
+You are asked to build a one-off, descriptive infographic (NOT the
+published, deterministic `flex-program-dashboard` recipe — that is the
+`refresh_dashboard` tool's job). Use the agent's `InfographicToolkit`
+render tools directly.
+
+## How to use this skill
+
+1. **Scope the request** — which datasets/KPIs does the user want
+   summarized? (e.g. "an infographic of this month's payroll picture",
+   "summarize proximity coverage for the CA region").
+2. **Gather the data** via the agent's normal tools
+   (`python_repl_pandas` over the registered datasets, cleaned through
+   `agents/flex_dashboard/normalize.py`, or the registered
+   `agents/flex_dashboard/transformers.py` functions when the request
+   matches a known KPI — reuse them instead of recomputing).
+3. **Render** via one of the `InfographicToolkit` tools:
+   - `infographic_render_data_template` / `infographic_render_template` —
+     when a registered template fits (list available ones first with
+     `infographic_list_templates`).
+   - `infographic_build_block` — to assemble ad-hoc structured blocks
+     (KPI cards, tables, charts) when no template matches.
+   - `infographic_validate_blocks` — validate before rendering to catch
+     shape issues early.
+4. **Return the render result** (artifact id / URL) to the user along
+   with a short caption.
+
+## Hard rules
+
+1. **Quote only figures you actually computed** from the currently loaded
+   data for this request — never copy a number from a prior turn or from
+   the published dashboard recipe without recomputing it for the current
+   scope.
+2. **This is tier-1, ad-hoc authoring** — it does NOT publish or modify
+   the `flex-program-dashboard` recipe. If the user wants a persistent,
+   refreshable dashboard, point them at the recipe/refresh lane instead.
+3. Prefer an existing registered `agents/flex_dashboard/transformers.py`
+   function over hand-rolled pandas aggregation whenever the request maps
+   to a known KPI (same figures, already tested).

--- a/agents/flex_dashboard/skills/widget/SKILL.md
+++ b/agents/flex_dashboard/skills/widget/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: widget
+description: >
+  Export a single Flex KPI (Payroll Contribution, Pay Code, Rep
+  Utilization, or Proximity Staffing) as an A2UI structured chart / map /
+  table / hero-card envelope for frontend rendering — always via the
+  registered transformer that already computes the KPI, never a
+  hand-rolled aggregation.
+triggers: ["/widget"]
+category: domain
+version: "1.0"
+---
+
+# /widget — Export a Flex KPI as a Structured A2UI Envelope
+
+You are asked to export ONE named KPI so the frontend can render it as a
+standalone widget (chart, map, table, or hero card). Every number MUST
+come from the KPI's registered `agents/flex_dashboard/transformers.py`
+function — never recomputed inline with pandas ad-hoc code.
+
+## How to use this skill
+
+1. **Identify the KPI** from the user's request (e.g. "worked hours by
+   month", "proximity staffing", "payroll % to revenue"). If ambiguous,
+   ask which one — do not guess.
+2. **Read `kpi-table.md`** (adjacent asset) for the exact transformer
+   name, its required dataset alias(es), the recipe data-model path the
+   dashboard binds it to, and which A2UI output mode it maps to.
+3. **Run the transformer's data** via the agent's normal tools
+   (`python_repl_pandas` over the registered datasets, or
+   `dataset_fetch_dataset` to materialize a lazy alias first) — reproduce
+   exactly what the transformer computes, using
+   `agents/flex_dashboard/normalize.py` for any currency/date/column
+   cleaning, same as the transformer itself does.
+4. **Emit the matching structured output mode** (see `kpi-table.md`):
+   - Month-series KPIs → `STRUCTURED_CHART` (line chart, x=`month`).
+   - Pay Code / Rep Utilization tabular KPIs → `STRUCTURED_TABLE`.
+   - Proximity Staffing → `STRUCTURED_MAP` (store + employee layers).
+   - Hero totals (Worked Hours, Payroll, P&L Revenue, Payroll % to
+     Revenue) → a `KPICard`-shaped structured envelope (single value +
+     label), one per requested total.
+5. If the user named a filter (month, flex_type, pay_code, cost_center,
+   category, radius_miles, nearest_n), apply ONLY the filters that KPI's
+   own dataset supports (per-section filter rule — see `kpi-table.md`'s
+   "Supported filters" column). A filter unsupported by the requested
+   KPI's dataset is a no-op for that KPI, never an error.
+
+## Hard rules
+
+1. **Never invent a number.** Every value in the widget must trace back to
+   the named transformer's output on the currently registered datasets.
+2. **Never widen the KPI's own filter scope.** A `flex_type` filter must
+   never narrow a finance-only KPI (Payroll/Revenue/Payroll %); a
+   `pay_code` filter must never narrow Rep Utilization or Proximity
+   Staffing.
+3. **State which filters were applied** in the response alongside the
+   widget, so the user can see what the numbers reflect.
+4. **Proximity Staffing defaults**: `radius_miles=50`, `nearest_n=3`
+   unless the user overrides them.

--- a/agents/flex_dashboard/skills/widget/kpi-table.md
+++ b/agents/flex_dashboard/skills/widget/kpi-table.md
@@ -1,0 +1,33 @@
+# Flex KPI → transformer → output mode reference
+
+Every row: KPI name, registered transformer (`agents/flex_dashboard/
+transformers.py`), required dataset alias(es), recipe data-model path
+(`agents/flex_dashboard.py::FlexDashboard.dashboard_descriptor()`),
+A2UI output mode, and supported filters (per-section filter rule).
+
+| KPI | Transformer | Dataset alias(es) | Recipe path | Output mode | Supported filters |
+|---|---|---|---|---|---|
+| Worked Hours (total) | `payroll_hero` | `hours`, `finance` | `/payroll_hero/worked_hours_total` | `KPICard` hero | none |
+| Payroll (total) | `payroll_hero` | `hours`, `finance` | `/payroll_hero/payroll_total` | `KPICard` hero | none |
+| P&L Revenue (total) | `payroll_hero` | `hours`, `finance` | `/payroll_hero/revenue_total` | `KPICard` hero | none |
+| Payroll % to Revenue (total) | `payroll_hero` | `hours`, `finance` | `/payroll_hero/payroll_pct` | `KPICard` hero | none |
+| Worked Hours by Month | `worked_hours_by_month` | `hours` | `/worked_hours_by_month/series` | `STRUCTURED_CHART` | month, pay_code, cost_center |
+| Payroll by Month | `payroll_by_month` | `finance` | `/payroll_by_month/series` | `STRUCTURED_CHART` | month |
+| P&L Revenue by Month | `revenue_by_month` | `finance` | `/revenue_by_month/series` | `STRUCTURED_CHART` | month |
+| Payroll % to Revenue by Month | `payroll_pct_by_month` | `finance` | `/payroll_pct_by_month/series` | `STRUCTURED_CHART` | month |
+| Pay Code Hours | `pay_code_hours` | `hours` | `/pay_code_hours/records` | `STRUCTURED_TABLE` | month, pay_code, cost_center |
+| Worked Hours by Pay Code Allocation | `pay_code_allocation` | `hours` | `/pay_code_allocation/records` | `STRUCTURED_TABLE` | month, cost_center |
+| Rep Utilization by Region | `rep_utilization_by_region` | `rep_utilization`, `region_utilization` | `/rep_utilization_by_region/records` | `STRUCTURED_TABLE` | month, category |
+| Proximity Staffing | `proximity_staffing` | `msl`, `employees` | `/proximity_staffing/{store_layer,employee_layer,coverage}` | `STRUCTURED_MAP` | flex_type, radius_miles, nearest_n |
+
+## Notes
+
+- Payroll % to Revenue is ALWAYS `sum(Payroll) / sum(Revenue)` — Revenue ALONE
+  as the denominator, never `Revenue + PC Revenue` (spec §2 resolved Q&A,
+  regression-pinned by `test_payroll_pct_denominator`).
+- Rep Utilization is ALWAYS recomputed as `employees_worked /
+  average_active` from `rep_utilization`; `region_utilization`'s
+  precomputed `Employee Utilization` is a cross-check value only.
+- Proximity Staffing's coverage table lists, per store, the nearest
+  `nearest_n` employees by haversine distance and a count of employees
+  within `radius_miles`.

--- a/agents/flex_dashboard/skills/widget/kpi-table.md
+++ b/agents/flex_dashboard/skills/widget/kpi-table.md
@@ -7,16 +7,16 @@ A2UI output mode, and supported filters (per-section filter rule).
 
 | KPI | Transformer | Dataset alias(es) | Recipe path | Output mode | Supported filters |
 |---|---|---|---|---|---|
-| Worked Hours (total) | `payroll_hero` | `hours`, `finance` | `/payroll_hero/worked_hours_total` | `KPICard` hero | none |
-| Payroll (total) | `payroll_hero` | `hours`, `finance` | `/payroll_hero/payroll_total` | `KPICard` hero | none |
-| P&L Revenue (total) | `payroll_hero` | `hours`, `finance` | `/payroll_hero/revenue_total` | `KPICard` hero | none |
-| Payroll % to Revenue (total) | `payroll_hero` | `hours`, `finance` | `/payroll_hero/payroll_pct` | `KPICard` hero | none |
+| Worked Hours (total) | `payroll_hero` | `hours`, `finance` | `/payroll_hero/worked_hours_total` | `KPICard` hero | month, pay_code, cost_center |
+| Payroll (total) | `payroll_hero` | `hours`, `finance` | `/payroll_hero/payroll_total` | `KPICard` hero | month, pay_code, cost_center |
+| P&L Revenue (total) | `payroll_hero` | `hours`, `finance` | `/payroll_hero/revenue_total` | `KPICard` hero | month |
+| Payroll % to Revenue (total) | `payroll_hero` | `hours`, `finance` | `/payroll_hero/payroll_pct` | `KPICard` hero | month |
 | Worked Hours by Month | `worked_hours_by_month` | `hours` | `/worked_hours_by_month/series` | `STRUCTURED_CHART` | month, pay_code, cost_center |
 | Payroll by Month | `payroll_by_month` | `finance` | `/payroll_by_month/series` | `STRUCTURED_CHART` | month |
 | P&L Revenue by Month | `revenue_by_month` | `finance` | `/revenue_by_month/series` | `STRUCTURED_CHART` | month |
 | Payroll % to Revenue by Month | `payroll_pct_by_month` | `finance` | `/payroll_pct_by_month/series` | `STRUCTURED_CHART` | month |
 | Pay Code Hours | `pay_code_hours` | `hours` | `/pay_code_hours/records` | `STRUCTURED_TABLE` | month, pay_code, cost_center |
-| Worked Hours by Pay Code Allocation | `pay_code_allocation` | `hours` | `/pay_code_allocation/records` | `STRUCTURED_TABLE` | month, cost_center |
+| Worked Hours by Pay Code Allocation | `pay_code_allocation` | `hours` | `/pay_code_allocation/records` | `STRUCTURED_TABLE` | month, pay_code, cost_center |
 | Rep Utilization by Region | `rep_utilization_by_region` | `rep_utilization`, `region_utilization` | `/rep_utilization_by_region/records` | `STRUCTURED_TABLE` | month, category |
 | Proximity Staffing | `proximity_staffing` | `msl`, `employees` | `/proximity_staffing/{store_layer,employee_layer,coverage}` | `STRUCTURED_MAP` | flex_type, radius_miles, nearest_n |
 

--- a/agents/flex_dashboard/transformers.py
+++ b/agents/flex_dashboard/transformers.py
@@ -1,0 +1,529 @@
+"""Flex dashboard transformers (FEAT-491 TASK-2694, spec §3 Module 2).
+
+Registered, PURE ``@infographic_transformer`` functions ``(inputs, params)
+-> dict`` over the six frozen Flex dataset aliases (spec §2): ``msl``,
+``finance``, ``hours``, ``employees``, ``region_utilization``,
+``rep_utilization``. Every number a Flex dashboard section shows comes from
+one of these — never from replaying LLM-generated code (FEAT-324 G1).
+
+All input cleaning goes through :mod:`agents.flex_dashboard.normalize`
+(TASK-2693) — no inline currency/date/column-name handling here (spec §7
+Known Risks).
+
+**Pinned formulas (spec §2, resolved Q&A — do NOT deviate):**
+
+- Payroll % to Revenue = ``sum(Payroll) / sum(Revenue)`` from ``finance``
+  (denominator is Revenue ALONE, never ``Revenue + PC Revenue``).
+- Worked Hours = ``sum(hours)`` from ``hours``; ``finance["Total Hours"]``
+  is never used here (FTE cross-check only, out of this module's scope).
+- Rep Utilization = ``employees_worked / average_active`` recomputed from
+  ``rep_utilization``; the ``region_utilization`` precomputed
+  ``Employee Utilization`` column is surfaced only as a cross-check value,
+  never as the source of truth.
+- Proximity Staffing = per-store nearest-N employees by haversine distance
+  (implemented with numpy — no new dependency), plus a coverage count
+  within a configurable radius (default 50 miles).
+
+``flex_narrative_facts`` consumes the OTHER transformers' output dict keys,
+not dataset aliases, and must be the LAST section in any published recipe
+(mirrors ``agents/finance_reporter.py``'s ``narrative_facts`` pattern).
+
+.. note::
+
+   Registered as ``flex_narrative_facts``, NOT the generic ``narrative_facts``
+   FinanceReporter uses: ``parrot.outputs.a2ui.recipes`` unconditionally
+   imports ``library.py`` as an import side effect (its own ``__init__.py``),
+   which registers a DIFFERENT, finance-specific ``narrative_facts`` function
+   on the same process-wide ``transformer_registry`` the moment anything
+   imports ``infographic_transformer`` — before this module's own decorators
+   even run. Two different functions can never share one registry name
+   (``TransformerRegistry.register`` raises), so the Flex narrative step
+   needs its own name (discovered empirically via TASK-2694's own tests;
+   see the Completion Note).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from parrot.outputs.a2ui.recipes.transformers import infographic_transformer
+
+from agents.flex_dashboard.normalize import (
+    canonicalize_columns,
+    month_period,
+    normalize_currency_columns,
+)
+
+__all__: list[str] = []  # registration is by import side effect, not re-export
+
+#: Earth radius in miles, used by the haversine distance calculation.
+_EARTH_RADIUS_MILES = 3958.8
+
+
+def _apply_filters(df: pd.DataFrame, filters: dict[str, Any]) -> pd.DataFrame:
+    """Apply zero or more equality filters to *df*.
+
+    Args:
+        df: Input frame.
+        filters: Column -> value. A ``None`` value means "no filter" and is
+            skipped (per-section filter rule: an absent param never narrows
+            a transformer's own dataset).
+
+    Returns:
+        The filtered frame (a view/copy per pandas boolean indexing).
+    """
+    for column, value in filters.items():
+        if value is not None:
+            df = df[df[column] == value]
+    return df
+
+
+def _haversine_miles(
+    lat1: np.ndarray, lon1: np.ndarray, lat2: np.ndarray, lon2: np.ndarray
+) -> np.ndarray:
+    """Great-circle distance in miles between two (arrays of) coordinates.
+
+    Pure numpy implementation (spec §7 External Dependencies: no new
+    ``haversine`` package dependency).
+
+    Args:
+        lat1: Latitude(s) of the first point(s), in degrees.
+        lon1: Longitude(s) of the first point(s), in degrees.
+        lat2: Latitude(s) of the second point(s), in degrees.
+        lon2: Longitude(s) of the second point(s), in degrees.
+
+    Returns:
+        Distance(s) in miles, broadcast per numpy rules.
+    """
+    phi1, phi2 = np.radians(lat1), np.radians(lat2)
+    dphi = np.radians(lat2 - lat1)
+    dlambda = np.radians(lon2 - lon1)
+    a = np.sin(dphi / 2.0) ** 2 + np.cos(phi1) * np.cos(phi2) * np.sin(dlambda / 2.0) ** 2
+    c = 2.0 * np.arctan2(np.sqrt(a), np.sqrt(1.0 - a))
+    return _EARTH_RADIUS_MILES * c
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Payroll Contribution
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@infographic_transformer(
+    "payroll_hero",
+    requires_columns={"hours": ["hours"], "finance": ["Payroll", "Revenue"]},
+    description=(
+        "Hero-row totals: Worked Hours (sum of hours.hours), Payroll and "
+        "Revenue totals (sum of finance.Payroll / finance.Revenue), and "
+        "Payroll % to Revenue = payroll_total / revenue_total (Revenue "
+        "ALONE as denominator — spec §2 resolved Q&A)."
+    ),
+)
+def payroll_hero(inputs: dict[str, pd.DataFrame], params: dict[str, Any]) -> dict[str, Any]:
+    """See the ``@infographic_transformer`` description above."""
+    hours = inputs["hours"]
+    finance = normalize_currency_columns(inputs["finance"], ["Payroll", "Revenue"])
+
+    worked_hours_total = float(hours["hours"].sum())
+    payroll_total = float(finance["Payroll"].sum())
+    revenue_total = float(finance["Revenue"].sum())
+    payroll_pct = (payroll_total / revenue_total) if revenue_total else 0.0
+
+    return {
+        "worked_hours_total": round(worked_hours_total, 2),
+        "payroll_total": round(payroll_total, 2),
+        "revenue_total": round(revenue_total, 2),
+        # Ratio, not money — kept at full float precision (no rounding),
+        # same convention as library.py's generic tabular helpers.
+        "payroll_pct": payroll_pct,
+    }
+
+
+@infographic_transformer(
+    "worked_hours_by_month",
+    requires_columns={"hours": ["month_start", "hours"]},
+    description="Worked Hours (sum of hours.hours) by month.",
+    params_schema={
+        "month": {"type": "string", "description": "YYYY-MM filter."},
+        "pay_code": {"type": "string"},
+        "cost_center": {"type": "string"},
+    },
+)
+def worked_hours_by_month(
+    inputs: dict[str, pd.DataFrame], params: dict[str, Any]
+) -> dict[str, Any]:
+    """See the ``@infographic_transformer`` description above."""
+    df = month_period(inputs["hours"], source="hours")
+    df = _apply_filters(
+        df,
+        {
+            "month": params.get("month"),
+            "pay_code": params.get("pay_code"),
+            "cost_center": params.get("cost_center"),
+        },
+    )
+    grouped = df.groupby("month", as_index=False)["hours"].sum().sort_values("month")
+    series = [
+        {"month": row.month, "worked_hours": round(float(row.hours), 2)}
+        for row in grouped.itertuples(index=False)
+    ]
+    return {"series": series}
+
+
+@infographic_transformer(
+    "payroll_by_month",
+    requires_columns={"finance": ["month", "Payroll"]},
+    description="Payroll total (sum of finance.Payroll) by month.",
+    params_schema={"month": {"type": "string", "description": "YYYY-MM filter."}},
+)
+def payroll_by_month(inputs: dict[str, pd.DataFrame], params: dict[str, Any]) -> dict[str, Any]:
+    """See the ``@infographic_transformer`` description above."""
+    df = month_period(inputs["finance"], source="finance")
+    df = normalize_currency_columns(df, ["Payroll"])
+    df = _apply_filters(df, {"month": params.get("month")})
+    grouped = df.groupby("month", as_index=False)["Payroll"].sum().sort_values("month")
+    series = [
+        {"month": row.month, "payroll": round(float(row.Payroll), 2)}
+        for row in grouped.itertuples(index=False)
+    ]
+    return {"series": series}
+
+
+@infographic_transformer(
+    "revenue_by_month",
+    requires_columns={"finance": ["month", "Revenue"]},
+    description="P&L Revenue total (sum of finance.Revenue) by month.",
+    params_schema={"month": {"type": "string", "description": "YYYY-MM filter."}},
+)
+def revenue_by_month(inputs: dict[str, pd.DataFrame], params: dict[str, Any]) -> dict[str, Any]:
+    """See the ``@infographic_transformer`` description above."""
+    df = month_period(inputs["finance"], source="finance")
+    df = normalize_currency_columns(df, ["Revenue"])
+    df = _apply_filters(df, {"month": params.get("month")})
+    grouped = df.groupby("month", as_index=False)["Revenue"].sum().sort_values("month")
+    series = [
+        {"month": row.month, "revenue": round(float(row.Revenue), 2)}
+        for row in grouped.itertuples(index=False)
+    ]
+    return {"series": series}
+
+
+@infographic_transformer(
+    "payroll_pct_by_month",
+    requires_columns={"finance": ["month", "Payroll", "Revenue"]},
+    description=(
+        "Payroll % to Revenue by month = sum(Payroll) / sum(Revenue) per "
+        "month (Revenue ALONE as denominator — spec §2 resolved Q&A)."
+    ),
+    params_schema={"month": {"type": "string", "description": "YYYY-MM filter."}},
+)
+def payroll_pct_by_month(
+    inputs: dict[str, pd.DataFrame], params: dict[str, Any]
+) -> dict[str, Any]:
+    """See the ``@infographic_transformer`` description above."""
+    df = month_period(inputs["finance"], source="finance")
+    df = normalize_currency_columns(df, ["Payroll", "Revenue"])
+    df = _apply_filters(df, {"month": params.get("month")})
+    grouped = df.groupby("month", as_index=False)[["Payroll", "Revenue"]].sum().sort_values(
+        "month"
+    )
+    series = [
+        {
+            "month": row.month,
+            # Ratio, not money — full float precision, no rounding.
+            "payroll_pct": (row.Payroll / row.Revenue) if row.Revenue else 0.0,
+        }
+        for row in grouped.itertuples(index=False)
+    ]
+    return {"series": series}
+
+
+@infographic_transformer(
+    "pay_code_hours",
+    requires_columns={"hours": ["pay_code", "hours"]},
+    description="Worked Hours (sum of hours.hours) by pay_code.",
+    params_schema={
+        "month": {"type": "string", "description": "YYYY-MM filter."},
+        "pay_code": {"type": "string"},
+        "cost_center": {"type": "string"},
+    },
+)
+def pay_code_hours(inputs: dict[str, pd.DataFrame], params: dict[str, Any]) -> dict[str, Any]:
+    """See the ``@infographic_transformer`` description above."""
+    df = month_period(inputs["hours"], source="hours")
+    df = _apply_filters(
+        df,
+        {
+            "month": params.get("month"),
+            "pay_code": params.get("pay_code"),
+            "cost_center": params.get("cost_center"),
+        },
+    )
+    grouped = df.groupby("pay_code", as_index=False)["hours"].sum().sort_values("pay_code")
+    records = [
+        {"pay_code": row.pay_code, "hours": round(float(row.hours), 2)}
+        for row in grouped.itertuples(index=False)
+    ]
+    return {"records": records}
+
+
+@infographic_transformer(
+    "pay_code_allocation",
+    requires_columns={"hours": ["pay_code", "hours"]},
+    description=(
+        "Worked Hours by Pay Code Allocation: each pay_code's share (%) of "
+        "total worked hours."
+    ),
+    params_schema={
+        "month": {"type": "string", "description": "YYYY-MM filter."},
+        "cost_center": {"type": "string"},
+    },
+)
+def pay_code_allocation(
+    inputs: dict[str, pd.DataFrame], params: dict[str, Any]
+) -> dict[str, Any]:
+    """See the ``@infographic_transformer`` description above."""
+    df = month_period(inputs["hours"], source="hours")
+    df = _apply_filters(
+        df, {"month": params.get("month"), "cost_center": params.get("cost_center")}
+    )
+    total_hours = float(df["hours"].sum())
+    grouped = df.groupby("pay_code", as_index=False)["hours"].sum().sort_values("pay_code")
+    records = [
+        {
+            "pay_code": row.pay_code,
+            "hours": round(float(row.hours), 2),
+            "share_pct": round((float(row.hours) / total_hours * 100.0) if total_hours else 0.0, 2),
+        }
+        for row in grouped.itertuples(index=False)
+    ]
+    return {"total_hours": round(total_hours, 2), "records": records}
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Rep (Representative) Utilization
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@infographic_transformer(
+    "rep_utilization_by_region",
+    requires_columns={
+        "rep_utilization": ["bop_date", "region", "catagory", "employees_worked", "average_active"],
+        "region_utilization": ["BOP Date", "FM Region", "Category", "Employee Utilization"],
+    },
+    description=(
+        "Rep Utilization by region/category/month = employees_worked / "
+        "average_active, RECOMPUTED from rep_utilization (spec §2 resolved "
+        "Q&A). The region_utilization precomputed Employee Utilization "
+        "column is attached only as cross_check_utilization, never as the "
+        "source of truth."
+    ),
+    params_schema={
+        "month": {"type": "string", "description": "YYYY-MM filter."},
+        "category": {"type": "string"},
+    },
+)
+def rep_utilization_by_region(
+    inputs: dict[str, pd.DataFrame], params: dict[str, Any]
+) -> dict[str, Any]:
+    """See the ``@infographic_transformer`` description above."""
+    rep = canonicalize_columns(inputs["rep_utilization"], source="rep_utilization")
+    rep = month_period(rep, source="fm")
+    rep = _apply_filters(
+        rep, {"month": params.get("month"), "category": params.get("category")}
+    )
+    rep_grouped = (
+        rep.groupby(["region", "category", "month"], as_index=False)[
+            ["employees_worked", "average_active"]
+        ]
+        .sum()
+        .sort_values(["region", "month"])
+    )
+
+    cross = canonicalize_columns(inputs["region_utilization"], source="region_utilization")
+    cross = month_period(cross, source="fm")
+    cross = _apply_filters(
+        cross, {"month": params.get("month"), "category": params.get("category")}
+    )
+    cross_grouped = cross.groupby(["region", "category", "month"], as_index=False)[
+        "employee_utilization"
+    ].mean()
+    cross_lookup = {
+        (row.region, row.category, row.month): float(row.employee_utilization)
+        for row in cross_grouped.itertuples(index=False)
+    }
+
+    records = []
+    for row in rep_grouped.itertuples(index=False):
+        utilization = (
+            float(row.employees_worked) / float(row.average_active)
+            if row.average_active
+            else 0.0
+        )
+        key = (row.region, row.category, row.month)
+        records.append(
+            {
+                "region": row.region,
+                "category": row.category,
+                "month": row.month,
+                # Ratios, not money — full float precision, no rounding.
+                "utilization": utilization,
+                "cross_check_utilization": cross_lookup.get(key),
+            }
+        )
+    return {"records": records}
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Proximity Staffing
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@infographic_transformer(
+    "proximity_staffing",
+    requires_columns={
+        "msl": ["store_name", "latitude", "longitude"],
+        "employees": ["display_name", "latitude", "longitude"],
+    },
+    description=(
+        "Per-store nearest-N employees by haversine distance, plus a "
+        "coverage count of employees within a configurable radius. Returns "
+        "a store map layer, an employee map layer, and a per-store "
+        "coverage table."
+    ),
+    params_schema={
+        "radius_miles": {"type": "number", "default": 50},
+        "nearest_n": {"type": "integer", "default": 3},
+        "flex_type": {"type": "string"},
+    },
+)
+def proximity_staffing(
+    inputs: dict[str, pd.DataFrame], params: dict[str, Any]
+) -> dict[str, Any]:
+    """See the ``@infographic_transformer`` description above."""
+    radius_miles = float(params.get("radius_miles") or 50)
+    nearest_n = int(params.get("nearest_n") or 3)
+
+    stores = inputs["msl"].sort_values("store_name").reset_index(drop=True)
+    employees = canonicalize_columns(inputs["employees"], source="employees")
+    employees = _apply_filters(employees, {"flex_type": params.get("flex_type")})
+    employees = employees.sort_values("display_name").reset_index(drop=True)
+
+    store_layer = [
+        {
+            "store_name": row.store_name,
+            "latitude": float(row.latitude),
+            "longitude": float(row.longitude),
+            "region_name": getattr(row, "region_name", None),
+            "state_code": getattr(row, "state_code", None),
+        }
+        for row in stores.itertuples(index=False)
+    ]
+    employee_layer = [
+        {
+            "display_name": row.display_name,
+            "latitude": float(row.latitude),
+            "longitude": float(row.longitude),
+            "flex_type": getattr(row, "flex_type", None),
+        }
+        for row in employees.itertuples(index=False)
+    ]
+
+    coverage = []
+    emp_lat = employees["latitude"].to_numpy(dtype=float)
+    emp_lon = employees["longitude"].to_numpy(dtype=float)
+    emp_names = employees["display_name"].to_numpy()
+
+    for store in stores.itertuples(index=False):
+        if len(employees) == 0:
+            coverage.append(
+                {
+                    "store_name": store.store_name,
+                    "nearest_employees": [],
+                    "employees_within_radius": 0,
+                }
+            )
+            continue
+
+        distances = _haversine_miles(
+            float(store.latitude), float(store.longitude), emp_lat, emp_lon
+        )
+        order = np.argsort(distances, kind="stable")
+        nearest = [
+            {
+                "display_name": str(emp_names[i]),
+                "distance_miles": round(float(distances[i]), 2),
+            }
+            for i in order[:nearest_n]
+        ]
+        within_radius = int(np.sum(distances <= radius_miles))
+        coverage.append(
+            {
+                "store_name": store.store_name,
+                "nearest_employees": nearest,
+                "employees_within_radius": within_radius,
+            }
+        )
+
+    return {
+        "store_layer": store_layer,
+        "employee_layer": employee_layer,
+        "coverage": coverage,
+        "radius_miles": radius_miles,
+        "nearest_n": nearest_n,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Narrative facts — MUST be the last section (consumes prior step outputs)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _series_trend(series: list[dict[str, Any]], value_key: str) -> str:
+    """Classify a month series' first-vs-last direction.
+
+    Args:
+        series: A ``[{"month": ..., value_key: ...}, ...]`` list, already
+            sorted by month.
+        value_key: The numeric field to compare.
+
+    Returns:
+        ``"increasing"``, ``"decreasing"``, or ``"flat"`` (also ``"flat"``
+        for fewer than two points).
+    """
+    if len(series) < 2:
+        return "flat"
+    first, last = series[0][value_key], series[-1][value_key]
+    if last > first:
+        return "increasing"
+    if last < first:
+        return "decreasing"
+    return "flat"
+
+
+@infographic_transformer(
+    "flex_narrative_facts",
+    requires_columns={},  # inputs are prior-step dict outputs, not frames
+    description=(
+        "Structured narrative facts derived from payroll_hero, "
+        "worked_hours_by_month and rep_utilization_by_region's outputs — "
+        "no English sentence generation (a downstream skill renders these "
+        "as prose). MUST be the last section in any recipe that includes "
+        "it (FinanceReporter pattern)."
+    ),
+)
+def flex_narrative_facts(inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+    """See the ``@infographic_transformer`` description above."""
+    hero = inputs["payroll_hero"]
+    worked_hours_series = inputs["worked_hours_by_month"]["series"]
+    utilization_records = inputs["rep_utilization_by_region"]["records"]
+
+    return {
+        "worked_hours_total": hero["worked_hours_total"],
+        "payroll_total": hero["payroll_total"],
+        "revenue_total": hero["revenue_total"],
+        "payroll_pct": hero["payroll_pct"],
+        "worked_hours_trend": _series_trend(worked_hours_series, "worked_hours"),
+        "regions_tracked": sorted({r["region"] for r in utilization_records}),
+    }

--- a/agents/flex_dashboard/transformers.py
+++ b/agents/flex_dashboard/transformers.py
@@ -405,8 +405,18 @@ def rep_utilization_by_region(inputs: dict[str, pd.DataFrame], params: dict[str,
 )
 def proximity_staffing(inputs: dict[str, pd.DataFrame], params: dict[str, Any]) -> dict[str, Any]:
     """See the ``@infographic_transformer`` description above."""
-    radius_miles = float(params.get("radius_miles") or 50)
-    nearest_n = int(params.get("nearest_n") or 3)
+    # Code-review finding (adopted): `or 50`/`or 3` would silently replace an
+    # explicit `radius_miles=0`/`nearest_n=0` with the default, since
+    # `bool(0)` is False — a real, reachable path (transformers are called
+    # directly with native Python ints/floats, not just RecipeRunner's
+    # resolved strings, e.g. from a `/widget` skill invocation). Use an
+    # explicit `is None` check instead. `""`/`None` (the recipe's own "no
+    # override" sentinel — see `agents/flex_dashboard.py::recipe_params()`)
+    # both correctly fall through to the default via this check.
+    raw_radius = params.get("radius_miles")
+    radius_miles = float(raw_radius) if raw_radius not in (None, "") else 50.0
+    raw_nearest_n = params.get("nearest_n")
+    nearest_n = int(raw_nearest_n) if raw_nearest_n not in (None, "") else 3
 
     stores = inputs["msl"].sort_values("store_name").reset_index(drop=True)
     employees = canonicalize_columns(inputs["employees"], source="employees")

--- a/agents/flex_dashboard/transformers.py
+++ b/agents/flex_dashboard/transformers.py
@@ -67,15 +67,20 @@ def _apply_filters(df: pd.DataFrame, filters: dict[str, Any]) -> pd.DataFrame:
 
     Args:
         df: Input frame.
-        filters: Column -> value. A ``None`` value means "no filter" and is
-            skipped (per-section filter rule: an absent param never narrows
-            a transformer's own dataset).
+        filters: Column -> value. A falsy value (``None`` OR ``""``) means
+            "no filter" and is skipped (per-section filter rule: an absent
+            param never narrows a transformer's own dataset). Empty string
+            is ALSO treated as unset (not just ``None``) because a published
+            recipe's declared ``RecipeParam`` for an optional filter MUST
+            have a concrete, non-``None`` default (`resolve_params` raises
+            otherwise — see `agents/flex_dashboard.py`'s `recipe_params()`,
+            TASK-2697) — ``""`` is that sentinel "no value" default.
 
     Returns:
         The filtered frame (a view/copy per pandas boolean indexing).
     """
     for column, value in filters.items():
-        if value is not None:
+        if value:
             df = df[df[column] == value]
     return df
 

--- a/agents/flex_dashboard/transformers.py
+++ b/agents/flex_dashboard/transformers.py
@@ -85,9 +85,7 @@ def _apply_filters(df: pd.DataFrame, filters: dict[str, Any]) -> pd.DataFrame:
     return df
 
 
-def _haversine_miles(
-    lat1: np.ndarray, lon1: np.ndarray, lat2: np.ndarray, lon2: np.ndarray
-) -> np.ndarray:
+def _haversine_miles(lat1: np.ndarray, lon1: np.ndarray, lat2: np.ndarray, lon2: np.ndarray) -> np.ndarray:
     """Great-circle distance in miles between two (arrays of) coordinates.
 
     Pure numpy implementation (spec §7 External Dependencies: no new
@@ -155,9 +153,7 @@ def payroll_hero(inputs: dict[str, pd.DataFrame], params: dict[str, Any]) -> dic
         "cost_center": {"type": "string"},
     },
 )
-def worked_hours_by_month(
-    inputs: dict[str, pd.DataFrame], params: dict[str, Any]
-) -> dict[str, Any]:
+def worked_hours_by_month(inputs: dict[str, pd.DataFrame], params: dict[str, Any]) -> dict[str, Any]:
     """See the ``@infographic_transformer`` description above."""
     df = month_period(inputs["hours"], source="hours")
     df = _apply_filters(
@@ -170,8 +166,7 @@ def worked_hours_by_month(
     )
     grouped = df.groupby("month", as_index=False)["hours"].sum().sort_values("month")
     series = [
-        {"month": row.month, "worked_hours": round(float(row.hours), 2)}
-        for row in grouped.itertuples(index=False)
+        {"month": row.month, "worked_hours": round(float(row.hours), 2)} for row in grouped.itertuples(index=False)
     ]
     return {"series": series}
 
@@ -188,10 +183,7 @@ def payroll_by_month(inputs: dict[str, pd.DataFrame], params: dict[str, Any]) ->
     df = normalize_currency_columns(df, ["Payroll"])
     df = _apply_filters(df, {"month": params.get("month")})
     grouped = df.groupby("month", as_index=False)["Payroll"].sum().sort_values("month")
-    series = [
-        {"month": row.month, "payroll": round(float(row.Payroll), 2)}
-        for row in grouped.itertuples(index=False)
-    ]
+    series = [{"month": row.month, "payroll": round(float(row.Payroll), 2)} for row in grouped.itertuples(index=False)]
     return {"series": series}
 
 
@@ -207,10 +199,7 @@ def revenue_by_month(inputs: dict[str, pd.DataFrame], params: dict[str, Any]) ->
     df = normalize_currency_columns(df, ["Revenue"])
     df = _apply_filters(df, {"month": params.get("month")})
     grouped = df.groupby("month", as_index=False)["Revenue"].sum().sort_values("month")
-    series = [
-        {"month": row.month, "revenue": round(float(row.Revenue), 2)}
-        for row in grouped.itertuples(index=False)
-    ]
+    series = [{"month": row.month, "revenue": round(float(row.Revenue), 2)} for row in grouped.itertuples(index=False)]
     return {"series": series}
 
 
@@ -223,16 +212,12 @@ def revenue_by_month(inputs: dict[str, pd.DataFrame], params: dict[str, Any]) ->
     ),
     params_schema={"month": {"type": "string", "description": "YYYY-MM filter."}},
 )
-def payroll_pct_by_month(
-    inputs: dict[str, pd.DataFrame], params: dict[str, Any]
-) -> dict[str, Any]:
+def payroll_pct_by_month(inputs: dict[str, pd.DataFrame], params: dict[str, Any]) -> dict[str, Any]:
     """See the ``@infographic_transformer`` description above."""
     df = month_period(inputs["finance"], source="finance")
     df = normalize_currency_columns(df, ["Payroll", "Revenue"])
     df = _apply_filters(df, {"month": params.get("month")})
-    grouped = df.groupby("month", as_index=False)[["Payroll", "Revenue"]].sum().sort_values(
-        "month"
-    )
+    grouped = df.groupby("month", as_index=False)[["Payroll", "Revenue"]].sum().sort_values("month")
     series = [
         {
             "month": row.month,
@@ -267,8 +252,7 @@ def pay_code_hours(inputs: dict[str, pd.DataFrame], params: dict[str, Any]) -> d
     )
     grouped = df.groupby("pay_code", as_index=False)["hours"].sum().sort_values("pay_code")
     records = [
-        {"pay_code": row.pay_code, "hours": round(float(row.hours), 2)}
-        for row in grouped.itertuples(index=False)
+        {"pay_code": row.pay_code, "hours": round(float(row.hours), 2)} for row in grouped.itertuples(index=False)
     ]
     return {"records": records}
 
@@ -276,23 +260,16 @@ def pay_code_hours(inputs: dict[str, pd.DataFrame], params: dict[str, Any]) -> d
 @infographic_transformer(
     "pay_code_allocation",
     requires_columns={"hours": ["pay_code", "hours"]},
-    description=(
-        "Worked Hours by Pay Code Allocation: each pay_code's share (%) of "
-        "total worked hours."
-    ),
+    description=("Worked Hours by Pay Code Allocation: each pay_code's share (%) of " "total worked hours."),
     params_schema={
         "month": {"type": "string", "description": "YYYY-MM filter."},
         "cost_center": {"type": "string"},
     },
 )
-def pay_code_allocation(
-    inputs: dict[str, pd.DataFrame], params: dict[str, Any]
-) -> dict[str, Any]:
+def pay_code_allocation(inputs: dict[str, pd.DataFrame], params: dict[str, Any]) -> dict[str, Any]:
     """See the ``@infographic_transformer`` description above."""
     df = month_period(inputs["hours"], source="hours")
-    df = _apply_filters(
-        df, {"month": params.get("month"), "cost_center": params.get("cost_center")}
-    )
+    df = _apply_filters(df, {"month": params.get("month"), "cost_center": params.get("cost_center")})
     total_hours = float(df["hours"].sum())
     grouped = df.groupby("pay_code", as_index=False)["hours"].sum().sort_values("pay_code")
     records = [
@@ -329,31 +306,21 @@ def pay_code_allocation(
         "category": {"type": "string"},
     },
 )
-def rep_utilization_by_region(
-    inputs: dict[str, pd.DataFrame], params: dict[str, Any]
-) -> dict[str, Any]:
+def rep_utilization_by_region(inputs: dict[str, pd.DataFrame], params: dict[str, Any]) -> dict[str, Any]:
     """See the ``@infographic_transformer`` description above."""
     rep = canonicalize_columns(inputs["rep_utilization"], source="rep_utilization")
     rep = month_period(rep, source="fm")
-    rep = _apply_filters(
-        rep, {"month": params.get("month"), "category": params.get("category")}
-    )
+    rep = _apply_filters(rep, {"month": params.get("month"), "category": params.get("category")})
     rep_grouped = (
-        rep.groupby(["region", "category", "month"], as_index=False)[
-            ["employees_worked", "average_active"]
-        ]
+        rep.groupby(["region", "category", "month"], as_index=False)[["employees_worked", "average_active"]]
         .sum()
         .sort_values(["region", "month"])
     )
 
     cross = canonicalize_columns(inputs["region_utilization"], source="region_utilization")
     cross = month_period(cross, source="fm")
-    cross = _apply_filters(
-        cross, {"month": params.get("month"), "category": params.get("category")}
-    )
-    cross_grouped = cross.groupby(["region", "category", "month"], as_index=False)[
-        "employee_utilization"
-    ].mean()
+    cross = _apply_filters(cross, {"month": params.get("month"), "category": params.get("category")})
+    cross_grouped = cross.groupby(["region", "category", "month"], as_index=False)["employee_utilization"].mean()
     cross_lookup = {
         (row.region, row.category, row.month): float(row.employee_utilization)
         for row in cross_grouped.itertuples(index=False)
@@ -361,11 +328,7 @@ def rep_utilization_by_region(
 
     records = []
     for row in rep_grouped.itertuples(index=False):
-        utilization = (
-            float(row.employees_worked) / float(row.average_active)
-            if row.average_active
-            else 0.0
-        )
+        utilization = float(row.employees_worked) / float(row.average_active) if row.average_active else 0.0
         key = (row.region, row.category, row.month)
         records.append(
             {
@@ -403,9 +366,7 @@ def rep_utilization_by_region(
         "flex_type": {"type": "string"},
     },
 )
-def proximity_staffing(
-    inputs: dict[str, pd.DataFrame], params: dict[str, Any]
-) -> dict[str, Any]:
+def proximity_staffing(inputs: dict[str, pd.DataFrame], params: dict[str, Any]) -> dict[str, Any]:
     """See the ``@infographic_transformer`` description above."""
     radius_miles = float(params.get("radius_miles") or 50)
     nearest_n = int(params.get("nearest_n") or 3)
@@ -451,9 +412,7 @@ def proximity_staffing(
             )
             continue
 
-        distances = _haversine_miles(
-            float(store.latitude), float(store.longitude), emp_lat, emp_lon
-        )
+        distances = _haversine_miles(float(store.latitude), float(store.longitude), emp_lat, emp_lon)
         order = np.argsort(distances, kind="stable")
         nearest = [
             {

--- a/agents/flex_dashboard/transformers.py
+++ b/agents/flex_dashboard/transformers.py
@@ -115,18 +115,41 @@ def _haversine_miles(lat1: np.ndarray, lon1: np.ndarray, lat2: np.ndarray, lon2:
 
 @infographic_transformer(
     "payroll_hero",
-    requires_columns={"hours": ["hours"], "finance": ["Payroll", "Revenue"]},
+    requires_columns={"hours": ["month_start", "hours"], "finance": ["month", "Payroll", "Revenue"]},
     description=(
         "Hero-row totals: Worked Hours (sum of hours.hours), Payroll and "
         "Revenue totals (sum of finance.Payroll / finance.Revenue), and "
         "Payroll % to Revenue = payroll_total / revenue_total (Revenue "
-        "ALONE as denominator — spec §2 resolved Q&A)."
+        "ALONE as denominator — spec §2 resolved Q&A). Reflects the SAME "
+        "active filters as the rest of the dashboard."
     ),
+    params_schema={
+        "month": {"type": "string", "description": "YYYY-MM filter."},
+        "pay_code": {"type": "string"},
+        "cost_center": {"type": "string"},
+    },
 )
 def payroll_hero(inputs: dict[str, pd.DataFrame], params: dict[str, Any]) -> dict[str, Any]:
     """See the ``@infographic_transformer`` description above."""
-    hours = inputs["hours"]
-    finance = normalize_currency_columns(inputs["finance"], ["Payroll", "Revenue"])
+    # Code-review finding (external `codex` review, adopted): the hero row
+    # must reflect the SAME active filters as the rest of the dashboard —
+    # otherwise a month/pay_code-filtered replay shows all-time totals in
+    # the hero cards next to a filtered month-series chart, an internally
+    # inconsistent dashboard. `month`/`pay_code`/`cost_center` narrow
+    # `hours`; `month` narrows `finance` (finance has no pay_code/
+    # cost_center column, so those two are naturally no-ops there).
+    hours = month_period(inputs["hours"], source="hours")
+    hours = _apply_filters(
+        hours,
+        {
+            "month": params.get("month"),
+            "pay_code": params.get("pay_code"),
+            "cost_center": params.get("cost_center"),
+        },
+    )
+    finance = month_period(inputs["finance"], source="finance")
+    finance = normalize_currency_columns(finance, ["Payroll", "Revenue"])
+    finance = _apply_filters(finance, {"month": params.get("month")})
 
     worked_hours_total = float(hours["hours"].sum())
     payroll_total = float(finance["Payroll"].sum())
@@ -260,16 +283,30 @@ def pay_code_hours(inputs: dict[str, pd.DataFrame], params: dict[str, Any]) -> d
 @infographic_transformer(
     "pay_code_allocation",
     requires_columns={"hours": ["pay_code", "hours"]},
-    description=("Worked Hours by Pay Code Allocation: each pay_code's share (%) of " "total worked hours."),
+    description=(
+        "Worked Hours by Pay Code Allocation: each pay_code's share (%) of "
+        "total worked hours. A pay_code filter narrows the allocation base "
+        "itself (consistent with the sibling pay_code_hours table) — with "
+        "one pay_code selected, its share is trivially 100%, same as "
+        "filtering any breakdown to a single category."
+    ),
     params_schema={
         "month": {"type": "string", "description": "YYYY-MM filter."},
+        "pay_code": {"type": "string"},
         "cost_center": {"type": "string"},
     },
 )
 def pay_code_allocation(inputs: dict[str, pd.DataFrame], params: dict[str, Any]) -> dict[str, Any]:
     """See the ``@infographic_transformer`` description above."""
     df = month_period(inputs["hours"], source="hours")
-    df = _apply_filters(df, {"month": params.get("month"), "cost_center": params.get("cost_center")})
+    df = _apply_filters(
+        df,
+        {
+            "month": params.get("month"),
+            "pay_code": params.get("pay_code"),
+            "cost_center": params.get("cost_center"),
+        },
+    )
     total_hours = float(df["hours"].sum())
     grouped = df.groupby("pay_code", as_index=False)["hours"].sum().sort_values("pay_code")
     records = [

--- a/examples/agents/a2ui/flex_dashboard_demo.py
+++ b/examples/agents/a2ui/flex_dashboard_demo.py
@@ -55,6 +55,7 @@ Usage::
    The ``interactive-html`` renderer output needs an HTTP origin — opening
    the files as ``file://`` breaks Chart.js canvas rendering. Use ``--serve``.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -229,9 +230,7 @@ async def lane_publish(agent: FlexDashboard, recipe_store: FileRecipeStore) -> b
     """Publish the dashboard recipe and declare its run-time filter params."""
     rule("1 — publish_recipe: sections → registered transformers → recipe")
 
-    recipe = await agent.publish_recipe(
-        RECIPE_NAME, FlexDashboard.dashboard_descriptor(), overwrite=True
-    )
+    recipe = await agent.publish_recipe(RECIPE_NAME, FlexDashboard.dashboard_descriptor(), overwrite=True)
     if isinstance(recipe, GapReport):
         print("  ✗ GAPS — unregistered transformers:")
         for gap in recipe.gaps:
@@ -274,9 +273,7 @@ async def lane_deterministic_replay(runner: RecipeRunner, pctx: Any) -> None:
 
     first = await runner.run(RECIPE_NAME, pctx=pctx)
     second = await runner.run(RECIPE_NAME, pctx=pctx)
-    identical = _normalize_render(first.content or b"") == _normalize_render(
-        second.content or b""
-    )
+    identical = _normalize_render(first.content or b"") == _normalize_render(second.content or b"")
     print(f"  replay #1     : {len(first.content or b''):,} bytes")
     print(f"  replay #2     : {len(second.content or b''):,} bytes")
     print(f"  identical     : {identical}  (modulo the renderer's per-render DOM")
@@ -288,12 +285,9 @@ async def lane_deterministic_replay(runner: RecipeRunner, pctx: Any) -> None:
 
     (OUTPUT_DIR / "01_dashboard_default.html").write_bytes(first.content or b"")
 
-    filtered = await runner.run(
-        RECIPE_NAME, params={"month": "2025-10", "pay_code": "Field Time"}, pctx=pctx
-    )
+    filtered = await runner.run(RECIPE_NAME, params={"month": "2025-10", "pay_code": "Field Time"}, pctx=pctx)
     (OUTPUT_DIR / "02_dashboard_2025-10_field-time.html").write_bytes(filtered.content or b"")
-    print(f"  filtered      : month=2025-10 pay_code='Field Time' → "
-          f"{len(filtered.content or b''):,} bytes")
+    print(f"  filtered      : month=2025-10 pay_code='Field Time' → " f"{len(filtered.content or b''):,} bytes")
 
     try:
         await runner.run(RECIPE_NAME, params={"moth": "oops"}, pctx=pctx)
@@ -431,9 +425,7 @@ async def main() -> None:
 
     executor = ToolManagerExecutor(agent.tool_manager)
     surfaces = InMemorySurfaceStore()
-    runtime = A2UIRuntime(
-        executor=executor, surfaces=surfaces, pending=InMemoryPendingCalls()
-    )
+    runtime = A2UIRuntime(executor=executor, surfaces=surfaces, pending=InMemoryPendingCalls())
     ctx = A2UICallContext(
         agent_id="flex_dashboard",
         user_id="demo-user",

--- a/examples/agents/a2ui/flex_dashboard_demo.py
+++ b/examples/agents/a2ui/flex_dashboard_demo.py
@@ -230,20 +230,18 @@ async def lane_publish(agent: FlexDashboard, recipe_store: FileRecipeStore) -> b
     """Publish the dashboard recipe and declare its run-time filter params."""
     rule("1 — publish_recipe: sections → registered transformers → recipe")
 
-    recipe = await agent.publish_recipe(RECIPE_NAME, FlexDashboard.dashboard_descriptor(), overwrite=True)
+    # `publish_dashboard_recipe` wraps `publish_recipe` + the
+    # `recipe.params = FlexDashboard.recipe_params(); recipe_store.save(...)`
+    # follow-up atomically (code-review finding, TASK-2699 amendment) — the
+    # base `publish_recipe()` has no `params=` argument, so skipping the
+    # follow-up would leave every `{month}`-style placeholder unresolved on
+    # replay, even the unfiltered default one.
+    recipe = await agent.publish_dashboard_recipe(overwrite=True)
     if isinstance(recipe, GapReport):
         print("  ✗ GAPS — unregistered transformers:")
         for gap in recipe.gaps:
             print(f"    - {gap.section}")
         return False
-
-    # publish_recipe carries descriptor.params onto every TransformStep, but
-    # the DECLARED run-time params (name/default, override whitelist) are the
-    # recipe author's call — declare them and re-save (FlexDashboard.
-    # recipe_params(), TASK-2697). An override for an undeclared name raises
-    # (typo protection).
-    recipe.params = FlexDashboard.recipe_params()
-    await recipe_store.save(recipe)
 
     print(f"  recipe        : {recipe.name}")
     print(f"  transforms    : {[t.transformer for t in recipe.transforms]}")

--- a/examples/agents/a2ui/flex_dashboard_demo.py
+++ b/examples/agents/a2ui/flex_dashboard_demo.py
@@ -1,0 +1,493 @@
+"""Flex Program Dashboard — offline end-to-end demo (FEAT-491 TASK-2699).
+
+Lineage: this is a domain-specific retelling of ``examples/agents/a2ui/
+deterministic_refresh_dashboard.py`` (FEAT-324/326 x FEAT-469) for the Flex
+program agent (`agents/flex_dashboard.py`, FEAT-491). Same shape: publish a
+deterministic recipe once (`FlexDashboard.dashboard_descriptor()`), replay
+it forever via `RecipeRunner`, and expose a `refresh_dashboard` agent
+function through the A2UI Agent Functions runtime (FEAT-469) so a renderer
+can ask for a re-render with inline filter state.
+
+Fully offline — no database, no network, no LLM:
+
+1. **Synthetic data** (`flex_synthetic_data.py`) — the six Flex dataset
+   aliases (spec §2), injected directly via ``DatasetManager.add_dataframe``
+   (bypassing `FlexDashboard.register_datasets()`'s lazy `QuerySlugSource`
+   registration entirely — slug data is prod-only, spec §7 "Slug data is
+   prod-only"; this demo never touches QuerySource).
+2. **Publish** — ``InfographicAuthoringMixin.publish_recipe()`` maps the
+   descriptor's ten sections to registered transformers
+   (`agents/flex_dashboard/transformers.py`) and persists an
+   ``InfographicRecipe`` whose ``LayoutSpec`` (v2) is used verbatim.
+3. **Deterministic replay** — ``RecipeRunner.run()`` twice with the same
+   params produces byte-identical HTML; a params override (month/pay_code)
+   gives a filtered variant. No narrator is configured — the
+   `flex_narrative_facts` step stays absent, proving the recipe replays
+   with no LLM (spec §5 "Recipe replays deterministically with NO narrator
+   configured").
+4. **The RPC leg** — an ``A2UIRuntime`` over the agent's own ``ToolManager``:
+   ``action`` + ``dataModel`` pushes inline filter state; `callAgentFunction`
+   → `refresh_dashboard` re-runs the recipe (explicit args win over the
+   persisted surface state).
+5. **Capabilities** — ``export_functions()`` / ``agent_capabilities()`` show
+   what a renderer discovers.
+
+**Server lane** (proposal U3, no code here): once a recipe is published to
+a SHARED recipe store (not this demo's throwaway ``tmp``-rooted
+``FileRecipeStore``), it is servable as-is through the existing
+``infographic_recipes`` / ``infographic_render`` handlers
+(``ai-parrot-server/src/parrot/handlers/infographic_recipes.py``) — no new
+server code is needed; only the store location changes from a local
+directory to whatever store the deployment's handlers are wired to.
+
+Prerequisites::
+
+    pip install ai-parrot ai-parrot-visualizations[a2ui]
+
+Usage::
+
+    source .venv/bin/activate
+    python examples/agents/a2ui/flex_dashboard_demo.py
+    python examples/agents/a2ui/flex_dashboard_demo.py --serve
+
+.. note::
+
+   The ``interactive-html`` renderer output needs an HTTP origin — opening
+   the files as ``file://`` breaks Chart.js canvas rendering. Use ``--serve``.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import http.server
+import importlib.util
+import json
+import os
+import re
+import socketserver
+import sys
+import threading
+import webbrowser
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_AGENTS_DIR = REPO_ROOT / "agents"
+_FLEX_PACKAGE_DIR = _AGENTS_DIR / "flex_dashboard"
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(REPO_ROOT))  # repo root, for `agents.*` cross-imports
+
+from flex_synthetic_data import build_flex_frames
+from parrot.auth.permission import build_principal_context
+from parrot.outputs.a2ui.catalog import DEFAULT_CATALOG_ID
+from parrot.outputs.a2ui.catalog.export import (
+    agent_capabilities,
+    export_functions,
+)
+from parrot.outputs.a2ui.recipes.store import FileRecipeStore
+from parrot.outputs.a2ui.runtime import (
+    A2UICallContext,
+    A2UIRuntime,
+    FunctionCallRecord,
+    SurfaceState,
+)
+from parrot.outputs.a2ui.runtime.adapters import ToolManagerExecutor
+from parrot.storage.artifacts import ArtifactStore
+from parrot.storage.backends import build_overflow_store
+from parrot.storage.backends.sqlite import ConversationSQLiteBackend
+from parrot.tools.infographic_recipes.runner import (
+    RecipeRunException,
+    RecipeRunner,
+)
+from parrot.tools.infographic_sections import GapReport
+
+# The ``interactive-html`` renderer registers itself on import; it ships from
+# ai-parrot-visualizations (namespace-merged). Without it, RecipeRunner's
+# default render profile cannot resolve.
+try:
+    import parrot.outputs.a2ui_renderers.interactive_html  # noqa: F401
+
+    _HAS_RENDERER = True
+except ImportError:
+    _HAS_RENDERER = False
+
+
+def _load_module(name: str, path: Path, search_dir: Path | None = None):
+    """File-path-load *path* under module *name* (worktree-safe).
+
+    ``agents/flex_dashboard.py`` (the agent FILE) and ``agents/
+    flex_dashboard/`` (the sibling PACKAGE for transformers/skills/kb) share
+    the same name — Python's FileFinder always resolves a plain ``import
+    agents.flex_dashboard`` to the PACKAGE, never the file (verified
+    empirically; same finding as this feature's test suite). This mirrors
+    how production actually loads agent files:
+    ``parrot.registry.registry.AgentRegistry._load_modules_from_directory``
+    globs ``agents/*.py`` and loads each one via
+    ``importlib.util.spec_from_file_location`` under a synthetic module
+    name — never a plain dotted ``agents.<name>`` import.
+    """
+    if name in sys.modules:
+        return sys.modules[name]
+    kwargs = {"submodule_search_locations": [str(search_dir)]} if search_dir else {}
+    spec = importlib.util.spec_from_file_location(name, path, **kwargs)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load {name!r} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+def _load_flex_dashboard_class():
+    # Pre-register the real "agents.flex_dashboard" package chain so the
+    # agent file's own `import agents.flex_dashboard.transformers` resolves
+    # deterministically, THEN load the agent file itself under its own
+    # distinct name (never "agents.flex_dashboard" — that name is reserved
+    # for the package).
+    _load_module("agents", _AGENTS_DIR / "__init__.py", _AGENTS_DIR)
+    _load_module("agents.flex_dashboard", _FLEX_PACKAGE_DIR / "__init__.py", _FLEX_PACKAGE_DIR)
+    _load_module("agents.flex_dashboard.normalize", _FLEX_PACKAGE_DIR / "normalize.py")
+    _load_module("agents.flex_dashboard.transformers", _FLEX_PACKAGE_DIR / "transformers.py")
+    module = _load_module("flex_dashboard_agent_module", _AGENTS_DIR / "flex_dashboard.py")
+    return module.FlexDashboard
+
+
+FlexDashboard = _load_flex_dashboard_class()
+
+OUTPUT_DIR = REPO_ROOT / "artifacts" / "flex_dashboard_demo"
+
+RECIPE_NAME = FlexDashboard.DASHBOARD_RECIPE_NAME
+#: RecipeRunner assembles the envelope with surface_id=f"{recipe.name}-infographic",
+#: so the surface id is stable across runs — the renderer can key its state on it.
+SURFACE_ID = f"{RECIPE_NAME}-infographic"
+SESSION_ID = "sess-flex-demo"
+
+
+def rule(title: str) -> None:
+    """Print a section rule with a title."""
+    print("\n" + "═" * 72)
+    print(f"  {title}")
+    print("═" * 72)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Step 1 — In-memory runtime adapters (Protocol-shaped, no Redis needed)
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Production uses ConversationMemorySurfaceStore (both protocols over
+# ConversationMemory metadata). The runtime takes the Protocols by injection,
+# so a dict-backed pair is all a self-contained example needs.
+
+
+class InMemorySurfaceStore:
+    """Dict-backed ``SurfaceStateStore``: the last ``dataModel`` per surface."""
+
+    def __init__(self) -> None:
+        self._store: dict[tuple, SurfaceState] = {}
+
+    async def get(self, session_id: str, surface_id: str) -> SurfaceState | None:
+        return self._store.get((session_id, surface_id))
+
+    async def put(self, session_id: str, state: SurfaceState) -> None:
+        self._store[(session_id, state.surface_id)] = state
+
+    async def delete(self, session_id: str, surface_id: str) -> None:
+        self._store.pop((session_id, surface_id), None)
+
+
+class InMemoryPendingCalls:
+    """Dict-backed ``PendingCallRegistry`` with the standard TTL semantics."""
+
+    def __init__(self) -> None:
+        self._store: dict[tuple, FunctionCallRecord] = {}
+
+    async def add(self, session_id: str, record: FunctionCallRecord) -> None:
+        self._store[(session_id, record.function_call_id)] = record
+
+    async def resolve(
+        self, session_id: str, function_call_id: str, value: Any, error: Any
+    ) -> FunctionCallRecord | None:
+        key = (session_id, function_call_id)
+        record = self._store.get(key)
+        if record is None:
+            return None
+        if datetime.now(UTC) > record.created_at + timedelta(seconds=record.ttl_seconds):
+            del self._store[key]
+            return None
+        del self._store[key]
+        return record
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Step 2 — Demo lanes
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+async def lane_publish(agent: FlexDashboard, recipe_store: FileRecipeStore) -> bool:
+    """Publish the dashboard recipe and declare its run-time filter params."""
+    rule("1 — publish_recipe: sections → registered transformers → recipe")
+
+    recipe = await agent.publish_recipe(
+        RECIPE_NAME, FlexDashboard.dashboard_descriptor(), overwrite=True
+    )
+    if isinstance(recipe, GapReport):
+        print("  ✗ GAPS — unregistered transformers:")
+        for gap in recipe.gaps:
+            print(f"    - {gap.section}")
+        return False
+
+    # publish_recipe carries descriptor.params onto every TransformStep, but
+    # the DECLARED run-time params (name/default, override whitelist) are the
+    # recipe author's call — declare them and re-save (FlexDashboard.
+    # recipe_params(), TASK-2697). An override for an undeclared name raises
+    # (typo protection).
+    recipe.params = FlexDashboard.recipe_params()
+    await recipe_store.save(recipe)
+
+    print(f"  recipe        : {recipe.name}")
+    print(f"  transforms    : {[t.transformer for t in recipe.transforms]}")
+    print(f"  data_sources  : {[ds.alias for ds in recipe.data_sources]}")
+    print(f"  declared params: {({p.name: p.default for p in recipe.params})}")
+    print(f"  surface_id    : {SURFACE_ID}  (stable across replays)")
+    return True
+
+
+#: The interactive-html renderer mints per-render DOM element ids
+#: (``chart-<hex8>``, ``tabs-<hex8>``, ``nested-<hex8>`` via ``uuid4``) — the
+#: one thing in the output that is NOT replay-stable. The FEAT-324 determinism
+#: guarantee lives at the data plane (params → transforms → dataModel →
+#: envelope, all replay-stable, surfaceId included); these ids are internal
+#: renderer wiring with no data content. Normalize them before comparing.
+_VOLATILE_DOM_ID = re.compile(rb"(chart|tabs|nested)-[0-9a-f]{8}")
+
+
+def _normalize_render(content: bytes) -> bytes:
+    """Replace the renderer's per-render DOM ids with a stable token."""
+    return _VOLATILE_DOM_ID.sub(rb"\1-x", content)
+
+
+async def lane_deterministic_replay(runner: RecipeRunner, pctx: Any) -> None:
+    """Prove the refresh is deterministic, then replay with filter overrides."""
+    rule("2 — RecipeRunner.run: deterministic replay + filtered variants")
+
+    first = await runner.run(RECIPE_NAME, pctx=pctx)
+    second = await runner.run(RECIPE_NAME, pctx=pctx)
+    identical = _normalize_render(first.content or b"") == _normalize_render(
+        second.content or b""
+    )
+    print(f"  replay #1     : {len(first.content or b''):,} bytes")
+    print(f"  replay #2     : {len(second.content or b''):,} bytes")
+    print(f"  identical     : {identical}  (modulo the renderer's per-render DOM")
+    print("                  element ids — every number, label, series and the")
+    print("                  surfaceId itself is replay-stable; no narrator is")
+    print("                  configured, so flex_narrative_facts stays absent)")
+    if not identical:
+        print("  ⚠ unexpected: same params should produce identical content")
+
+    (OUTPUT_DIR / "01_dashboard_default.html").write_bytes(first.content or b"")
+
+    filtered = await runner.run(
+        RECIPE_NAME, params={"month": "2025-10", "pay_code": "Field Time"}, pctx=pctx
+    )
+    (OUTPUT_DIR / "02_dashboard_2025-10_field-time.html").write_bytes(filtered.content or b"")
+    print(f"  filtered      : month=2025-10 pay_code='Field Time' → "
+          f"{len(filtered.content or b''):,} bytes")
+
+    try:
+        await runner.run(RECIPE_NAME, params={"moth": "oops"}, pctx=pctx)
+    except RecipeRunException as exc:
+        print(f"  typo guard    : undeclared override rejected — {exc.error.detail}")
+
+
+async def lane_rpc(
+    runtime: A2UIRuntime,
+    ctx: A2UICallContext,
+    surfaces: InMemorySurfaceStore,
+    refresh_tool: Any,
+) -> None:
+    """Drive the four FEAT-469 flows the way a renderer would."""
+    rule("3 — action + dataModel: the surface pushes its inline filter state")
+
+    action_env = {
+        "version": "v1.0",
+        "action": {
+            "name": "filters_changed",
+            "surfaceId": SURFACE_ID,
+            "sourceComponentId": "filter-bar",
+            "timestamp": datetime.now(UTC).isoformat(),
+            "context": {},
+            "dataModel": {"filters": {"month": "2025-09", "flex_type": "Flex"}},
+        },
+    }
+    res = await runtime.dispatch(action_env, ctx)
+    print(f"  responses     : {res.messages or '(none — actions ack silently)'}")
+    print(f"  user_turn     : {res.user_turn}")
+    stored = await surfaces.get(SESSION_ID, SURFACE_ID)
+    print(f"  surface state : {stored.data_model if stored else None}")
+
+    rule("4 — callAgentFunction: the renderer asks for a filtered refresh")
+
+    call_env = {
+        "version": "v1.0",
+        "callAgentFunction": {
+            "surfaceId": SURFACE_ID,
+            "functionCallId": "fc-refresh-1",
+            "callFunction": {
+                "call": "refresh_dashboard",
+                "args": {"month": "2025-10"},  # explicit arg wins over state
+                "catalogId": DEFAULT_CATALOG_ID,
+            },
+        },
+    }
+    res = await runtime.dispatch(call_env, ctx)
+    reply = res.messages[0]
+    print(f"  envelope key  : {[k for k in reply if k != 'version']}")
+    value = reply.get("agentFunctionResponse", {}).get("value")
+    print(f"  tool result   : {json.dumps(value, indent=2) if value else reply}")
+
+    rule("5 — surface-state refresh: no args, filters come from the dataModel")
+
+    state = await surfaces.get(SESSION_ID, SURFACE_ID)
+    result = await refresh_tool.execute(_a2ui_surface_state=state)
+    print(f"  tool result   : {json.dumps(result.result, indent=2)}")
+
+    rule("6 — callRendererFunction: the agent calls the renderer back")
+
+    fc_id, outbound = await runtime.call_renderer(
+        SESSION_ID,
+        SURFACE_ID,
+        "updateDataModel",
+        {"path": "/lastRefreshed", "value": datetime.now(UTC).isoformat()},
+    )
+    print(f"  outbound      : {json.dumps(outbound)}")
+
+    response_env = {
+        "version": "v1.0",
+        "rendererFunctionResponse": {"functionCallId": fc_id, "value": {"applied": True}},
+    }
+    res = await runtime.dispatch(response_env, ctx)
+    print(f"  correlated    : {'yes (no error envelope)' if not res.messages else res.messages}")
+
+
+def lane_capabilities(executor: ToolManagerExecutor) -> None:
+    """Show what a renderer discovers about this agent."""
+    rule("7 — export_functions / agent_capabilities: the discovery documents")
+
+    functions = export_functions(executor)
+    capabilities = agent_capabilities([DEFAULT_CATALOG_ID])
+
+    print(f"  functions     : {sorted(functions)}")
+    print(f"  capabilities  : {json.dumps(capabilities)}")
+
+    doc = OUTPUT_DIR / "03_capabilities.json"
+    doc.write_text(json.dumps({"functions": functions, "capabilities": capabilities}, indent=2))
+    print(f"  wrote         : {doc.relative_to(REPO_ROOT)}")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Main
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+async def main() -> None:
+    """Wire storage + agent + runtime, then run every lane."""
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    if not _HAS_RENDERER:
+        print("✗ ai-parrot-visualizations[a2ui] is not importable — the recipe's")
+        print("  'interactive-html' render profile cannot resolve. Install it first.")
+        return
+
+    backend = ConversationSQLiteBackend(path=str(OUTPUT_DIR / "artifacts.db"))
+    await backend.initialize()
+    artifact_store = ArtifactStore(backend, build_overflow_store())
+    recipe_store = FileRecipeStore(OUTPUT_DIR / "recipes")
+
+    agent = FlexDashboard(
+        name="flex-dashboard-demo",
+        artifact_store=artifact_store,
+        recipe_store=recipe_store,
+        injection_detection=False,
+    )
+
+    # Offline injection lane (spec §7: slug data is prod-only — this demo
+    # NEVER touches QuerySource). Bypasses `register_datasets()`'s lazy
+    # `add_query(query_slug=...)` registration entirely; each alias is
+    # registered directly as an in-memory frame instead.
+    for alias, frame in build_flex_frames().items():
+        agent._dataset_manager.add_dataframe(alias, frame, description=f"Synthetic {alias} frame")
+
+    if not await lane_publish(agent, recipe_store):
+        return
+
+    pctx = build_principal_context("demo-user", channel="script")
+    runner = RecipeRunner(recipe_store, agent._dataset_manager)
+    await lane_deterministic_replay(runner, pctx)
+
+    # --- FEAT-469 runtime over the agent's own ToolManager ---
+    refresh_tool = agent.build_refresh_tool(pctx)
+
+    executor = ToolManagerExecutor(agent.tool_manager)
+    surfaces = InMemorySurfaceStore()
+    runtime = A2UIRuntime(
+        executor=executor, surfaces=surfaces, pending=InMemoryPendingCalls()
+    )
+    ctx = A2UICallContext(
+        agent_id="flex_dashboard",
+        user_id="demo-user",
+        session_id=SESSION_ID,
+        surface_id=SURFACE_ID,
+        transport="http",
+        permission_context=pctx,
+    )
+
+    await lane_rpc(runtime, ctx, surfaces, refresh_tool)
+    lane_capabilities(executor)
+
+    rule("Done")
+    print(f"  artifacts in  : {OUTPUT_DIR.relative_to(REPO_ROOT)}")
+    for f in sorted(OUTPUT_DIR.glob("*.html")):
+        print(f"    - {f.name}")
+
+
+def _serve_and_open(directory: Path, port: int = 8092) -> None:
+    """Serve OUTPUT_DIR over HTTP and open the default dashboard."""
+    os.chdir(directory)
+    socketserver.TCPServer.allow_reuse_address = True
+    try:
+        httpd = socketserver.TCPServer(("", port), http.server.SimpleHTTPRequestHandler)
+    except OSError as exc:
+        print(f"  ⚠ could not bind port {port}: {exc}")
+        return
+
+    url = f"http://localhost:{port}/01_dashboard_default.html"
+    print(f"\n  🌐 serving at {url} — Ctrl+C to stop\n")
+    threading.Timer(0.5, webbrowser.open, args=(url,)).start()
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("\n  server stopped.")
+    finally:
+        httpd.server_close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Flex Program Dashboard — offline deterministic demo",
+    )
+    parser.add_argument("--serve", action="store_true", help="serve + open the output")
+    parser.add_argument("--port", type=int, default=8092)
+    args = parser.parse_args()
+
+    asyncio.run(main())
+
+    if args.serve:
+        _serve_and_open(OUTPUT_DIR, port=args.port)
+
+    # Some parrot subsystems may leave non-daemon threads alive; flush + _exit
+    # is the same belt-and-suspenders guard the sibling examples use.
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0)

--- a/examples/agents/a2ui/flex_synthetic_data.py
+++ b/examples/agents/a2ui/flex_synthetic_data.py
@@ -1,0 +1,270 @@
+"""Synthetic six-alias Flex frames for the offline demo (FEAT-491 TASK-2699).
+
+Mirrors the `flex_frames` fixture in `packages/ai-parrot/tests/unit/bots/
+conftest.py` (same dirty shapes — currency strings, the three date-grain
+conventions, the `catagory` typo — sourced from `sdd/state/FEAT-517/
+source.md`'s sample rows plus a few extra rows for month-series/filter
+variety), reimplemented here as builder functions so
+`examples/agents/a2ui/flex_dashboard_demo.py` does not import test code.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def build_msl() -> pd.DataFrame:
+    """Master Store List — district/region/market/account/store, lat/lon."""
+    return pd.DataFrame(
+        [
+            {
+                "district_name": "IL - Chicago",
+                "region_name": "Midwest Region",
+                "market_name": "IL - Chicago - Oak Park",
+                "account_name": "T-Mobile",
+                "store_name": "T-Mobile 3SFD Norridge IL",
+                "latitude": 41.95535,
+                "longitude": -87.80886,
+                "city": "Norridge",
+                "state_code": "IL",
+            },
+            {
+                "district_name": "PA - Philadelphia",
+                "region_name": "Northeast Region",
+                "market_name": "PA - Philadelphia - Media",
+                "account_name": "T-Mobile",
+                "store_name": "T-Mobile Media PA",
+                "latitude": 39.9168,
+                "longitude": -75.3902,
+                "city": "Media",
+                "state_code": "PA",
+            },
+            {
+                "district_name": "CA - Los Angeles",
+                "region_name": "West Region",
+                "market_name": "CA - LA - Downtown",
+                "account_name": "T-Mobile",
+                "store_name": "T-Mobile Downtown LA",
+                "latitude": 34.0407,
+                "longitude": -118.2468,
+                "city": "Los Angeles",
+                "state_code": "CA",
+            },
+        ]
+    )
+
+
+def build_finance() -> pd.DataFrame:
+    """Monthly P&L per project — currency strings, month-end dates."""
+    return pd.DataFrame(
+        [
+            {
+                "project": "Flex - General",
+                "month": "2025-09-30",
+                "Revenue": "$120,000.00",
+                "PC Revenue": "$40,000.00",
+                "EBITDA": "$9,000.00",
+                "Payroll": "$18,000.00",
+                "Travel and Expenses": "$12,000.00",
+                "Program Overhead Allocation": "$0.00",
+                "Other Related Expenses": "-$40,000.00",
+                "Total Hours": 2100.0,
+                "FTE": 16.5,
+                "Visits": 220,
+            },
+            {
+                "project": "Flex - General",
+                "month": "2025-10-31",
+                "Revenue": "$137,456.85",
+                "PC Revenue": "$51,229.85",
+                "EBITDA": "$10,222.16",
+                "Payroll": "$20,682.27",
+                "Travel and Expenses": "$13,746.44",
+                "Program Overhead Allocation": "$0.00",
+                "Other Related Expenses": "-$44,621.24",
+                "Total Hours": 2250.866693,
+                "FTE": 17.278409301948,
+                "Visits": 241,
+            },
+        ]
+    )
+
+
+def build_hours() -> pd.DataFrame:
+    """Hours/wages by month, program, pay_code, cost_center."""
+    return pd.DataFrame(
+        [
+            {
+                "month_start": "2025-09-01",
+                "month_end": "2025-09-30",
+                "program": "Flex - General",
+                "pay_code": "Admin Time",
+                "cost_center": "Flex",
+                "hours": 25.0,
+                "wages": 575.0,
+            },
+            {
+                "month_start": "2025-09-01",
+                "month_end": "2025-09-30",
+                "program": "Flex - General",
+                "pay_code": "Field Time",
+                "cost_center": "Flex",
+                "hours": 1800.0,
+                "wages": 41000.0,
+            },
+            {
+                "month_start": "2025-10-01",
+                "month_end": "2025-10-31",
+                "program": "Flex - General",
+                "pay_code": "Admin Time",
+                "cost_center": "Flex",
+                "hours": 30.199996,
+                "wages": 693.749909,
+            },
+            {
+                "month_start": "2025-10-01",
+                "month_end": "2025-10-31",
+                "program": "Flex - General",
+                "pay_code": "Field Time",
+                "cost_center": "Flex",
+                "hours": 1900.0,
+                "wages": 43000.0,
+            },
+        ]
+    )
+
+
+def build_employees() -> pd.DataFrame:
+    """Employee roster with lat/lon, Flex Type, service tenure."""
+    return pd.DataFrame(
+        [
+            {
+                "display_name": "Abby Halladay",
+                "start_date": "2025-12-31",
+                "job_code_title": "Mobile Retail Display Technician",
+                "referred_by": None,
+                "legal_city": "MEDIA",
+                "legal_state": "PA",
+                "zipcode": "19063",
+                "phone_mobile": "(267) 346-0701",
+                "latitude": 39.9222285,
+                "longitude": -75.414058,
+                "Flex Employees": 1,
+                "Flex Type": "Flex",
+                "Years of Service": 1,
+                "Months of Service": 8,
+                "Days of Service": 244,
+                "Days of Service Retention": 244,
+            },
+            {
+                "display_name": "Jordan Reyes",
+                "start_date": "2025-06-15",
+                "job_code_title": "Retail Sales Associate",
+                "referred_by": None,
+                "legal_city": "Norridge",
+                "legal_state": "IL",
+                "zipcode": "60706",
+                "phone_mobile": "(312) 555-0100",
+                "latitude": 41.9600,
+                "longitude": -87.8100,
+                "Flex Employees": 1,
+                "Flex Type": "Flex",
+                "Years of Service": 2,
+                "Months of Service": 3,
+                "Days of Service": 825,
+                "Days of Service Retention": 825,
+            },
+            {
+                "display_name": "Casey Kim",
+                "start_date": "2024-01-01",
+                "job_code_title": "Store Manager",
+                "referred_by": "Referral Program",
+                "legal_city": "Los Angeles",
+                "legal_state": "CA",
+                "zipcode": "90012",
+                "phone_mobile": "(213) 555-0199",
+                "latitude": 34.0500,
+                "longitude": -118.2500,
+                "Flex Employees": 0,
+                "Flex Type": "Core",
+                "Years of Service": 3,
+                "Months of Service": 0,
+                "Days of Service": 1095,
+                "Days of Service Retention": 1095,
+            },
+        ]
+    )
+
+
+def build_region_utilization() -> pd.DataFrame:
+    """Regional monthly employee utilization (BOP/EOP dates)."""
+    return pd.DataFrame(
+        [
+            {
+                "BOP Date": "2026-03-01",
+                "EOP Date": "2026-03-31",
+                "FM Region": "CA",
+                "State Code": "CA",
+                "State": "California",
+                "Category": "Flex",
+                "Employees Worked": 11,
+                "Average Active Employees": 75.5,
+                "Flex Employees": 68,
+                "Employee Utilization": 0.145695364238411,
+            },
+            {
+                "BOP Date": "2026-04-01",
+                "EOP Date": "2026-04-30",
+                "FM Region": "IL",
+                "State Code": "IL",
+                "State": "Illinois",
+                "Category": "Flex",
+                "Employees Worked": 15,
+                "Average Active Employees": 60.0,
+                "Flex Employees": 50,
+                "Employee Utilization": 0.25,
+            },
+        ]
+    )
+
+
+def build_rep_utilization() -> pd.DataFrame:
+    """Rep utilization by region/state/category (raw `catagory` typo column)."""
+    return pd.DataFrame(
+        [
+            {
+                "bop_date": "2026-05-01",
+                "eop_date": "2026-05-31",
+                "region": "CA",
+                "state": "CA",
+                "catagory": "Flex",
+                "hours_worked": 167.550001,
+                "work_shifts": 76,
+                "employees_worked": 12,
+                "average_active": 63,
+            },
+            {
+                "bop_date": "2026-06-01",
+                "eop_date": "2026-06-30",
+                "region": "IL",
+                "state": "IL",
+                "catagory": "Flex",
+                "hours_worked": 140.0,
+                "work_shifts": 60,
+                "employees_worked": 10,
+                "average_active": 50,
+            },
+        ]
+    )
+
+
+def build_flex_frames() -> dict[str, pd.DataFrame]:
+    """Return all six Flex dataset aliases (spec §2) as synthetic frames."""
+    return {
+        "msl": build_msl(),
+        "finance": build_finance(),
+        "hours": build_hours(),
+        "employees": build_employees(),
+        "region_utilization": build_region_utilization(),
+        "rep_utilization": build_rep_utilization(),
+    }

--- a/packages/ai-parrot/tests/integration/test_flex_dashboard_e2e.py
+++ b/packages/ai-parrot/tests/integration/test_flex_dashboard_e2e.py
@@ -1,0 +1,326 @@
+"""End-to-end integration tests for FEAT-491 (Module 7): FlexDashboard's
+publish / deterministic-replay / refresh-RPC path.
+
+Proves the feature's headline claims end-to-end (pipeline-wide properties a
+unit test cannot establish):
+
+- ``test_flex_dashboard_publish_replay`` — publish → ``RecipeRunner.run()``
+  twice → byte-identical HTML, with NO narrator configured (spec §5:
+  "Recipe replays deterministically with NO narrator configured").
+- ``test_flex_dashboard_filtered_replay`` — a params override (month /
+  pay_code) produces a deterministic filtered variant, distinct from the
+  unfiltered replay.
+- ``test_flex_refresh_rpc`` — ``A2UIRuntime`` surface-state
+  push → ``callAgentFunction`` → ``refresh_dashboard`` honors per-surface
+  filter state; explicit args win.
+
+Uses synthetic in-memory frames for all six Flex aliases (spec §7: slug
+data is prod-only — NOTHING here touches QuerySource) via
+``DatasetManager.add_dataframe``, mirroring
+``tests/integration/test_finance_reporter_narrative_e2e.py``'s established
+fixture approach. No live LLM call anywhere — no narrator is configured at
+all (the recipe's narrative step is proven optional by its own absence).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("parrot.outputs.a2ui_renderers.interactive_html")
+
+import parrot.outputs.a2ui_renderers.interactive_html  # noqa: F401
+from parrot.auth.permission import build_principal_context
+from parrot.outputs.a2ui.recipes.store import FileRecipeStore
+from parrot.outputs.a2ui.runtime import (
+    A2UICallContext,
+    A2UIRuntime,
+    FunctionCallRecord,
+    SurfaceState,
+)
+from parrot.outputs.a2ui.runtime.adapters import ToolManagerExecutor
+from parrot.storage.artifacts import ArtifactStore
+from parrot.storage.backends import build_overflow_store
+from parrot.storage.backends.sqlite import ConversationSQLiteBackend
+from parrot.tools.infographic_recipes.runner import RecipeRunner
+from parrot.tools.infographic_sections import GapReport
+
+# Worktree-safe file-path loading — same technique as this feature's unit
+# tests (see test_flex_dashboard_agent.py's longer comment for why
+# "agents.flex_dashboard" is reserved for the real package and the agent
+# FILE is loaded under its own distinct synthetic name).
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_AGENTS_DIR = _REPO_ROOT / "agents"
+_FLEX_DIR = _AGENTS_DIR / "flex_dashboard"
+_EXAMPLES_DIR = _REPO_ROOT / "examples" / "agents" / "a2ui"
+
+
+def _load_package(name: str, init_path: Path, search_dir: Path):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(
+        name, init_path, submodule_search_locations=[str(search_dir)]
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load package {name!r} from {init_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+def _load_module(name: str, path: Path):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+def _load_flex_dashboard_class():
+    _load_package("agents", _AGENTS_DIR / "__init__.py", _AGENTS_DIR)
+    _load_package("agents.flex_dashboard", _FLEX_DIR / "__init__.py", _FLEX_DIR)
+    _load_module("agents.flex_dashboard.normalize", _FLEX_DIR / "normalize.py")
+    _load_module("agents.flex_dashboard.transformers", _FLEX_DIR / "transformers.py")
+    module = _load_module("flex_dashboard_agent_module_e2e", _AGENTS_DIR / "flex_dashboard.py")
+    return module.FlexDashboard
+
+
+FlexDashboard = _load_flex_dashboard_class()
+
+sys.path.insert(0, str(_EXAMPLES_DIR))
+from flex_synthetic_data import build_flex_frames
+
+RECIPE_NAME = FlexDashboard.DASHBOARD_RECIPE_NAME
+
+#: The interactive-html renderer mints per-render DOM element ids
+#: (uuid4-derived) — normalize them before a byte-identity comparison (same
+#: technique as `examples/agents/a2ui/deterministic_refresh_dashboard.py`
+#: and `flex_dashboard_demo.py`).
+_VOLATILE_DOM_ID = re.compile(rb"(chart|tabs|nested)-[0-9a-f]{8}")
+
+
+def _normalize_render(content: bytes) -> bytes:
+    return _VOLATILE_DOM_ID.sub(rb"\1-x", content)
+
+
+@pytest.fixture
+def flex_frames() -> dict[str, Any]:
+    return build_flex_frames()
+
+
+@pytest.fixture
+async def recipe_store(tmp_path):
+    return FileRecipeStore(tmp_path / "recipes")
+
+
+@pytest.fixture
+async def wired_agent(tmp_path, recipe_store, flex_frames):
+    """A FlexDashboard with all six aliases registered as in-memory frames."""
+    backend = ConversationSQLiteBackend(path=str(tmp_path / "artifacts.db"))
+    await backend.initialize()
+    artifact_store = ArtifactStore(backend, build_overflow_store())
+    agent = FlexDashboard(
+        name="flex-dashboard-e2e",
+        artifact_store=artifact_store,
+        recipe_store=recipe_store,
+        injection_detection=False,
+    )
+    # Bypass register_datasets() (live QuerySource slugs, prod-only, spec §7)
+    # — register the SAME six aliases as in-memory frames instead.
+    for alias, frame in flex_frames.items():
+        agent._dataset_manager.add_dataframe(alias, frame)
+    return agent
+
+
+@pytest.fixture
+def pctx():
+    return build_principal_context("e2e-user", channel="test")
+
+
+@pytest.fixture
+async def published_recipe(wired_agent, recipe_store):
+    recipe = await wired_agent.publish_recipe(
+        RECIPE_NAME, FlexDashboard.dashboard_descriptor(), overwrite=True
+    )
+    assert not isinstance(recipe, GapReport), (
+        f"expected a full recipe, got a GapReport: {getattr(recipe, 'gaps', None)}"
+    )
+    recipe.params = FlexDashboard.recipe_params()
+    await recipe_store.save(recipe)
+    return recipe
+
+
+class TestFlexDashboardPublishReplay:
+    async def test_publish_recipe_succeeds_not_gapreport(self, published_recipe):
+        assert published_recipe.name == RECIPE_NAME
+        transformer_names = {t.transformer for t in published_recipe.transforms}
+        assert transformer_names == {
+            "payroll_hero",
+            "worked_hours_by_month",
+            "payroll_by_month",
+            "revenue_by_month",
+            "payroll_pct_by_month",
+            "pay_code_hours",
+            "pay_code_allocation",
+            "rep_utilization_by_region",
+            "proximity_staffing",
+            "flex_narrative_facts",
+        }
+
+    async def test_flex_dashboard_publish_replay(
+        self, wired_agent, recipe_store, published_recipe, pctx
+    ):
+        """Two replays with identical (default) params produce byte-identical
+        HTML — no narrator configured, proving the narrative step is
+        genuinely optional (spec §5)."""
+        runner = RecipeRunner(recipe_store, wired_agent._dataset_manager)
+
+        first = await runner.run(RECIPE_NAME, pctx=pctx)
+        second = await runner.run(RECIPE_NAME, pctx=pctx)
+
+        assert first.content
+        assert _normalize_render(first.content) == _normalize_render(second.content)
+
+
+class TestFlexDashboardFilteredReplay:
+    async def test_flex_dashboard_filtered_replay(
+        self, wired_agent, recipe_store, published_recipe, pctx
+    ):
+        """A params override (month/pay_code) gives a deterministic filtered
+        variant — repeated with the SAME override still byte-identical, and
+        different from the unfiltered default replay."""
+        runner = RecipeRunner(recipe_store, wired_agent._dataset_manager)
+
+        default = await runner.run(RECIPE_NAME, pctx=pctx)
+        filtered_a = await runner.run(
+            RECIPE_NAME, params={"month": "2025-10", "pay_code": "Field Time"}, pctx=pctx
+        )
+        filtered_b = await runner.run(
+            RECIPE_NAME, params={"month": "2025-10", "pay_code": "Field Time"}, pctx=pctx
+        )
+
+        assert _normalize_render(filtered_a.content) == _normalize_render(filtered_b.content)
+        assert _normalize_render(filtered_a.content) != _normalize_render(default.content)
+
+
+class TestFlexRefreshRpc:
+    async def test_refresh_tool_direct_args(self, wired_agent, published_recipe, pctx):
+        """`build_refresh_tool` wires a RecipeRunner + pctx; explicit args
+        drive a filtered re-render."""
+        refresh_tool = wired_agent.build_refresh_tool(pctx)
+
+        result = await refresh_tool.execute(month="2025-10")
+
+        assert result.result["filters"] == {"month": "2025-10"}
+        assert result.result["filter_source"] == "args"
+        assert result.result["bytes"] > 0
+
+    async def test_refresh_rpc_honors_surface_state(self, wired_agent, published_recipe, pctx):
+        """`A2UIRuntime` surface-state push -> `callAgentFunction` ->
+        `refresh_dashboard`; explicit args win over the persisted state."""
+
+        class InMemorySurfaceStore:
+            def __init__(self) -> None:
+                self._store: dict[tuple, SurfaceState] = {}
+
+            async def get(self, session_id: str, surface_id: str):
+                return self._store.get((session_id, surface_id))
+
+            async def put(self, session_id: str, state: SurfaceState) -> None:
+                self._store[(session_id, state.surface_id)] = state
+
+            async def delete(self, session_id: str, surface_id: str) -> None:
+                self._store.pop((session_id, surface_id), None)
+
+        class InMemoryPendingCalls:
+            def __init__(self) -> None:
+                self._store: dict[tuple, FunctionCallRecord] = {}
+
+            async def add(self, session_id: str, record: FunctionCallRecord) -> None:
+                self._store[(session_id, record.function_call_id)] = record
+
+            async def resolve(self, session_id, function_call_id, value, error):
+                return self._store.pop((session_id, function_call_id), None)
+
+        surface_id = f"{RECIPE_NAME}-infographic"
+        session_id = "sess-e2e"
+
+        # `build_refresh_tool` already registers the tool on the agent's
+        # ToolManager — do not add it again (would raise a name collision).
+        wired_agent.build_refresh_tool(pctx)
+
+        surfaces = InMemorySurfaceStore()
+        runtime = A2UIRuntime(
+            executor=ToolManagerExecutor(wired_agent.tool_manager),
+            surfaces=surfaces,
+            pending=InMemoryPendingCalls(),
+        )
+        ctx = A2UICallContext(
+            agent_id="flex_dashboard",
+            user_id="e2e-user",
+            session_id=session_id,
+            surface_id=surface_id,
+            transport="http",
+            permission_context=pctx,
+        )
+
+        # Push inline filter state via `action` + `dataModel`.
+        action_env = {
+            "version": "v1.0",
+            "action": {
+                "name": "filters_changed",
+                "surfaceId": surface_id,
+                "sourceComponentId": "filter-bar",
+                "timestamp": "2026-01-01T00:00:00+00:00",
+                "context": {},
+                "dataModel": {"filters": {"month": "2025-09", "flex_type": "Flex"}},
+            },
+        }
+        await runtime.dispatch(action_env, ctx)
+        stored = await surfaces.get(session_id, surface_id)
+        assert stored.data_model["filters"] == {"month": "2025-09", "flex_type": "Flex"}
+
+        # `callAgentFunction` -> `ToolManagerExecutor.call` ->
+        # `ToolManager.execute_tool` does NOT itself inject surface state
+        # (verified: it only forwards `permission_context`) — an explicit
+        # arg via `callAgentFunction` always reaches the tool as a plain
+        # arg. The "no args -> filters come from the surface state" lane is
+        # a DIRECT `execute(_a2ui_surface_state=...)` call instead (the
+        # same reserved kwarg `AbstractBot.ask(a2ui_surface_state=...)`
+        # uses for every tool in an A2UI-triggered turn) — mirrors
+        # `examples/agents/a2ui/deterministic_refresh_dashboard.py`'s own
+        # Step 5 / `flex_dashboard_demo.py`'s lane_rpc Step 5.
+        refresh_tool = wired_agent.tool_manager.get_tool("refresh_dashboard")
+        result = await refresh_tool.execute(_a2ui_surface_state=stored)
+        assert result.result["filters"] == {"month": "2025-09", "flex_type": "Flex"}
+        assert result.result["filter_source"] == "surface_state"
+
+        # callAgentFunction WITH explicit args reaches the tool as plain args.
+        from parrot.outputs.a2ui.catalog import DEFAULT_CATALOG_ID
+
+        call_env = {
+            "version": "v1.0",
+            "callAgentFunction": {
+                "surfaceId": surface_id,
+                "functionCallId": "fc-1",
+                "callFunction": {
+                    "call": "refresh_dashboard",
+                    "args": {"month": "2025-10"},
+                    "catalogId": DEFAULT_CATALOG_ID,
+                },
+            },
+        }
+        res = await runtime.dispatch(call_env, ctx)
+        value = res.messages[0]["agentFunctionResponse"]["value"]
+        assert value["filters"]["month"] == "2025-10"
+        assert value["filter_source"] == "args"

--- a/packages/ai-parrot/tests/integration/test_flex_dashboard_e2e.py
+++ b/packages/ai-parrot/tests/integration/test_flex_dashboard_e2e.py
@@ -63,9 +63,7 @@ _EXAMPLES_DIR = _REPO_ROOT / "examples" / "agents" / "a2ui"
 def _load_package(name: str, init_path: Path, search_dir: Path):
     if name in sys.modules:
         return sys.modules[name]
-    spec = importlib.util.spec_from_file_location(
-        name, init_path, submodule_search_locations=[str(search_dir)]
-    )
+    spec = importlib.util.spec_from_file_location(name, init_path, submodule_search_locations=[str(search_dir)])
     if spec is None or spec.loader is None:
         raise ImportError(f"Cannot load package {name!r} from {init_path}")
     module = importlib.util.module_from_spec(spec)
@@ -149,12 +147,10 @@ def pctx():
 
 @pytest.fixture
 async def published_recipe(wired_agent, recipe_store):
-    recipe = await wired_agent.publish_recipe(
-        RECIPE_NAME, FlexDashboard.dashboard_descriptor(), overwrite=True
-    )
-    assert not isinstance(recipe, GapReport), (
-        f"expected a full recipe, got a GapReport: {getattr(recipe, 'gaps', None)}"
-    )
+    recipe = await wired_agent.publish_recipe(RECIPE_NAME, FlexDashboard.dashboard_descriptor(), overwrite=True)
+    assert not isinstance(
+        recipe, GapReport
+    ), f"expected a full recipe, got a GapReport: {getattr(recipe, 'gaps', None)}"
     recipe.params = FlexDashboard.recipe_params()
     await recipe_store.save(recipe)
     return recipe
@@ -177,9 +173,7 @@ class TestFlexDashboardPublishReplay:
             "flex_narrative_facts",
         }
 
-    async def test_flex_dashboard_publish_replay(
-        self, wired_agent, recipe_store, published_recipe, pctx
-    ):
+    async def test_flex_dashboard_publish_replay(self, wired_agent, recipe_store, published_recipe, pctx):
         """Two replays with identical (default) params produce byte-identical
         HTML — no narrator configured, proving the narrative step is
         genuinely optional (spec §5)."""
@@ -193,21 +187,15 @@ class TestFlexDashboardPublishReplay:
 
 
 class TestFlexDashboardFilteredReplay:
-    async def test_flex_dashboard_filtered_replay(
-        self, wired_agent, recipe_store, published_recipe, pctx
-    ):
+    async def test_flex_dashboard_filtered_replay(self, wired_agent, recipe_store, published_recipe, pctx):
         """A params override (month/pay_code) gives a deterministic filtered
         variant — repeated with the SAME override still byte-identical, and
         different from the unfiltered default replay."""
         runner = RecipeRunner(recipe_store, wired_agent._dataset_manager)
 
         default = await runner.run(RECIPE_NAME, pctx=pctx)
-        filtered_a = await runner.run(
-            RECIPE_NAME, params={"month": "2025-10", "pay_code": "Field Time"}, pctx=pctx
-        )
-        filtered_b = await runner.run(
-            RECIPE_NAME, params={"month": "2025-10", "pay_code": "Field Time"}, pctx=pctx
-        )
+        filtered_a = await runner.run(RECIPE_NAME, params={"month": "2025-10", "pay_code": "Field Time"}, pctx=pctx)
+        filtered_b = await runner.run(RECIPE_NAME, params={"month": "2025-10", "pay_code": "Field Time"}, pctx=pctx)
 
         assert _normalize_render(filtered_a.content) == _normalize_render(filtered_b.content)
         assert _normalize_render(filtered_a.content) != _normalize_render(default.content)

--- a/packages/ai-parrot/tests/integration/test_flex_dashboard_e2e.py
+++ b/packages/ai-parrot/tests/integration/test_flex_dashboard_e2e.py
@@ -146,13 +146,16 @@ def pctx():
 
 
 @pytest.fixture
-async def published_recipe(wired_agent, recipe_store):
-    recipe = await wired_agent.publish_recipe(RECIPE_NAME, FlexDashboard.dashboard_descriptor(), overwrite=True)
+async def published_recipe(wired_agent):
+    # `publish_dashboard_recipe` wraps `publish_recipe` + the
+    # `recipe.params = recipe_params(); recipe_store.save(...)` follow-up
+    # atomically (code-review finding, TASK-2699 amendment) — see its
+    # docstring for why skipping the follow-up breaks even the unfiltered
+    # default replay.
+    recipe = await wired_agent.publish_dashboard_recipe(overwrite=True)
     assert not isinstance(
         recipe, GapReport
     ), f"expected a full recipe, got a GapReport: {getattr(recipe, 'gaps', None)}"
-    recipe.params = FlexDashboard.recipe_params()
-    await recipe_store.save(recipe)
     return recipe
 
 

--- a/packages/ai-parrot/tests/unit/bots/conftest.py
+++ b/packages/ai-parrot/tests/unit/bots/conftest.py
@@ -1,0 +1,261 @@
+"""Shared fixtures for the Flex A2UI dashboard agent tests (FEAT-491).
+
+``flex_frames`` provides synthetic frames for all six Flex dataset aliases
+(spec §2), shaped EXACTLY like the sample rows in
+``sdd/state/FEAT-517/source.md``: currency strings, the three date-grain
+conventions, and the ``catagory`` typo column — with a couple of extra rows
+per frame (different months / pay codes / stores) so month-series and
+per-section-filter tests (TASK-2694) have something to group and filter
+over. No network/database access — everything here is inline data.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def flex_frames() -> dict[str, pd.DataFrame]:
+    """Synthetic frames for all six Flex dataset aliases (spec §2).
+
+    Returns:
+        A dict keyed by alias (``msl``, ``finance``, ``hours``,
+        ``employees``, ``region_utilization``, ``rep_utilization``) mapping
+        to a fresh :class:`pandas.DataFrame` per test.
+    """
+    msl = pd.DataFrame(
+        [
+            {
+                "district_name": "IL - Chicago",
+                "region_name": "Midwest Region",
+                "market_name": "IL - Chicago - Oak Park",
+                "account_name": "T-Mobile",
+                "store_name": "T-Mobile 3SFD Norridge IL",
+                "latitude": 41.95535,
+                "longitude": -87.80886,
+                "city": "Norridge",
+                "state_code": "IL",
+            },
+            {
+                "district_name": "PA - Philadelphia",
+                "region_name": "Northeast Region",
+                "market_name": "PA - Philadelphia - Media",
+                "account_name": "T-Mobile",
+                "store_name": "T-Mobile Media PA",
+                "latitude": 39.9168,
+                "longitude": -75.3902,
+                "city": "Media",
+                "state_code": "PA",
+            },
+            {
+                "district_name": "CA - Los Angeles",
+                "region_name": "West Region",
+                "market_name": "CA - LA - Downtown",
+                "account_name": "T-Mobile",
+                "store_name": "T-Mobile Downtown LA",
+                "latitude": 34.0407,
+                "longitude": -118.2468,
+                "city": "Los Angeles",
+                "state_code": "CA",
+            },
+        ]
+    )
+
+    finance = pd.DataFrame(
+        [
+            {
+                "project": "Flex - General",
+                "month": "2025-09-30",
+                "Revenue": "$120,000.00",
+                "PC Revenue": "$40,000.00",
+                "EBITDA": "$9,000.00",
+                "Payroll": "$18,000.00",
+                "Travel and Expenses": "$12,000.00",
+                "Program Overhead Allocation": "$0.00",
+                "Other Related Expenses": "-$40,000.00",
+                "Total Hours": 2100.0,
+                "FTE": 16.5,
+                "Visits": 220,
+            },
+            {
+                "project": "Flex - General",
+                "month": "2025-10-31",
+                "Revenue": "$137,456.85",
+                "PC Revenue": "$51,229.85",
+                "EBITDA": "$10,222.16",
+                "Payroll": "$20,682.27",
+                "Travel and Expenses": "$13,746.44",
+                "Program Overhead Allocation": "$0.00",
+                "Other Related Expenses": "-$44,621.24",
+                "Total Hours": 2250.866693,
+                "FTE": 17.278409301948,
+                "Visits": 241,
+            },
+        ]
+    )
+
+    hours = pd.DataFrame(
+        [
+            {
+                "month_start": "2025-09-01",
+                "month_end": "2025-09-30",
+                "program": "Flex - General",
+                "pay_code": "Admin Time",
+                "cost_center": "Flex",
+                "hours": 25.0,
+                "wages": 575.0,
+            },
+            {
+                "month_start": "2025-09-01",
+                "month_end": "2025-09-30",
+                "program": "Flex - General",
+                "pay_code": "Field Time",
+                "cost_center": "Flex",
+                "hours": 1800.0,
+                "wages": 41000.0,
+            },
+            {
+                "month_start": "2025-10-01",
+                "month_end": "2025-10-31",
+                "program": "Flex - General",
+                "pay_code": "Admin Time",
+                "cost_center": "Flex",
+                "hours": 30.199996,
+                "wages": 693.749909,
+            },
+            {
+                "month_start": "2025-10-01",
+                "month_end": "2025-10-31",
+                "program": "Flex - General",
+                "pay_code": "Field Time",
+                "cost_center": "Flex",
+                "hours": 1900.0,
+                "wages": 43000.0,
+            },
+        ]
+    )
+
+    employees = pd.DataFrame(
+        [
+            {
+                "display_name": "Abby Halladay",
+                "start_date": "2025-12-31",
+                "job_code_title": "Mobile Retail Display Technician",
+                "referred_by": None,
+                "legal_city": "MEDIA",
+                "legal_state": "PA",
+                "zipcode": "19063",
+                "phone_mobile": "(267) 346-0701",
+                "latitude": 39.9222285,
+                "longitude": -75.414058,
+                "Flex Employees": 1,
+                "Flex Type": "Flex",
+                "Years of Service": 1,
+                "Months of Service": 8,
+                "Days of Service": 244,
+                "Days of Service Retention": 244,
+            },
+            {
+                "display_name": "Jordan Reyes",
+                "start_date": "2025-06-15",
+                "job_code_title": "Retail Sales Associate",
+                "referred_by": None,
+                "legal_city": "Norridge",
+                "legal_state": "IL",
+                "zipcode": "60706",
+                "phone_mobile": "(312) 555-0100",
+                "latitude": 41.9600,
+                "longitude": -87.8100,
+                "Flex Employees": 1,
+                "Flex Type": "Flex",
+                "Years of Service": 2,
+                "Months of Service": 3,
+                "Days of Service": 825,
+                "Days of Service Retention": 825,
+            },
+            {
+                "display_name": "Casey Kim",
+                "start_date": "2024-01-01",
+                "job_code_title": "Store Manager",
+                "referred_by": "Referral Program",
+                "legal_city": "Los Angeles",
+                "legal_state": "CA",
+                "zipcode": "90012",
+                "phone_mobile": "(213) 555-0199",
+                "latitude": 34.0500,
+                "longitude": -118.2500,
+                "Flex Employees": 0,
+                "Flex Type": "Core",
+                "Years of Service": 3,
+                "Months of Service": 0,
+                "Days of Service": 1095,
+                "Days of Service Retention": 1095,
+            },
+        ]
+    )
+
+    region_utilization = pd.DataFrame(
+        [
+            {
+                "BOP Date": "2026-03-01",
+                "EOP Date": "2026-03-31",
+                "FM Region": "CA",
+                "State Code": "CA",
+                "State": "California",
+                "Category": "Flex",
+                "Employees Worked": 11,
+                "Average Active Employees": 75.5,
+                "Flex Employees": 68,
+                "Employee Utilization": 0.145695364238411,
+            },
+            {
+                "BOP Date": "2026-04-01",
+                "EOP Date": "2026-04-30",
+                "FM Region": "IL",
+                "State Code": "IL",
+                "State": "Illinois",
+                "Category": "Flex",
+                "Employees Worked": 15,
+                "Average Active Employees": 60.0,
+                "Flex Employees": 50,
+                "Employee Utilization": 0.25,
+            },
+        ]
+    )
+
+    rep_utilization = pd.DataFrame(
+        [
+            {
+                "bop_date": "2026-05-01",
+                "eop_date": "2026-05-31",
+                "region": "CA",
+                "state": "CA",
+                "catagory": "Flex",
+                "hours_worked": 167.550001,
+                "work_shifts": 76,
+                "employees_worked": 12,
+                "average_active": 63,
+            },
+            {
+                "bop_date": "2026-06-01",
+                "eop_date": "2026-06-30",
+                "region": "IL",
+                "state": "IL",
+                "catagory": "Flex",
+                "hours_worked": 140.0,
+                "work_shifts": 60,
+                "employees_worked": 10,
+                "average_active": 50,
+            },
+        ]
+    )
+
+    return {
+        "msl": msl,
+        "finance": finance,
+        "hours": hours,
+        "employees": employees,
+        "region_utilization": region_utilization,
+        "rep_utilization": rep_utilization,
+    }

--- a/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_agent.py
+++ b/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_agent.py
@@ -1,0 +1,187 @@
+"""Unit tests for `agents/flex_dashboard.py` (FEAT-491 TASK-2696)."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+# Worktree-safe file-path loading, same technique as the other flex tests.
+# `agents/flex_dashboard.py` (the agent FILE) and `agents/flex_dashboard/`
+# (the sibling PACKAGE for transformers/skills/kb) share the same name —
+# Python's FileFinder always resolves a plain `import agents.flex_dashboard`
+# to the PACKAGE (verified empirically), matching how production actually
+# loads agent files: `parrot.registry.registry.AgentRegistry
+# ._load_modules_from_directory` globs `agents/*.py` and loads each one via
+# `importlib.util.spec_from_file_location` under a SYNTHETIC module name
+# (`parrot.dynamic_agents.dir_<hash>.<stem>`) — never a plain dotted
+# `agents.<name>` import. This test mirrors that: the agent file is loaded
+# under its OWN distinct synthetic name, never "agents.flex_dashboard" —
+# that name is reserved for the real package the agent file's own
+# `import agents.flex_dashboard.transformers` statement resolves against.
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_AGENTS_DIR = _REPO_ROOT / "agents"
+_FLEX_DIR = _AGENTS_DIR / "flex_dashboard"
+_AGENT_FILE = _AGENTS_DIR / "flex_dashboard.py"
+
+
+def _load_package(name: str, init_path: Path, search_dir: Path):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(
+        name, init_path, submodule_search_locations=[str(search_dir)]
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load package {name!r} from {init_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+def _load_module(name: str, path: Path):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+def _load_flex_dashboard_agent_module():
+    # Pre-register the real "agents.flex_dashboard" package chain so the
+    # agent file's own `import agents.flex_dashboard.transformers` resolves
+    # from THIS worktree deterministically (same defensive chain as
+    # test_flex_dashboard_transformers.py).
+    _load_package("agents", _AGENTS_DIR / "__init__.py", _AGENTS_DIR)
+    _load_package("agents.flex_dashboard", _FLEX_DIR / "__init__.py", _FLEX_DIR)
+    _load_module("agents.flex_dashboard.normalize", _FLEX_DIR / "normalize.py")
+    _load_module("agents.flex_dashboard.transformers", _FLEX_DIR / "transformers.py")
+    # The agent FILE gets its own, distinct synthetic name.
+    return _load_module("flex_dashboard_agent_under_test", _AGENT_FILE)
+
+
+@pytest.fixture(scope="module")
+def flex_dashboard_module():
+    return _load_flex_dashboard_agent_module()
+
+
+@pytest.fixture
+def flex_agent(flex_dashboard_module):
+    """A bare FlexDashboard instance — offline, no network/DB."""
+    FlexDashboard = flex_dashboard_module.FlexDashboard
+    return FlexDashboard(name="flex-dashboard-test", injection_detection=False)
+
+
+class TestAgentConstruction:
+    def test_instantiates_offline(self, flex_agent):
+        assert flex_agent.agent_id == "flex_dashboard"
+        assert flex_agent._dataset_manager is not None
+
+    def test_output_routing_enabled(self, flex_agent):
+        assert flex_agent._output_routing_enabled is True
+
+    def test_use_kb_enabled(self, flex_agent):
+        assert flex_agent.use_kb is True
+        assert flex_agent.kb_store is not None
+
+    def test_working_memory_and_infographic_toolkits_attached(
+        self, flex_agent, flex_dashboard_module
+    ):
+        from parrot.tools.infographic_toolkit import InfographicToolkit
+        from parrot.tools.working_memory import WorkingMemoryToolkit
+
+        # ToolManager stores per-method `ToolkitTool` wrappers, not the
+        # toolkit instances themselves — recover the parent toolkit via
+        # `bound_method.__self__` (same technique
+        # `ToolManager.cleanup_toolkits` uses, manager.py:2183-2184).
+        parents = {
+            getattr(getattr(t, "bound_method", None), "__self__", None)
+            for t in flex_agent.tool_manager.tools.values()
+        }
+        assert any(isinstance(p, WorkingMemoryToolkit) for p in parents)
+        assert any(isinstance(p, InfographicToolkit) for p in parents)
+
+    def test_mixin_order(self, flex_dashboard_module):
+        from parrot.bots.mixins import InfographicAuthoringMixin, NarrativeMixin
+
+        FlexDashboard = flex_dashboard_module.FlexDashboard
+        mro = FlexDashboard.__mro__
+        assert mro.index(NarrativeMixin) < mro.index(InfographicAuthoringMixin)
+
+    def test_skill_paths_anchored_to_file(self, flex_dashboard_module):
+        FlexDashboard = flex_dashboard_module.FlexDashboard
+        assert FlexDashboard.skill_paths == [flex_dashboard_module.SKILLS_DIR]
+        assert flex_dashboard_module.SKILLS_DIR.is_absolute()
+
+
+class TestAgentDatasets:
+    @pytest.mark.asyncio
+    async def test_agent_datasets(self, flex_agent, flex_dashboard_module):
+        await flex_agent.register_datasets()
+
+        expected = flex_dashboard_module.DATASET_SLUGS
+        assert set(expected) == {
+            "msl",
+            "finance",
+            "hours",
+            "employees",
+            "region_utilization",
+            "rep_utilization",
+        }
+
+        for alias, slug in expected.items():
+            entry = flex_agent._dataset_manager.get_dataset_entry(alias)
+            assert entry is not None, f"missing dataset entry for alias {alias!r}"
+            assert entry.query_slug == slug, f"alias {alias!r} slug mismatch"
+
+    @pytest.mark.asyncio
+    async def test_finance_slug_capitalization_preserved(self, flex_agent):
+        await flex_agent.register_datasets()
+        entry = flex_agent._dataset_manager.get_dataset_entry("finance")
+        assert entry.query_slug == "Finance_results_bi"
+
+    @pytest.mark.asyncio
+    async def test_register_datasets_does_not_fetch(self, flex_agent):
+        """add_query is lazy — no DataFrame is loaded at registration."""
+        await flex_agent.register_datasets()
+        for alias in ("msl", "finance", "hours", "employees", "region_utilization", "rep_utilization"):
+            entry = flex_agent._dataset_manager.get_dataset_entry(alias)
+            assert entry.df is None
+
+
+class TestKbDocsLoaded:
+    @pytest.mark.asyncio
+    async def test_kb_docs_loaded(self, flex_agent):
+        flex_agent.kb_store.add_facts = AsyncMock()
+
+        await flex_agent._load_kb_docs()
+
+        flex_agent.kb_store.add_facts.assert_awaited_once()
+        facts = flex_agent.kb_store.add_facts.call_args.args[0]
+        assert len(facts) == 5  # one per agents/flex_dashboard/kb/*.md
+
+        kpis = {f["metadata"]["kpi"] for f in facts}
+        assert kpis == {
+            "payroll_contribution",
+            "pay_code_allocation",
+            "rep_utilization",
+            "proximity_staffing",
+            "datasets",
+        }
+        for fact in facts:
+            assert fact["metadata"]["category"] == "kpi"
+            assert fact["content"]  # non-empty markdown text
+
+    @pytest.mark.asyncio
+    async def test_load_kb_docs_noop_without_kb_store(self, flex_agent):
+        # use_kb=True is hardcoded by design (spec §3 Module 3); simulate the
+        # defensive branch directly rather than fighting the agent's own
+        # forced kwarg.
+        flex_agent.kb_store = None
+        # Should not raise even though kb_store is None.
+        await flex_agent._load_kb_docs()

--- a/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_agent.py
+++ b/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_agent.py
@@ -29,9 +29,7 @@ _AGENT_FILE = _AGENTS_DIR / "flex_dashboard.py"
 def _load_package(name: str, init_path: Path, search_dir: Path):
     if name in sys.modules:
         return sys.modules[name]
-    spec = importlib.util.spec_from_file_location(
-        name, init_path, submodule_search_locations=[str(search_dir)]
-    )
+    spec = importlib.util.spec_from_file_location(name, init_path, submodule_search_locations=[str(search_dir)])
     if spec is None or spec.loader is None:
         raise ImportError(f"Cannot load package {name!r} from {init_path}")
     module = importlib.util.module_from_spec(spec)
@@ -89,9 +87,7 @@ class TestAgentConstruction:
         assert flex_agent.use_kb is True
         assert flex_agent.kb_store is not None
 
-    def test_working_memory_and_infographic_toolkits_attached(
-        self, flex_agent, flex_dashboard_module
-    ):
+    def test_working_memory_and_infographic_toolkits_attached(self, flex_agent, flex_dashboard_module):
         from parrot.tools.infographic_toolkit import InfographicToolkit
         from parrot.tools.working_memory import WorkingMemoryToolkit
 
@@ -100,8 +96,7 @@ class TestAgentConstruction:
         # `bound_method.__self__` (same technique
         # `ToolManager.cleanup_toolkits` uses, manager.py:2183-2184).
         parents = {
-            getattr(getattr(t, "bound_method", None), "__self__", None)
-            for t in flex_agent.tool_manager.tools.values()
+            getattr(getattr(t, "bound_method", None), "__self__", None) for t in flex_agent.tool_manager.tools.values()
         }
         assert any(isinstance(p, WorkingMemoryToolkit) for p in parents)
         assert any(isinstance(p, InfographicToolkit) for p in parents)

--- a/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_descriptors.py
+++ b/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_descriptors.py
@@ -258,9 +258,7 @@ class TestRefreshDashboardTool:
         assert kwargs["pctx"] == "per-call-pctx"
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_constructor_pctx_without_per_call_context(
-        self, flex_dashboard_module
-    ):
+    async def test_falls_back_to_constructor_pctx_without_per_call_context(self, flex_dashboard_module):
         """Direct/demo calls (never routed through ToolManager.execute_tool)
         never get `_current_pctx` set — the constructor pctx is the only
         one available and must still be used."""
@@ -309,9 +307,7 @@ class TestPublishDashboardRecipe:
         recipe_store.save.assert_awaited_once_with(published)
 
     @pytest.mark.asyncio
-    async def test_publish_dashboard_recipe_returns_gap_report_unsaved(
-        self, flex_dashboard_module
-    ):
+    async def test_publish_dashboard_recipe_returns_gap_report_unsaved(self, flex_dashboard_module):
         FlexDashboard = flex_dashboard_module.FlexDashboard
         GapReport = flex_dashboard_module.GapReport
 

--- a/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_descriptors.py
+++ b/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_descriptors.py
@@ -23,9 +23,7 @@ _AGENT_FILE = _AGENTS_DIR / "flex_dashboard.py"
 def _load_package(name: str, init_path: Path, search_dir: Path):
     if name in sys.modules:
         return sys.modules[name]
-    spec = importlib.util.spec_from_file_location(
-        name, init_path, submodule_search_locations=[str(search_dir)]
-    )
+    spec = importlib.util.spec_from_file_location(name, init_path, submodule_search_locations=[str(search_dir)])
     if spec is None or spec.loader is None:
         raise ImportError(f"Cannot load package {name!r} from {init_path}")
     module = importlib.util.module_from_spec(spec)
@@ -99,10 +97,7 @@ class TestDashboardDescriptor:
     def test_hero_bindings(self, descriptor):
         props = descriptor.layout.props
         hero_section = props["sections"][0]
-        bindings = {
-            c["properties"]["label"]: c["properties"]["value"]["path"]
-            for c in hero_section["components"]
-        }
+        bindings = {c["properties"]["label"]: c["properties"]["value"]["path"] for c in hero_section["components"]}
         assert bindings == {
             "Worked Hours": "/payroll_hero/worked_hours_total",
             "Payroll": "/payroll_hero/payroll_total",
@@ -176,9 +171,7 @@ class TestDashboardDescriptor:
         for param in flex_dashboard_module.FlexDashboard.recipe_params():
             assert param.default is not None, f"{param.name} has no default"
 
-    def test_descriptor_param_templates_match_declared_params(
-        self, flex_dashboard_module, descriptor
-    ):
+    def test_descriptor_param_templates_match_declared_params(self, flex_dashboard_module, descriptor):
         declared_names = {p.name for p in flex_dashboard_module.FlexDashboard.recipe_params()}
         template_names = set(descriptor.params)
         assert template_names == declared_names
@@ -193,9 +186,7 @@ class TestRefreshDashboardTool:
         runner = SimpleNamespace(run=AsyncMock(return_value=fake_artifact))
         tool = RefreshDashboardTool(runner=runner, pctx="fake-pctx")
 
-        surface_state = SimpleNamespace(
-            data_model={"filters": {"month": "2025-09", "pay_code": "Field Time"}}
-        )
+        surface_state = SimpleNamespace(data_model={"filters": {"month": "2025-09", "pay_code": "Field Time"}})
 
         # `_execute` looks up `current_a2ui_surface_state` as a name in
         # `agents/flex_dashboard.py`'s OWN module namespace (imported there

--- a/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_descriptors.py
+++ b/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_descriptors.py
@@ -114,22 +114,30 @@ class TestDashboardDescriptor:
         assert descriptor.narrative.skill == flex_dashboard_module.FlexDashboard.narrative_skill
         assert descriptor.narrative.facts_key == "flex_narrative_facts"
 
-    def test_narrative_binds_are_optional(self, descriptor):
+    def test_no_narrative_layout_binding(self, descriptor):
         """A no-narrator replay must not abort at the drift check.
 
-        v2 (FEAT-470 TASK-2542): a binding is a plain ``{"path": ...}`` — its
-        ``optional``-ness is declared by listing the pointer in the layout's
-        own ``metadata.extensions.parrot_optional``.
+        Deviation (TASK-2699 finding): unlike FinanceReporter's identical-
+        looking ``"text": {"path": "/narrative"}`` pattern, this layout
+        deliberately binds NOTHING to ``/narrative`` —
+        ``RecipeRunner._assemble_envelope_or_raise``'s Infographic path
+        (``build_infographic`` -> ``build_surface``) never threads
+        ``layout.metadata`` (and therefore never
+        ``metadata.extensions.parrot_optional``) onto the built wire
+        ``Component``, so ANY layout-level binding to an absent
+        ``/narrative`` key raises ``BakeError`` unconditionally at render
+        time regardless of what the descriptor declares — a pre-existing,
+        cross-cutting core bug confirmed reproducible on `dev`
+        independently of this feature (FinanceReporter's own
+        `test_dashboard_profile_replay` AND
+        `test_report_profile_replay_no_narrator` are both currently broken
+        by it too). The narrative step therefore has no VISUAL binding
+        here; ``narrative=NarrativeSpec(...)`` is still declared (see
+        `test_declares_narrative`) so a configured narrator still runs and
+        populates `/narrative` in the data model — it is just never read
+        back into the layout.
         """
         layout = descriptor.layout
-        optional_pointers = set(
-            (
-                layout.metadata.extensions.root.get("parrot_optional")
-                if layout.metadata and layout.metadata.extensions
-                else None
-            )
-            or []
-        )
         found = []
 
         def walk(v):
@@ -143,9 +151,7 @@ class TestDashboardDescriptor:
                     walk(i)
 
         walk(layout.props)
-        assert found, "expected at least one narrative binding"
-        for pointer in found:
-            assert pointer in optional_pointers, f"non-optional narrative bind: {pointer}"
+        assert found == [], f"unexpected narrative binding(s) in layout: {found}"
 
     def test_narrative_facts_last_and_inputs_are_output_keys(self, descriptor):
         names = [s.name for s in descriptor.sections]

--- a/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_descriptors.py
+++ b/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_descriptors.py
@@ -1,0 +1,233 @@
+"""Descriptor validity + refresh-tool tests for `FlexDashboard` (FEAT-491 TASK-2697)."""
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from parrot.outputs.a2ui.recipes.transformers import transformer_registry
+
+# Worktree-safe file-path loading — same technique used across this
+# feature's other test files (see test_flex_dashboard_agent.py's longer
+# comment for why "agents.flex_dashboard" is reserved for the real
+# package and the agent FILE is loaded under its own distinct name).
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_AGENTS_DIR = _REPO_ROOT / "agents"
+_FLEX_DIR = _AGENTS_DIR / "flex_dashboard"
+_AGENT_FILE = _AGENTS_DIR / "flex_dashboard.py"
+
+
+def _load_package(name: str, init_path: Path, search_dir: Path):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(
+        name, init_path, submodule_search_locations=[str(search_dir)]
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load package {name!r} from {init_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+def _load_module(name: str, path: Path):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+def _load_flex_dashboard_module():
+    _load_package("agents", _AGENTS_DIR / "__init__.py", _AGENTS_DIR)
+    _load_package("agents.flex_dashboard", _FLEX_DIR / "__init__.py", _FLEX_DIR)
+    _load_module("agents.flex_dashboard.normalize", _FLEX_DIR / "normalize.py")
+    _load_module("agents.flex_dashboard.transformers", _FLEX_DIR / "transformers.py")
+    return _load_module("flex_dashboard_agent_under_test", _AGENT_FILE)
+
+
+@pytest.fixture(scope="module")
+def flex_dashboard_module():
+    return _load_flex_dashboard_module()
+
+
+@pytest.fixture(scope="module")
+def descriptor(flex_dashboard_module):
+    return flex_dashboard_module.FlexDashboard.dashboard_descriptor()
+
+
+_EXPECTED_SECTION_ORDER = [
+    "payroll_hero",
+    "worked_hours_by_month",
+    "payroll_by_month",
+    "revenue_by_month",
+    "payroll_pct_by_month",
+    "pay_code_hours",
+    "pay_code_allocation",
+    "rep_utilization_by_region",
+    "proximity_staffing",
+    "flex_narrative_facts",
+]
+
+
+class TestDashboardDescriptor:
+    def test_every_section_resolves_to_a_transformer(self, descriptor):
+        """This is what makes publish_recipe return a recipe, not a GapReport."""
+        for section in descriptor.sections:
+            name = re.sub(r"\W+", "_", section.name).strip("_")
+            transformer_registry.get(name)  # raises KeyError if unmapped
+
+    def test_section_order(self, descriptor):
+        names = [s.name for s in descriptor.sections]
+        assert names == _EXPECTED_SECTION_ORDER
+
+    def test_layout_is_infographic(self, descriptor):
+        assert descriptor.layout.component == "Infographic"
+
+    def test_layout_satisfies_catalog_required_keys(self, descriptor):
+        props = descriptor.layout.props
+        assert "title" in props and "sections" in props
+
+    def test_hero_bindings(self, descriptor):
+        props = descriptor.layout.props
+        hero_section = props["sections"][0]
+        bindings = {
+            c["properties"]["label"]: c["properties"]["value"]["path"]
+            for c in hero_section["components"]
+        }
+        assert bindings == {
+            "Worked Hours": "/payroll_hero/worked_hours_total",
+            "Payroll": "/payroll_hero/payroll_total",
+            "P&L Revenue": "/payroll_hero/revenue_total",
+            "Payroll % to Revenue": "/payroll_hero/payroll_pct",
+        }
+
+    def test_declares_narrative(self, flex_dashboard_module, descriptor):
+        assert descriptor.narrative.skill == flex_dashboard_module.FlexDashboard.narrative_skill
+        assert descriptor.narrative.facts_key == "flex_narrative_facts"
+
+    def test_narrative_binds_are_optional(self, descriptor):
+        """A no-narrator replay must not abort at the drift check.
+
+        v2 (FEAT-470 TASK-2542): a binding is a plain ``{"path": ...}`` — its
+        ``optional``-ness is declared by listing the pointer in the layout's
+        own ``metadata.extensions.parrot_optional``.
+        """
+        layout = descriptor.layout
+        optional_pointers = set(
+            (
+                layout.metadata.extensions.root.get("parrot_optional")
+                if layout.metadata and layout.metadata.extensions
+                else None
+            )
+            or []
+        )
+        found = []
+
+        def walk(v):
+            if isinstance(v, dict):
+                if "path" in v and "/narrative" in str(v["path"]):
+                    found.append(v["path"])
+                for i in v.values():
+                    walk(i)
+            elif isinstance(v, list):
+                for i in v:
+                    walk(i)
+
+        walk(layout.props)
+        assert found, "expected at least one narrative binding"
+        for pointer in found:
+            assert pointer in optional_pointers, f"non-optional narrative bind: {pointer}"
+
+    def test_narrative_facts_last_and_inputs_are_output_keys(self, descriptor):
+        names = [s.name for s in descriptor.sections]
+        assert names[-1] == "flex_narrative_facts"
+        last = descriptor.sections[-1]
+        for dep in ("payroll_hero", "worked_hours_by_month", "rep_utilization_by_region"):
+            assert dep in last.datasets
+            assert names.index(dep) < len(names) - 1
+
+    def test_frozen_dataset_aliases_used_verbatim(self, descriptor):
+        by_name = {s.name: s for s in descriptor.sections}
+        assert by_name["payroll_hero"].datasets == ["hours", "finance"]
+        assert by_name["proximity_staffing"].datasets == ["msl", "employees"]
+        assert by_name["rep_utilization_by_region"].datasets == [
+            "rep_utilization",
+            "region_utilization",
+        ]
+
+    def test_recipe_params_have_concrete_defaults(self, flex_dashboard_module):
+        """resolve_params() raises when a declared param has no default and
+        no override — every declared param here must have one."""
+        for param in flex_dashboard_module.FlexDashboard.recipe_params():
+            assert param.default is not None, f"{param.name} has no default"
+
+    def test_descriptor_param_templates_match_declared_params(
+        self, flex_dashboard_module, descriptor
+    ):
+        declared_names = {p.name for p in flex_dashboard_module.FlexDashboard.recipe_params()}
+        template_names = set(descriptor.params)
+        assert template_names == declared_names
+
+
+class TestRefreshDashboardTool:
+    @pytest.mark.asyncio
+    async def test_refresh_tool_args_win_over_surface_state(self, flex_dashboard_module):
+        RefreshDashboardTool = flex_dashboard_module.RefreshDashboardTool
+
+        fake_artifact = SimpleNamespace(artifact_id="art-1", content=b"<html/>")
+        runner = SimpleNamespace(run=AsyncMock(return_value=fake_artifact))
+        tool = RefreshDashboardTool(runner=runner, pctx="fake-pctx")
+
+        surface_state = SimpleNamespace(
+            data_model={"filters": {"month": "2025-09", "pay_code": "Field Time"}}
+        )
+
+        # `_execute` looks up `current_a2ui_surface_state` as a name in
+        # `agents/flex_dashboard.py`'s OWN module namespace (imported there
+        # via `from parrot.tools.abstract import ... current_a2ui_surface_state`)
+        # — patch it there directly.
+        original = flex_dashboard_module.current_a2ui_surface_state
+        flex_dashboard_module.current_a2ui_surface_state = lambda: surface_state
+        try:
+            result = await tool._execute(month="2025-10")
+        finally:
+            flex_dashboard_module.current_a2ui_surface_state = original
+
+        # Explicit arg (month="2025-10") wins over surface state ("2025-09");
+        # surface state fills in the rest (pay_code).
+        assert result["filters"]["month"] == "2025-10"
+        assert result["filters"]["pay_code"] == "Field Time"
+        assert result["filter_source"] == "args"
+        runner.run.assert_awaited_once()
+        _, kwargs = runner.run.call_args
+        assert kwargs["pctx"] == "fake-pctx"
+
+    @pytest.mark.asyncio
+    async def test_refresh_tool_defaults_with_no_state_no_args(self, flex_dashboard_module):
+        RefreshDashboardTool = flex_dashboard_module.RefreshDashboardTool
+
+        fake_artifact = SimpleNamespace(artifact_id="art-2", content=b"<html/>")
+        runner = SimpleNamespace(run=AsyncMock(return_value=fake_artifact))
+        tool = RefreshDashboardTool(runner=runner, pctx="fake-pctx")
+
+        original = flex_dashboard_module.current_a2ui_surface_state
+        flex_dashboard_module.current_a2ui_surface_state = lambda: None
+        try:
+            result = await tool._execute()
+        finally:
+            flex_dashboard_module.current_a2ui_surface_state = original
+
+        assert result["filters"] == {}
+        assert result["filter_source"] == "defaults"
+
+    def test_distinct_recipe_name_constant(self, flex_dashboard_module):
+        assert flex_dashboard_module.FlexDashboard.DASHBOARD_RECIPE_NAME == "flex-program-dashboard"

--- a/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_descriptors.py
+++ b/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_descriptors.py
@@ -228,3 +228,107 @@ class TestRefreshDashboardTool:
 
     def test_distinct_recipe_name_constant(self, flex_dashboard_module):
         assert flex_dashboard_module.FlexDashboard.DASHBOARD_RECIPE_NAME == "flex-program-dashboard"
+
+    @pytest.mark.asyncio
+    async def test_per_call_pctx_wins_over_constructor_pctx(self, flex_dashboard_module):
+        """Code-review finding (adopted): on a shared/pooled agent, the
+        PER-CALL PermissionContext (injected by ``AbstractTool.execute()``
+        onto ``self._current_pctx`` from the ``_permission_context`` kwarg
+        — e.g. via ``ToolManagerExecutor.call`` ->
+        ``ToolManager.execute_tool``) must win over the ``pctx`` captured
+        when the tool was built, so a refresh never runs under a stale or
+        another caller's principal."""
+        RefreshDashboardTool = flex_dashboard_module.RefreshDashboardTool
+
+        fake_artifact = SimpleNamespace(artifact_id="art-3", content=b"<html/>")
+        runner = SimpleNamespace(run=AsyncMock(return_value=fake_artifact))
+        tool = RefreshDashboardTool(runner=runner, pctx="construction-time-pctx")
+
+        original = flex_dashboard_module.current_a2ui_surface_state
+        flex_dashboard_module.current_a2ui_surface_state = lambda: None
+        try:
+            # Simulate what AbstractTool.execute() does before calling
+            # _execute(): stash the per-call pctx on the instance.
+            tool._current_pctx = "per-call-pctx"
+            await tool._execute()
+        finally:
+            flex_dashboard_module.current_a2ui_surface_state = original
+
+        _, kwargs = runner.run.call_args
+        assert kwargs["pctx"] == "per-call-pctx"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_constructor_pctx_without_per_call_context(
+        self, flex_dashboard_module
+    ):
+        """Direct/demo calls (never routed through ToolManager.execute_tool)
+        never get `_current_pctx` set — the constructor pctx is the only
+        one available and must still be used."""
+        RefreshDashboardTool = flex_dashboard_module.RefreshDashboardTool
+
+        fake_artifact = SimpleNamespace(artifact_id="art-4", content=b"<html/>")
+        runner = SimpleNamespace(run=AsyncMock(return_value=fake_artifact))
+        tool = RefreshDashboardTool(runner=runner, pctx="construction-time-pctx")
+
+        original = flex_dashboard_module.current_a2ui_surface_state
+        flex_dashboard_module.current_a2ui_surface_state = lambda: None
+        try:
+            await tool._execute()
+        finally:
+            flex_dashboard_module.current_a2ui_surface_state = original
+
+        _, kwargs = runner.run.call_args
+        assert kwargs["pctx"] == "construction-time-pctx"
+
+
+class TestPublishDashboardRecipe:
+    @pytest.mark.asyncio
+    async def test_publish_dashboard_recipe_persists_params(self, flex_dashboard_module):
+        """Code-review finding (adopted): `publish_recipe()` alone never
+        persists `RecipeParam` declarations — `publish_dashboard_recipe()`
+        must do both steps atomically."""
+        FlexDashboard = flex_dashboard_module.FlexDashboard
+
+        published = SimpleNamespace(params=[])
+        recipe_store = SimpleNamespace(save=AsyncMock())
+
+        class _FakeAgent:
+            DASHBOARD_RECIPE_NAME = FlexDashboard.DASHBOARD_RECIPE_NAME
+            dashboard_descriptor = staticmethod(FlexDashboard.dashboard_descriptor)
+            recipe_params = staticmethod(FlexDashboard.recipe_params)
+            publish_recipe = AsyncMock(return_value=published)
+            _require_recipe_store = lambda self: recipe_store
+
+            publish_dashboard_recipe = FlexDashboard.publish_dashboard_recipe
+
+        agent = _FakeAgent()
+        result = await agent.publish_dashboard_recipe(overwrite=True)
+
+        assert result is published
+        assert result.params == FlexDashboard.recipe_params()
+        recipe_store.save.assert_awaited_once_with(published)
+
+    @pytest.mark.asyncio
+    async def test_publish_dashboard_recipe_returns_gap_report_unsaved(
+        self, flex_dashboard_module
+    ):
+        FlexDashboard = flex_dashboard_module.FlexDashboard
+        GapReport = flex_dashboard_module.GapReport
+
+        gap_report = GapReport(gaps=[], covered=[])
+        recipe_store = SimpleNamespace(save=AsyncMock())
+
+        class _FakeAgent:
+            DASHBOARD_RECIPE_NAME = FlexDashboard.DASHBOARD_RECIPE_NAME
+            dashboard_descriptor = staticmethod(FlexDashboard.dashboard_descriptor)
+            recipe_params = staticmethod(FlexDashboard.recipe_params)
+            publish_recipe = AsyncMock(return_value=gap_report)
+            _require_recipe_store = lambda self: recipe_store
+
+            publish_dashboard_recipe = FlexDashboard.publish_dashboard_recipe
+
+        agent = _FakeAgent()
+        result = await agent.publish_dashboard_recipe()
+
+        assert result is gap_report
+        recipe_store.save.assert_not_awaited()

--- a/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_kb_docs.py
+++ b/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_kb_docs.py
@@ -1,0 +1,60 @@
+"""Presence + structure tests for the Flex KPI kb docs (FEAT-491 TASK-2695)."""
+
+from pathlib import Path
+
+# Repo root, resolved the same worktree-safe way as the other flex tests:
+# packages/ai-parrot/tests/unit/bots/<this file> -> repo root is parents[5].
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_KB_DIR = _REPO_ROOT / "agents" / "flex_dashboard" / "kb"
+
+_REQUIRED_DOCS = {
+    "payroll_contribution.md",
+    "pay_code_allocation.md",
+    "rep_utilization.md",
+    "proximity_staffing.md",
+    "datasets.md",
+}
+
+_REQUIRED_SECTIONS = [
+    "Definition",
+    "Formula",
+    "Source columns",
+    "Normalization rules",
+    "Filters",
+    "Worked example",
+]
+
+
+def test_kb_docs_present_and_structured():
+    docs = sorted(_KB_DIR.glob("*.md"))
+    assert {d.name for d in docs} >= _REQUIRED_DOCS
+
+    for doc in docs:
+        text = doc.read_text()
+        for section in _REQUIRED_SECTIONS:
+            assert section in text, f"{doc.name} missing {section!r} section"
+
+
+def test_payroll_pct_denominator_is_documented():
+    text = (_KB_DIR / "payroll_contribution.md").read_text()
+    assert "Revenue ALONE" in text
+    assert "sum(Payroll) / sum(Revenue)" in text
+
+
+def test_rep_utilization_recompute_rule_is_documented():
+    text = (_KB_DIR / "rep_utilization.md").read_text()
+    assert "RECOMPUTED" in text
+    assert "employees_worked / average_active" in text
+    assert "cross_check_utilization" in text or "cross-check" in text.lower()
+
+
+def test_worked_examples_match_hand_computation():
+    payroll_doc = (_KB_DIR / "payroll_contribution.md").read_text()
+    assert "0.15046372734425384" in payroll_doc
+
+    rep_doc = (_KB_DIR / "rep_utilization.md").read_text()
+    assert "0.19047619047619047" in rep_doc
+    assert "0.1456953642384106" in rep_doc
+
+    proximity_doc = (_KB_DIR / "proximity_staffing.md").read_text()
+    assert "661.38" in proximity_doc

--- a/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_normalize.py
+++ b/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_normalize.py
@@ -108,16 +108,12 @@ class TestMonthAlignment:
 
 class TestColumnCanonicalization:
     def test_column_canonicalization(self, normalize, flex_frames):
-        rep_out = normalize.canonicalize_columns(
-            flex_frames["rep_utilization"], source="rep_utilization"
-        )
+        rep_out = normalize.canonicalize_columns(flex_frames["rep_utilization"], source="rep_utilization")
         assert "category" in rep_out.columns
         assert "catagory" not in rep_out.columns
         assert rep_out["category"].iloc[0] == "Flex"
 
-        region_out = normalize.canonicalize_columns(
-            flex_frames["region_utilization"], source="region_utilization"
-        )
+        region_out = normalize.canonicalize_columns(flex_frames["region_utilization"], source="region_utilization")
         assert "region" in region_out.columns
         assert "state" in region_out.columns
         assert "employees_worked" in region_out.columns

--- a/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_normalize.py
+++ b/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_normalize.py
@@ -1,0 +1,135 @@
+"""Unit tests for `agents/flex_dashboard/normalize.py` (FEAT-491 TASK-2693)."""
+
+import importlib.util
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+# `agents/` is a local, gitignored-by-default directory (`/agents/` in
+# .gitignore; individual agent files/packages must be `git add -f`'d to
+# ship — see CLAUDE.md's "Heads-up" note on the equivalent `sdd/templates/`
+# pattern). Some `parrot` submodule imports also trigger a settings
+# bootstrap (`navconfig.conf`) that `os.chdir()`s to the MAIN repo checkout,
+# which can make a plain `import agents.flex_dashboard.normalize` resolve
+# inconsistently when tests run from a git worktree. Load the module
+# directly from this worktree's own file path instead — same technique as
+# `test_finance_reporter_descriptors.py::_load_finance_reporter`.
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_NORMALIZE_PATH = _REPO_ROOT / "agents" / "flex_dashboard" / "normalize.py"
+
+
+def _load_normalize():
+    module_name = "agents.flex_dashboard.normalize"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(module_name, _NORMALIZE_PATH)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load {_NORMALIZE_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+@pytest.fixture(scope="module")
+def normalize():
+    return _load_normalize()
+
+
+class TestParseCurrency:
+    def test_parse_currency(self, normalize):
+        assert normalize.parse_currency("$137,456.85") == pytest.approx(137456.85)
+        assert normalize.parse_currency("-$44,621.24") == pytest.approx(-44621.24)
+        assert normalize.parse_currency("$0.00") == pytest.approx(0.0)
+
+    def test_parse_currency_passthrough_numeric(self, normalize):
+        assert normalize.parse_currency(42) == pytest.approx(42.0)
+        assert normalize.parse_currency(3.14) == pytest.approx(3.14)
+
+    def test_parse_currency_nan_safe(self, normalize):
+        assert math.isnan(normalize.parse_currency(None))
+        assert math.isnan(normalize.parse_currency(float("nan")))
+        assert math.isnan(normalize.parse_currency(""))
+        assert math.isnan(normalize.parse_currency("not-a-number"))
+
+    def test_normalize_currency_columns(self, normalize, flex_frames):
+        finance = flex_frames["finance"]
+        currency_columns = [
+            "Revenue",
+            "PC Revenue",
+            "EBITDA",
+            "Payroll",
+            "Travel and Expenses",
+            "Program Overhead Allocation",
+            "Other Related Expenses",
+        ]
+        out = normalize.normalize_currency_columns(finance, currency_columns)
+        # Original frame is untouched (pure function, never mutate in place).
+        assert finance["Revenue"].iloc[1] == "$137,456.85"
+        assert out["Revenue"].iloc[1] == pytest.approx(137456.85)
+        assert out["Other Related Expenses"].iloc[1] == pytest.approx(-44621.24)
+
+
+class TestMonthAlignment:
+    def test_month_alignment(self, normalize, flex_frames):
+        finance_out = normalize.month_period(flex_frames["finance"], source="finance")
+        assert finance_out["month"].iloc[1] == "2025-10"
+
+        hours_out = normalize.month_period(flex_frames["hours"], source="hours")
+        assert hours_out["month"].iloc[2] == "2025-10"
+
+        region_out = normalize.month_period(flex_frames["region_utilization"], source="fm")
+        assert region_out["month"].iloc[0] == "2026-03"
+
+        rep_out = normalize.month_period(flex_frames["rep_utilization"], source="fm")
+        assert rep_out["month"].iloc[0] == "2026-05"
+
+    def test_month_period_does_not_mutate_input(self, normalize, flex_frames):
+        # finance's own date column is already named "month" (spec §2); the
+        # mutation check is that its RAW string values survive untouched.
+        finance = flex_frames["finance"]
+        normalize.month_period(finance, source="finance")
+        assert finance["month"].iloc[0] == "2025-09-30"
+
+        hours = flex_frames["hours"]
+        normalize.month_period(hours, source="hours")
+        assert "month" not in hours.columns
+
+    def test_month_period_unknown_source_raises(self, normalize, flex_frames):
+        with pytest.raises(ValueError):
+            normalize.month_period(flex_frames["finance"], source="bogus")
+
+    def test_month_period_missing_column_raises(self, normalize, flex_frames):
+        with pytest.raises(KeyError):
+            normalize.month_period(flex_frames["msl"], source="finance")
+
+
+class TestColumnCanonicalization:
+    def test_column_canonicalization(self, normalize, flex_frames):
+        rep_out = normalize.canonicalize_columns(
+            flex_frames["rep_utilization"], source="rep_utilization"
+        )
+        assert "category" in rep_out.columns
+        assert "catagory" not in rep_out.columns
+        assert rep_out["category"].iloc[0] == "Flex"
+
+        region_out = normalize.canonicalize_columns(
+            flex_frames["region_utilization"], source="region_utilization"
+        )
+        assert "region" in region_out.columns
+        assert "state" in region_out.columns
+        assert "employees_worked" in region_out.columns
+        assert "average_active" in region_out.columns
+        assert "employee_utilization" in region_out.columns
+        assert "FM Region" not in region_out.columns
+
+    def test_canonicalize_columns_does_not_mutate_input(self, normalize, flex_frames):
+        rep = flex_frames["rep_utilization"]
+        normalize.canonicalize_columns(rep, source="rep_utilization")
+        assert "catagory" in rep.columns
+
+    def test_canonicalize_columns_unknown_source_raises(self, normalize, flex_frames):
+        with pytest.raises(ValueError):
+            normalize.canonicalize_columns(flex_frames["msl"], source="bogus")

--- a/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_skills.py
+++ b/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_skills.py
@@ -1,0 +1,152 @@
+"""Discovery + trigger tests for the Flex skills (FEAT-491 TASK-2698)."""
+
+from pathlib import Path
+
+import pytest
+from parrot.skills.loader import SkillsDirectoryLoader
+from parrot.skills.models import SkillDefinition
+from parrot.skills.parsers import parse_skill_directory, parse_skill_file
+
+# Anchored to this test file's own location (worktree-safe — see
+# test_budget_narrative_skill.py's comment for why).
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+SKILLS_DIR = _REPO_ROOT / "agents" / "flex_dashboard" / "skills"
+WIDGET_DIR = SKILLS_DIR / "widget"
+INFOGRAPHIC_DIR = SKILLS_DIR / "infographic"
+NARRATIVE_DIR = SKILLS_DIR / "flex-narrative"
+
+
+class TestSkillsParse:
+    def test_widget_skill_md_parses(self):
+        definition = parse_skill_file(WIDGET_DIR / "SKILL.md")
+        assert definition.name == "widget"
+        assert definition.description
+        assert definition.triggers == ["/widget"]
+
+    def test_infographic_skill_md_parses(self):
+        definition = parse_skill_file(INFOGRAPHIC_DIR / "SKILL.md")
+        assert definition.name == "infographic"
+        assert definition.triggers == ["/infographic"]
+
+    def test_flex_narrative_skill_md_parses(self):
+        definition = parse_skill_file(NARRATIVE_DIR / "SKILL.md")
+        assert definition.name == "flex-narrative"
+        assert definition.triggers == []
+
+    @pytest.mark.parametrize("skill_dir", [WIDGET_DIR, INFOGRAPHIC_DIR, NARRATIVE_DIR])
+    def test_body_under_token_cap(self, skill_dir):
+        definition = parse_skill_file(skill_dir / "SKILL.md")
+        assert definition.token_count < SkillDefinition.MAX_TOKENS
+
+    def test_widget_composite_sets_assets_dir(self):
+        definition = parse_skill_directory(WIDGET_DIR)
+        assert definition.assets_dir == WIDGET_DIR
+
+    def test_widget_kpi_table_asset_present(self):
+        names = {p.name for p in WIDGET_DIR.iterdir()}
+        assert {"SKILL.md", "kpi-table.md"} <= names
+
+    def test_no_executable_assets(self):
+        for skill_dir in (WIDGET_DIR, INFOGRAPHIC_DIR, NARRATIVE_DIR):
+            assert not [p for p in skill_dir.iterdir() if p.suffix in {".py", ".sh"}]
+
+
+class TestWidgetBodyContent:
+    def test_widget_maps_every_kpi_to_an_output_mode(self):
+        kpi_table = (WIDGET_DIR / "kpi-table.md").read_text()
+        for kpi_row in (
+            "Worked Hours (total)",
+            "Payroll (total)",
+            "P&L Revenue (total)",
+            "Payroll % to Revenue (total)",
+            "Worked Hours by Month",
+            "Payroll by Month",
+            "P&L Revenue by Month",
+            "Payroll % to Revenue by Month",
+            "Pay Code Hours",
+            "Worked Hours by Pay Code Allocation",
+            "Rep Utilization by Region",
+            "Proximity Staffing",
+        ):
+            assert kpi_row in kpi_table, f"missing KPI row: {kpi_row}"
+
+        for output_mode in ("KPICard", "STRUCTURED_CHART", "STRUCTURED_TABLE", "STRUCTURED_MAP"):
+            assert output_mode in kpi_table
+
+    def test_widget_states_payroll_pct_denominator_rule(self):
+        body = (WIDGET_DIR / "SKILL.md").read_text() + (WIDGET_DIR / "kpi-table.md").read_text()
+        assert "Revenue ALONE" in body
+
+
+class TestFlexNarrativeBodyContent:
+    def test_states_no_invented_figures_rule(self):
+        body = (NARRATIVE_DIR / "SKILL.md").read_text()
+        assert "not in the facts" in body.lower() or "only figures" in body.lower()
+
+    def test_references_flex_narrative_facts_fields(self):
+        body = (NARRATIVE_DIR / "SKILL.md").read_text()
+        for field in (
+            "worked_hours_total",
+            "payroll_total",
+            "revenue_total",
+            "payroll_pct",
+            "worked_hours_trend",
+            "regions_tracked",
+        ):
+            assert field in body
+
+
+class TestSkillsDiscovered:
+    @pytest.mark.asyncio
+    async def test_skills_discovered(self):
+        loader = SkillsDirectoryLoader(paths=[SKILLS_DIR])
+        found = await loader.discover()
+        names = {s.name for s in found}
+        assert {"widget", "infographic", "flex-narrative"} <= names
+
+    @pytest.mark.asyncio
+    async def test_widget_and_infographic_triggers(self):
+        loader = SkillsDirectoryLoader(paths=[SKILLS_DIR])
+        found = {s.name: s for s in await loader.discover()}
+        assert "/widget" in found["widget"].triggers
+        assert "/infographic" in found["infographic"].triggers
+        assert found["flex-narrative"].triggers == []
+
+    @pytest.mark.asyncio
+    async def test_discovered_via_agent_skill_paths(self):
+        """Discovery through the exact path FlexDashboard.skill_paths declares."""
+        import importlib.util
+        import sys
+
+        agents_dir = _REPO_ROOT / "agents"
+        flex_dir = agents_dir / "flex_dashboard"
+
+        def _load_package(name, init_path, search_dir):
+            if name in sys.modules:
+                return sys.modules[name]
+            spec = importlib.util.spec_from_file_location(
+                name, init_path, submodule_search_locations=[str(search_dir)]
+            )
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[name] = module
+            spec.loader.exec_module(module)
+            return module
+
+        def _load_module(name, path):
+            if name in sys.modules:
+                return sys.modules[name]
+            spec = importlib.util.spec_from_file_location(name, path)
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[name] = module
+            spec.loader.exec_module(module)
+            return module
+
+        _load_package("agents", agents_dir / "__init__.py", agents_dir)
+        _load_package("agents.flex_dashboard", flex_dir / "__init__.py", flex_dir)
+        _load_module("agents.flex_dashboard.normalize", flex_dir / "normalize.py")
+        _load_module("agents.flex_dashboard.transformers", flex_dir / "transformers.py")
+        module = _load_module("flex_dashboard_agent_under_test", agents_dir / "flex_dashboard.py")
+
+        loader = SkillsDirectoryLoader(paths=list(module.FlexDashboard.skill_paths))
+        found = {s.name for s in await loader.discover()}
+        assert {"widget", "infographic", "flex-narrative"} <= found

--- a/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_skills.py
+++ b/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_skills.py
@@ -124,9 +124,7 @@ class TestSkillsDiscovered:
         def _load_package(name, init_path, search_dir):
             if name in sys.modules:
                 return sys.modules[name]
-            spec = importlib.util.spec_from_file_location(
-                name, init_path, submodule_search_locations=[str(search_dir)]
-            )
+            spec = importlib.util.spec_from_file_location(name, init_path, submodule_search_locations=[str(search_dir)])
             module = importlib.util.module_from_spec(spec)
             sys.modules[name] = module
             spec.loader.exec_module(module)

--- a/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_transformers.py
+++ b/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_transformers.py
@@ -107,9 +107,7 @@ class TestPayrollHero:
         SAME filters as the rest of the dashboard — a month-filtered replay
         must not show all-time totals in the hero cards."""
         payroll_hero = loaded_flex_transformers.payroll_hero
-        unfiltered = payroll_hero(
-            {"hours": flex_frames["hours"], "finance": flex_frames["finance"]}, {}
-        )
+        unfiltered = payroll_hero({"hours": flex_frames["hours"], "finance": flex_frames["finance"]}, {})
         filtered = payroll_hero(
             {"hours": flex_frames["hours"], "finance": flex_frames["finance"]},
             {"month": "2025-10"},
@@ -182,9 +180,7 @@ class TestPayCodeSections:
         """Code-review finding (adopted): consistent with the sibling
         pay_code_hours table — a pay_code filter narrows the allocation
         base too (trivially 100% for the one selected code)."""
-        out = loaded_flex_transformers.pay_code_allocation(
-            {"hours": flex_frames["hours"]}, {"pay_code": "Admin Time"}
-        )
+        out = loaded_flex_transformers.pay_code_allocation({"hours": flex_frames["hours"]}, {"pay_code": "Admin Time"})
         assert [r["pay_code"] for r in out["records"]] == ["Admin Time"]
         assert out["records"][0]["share_pct"] == pytest.approx(100.0)
         assert out["total_hours"] == pytest.approx(25.0 + 30.199996)

--- a/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_transformers.py
+++ b/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_transformers.py
@@ -26,9 +26,7 @@ _FLEX_DIR = _AGENTS_DIR / "flex_dashboard"
 def _load_package(name: str, init_path: Path, search_dir: Path):
     if name in sys.modules:
         return sys.modules[name]
-    spec = importlib.util.spec_from_file_location(
-        name, init_path, submodule_search_locations=[str(search_dir)]
-    )
+    spec = importlib.util.spec_from_file_location(name, init_path, submodule_search_locations=[str(search_dir)])
     if spec is None or spec.loader is None:
         raise ImportError(f"Cannot load package {name!r} from {init_path}")
     module = importlib.util.module_from_spec(spec)
@@ -125,17 +123,13 @@ class TestMonthSeriesTransformers:
         assert series["2025-10"] == pytest.approx(137456.85)
 
     def test_payroll_pct_by_month(self, loaded_flex_transformers, flex_frames):
-        out = loaded_flex_transformers.payroll_pct_by_month(
-            {"finance": flex_frames["finance"]}, {}
-        )
+        out = loaded_flex_transformers.payroll_pct_by_month({"finance": flex_frames["finance"]}, {})
         series = {row["month"]: row["payroll_pct"] for row in out["series"]}
         assert series["2025-09"] == pytest.approx(18000.0 / 120000.0, rel=1e-6)
         assert series["2025-10"] == pytest.approx(20682.27 / 137456.85, rel=1e-6)
 
     def test_month_filter_narrows_series(self, loaded_flex_transformers, flex_frames):
-        out = loaded_flex_transformers.payroll_by_month(
-            {"finance": flex_frames["finance"]}, {"month": "2025-10"}
-        )
+        out = loaded_flex_transformers.payroll_by_month({"finance": flex_frames["finance"]}, {"month": "2025-10"})
         assert [row["month"] for row in out["series"]] == ["2025-10"]
 
 
@@ -147,23 +141,17 @@ class TestPayCodeSections:
         assert records["Field Time"] == pytest.approx(1800.0 + 1900.0)
 
     def test_pay_code_hours_respects_pay_code_param(self, loaded_flex_transformers, flex_frames):
-        out = loaded_flex_transformers.pay_code_hours(
-            {"hours": flex_frames["hours"]}, {"pay_code": "Admin Time"}
-        )
+        out = loaded_flex_transformers.pay_code_hours({"hours": flex_frames["hours"]}, {"pay_code": "Admin Time"})
         assert [r["pay_code"] for r in out["records"]] == ["Admin Time"]
 
     def test_pay_code_allocation(self, loaded_flex_transformers, flex_frames):
-        out = loaded_flex_transformers.pay_code_allocation(
-            {"hours": flex_frames["hours"]}, {}
-        )
+        out = loaded_flex_transformers.pay_code_allocation({"hours": flex_frames["hours"]}, {})
         shares = {row["pay_code"]: row["share_pct"] for row in out["records"]}
         assert sum(shares.values()) == pytest.approx(100.0, abs=0.01)
 
     def test_per_section_filters(self, loaded_flex_transformers, flex_frames):
         """A flex_type param must never reach/alter a finance-only transformer."""
-        baseline = loaded_flex_transformers.payroll_by_month(
-            {"finance": flex_frames["finance"]}, {}
-        )
+        baseline = loaded_flex_transformers.payroll_by_month({"finance": flex_frames["finance"]}, {})
         with_bogus_filter = loaded_flex_transformers.payroll_by_month(
             {"finance": flex_frames["finance"]}, {"flex_type": "Flex"}
         )
@@ -248,9 +236,7 @@ class TestProximityStaffing:
         assert norridge["nearest_employees"][0]["distance_miles"] < 5.0
         assert norridge["employees_within_radius"] >= 1
 
-    def test_proximity_staffing_radius_and_nearest_n_params(
-        self, loaded_flex_transformers, flex_frames
-    ):
+    def test_proximity_staffing_radius_and_nearest_n_params(self, loaded_flex_transformers, flex_frames):
         out = loaded_flex_transformers.proximity_staffing(
             {"msl": flex_frames["msl"], "employees": flex_frames["employees"]},
             {"radius_miles": 1, "nearest_n": 1},
@@ -274,9 +260,7 @@ class TestNarrativeFacts:
         hero = loaded_flex_transformers.payroll_hero(
             {"hours": flex_frames["hours"], "finance": flex_frames["finance"]}, {}
         )
-        worked_hours = loaded_flex_transformers.worked_hours_by_month(
-            {"hours": flex_frames["hours"]}, {}
-        )
+        worked_hours = loaded_flex_transformers.worked_hours_by_month({"hours": flex_frames["hours"]}, {})
         utilization = loaded_flex_transformers.rep_utilization_by_region(
             {
                 "rep_utilization": flex_frames["rep_utilization"],

--- a/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_transformers.py
+++ b/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_transformers.py
@@ -1,0 +1,298 @@
+"""Unit tests for `agents/flex_dashboard/transformers.py` (FEAT-491 TASK-2694)."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from parrot.outputs.a2ui.recipes.transformers import transformer_registry
+
+# Same worktree-safe file-path loading technique as
+# `test_finance_reporter_descriptors.py::_load_finance_reporter` and
+# `test_flex_dashboard_normalize.py::_load_normalize`. `transformers.py`
+# additionally does `from agents.flex_dashboard.normalize import ...` (an
+# absolute, real package import) — to make that resolve deterministically
+# from THIS worktree's files (and not risk crossing into a different
+# worktree's `agents/` via ambient sys.path state), the full package chain
+# ("agents" -> "agents.flex_dashboard" -> "...normalize" -> "...transformers")
+# is pre-registered in `sys.modules` in dependency order before exec'ing
+# transformers.py, so its internal import resolves purely from cache.
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_AGENTS_DIR = _REPO_ROOT / "agents"
+_FLEX_DIR = _AGENTS_DIR / "flex_dashboard"
+
+
+def _load_package(name: str, init_path: Path, search_dir: Path):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(
+        name, init_path, submodule_search_locations=[str(search_dir)]
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load package {name!r} from {init_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+def _load_module(name: str, path: Path):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+def _load_flex_transformers():
+    _load_package("agents", _AGENTS_DIR / "__init__.py", _AGENTS_DIR)
+    _load_package("agents.flex_dashboard", _FLEX_DIR / "__init__.py", _FLEX_DIR)
+    _load_module("agents.flex_dashboard.normalize", _FLEX_DIR / "normalize.py")
+    return _load_module("agents.flex_dashboard.transformers", _FLEX_DIR / "transformers.py")
+
+
+@pytest.fixture(scope="module")
+def loaded_flex_transformers():
+    return _load_flex_transformers()
+
+
+_EXPECTED_TRANSFORMERS = [
+    "payroll_hero",
+    "worked_hours_by_month",
+    "payroll_by_month",
+    "revenue_by_month",
+    "payroll_pct_by_month",
+    "pay_code_hours",
+    "pay_code_allocation",
+    "rep_utilization_by_region",
+    "proximity_staffing",
+    "flex_narrative_facts",
+]
+
+
+def test_transformers_registered(loaded_flex_transformers):
+    for name in _EXPECTED_TRANSFORMERS:
+        assert transformer_registry.get(name) is not None
+
+
+class TestPayrollHero:
+    def test_payroll_hero_totals(self, loaded_flex_transformers, flex_frames):
+        payroll_hero = loaded_flex_transformers.payroll_hero
+        out = payroll_hero({"hours": flex_frames["hours"], "finance": flex_frames["finance"]}, {})
+
+        expected_hours = flex_frames["hours"]["hours"].sum()
+        assert out["worked_hours_total"] == pytest.approx(expected_hours, abs=0.01)
+        assert out["payroll_total"] == pytest.approx(18000.0 + 20682.27, abs=0.01)
+        assert out["revenue_total"] == pytest.approx(120000.0 + 137456.85, abs=0.01)
+
+    def test_payroll_pct_denominator(self, loaded_flex_transformers, flex_frames):
+        """Regression pin: denominator is Revenue ALONE, not Revenue + PC Revenue."""
+        payroll_hero = loaded_flex_transformers.payroll_hero
+        out = payroll_hero({"hours": flex_frames["hours"], "finance": flex_frames["finance"]}, {})
+
+        payroll_total = 18000.0 + 20682.27
+        revenue_total = 120000.0 + 137456.85
+        pc_revenue_total = 40000.0 + 51229.85
+
+        assert out["payroll_pct"] == pytest.approx(payroll_total / revenue_total, rel=1e-6)
+        # NOT payroll / (revenue + pc_revenue)
+        wrong_pct = payroll_total / (revenue_total + pc_revenue_total)
+        assert out["payroll_pct"] != pytest.approx(wrong_pct, rel=1e-6)
+
+
+class TestMonthSeriesTransformers:
+    def test_worked_hours_by_month(self, loaded_flex_transformers, flex_frames):
+        out = loaded_flex_transformers.worked_hours_by_month({"hours": flex_frames["hours"]}, {})
+        series = {row["month"]: row["worked_hours"] for row in out["series"]}
+        assert series["2025-09"] == pytest.approx(25.0 + 1800.0)
+        assert series["2025-10"] == pytest.approx(30.199996 + 1900.0)
+
+    def test_payroll_by_month(self, loaded_flex_transformers, flex_frames):
+        out = loaded_flex_transformers.payroll_by_month({"finance": flex_frames["finance"]}, {})
+        series = {row["month"]: row["payroll"] for row in out["series"]}
+        assert series["2025-09"] == pytest.approx(18000.0)
+        assert series["2025-10"] == pytest.approx(20682.27)
+
+    def test_revenue_by_month(self, loaded_flex_transformers, flex_frames):
+        out = loaded_flex_transformers.revenue_by_month({"finance": flex_frames["finance"]}, {})
+        series = {row["month"]: row["revenue"] for row in out["series"]}
+        assert series["2025-09"] == pytest.approx(120000.0)
+        assert series["2025-10"] == pytest.approx(137456.85)
+
+    def test_payroll_pct_by_month(self, loaded_flex_transformers, flex_frames):
+        out = loaded_flex_transformers.payroll_pct_by_month(
+            {"finance": flex_frames["finance"]}, {}
+        )
+        series = {row["month"]: row["payroll_pct"] for row in out["series"]}
+        assert series["2025-09"] == pytest.approx(18000.0 / 120000.0, rel=1e-6)
+        assert series["2025-10"] == pytest.approx(20682.27 / 137456.85, rel=1e-6)
+
+    def test_month_filter_narrows_series(self, loaded_flex_transformers, flex_frames):
+        out = loaded_flex_transformers.payroll_by_month(
+            {"finance": flex_frames["finance"]}, {"month": "2025-10"}
+        )
+        assert [row["month"] for row in out["series"]] == ["2025-10"]
+
+
+class TestPayCodeSections:
+    def test_pay_code_hours(self, loaded_flex_transformers, flex_frames):
+        out = loaded_flex_transformers.pay_code_hours({"hours": flex_frames["hours"]}, {})
+        records = {row["pay_code"]: row["hours"] for row in out["records"]}
+        assert records["Admin Time"] == pytest.approx(25.0 + 30.199996)
+        assert records["Field Time"] == pytest.approx(1800.0 + 1900.0)
+
+    def test_pay_code_hours_respects_pay_code_param(self, loaded_flex_transformers, flex_frames):
+        out = loaded_flex_transformers.pay_code_hours(
+            {"hours": flex_frames["hours"]}, {"pay_code": "Admin Time"}
+        )
+        assert [r["pay_code"] for r in out["records"]] == ["Admin Time"]
+
+    def test_pay_code_allocation(self, loaded_flex_transformers, flex_frames):
+        out = loaded_flex_transformers.pay_code_allocation(
+            {"hours": flex_frames["hours"]}, {}
+        )
+        shares = {row["pay_code"]: row["share_pct"] for row in out["records"]}
+        assert sum(shares.values()) == pytest.approx(100.0, abs=0.01)
+
+    def test_per_section_filters(self, loaded_flex_transformers, flex_frames):
+        """A flex_type param must never reach/alter a finance-only transformer."""
+        baseline = loaded_flex_transformers.payroll_by_month(
+            {"finance": flex_frames["finance"]}, {}
+        )
+        with_bogus_filter = loaded_flex_transformers.payroll_by_month(
+            {"finance": flex_frames["finance"]}, {"flex_type": "Flex"}
+        )
+        assert baseline == with_bogus_filter
+
+
+class TestRepUtilization:
+    def test_rep_utilization_formula(self, loaded_flex_transformers, flex_frames):
+        out = loaded_flex_transformers.rep_utilization_by_region(
+            {
+                "rep_utilization": flex_frames["rep_utilization"],
+                "region_utilization": flex_frames["region_utilization"],
+            },
+            {},
+        )
+        by_region_month = {(r["region"], r["month"]): r for r in out["records"]}
+
+        rep_ca = by_region_month[("CA", "2026-05")]
+        assert rep_ca["utilization"] == pytest.approx(12 / 63, rel=1e-6)
+        # region_utilization has no CA row for 2026-05 -> no cross-check available.
+        assert rep_ca["cross_check_utilization"] is None
+
+        rep_il = by_region_month[("IL", "2026-06")]
+        assert rep_il["utilization"] == pytest.approx(10 / 50, rel=1e-6)
+
+    def test_rep_utilization_cross_check_when_available(self, loaded_flex_transformers):
+        """When region/category/month line up, the precomputed column is attached."""
+        rep_df = pd.DataFrame(
+            [
+                {
+                    "bop_date": "2026-03-01",
+                    "eop_date": "2026-03-31",
+                    "region": "CA",
+                    "state": "CA",
+                    "catagory": "Flex",
+                    "hours_worked": 100.0,
+                    "work_shifts": 10,
+                    "employees_worked": 11,
+                    "average_active": 75.5,
+                }
+            ]
+        )
+        region_df = pd.DataFrame(
+            [
+                {
+                    "BOP Date": "2026-03-01",
+                    "EOP Date": "2026-03-31",
+                    "FM Region": "CA",
+                    "State Code": "CA",
+                    "State": "California",
+                    "Category": "Flex",
+                    "Employees Worked": 11,
+                    "Average Active Employees": 75.5,
+                    "Flex Employees": 68,
+                    "Employee Utilization": 0.145695364238411,
+                }
+            ]
+        )
+        out = loaded_flex_transformers.rep_utilization_by_region(
+            {"rep_utilization": rep_df, "region_utilization": region_df}, {}
+        )
+        record = out["records"][0]
+        assert record["utilization"] == pytest.approx(11 / 75.5, rel=1e-6)
+        assert record["cross_check_utilization"] == pytest.approx(0.145695364238411, rel=1e-6)
+
+
+class TestProximityStaffing:
+    def test_proximity_staffing(self, loaded_flex_transformers, flex_frames):
+        out = loaded_flex_transformers.proximity_staffing(
+            {"msl": flex_frames["msl"], "employees": flex_frames["employees"]}, {}
+        )
+        assert len(out["store_layer"]) == 3
+        assert len(out["employee_layer"]) == 3
+        assert out["radius_miles"] == 50
+        assert out["nearest_n"] == 3
+
+        coverage = {row["store_name"]: row for row in out["coverage"]}
+        norridge = coverage["T-Mobile 3SFD Norridge IL"]
+        # Jordan Reyes is seeded a few miles from the Norridge store.
+        nearest_names = [e["display_name"] for e in norridge["nearest_employees"]]
+        assert nearest_names[0] == "Jordan Reyes"
+        assert norridge["nearest_employees"][0]["distance_miles"] < 5.0
+        assert norridge["employees_within_radius"] >= 1
+
+    def test_proximity_staffing_radius_and_nearest_n_params(
+        self, loaded_flex_transformers, flex_frames
+    ):
+        out = loaded_flex_transformers.proximity_staffing(
+            {"msl": flex_frames["msl"], "employees": flex_frames["employees"]},
+            {"radius_miles": 1, "nearest_n": 1},
+        )
+        assert out["radius_miles"] == 1
+        assert out["nearest_n"] == 1
+        for row in out["coverage"]:
+            assert len(row["nearest_employees"]) <= 1
+
+    def test_proximity_staffing_flex_type_filter(self, loaded_flex_transformers, flex_frames):
+        out = loaded_flex_transformers.proximity_staffing(
+            {"msl": flex_frames["msl"], "employees": flex_frames["employees"]},
+            {"flex_type": "Core"},
+        )
+        assert len(out["employee_layer"]) == 1
+        assert out["employee_layer"][0]["display_name"] == "Casey Kim"
+
+
+class TestNarrativeFacts:
+    def test_narrative_facts_consumes_prior_outputs(self, loaded_flex_transformers, flex_frames):
+        hero = loaded_flex_transformers.payroll_hero(
+            {"hours": flex_frames["hours"], "finance": flex_frames["finance"]}, {}
+        )
+        worked_hours = loaded_flex_transformers.worked_hours_by_month(
+            {"hours": flex_frames["hours"]}, {}
+        )
+        utilization = loaded_flex_transformers.rep_utilization_by_region(
+            {
+                "rep_utilization": flex_frames["rep_utilization"],
+                "region_utilization": flex_frames["region_utilization"],
+            },
+            {},
+        )
+        out = loaded_flex_transformers.flex_narrative_facts(
+            {
+                "payroll_hero": hero,
+                "worked_hours_by_month": worked_hours,
+                "rep_utilization_by_region": utilization,
+            },
+            {},
+        )
+        assert out["worked_hours_total"] == hero["worked_hours_total"]
+        assert out["payroll_pct"] == hero["payroll_pct"]
+        assert out["worked_hours_trend"] == "increasing"
+        assert out["regions_tracked"] == ["CA", "IL"]

--- a/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_transformers.py
+++ b/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_transformers.py
@@ -102,6 +102,35 @@ class TestPayrollHero:
         wrong_pct = payroll_total / (revenue_total + pc_revenue_total)
         assert out["payroll_pct"] != pytest.approx(wrong_pct, rel=1e-6)
 
+    def test_payroll_hero_reflects_active_filters(self, loaded_flex_transformers, flex_frames):
+        """Code-review finding (adopted): the hero row must narrow with the
+        SAME filters as the rest of the dashboard — a month-filtered replay
+        must not show all-time totals in the hero cards."""
+        payroll_hero = loaded_flex_transformers.payroll_hero
+        unfiltered = payroll_hero(
+            {"hours": flex_frames["hours"], "finance": flex_frames["finance"]}, {}
+        )
+        filtered = payroll_hero(
+            {"hours": flex_frames["hours"], "finance": flex_frames["finance"]},
+            {"month": "2025-10"},
+        )
+
+        assert filtered["worked_hours_total"] == pytest.approx(30.199996 + 1900.0)
+        assert filtered["payroll_total"] == pytest.approx(20682.27)
+        assert filtered["revenue_total"] == pytest.approx(137456.85)
+        assert filtered["worked_hours_total"] != pytest.approx(unfiltered["worked_hours_total"])
+
+    def test_payroll_hero_pay_code_filter(self, loaded_flex_transformers, flex_frames):
+        payroll_hero = loaded_flex_transformers.payroll_hero
+        out = payroll_hero(
+            {"hours": flex_frames["hours"], "finance": flex_frames["finance"]},
+            {"pay_code": "Admin Time"},
+        )
+        # Only Admin Time hours narrow; finance has no pay_code column, so
+        # its totals stay at the full (unfiltered) amount.
+        assert out["worked_hours_total"] == pytest.approx(25.0 + 30.199996)
+        assert out["payroll_total"] == pytest.approx(18000.0 + 20682.27)
+
 
 class TestMonthSeriesTransformers:
     def test_worked_hours_by_month(self, loaded_flex_transformers, flex_frames):
@@ -148,6 +177,17 @@ class TestPayCodeSections:
         out = loaded_flex_transformers.pay_code_allocation({"hours": flex_frames["hours"]}, {})
         shares = {row["pay_code"]: row["share_pct"] for row in out["records"]}
         assert sum(shares.values()) == pytest.approx(100.0, abs=0.01)
+
+    def test_pay_code_allocation_honors_pay_code_filter(self, loaded_flex_transformers, flex_frames):
+        """Code-review finding (adopted): consistent with the sibling
+        pay_code_hours table — a pay_code filter narrows the allocation
+        base too (trivially 100% for the one selected code)."""
+        out = loaded_flex_transformers.pay_code_allocation(
+            {"hours": flex_frames["hours"]}, {"pay_code": "Admin Time"}
+        )
+        assert [r["pay_code"] for r in out["records"]] == ["Admin Time"]
+        assert out["records"][0]["share_pct"] == pytest.approx(100.0)
+        assert out["total_hours"] == pytest.approx(25.0 + 30.199996)
 
     def test_per_section_filters(self, loaded_flex_transformers, flex_frames):
         """A flex_type param must never reach/alter a finance-only transformer."""

--- a/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_transformers.py
+++ b/packages/ai-parrot/tests/unit/bots/test_flex_dashboard_transformers.py
@@ -282,6 +282,23 @@ class TestProximityStaffing:
         for row in out["coverage"]:
             assert len(row["nearest_employees"]) <= 1
 
+    def test_proximity_staffing_zero_radius_and_nearest_n_are_explicit_values(
+        self, loaded_flex_transformers, flex_frames
+    ):
+        """Code-review finding (adopted): `radius_miles=0`/`nearest_n=0` are
+        legitimate explicit overrides ("exact location only" / "no nearest
+        list"), not "unset" — must NOT silently fall back to the defaults
+        (50 / 3) the way a naive `params.get(...) or default` would."""
+        out = loaded_flex_transformers.proximity_staffing(
+            {"msl": flex_frames["msl"], "employees": flex_frames["employees"]},
+            {"radius_miles": 0, "nearest_n": 0},
+        )
+        assert out["radius_miles"] == 0
+        assert out["nearest_n"] == 0
+        for row in out["coverage"]:
+            assert row["nearest_employees"] == []
+            assert row["employees_within_radius"] == 0
+
     def test_proximity_staffing_flex_type_filter(self, loaded_flex_transformers, flex_frames):
         out = loaded_flex_transformers.proximity_staffing(
             {"msl": flex_frames["msl"], "employees": flex_frames["employees"]},

--- a/sdd/tasks/completed/TASK-2693-flex-normalization-layer.md
+++ b/sdd/tasks/completed/TASK-2693-flex-normalization-layer.md
@@ -166,10 +166,31 @@ def test_column_canonicalization(flex_frames):
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-09-01
+**Notes**: Implemented `parse_currency`, `normalize_currency_columns`,
+`month_period`, `canonicalize_columns` as pure functions in
+`agents/flex_dashboard/normalize.py`. Added the shared `flex_frames`
+fixture in `packages/ai-parrot/tests/unit/bots/conftest.py` with a couple
+of extra rows per alias (beyond the single sample row per dataset in
+`sdd/state/FEAT-517/source.md`) so month-series/filter tests in TASK-2694
+have something to group over — same dirty shapes (currency strings, three
+date conventions, `catagory` typo) as the sample data. 11 unit tests pass;
+`ruff check agents/flex_dashboard/` is clean.
 
-**Completed by**:
-**Date**:
-**Notes**:
+Pre-existing, unrelated repo breakage discovered while validating: `dev`
+commit `f1a029a70` ("config settings") added an import of a
+`mock_fspath_guard` module in `packages/ai-parrot/conftest.py` that was
+never committed anywhere in git history — this currently breaks `pytest`
+collection for the ENTIRE `packages/ai-parrot` test suite (verified this
+also fails on `dev`/main checkout, not just this worktree). Worked around
+locally with an external, non-repo stub (`PYTHONPATH=/tmp/pytest_shim`,
+never committed) purely to validate this task's and later tasks'
+acceptance criteria — this feature does NOT fix that bug (out of scope);
+flagging it here so it's visible to the human reviewer. Also had to copy
+the compiled `parrot.utils.types` Cython extension
+(`types.cpython-312-x86_64-linux-gnu.so`) from the main checkout into this
+worktree to get past an unrelated missing-`.so` import error (documented
+worktree gotcha, not part of this feature).
 
 **Deviations from spec**: none

--- a/sdd/tasks/completed/TASK-2694-flex-transformers.md
+++ b/sdd/tasks/completed/TASK-2694-flex-transformers.md
@@ -184,10 +184,29 @@ def test_payroll_pct_denominator(flex_frames):
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-09-01
+**Notes**: Implemented all 10 registered transformers in
+`agents/flex_dashboard/transformers.py`: `payroll_hero`,
+`worked_hours_by_month`, `payroll_by_month`, `revenue_by_month`,
+`payroll_pct_by_month`, `pay_code_hours`, `pay_code_allocation`,
+`rep_utilization_by_region`, `proximity_staffing`, and the narrative step
+(see deviation below). Haversine implemented with numpy (no new
+dependency). 18 unit tests pass (29 total with TASK-2693's suite);
+`ruff check agents/flex_dashboard/` is clean.
 
-**Completed by**:
-**Date**:
-**Notes**:
-
-**Deviations from spec**: none
+**Deviations from spec**: The narrative-step transformer is registered as
+**`flex_narrative_facts`**, not the generic `narrative_facts` name spec §3
+Module 2 names. Discovered empirically: `parrot.outputs.a2ui.recipes`'s
+`__init__.py` unconditionally imports `library.py` as an import side
+effect the moment anything imports `infographic_transformer` (which
+`transformers.py` must do), and `library.py` already registers its OWN,
+finance-specific `narrative_facts` function on the same process-wide
+`transformer_registry`. `TransformerRegistry.register` raises when a
+different function claims an already-used name — confirmed via a failing
+test run, not assumed. This is unrelated to the FinanceReporter
+`SectionSpec.name="narrative_facts"` *pattern* (last section, consumes
+prior-step outputs), which is preserved exactly; only the registry KEY had
+to change to avoid a real, unavoidable cross-domain name collision.
+TASK-2697's recipe descriptor must use `flex_narrative_facts` as its
+narrative section's name.

--- a/sdd/tasks/completed/TASK-2695-flex-kb-documents.md
+++ b/sdd/tasks/completed/TASK-2695-flex-kb-documents.md
@@ -162,10 +162,17 @@ def test_kb_docs_present_and_structured():
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**:
-**Date**:
-**Notes**:
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-09-01
+**Notes**: Authored all five kb docs under `agents/flex_dashboard/kb/`
+(`payroll_contribution.md`, `pay_code_allocation.md`,
+`rep_utilization.md`, `proximity_staffing.md`, `datasets.md`), each with
+the six required sections. All worked-example numbers were computed by
+hand from the single sample row per dataset in
+`sdd/state/FEAT-517/source.md` (payroll % = `20682.27/137456.85`, rep
+utilization = `12/63`, region cross-check = `11/75.5`, proximity haversine
+distance computed via the exact formula documented in
+`proximity_staffing.md` and cross-checked with a throwaway numpy snippet —
+no invented figures). 4 unit tests pass; `ruff check` is clean.
 
 **Deviations from spec**: none

--- a/sdd/tasks/completed/TASK-2696-flex-dashboard-agent.md
+++ b/sdd/tasks/completed/TASK-2696-flex-dashboard-agent.md
@@ -87,6 +87,21 @@ class DatasetManager(AbstractToolkit):                      # line 501
     async def add_dataset(self, name, ..., query_slug=None, ...,
                           permanent_filter=None, ...)       # line 966
     # exactly ONE of query_slug / query / table / dataframe (lines 1031-1037)
+    # ⚠ CONTRACT CORRECTION (verified 2026-09-01 while implementing TASK-2696):
+    # add_dataset(query_slug=...) is EAGER — its own docstring says "Unlike
+    # the lazy add_query / add_table_source methods, this executes the
+    # source immediately" (fetches via `await source.fetch(**params)` at
+    # tool.py:1049-1050). It is NOT the lazy method the spec's Overview and
+    # this task's Scope describe. The genuinely lazy registration method is:
+    def add_query(self, name: str, query_slug: str, description=None,
+                  metadata=None, is_active=True, permanent_filter=None,
+                  query_filter=None, computed_columns=None,
+                  usage_guidance=None) -> str: ...   # line ~1405 — SYNC, no await
+    # Registers a QuerySlugSource with NO fetch; data loads later on first
+    # `fetch_dataset()`/REPL access. `register_datasets()` MUST call
+    # `self._dataset_manager.add_query(name=<alias>, query_slug=<slug>, ...)`
+    # for all six aliases — NOT `add_dataset` — to satisfy "no eager fetch
+    # at construction/configure time".
 
 # packages/ai-parrot/src/parrot/bots/abstract.py  (AbstractBot — PandasAgent base)
 #   __init__ kwargs: use_kb: bool = False (line 287), local_kb (line 288),
@@ -106,6 +121,29 @@ class FinanceReporter(NarrativeMixin, InfographicAuthoringMixin, PandasAgent):  
     async def configure(self, app=None, queries=None):      # line 179
         await self.register_datasets()
         await super().configure(app=app, queries=queries)
+
+# ⚠ CONTRACT ADDITION (verified 2026-09-01): InfographicToolkit REQUIRES a
+# real ArtifactStore (no default) — `InfographicToolkit.__init__(self, *,
+# artifact_store: ArtifactStore, ...)` (infographic_toolkit.py:213). Simply
+# constructing `InfographicToolkit()` bare and appending it to `tools=`
+# would both fail (missing required arg) AND bypass
+# `InfographicAuthoringMixin`'s own tier-1 wiring (`self._infographic_toolkit
+# .set_bot(self)` — prompt-guidance injection, `generate_infographic()`).
+# packages/ai-parrot/src/parrot/bots/mixins/infographic_authoring.py:72-98
+class InfographicAuthoringMixin:
+    def __init__(self, *args, infographic_toolkit=None, artifact_store=None,
+                 recipe_store=None, template_dirs=None, **kwargs) -> None:
+        # builds InfographicToolkit(artifact_store=..., recipe_store=...,
+        # template_dirs=...) itself when infographic_toolkit is None and
+        # artifact_store is not None, appends it to kwargs["tools"], THEN
+        # chains super().__init__(*args, **kwargs).
+        ...
+# => FlexDashboard.__init__ must accept/forward `artifact_store=`/
+# `recipe_store=` kwargs (building an offline-safe default artifact_store
+# when the caller doesn't supply one — local SQLite + local-filesystem
+# overflow, no network — per `examples/agents/a2ui/
+# deterministic_refresh_dashboard.py`'s own offline pattern) rather than
+# constructing `InfographicToolkit` by hand.
 ```
 
 ### Does NOT Exist
@@ -198,10 +236,45 @@ def test_mixin_order():
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-09-01
+**Notes**: Implemented `FlexDashboard` in `agents/flex_dashboard.py` per
+scope. 11 unit tests pass; `ruff check` is clean. Two Codebase Contract
+corrections were discovered and documented in-place in this task file
+BEFORE implementing (per the anti-hallucination protocol):
 
-**Completed by**:
-**Date**:
-**Notes**:
+1. **`add_dataset(query_slug=...)` is EAGER, not lazy** — its own docstring
+   says it fetches immediately. The genuinely lazy method is
+   `DatasetManager.add_query(name, query_slug, ...)` (sync, no `await`),
+   which `register_datasets()` uses instead. Verified by reading
+   `tool.py`'s `add_query` docstring ("Register a query slug for lazy
+   loading") and confirmed by `test_register_datasets_does_not_fetch`
+   (each dataset's `.df is None` after registration).
+2. **`InfographicToolkit` requires a real `ArtifactStore`** (no default) —
+   simply appending a bare `InfographicToolkit()` to `tools=` would both
+   fail (missing required arg) and bypass
+   `InfographicAuthoringMixin.__init__`'s own toolkit-building/binding
+   logic (`artifact_store=`/`recipe_store=` kwargs already build and
+   attach the toolkit, then call `set_bot(self)`). `FlexDashboard.__init__`
+   forwards `artifact_store=`/`recipe_store=` to the mixin instead of
+   constructing the toolkit by hand, defaulting to an offline-safe local
+   SQLite + local-filesystem `ArtifactStore` (same primitives
+   `deterministic_refresh_dashboard.py` uses) when the caller supplies
+   none — satisfying "instantiates without network/DB".
 
-**Deviations from spec**: none
+Also verified empirically that `agents/flex_dashboard.py` (module) and
+`agents/flex_dashboard/` (package) coexisting under the same name is safe:
+production's `AgentRegistry._load_modules_from_directory` loads `agents/
+*.py` files via `importlib.util.spec_from_file_location` under a synthetic
+name — never a plain `import agents.flex_dashboard` — so the file is never
+shadowed by the package in practice. Confirmed the opposite is true for a
+plain dotted import (`import agents.flex_dashboard` resolves to the
+PACKAGE, not this file) and designed `test_flex_dashboard_agent.py`'s
+loader accordingly (mirrors the production loader's technique, loading the
+agent file under its own distinct synthetic name).
+
+**Deviations from spec**: `register_datasets()` calls
+`DatasetManager.add_query`, not `add_dataset` as spec §2/§3 Module 3 and
+this task's original Scope/Codebase Contract stated — required to satisfy
+the "no eager fetch" requirement those same sections also state (the two
+were in tension until traced to the real method signatures; see Notes).

--- a/sdd/tasks/completed/TASK-2697-flex-dashboard-recipe-refresh.md
+++ b/sdd/tasks/completed/TASK-2697-flex-dashboard-recipe-refresh.md
@@ -228,3 +228,26 @@ comments:
 overrides at all, which the spec's own "narrative step stays optional so
 replay works with no narrator" principle implies should also hold for the
 per-section filters.
+
+**ADDENDUM (during TASK-2699, same worktree/session)**: the
+"Proximity Staffing" section's `"text": {"path": "/narrative"}` binding +
+the layout's `metadata.extensions.parrot_optional` entry were REMOVED.
+Root cause: `RecipeRunner._assemble_envelope_or_raise`'s Infographic path
+(`build_infographic` → `build_surface`, `parrot/outputs/a2ui/builders.py`)
+never threads `layout.metadata` onto the built wire `Component` — so ANY
+layout-level binding to an absent key raises `BakeError` unconditionally
+at render time, regardless of what `parrot_optional` declares. This is a
+pre-existing, cross-cutting CORE bug (confirmed reproducible on `dev`,
+completely unrelated to FEAT-491): FinanceReporter's own e2e tests
+`test_dashboard_profile_replay` AND `test_report_profile_replay_no_narrator`
+are BOTH independently broken by it too (verified by running them
+directly against dev's current `packages/ai-parrot/tests/integration/
+test_finance_reporter_narrative_e2e.py`). Fixing it is out of this
+feature's scope (spec §1 Non-Goals: "No changes to core packages").
+`narrative=cls._narrative_spec()` is kept — a configured narrator still
+runs and populates `/narrative` in the data model, it is just never bound
+in the layout. `test_flex_dashboard_descriptors.py::
+test_narrative_binds_are_optional` was renamed to
+`test_no_narrative_layout_binding` and now asserts the ABSENCE of any
+`/narrative` layout binding, with the full reasoning in its docstring.
+See TASK-2699's Completion Note for the full reproduction.

--- a/sdd/tasks/completed/TASK-2697-flex-dashboard-recipe-refresh.md
+++ b/sdd/tasks/completed/TASK-2697-flex-dashboard-recipe-refresh.md
@@ -191,10 +191,40 @@ def test_refresh_tool_args_win_over_surface_state(): ...
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-09-01
+**Notes**: Added `dashboard_descriptor()`, `_transform_sections()`,
+`_narrative_spec()`, `recipe_params()`, `build_refresh_tool()`, plus
+module-level `RefreshDashboardArgs`/`RefreshDashboardTool` to
+`agents/flex_dashboard.py`. 14 new descriptor/refresh-tool tests pass (58
+total across the feature's test files); `ruff check` is clean.
 
-**Completed by**:
-**Date**:
-**Notes**:
+Two things discovered while implementing, both documented in-line as code
+comments:
 
-**Deviations from spec**: none
+1. **Narrative section name is `flex_narrative_facts`**, not
+   `narrative_facts` (TASK-2694's deviation) — the section's `name` MUST
+   equal the transformer registry key `publish_recipe` resolves against,
+   so this task's `_transform_sections()`/`NarrativeSpec(facts_key=...)`
+   use `flex_narrative_facts` throughout, not the generic name this task's
+   Scope text used.
+2. **`resolve_params()` (`parrot.outputs.a2ui.recipes.params`) raises when
+   a declared `RecipeParam` has no default AND no run-time override** —
+   there is no built-in "optional filter" concept at the recipe-params
+   layer. To keep the per-section filters (`month`, `flex_type`, `pay_code`,
+   `cost_center`, `category`) truly optional (unfiltered default replay),
+   `recipe_params()` declares `default=""` for each, and
+   `agents/flex_dashboard/transformers.py`'s `_apply_filters` helper
+   (TASK-2694) was changed from an `is not None` check to a truthy check
+   (`if value:`) so `""` is ALSO treated as "no filter" — a one-line,
+   additive, backward-compatible change (all TASK-2694 tests still pass
+   unchanged; no filter value used anywhere is legitimately falsy other
+   than the new empty-string sentinel).
+
+**Deviations from spec**: `flex_narrative_facts` section/facts_key name
+(see #1 above, same root cause as TASK-2694's already-recorded deviation);
+`agents/flex_dashboard/transformers.py::_apply_filters` truthy-check change
+(see #2 above) — required for the recipe to be replayable with no filter
+overrides at all, which the spec's own "narrative step stays optional so
+replay works with no narrator" principle implies should also hold for the
+per-section filters.

--- a/sdd/tasks/completed/TASK-2698-flex-skills.md
+++ b/sdd/tasks/completed/TASK-2698-flex-skills.md
@@ -164,10 +164,42 @@ def test_triggers():
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-09-01
+**Notes**: Created the three composite skills under
+`agents/flex_dashboard/skills/` plus a `kpi-table.md` asset for `/widget`
+(KPI → transformer → dataset → recipe path → output mode → supported
+filters, mirroring `datasets.md`'s reference style). 16 unit tests pass in
+isolation (`pytest packages/ai-parrot/tests/unit/bots/
+test_flex_dashboard_skills.py -q` — verified repeatedly); `ruff check` is
+clean.
 
-**Completed by**:
-**Date**:
-**Notes**:
+**IMPORTANT finding, out of TASK-2698's scope, flagged for the reviewer /
+TASK-2699**: while investigating an unrelated, machine-load-induced test
+timeout (this dev box has multiple concurrent `sdd-worker` sessions and a
+background `pylint` run competing for CPU — `navconfig`'s Vault-backed
+settings bootstrap alone took 5-50s+ under that contention, unrelated to
+any test logic), I discovered a SEPARATE, deterministic (not flaky) bug:
+running `pytest packages/ai-parrot/tests/unit/bots/ -k flex_dashboard`
+(i.e. ALL of this feature's test files together — the invocation pattern
+spec §4/§5 ultimately requires) makes
+`test_flex_dashboard_agent.py::TestAgentConstruction::
+test_working_memory_and_infographic_toolkits_attached` fail 100% of the
+time, even though it passes 100% of the time standalone or paired with
+just `test_flex_dashboard_descriptors.py`/`test_flex_dashboard_skills.py`.
+Root-caused (with a throwaway debug script, since reverted) to two
+DIFFERENT `id()`s for `parrot.tools.infographic_toolkit.InfographicToolkit`
+depending on which combination of test files ran first in the session —
+`WorkingMemoryToolkit` and `DatasetManager` do NOT show the same split, so
+it is specific to `InfographicToolkit`'s import path, not a generic
+worktree-vs-sys.path issue. I did not chase this further: it is a
+pre-existing property of TASK-2696's already-committed test file
+(reproducible with combinations that include ZERO of TASK-2698's files,
+e.g. `test_flex_dashboard_agent.py` + `test_flex_dashboard_normalize.py`
+alone), so fixing it is out of this task's file scope
+(`agents/flex_dashboard/skills/**`, `test_flex_dashboard_skills.py`).
+Recommend investigating during TASK-2699 (which will need the full
+`test_flex_dashboard*.py` glob to pass per the spec's own Acceptance
+Criteria) or as its own follow-up fix.
 
-**Deviations from spec**: none
+**Deviations from spec**: none.

--- a/sdd/tasks/completed/TASK-2699-flex-example-runner-e2e.md
+++ b/sdd/tasks/completed/TASK-2699-flex-example-runner-e2e.md
@@ -186,10 +186,90 @@ async def test_flex_refresh_rpc(tmp_path, flex_frames):
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-09-01
+**Notes**: Created `examples/agents/a2ui/flex_synthetic_data.py` (six
+builder functions + `build_flex_frames()`, mirroring TASK-2693's fixture
+shapes) and `examples/agents/a2ui/flex_dashboard_demo.py` (retelling of
+`deterministic_refresh_dashboard.py` for FlexDashboard: publish, two
+identical replays, one filtered replay, an undeclared-param typo-guard
+check, the full FEAT-469 RPC lane 3-6, and `export_functions`/
+`agent_capabilities` dump under `artifacts/flex_dashboard_demo/`).
+`packages/ai-parrot/tests/integration/test_flex_dashboard_e2e.py` covers
+publish/replay/filtered-replay/refresh-RPC (5 tests). **Ran the actual
+demo script end-to-end** (`python examples/agents/a2ui/
+flex_dashboard_demo.py`) and confirmed byte-identical replay (`identical:
+True`, 224,042 bytes both runs) plus a working filtered variant and full
+RPC lane — not just the pytest suite. All 5 integration tests pass; the
+full feature glob (`pytest packages/ai-parrot/tests/unit/bots/
+test_flex_dashboard*.py packages/ai-parrot/tests/integration/
+test_flex_dashboard_e2e.py -q`) passes 79/79, run twice for stability.
+`ruff check` is clean on every file this task touched. Diff confinement
+verified: `git diff --stat dev...HEAD` for this feature touches only
+`agents/`, `examples/`, and `packages/ai-parrot/tests/` (spec §5 final
+criterion).
 
-**Completed by**:
-**Date**:
-**Notes**:
+**Key import-mechanics note**: `examples/agents/a2ui/flex_dashboard_demo.py`
+and `test_flex_dashboard_e2e.py` do NOT plainly `import agents.flex_dashboard`
+(that name is a real Python package — `agents/flex_dashboard/` — and would
+shadow the agent FILE, `agents/flex_dashboard.py`, entirely per Python's
+FileFinder precedence, verified empirically during TASK-2696). Both load
+the agent file via `importlib.util.spec_from_file_location` under a
+distinct synthetic name, after pre-registering the real package chain —
+mirroring how `parrot.registry.registry.AgentRegistry
+._load_modules_from_directory` actually loads `agents/*.py` files in
+production (never a plain dotted import).
 
-**Deviations from spec**: none
+**CRITICAL, out-of-scope finding — pre-existing CORE bug**: while wiring
+the dashboard layout's narrative text binding (exactly matching
+FinanceReporter's `agents/finance_reporter.py` "Top Movers" pattern —
+`"text": {"path": "/narrative"}` + `metadata.extensions.parrot_optional:
+["/narrative"]`), the FIRST live run of the demo raised
+`parrot.outputs.a2ui.baking.BakeError: Unresolvable data-model path
+'/narrative'` on every no-narrator replay. Root-caused to
+`RecipeRunner._assemble_envelope_or_raise`'s Infographic branch
+(`build_infographic` → `build_surface`, `parrot/outputs/a2ui/builders.py`
+:203-221): it builds the wire `Component` from `title`/`sections`/
+`subtitle`/`theme` only — `layout.metadata` (and therefore
+`extensions.parrot_optional`) is NEVER passed through, so
+`_bake_component`'s `_optional_paths(component)` always sees an empty set
+for an Infographic-profile component, and ANY layout binding to an absent
+data-model key raises unconditionally. **Confirmed this is NOT specific to
+FEAT-491**: ran FinanceReporter's own already-merged e2e tests directly
+against unmodified `dev` — `pytest packages/ai-parrot/tests/integration/
+test_finance_reporter_narrative_e2e.py -k "test_dashboard_profile_replay or
+test_report_profile_replay_no_narrator"` — and BOTH fail with the identical
+`BakeError`/`'narrative' not found` symptom, independent of any FEAT-491
+code. This is a pre-existing, cross-cutting regression in
+`parrot.outputs.a2ui.baking`/`builders.build_infographic`, breaking the
+FEAT-420 G-E acceptance criterion ("no-narrator replay renders
+successfully with narrative elements ABSENT") for the Infographic
+component profile specifically (the "Report" profile shares the same
+proximate cause via `build_surface`, and its own no-narrator test is
+ALSO currently broken).
+
+Given spec §1 Non-Goals ("No changes to core packages... this feature is
+pure composition"), I did NOT touch `parrot/outputs/a2ui/`. Instead
+(amending TASK-2697's already-completed work in this same worktree/
+session — see that task's ADDENDUM): removed the `"text": {"path":
+"/narrative"}` binding and the now-inert `parrot_optional` metadata entry
+from `dashboard_descriptor()`'s Proximity Staffing section.
+`narrative=cls._narrative_spec()` is kept (a configured narrator, if ever
+wired, still runs and populates `/narrative` in the data model — it is
+simply never displayed in this layout). Updated
+`test_flex_dashboard_descriptors.py`'s narrative-binding test accordingly
+(renamed to `test_no_narrative_layout_binding`, asserting the deliberate
+absence, with the full citation in its docstring).
+
+**Recommend filing a separate hotfix/ticket** for
+`build_infographic`/`build_surface` dropping `layout.metadata` — it
+silently breaks the "no-narrator dashboard replay" guarantee for EVERY
+agent using the Infographic/Report LayoutSpec profiles with an optional
+text binding, not just this feature's dashboard, and currently leaves
+TWO of FinanceReporter's own already-merged e2e tests red on `dev`.
+
+**Deviations from spec**: dashboard layout carries no `/narrative`
+binding (see CRITICAL finding above) — `narrative=NarrativeSpec(...)` is
+still declared and a narrator would still run if configured; the
+narrative prose is simply not surfaced in the Proximity Staffing section
+until the underlying core bug is fixed upstream.

--- a/sdd/tasks/index/flex-agent-infographic-a2ui.json
+++ b/sdd/tasks/index/flex-agent-infographic-a2ui.json
@@ -52,7 +52,7 @@
       "feature_id": "FEAT-491",
       "feature": "flex-agent-infographic-a2ui",
       "spec": "sdd/specs/flex-agent-infographic-a2ui.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "S",
       "depends_on": [],
@@ -60,8 +60,8 @@
       "parallelism_notes": "Pure markdown from spec §2 formulas; shares no code files with TASK-2693/2694 (only the agents/flex_dashboard/ directory). Can run any time before TASK-2696.",
       "assigned_to": null,
       "started_at": "2026-09-01T16:59:27+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2695-flex-kb-documents.md"
+      "completed_at": "2026-09-01T17:44:43+00:00",
+      "file": "sdd/tasks/completed/TASK-2695-flex-kb-documents.md"
     },
     {
       "id": "TASK-2696",

--- a/sdd/tasks/index/flex-agent-infographic-a2ui.json
+++ b/sdd/tasks/index/flex-agent-infographic-a2ui.json
@@ -14,7 +14,7 @@
       "feature_id": "FEAT-491",
       "feature": "flex-agent-infographic-a2ui",
       "spec": "sdd/specs/flex-agent-infographic-a2ui.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [],
@@ -22,8 +22,8 @@
       "parallelism_notes": "Foundation module — every transformer imports it; runs first.",
       "assigned_to": null,
       "started_at": "2026-09-01T16:59:27+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2693-flex-normalization-layer.md"
+      "completed_at": "2026-09-01T17:19:47+00:00",
+      "file": "sdd/tasks/completed/TASK-2693-flex-normalization-layer.md"
     },
     {
       "id": "TASK-2694",

--- a/sdd/tasks/index/flex-agent-infographic-a2ui.json
+++ b/sdd/tasks/index/flex-agent-infographic-a2ui.json
@@ -32,7 +32,7 @@
       "feature_id": "FEAT-491",
       "feature": "flex-agent-infographic-a2ui",
       "spec": "sdd/specs/flex-agent-infographic-a2ui.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "depends_on": [
@@ -42,8 +42,8 @@
       "parallelism_notes": "Imports normalize.py (TASK-2693); shares agents/flex_dashboard/ package.",
       "assigned_to": null,
       "started_at": "2026-09-01T16:59:27+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2694-flex-transformers.md"
+      "completed_at": "2026-09-01T17:38:44+00:00",
+      "file": "sdd/tasks/completed/TASK-2694-flex-transformers.md"
     },
     {
       "id": "TASK-2695",

--- a/sdd/tasks/index/flex-agent-infographic-a2ui.json
+++ b/sdd/tasks/index/flex-agent-infographic-a2ui.json
@@ -70,7 +70,7 @@
       "feature_id": "FEAT-491",
       "feature": "flex-agent-infographic-a2ui",
       "spec": "sdd/specs/flex-agent-infographic-a2ui.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -81,8 +81,8 @@
       "parallelism_notes": "Imports transformers module and loads kb docs at configure.",
       "assigned_to": null,
       "started_at": "2026-09-01T16:59:27+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2696-flex-dashboard-agent.md"
+      "completed_at": "2026-09-01T18:16:12+00:00",
+      "file": "sdd/tasks/completed/TASK-2696-flex-dashboard-agent.md"
     },
     {
       "id": "TASK-2697",

--- a/sdd/tasks/index/flex-agent-infographic-a2ui.json
+++ b/sdd/tasks/index/flex-agent-infographic-a2ui.json
@@ -91,7 +91,7 @@
       "feature_id": "FEAT-491",
       "feature": "flex-agent-infographic-a2ui",
       "spec": "sdd/specs/flex-agent-infographic-a2ui.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "depends_on": [
@@ -101,8 +101,8 @@
       "parallelism_notes": "Modifies agents/flex_dashboard.py created by TASK-2696.",
       "assigned_to": null,
       "started_at": "2026-09-01T16:59:27+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2697-flex-dashboard-recipe-refresh.md"
+      "completed_at": "2026-09-01T18:33:41+00:00",
+      "file": "sdd/tasks/completed/TASK-2697-flex-dashboard-recipe-refresh.md"
     },
     {
       "id": "TASK-2698",

--- a/sdd/tasks/index/flex-agent-infographic-a2ui.json
+++ b/sdd/tasks/index/flex-agent-infographic-a2ui.json
@@ -111,7 +111,7 @@
       "feature_id": "FEAT-491",
       "feature": "flex-agent-infographic-a2ui",
       "spec": "sdd/specs/flex-agent-infographic-a2ui.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "M",
       "depends_on": [
@@ -121,8 +121,8 @@
       "parallelism_notes": "Markdown-only, but its discovery test exercises the TASK-2696 agent's skill_paths; sequenced after 2696 in the same worktree (could overlap with TASK-2697 — different files).",
       "assigned_to": null,
       "started_at": "2026-09-01T16:59:27+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2698-flex-skills.md"
+      "completed_at": "2026-09-01T19:24:33+00:00",
+      "file": "sdd/tasks/completed/TASK-2698-flex-skills.md"
     },
     {
       "id": "TASK-2699",

--- a/sdd/tasks/index/flex-agent-infographic-a2ui.json
+++ b/sdd/tasks/index/flex-agent-infographic-a2ui.json
@@ -5,7 +5,7 @@
   "type": "feature",
   "base_branch": "dev",
   "created_at": "2026-09-01T17:45:00+02:00",
-  "completed_at": null,
+  "completed_at": "2026-09-01T21:40:56+00:00",
   "tasks": [
     {
       "id": "TASK-2693",
@@ -23,7 +23,8 @@
       "assigned_to": null,
       "started_at": "2026-09-01T16:59:27+00:00",
       "completed_at": "2026-09-01T17:19:47+00:00",
-      "file": "sdd/tasks/completed/TASK-2693-flex-normalization-layer.md"
+      "file": "sdd/tasks/completed/TASK-2693-flex-normalization-layer.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2694",
@@ -43,7 +44,8 @@
       "assigned_to": null,
       "started_at": "2026-09-01T16:59:27+00:00",
       "completed_at": "2026-09-01T17:38:44+00:00",
-      "file": "sdd/tasks/completed/TASK-2694-flex-transformers.md"
+      "file": "sdd/tasks/completed/TASK-2694-flex-transformers.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2695",
@@ -61,7 +63,8 @@
       "assigned_to": null,
       "started_at": "2026-09-01T16:59:27+00:00",
       "completed_at": "2026-09-01T17:44:43+00:00",
-      "file": "sdd/tasks/completed/TASK-2695-flex-kb-documents.md"
+      "file": "sdd/tasks/completed/TASK-2695-flex-kb-documents.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2696",
@@ -82,7 +85,8 @@
       "assigned_to": null,
       "started_at": "2026-09-01T16:59:27+00:00",
       "completed_at": "2026-09-01T18:16:12+00:00",
-      "file": "sdd/tasks/completed/TASK-2696-flex-dashboard-agent.md"
+      "file": "sdd/tasks/completed/TASK-2696-flex-dashboard-agent.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2697",
@@ -102,7 +106,8 @@
       "assigned_to": null,
       "started_at": "2026-09-01T16:59:27+00:00",
       "completed_at": "2026-09-01T18:33:41+00:00",
-      "file": "sdd/tasks/completed/TASK-2697-flex-dashboard-recipe-refresh.md"
+      "file": "sdd/tasks/completed/TASK-2697-flex-dashboard-recipe-refresh.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2698",
@@ -122,7 +127,8 @@
       "assigned_to": null,
       "started_at": "2026-09-01T16:59:27+00:00",
       "completed_at": "2026-09-01T19:24:33+00:00",
-      "file": "sdd/tasks/completed/TASK-2698-flex-skills.md"
+      "file": "sdd/tasks/completed/TASK-2698-flex-skills.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2699",
@@ -143,7 +149,8 @@
       "assigned_to": null,
       "started_at": "2026-09-01T16:59:27+00:00",
       "completed_at": "2026-09-01T20:08:25+00:00",
-      "file": "sdd/tasks/completed/TASK-2699-flex-example-runner-e2e.md"
+      "file": "sdd/tasks/completed/TASK-2699-flex-example-runner-e2e.md",
+      "verification": "verified"
     }
   ]
 }

--- a/sdd/tasks/index/flex-agent-infographic-a2ui.json
+++ b/sdd/tasks/index/flex-agent-infographic-a2ui.json
@@ -131,7 +131,7 @@
       "feature_id": "FEAT-491",
       "feature": "flex-agent-infographic-a2ui",
       "spec": "sdd/specs/flex-agent-infographic-a2ui.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "L",
       "depends_on": [
@@ -142,8 +142,8 @@
       "parallelism_notes": "End-to-end over everything prior; last.",
       "assigned_to": null,
       "started_at": "2026-09-01T16:59:27+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2699-flex-example-runner-e2e.md"
+      "completed_at": "2026-09-01T20:08:25+00:00",
+      "file": "sdd/tasks/completed/TASK-2699-flex-example-runner-e2e.md"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Implements the Flex A2UI Dashboard Agent (`agents/flex_dashboard.py`) — a
new PandasAgent-based dashboard agent surfacing Flex payroll/utilization/
staffing KPIs through the A2UI infographic pipeline.

All 7 tasks verified: matching commits found and every file listed in each
task's "Files to Create/Modify" table exists in the branch.

## Tasks

7/7 tasks verified:
  - TASK-2693 — Flex normalization layer (currency, month grain, column canonicalization)
  - TASK-2694 — Flex infographic transformers (Payroll Contribution, Utilization, Proximity)
  - TASK-2695 — Flex KPI knowledge-base documents
  - TASK-2696 — FlexDashboard agent class (datasets, toolkits, kb wiring)
  - TASK-2697 — Flex dashboard recipe, LayoutSpec v2 & refresh lane
  - TASK-2698 — Flex skills — /widget, /infographic, flex-narrative
  - TASK-2699 — Flex example runner + deterministic-replay integration tests

Post-implementation review follow-ups (codex code-review + second-round
findings) and black formatting are also included in this branch.

---
_Closed by /sdd-done_