### PR TITLE
fix(clients): raise InvokeError on MAX_TOKENS-truncated structured output

### DIFF
--- a/packages/ai-parrot/src/parrot/clients/base.py
+++ b/packages/ai-parrot/src/parrot/clients/base.py
@@ -8,7 +8,8 @@ from typing import (
     Union,
     TypedDict,
     Any,
-    Callable
+    Callable,
+    FrozenSet,
 )
 from parrot._imports import lazy_import
 from datetime import datetime
@@ -53,7 +54,7 @@ from ..models import (
 )
 from ..models.responses import InvokeResult
 from ..models.basic import CompletionUsage
-from ..exceptions import InvokeError
+from ..exceptions import InvokeError, TruncatedResponseError
 from ..tools.abstract import AbstractTool, ToolResult
 from ..tools.manager import (
     ToolManager,
@@ -1896,8 +1897,125 @@ $backstory
 
         Returns:
             An :class:`InvokeError` with ``original`` set to the given exception.
+            An exception that already is an :class:`InvokeError` (e.g. a
+            :class:`TruncatedResponseError` raised by the shared parsing guard)
+            is returned unchanged so it is never double-wrapped.
         """
+        if isinstance(exception, InvokeError):
+            return exception
         return InvokeError(str(exception), original=exception)
+
+    # ------------------------------------------------------------------ #
+    # finish_reason truncation guard — shared by every provider           #
+    # ------------------------------------------------------------------ #
+
+    #: Provider finish/stop reasons that mean the completion was cut off by the
+    #: output-token limit. Compared after :meth:`_normalize_finish_reason`
+    #: (lower-cased, enum-class prefix stripped).
+    TRUNCATED_FINISH_REASONS: FrozenSet[str] = frozenset({
+        "max_tokens",         # Anthropic Messages API, Bedrock Converse
+        "max_output_tokens",  # Google / OpenAI Responses (incomplete_details)
+        "length",             # OpenAI-compatible chat completions (OpenAI, Groq,
+                              #   Z.AI, vLLM, LocalLLM, HuggingFace, ...)
+        "reason_max_len",     # xAI Grok SDK (sample_pb2.FinishReason)
+    })
+
+    @staticmethod
+    def _normalize_finish_reason(finish_reason: Any) -> Optional[str]:
+        """Normalise a provider finish/stop reason to a lower-case token.
+
+        Accepts the three shapes providers use: a plain string (``"length"``,
+        ``"max_tokens"``), an enum member exposing ``.name``
+        (``google.genai.types.FinishReason.MAX_TOKENS``), or the enum's string
+        representation (``"FinishReason.MAX_TOKENS"``).
+
+        Args:
+            finish_reason: Raw finish reason from the provider, or ``None``.
+
+        Returns:
+            Lower-case token with any ``Enum.`` prefix stripped, or ``None`` if
+            the value is empty.
+        """
+        if finish_reason is None:
+            return None
+        name = getattr(finish_reason, "name", None)
+        text = name if isinstance(name, str) else str(finish_reason)
+        text = text.strip()
+        if not text:
+            return None
+        return text.rsplit(".", 1)[-1].lower()
+
+    @staticmethod
+    def _extract_finish_reason(response: Any) -> Any:
+        """Best-effort extraction of the finish/stop reason from a raw response.
+
+        Understands the response shapes of every supported provider without
+        importing any SDK: OpenAI-compatible ``choices[0].finish_reason``,
+        Google ``candidates[0].finish_reason``, Anthropic ``stop_reason``, xAI
+        ``finish_reason``, and the Bedrock / Anthropic ``model_dump()``
+        dictionaries (``stopReason`` / ``stop_reason`` / ``finish_reason``).
+
+        Args:
+            response: Raw provider response object or mapping.
+
+        Returns:
+            The raw finish reason (string or enum), or ``None`` when the shape
+            is unknown or the field is absent.
+        """
+        if response is None:
+            return None
+        if isinstance(response, dict):
+            for key in ("stopReason", "stop_reason", "finish_reason"):
+                if response.get(key) is not None:
+                    return response[key]
+            return None
+        for container in ("choices", "candidates"):
+            items = getattr(response, container, None)
+            if isinstance(items, (list, tuple)) and items:
+                reason = getattr(items[0], "finish_reason", None)
+                if reason is None:
+                    reason = getattr(items[0], "stop_reason", None)
+                if reason is not None:
+                    return reason
+        for attr in ("stop_reason", "finish_reason"):
+            reason = getattr(response, attr, None)
+            if reason is not None and not callable(reason):
+                return reason
+        return None
+
+    def _raise_if_truncated(
+        self,
+        finish_reason: Any,
+        *,
+        model: Optional[str] = None,
+    ) -> None:
+        """Raise :class:`TruncatedResponseError` if ``finish_reason`` means truncation.
+
+        Call this *before* attempting to parse structured output: a response
+        that stopped at the output-token limit is known-incomplete, so parsing
+        it can only yield a silent raw-string fallback or a validation error
+        that misattributes the cause.
+
+        Args:
+            finish_reason: Raw provider finish reason (any shape accepted by
+                :meth:`_normalize_finish_reason`), or ``None`` to skip the check.
+            model: Model identifier, included in the error message when known.
+
+        Raises:
+            TruncatedResponseError: When the normalised reason is one of
+                :attr:`TRUNCATED_FINISH_REASONS`.
+        """
+        normalized = self._normalize_finish_reason(finish_reason)
+        if normalized is None or normalized not in self.TRUNCATED_FINISH_REASONS:
+            return
+        model_part = f" from model {model!r}" if model else ""
+        raise TruncatedResponseError(
+            f"Response{model_part} was truncated by the provider "
+            f"(finish_reason={normalized!r}) before structured output could be "
+            "parsed. Increase max_tokens or shorten the prompt/schema.",
+            finish_reason=normalized,
+            model=model,
+        )
 
     async def _handle_structured_output(
         self,
@@ -2269,9 +2387,34 @@ $backstory
     async def _parse_structured_output(  # noqa: C901
         self,
         response_text: str,
-        structured_output: StructuredOutputConfig
+        structured_output: StructuredOutputConfig,
+        *,
+        finish_reason: Any = None,
+        model: Optional[str] = None,
     ) -> Any:
-        """Parse structured output based on format."""
+        """Parse structured output based on format.
+
+        Args:
+            response_text: Raw assistant text to parse.
+            structured_output: Output configuration (type + format).
+            finish_reason: Provider finish/stop reason for the response that
+                produced ``response_text``. When it denotes truncation
+                (see :attr:`TRUNCATED_FINISH_REASONS`) a
+                :class:`TruncatedResponseError` is raised *before* any parse
+                attempt instead of falling back to the raw string. ``None``
+                skips the check (legacy behaviour).
+            model: Model identifier, used only to enrich the truncation error.
+
+        Returns:
+            The parsed object, or ``response_text`` itself when parsing fails
+            and the response was not known to be truncated.
+
+        Raises:
+            TruncatedResponseError: If ``finish_reason`` denotes truncation.
+        """
+        # Known-truncated responses must never reach the parser: the fallbacks
+        # below return the raw string on failure, which hides the real cause.
+        self._raise_if_truncated(finish_reason, model=model)
         try:
             output_type = structured_output.output_type
             if not output_type:

--- a/packages/ai-parrot/src/parrot/clients/base.py
+++ b/packages/ai-parrot/src/parrot/clients/base.py
@@ -2020,11 +2020,37 @@ $backstory
     async def _handle_structured_output(
         self,
         result: Dict[str, Any],
-        structured_output: Optional[type]
+        structured_output: Optional[type],
+        *,
+        finish_reason: Any = None,
+        model: Optional[str] = None,
     ) -> Any:
-        """Parse response into structured output format."""
+        """Parse a Chat-style ``result`` dict into ``structured_output``.
+
+        Legacy helper used by the local backends (HuggingFace, Gemma4). Like
+        :meth:`_parse_structured_output` it falls back to returning the input
+        unchanged when parsing fails, so the truncation guard runs first.
+
+        Args:
+            result: Chat-style response dict with a ``content`` block list.
+            structured_output: Target type, or ``None`` to skip parsing.
+            finish_reason: Provider finish/stop reason for this response;
+                truncation raises :class:`TruncatedResponseError` before parsing.
+                Defaults to ``result["stop_reason"]`` when present.
+            model: Model identifier, used only to enrich the truncation error.
+
+        Returns:
+            Parsed object, or ``result`` when parsing is skipped or fails.
+
+        Raises:
+            TruncatedResponseError: If the finish reason denotes truncation.
+        """
         if not structured_output:
             return result
+
+        if finish_reason is None and isinstance(result, dict):
+            finish_reason = result.get("stop_reason") or result.get("finish_reason")
+        self._raise_if_truncated(finish_reason, model=model)
 
         text_content = "".join(
             content_block["text"]

--- a/packages/ai-parrot/src/parrot/clients/bedrock.py
+++ b/packages/ai-parrot/src/parrot/clients/bedrock.py
@@ -997,6 +997,8 @@ class BedrockConverseBase(AbstractClient):
         assistant_response_text = "".join(block.get("text", "") for block in content_blocks if "text" in block)
         if output_config:
             try:
+                # Known-truncated output must not reach a custom parser either.
+                self._raise_if_truncated(result.get("stopReason"), model=resolved_model)
                 if output_config.custom_parser:
                     final_output = await output_config.custom_parser(assistant_response_text)
                 else:
@@ -1609,6 +1611,8 @@ class BedrockConverseBase(AbstractClient):
 
             output: Any = raw_text
             if config:
+                # Known-truncated output must not reach a custom parser either.
+                self._raise_if_truncated(self._extract_finish_reason(result), model=resolved_model)
                 if config.custom_parser:
                     output = config.custom_parser(raw_text)
                 else:

--- a/packages/ai-parrot/src/parrot/clients/bedrock.py
+++ b/packages/ai-parrot/src/parrot/clients/bedrock.py
@@ -1000,7 +1000,14 @@ class BedrockConverseBase(AbstractClient):
                 if output_config.custom_parser:
                     final_output = await output_config.custom_parser(assistant_response_text)
                 else:
-                    final_output = await self._parse_structured_output(assistant_response_text, output_config)
+                    final_output = await self._parse_structured_output(
+                        assistant_response_text,
+                        output_config,
+                        finish_reason=result.get("stopReason"),
+                        model=resolved_model,
+                    )
+            except InvokeError:
+                raise
             except Exception:
                 final_output = assistant_response_text
         elif output_schema:
@@ -1605,7 +1612,12 @@ class BedrockConverseBase(AbstractClient):
                 if config.custom_parser:
                     output = config.custom_parser(raw_text)
                 else:
-                    output = await self._parse_structured_output(raw_text, config)
+                    output = await self._parse_structured_output(
+                        raw_text,
+                        config,
+                        finish_reason=self._extract_finish_reason(result),
+                        model=resolved_model,
+                    )
 
             usage = CompletionUsage.from_bedrock(result.get("usage", {}))
 

--- a/packages/ai-parrot/src/parrot/clients/claude.py
+++ b/packages/ai-parrot/src/parrot/clients/claude.py
@@ -670,6 +670,8 @@ class AnthropicClient(AbstractClient):
                 if content_block["type"] == "text"
             )
             try:
+                # Known-truncated output must not reach a custom parser either.
+                self._raise_if_truncated(result.get("stop_reason"))
                 if output_config.custom_parser:
                     final_output = await output_config.custom_parser(
                         text_content
@@ -2018,6 +2020,8 @@ Provide your final answer with:
             # Parse structured output
             output: Any = raw_text
             if config:
+                # Known-truncated output must not reach a custom parser either.
+                self._raise_if_truncated(self._extract_finish_reason(response), model=resolved_model)
                 if config.custom_parser:
                     output = config.custom_parser(raw_text)
                 else:

--- a/packages/ai-parrot/src/parrot/clients/claude.py
+++ b/packages/ai-parrot/src/parrot/clients/claude.py
@@ -676,8 +676,11 @@ class AnthropicClient(AbstractClient):
                     )
                 final_output = await self._parse_structured_output(
                     text_content,
-                    output_config
+                    output_config,
+                    finish_reason=result.get("stop_reason"),
                 )
+            except InvokeError:
+                raise
             except Exception:
                 final_output = text_content
 
@@ -1486,8 +1489,11 @@ class AnthropicClient(AbstractClient):
             try:
                 final_output = await self._parse_structured_output(
                     text_content,
-                    output_config
+                    output_config,
+                    finish_reason=result.get("stop_reason"),
                 )
+            except InvokeError:
+                raise
             except Exception:
                 final_output = text_content
         else:
@@ -2015,7 +2021,12 @@ Provide your final answer with:
                 if config.custom_parser:
                     output = config.custom_parser(raw_text)
                 else:
-                    output = await self._parse_structured_output(raw_text, config)
+                    output = await self._parse_structured_output(
+                        raw_text,
+                        config,
+                        finish_reason=self._extract_finish_reason(response),
+                        model=resolved_model,
+                    )
 
             usage_dict = {}
             if hasattr(response, 'usage') and response.usage:

--- a/packages/ai-parrot/src/parrot/clients/claude_agent.py
+++ b/packages/ai-parrot/src/parrot/clients/claude_agent.py
@@ -999,6 +999,8 @@ class ClaudeAgentClient(AbstractClient):
         # Parse the assistant text into ``output_type`` when asked.
         parsed: Any = structured_output if structured_output is not None else ai_message.response
         if structured_output is None and output_type is not None and ai_message.response:
+            # Known-truncated output must not be parsed (shared guard).
+            self._raise_if_truncated(ai_message.stop_reason, model=resolved_model)
             parsed = self._parse_structured_output(ai_message.response, output_type)
 
         return InvokeResult(

--- a/packages/ai-parrot/src/parrot/clients/codex_agent.py
+++ b/packages/ai-parrot/src/parrot/clients/codex_agent.py
@@ -263,7 +263,12 @@ class OpenAICodexClient(AbstractClient):
             )
             parsed: Any = result.output
             if structured_config is not None:
-                parsed = await self._parse_structured_output(result.output, structured_config)
+                parsed = await self._parse_structured_output(
+                    result.output,
+                    structured_config,
+                    finish_reason=result.finish_reason,
+                    model=resolved_model,
+                )
             return InvokeResult(
                 output=parsed,
                 output_type=output_type,

--- a/packages/ai-parrot/src/parrot/clients/google/analysis.py
+++ b/packages/ai-parrot/src/parrot/clients/google/analysis.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 from typing import Any, Dict, List, Optional, Union, Tuple
+
+from ...exceptions import InvokeError
 import os
 import logging
 import asyncio
@@ -467,6 +469,7 @@ class GoogleAnalysis:
                 final_output = await self._parse_structured_output(
                     final_response,
                     output_config,
+                    finish_reason=self._extract_finish_reason(response),
                 )
 
             if not stateless:
@@ -638,6 +641,7 @@ class GoogleAnalysis:
                 structured_output = await self._parse_structured_output(
                     final_response,
                     output_config,
+                    finish_reason=self._extract_finish_reason(response),
                 )
             elif (detect_objects or response_schema) and original_size:
                 # Attempt to parse json and descale bounding boxes
@@ -879,7 +883,13 @@ class GoogleAnalysis:
             final_output: Any = None
             if output_config:
                 try:
-                    final_output = await self._parse_structured_output(final_response, output_config)
+                    final_output = await self._parse_structured_output(
+                        final_response,
+                        output_config,
+                        finish_reason=self._extract_finish_reason(response),
+                    )
+                except InvokeError:
+                    raise
                 except Exception as parse_exc:
                     self.logger.warning(
                         "Failed to parse structured output from document model: %s", parse_exc

--- a/packages/ai-parrot/src/parrot/clients/google/client.py
+++ b/packages/ai-parrot/src/parrot/clients/google/client.py
@@ -3404,10 +3404,13 @@ class GoogleGenAIClient(AbstractClient, GoogleGeneration, GoogleAnalysis):
 
         # Handle structured output
         final_output = None
-        if (structured_output_for_later or output_config) and assistant_response_text:
+        if structured_output_for_later or output_config:
             # A MAX_TOKENS response is known-truncated: fail here, before the
             # fast-path/reformat/combined-mode parsers below can leak the
             # truncated text as a plain string or "reformat" a partial answer.
+            # Deliberately NOT gated on non-empty text: a reasoning model can
+            # burn the whole output budget on thinking and return MAX_TOKENS
+            # with no text at all, which must not parse as "".
             self._raise_if_truncated(self._extract_finish_reason(final_response), model=model)
         if structured_output_for_later and use_tools and assistant_response_text:
             try:
@@ -3563,6 +3566,9 @@ class GoogleGenAIClient(AbstractClient, GoogleGeneration, GoogleAnalysis):
                     )
                 else:
                     final_output = parsed
+            except InvokeError:
+                # A truncated reformat response is a real error, not a fallback case.
+                raise
             except Exception as e:
                 self.logger.warning(
                     "Combined-mode parse raised %s — falling back to reformat call.",
@@ -3575,6 +3581,8 @@ class GoogleGenAIClient(AbstractClient, GoogleGeneration, GoogleAnalysis):
                         temperature=temperature,
                         max_tokens=max_tokens,
                     )
+                except InvokeError:
+                    raise
                 except Exception as reformat_err:
                     self.logger.error("Recovery reformat also failed: %s", reformat_err)
                     final_output = assistant_response_text

--- a/packages/ai-parrot/src/parrot/clients/google/client.py
+++ b/packages/ai-parrot/src/parrot/clients/google/client.py
@@ -3536,6 +3536,9 @@ class GoogleGenAIClient(AbstractClient, GoogleGeneration, GoogleAnalysis):
                     else:
                         self.logger.warning("No structured text received, falling back to original response")
                         final_output = assistant_response_text
+            except InvokeError:
+                # A truncated reformat response is a real error, not a fallback case.
+                raise
             except Exception as e:
                 self.logger.error(f"Error parsing structured output: {e}")
                 # Fallback to original text if structured output fails
@@ -5603,6 +5606,8 @@ class GoogleGenAIClient(AbstractClient, GoogleGeneration, GoogleAnalysis):
             # Parse output
             output: Any = raw_text
             if config:
+                # Known-truncated output must not reach a custom parser either.
+                self._raise_if_truncated(self._extract_finish_reason(final_response), model=resolved_model)
                 if config.custom_parser:
                     output = config.custom_parser(raw_text)
                 else:

--- a/packages/ai-parrot/src/parrot/clients/google/client.py
+++ b/packages/ai-parrot/src/parrot/clients/google/client.py
@@ -1041,7 +1041,11 @@ class GoogleGenAIClient(AbstractClient, GoogleGeneration, GoogleAnalysis):
             return text
 
         if isinstance(output_config, StructuredOutputConfig):
-            return await self._parse_structured_output(structured_text, output_config)
+            return await self._parse_structured_output(
+                structured_text,
+                output_config,
+                finish_reason=self._extract_finish_reason(structured_response),
+            )
         elif isinstance(output_config, type):
             if hasattr(output_config, "model_validate_json"):
                 return output_config.model_validate_json(structured_text)
@@ -3400,6 +3404,11 @@ class GoogleGenAIClient(AbstractClient, GoogleGeneration, GoogleAnalysis):
 
         # Handle structured output
         final_output = None
+        if (structured_output_for_later or output_config) and assistant_response_text:
+            # A MAX_TOKENS response is known-truncated: fail here, before the
+            # fast-path/reformat/combined-mode parsers below can leak the
+            # truncated text as a plain string or "reformat" a partial answer.
+            self._raise_if_truncated(self._extract_finish_reason(final_response), model=model)
         if structured_output_for_later and use_tools and assistant_response_text:
             try:
                 # Create a new generation config for structured output only
@@ -3512,7 +3521,9 @@ class GoogleGenAIClient(AbstractClient, GoogleGeneration, GoogleAnalysis):
                         # Parse the structured output
                         if isinstance(structured_output_for_later, StructuredOutputConfig):
                             final_output = await self._parse_structured_output(
-                                structured_text, structured_output_for_later
+                                structured_text,
+                                structured_output_for_later,
+                                finish_reason=self._extract_finish_reason(structured_response),
                             )
                         elif isinstance(structured_output_for_later, type):
                             if hasattr(structured_output_for_later, "model_validate_json"):
@@ -4811,7 +4822,11 @@ class GoogleGenAIClient(AbstractClient, GoogleGeneration, GoogleAnalysis):
                     try:
                         output_config = self._get_structured_config(structured_output)
                         if isinstance(output_config, StructuredOutputConfig):
-                            final_output = await self._parse_structured_output(text_response, output_config)
+                            final_output = await self._parse_structured_output(
+                                text_response,
+                                output_config,
+                                finish_reason=self._extract_finish_reason(item),
+                            )
                         elif isinstance(structured_output, type):
                             if hasattr(structured_output, "model_validate_json"):
                                 final_output = structured_output.model_validate_json(text_response)
@@ -4991,7 +5006,13 @@ class GoogleGenAIClient(AbstractClient, GoogleGeneration, GoogleAnalysis):
         final_output = None
         if structured_output_config:
             try:
-                final_output = await self._parse_structured_output(response.text, structured_output_config)
+                final_output = await self._parse_structured_output(
+                    response.text,
+                    structured_output_config,
+                    finish_reason=self._extract_finish_reason(response),
+                )
+            except InvokeError:
+                raise
             except Exception as e:
                 self.logger.error(f"Failed to parse structured output from vision model: {e}")
                 final_output = response.text
@@ -5320,7 +5341,13 @@ class GoogleGenAIClient(AbstractClient, GoogleGeneration, GoogleAnalysis):
         _extracted_text = self._safe_extract_text(response)
         if output_config:
             try:
-                final_output = await self._parse_structured_output(_extracted_text, output_config)
+                final_output = await self._parse_structured_output(
+                    _extracted_text,
+                    output_config,
+                    finish_reason=self._extract_finish_reason(response),
+                )
+            except InvokeError:
+                raise
             except Exception:
                 final_output = _extracted_text
 
@@ -5579,7 +5606,12 @@ class GoogleGenAIClient(AbstractClient, GoogleGeneration, GoogleAnalysis):
                 if config.custom_parser:
                     output = config.custom_parser(raw_text)
                 else:
-                    output = await self._parse_structured_output(raw_text, config)
+                    output = await self._parse_structured_output(
+                        raw_text,
+                        config,
+                        finish_reason=self._extract_finish_reason(final_response),
+                        model=resolved_model,
+                    )
 
             # Extract usage
             usage_dict: Dict[str, Any] = {}

--- a/packages/ai-parrot/src/parrot/clients/gpt.py
+++ b/packages/ai-parrot/src/parrot/clients/gpt.py
@@ -640,6 +640,19 @@ class OpenAIClient(OpenAIBaseClient):
             if isinstance(item, dict):
                 stop_reason = stop_reason or item.get("stop_reason")
 
+        # 4b) The Responses API reports truncation at the top level, not per
+        #     output item: ``status="incomplete"`` with
+        #     ``incomplete_details.reason`` ("max_output_tokens" |
+        #     "content_filter"). Surface it as the Chat-style finish_reason so
+        #     the shared truncation guard (_raise_if_truncated) can see it.
+        if finish_reason is None and getattr(resp, "status", None) == "incomplete":
+            details = getattr(resp, "incomplete_details", None)
+            if isinstance(details, dict):
+                finish_reason = details.get("reason")
+            else:
+                finish_reason = getattr(details, "reason", None)
+            finish_reason = finish_reason or "incomplete"
+
         # 5) Build a Chat-like container
         class _Msg:
             def __init__(self, content, tool_calls):
@@ -938,6 +951,8 @@ class OpenAIClient(OpenAIBaseClient):
         final_output = None
         if output_config:
             try:
+                # Known-truncated output must not reach a custom parser either.
+                self._raise_if_truncated(self._extract_finish_reason(response), model=model_str)
                 if output_config.custom_parser:
                     final_output = output_config.custom_parser(response_text)
                 else:

--- a/packages/ai-parrot/src/parrot/clients/gpt.py
+++ b/packages/ai-parrot/src/parrot/clients/gpt.py
@@ -941,7 +941,14 @@ class OpenAIClient(OpenAIBaseClient):
                 if output_config.custom_parser:
                     final_output = output_config.custom_parser(response_text)
                 else:
-                    final_output = await self._parse_structured_output(response_text, output_config)
+                    final_output = await self._parse_structured_output(
+                        response_text,
+                        output_config,
+                        finish_reason=self._extract_finish_reason(response),
+                        model=model_str,
+                    )
+            except InvokeError:
+                raise
             except Exception:  # pylint: disable=broad-except
                 final_output = response_text
 

--- a/packages/ai-parrot/src/parrot/clients/grok.py
+++ b/packages/ai-parrot/src/parrot/clients/grok.py
@@ -367,6 +367,8 @@ class GrokClient(AbstractClient):
         structured_payload = None
         if output_config:
             try:
+                # Known-truncated output must not reach a custom parser either.
+                self._raise_if_truncated(self._extract_finish_reason(final_response))
                 if output_config.custom_parser:
                     structured_payload = output_config.custom_parser(text_content)
                 else:
@@ -765,6 +767,8 @@ class GrokClient(AbstractClient):
                 raw_text = response.content or ""
                 output = raw_text
                 if config:
+                    # Known-truncated output must not reach a custom parser either.
+                    self._raise_if_truncated(self._extract_finish_reason(response), model=resolved_model)
                     if config.custom_parser:
                         output = config.custom_parser(raw_text)
                     else:

--- a/packages/ai-parrot/src/parrot/clients/grok.py
+++ b/packages/ai-parrot/src/parrot/clients/grok.py
@@ -370,7 +370,13 @@ class GrokClient(AbstractClient):
                 if output_config.custom_parser:
                     structured_payload = output_config.custom_parser(text_content)
                 else:
-                    structured_payload = await self._parse_structured_output(text_content, output_config)
+                    structured_payload = await self._parse_structured_output(
+                        text_content,
+                        output_config,
+                        finish_reason=self._extract_finish_reason(final_response),
+                    )
+            except InvokeError:
+                raise
             except Exception:
                 pass
 
@@ -762,7 +768,12 @@ class GrokClient(AbstractClient):
                     if config.custom_parser:
                         output = config.custom_parser(raw_text)
                     else:
-                        output = await self._parse_structured_output(raw_text, config)
+                        output = await self._parse_structured_output(
+                        raw_text,
+                        config,
+                        finish_reason=self._extract_finish_reason(response),
+                        model=resolved_model,
+                    )
 
             usage = CompletionUsage.from_grok(response.usage) if hasattr(response, 'usage') else CompletionUsage()
             return self._build_invoke_result(

--- a/packages/ai-parrot/src/parrot/clients/grok.py
+++ b/packages/ai-parrot/src/parrot/clients/grok.py
@@ -761,6 +761,9 @@ class GrokClient(AbstractClient):
             output: Any
             if use_sdk_parse and config:
                 response, parsed = await chat.parse(config.output_type)
+                # The SDK may have parsed a truncated payload (or raised a
+                # generic error on it): attribute the failure to truncation.
+                self._raise_if_truncated(self._extract_finish_reason(response), model=resolved_model)
                 output = parsed
             else:
                 response = await chat.sample()
@@ -773,11 +776,11 @@ class GrokClient(AbstractClient):
                         output = config.custom_parser(raw_text)
                     else:
                         output = await self._parse_structured_output(
-                        raw_text,
-                        config,
-                        finish_reason=self._extract_finish_reason(response),
-                        model=resolved_model,
-                    )
+                            raw_text,
+                            config,
+                            finish_reason=self._extract_finish_reason(response),
+                            model=resolved_model,
+                        )
 
             usage = CompletionUsage.from_grok(response.usage) if hasattr(response, 'usage') else CompletionUsage()
             return self._build_invoke_result(

--- a/packages/ai-parrot/src/parrot/clients/groq.py
+++ b/packages/ai-parrot/src/parrot/clients/groq.py
@@ -652,16 +652,21 @@ class GroqClient(OpenAIBaseClient):
             ) else structured_response.choices[0].message
 
             parsed_config = structured_output_for_later
+            _final_response = structured_response
         else:
             parsed_config = request_output_config
+            _final_response = response
 
         response_text = result.content if isinstance(result.content, str) else self._json.dumps(result.content)
         if parsed_config:
             try:
                 final_output = await self._parse_structured_output(
                     response_text,
-                    parsed_config
+                    parsed_config,
+                    finish_reason=self._extract_finish_reason(_final_response),
                 )
+            except InvokeError:
+                raise
             except Exception:  # pylint: disable=broad-except
                 final_output = response_text
         else:
@@ -1201,8 +1206,11 @@ Format your response clearly with these sections.
             try:
                 final_output = await self._parse_structured_output(
                     result.content,
-                    output_config
+                    output_config,
+                    finish_reason=self._extract_finish_reason(response),
                 )
+            except InvokeError:
+                raise
             except Exception:
                 final_output = result.content
 
@@ -1327,8 +1335,11 @@ Format your response clearly with these sections.
         try:
             final_output = await self._parse_structured_output(
                 result.content,
-                output_config
+                output_config,
+                finish_reason=self._extract_finish_reason(response),
             )
+        except InvokeError:
+            raise
         except Exception:
             final_output = result.content
 
@@ -1467,7 +1478,12 @@ Format your response clearly with these sections.
                 if config.custom_parser:
                     output = config.custom_parser(raw_text)
                 else:
-                    output = await self._parse_structured_output(raw_text, config)
+                    output = await self._parse_structured_output(
+                        raw_text,
+                        config,
+                        finish_reason=self._extract_finish_reason(final_response),
+                        model=resolved_model,
+                    )
 
             usage = CompletionUsage.from_groq(final_response.usage)
             return self._build_invoke_result(

--- a/packages/ai-parrot/src/parrot/clients/groq.py
+++ b/packages/ai-parrot/src/parrot/clients/groq.py
@@ -1475,6 +1475,8 @@ Format your response clearly with these sections.
             # Parse output
             output: Any = raw_text
             if config:
+                # Known-truncated output must not reach a custom parser either.
+                self._raise_if_truncated(self._extract_finish_reason(final_response), model=resolved_model)
                 if config.custom_parser:
                     output = config.custom_parser(raw_text)
                 else:

--- a/packages/ai-parrot/src/parrot/clients/localllm.py
+++ b/packages/ai-parrot/src/parrot/clients/localllm.py
@@ -289,7 +289,12 @@ class LocalLLMClient(OpenAIBaseClient):
                 if config.custom_parser:
                     output = config.custom_parser(raw_text)
                 else:
-                    output = await self._parse_structured_output(raw_text, config)
+                    output = await self._parse_structured_output(
+                        raw_text,
+                        config,
+                        finish_reason=self._extract_finish_reason(response),
+                        model=resolved_model,
+                    )
 
             usage = CompletionUsage.from_openai(response.usage)
             return self._build_invoke_result(
@@ -363,7 +368,12 @@ class LocalLLMClient(OpenAIBaseClient):
             if config.custom_parser:
                 output = config.custom_parser(raw_text)
             else:
-                output = await self._parse_structured_output(raw_text, config)
+                output = await self._parse_structured_output(
+                    raw_text,
+                    config,
+                    finish_reason=self._extract_finish_reason(response),
+                    model=model,
+                )
 
             usage = CompletionUsage.from_openai(response.usage)
             return self._build_invoke_result(output, output_type, model, usage, response)

--- a/packages/ai-parrot/src/parrot/clients/localllm.py
+++ b/packages/ai-parrot/src/parrot/clients/localllm.py
@@ -286,6 +286,8 @@ class LocalLLMClient(OpenAIBaseClient):
 
             output: Any = raw_text
             if config:
+                # Known-truncated output must not reach a custom parser either.
+                self._raise_if_truncated(self._extract_finish_reason(response), model=resolved_model)
                 if config.custom_parser:
                     output = config.custom_parser(raw_text)
                 else:
@@ -365,6 +367,8 @@ class LocalLLMClient(OpenAIBaseClient):
             raw_text = response.choices[0].message.content or ""
 
             output: Any = raw_text
+            # Known-truncated output must not reach a custom parser either.
+            self._raise_if_truncated(self._extract_finish_reason(response), model=model)
             if config.custom_parser:
                 output = config.custom_parser(raw_text)
             else:

--- a/packages/ai-parrot/src/parrot/clients/openai_base.py
+++ b/packages/ai-parrot/src/parrot/clients/openai_base.py
@@ -695,6 +695,8 @@ class OpenAIBaseClient(AbstractClient):
         final_output = None
         if output_config:
             try:
+                # Known-truncated output must not reach a custom parser either.
+                self._raise_if_truncated(self._extract_finish_reason(response), model=model_str)
                 if output_config.custom_parser:
                     final_output = output_config.custom_parser(response_text)
                 else:
@@ -1246,6 +1248,8 @@ class OpenAIBaseClient(AbstractClient):
 
             output: Any = raw_text
             if config:
+                # Known-truncated output must not reach a custom parser either.
+                self._raise_if_truncated(self._extract_finish_reason(response), model=resolved_model)
                 if config.custom_parser:
                     output = config.custom_parser(raw_text)
                 else:

--- a/packages/ai-parrot/src/parrot/clients/openai_base.py
+++ b/packages/ai-parrot/src/parrot/clients/openai_base.py
@@ -698,7 +698,14 @@ class OpenAIBaseClient(AbstractClient):
                 if output_config.custom_parser:
                     final_output = output_config.custom_parser(response_text)
                 else:
-                    final_output = await self._parse_structured_output(response_text, output_config)
+                    final_output = await self._parse_structured_output(
+                        response_text,
+                        output_config,
+                        finish_reason=self._extract_finish_reason(response),
+                        model=model_str,
+                    )
+            except InvokeError:
+                raise
             except Exception:  # noqa: BLE001 pylint: disable=broad-except
                 final_output = response_text
 
@@ -1242,7 +1249,12 @@ class OpenAIBaseClient(AbstractClient):
                 if config.custom_parser:
                     output = config.custom_parser(raw_text)
                 else:
-                    output = await self._parse_structured_output(raw_text, config)
+                    output = await self._parse_structured_output(
+                        raw_text,
+                        config,
+                        finish_reason=self._extract_finish_reason(response),
+                        model=resolved_model,
+                    )
 
             usage = CompletionUsage.from_openai(response.usage)
             return self._build_invoke_result(output, output_type, resolved_model, usage, response)

--- a/packages/ai-parrot/src/parrot/clients/zai.py
+++ b/packages/ai-parrot/src/parrot/clients/zai.py
@@ -1069,6 +1069,8 @@ class ZaiClient(OpenAIBaseClient):
 
             output: Any = raw_text
             if config:
+                # Known-truncated output must not reach a custom parser either.
+                self._raise_if_truncated(self._extract_finish_reason(response), model=resolved_model)
                 if config.custom_parser:
                     output = config.custom_parser(raw_text)
                 else:

--- a/packages/ai-parrot/src/parrot/clients/zai.py
+++ b/packages/ai-parrot/src/parrot/clients/zai.py
@@ -514,7 +514,12 @@ class ZaiClient(OpenAIBaseClient):
             content = getattr(response.choices[0].message, "content", None) or ""
             parsed_output = None
             if output_config:
-                parsed_output = await self._parse_structured_output(content, output_config)
+                parsed_output = await self._parse_structured_output(
+                    content,
+                    output_config,
+                    finish_reason=self._extract_finish_reason(response),
+                    model=resolved_model,
+                )
 
             response_time = time.perf_counter() - started
             ai_message = self._create_ai_message(
@@ -1067,7 +1072,12 @@ class ZaiClient(OpenAIBaseClient):
                 if config.custom_parser:
                     output = config.custom_parser(raw_text)
                 else:
-                    output = await self._parse_structured_output(raw_text, config)
+                    output = await self._parse_structured_output(
+                        raw_text,
+                        config,
+                        finish_reason=self._extract_finish_reason(response),
+                        model=resolved_model,
+                    )
 
             usage = self._usage_from_response(response)
             return self._build_invoke_result(output, output_type, resolved_model, usage, response)

--- a/packages/ai-parrot/src/parrot/exceptions.py
+++ b/packages/ai-parrot/src/parrot/exceptions.py
@@ -83,3 +83,37 @@ class InvokeError(ParrotError):
     ) -> None:
         super().__init__(message, *args, **kwargs)
         self.original: Optional[Exception] = original
+
+
+class TruncatedResponseError(InvokeError):
+    """Raised when a provider stopped generating because of the output-token limit.
+
+    A response whose ``finish_reason`` / ``stop_reason`` reports truncation
+    (``MAX_TOKENS``, ``max_tokens``, ``length``, ``REASON_MAX_LEN``, ...) is
+    known to be incomplete *before* any structured-output parse is attempted.
+    Surfacing it as an :class:`InvokeError` prevents the truncated text from
+    silently leaking to callers as a plain ``str``.
+
+    Args:
+        message: Human-readable error description.
+        *args: Forwarded to :class:`InvokeError`.
+        finish_reason: The normalised provider finish reason that triggered the error.
+        model: Model identifier used for the call, when known.
+        **kwargs: Forwarded to :class:`InvokeError`.
+
+    Attributes:
+        finish_reason: Normalised finish reason (e.g. ``"max_tokens"``).
+        model: Model identifier used for the call, or ``None``.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *args,
+        finish_reason: Optional[str] = None,
+        model: Optional[str] = None,
+        **kwargs
+    ) -> None:
+        super().__init__(message, *args, **kwargs)
+        self.finish_reason: Optional[str] = finish_reason
+        self.model: Optional[str] = model

--- a/tests/unit/test_finish_reason_truncation.py
+++ b/tests/unit/test_finish_reason_truncation.py
@@ -188,6 +188,33 @@ class TestParseStructuredOutputGuard:
 
 
 # --------------------------------------------------------------------------- #
+# _handle_structured_output (legacy helper used by local backends)
+# --------------------------------------------------------------------------- #
+class TestHandleStructuredOutputGuard:
+    async def test_truncated_raises_before_parsing(self, client):
+        result = {"content": [{"type": "text", "text": '{"value": "ab'}]}
+        with pytest.raises(TruncatedResponseError):
+            await client._handle_structured_output(result, Payload, finish_reason="max_tokens")
+
+    async def test_stop_reason_in_result_dict_is_honoured(self, client):
+        result = {
+            "content": [{"type": "text", "text": '{"value": "ab'}],
+            "stop_reason": "max_tokens",
+        }
+        with pytest.raises(TruncatedResponseError):
+            await client._handle_structured_output(result, Payload)
+
+    async def test_no_signal_keeps_legacy_fallback(self, client):
+        result = {"content": [{"type": "text", "text": '{"value": "ab'}]}
+        assert await client._handle_structured_output(result, Payload) is result
+
+    async def test_parses_when_complete(self, client):
+        result = {"content": [{"type": "text", "text": '{"value": "ab"}'}]}
+        parsed = await client._handle_structured_output(result, Payload, finish_reason="stop")
+        assert isinstance(parsed, Payload)
+
+
+# --------------------------------------------------------------------------- #
 # _handle_invoke_error — never double-wrap
 # --------------------------------------------------------------------------- #
 class TestHandleInvokeErrorPassthrough:

--- a/tests/unit/test_finish_reason_truncation.py
+++ b/tests/unit/test_finish_reason_truncation.py
@@ -259,6 +259,89 @@ class TestGoogleInvokeTruncation:
         assert isinstance(result.output, str)
 
 
+def _make_openai_client():
+    from parrot.clients.gpt import OpenAIClient
+
+    client = OpenAIClient.__new__(OpenAIClient)
+    client.model = "gpt-4o"
+    client._lightweight_model = "gpt-4.1"
+    client._fallback_model = None
+    client.logger = MagicMock()
+    client._tool_manager = MagicMock()
+    client._tool_manager.get_tool_schemas.return_value = []
+    client._tool_manager.tools = {}
+    from datamodel.parsers.json import JSONContent
+
+    client._json = JSONContent()
+    client._clients_by_loop = {}
+    client._locks_by_loop = {}
+    return client
+
+
+class TestOpenAIResponsesShimTruncation:
+    """Responses API reports truncation top-level (status/incomplete_details)."""
+
+    async def test_incomplete_max_output_tokens_maps_to_finish_reason(self):
+        client = _make_openai_client()
+        item = SimpleNamespace(content=[{"type": "output_text", "text": '{"value": "ab'}])
+        resp = SimpleNamespace(
+            output=[item],
+            output_text=None,
+            status="incomplete",
+            incomplete_details=SimpleNamespace(reason="max_output_tokens"),
+            usage=None,
+        )
+        client._prepare_responses_args = MagicMock(return_value={})
+        client._call_responses_create = AsyncMock(return_value=resp)
+
+        compat = await client._responses_completion(
+            model="gpt-5", messages=[{"role": "user", "content": "x"}]
+        )
+
+        assert compat.choices[0].finish_reason == "max_output_tokens"
+        assert client._extract_finish_reason(compat) == "max_output_tokens"
+        with pytest.raises(TruncatedResponseError):
+            client._raise_if_truncated(client._extract_finish_reason(compat))
+
+    async def test_completed_status_leaves_finish_reason_none(self):
+        client = _make_openai_client()
+        item = SimpleNamespace(content=[{"type": "output_text", "text": "ok"}])
+        resp = SimpleNamespace(
+            output=[item], output_text=None, status="completed", incomplete_details=None, usage=None
+        )
+        client._prepare_responses_args = MagicMock(return_value={})
+        client._call_responses_create = AsyncMock(return_value=resp)
+
+        compat = await client._responses_completion(model="gpt-5", messages=[])
+        assert compat.choices[0].finish_reason is None
+        client._raise_if_truncated(client._extract_finish_reason(compat))  # no raise
+
+
+class TestCustomParserGuard:
+    """A custom_parser must not receive known-truncated text either."""
+
+    async def test_openai_invoke_custom_parser_raises_on_length(self, bind_sdk_client):
+        client = _make_openai_client()
+        message = SimpleNamespace(content='{"value": "ab', tool_calls=None)
+        choice = SimpleNamespace(message=message, finish_reason="length")
+        usage = SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+        sdk = MagicMock()
+        sdk.chat = MagicMock()
+        sdk.chat.completions = MagicMock()
+        sdk.chat.completions.create = AsyncMock(
+            return_value=SimpleNamespace(choices=[choice], usage=usage)
+        )
+        bind_sdk_client(client, sdk)
+
+        parser = MagicMock(return_value=Payload(value="should-not-run"))
+        cfg = StructuredOutputConfig(
+            output_type=Payload, format=OutputFormat.CUSTOM, custom_parser=parser
+        )
+        with pytest.raises(TruncatedResponseError):
+            await client.invoke("extract", structured_output=cfg)
+        parser.assert_not_called()
+
+
 class TestOpenAIInvokeTruncation:
     async def test_length_raises_invoke_error(self, bind_sdk_client):
         from parrot.clients.gpt import OpenAIClient

--- a/tests/unit/test_finish_reason_truncation.py
+++ b/tests/unit/test_finish_reason_truncation.py
@@ -1,0 +1,293 @@
+"""Unit tests for the shared finish_reason truncation guard.
+
+A provider response that stopped because of the output-token limit
+(``MAX_TOKENS`` / ``max_tokens`` / ``length`` / ``REASON_MAX_LEN``) is known
+to be truncated *before* any structured-output parse is attempted.  The shared
+``AbstractClient`` helpers must turn that into a
+:class:`~parrot.exceptions.TruncatedResponseError` (an ``InvokeError``)
+instead of letting ``_parse_structured_output`` fall back to the raw string.
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import BaseModel
+
+from parrot.exceptions import InvokeError, TruncatedResponseError
+from parrot.models.outputs import OutputFormat, StructuredOutputConfig
+
+
+class Payload(BaseModel):
+    """Fixture model for structured output."""
+
+    value: str
+
+
+def _make_client():
+    """Create a concrete AbstractClient subclass without network setup."""
+    from parrot.clients.base import AbstractClient
+
+    class _TestClient(AbstractClient):
+        _default_model = "test-model"
+        model = "test-model"
+
+        async def ask(self, *args, **kwargs):
+            raise NotImplementedError
+
+        async def ask_stream(self, *args, **kwargs):
+            raise NotImplementedError
+
+        async def resume(self, *args, **kwargs):
+            raise NotImplementedError
+
+        async def invoke(self, *args, **kwargs):
+            raise NotImplementedError
+
+        async def get_client(self):
+            return None
+
+    client = _TestClient.__new__(_TestClient)
+    client.model = "test-model"
+    client._lightweight_model = None
+    client._fallback_model = None
+    client.logger = MagicMock()
+    from datamodel.parsers.json import JSONContent
+
+    client._json = JSONContent()
+    return client
+
+
+@pytest.fixture
+def client():
+    return _make_client()
+
+
+@pytest.fixture
+def config():
+    return StructuredOutputConfig(output_type=Payload, format=OutputFormat.JSON)
+
+
+# --------------------------------------------------------------------------- #
+# _normalize_finish_reason
+# --------------------------------------------------------------------------- #
+class TestNormalizeFinishReason:
+    def test_none_passthrough(self, client):
+        assert client._normalize_finish_reason(None) is None
+
+    def test_empty_string_is_none(self, client):
+        assert client._normalize_finish_reason("   ") is None
+
+    def test_plain_string_lowercased(self, client):
+        assert client._normalize_finish_reason("STOP") == "stop"
+        assert client._normalize_finish_reason("length") == "length"
+
+    def test_enum_like_uses_name(self, client):
+        enum_like = SimpleNamespace(name="MAX_TOKENS")
+        assert client._normalize_finish_reason(enum_like) == "max_tokens"
+
+    def test_enum_repr_string_strips_prefix(self, client):
+        # str(google.genai.types.FinishReason.MAX_TOKENS) == "FinishReason.MAX_TOKENS"
+        assert client._normalize_finish_reason("FinishReason.MAX_TOKENS") == "max_tokens"
+
+    def test_mock_object_does_not_match(self, client):
+        # MagicMock().name is itself a MagicMock — must not be treated as truncation.
+        assert client._normalize_finish_reason(MagicMock()) not in client.TRUNCATED_FINISH_REASONS
+
+
+# --------------------------------------------------------------------------- #
+# _extract_finish_reason
+# --------------------------------------------------------------------------- #
+class TestExtractFinishReason:
+    def test_openai_like_choices(self, client):
+        resp = SimpleNamespace(choices=[SimpleNamespace(finish_reason="length")])
+        assert client._extract_finish_reason(resp) == "length"
+
+    def test_google_like_candidates(self, client):
+        resp = SimpleNamespace(candidates=[SimpleNamespace(finish_reason="MAX_TOKENS")])
+        assert client._extract_finish_reason(resp) == "MAX_TOKENS"
+
+    def test_anthropic_like_stop_reason(self, client):
+        resp = SimpleNamespace(stop_reason="max_tokens")
+        assert client._extract_finish_reason(resp) == "max_tokens"
+
+    def test_xai_like_finish_reason_attr(self, client):
+        resp = SimpleNamespace(finish_reason="REASON_MAX_LEN")
+        assert client._extract_finish_reason(resp) == "REASON_MAX_LEN"
+
+    def test_bedrock_dict(self, client):
+        assert client._extract_finish_reason({"stopReason": "max_tokens"}) == "max_tokens"
+
+    def test_anthropic_dump_dict(self, client):
+        assert client._extract_finish_reason({"stop_reason": "end_turn"}) == "end_turn"
+
+    def test_unknown_shape_is_none(self, client):
+        assert client._extract_finish_reason(object()) is None
+        assert client._extract_finish_reason(None) is None
+        assert client._extract_finish_reason(SimpleNamespace(choices=[])) is None
+
+
+# --------------------------------------------------------------------------- #
+# _raise_if_truncated
+# --------------------------------------------------------------------------- #
+class TestRaiseIfTruncated:
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            "max_tokens",                          # Anthropic / Bedrock
+            "MAX_TOKENS",                          # Google (str)
+            "FinishReason.MAX_TOKENS",             # Google (enum repr)
+            SimpleNamespace(name="MAX_TOKENS"),    # Google (enum object)
+            "length",                              # OpenAI-compatible
+            "REASON_MAX_LEN",                      # xAI Grok
+        ],
+    )
+    def test_raises_for_truncation_vocabulary(self, client, reason):
+        with pytest.raises(TruncatedResponseError) as exc_info:
+            client._raise_if_truncated(reason, model="m-1")
+        err = exc_info.value
+        assert isinstance(err, InvokeError)
+        assert err.finish_reason
+        assert "m-1" in str(err)
+
+    @pytest.mark.parametrize(
+        "reason", [None, "", "stop", "STOP", "end_turn", "tool_calls", "tool_use", "REASON_STOP", "SAFETY"]
+    )
+    def test_no_raise_for_non_truncation(self, client, reason):
+        client._raise_if_truncated(reason)  # must not raise
+
+
+# --------------------------------------------------------------------------- #
+# _parse_structured_output — guard runs BEFORE any parse attempt
+# --------------------------------------------------------------------------- #
+class TestParseStructuredOutputGuard:
+    async def test_truncated_raises_before_parsing(self, client, config):
+        # Truncated JSON — would otherwise silently come back as the raw str.
+        with pytest.raises(TruncatedResponseError):
+            await client._parse_structured_output(
+                '{"value": "abc', config, finish_reason="MAX_TOKENS"
+            )
+
+    async def test_truncated_raises_even_if_text_parses(self, client, config):
+        # Known-truncated wins over "looks fine": the payload may be an accidental prefix.
+        with pytest.raises(TruncatedResponseError):
+            await client._parse_structured_output(
+                '{"value": "abc"}', config, finish_reason="length"
+            )
+
+    async def test_no_finish_reason_keeps_legacy_fallback(self, client, config):
+        # Backward compatible: callers that do not pass finish_reason keep the old behaviour.
+        result = await client._parse_structured_output('{"value": "abc', config)
+        assert isinstance(result, str)
+
+    async def test_stop_parses_normally(self, client, config):
+        result = await client._parse_structured_output(
+            '{"value": "abc"}', config, finish_reason="stop"
+        )
+        assert isinstance(result, Payload)
+        assert result.value == "abc"
+
+
+# --------------------------------------------------------------------------- #
+# _handle_invoke_error — never double-wrap
+# --------------------------------------------------------------------------- #
+class TestHandleInvokeErrorPassthrough:
+    def test_invoke_error_returned_as_is(self, client):
+        original = TruncatedResponseError("cut", finish_reason="max_tokens")
+        assert client._handle_invoke_error(original) is original
+
+    def test_other_exception_wrapped(self, client):
+        exc = ValueError("boom")
+        wrapped = client._handle_invoke_error(exc)
+        assert isinstance(wrapped, InvokeError)
+        assert wrapped.original is exc
+
+
+# --------------------------------------------------------------------------- #
+# Provider wiring — invoke() surfaces truncation as InvokeError
+# --------------------------------------------------------------------------- #
+class TestGoogleInvokeTruncation:
+    def _client(self, finish_reason):
+        from parrot.clients.google.client import GoogleGenAIClient
+
+        client = GoogleGenAIClient.__new__(GoogleGenAIClient)
+        client._clients_by_loop = {}
+        client.model = "gemini-2.5-flash"
+        client._lightweight_model = "gemini-3-flash-lite"
+        client._fallback_model = None
+        client.logger = MagicMock()
+        client._tool_manager = MagicMock()
+        client._tool_manager.get_tool_schemas.return_value = []
+        client._tool_manager.tools = {}
+        from datamodel.parsers.json import JSONContent
+
+        client._json = JSONContent()
+
+        part = SimpleNamespace(text='{"value": "ab')
+        candidate = SimpleNamespace(
+            content=SimpleNamespace(parts=[part]),
+            finish_reason=SimpleNamespace(name=finish_reason),
+        )
+        response = SimpleNamespace(
+            candidates=[candidate],
+            text='{"value": "ab',
+            usage_metadata=SimpleNamespace(
+                prompt_token_count=1, candidates_token_count=1, total_token_count=2
+            ),
+        )
+        sdk_client = MagicMock()
+        sdk_client.aio = MagicMock()
+        sdk_client.aio.models = MagicMock()
+        sdk_client.aio.models.generate_content = AsyncMock(return_value=response)
+        type(client).client = property(lambda self: sdk_client, lambda self, val: None)
+
+        async def _ensure(model=None, **hints):
+            return sdk_client
+
+        client._ensure_client = _ensure
+        return client
+
+    async def test_max_tokens_raises_invoke_error(self):
+        client = self._client("MAX_TOKENS")
+        with pytest.raises(InvokeError) as exc_info:
+            await client.invoke("extract", output_type=Payload)
+        assert isinstance(exc_info.value, TruncatedResponseError)
+
+    async def test_stop_with_bad_json_still_falls_back(self):
+        # Not truncated — legacy behaviour (raw string fallback) is preserved.
+        client = self._client("STOP")
+        result = await client.invoke("extract", output_type=Payload)
+        assert isinstance(result.output, str)
+
+
+class TestOpenAIInvokeTruncation:
+    async def test_length_raises_invoke_error(self, bind_sdk_client):
+        from parrot.clients.gpt import OpenAIClient
+
+        client = OpenAIClient.__new__(OpenAIClient)
+        client.model = "gpt-4o"
+        client._lightweight_model = "gpt-4.1"
+        client._fallback_model = None
+        client.logger = MagicMock()
+        client._tool_manager = MagicMock()
+        client._tool_manager.get_tool_schemas.return_value = []
+        client._tool_manager.tools = {}
+        from datamodel.parsers.json import JSONContent
+
+        client._json = JSONContent()
+        client._clients_by_loop = {}
+        client._locks_by_loop = {}
+
+        message = SimpleNamespace(content='{"value": "ab', tool_calls=None)
+        choice = SimpleNamespace(message=message, finish_reason="length")
+        usage = SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+        sdk = MagicMock()
+        sdk.chat = MagicMock()
+        sdk.chat.completions = MagicMock()
+        sdk.chat.completions.create = AsyncMock(
+            return_value=SimpleNamespace(choices=[choice], usage=usage)
+        )
+        bind_sdk_client(client, sdk)
+
+        with pytest.raises(InvokeError) as exc_info:
+            await client.invoke("extract", output_type=Payload)
+        assert isinstance(exc_info.value, TruncatedResponseError)


### PR DESCRIPTION
## Summary

A response whose provider finish reason denotes output-token truncation (`MAX_TOKENS` / `max_tokens` / `length` / `REASON_MAX_LEN`) is known-incomplete before any parse is attempted, yet the shared `_parse_structured_output` fell back to returning the raw string on parse failure. The truncated text silently leaked to callers as a plain `str`, and multi-turn `ask()` loops (notably `GoogleGenAIClient` combined / two-phase paths) carried on with it.

This PR checks `finish_reason` **before** parsing, in shared code, for every provider, and raises `TruncatedResponseError` (a subclass of `InvokeError`).

## Changes

- **exceptions**: `TruncatedResponseError(InvokeError)` with `finish_reason` and `model` attributes.
- **base**: `TRUNCATED_FINISH_REASONS`, `_normalize_finish_reason()` (plain str, enum `.name`, `FinishReason.MAX_TOKENS` repr), `_extract_finish_reason()` (OpenAI / Google / Anthropic / xAI / Bedrock shapes), `_raise_if_truncated()`. `_parse_structured_output()` and the legacy `_handle_structured_output()` accept `finish_reason=` / `model=` and run the guard first. `_handle_invoke_error()` never double-wraps an `InvokeError`.
- **all clients**: `finish_reason` wired into every `ask()` / `invoke()` parse site (Anthropic, Bedrock, OpenAI-base, GPT, Groq, Grok, Z.AI, LocalLLM, Codex, Google client + analysis, Claude Agent), and ahead of every `custom_parser` branch. Broad `except Exception` fallbacks re-raise `InvokeError` first.
- **google ask()**: single up-front guard on the final multi-turn response (not gated on non-empty text, so a reasoning model that spends the whole budget thinking fails loudly instead of parsing `""`); combined-mode / two-phase reformat fallbacks re-raise.
- **gpt Responses API shim**: maps `status="incomplete"` + `incomplete_details.reason` (`max_output_tokens`) into the Chat-style `finish_reason`.

## Not in scope

- `ask_stream()` paths are deliberately not wired: raising after chunks were already yielded changes the streaming contract and deserves its own decision.
- HuggingFace / Gemma4 produce no finish reason; the guard in `_handle_structured_output` covers them once a signal exists.
- Pre-existing bug in Anthropic `ask()` where the custom-parser result is overwritten by the generic parse (no `else`) is left as-is.

## Verification

- New `tests/unit/test_finish_reason_truncation.py` (44 tests): vocabulary, extraction, guard, parse helpers, Responses shim, custom-parser path, end-to-end Google and OpenAI `invoke()` truncation.
- Client regression suite (`tests/clients/`, invoke / google / stream / handler unit tests): identical 29 pre-existing failures on this branch and on untouched `dev`, zero new failures.
- Adversarial review by codex plus an independent Claude reviewer; all confirmed findings addressed (see commits 2 and 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)