### PR TITLE
feat(meta-llm-client): FEAT-526 — Meta Model API (Muse Spark) LLM Client

### DIFF
--- a/docs/clients/meta.md
+++ b/docs/clients/meta.md
@@ -1,0 +1,277 @@
+# Meta Model API Client (Muse Spark)
+
+**Audience**: Engineers who want to call Meta's hosted Muse Spark models
+(1,048,576-token context, agentic/coding tuned) through the OpenAI-compatible
+wire protocol, with optional Responses-API features (search grounding, input
+token counting).
+
+**Related files**:
+
+- `packages/ai-parrot/src/parrot/clients/meta/client.py` — `MetaClient`
+- `packages/ai-parrot/src/parrot/clients/meta/models.py` — `MetaModel` catalog
+- `packages/ai-parrot/src/parrot/clients/openai_base.py` — inherited `OpenAIBaseClient` machinery (FEAT-438)
+- `packages/ai-parrot/src/parrot/clients/factory.py` — `LLMFactory` registration
+- `tests/clients/test_meta_*.py` — unit tests
+- `tests/e2e/test_meta_live.py` — live, credential-gated end-to-end suite
+- `examples/clients/smoke/smoke_meta.py` — manual smoke script
+- `sdd/specs/meta-llm-client.spec.md` — full design (FEAT-526)
+- `docs/clients/openai-compatible.md` — the shared `OpenAIBaseClient` hierarchy (FEAT-438)
+
+---
+
+## What This Is
+
+Meta Model API is Meta's hosted inference service for the **Muse Spark**
+model family, reachable at `https://api.meta.ai/v1`. It is OpenAI-wire
+compatible for Chat Completions, and additionally exposes an OpenAI-shaped
+**Responses API** with two capabilities not available on Chat Completions:
+native web-search grounding and standalone input-token counting.
+
+`MetaClient` subclasses `OpenAIBaseClient` (FEAT-438) — the neutral
+OpenAI-wire layer that declares **zero** OpenAI-provider model defaults —
+following the same pattern as `OpenRouterClient`/`MoonshotClient`. Chat
+Completions (`ask`/`ask_stream`/`resume`/`invoke` when `use_responses=False`)
+is fully inherited, unmodified. The Responses API path is
+**`MetaClient`-local** (design decision D1): `OpenAIBaseClient` has no
+Responses-API support by design, so `MetaClient` overrides `ask()`/
+`ask_stream()` to route there when `use_responses=True` (the default).
+
+---
+
+## Quickstart
+
+```python
+from parrot.clients.factory import LLMFactory
+
+client = LLMFactory.create("meta:muse-spark-1.3")
+async with client:
+    response = await client.ask("Explain quantum entanglement simply.")
+    print(response.output)
+```
+
+`async with client:` is required — `AbstractClient` does not auto-enter its
+async context for `ask()`/`ask_stream()`/`invoke()` (only the convenience
+`complete()` wrapper does).
+
+Aliases: `"meta"`, `"muse"`, `"meta-muse"` all resolve to `MetaClient`
+(`MetaClient.provider_keys == ("meta", "muse", "meta-muse")`).
+
+---
+
+## Credentials
+
+Resolution order, first match wins:
+
+1. explicit `api_key` kwarg;
+2. `META_API_KEY` env var (the recommended default — `MODEL_API_KEY` is
+   considered too generic a name for a library default);
+3. `MODEL_API_KEY` env var (kept as a secondary fallback so upstream
+   vendor examples that use this generic name work unmodified).
+
+**⚠️ This chain never falls through to `OPENAI_API_KEY`.** The `AsyncOpenAI`
+SDK reads that env var by default when no key is passed explicitly —
+`MetaClient` always passes a resolved key (or `None`) explicitly to
+`AsyncOpenAI`, so an OpenAI key can never be silently shipped to Meta. This
+is enforced by a regression test
+(`test_never_falls_back_to_openai_api_key` in `tests/clients/test_meta_client.py`).
+
+---
+
+## ⚠️ The Reasoning-Budget Gotcha (read this before setting `max_tokens`)
+
+**This is the single most useful paragraph in this document.**
+
+Muse Spark is a reasoning model: it spends a large, often *dominant* share
+of its output-token budget on private, hidden reasoning **before** any
+visible text is produced. Measured live against
+`muse-spark-1.3-contributor` for the one-word target answer `"pong"`:
+
+| Path | Total completion/output tokens | Reasoning tokens | Visible text tokens |
+|---|---|---|---|
+| Chat Completions | 210 | **199** (94.8%) | 11 |
+| Responses | 153 | **142** (92.8%) | 11 |
+
+**A conventional small `max_tokens` (e.g. 64) reliably returns EMPTY visible
+text**, or raises `openai.LengthFinishReasonError` (Chat Completions,
+structured-output parsing) — not because the request failed, but because
+the entire budget was consumed by reasoning before any answer text could be
+emitted. This was reproduced live on **both** wire protocols with
+`max_tokens=64` during implementation.
+
+Mitigations already in place:
+
+- `MetaClient._default_timeout` is raised to **120.0s** (vs. the base's
+  60s) — Muse Spark's reasoning pass is also measurably slower, not just
+  token-hungry.
+- Give every call a **generous** output budget. There is no safe universal
+  number — the reasoning tokens scale with problem complexity, not answer
+  length — but budgets under ~150–200 tokens are known to fail even for a
+  single-word answer.
+- `examples/clients/smoke/_runner.py`'s shared smoke harness hardcodes
+  `max_tokens=64` for its `ask()` leg (by design, shared across every
+  provider) — **this is known and expected to FAIL for Muse Spark**
+  specifically; it is not a `MetaClient` defect. Do not "fix" this by
+  loosening the harness for one provider; if you need a reliable smoke
+  check for Meta specifically, call `client.ask(...)` directly with a
+  larger `max_tokens` outside the shared harness.
+
+---
+
+## ⚠️ Contributor Tier — Training Consent
+
+`MetaModel` includes `-contributor` variants
+(`muse-spark-1.3-contributor`, `muse-spark-1.2-contributor`). These are a
+**separate, cheaper tier that grants Meta permission to train on your
+prompts and completions.**
+
+- `MetaClient._default_model` is `muse-spark-1.3` (Standard tier) and is
+  asserted by test never to be a `-contributor` id.
+- Use a `-contributor` model **only** for synthetic end-to-end test
+  prompts (see `tests/e2e/test_meta_live.py`, `examples/clients/smoke/smoke_meta.py`)
+  — never for real user, company, or repository content.
+- `muse-spark-1.1` has **no** contributor variant.
+
+---
+
+## The Two Protocols
+
+`use_responses: bool` (constructor kwarg, default `True`) selects which
+wire protocol `ask()`/`ask_stream()` route through:
+
+| Capability | Chat Completions (`use_responses=False`) | Responses (`use_responses=True`, default) |
+|---|---|---|
+| `ask()` / `ask_stream()` / `resume()` / `invoke()` | ✅ fully inherited from `OpenAIBaseClient` | ✅ `MetaClient`-local override |
+| Tool calling | ✅ | ✅ (full round trip via the same generic tool loop) |
+| Structured output (`structured_output=`) | ✅ | ❌ not yet supported — ignored |
+| `search_grounding=True` | ❌ raises `ValueError` | ✅ injects native `{"type": "web_search"}` |
+| `count_input_tokens()` | ✅ (standalone endpoint, works regardless) | ✅ |
+| `cached_tokens` usage observability | ❌ not currently surfaced (see note below) | ✅ `ai_message.usage.extra_usage["cached_tokens"]` |
+
+```python
+# Responses path (default) — search grounding, full tool round trip
+client = LLMFactory.create("meta:muse-spark-1.3")
+
+# Chat Completions path — needed for structured_output today
+client = LLMFactory.create("meta:muse-spark-1.3", use_responses=False)
+```
+
+> **Note**: `cached_tokens` surfacing on the Chat Completions path would
+> require extending the shared `CompletionUsage.from_openai()` helper
+> (`parrot/models/basic.py`, used by every OpenAI-wire client) — out of
+> scope for this feature; tracked as a follow-up.
+
+### Search grounding
+
+```python
+result = await client.ask(
+    "What year is it right now?",
+    search_grounding=True,
+)
+if result.metadata.get("web_search_calls"):
+    print("Answer was grounded via live web search:", result.metadata["web_search_calls"])
+```
+
+- Opt-in, defaults to `False` — it triggers live web requests and bills
+  for extra model iterations.
+- Requires `use_responses=True`; raises `ValueError` otherwise.
+- **Citation/annotation extraction is deliberately NOT implemented.** A
+  verified-good, genuinely-grounded live response (`"Spain won 2026 World
+  Cup"`) returned **empty** `annotations` on every message part despite
+  Meta's docs advertising inline citations. Do not build citation
+  extraction against `annotations` until this is re-verified upstream.
+
+### Input token counting
+
+```python
+count = await client.count_input_tokens(input="How many tokens is this?")
+```
+
+Standalone endpoint (`POST /v1/responses/input_tokens`) — works regardless
+of `use_responses`, since it does not depend on the generation path.
+
+---
+
+## Constraints
+
+- **`tool_choice` must be `"auto"`.** Any other value (`"required"`, a
+  named tool) is HTTP 400: `'only "auto" is supported for `tool_choice`'`.
+  Both wire protocols enforce this — `MetaClient` never sends anything
+  else, even if a caller tries to override it.
+- **`logprobs` is unsupported** (HTTP 400) — Muse Spark is a reasoning
+  model.
+- **`reasoning_content` is redacted to empty** for external API keys on
+  Chat Completions. Never surface it as visible "thinking" output.
+- **Recursive/`$ref`-cycle schemas → HTTP 400** on every surface, and
+  under `strict: true` also `allOf`/`oneOf` anywhere and `anyOf` at the
+  schema root.
+- **Responses tool shape differs from Chat Completions.** `MetaClient`
+  handles this internally (`_to_responses_tool()` flattens
+  `{"type":"function","function":{...}}` to
+  `{"type":"function","name":...,...}`), and tool-call round trips use
+  top-level `function_call`/`function_call_output` input items rather
+  than the Chat-Completions `role`/`content` message shape — both were
+  live-verified corrections discovered during implementation. This is
+  purely an internal wire-format detail; callers never construct these
+  shapes directly.
+
+---
+
+## Model Catalog
+
+`MetaModel` — verified live against `GET /v1/models` on 2026-09-04:
+
+| Model | Contributor variant | Notes |
+|---|---|---|
+| `muse-spark-1.3` | `muse-spark-1.3-contributor` | Default (Standard tier) |
+| `muse-spark-1.2` | `muse-spark-1.2-contributor` | |
+| `muse-spark-1.1` | *(none)* | No contributor tier for this version |
+| `muse-image-1.0` | — | Reserved; **out of scope** — no endpoint work |
+| `muse-voice-transcribe-1.0` | — | Reserved; **out of scope** — no endpoint work |
+
+- **Context window**: `1,048,576` tokens, uniform across all Muse Spark models.
+- **Not on Model API at all**: Muse Glimmer (open-weight, self-hosted).
+- **Deferred**: the Anthropic-shaped Messages API (`POST /v1/messages`) — a
+  third protocol, not implemented here.
+
+---
+
+## Smoke Script and Live Tests
+
+```bash
+python examples/clients/smoke/smoke_meta.py            # with META_API_KEY
+env -u META_API_KEY python examples/clients/smoke/smoke_meta.py   # -> SKIPPED, exit 0
+```
+
+The shared smoke harness's `ask` leg uses a fixed `max_tokens=64` across
+every provider and is **known to FAIL for Meta** specifically — see the
+reasoning-budget gotcha above. The `ask+tool` and `invoke` legs pass
+normally.
+
+```bash
+pytest tests/e2e/test_meta_live.py -v   # credential-gated; skips cleanly without META_API_KEY
+```
+
+### Worktree gotcha
+
+Running a smoke script (or any live check) directly from inside
+`.claude/worktrees/<feature>/` will silently import the **main**
+checkout's compiled code — the editable-install `.pth` entries point
+there, and Cython-compiled `.so` files are not automatically present in a
+fresh worktree. Prepend the worktree's `src` dirs via `PYTHONPATH` and
+ensure the compiled `.so` files exist before trusting results:
+
+```bash
+export PYTHONPATH="$(pwd)/packages/ai-parrot/src:$PYTHONPATH"
+```
+
+---
+
+## Out of Scope (v1)
+
+- Muse Image and Muse Voice Transcribe — enum members reserved only.
+- Muse Glimmer — not served on Model API.
+- The Anthropic-shaped Messages API (`POST /v1/messages`).
+- Citation/annotation extraction from search grounding (see Constraints).
+- Mapping parrot's client-side `search_tools` onto Meta's native
+  `tool_search` — a separate, explicitly droppable follow-on unit
+  (measured slower than parrot's own client-side search).

--- a/examples/clients/smoke/smoke_meta.py
+++ b/examples/clients/smoke/smoke_meta.py
@@ -1,0 +1,31 @@
+"""FEAT-526 smoke script — Meta Model API (MetaClient, Muse Spark family).
+
+Exercises ask() / ask()+tool / invoke() against Meta's Muse Spark model on
+the Responses API path (``use_responses=True``, the default).
+
+.. warning::
+    Uses ``muse-spark-1.3-contributor`` — the Contributor tier, which
+    grants Meta permission to **train on prompts and completions**. This
+    is intentional for a synthetic smoke-test prompt only; never adopt
+    this model id as a library default or for real user content. The
+    Standard-tier default is ``muse-spark-1.3``.
+
+Usage:
+    python examples/clients/smoke/smoke_meta.py
+
+Environment Variables:
+    META_API_KEY    Required. Skips (exit 0) if unset.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from _runner import main_for
+
+if __name__ == "__main__":
+    main_for(
+        provider="meta",
+        model="muse-spark-1.3-contributor",
+        env_vars=["META_API_KEY"],
+    )

--- a/examples/clients/smoke/smoke_meta.py
+++ b/examples/clients/smoke/smoke_meta.py
@@ -16,6 +16,7 @@ Usage:
 Environment Variables:
     META_API_KEY    Required. Skips (exit 0) if unset.
 """
+
 import os
 import sys
 

--- a/packages/ai-parrot/src/parrot/clients/factory.py
+++ b/packages/ai-parrot/src/parrot/clients/factory.py
@@ -11,6 +11,7 @@ from .vllm import vLLMClient
 from .nvidia import NvidiaClient
 from .zai import ZaiClient
 from .moonshot import MoonshotClient
+from .meta import MetaClient
 
 
 def _lazy_gemma4():
@@ -135,6 +136,10 @@ SUPPORTED_CLIENTS = {
     "nvidia": NvidiaClient,
     "moonshot": MoonshotClient,
     "kimi": MoonshotClient,
+    # FEAT-526: Meta Model API (Muse Spark family).
+    "meta": MetaClient,
+    "muse": MetaClient,
+    "meta-muse": MetaClient,
     "local": LocalLLMClient,
     "localllm": LocalLLMClient,
     "ollama": LocalLLMClient,

--- a/packages/ai-parrot/src/parrot/clients/factory.py
+++ b/packages/ai-parrot/src/parrot/clients/factory.py
@@ -16,6 +16,7 @@ from .meta import MetaClient
 
 def _lazy_gemma4():
     from .gemma4 import Gemma4Client
+
     return Gemma4Client
 
 
@@ -32,6 +33,7 @@ def _lazy_bedrock_converse():
         The :class:`BedrockConverseClient` class.
     """
     from .bedrock import BedrockConverseClient
+
     return BedrockConverseClient
 
 
@@ -50,6 +52,7 @@ def _lazy_nova():
         The :class:`NovaClient` class.
     """
     from .nova import NovaClient
+
     return NovaClient
 
 
@@ -63,6 +66,7 @@ def _lazy_bedrock_mantle():
         The :class:`BedrockMantleClient` class.
     """
     from .nova.mantle import BedrockMantleClient
+
     return BedrockMantleClient
 
 
@@ -86,11 +90,11 @@ def _lazy_claude_agent():
     """
     try:
         from .claude_agent import ClaudeAgentClient
+
         return ClaudeAgentClient
     except ImportError as exc:
         raise ImportError(
-            "ClaudeAgentClient requires claude-agent-sdk. "
-            "Install with: pip install ai-parrot[claude-agent]"
+            "ClaudeAgentClient requires claude-agent-sdk. " "Install with: pip install ai-parrot[claude-agent]"
         ) from exc
 
 
@@ -102,6 +106,7 @@ def _lazy_openai_codex():
     SDK backend is used; the CLI backend can reuse installed Codex CLI auth.
     """
     from .codex_agent import OpenAICodexClient
+
     return OpenAICodexClient
 
 
@@ -172,6 +177,7 @@ class LLMFactory:
     - "provider" → uses default model for provider
     - Direct client class or instance
     """
+
     @staticmethod
     def parse_llm_string(llm: str) -> Tuple[str, Optional[str]]:
         """
@@ -189,17 +195,14 @@ class LLMFactory:
             >>> LLMFactory.parse_llm_string("anthropic")
             ('anthropic', None)
         """
-        if ':' in llm:
-            provider, model = llm.split(':', 1)
+        if ":" in llm:
+            provider, model = llm.split(":", 1)
             return provider.strip(), model.strip()
         return llm.strip(), None
 
     @staticmethod
     def create(
-        llm: str,
-        model_args: Optional[Dict[str, Any]] = None,
-        tool_manager: Optional[Any] = None,
-        **kwargs
+        llm: str, model_args: Optional[Dict[str, Any]] = None, tool_manager: Optional[Any] = None, **kwargs
     ) -> AbstractClient:
         """
         Create an LLM client instance from string specification.
@@ -227,9 +230,7 @@ class LLMFactory:
             ... )
         """
         if not isinstance(llm, str):
-            raise ValueError(
-                f"LLMFactory.create expects string, got {type(llm).__name__}"
-            )
+            raise ValueError(f"LLMFactory.create expects string, got {type(llm).__name__}")
 
         # Parse provider and model
         provider, model = LLMFactory.parse_llm_string(llm)
@@ -237,10 +238,7 @@ class LLMFactory:
 
         # Validate provider
         if provider not in SUPPORTED_CLIENTS:
-            raise ValueError(
-                f"Unsupported LLM provider: '{provider}'. "
-                f"Supported: {list(SUPPORTED_CLIENTS.keys())}"
-            )
+            raise ValueError(f"Unsupported LLM provider: '{provider}'. " f"Supported: {list(SUPPORTED_CLIENTS.keys())}")
 
         # Get client class (resolve lazy loaders)
         client_class = SUPPORTED_CLIENTS[provider]
@@ -252,16 +250,18 @@ class LLMFactory:
 
         # Add model if specified
         if model:
-            init_params['model'] = model
+            init_params["model"] = model
 
         # Add model_args parameters
         if model_args:
-            init_params.update({
-                'temperature': model_args.get('temperature'),
-                'top_k': model_args.get('top_k'),
-                'top_p': model_args.get('top_p'),
-                'max_tokens': model_args.get('max_tokens'),
-            })
+            init_params.update(
+                {
+                    "temperature": model_args.get("temperature"),
+                    "top_k": model_args.get("top_k"),
+                    "top_p": model_args.get("top_p"),
+                    "max_tokens": model_args.get("max_tokens"),
+                }
+            )
             # Remove None values
             init_params = {k: v for k, v in init_params.items() if v is not None}
 
@@ -272,7 +272,7 @@ class LLMFactory:
 
         # Add tool_manager if provided
         if tool_manager:
-            init_params['tool_manager'] = tool_manager
+            init_params["tool_manager"] = tool_manager
 
         # Merge additional kwargs
         init_params.update(kwargs)

--- a/packages/ai-parrot/src/parrot/clients/meta/__init__.py
+++ b/packages/ai-parrot/src/parrot/clients/meta/__init__.py
@@ -4,6 +4,7 @@ Exposes ``MetaModel`` (the model catalog) and ``MetaClient`` (the
 ``OpenAIBaseClient`` subclass for Meta's Muse Spark family). See
 ``sdd/specs/meta-llm-client.spec.md`` (FEAT-526).
 """
+
 from .models import (
     MetaModel,
     CONTRIBUTOR_MODELS,

--- a/packages/ai-parrot/src/parrot/clients/meta/__init__.py
+++ b/packages/ai-parrot/src/parrot/clients/meta/__init__.py
@@ -1,8 +1,8 @@
 """Meta Model API client package for AI-Parrot.
 
-Exposes ``MetaModel`` (the model catalog) and, once implemented,
-``MetaClient`` (the ``OpenAIBaseClient`` subclass for Meta's Muse Spark
-family). See ``sdd/specs/meta-llm-client.spec.md`` (FEAT-526).
+Exposes ``MetaModel`` (the model catalog) and ``MetaClient`` (the
+``OpenAIBaseClient`` subclass for Meta's Muse Spark family). See
+``sdd/specs/meta-llm-client.spec.md`` (FEAT-526).
 """
 from .models import (
     MetaModel,
@@ -12,10 +12,7 @@ from .models import (
     TRANSCRIBE_MODELS,
     CONTEXT_WINDOW,
 )
-
-# NOTE: `MetaClient` is re-exported here by TASK-2834 once
-# `parrot/clients/meta/client.py` exists. Do not import a module that
-# does not exist yet.
+from .client import MetaClient, config
 
 __all__ = [
     "MetaModel",
@@ -24,4 +21,5 @@ __all__ = [
     "IMAGE_MODELS",
     "TRANSCRIBE_MODELS",
     "CONTEXT_WINDOW",
+    "MetaClient",
 ]

--- a/packages/ai-parrot/src/parrot/clients/meta/__init__.py
+++ b/packages/ai-parrot/src/parrot/clients/meta/__init__.py
@@ -1,0 +1,27 @@
+"""Meta Model API client package for AI-Parrot.
+
+Exposes ``MetaModel`` (the model catalog) and, once implemented,
+``MetaClient`` (the ``OpenAIBaseClient`` subclass for Meta's Muse Spark
+family). See ``sdd/specs/meta-llm-client.spec.md`` (FEAT-526).
+"""
+from .models import (
+    MetaModel,
+    CONTRIBUTOR_MODELS,
+    SPARK_MODELS,
+    IMAGE_MODELS,
+    TRANSCRIBE_MODELS,
+    CONTEXT_WINDOW,
+)
+
+# NOTE: `MetaClient` is re-exported here by TASK-2834 once
+# `parrot/clients/meta/client.py` exists. Do not import a module that
+# does not exist yet.
+
+__all__ = [
+    "MetaModel",
+    "CONTRIBUTOR_MODELS",
+    "SPARK_MODELS",
+    "IMAGE_MODELS",
+    "TRANSCRIBE_MODELS",
+    "CONTEXT_WINDOW",
+]

--- a/packages/ai-parrot/src/parrot/clients/meta/client.py
+++ b/packages/ai-parrot/src/parrot/clients/meta/client.py
@@ -21,6 +21,7 @@ subclassed, or modified; some duplication is the accepted, reversible trade.
 
 See ``sdd/specs/meta-llm-client.spec.md`` (FEAT-526).
 """
+
 from __future__ import annotations
 
 import json
@@ -142,9 +143,7 @@ class MetaClient(OpenAIBaseClient):
         **kwargs: Any,
     ) -> None:
         self.use_responses = use_responses
-        resolved_key = (
-            api_key or config.get("META_API_KEY") or config.get("MODEL_API_KEY")
-        )
+        resolved_key = api_key or config.get("META_API_KEY") or config.get("MODEL_API_KEY")
         super().__init__(
             api_key=resolved_key,
             base_url=base_url or "https://api.meta.ai/v1",
@@ -168,8 +167,7 @@ class MetaClient(OpenAIBaseClient):
             from openai import AsyncOpenAI
         except ImportError as exc:
             raise ImportError(
-                "MetaClient requires the 'openai' SDK. "
-                "Install with: pip install ai-parrot[openai]"
+                "MetaClient requires the 'openai' SDK. " "Install with: pip install ai-parrot[openai]"
             ) from exc
         return AsyncOpenAI(
             api_key=self.api_key,
@@ -305,9 +303,7 @@ class MetaClient(OpenAIBaseClient):
             return flat
         return tool
 
-    def _prepare_responses_args(
-        self, *, messages: list[dict[str, Any]], args: dict[str, Any]
-    ) -> dict[str, Any]:
+    def _prepare_responses_args(self, *, messages: list[dict[str, Any]], args: dict[str, Any]) -> dict[str, Any]:
         """Map a Chat-Completions-style message list into a Responses payload.
 
         Lifts the first ``system`` message into ``instructions``; the rest
@@ -488,16 +484,16 @@ class MetaClient(OpenAIBaseClient):
         if isinstance(usage, dict):
             details = usage.get("prompt_tokens_details") or usage.get("input_tokens_details")
         else:
-            details = getattr(usage, "prompt_tokens_details", None) or getattr(
-                usage, "input_tokens_details", None
-            )
+            details = getattr(usage, "prompt_tokens_details", None) or getattr(usage, "input_tokens_details", None)
         if details is None:
             return None
         if isinstance(details, dict):
             return details.get("cached_tokens")
         return getattr(details, "cached_tokens", None)
 
-    async def count_input_tokens(self, *, model: str | None = None, input: Any, **kwargs: Any) -> int:  # noqa: A002 — spec-mandated parameter name
+    async def count_input_tokens(
+        self, *, model: str | None = None, input: Any, **kwargs: Any
+    ) -> int:  # noqa: A002 — spec-mandated parameter name
         """Count input tokens for a prospective Responses API request.
 
         Standalone endpoint (``POST /v1/responses/input_tokens``) — it does

--- a/packages/ai-parrot/src/parrot/clients/meta/client.py
+++ b/packages/ai-parrot/src/parrot/clients/meta/client.py
@@ -5,18 +5,26 @@
 declares no OpenAI-provider model defaults — to speak to Meta's Muse Spark
 model family (https://api.meta.ai/v1).
 
-Almost everything is inherited: Chat Completions (``ask``/``ask_stream``/
-``resume``/``invoke``) already funnels through
+Chat Completions (``ask``/``ask_stream``/``resume``/``invoke`` when
+``use_responses=False``) is inherited unchanged: it already funnels through
 ``OpenAIBaseClient._chat_completion()``, and live testing confirmed the
 base's existing emissions are Meta-legal (``tool_choice="auto"`` and
-``max_tokens``). This module adds only credential resolution, the Meta
-base URL, a raised request timeout (Muse Spark is a reasoning model and
-routinely slow), and ``list_models()``.
+``max_tokens``).
+
+The Responses API path (``use_responses=True``, the default) is net-new and
+**local to this class** (design decision D1): ``OpenAIBaseClient`` has no
+Responses-API support by design, so ``ask()``/``ask_stream()`` are overridden
+here to route to :meth:`MetaClient._responses_completion`. The *structure* of
+:class:`~parrot.clients.gpt.OpenAIClient`'s equivalent methods
+(``gpt.py:353-680``) is mirrored as a read-only reference — never imported,
+subclassed, or modified; some duplication is the accepted, reversible trade.
 
 See ``sdd/specs/meta-llm-client.spec.md`` (FEAT-526).
 """
 from __future__ import annotations
 
+import json
+import uuid
 from typing import Any, TYPE_CHECKING
 from logging import getLogger
 
@@ -24,12 +32,71 @@ import aiohttp
 from navconfig import config
 
 from ..openai_base import OpenAIBaseClient
+from ...models import AIMessage, AIMessageFactory, CompletionUsage
+from parrot.observability.context import current_session_id, current_user_id
 from .models import MetaModel
 
 if TYPE_CHECKING:
     from openai import AsyncOpenAI
 
 logger = getLogger(__name__)
+
+
+class _ToolCallFunction:
+    """Chat-Completions-shaped ``function`` sub-object for a tool call."""
+
+    def __init__(self, name: str | None, arguments: str) -> None:
+        self.name = name
+        self.arguments = arguments
+
+
+class _ToolCall:
+    """Chat-Completions-shaped tool call, folded from a Responses
+    ``function_call`` output item."""
+
+    def __init__(self, tc_id: str, function: _ToolCallFunction) -> None:
+        self.id = tc_id
+        self.function = function
+
+
+class _Message:
+    """Chat-Completions-shaped ``choices[0].message`` compatibility shim."""
+
+    def __init__(self, content: str, tool_calls: list[_ToolCall]) -> None:
+        self.content = content
+        self.tool_calls = tool_calls
+
+
+class _Choice:
+    """Chat-Completions-shaped ``choices[0]`` compatibility shim."""
+
+    def __init__(self, message: _Message, *, finish_reason: str | None = None) -> None:
+        self.message = message
+        self.finish_reason = finish_reason
+        self.stop_reason = finish_reason
+
+
+class _ResponsesCompatResult:
+    """Chat-Completions-shaped adapter over a Responses API result.
+
+    Lets the generic Chat-Completions machinery inherited from
+    :class:`~parrot.clients.openai_base.OpenAIBaseClient`
+    (``_run_tool_call_loop``, :class:`~parrot.models.responses.AIMessageFactory`)
+    drive the Responses wire protocol unchanged — mirrors the
+    ``_CompatResp``/``_Choice``/``_Msg`` pattern in
+    ``OpenAIClient._responses_completion`` (``gpt.py:661-686``), read as a
+    structural reference only.
+    """
+
+    def __init__(self, raw: Any, message: _Message, *, finish_reason: str | None = None) -> None:
+        self.raw = raw
+        self.choices = [_Choice(message, finish_reason=finish_reason)]
+        # FEAT-397: Chat Completions and Responses usage objects are read
+        # the same way downstream (getattr-based), even though the
+        # Responses shape uses input_tokens/output_tokens rather than
+        # prompt_tokens/completion_tokens — matches the existing gpt.py
+        # Responses path, not "fixed" here (D1: mirror the structure).
+        self.usage = getattr(raw, "usage", None)
 
 
 class MetaClient(OpenAIBaseClient):
@@ -44,9 +111,8 @@ class MetaClient(OpenAIBaseClient):
         base_url: Override for Meta's API base URL. Defaults to
             ``https://api.meta.ai/v1``.
         use_responses: Whether to route ``ask()``/``ask_stream()`` through
-            the Responses API instead of Chat Completions. Stored here;
-            consumed by the Responses-API override added in a later task
-            (TASK-2836) — otherwise inert.
+            the Responses API (default) instead of the inherited Chat
+            Completions funnel. Set ``False`` to use Chat Completions.
         **kwargs: Additional arguments passed to
             :class:`~parrot.clients.openai_base.OpenAIBaseClient`.
 
@@ -132,3 +198,493 @@ class MetaClient(OpenAIBaseClient):
                 data = await response.json()
 
         return data.get("data", [])
+
+    # ------------------------------------------------------------------
+    # Responses API path (D1: MetaClient-local; spec §3 Module 3).
+    # ------------------------------------------------------------------
+
+    def _fold_output(self, output: list[Any]) -> str:
+        """Fold Responses API ``output[]`` items into visible text.
+
+        Concatenates text from items whose ``type == "message"``, skipping
+        ``reasoning`` items — their content is redacted to empty for
+        external keys, and treating them as text yields blank output for a
+        conventional-budget call (spec §7 gotchas 1 and 4).
+
+        Args:
+            output: The ``output`` list from a Responses API response — raw
+                dicts, or SDK objects exposing the same shape via attributes.
+
+        Returns:
+            The concatenated visible text.
+        """
+        text = ""
+        for item in output or []:
+            item_type = item.get("type") if isinstance(item, dict) else getattr(item, "type", None)
+            if item_type != "message":
+                continue
+            content = item.get("content") if isinstance(item, dict) else getattr(item, "content", None)
+            for part in content or []:
+                if isinstance(part, dict):
+                    if part.get("type") == "output_text":
+                        text += part.get("text", "") or ""
+                elif getattr(part, "type", None) == "output_text":
+                    text += getattr(part, "text", "") or ""
+        return text
+
+    def _extract_tool_calls(self, output: list[Any]) -> list[_ToolCall]:
+        """Extract Chat-Completions-shaped tool calls from ``output[]``.
+
+        Maps Responses ``function_call`` output items to the same
+        ``{id, function: {name, arguments}}`` shape the inherited
+        ``_run_tool_call_loop`` and ``AIMessageFactory.from_openai`` expect
+        from a Chat Completions response, so the same generic tool-execution
+        loop drives both wire protocols unchanged.
+
+        Args:
+            output: The ``output`` list from a Responses API response.
+
+        Returns:
+            A list of :class:`_ToolCall` shims.
+        """
+        tool_calls: list[_ToolCall] = []
+        for item in output or []:
+            item_type = item.get("type") if isinstance(item, dict) else getattr(item, "type", None)
+            if item_type != "function_call":
+                continue
+            if isinstance(item, dict):
+                call_id = item.get("call_id") or item.get("id")
+                name = item.get("name")
+                arguments = item.get("arguments")
+            else:
+                call_id = getattr(item, "call_id", None) or getattr(item, "id", None)
+                name = getattr(item, "name", None)
+                arguments = getattr(item, "arguments", None)
+            if not isinstance(arguments, str):
+                arguments = json.dumps(arguments or {})
+            tool_calls.append(
+                _ToolCall(
+                    tc_id=call_id or str(uuid.uuid4()),
+                    function=_ToolCallFunction(name=name, arguments=arguments),
+                )
+            )
+        return tool_calls
+
+    def _prepare_responses_args(
+        self, *, messages: list[dict[str, Any]], args: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Map a Chat-Completions-style message list into a Responses payload.
+
+        Lifts the first ``system`` message into ``instructions``; the rest
+        become the ``input`` list. Tool-call round trips are represented the
+        same way :class:`~parrot.clients.gpt.OpenAIClient` mirrors them
+        (``tool_output``/``tool_call`` content blocks) — read as a structural
+        reference only, per D1.
+
+        Args:
+            messages: Chat-Completions-shaped message dicts.
+            args: Chat-Completions-style extra kwargs (``tools``,
+                ``tool_choice``, ``max_output_tokens`` or ``max_tokens``,
+                ``temperature``, ...).
+
+        Returns:
+            A Responses API request payload (without ``model``).
+        """
+
+        def _content_blocks(role: str, content: Any, message: dict[str, Any]) -> list[dict[str, Any]]:
+            if role == "tool":
+                if isinstance(content, list):
+                    text = "\n".join(
+                        str(part) if not isinstance(part, dict) else str(part.get("text") or part.get("output") or "")
+                        for part in content
+                    )
+                else:
+                    text = "" if content is None else str(content)
+                block: dict[str, Any] = {
+                    "type": "tool_output",
+                    "tool_call_id": message.get("tool_call_id"),
+                    "output": text,
+                }
+                if message.get("name"):
+                    block["name"] = message["name"]
+                return [block]
+
+            text_type = "input_text" if role in {"user", "system"} else "output_text"
+            parts: list[dict[str, Any]] = []
+            if isinstance(content, list):
+                for item in content:
+                    if isinstance(item, dict):
+                        item_type = item.get("type")
+                        if item_type in {"input_text", "output_text", "tool_output", "tool_call"}:
+                            parts.append(item)
+                        elif item_type == "text":
+                            text_val = item.get("text")
+                            if text_val:
+                                parts.append({"type": text_type, "text": str(text_val)})
+                        else:
+                            parts.append(item)
+                    elif item:
+                        parts.append({"type": text_type, "text": str(item)})
+            elif content:
+                parts.append({"type": text_type, "text": str(content)})
+
+            if role == "assistant" and message.get("tool_calls"):
+                for tool_call in message["tool_calls"]:
+                    function = tool_call.get("function", {}) if isinstance(tool_call, dict) else {}
+                    parts.append(
+                        {
+                            "type": "tool_call",
+                            "id": tool_call.get("id") if isinstance(tool_call, dict) else None,
+                            "name": function.get("name"),
+                            "arguments": function.get("arguments"),
+                        }
+                    )
+            return parts
+
+        instructions = None
+        input_msgs: list[dict[str, Any]] = []
+        for message in messages:
+            role = message.get("role")
+            content = message.get("content")
+            if role == "system" and instructions is None:
+                instructions = content if isinstance(content, str) else str(content)
+                continue
+            item: dict[str, Any] = {"role": role, "content": _content_blocks(role, content, message)}
+            if message.get("tool_call_id"):
+                item["tool_call_id"] = message["tool_call_id"]
+            input_msgs.append(item)
+
+        req: dict[str, Any] = {"input": input_msgs}
+        if instructions:
+            req["instructions"] = instructions
+        if args.get("tools"):
+            req["tools"] = args["tools"]
+        # Meta HTTP 400s on any tool_choice value other than "auto" (spec §7
+        # gotcha 2) — never forward a caller-supplied override.
+        if "tool_choice" in args:
+            req["tool_choice"] = "auto"
+        if args.get("temperature") is not None:
+            req["temperature"] = args["temperature"]
+        # Responses' output-budget parameter is `max_output_tokens`, not
+        # Chat Completions' `max_tokens` (spec §7 gotcha 1 — Muse Spark
+        # burns most of a small budget on hidden reasoning).
+        max_output_tokens = args.get("max_output_tokens", args.get("max_tokens"))
+        if max_output_tokens is not None:
+            req["max_output_tokens"] = max_output_tokens
+        return req
+
+    async def _responses_completion(
+        self, *, model: str, messages: list[dict[str, Any]], use_tools: bool = False, **args: Any
+    ) -> _ResponsesCompatResult:
+        """Call ``responses.create()`` and adapt the result to Chat-Completions shape.
+
+        Args:
+            model: The resolved model id.
+            messages: The Chat-Completions-shaped message list.
+            use_tools: Accepted for signature parity with
+                :meth:`~parrot.clients.openai_base.OpenAIBaseClient._chat_completion`
+                (the inherited ``_run_tool_call_loop`` calls both the same
+                way); unused here, since tools are always forwarded via
+                ``args["tools"]`` when present.
+            **args: Additional Responses request kwargs (``tools``,
+                ``tool_choice``, ``max_output_tokens``, ``temperature``).
+
+        Returns:
+            A :class:`_ResponsesCompatResult` exposing
+            ``.choices[0].message.{content,tool_calls}`` and ``.usage``, so
+            the generic Chat-Completions tool loop and
+            ``AIMessageFactory.from_openai`` can consume it unchanged.
+        """
+        del use_tools  # see docstring
+        await self._ensure_client()
+        req = self._prepare_responses_args(messages=messages, args=args)
+        req["model"] = model
+
+        resp = await self.client.responses.create(**req)
+
+        output = getattr(resp, "output", None)
+        if output is None and isinstance(resp, dict):
+            output = resp.get("output")
+        output = output or []
+
+        content = getattr(resp, "output_text", None)
+        if content is None:
+            content = self._fold_output(output)
+
+        tool_calls = self._extract_tool_calls(output)
+        message = _Message(content=content or "", tool_calls=tool_calls)
+
+        status = getattr(resp, "status", None)
+        if status is None and isinstance(resp, dict):
+            status = resp.get("status")
+        finish_reason = "incomplete" if status == "incomplete" else None
+
+        return _ResponsesCompatResult(raw=resp, message=message, finish_reason=finish_reason)
+
+    async def ask(
+        self,
+        prompt: str,
+        model: Any | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        files: list[Any] | None = None,
+        system_prompt: str | None = None,
+        history: Any | None = None,
+        structured_output: Any | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        use_tools: bool | None = None,
+        lazy_loading: bool = False,
+    ) -> AIMessage:
+        """Ask Meta Model API a question, routing via ``use_responses``.
+
+        When ``self.use_responses`` is ``False``, delegates unchanged to the
+        inherited Chat Completions funnel
+        (:meth:`~parrot.clients.openai_base.OpenAIBaseClient.ask`). When
+        ``True`` (the default), routes to the Responses API via
+        :meth:`_responses_completion`, reusing the same generic tool-call
+        loop (:meth:`~parrot.clients.openai_base.OpenAIBaseClient._run_tool_call_loop`)
+        so a full tool-calling round trip works on both paths.
+
+        Keeps the base's signature exactly (spec §6/§7) so the funnel-parity
+        sweep in ``tests/clients/test_openai_base_parity.py`` continues to
+        pass.
+
+        Args:
+            prompt: The prompt to send to the model.
+            model: The model to use, or ``None`` to use the configured one.
+            max_tokens: Maximum output tokens (mapped to
+                ``max_output_tokens`` on this path).
+            temperature: Sampling temperature.
+            files: Files to upload before the call.
+            system_prompt: System prompt to prepend.
+            history: Already-rendered conversation history.
+            structured_output: Not yet supported on the Responses path;
+                ignored when ``use_responses`` is ``True``.
+            tools: Tools to register for this call.
+            use_tools: Whether to use tools; defaults to ``self.enable_tools``.
+            lazy_loading: If ``True``, enable dynamic tool searching.
+
+        Returns:
+            The response from the model.
+        """
+        if not self.use_responses:
+            return await super().ask(
+                prompt,
+                model=model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                files=files,
+                system_prompt=system_prompt,
+                history=history,
+                structured_output=structured_output,
+                tools=tools,
+                use_tools=use_tools,
+                lazy_loading=lazy_loading,
+            )
+
+        turn_id = str(uuid.uuid4())
+        original_prompt = prompt
+        _use_tools = use_tools if use_tools is not None else self.enable_tools
+        model_str = self._resolve_model(model)
+
+        messages = self._build_messages(prompt, files, history)
+
+        if system_prompt:
+            if isinstance(system_prompt, list):
+                system_prompt = "\n\n".join(s.text for s in system_prompt)
+            messages.insert(0, {"role": "system", "content": system_prompt})
+
+        if tools and isinstance(tools, list):
+            for tool in tools:
+                self.register_tool(tool)
+
+        active_tool_names: set[str] = set()
+        prepared_tools = None
+        if _use_tools:
+            if lazy_loading:
+                prepared_tools = self._prepare_lazy_tools()
+                if prepared_tools:
+                    active_tool_names.add("search_tools")
+            else:
+                prepared_tools = self._prepare_tools()
+
+        args: dict[str, Any] = {}
+        if prepared_tools:
+            args["tools"] = prepared_tools
+            args["tool_choice"] = "auto"
+
+        resolved_max_tokens = self._resolve_max_tokens(max_tokens)
+        if resolved_max_tokens is not None:
+            args["max_output_tokens"] = resolved_max_tokens
+        if temperature:
+            args["temperature"] = temperature
+
+        response = await self._responses_completion(model=model_str, messages=messages, use_tools=_use_tools, **args)
+        result = response.choices[0].message
+
+        result, response, all_tool_calls, accumulated_usage, round_number = await self._run_tool_call_loop(
+            result=result,
+            response=response,
+            messages=messages,
+            model_str=model_str,
+            use_tools=_use_tools,
+            args=args,
+            session_id=current_session_id.get(),
+            call_completion=self._responses_completion,
+            lazy_loading=lazy_loading,
+            active_tool_names=active_tool_names,
+            track_usage=True,
+        )
+
+        messages.append({"role": "assistant", "content": result.content})
+
+        ai_message = AIMessageFactory.from_openai(
+            response=response,
+            input_text=original_prompt,
+            model=model_str,
+            user_id=current_user_id.get(),
+            session_id=current_session_id.get(),
+            turn_id=turn_id,
+        )
+
+        if accumulated_usage is not None:
+            if round_number > 1:
+                accumulated_usage.extra_usage["rounds"] = round_number
+            ai_message.usage = accumulated_usage
+
+        ai_message.tool_calls = all_tool_calls
+        return ai_message
+
+    async def ask_stream(
+        self,
+        prompt: str,
+        model: Any | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        files: list[Any] | None = None,
+        system_prompt: str | None = None,
+        history: Any | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        use_tools: bool = True,
+        structured_output: Any | None = None,
+        lazy_loading: bool = False,
+        **kwargs: Any,
+    ):
+        """Stream a response, routing via ``use_responses``.
+
+        When ``self.use_responses`` is ``False``, delegates unchanged to the
+        inherited Chat Completions streaming funnel. When ``True`` (the
+        default), streams text deltas from the Responses API.
+
+        Note:
+            Unlike :meth:`ask`, the Responses streaming path here does not
+            run a tool-calling round trip mid-stream — it yields the
+            streamed text and a final :class:`~parrot.models.responses.AIMessage`.
+            Use :meth:`ask` (``use_responses=True``) for a full tool-calling
+            round trip on the Responses path.
+
+        Yields:
+            Successive string chunks, followed by a final
+            :class:`~parrot.models.responses.AIMessage`.
+        """
+        if not self.use_responses:
+            async for item in super().ask_stream(
+                prompt,
+                model=model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                files=files,
+                system_prompt=system_prompt,
+                history=history,
+                tools=tools,
+                use_tools=use_tools,
+                structured_output=structured_output,
+                lazy_loading=lazy_loading,
+                **kwargs,
+            ):
+                yield item
+            return
+
+        turn_id = str(uuid.uuid4())
+        model_str = self._resolve_model(model)
+        messages = self._build_messages(prompt, files, history)
+
+        if system_prompt:
+            if isinstance(system_prompt, list):
+                system_prompt = "\n\n".join(s.text for s in system_prompt)
+            messages.insert(0, {"role": "system", "content": system_prompt})
+
+        if tools and isinstance(tools, list):
+            for tool in tools:
+                self.register_tool(tool)
+
+        tools_payload = None
+        if use_tools and self.tools:
+            if lazy_loading:
+                tools_payload = self._prepare_lazy_tools()
+            else:
+                tools_payload = self._prepare_tools()
+
+        args: dict[str, Any] = {}
+        if tools_payload:
+            args["tools"] = tools_payload
+            args["tool_choice"] = "auto"
+
+        resolved_max_tokens = self._resolve_max_tokens(max_tokens)
+        if resolved_max_tokens is not None:
+            args["max_output_tokens"] = resolved_max_tokens
+        temperature_value = temperature if temperature is not None else self.temperature
+        if temperature_value is not None:
+            args["temperature"] = temperature_value
+
+        await self._ensure_client()
+        req = self._prepare_responses_args(messages=messages, args=args)
+        req["model"] = model_str
+
+        assistant_content = ""
+        final_response = None
+        stream_cm = self.client.responses.stream(**req)
+        async with stream_cm as stream:
+            async for event in stream:
+                event_type = getattr(event, "type", None)
+                if event_type is None and isinstance(event, dict):
+                    event_type = event.get("type")
+                if event_type == "response.output_text.delta":
+                    delta = getattr(event, "delta", None)
+                    if delta is None and isinstance(event, dict):
+                        delta = event.get("delta")
+                    if delta:
+                        assistant_content += delta
+                        yield delta
+            try:
+                final_response = await stream.get_final_response()
+            except Exception:  # noqa: BLE001 pylint: disable=broad-except
+                final_response = None
+
+        if final_response is not None and not assistant_content:
+            output = getattr(final_response, "output", None)
+            if output is None and isinstance(final_response, dict):
+                output = final_response.get("output")
+            assistant_content = self._fold_output(output or [])
+            if assistant_content:
+                yield assistant_content
+
+        usage_obj = getattr(final_response, "usage", None) if final_response is not None else None
+        usage = (
+            CompletionUsage.from_openai(usage_obj)
+            if usage_obj is not None
+            else CompletionUsage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
+        )
+
+        ai_message = AIMessage(
+            input=prompt,
+            output=assistant_content,
+            response=assistant_content,
+            model=model_str,
+            provider=self.client_type,
+            usage=usage,
+            user_id=current_user_id.get(),
+            session_id=current_session_id.get(),
+            turn_id=turn_id,
+        )
+        yield ai_message

--- a/packages/ai-parrot/src/parrot/clients/meta/client.py
+++ b/packages/ai-parrot/src/parrot/clients/meta/client.py
@@ -270,16 +270,55 @@ class MetaClient(OpenAIBaseClient):
             )
         return tool_calls
 
+    @staticmethod
+    def _to_responses_tool(tool: dict[str, Any]) -> dict[str, Any]:
+        """Convert a Chat-Completions-shaped function tool to the Responses shape.
+
+        Chat Completions nests the function definition:
+        ``{"type": "function", "function": {"name", "description",
+        "parameters", ...}}`` (what ``AbstractClient._prepare_tools()``
+        always produces). The Responses API expects the same fields
+        **flattened** onto the tool dict itself:
+        ``{"type": "function", "name", "description", "parameters", ...}``
+        — sending the nested Chat-Completions shape live 400s with
+        ``'tools[0]' missing required field 'name'``.
+
+        Non-function tools (e.g. ``{"type": "web_search"}``, already flat)
+        pass through unchanged.
+
+        Args:
+            tool: A single tool dict, in either shape.
+
+        Returns:
+            The Responses-shaped tool dict.
+        """
+        if isinstance(tool, dict) and tool.get("type") == "function" and "function" in tool:
+            function = tool["function"]
+            flat: dict[str, Any] = {
+                "type": "function",
+                "name": function.get("name"),
+                "description": function.get("description"),
+                "parameters": function.get("parameters", {}),
+            }
+            if "strict" in function:
+                flat["strict"] = function["strict"]
+            return flat
+        return tool
+
     def _prepare_responses_args(
         self, *, messages: list[dict[str, Any]], args: dict[str, Any]
     ) -> dict[str, Any]:
         """Map a Chat-Completions-style message list into a Responses payload.
 
         Lifts the first ``system`` message into ``instructions``; the rest
-        become the ``input`` list. Tool-call round trips are represented the
-        same way :class:`~parrot.clients.gpt.OpenAIClient` mirrors them
-        (``tool_output``/``tool_call`` content blocks) — read as a structural
-        reference only, per D1.
+        become the ``input`` list. Tool-call round trips are represented as
+        top-level ``function_call``/``function_call_output`` input items —
+        the *real*, live-verified Responses wire shape (NOT a
+        ``role``/``content`` wrapper like Chat Completions; NOT the
+        ``tool_output``/``tool_call`` content-block shape
+        :class:`~parrot.clients.gpt.OpenAIClient` mirrors, which was tried
+        first here and 400s live with ``'input[N].content' did not match
+        any supported type`` — corrected during implementation).
 
         Args:
             messages: Chat-Completions-shaped message dicts.
@@ -291,31 +330,14 @@ class MetaClient(OpenAIBaseClient):
             A Responses API request payload (without ``model``).
         """
 
-        def _content_blocks(role: str, content: Any, message: dict[str, Any]) -> list[dict[str, Any]]:
-            if role == "tool":
-                if isinstance(content, list):
-                    text = "\n".join(
-                        str(part) if not isinstance(part, dict) else str(part.get("text") or part.get("output") or "")
-                        for part in content
-                    )
-                else:
-                    text = "" if content is None else str(content)
-                block: dict[str, Any] = {
-                    "type": "tool_output",
-                    "tool_call_id": message.get("tool_call_id"),
-                    "output": text,
-                }
-                if message.get("name"):
-                    block["name"] = message["name"]
-                return [block]
-
+        def _text_content(role: str, content: Any) -> list[dict[str, Any]]:
             text_type = "input_text" if role in {"user", "system"} else "output_text"
             parts: list[dict[str, Any]] = []
             if isinstance(content, list):
                 for item in content:
                     if isinstance(item, dict):
                         item_type = item.get("type")
-                        if item_type in {"input_text", "output_text", "tool_output", "tool_call"}:
+                        if item_type in {"input_text", "output_text"}:
                             parts.append(item)
                         elif item_type == "text":
                             text_val = item.get("text")
@@ -327,18 +349,6 @@ class MetaClient(OpenAIBaseClient):
                         parts.append({"type": text_type, "text": str(item)})
             elif content:
                 parts.append({"type": text_type, "text": str(content)})
-
-            if role == "assistant" and message.get("tool_calls"):
-                for tool_call in message["tool_calls"]:
-                    function = tool_call.get("function", {}) if isinstance(tool_call, dict) else {}
-                    parts.append(
-                        {
-                            "type": "tool_call",
-                            "id": tool_call.get("id") if isinstance(tool_call, dict) else None,
-                            "name": function.get("name"),
-                            "arguments": function.get("arguments"),
-                        }
-                    )
             return parts
 
         instructions = None
@@ -346,19 +356,55 @@ class MetaClient(OpenAIBaseClient):
         for message in messages:
             role = message.get("role")
             content = message.get("content")
+
             if role == "system" and instructions is None:
                 instructions = content if isinstance(content, str) else str(content)
                 continue
-            item: dict[str, Any] = {"role": role, "content": _content_blocks(role, content, message)}
-            if message.get("tool_call_id"):
-                item["tool_call_id"] = message["tool_call_id"]
-            input_msgs.append(item)
+
+            if role == "tool":
+                # Real Responses input item for a tool result: a top-level
+                # `function_call_output`, keyed by `call_id` — NOT a
+                # `{"role": "tool", ...}` message wrapper.
+                if isinstance(content, list):
+                    output_text = "\n".join(
+                        str(part) if not isinstance(part, dict) else str(part.get("text") or part.get("output") or "")
+                        for part in content
+                    )
+                else:
+                    output_text = "" if content is None else str(content)
+                input_msgs.append(
+                    {
+                        "type": "function_call_output",
+                        "call_id": message.get("tool_call_id"),
+                        "output": output_text,
+                    }
+                )
+                continue
+
+            if role == "assistant" and message.get("tool_calls"):
+                # Real text (if any) first, then one top-level `function_call`
+                # item per tool call — NOT nested inside the message content.
+                if content:
+                    input_msgs.append({"role": role, "content": _text_content(role, content)})
+                for tool_call in message["tool_calls"]:
+                    function = tool_call.get("function", {}) if isinstance(tool_call, dict) else {}
+                    input_msgs.append(
+                        {
+                            "type": "function_call",
+                            "call_id": tool_call.get("id") if isinstance(tool_call, dict) else None,
+                            "name": function.get("name"),
+                            "arguments": function.get("arguments"),
+                        }
+                    )
+                continue
+
+            input_msgs.append({"role": role, "content": _text_content(role, content)})
 
         req: dict[str, Any] = {"input": input_msgs}
         if instructions:
             req["instructions"] = instructions
         if args.get("tools"):
-            req["tools"] = args["tools"]
+            req["tools"] = [self._to_responses_tool(tool) for tool in args["tools"]]
         # Meta HTTP 400s on any tool_choice value other than "auto" (spec §7
         # gotcha 2) — never forward a caller-supplied override.
         if "tool_choice" in args:
@@ -470,7 +516,13 @@ class MetaClient(OpenAIBaseClient):
         """
         await self._ensure_client()
         model_str = self._resolve_model(model)
-        resp = await self.client.responses.input_tokens(model=model_str, input=input, **kwargs)
+        # `responses.input_tokens` is an SDK sub-resource (`AsyncInputTokens`),
+        # not directly callable — the actual RPC is `.count(...)`. Verified
+        # against the installed `openai` SDK during implementation; earlier
+        # revisions of this method called `responses.input_tokens(...)`
+        # directly, which raises `TypeError: 'AsyncInputTokens' object is
+        # not callable`.
+        resp = await self.client.responses.input_tokens.count(model=model_str, input=input, **kwargs)
         count = getattr(resp, "input_tokens", None)
         if count is None and isinstance(resp, dict):
             count = resp.get("input_tokens")

--- a/packages/ai-parrot/src/parrot/clients/meta/client.py
+++ b/packages/ai-parrot/src/parrot/clients/meta/client.py
@@ -421,6 +421,61 @@ class MetaClient(OpenAIBaseClient):
 
         return _ResponsesCompatResult(raw=resp, message=message, finish_reason=finish_reason)
 
+    @staticmethod
+    def _extract_cached_tokens(usage: Any) -> int | None:
+        """Extract ``cached_tokens`` from either usage-details shape.
+
+        Chat Completions reports it at ``usage.prompt_tokens_details.cached_tokens``;
+        Responses reports the same value at
+        ``usage.input_tokens_details.cached_tokens``. Prompt caching itself
+        is automatic server-side — this is observability only (spec §1
+        Non-Goals).
+
+        Args:
+            usage: The raw SDK usage object (or dict) from either wire shape.
+
+        Returns:
+            The cached-token count, or ``None`` if not present.
+        """
+        if usage is None:
+            return None
+        if isinstance(usage, dict):
+            details = usage.get("prompt_tokens_details") or usage.get("input_tokens_details")
+        else:
+            details = getattr(usage, "prompt_tokens_details", None) or getattr(
+                usage, "input_tokens_details", None
+            )
+        if details is None:
+            return None
+        if isinstance(details, dict):
+            return details.get("cached_tokens")
+        return getattr(details, "cached_tokens", None)
+
+    async def count_input_tokens(self, *, model: str | None = None, input: Any, **kwargs: Any) -> int:  # noqa: A002 — spec-mandated parameter name
+        """Count input tokens for a prospective Responses API request.
+
+        Standalone endpoint (``POST /v1/responses/input_tokens``) — it does
+        not depend on the generation path, only on the client's
+        credentials and base URL, so it works regardless of
+        ``self.use_responses``.
+
+        Args:
+            model: Model to count for, or ``None`` to use the configured one.
+            input: The Responses-shaped ``input`` payload to count tokens for.
+            **kwargs: Additional args forwarded to the SDK call (e.g.
+                ``instructions``, ``tools``).
+
+        Returns:
+            The input token count.
+        """
+        await self._ensure_client()
+        model_str = self._resolve_model(model)
+        resp = await self.client.responses.input_tokens(model=model_str, input=input, **kwargs)
+        count = getattr(resp, "input_tokens", None)
+        if count is None and isinstance(resp, dict):
+            count = resp.get("input_tokens")
+        return int(count) if count is not None else 0
+
     async def ask(
         self,
         prompt: str,
@@ -434,6 +489,7 @@ class MetaClient(OpenAIBaseClient):
         tools: list[dict[str, Any]] | None = None,
         use_tools: bool | None = None,
         lazy_loading: bool = False,
+        search_grounding: bool = False,
     ) -> AIMessage:
         """Ask Meta Model API a question, routing via ``use_responses``.
 
@@ -445,7 +501,8 @@ class MetaClient(OpenAIBaseClient):
         loop (:meth:`~parrot.clients.openai_base.OpenAIBaseClient._run_tool_call_loop`)
         so a full tool-calling round trip works on both paths.
 
-        Keeps the base's signature exactly (spec §6/§7) so the funnel-parity
+        Keeps the base's signature exactly, plus the additive
+        ``search_grounding`` keyword (spec §6/§7), so the funnel-parity
         sweep in ``tests/clients/test_openai_base_parity.py`` continues to
         pass.
 
@@ -463,10 +520,30 @@ class MetaClient(OpenAIBaseClient):
             tools: Tools to register for this call.
             use_tools: Whether to use tools; defaults to ``self.enable_tools``.
             lazy_loading: If ``True``, enable dynamic tool searching.
+            search_grounding: If ``True``, inject Meta's native web-search
+                tool (``{"type": "web_search"}``) into the Responses
+                request, enabling live retrieval grounding. Opt-in and
+                ``False`` by default — it triggers live web requests and
+                bills for extra model iterations. Requires
+                ``self.use_responses`` (Responses-API only); citation/
+                annotation extraction is explicitly NOT implemented — a
+                verified-good grounded response returned empty
+                ``annotations`` (spec §7 gotcha 5).
 
         Returns:
             The response from the model.
+
+        Raises:
+            ValueError: If ``search_grounding=True`` while
+                ``self.use_responses`` is ``False``.
         """
+        if search_grounding and not self.use_responses:
+            raise ValueError(
+                "search_grounding requires the Responses API path "
+                "(use_responses=True); this client was configured with "
+                "use_responses=False."
+            )
+
         if not self.use_responses:
             return await super().ask(
                 prompt,
@@ -513,6 +590,13 @@ class MetaClient(OpenAIBaseClient):
             args["tools"] = prepared_tools
             args["tool_choice"] = "auto"
 
+        if search_grounding:
+            web_search_tool = {"type": "web_search"}
+            existing_tools = args.get("tools") or []
+            if web_search_tool not in existing_tools:
+                args["tools"] = [*existing_tools, web_search_tool]
+                args["tool_choice"] = "auto"
+
         resolved_max_tokens = self._resolve_max_tokens(max_tokens)
         if resolved_max_tokens is not None:
             args["max_output_tokens"] = resolved_max_tokens
@@ -553,6 +637,31 @@ class MetaClient(OpenAIBaseClient):
             ai_message.usage = accumulated_usage
 
         ai_message.tool_calls = all_tool_calls
+
+        # Surface web_search_call output items so callers can distinguish a
+        # grounded answer from an ungrounded one. Deliberately NOT extracting
+        # citations/annotations here — a verified-good grounded response
+        # returned empty `annotations` (spec §7 gotcha 5); no promise the
+        # API does not currently keep.
+        raw_output = getattr(response.raw, "output", None)
+        if raw_output is None and isinstance(response.raw, dict):
+            raw_output = response.raw.get("output")
+        web_search_call_ids = [
+            (item.get("id") if isinstance(item, dict) else getattr(item, "id", None))
+            for item in (raw_output or [])
+            if (item.get("type") if isinstance(item, dict) else getattr(item, "type", None)) == "web_search_call"
+        ]
+        if web_search_call_ids:
+            ai_message.metadata["web_search_calls"] = web_search_call_ids
+            ai_message.metadata["search_grounded"] = True
+
+        # Cached-token observability (spec §1 Non-Goal: caching itself is
+        # automatic server-side; nothing to implement beyond surfacing it).
+        raw_usage = getattr(response.raw, "usage", None)
+        cached_tokens = self._extract_cached_tokens(raw_usage)
+        if cached_tokens is not None:
+            ai_message.usage.extra_usage["cached_tokens"] = cached_tokens
+
         return ai_message
 
     async def ask_stream(

--- a/packages/ai-parrot/src/parrot/clients/meta/client.py
+++ b/packages/ai-parrot/src/parrot/clients/meta/client.py
@@ -1,0 +1,134 @@
+"""Meta Model API client for AI-Parrot.
+
+``MetaClient`` subclasses :class:`~parrot.clients.openai_base.OpenAIBaseClient`
+— the neutral OpenAI-wire layer (FEAT-438) that owns the wire protocol and
+declares no OpenAI-provider model defaults — to speak to Meta's Muse Spark
+model family (https://api.meta.ai/v1).
+
+Almost everything is inherited: Chat Completions (``ask``/``ask_stream``/
+``resume``/``invoke``) already funnels through
+``OpenAIBaseClient._chat_completion()``, and live testing confirmed the
+base's existing emissions are Meta-legal (``tool_choice="auto"`` and
+``max_tokens``). This module adds only credential resolution, the Meta
+base URL, a raised request timeout (Muse Spark is a reasoning model and
+routinely slow), and ``list_models()``.
+
+See ``sdd/specs/meta-llm-client.spec.md`` (FEAT-526).
+"""
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+from logging import getLogger
+
+import aiohttp
+from navconfig import config
+
+from ..openai_base import OpenAIBaseClient
+from .models import MetaModel
+
+if TYPE_CHECKING:
+    from openai import AsyncOpenAI
+
+logger = getLogger(__name__)
+
+
+class MetaClient(OpenAIBaseClient):
+    """Client for Meta Model API (Muse Spark family).
+
+    Args:
+        api_key: Meta Model API key. Resolution order: ``api_key`` kwarg
+            → ``META_API_KEY`` env var → ``MODEL_API_KEY`` env var. This
+            chain MUST NOT fall through to ``OPENAI_API_KEY`` — the
+            ``AsyncOpenAI`` SDK would otherwise silently pick that up and
+            ship an OpenAI key to Meta.
+        base_url: Override for Meta's API base URL. Defaults to
+            ``https://api.meta.ai/v1``.
+        use_responses: Whether to route ``ask()``/``ask_stream()`` through
+            the Responses API instead of Chat Completions. Stored here;
+            consumed by the Responses-API override added in a later task
+            (TASK-2836) — otherwise inert.
+        **kwargs: Additional arguments passed to
+            :class:`~parrot.clients.openai_base.OpenAIBaseClient`.
+
+    Example:
+        >>> client = MetaClient()
+        >>> response = await client.ask("Hello!")
+    """
+
+    client_type: str = "meta"
+    client_name: str = "meta"
+    _default_model: str = MetaModel.MUSE_SPARK_1_3.value
+    # Muse Spark is a reasoning model: a live one-word answer ("pong") spent
+    # 199 of 210 completion tokens on reasoning. A conventional 60s timeout
+    # is measurably too tight for heavier prompts.
+    _default_timeout: float = 120.0
+
+    # FEAT-523 discovery contract: every factory key this class answers to
+    # (primary first), and the model catalog enum it owns.
+    provider_keys: tuple[str, ...] = ("meta", "muse", "meta-muse")
+    models: type[MetaModel] = MetaModel
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        use_responses: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        self.use_responses = use_responses
+        resolved_key = (
+            api_key or config.get("META_API_KEY") or config.get("MODEL_API_KEY")
+        )
+        super().__init__(
+            api_key=resolved_key,
+            base_url=base_url or "https://api.meta.ai/v1",
+            **kwargs,
+        )
+        # Re-set after super().__init__ — AbstractClient may overwrite it.
+        self.api_key = resolved_key
+
+    async def get_client(self) -> "AsyncOpenAI":
+        """Initialize AsyncOpenAI configured for Meta Model API.
+
+        Returns:
+            An ``AsyncOpenAI`` instance pointed at Meta's base URL, with
+            the resolved Meta API key passed explicitly (never relying on
+            the SDK's ``OPENAI_API_KEY`` default).
+
+        Raises:
+            ImportError: If the ``openai`` package is not installed.
+        """
+        try:
+            from openai import AsyncOpenAI
+        except ImportError as exc:
+            raise ImportError(
+                "MetaClient requires the 'openai' SDK. "
+                "Install with: pip install ai-parrot[openai]"
+            ) from exc
+        return AsyncOpenAI(
+            api_key=self.api_key,
+            base_url=self.base_url,
+            timeout=self._timeout,
+        )
+
+    async def list_models(self) -> list[dict[str, Any]]:
+        """List available models from Meta Model API.
+
+        Fetches the model catalog from ``GET /v1/models``.
+
+        Returns:
+            List of model dicts as returned by the endpoint's ``data`` key.
+
+        Raises:
+            aiohttp.ClientError: If the HTTP request fails.
+        """
+        url = f"{self.base_url}/models"
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+        }
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, headers=headers) as response:
+                response.raise_for_status()
+                data = await response.json()
+
+        return data.get("data", [])

--- a/packages/ai-parrot/src/parrot/clients/meta/models.py
+++ b/packages/ai-parrot/src/parrot/clients/meta/models.py
@@ -11,6 +11,7 @@ by the existing AIMessage / CompletionUsage models.
     used as a library default — reserve them for synthetic end-to-end
     test prompts only.
 """
+
 from enum import Enum
 
 
@@ -40,32 +41,40 @@ class MetaModel(str, Enum):
 # Meta permission to train on your prompts and completions. Never use one
 # of these as a default anywhere in library code; synthetic e2e test
 # prompts only.
-CONTRIBUTOR_MODELS: frozenset[str] = frozenset({
-    MetaModel.MUSE_SPARK_1_3_CONTRIBUTOR.value,
-    MetaModel.MUSE_SPARK_1_2_CONTRIBUTOR.value,
-})
+CONTRIBUTOR_MODELS: frozenset[str] = frozenset(
+    {
+        MetaModel.MUSE_SPARK_1_3_CONTRIBUTOR.value,
+        MetaModel.MUSE_SPARK_1_2_CONTRIBUTOR.value,
+    }
+)
 
 # Muse Spark (text/agentic/coding) chat models — both Standard and
 # Contributor tiers.
-SPARK_MODELS: frozenset[str] = frozenset({
-    MetaModel.MUSE_SPARK_1_3.value,
-    MetaModel.MUSE_SPARK_1_3_CONTRIBUTOR.value,
-    MetaModel.MUSE_SPARK_1_2.value,
-    MetaModel.MUSE_SPARK_1_2_CONTRIBUTOR.value,
-    MetaModel.MUSE_SPARK_1_1.value,
-})
+SPARK_MODELS: frozenset[str] = frozenset(
+    {
+        MetaModel.MUSE_SPARK_1_3.value,
+        MetaModel.MUSE_SPARK_1_3_CONTRIBUTOR.value,
+        MetaModel.MUSE_SPARK_1_2.value,
+        MetaModel.MUSE_SPARK_1_2_CONTRIBUTOR.value,
+        MetaModel.MUSE_SPARK_1_1.value,
+    }
+)
 
 # Muse Image — reserved, out of scope (Non-Goal). No endpoint work exists
 # for this model; the enum member is a placeholder only.
-IMAGE_MODELS: frozenset[str] = frozenset({
-    MetaModel.MUSE_IMAGE_1_0.value,
-})
+IMAGE_MODELS: frozenset[str] = frozenset(
+    {
+        MetaModel.MUSE_IMAGE_1_0.value,
+    }
+)
 
 # Muse Voice Transcribe — reserved, out of scope (Non-Goal). No endpoint
 # work exists for this model; the enum member is a placeholder only.
-TRANSCRIBE_MODELS: frozenset[str] = frozenset({
-    MetaModel.MUSE_VOICE_TRANSCRIBE_1_0.value,
-})
+TRANSCRIBE_MODELS: frozenset[str] = frozenset(
+    {
+        MetaModel.MUSE_VOICE_TRANSCRIBE_1_0.value,
+    }
+)
 
 # Context window (in tokens), uniform across all Muse Spark models.
 CONTEXT_WINDOW: int = 1_048_576

--- a/packages/ai-parrot/src/parrot/clients/meta/models.py
+++ b/packages/ai-parrot/src/parrot/clients/meta/models.py
@@ -1,0 +1,71 @@
+"""Meta Model API data models for AI-Parrot.
+
+Model enums and capability constants for Meta Model API
+(https://api.meta.ai/v1). No Pydantic wrappers are needed — Meta's
+Chat Completions response shape matches OpenAI's and is already covered
+by the existing AIMessage / CompletionUsage models.
+
+.. warning::
+    Contributor-tier models (see ``CONTRIBUTOR_MODELS``) grant Meta
+    permission to train on prompts and completions. They MUST NEVER be
+    used as a library default — reserve them for synthetic end-to-end
+    test prompts only.
+"""
+from enum import Enum
+
+
+class MetaModel(str, Enum):
+    """Meta Model API model identifiers.
+
+    String-valued enum so members interchange with raw model strings
+    in OpenAI SDK calls (e.g. ``model=MetaModel.MUSE_SPARK_1_3.value``
+    or simply ``model=MetaModel.MUSE_SPARK_1_3`` since the class
+    inherits from ``str``).
+
+    Verified live against ``GET /v1/models`` on 2026-09-04 (finding
+    F013 of the FEAT-526 research audit). Do not add, rename, or
+    "correct" any of these ids without a fresh live verification.
+    """
+
+    MUSE_SPARK_1_3 = "muse-spark-1.3"
+    MUSE_SPARK_1_3_CONTRIBUTOR = "muse-spark-1.3-contributor"
+    MUSE_SPARK_1_2 = "muse-spark-1.2"
+    MUSE_SPARK_1_2_CONTRIBUTOR = "muse-spark-1.2-contributor"
+    MUSE_SPARK_1_1 = "muse-spark-1.1"  # NOTE: no contributor variant
+    MUSE_IMAGE_1_0 = "muse-image-1.0"  # reserved — out of scope (Non-Goal)
+    MUSE_VOICE_TRANSCRIBE_1_0 = "muse-voice-transcribe-1.0"  # reserved — out of scope
+
+
+# Models on the "contributor" tier — a lower price in exchange for granting
+# Meta permission to train on your prompts and completions. Never use one
+# of these as a default anywhere in library code; synthetic e2e test
+# prompts only.
+CONTRIBUTOR_MODELS: frozenset[str] = frozenset({
+    MetaModel.MUSE_SPARK_1_3_CONTRIBUTOR.value,
+    MetaModel.MUSE_SPARK_1_2_CONTRIBUTOR.value,
+})
+
+# Muse Spark (text/agentic/coding) chat models — both Standard and
+# Contributor tiers.
+SPARK_MODELS: frozenset[str] = frozenset({
+    MetaModel.MUSE_SPARK_1_3.value,
+    MetaModel.MUSE_SPARK_1_3_CONTRIBUTOR.value,
+    MetaModel.MUSE_SPARK_1_2.value,
+    MetaModel.MUSE_SPARK_1_2_CONTRIBUTOR.value,
+    MetaModel.MUSE_SPARK_1_1.value,
+})
+
+# Muse Image — reserved, out of scope (Non-Goal). No endpoint work exists
+# for this model; the enum member is a placeholder only.
+IMAGE_MODELS: frozenset[str] = frozenset({
+    MetaModel.MUSE_IMAGE_1_0.value,
+})
+
+# Muse Voice Transcribe — reserved, out of scope (Non-Goal). No endpoint
+# work exists for this model; the enum member is a placeholder only.
+TRANSCRIBE_MODELS: frozenset[str] = frozenset({
+    MetaModel.MUSE_VOICE_TRANSCRIBE_1_0.value,
+})
+
+# Context window (in tokens), uniform across all Muse Spark models.
+CONTEXT_WINDOW: int = 1_048_576

--- a/sdd/tasks/completed/TASK-2833-meta-model-catalog.md
+++ b/sdd/tasks/completed/TASK-2833-meta-model-catalog.md
@@ -51,7 +51,18 @@ spec Non-Goal — the enum members are reserved placeholders only).
 |---|---|---|
 | `packages/ai-parrot/src/parrot/clients/meta/__init__.py` | CREATE | Package init; re-exports `MetaModel` |
 | `packages/ai-parrot/src/parrot/clients/meta/models.py` | CREATE | Enum + frozensets |
-| `packages/ai-parrot/tests/clients/test_meta_models.py` | CREATE | Unit tests |
+| `tests/clients/test_meta_models.py` | CREATE | Unit tests |
+
+> **Codebase Contract correction (verified during implementation,
+> 2026-09-04)**: the task file originally listed
+> `packages/ai-parrot/tests/clients/test_meta_models.py`, but the root
+> `pyproject.toml` sets `testpaths = ["tests"]` and every sibling wire
+> client's tests (e.g. `test_moonshot_client.py`, and the roster files
+> `test_openai_compatible_defaults.py:49` / `test_openai_base_parity.py:341`
+> referenced elsewhere in this spec) live under the **root** `tests/clients/`,
+> not `packages/ai-parrot/tests/clients/` (a separate, unrelated test tree
+> for bedrock/nova). Corrected to `tests/clients/test_meta_models.py` to
+> match the actual collected/runnable location and sibling convention.
 
 > `client.py` is created by TASK-2834, which also extends `__init__.py` to
 > re-export `MetaClient`. Leave a placeholder comment in `__init__.py` marking
@@ -213,7 +224,17 @@ class TestMetaModel:
 
 ## Completion Note
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
-**Notes**:
-**Deviations from spec**: none | describe if any
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-09-04
+**Notes**: Created `parrot/clients/meta/{__init__,models}.py` per the FEAT-523
+folder convention. `MetaModel` enum has exactly the 7 live-verified ids;
+`CONTRIBUTOR_MODELS`/`SPARK_MODELS`/`IMAGE_MODELS`/`TRANSCRIBE_MODELS`/
+`CONTEXT_WINDOW` all present. `client.py` intentionally not created here
+(TASK-2834). 8/8 unit tests pass, `ruff` clean.
+**Deviations from spec**: Corrected a stale Codebase Contract entry in this
+task file: the test file lives at `tests/clients/test_meta_models.py`
+(root-level, matching `pyproject.toml`'s `testpaths = ["tests"]` and the
+sibling `test_moonshot_client.py`), not
+`packages/ai-parrot/tests/clients/test_meta_models.py` as originally
+written — that path is an unrelated bedrock/nova test tree not on the
+default `pytest` collection path.

--- a/sdd/tasks/completed/TASK-2834-metaclient-chat-completions.md
+++ b/sdd/tasks/completed/TASK-2834-metaclient-chat-completions.md
@@ -54,7 +54,13 @@ to `openai_base.py`, `base.py`, or `gpt.py`.
 |---|---|---|
 | `packages/ai-parrot/src/parrot/clients/meta/client.py` | CREATE | `MetaClient` |
 | `packages/ai-parrot/src/parrot/clients/meta/__init__.py` | MODIFY | add `MetaClient` re-export |
-| `packages/ai-parrot/tests/clients/test_meta_client.py` | CREATE | Unit tests |
+| `tests/clients/test_meta_client.py` | CREATE | Unit tests |
+
+> **Codebase Contract correction (same as TASK-2833, re-verified
+> 2026-09-04)**: test path corrected from
+> `packages/ai-parrot/tests/clients/test_meta_client.py` to the root
+> `tests/clients/test_meta_client.py` — `pyproject.toml` sets
+> `testpaths = ["tests"]` and all sibling wire-client tests live there.
 
 ---
 
@@ -294,7 +300,17 @@ class TestMetaClient:
 
 ## Completion Note
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
-**Notes**:
-**Deviations from spec**: none | describe if any
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-09-04
+**Notes**: Created `MetaClient(OpenAIBaseClient)` in `clients/meta/client.py`.
+Credential chain `api_key` → `META_API_KEY` → `MODEL_API_KEY`, never
+`OPENAI_API_KEY` (regression-tested). `_default_model="muse-spark-1.3"`,
+`_default_timeout=120.0`, `provider_keys=("meta","muse","meta-muse")`,
+`models=MetaModel`. `__init__.py` re-exports `MetaClient` and `config` (the
+latter so tests can `monkeypatch.setattr("parrot.clients.meta.config.get",
+...)` per the sibling `test_moonshot_client.py` convention, extended one
+level for the package layout). `_chat_completion` NOT overridden — fully
+inherited. 15/15 unit tests pass, `ruff` clean.
+**Deviations from spec**: none beyond the test-path correction already
+noted in TASK-2833 (root `tests/clients/`, not
+`packages/ai-parrot/tests/clients/`).

--- a/sdd/tasks/completed/TASK-2835-factory-registration-and-rosters.md
+++ b/sdd/tasks/completed/TASK-2835-factory-registration-and-rosters.md
@@ -41,7 +41,11 @@ or `PROVIDER_BACKEND` (that is an Anthropic-backend mechanism, irrelevant here).
 | `packages/ai-parrot/src/parrot/clients/factory.py` | MODIFY | import + 3 registry keys |
 | `tests/clients/test_openai_compatible_defaults.py` | MODIFY | add to `WIRE_SUBCLASSES` |
 | `tests/clients/test_openai_base_parity.py` | MODIFY | add to `WIRE_SUBCLASSES` |
-| `packages/ai-parrot/tests/clients/test_meta_client.py` | MODIFY | factory tests |
+| `tests/clients/test_meta_client.py` | MODIFY | factory tests |
+
+> **Codebase Contract correction (same as TASK-2833/2834)**: test path
+> corrected to the root `tests/clients/test_meta_client.py` (created by
+> TASK-2834), not `packages/ai-parrot/tests/clients/test_meta_client.py`.
 
 ---
 
@@ -166,7 +170,23 @@ class TestMetaFactoryRegistration:
 
 ## Completion Note
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
-**Notes**:
-**Deviations from spec**: none | describe if any
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-09-04
+**Notes**: Registered `MetaClient` in `SUPPORTED_CLIENTS` under `"meta"`,
+`"muse"`, `"meta-muse"` (direct import, matching `OpenRouterClient` — no
+lazy loader needed). Added `MetaClient` to `WIRE_SUBCLASSES` in both
+`test_openai_compatible_defaults.py` and `test_openai_base_parity.py`;
+all 96 tests across both files pass with zero further changes, confirming
+TASK-2834's implementation is funnel-clean. `PROVIDER_BACKEND` untouched.
+One test in the task's own scaffold needed adjusting:
+`test_create_with_default_model` originally asserted
+`LLMFactory.create("meta").model == "muse-spark-1.3"`, but `.model` is only
+populated when a model kwarg is explicitly passed (per
+`AbstractClient`/`OpenAIBaseClient` — the default is resolved lazily via
+`default_model`/`_resolve_model` at call time, never stamped onto `.model`
+at construction). Rewrote the assertion to check `client.default_model`
+instead, matching `MoonshotClient`'s own factory tests
+(`test_factory_create_moonshot`), which never assert `.model` for a
+no-argument `LLMFactory.create()`.
+**Deviations from spec**: test-path correction (see TASK-2833/2834); the
+`test_create_with_default_model` assertion described above.

--- a/sdd/tasks/completed/TASK-2836-responses-api-path.md
+++ b/sdd/tasks/completed/TASK-2836-responses-api-path.md
@@ -48,7 +48,23 @@ Some duplication is the accepted, reversible trade.
 | File | Action | Description |
 |---|---|---|
 | `packages/ai-parrot/src/parrot/clients/meta/client.py` | MODIFY | Responses path |
-| `packages/ai-parrot/tests/clients/test_meta_responses.py` | CREATE | Unit tests |
+| `tests/clients/test_meta_responses.py` | CREATE | Unit tests |
+
+> **Codebase Contract correction (same as TASK-2833/2834/2835)**: test
+> path corrected to the root `tests/clients/test_meta_responses.py`.
+>
+> **Additional correction discovered during implementation**: enrolling
+> `MetaClient` in `WIRE_SUBCLASSES` (TASK-2835) plus this task's
+> `use_responses=True` default meant the funnel-parity sweeps in
+> `tests/clients/test_openai_base_parity.py` and
+> `test_openai_compatible_defaults.py` started routing `MetaClient.ask()`
+> to the new Responses override instead of the mocked `_chat_completion` —
+> those sweeps exist to exercise the *Chat-Completions* funnel. Fixed by
+> adding a `MetaClient: {"use_responses": False}` case to each file's
+> `_parity_client_kwargs()`/`_client_kwargs()` helper (the established
+> mechanism those files already use for BedrockMantleClient/LocalLLM/vLLM
+> quirks) — both files were therefore also MODIFY, not just the two listed
+> above.
 
 ---
 
@@ -236,7 +252,37 @@ class TestMetaResponses:
 
 ## Completion Note
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
-**Notes**:
-**Deviations from spec**: none | describe if any
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-09-04
+**Notes**: Added `_fold_output()`, `_extract_tool_calls()`,
+`_prepare_responses_args()`, `_responses_completion()`, and `ask()`/
+`ask_stream()` overrides to `MetaClient`. `_responses_completion()` adapts
+the Responses result to a Chat-Completions-shaped
+`_ResponsesCompatResult`/`_Choice`/`_Message`/`_ToolCall` (mirroring
+`gpt.py`'s `_CompatResp`/`_Choice`/`_Msg` — structural reference only, no
+import/subclass), which lets `ask()` reuse the inherited generic
+`_run_tool_call_loop` unchanged for a full tool-calling round trip on the
+Responses path (verified in `test_tool_calling_round_trip`). `ask_stream()`
+streams text deltas via `client.responses.stream()` for the Responses path
+but — documented explicitly in its docstring — does NOT run a mid-stream
+tool-calling loop (use `ask()` for that); this is a deliberate, bounded
+simplification, not an oversight. `max_output_tokens` (not `max_tokens`)
+is used on the wire; `tool_choice` is always forced to `"auto"`. 16/16 new
+unit tests pass; the full `tests/clients/` suite shows zero regressions
+(the 12 pre-existing failures in Anthropic/Google fallback tests are
+reproducible identically on the pre-TASK-2836 commit — confirmed via
+`git stash`). `gpt.py`, `openai_base.py`, `base.py` are unmodified
+(`git diff --stat` empty for all three). `ruff` clean on all changed files.
+**Deviations from spec**: (1) test-path correction, same as prior tasks;
+(2) `MetaClient`'s `use_responses=True` default meant it began routing
+`ask()` away from `_chat_completion` inside the two shared funnel-parity
+test files (`test_openai_base_parity.py`, `test_openai_compatible_defaults.py`)
+once enrolled in `WIRE_SUBCLASSES` (TASK-2835) — fixed via a
+`MetaClient: {"use_responses": False}` case in each file's existing
+per-client kwargs helper, the same mechanism already used for
+BedrockMantleClient/LocalLLM/vLLM. Both files are therefore MODIFY for
+this task too, beyond the two originally listed. (3) `_run_tool_call_loop`
+is called without `initial_duration_ms`/`on_round` (both have safe
+defaults on the base) — telemetry round-events are not emitted for the
+Responses path; noted as a gap for a follow-up if observability parity
+with Chat Completions is later required.

--- a/sdd/tasks/completed/TASK-2837-search-grounding-token-counting.md
+++ b/sdd/tasks/completed/TASK-2837-search-grounding-token-counting.md
@@ -41,7 +41,10 @@ see constraint 3 below), `tool_search` (TASK-2840), live e2e (TASK-2838).
 | File | Action | Description |
 |---|---|---|
 | `packages/ai-parrot/src/parrot/clients/meta/client.py` | MODIFY | grounding + token counting |
-| `packages/ai-parrot/tests/clients/test_meta_grounding.py` | CREATE | Unit tests |
+| `tests/clients/test_meta_grounding.py` | CREATE | Unit tests |
+
+> **Codebase Contract correction (same as TASK-2833/2834/2835/2836)**: test
+> path corrected to the root `tests/clients/test_meta_grounding.py`.
 
 ---
 
@@ -173,7 +176,40 @@ class TestCountInputTokens:
 
 ## Completion Note
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
-**Notes**:
-**Deviations from spec**: none | describe if any
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-09-04
+**Notes**: Added `search_grounding: bool = False` kwarg to `ask()`,
+injecting `{"type": "web_search"}` into the Responses `tools` list (merged
+with any function-calling tools already prepared); raises `ValueError`
+when `search_grounding=True` and `use_responses=False`. Surfaces
+`web_search_call` output-item ids on `ai_message.metadata["web_search_calls"]`
++ `metadata["search_grounded"]` (only inspects the FINAL round's raw
+output — noted as a scoped limitation for multi-round tool-calling +
+grounding combos). Added `count_input_tokens()` calling
+`self.client.responses.input_tokens(model=..., input=..., **kwargs)` —
+standalone, works with `use_responses=False` too (never checks that flag).
+Added `_extract_cached_tokens()` static helper reading either
+`prompt_tokens_details.cached_tokens` (Chat Completions) or
+`input_tokens_details.cached_tokens` (Responses), applied to
+`ai_message.usage.extra_usage["cached_tokens"]` on the Responses path. No
+citation/annotation extraction implemented (explicit Non-Goal). 12/12 new
+unit tests pass; full `tests/clients/` suite: 555 passed (was 543
+pre-task — the 12 new tests), same 12 pre-existing unrelated failures.
+`gpt.py`/`openai_base.py`/`base.py` untouched. `ruff` clean.
+**Deviations from spec**: (1) test-path correction, same as prior tasks.
+(2) **`cached_tokens` surfacing is Responses-path only.** The AC says
+"surfaced from both usage shapes" — `_extract_cached_tokens()` itself
+correctly reads either shape (unit-tested against both), but wiring it
+into the Chat-Completions `ask()` path (`use_responses=False`) is not
+possible without either (a) modifying `CompletionUsage.from_openai()` in
+`parrot/models/basic.py` (not listed in this task's file scope — only
+`client.py` is) or (b) re-implementing the entire inherited
+Chat-Completions `ask()` body just to intercept its usage construction
+(directly contradicts TASK-2834's "do NOT override `_chat_completion()`"
+guidance and this task's own "NOT in scope" list). Flagging this as a
+genuine spec/file-scope tension rather than silently doing a partial job:
+when `use_responses=False`, `ask()` fully delegates to
+`super().ask(...)`, so no cached-token surfacing occurs on that path
+today. A follow-up task should decide whether to extend
+`CompletionUsage.from_openai()` (benefits every OpenAI-wire client, not
+just Meta) or accept a `MetaClient`-local `_chat_completion` override.

--- a/sdd/tasks/completed/TASK-2838-live-e2e-suite.md
+++ b/sdd/tasks/completed/TASK-2838-live-e2e-suite.md
@@ -47,7 +47,29 @@ the owning task, do not weaken the test.
 
 > Note: an untracked `tests/e2e/` directory already exists in the working tree
 > from unrelated work. Add this file to it; do not restructure the directory or
-> touch anything already there.
+> touch anything already there. (In practice this worktree's `tests/e2e/` did
+> not exist yet — worktrees only inherit tracked files — so this task creates
+> the directory fresh; nothing pre-existing was touched.)
+
+> **File-scope expansion (per this task's own "fix the defect in the owning
+> task, do not weaken the test" instruction)**: running the live suite with
+> real credentials surfaced two genuine wire-shape defects in TASK-2836's
+> `_prepare_responses_args()` (owning task, already completed) that no
+> mocked unit test had caught:
+> 1. Tool *definitions* were forwarded in the Chat-Completions-nested shape
+>    (`{"type":"function","function":{...}}`) — Responses live 400s with
+>    `'tools[0]' missing required field 'name'`; it needs the flat shape.
+> 2. Tool-call *round trips* were represented as invented
+>    `tool_output`/`tool_call` content blocks (mirroring `gpt.py`'s
+>    structural pattern) — Responses live 400s with `'input[N].content' did
+>    not match any supported type`; the real shape is top-level
+>    `function_call`/`function_call_output` items.
+>
+> Both are fixed in `packages/ai-parrot/src/parrot/clients/meta/client.py`
+> (added `_to_responses_tool()`; rewrote the tool-call branches of
+> `_prepare_responses_args()`), with matching unit-test updates in
+> `tests/clients/test_meta_responses.py`. Both files are therefore also
+> MODIFY for this task, beyond the one originally listed.
 
 ---
 
@@ -194,7 +216,43 @@ class TestMetaLive:
 
 ## Completion Note
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
-**Notes**:
-**Deviations from spec**: none | describe if any
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-09-04
+**Notes**: Created `tests/e2e/test_meta_live.py`, gated on `META_API_KEY`
+(present in this environment), marked `@pytest.mark.live`. Ran the full
+suite live against `muse-spark-1.3-contributor`: **7/7 passed** —
+non-empty visible text (F015 guard), full tool-calling round trip
+(Responses path), structured output (Chat Completions path — not yet
+supported on Responses, per `MetaClient.ask()`'s own docstring),
+Responses `status == "completed"`, search grounding surfacing
+`web_search_calls` metadata, `count_input_tokens()` returning a positive
+int, and `tool_choice="required"` raising `openai.BadRequestError`. All
+prompts synthetic. `ruff` clean.
+
+**Two genuine live-discovered defects fixed** (in TASK-2836's owning file,
+per this task's "fix the defect in the owning task" instruction — see the
+file-scope note above):
+1. `count_input_tokens()` called `self.client.responses.input_tokens(...)`
+   directly — that attribute is an SDK sub-resource
+   (`AsyncInputTokens`), not callable; the real method is `.count(...)`.
+2. `_prepare_responses_args()` sent tool *definitions* in the
+   Chat-Completions-nested shape and tool-call *round trips* as invented
+   `tool_output`/`tool_call` content blocks (both mirrored from `gpt.py`'s
+   structural reference, which turned out not to match Meta's actual
+   Responses wire shape for either case). Both 400s live; fixed with a new
+   `_to_responses_tool()` flattening helper and top-level
+   `function_call`/`function_call_output` input items respectively.
+   Corresponding unit tests updated/added in `test_meta_responses.py` and
+   `test_meta_grounding.py` (mock-shape fix for `.count`).
+
+**Deviations from spec**: (1) `LLMFactory.create(E2E_MODEL).model` is not
+literally `result.content` as the task's illustrative test snippet
+showed — the real `AIMessage` field is `.output` (per
+`AIMessageFactory.from_openai`); tests use `.output`. (2) The
+`test_live_tool_choice_required_raises` snippet showed `ask(...,
+tool_choice="required")`, but `ask()` never exposes a raw `tool_choice`
+override (the base always forces `"auto"` when tools are prepared) — the
+test instead calls `client._chat_completion(...)` directly with an
+explicit `tool_choice="required"` override, which is the only way to
+actually put that value on the wire. (3) File scope expanded beyond the
+single listed file — see the note added to this task file above.

--- a/sdd/tasks/completed/TASK-2839-smoke-script-and-docs.md
+++ b/sdd/tasks/completed/TASK-2839-smoke-script-and-docs.md
@@ -121,6 +121,11 @@ ensure the compiled `.so` files exist before trusting results.
 
 ## Acceptance Criteria
 
+> **Correction discovered during implementation**: the "ask" leg CANNOT
+> report PASS for Muse Spark — see the Completion Note. Verified live on
+> both wire protocols; not a `MetaClient` defect, and out of scope to fix
+> (would require editing the shared `_runner.py`).
+
 - [ ] `python examples/clients/smoke/smoke_meta.py` exits 0 with `SKIPPED`
       when `META_API_KEY` is unset.
 - [ ] With credentials, all three legs report `PASS`.
@@ -154,7 +159,50 @@ env -u META_API_KEY python examples/clients/smoke/smoke_meta.py   # -> SKIPPED, 
 
 ## Completion Note
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
-**Notes**:
-**Deviations from spec**: none | describe if any
+**Completed by**: sdd-worker (Claude)
+**Date**: 2026-09-04
+**Notes**: Created `examples/clients/smoke/smoke_meta.py` using the exact
+`main_for(...)` one-liner pattern (no bespoke runner logic), and
+`docs/clients/meta.md` covering all 7 required points plus the worktree
+gotcha. `ruff` clean.
+
+Ran the smoke script live with credentials:
+```
+[meta:muse-spark-1.3-contributor] ask        FAIL — AssertionError: ask() returned an empty response
+[meta:muse-spark-1.3-contributor] ask+tool   PASS
+[meta:muse-spark-1.3-contributor] invoke     PASS
+```
+
+**Deviations from spec**: **The "ask" leg cannot pass for Muse Spark, on
+either wire protocol.** `_runner.py`'s shared `_ask_plain()` leg hardcodes
+`max_tokens=64` (by design, shared across every provider's smoke script;
+this task's scope explicitly forbids editing `_runner.py`). Verified live
+during implementation that Muse Spark exhausts a 64-token budget on hidden
+reasoning before emitting any visible text on **both** paths:
+- Responses: `ask()` returns empty `.output` (no exception).
+- Chat Completions: raises `openai.LengthFinishReasonError` — reasoning
+  tokens: 61/64.
+
+This is the live, first-hand reproduction of the exact F015 finding this
+whole feature was built around (`docs/clients/meta.md`'s reasoning-budget
+gotcha section exists specifically because of it) — not a `MetaClient`
+defect, and not fixable without either editing the shared harness (out of
+scope) or the model simply not being viable for a 64-token smoke check.
+Documented prominently in `docs/clients/meta.md` (§ Smoke Script and Live
+Tests) so nobody mistakes the "ask" FAIL for a regression. `ask+tool` and
+`invoke` legs pass because they either allow a tool round trip (which
+apparently better anchors the model into non-reasoning-dominant output for
+this task's prompt) or use a below-the-radar simple reply. `AC17`
+("all three legs PASS") is therefore not achievable as written for this
+provider; a follow-up could add a `min_max_tokens` override parameter to
+`run_smoke()`/`main_for()` in `_runner.py` for reasoning-heavy providers,
+but that is a shared-file change outside this task's scope.
+
+Also verified: could not empirically confirm the `SKIPPED` exit-0 path
+locally, because `META_API_KEY` is defined in the main repo's `env/.env`
+and loaded by `navconfig` independent of shell-level `env -u` removal —
+the same limitation would apply to every existing sibling smoke script
+using a key also present in `env/.env` (e.g. `OPENROUTER_API_KEY`). The
+`check_env_vars()`/`main_for()` code path itself is unchanged from the
+already-proven pattern used by 8 other smoke scripts, so this is a
+test-environment limitation, not a code-correctness concern.

--- a/sdd/tasks/index/meta-llm-client.json
+++ b/sdd/tasks/index/meta-llm-client.json
@@ -133,7 +133,7 @@
       "feature_id": "FEAT-526",
       "feature": "meta-llm-client",
       "spec": "sdd/specs/meta-llm-client.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "S",
       "depends_on": [
@@ -143,8 +143,8 @@
       "parallelism_notes": "Creates two new files (smoke script, doc page) touched by nothing else - CAN run beside TASK-2838.",
       "assigned_to": null,
       "started_at": "2026-09-04T14:09:37+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2839-smoke-script-and-docs.md"
+      "completed_at": "2026-09-04T14:53:07+00:00",
+      "file": "sdd/tasks/completed/TASK-2839-smoke-script-and-docs.md"
     },
     {
       "id": "TASK-2840",

--- a/sdd/tasks/index/meta-llm-client.json
+++ b/sdd/tasks/index/meta-llm-client.json
@@ -14,7 +14,7 @@
       "feature_id": "FEAT-526",
       "feature": "meta-llm-client",
       "spec": "sdd/specs/meta-llm-client.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "S",
       "depends_on": [],
@@ -22,8 +22,8 @@
       "parallelism_notes": "Creates the parrot/clients/meta/ package (__init__.py + models.py) per the FEAT-523 folder convention; shares no files with any other task. Root of the dependency graph.",
       "assigned_to": null,
       "started_at": "2026-09-04T14:09:37+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2833-meta-model-catalog.md"
+      "completed_at": "2026-09-04T14:13:26+00:00",
+      "file": "sdd/tasks/completed/TASK-2833-meta-model-catalog.md"
     },
     {
       "id": "TASK-2834",

--- a/sdd/tasks/index/meta-llm-client.json
+++ b/sdd/tasks/index/meta-llm-client.json
@@ -72,7 +72,7 @@
       "feature_id": "FEAT-526",
       "feature": "meta-llm-client",
       "spec": "sdd/specs/meta-llm-client.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "depends_on": [
@@ -82,8 +82,8 @@
       "parallelism_notes": "Edits clients/meta/client.py, same file as TASK-2834/2837/2840. The main engineering task (D1).",
       "assigned_to": null,
       "started_at": "2026-09-04T14:09:37+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2836-responses-api-path.md"
+      "completed_at": "2026-09-04T14:31:55+00:00",
+      "file": "sdd/tasks/completed/TASK-2836-responses-api-path.md"
     },
     {
       "id": "TASK-2837",

--- a/sdd/tasks/index/meta-llm-client.json
+++ b/sdd/tasks/index/meta-llm-client.json
@@ -52,7 +52,7 @@
       "feature_id": "FEAT-526",
       "feature": "meta-llm-client",
       "spec": "sdd/specs/meta-llm-client.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "S",
       "depends_on": [
@@ -62,8 +62,8 @@
       "parallelism_notes": "Touches factory.py and two roster files only - disjoint from clients/meta/client.py, so it CAN run beside TASK-2836 in a separate worktree.",
       "assigned_to": null,
       "started_at": "2026-09-04T14:09:37+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2835-factory-registration-and-rosters.md"
+      "completed_at": "2026-09-04T14:19:35+00:00",
+      "file": "sdd/tasks/completed/TASK-2835-factory-registration-and-rosters.md"
     },
     {
       "id": "TASK-2836",

--- a/sdd/tasks/index/meta-llm-client.json
+++ b/sdd/tasks/index/meta-llm-client.json
@@ -32,7 +32,7 @@
       "feature_id": "FEAT-526",
       "feature": "meta-llm-client",
       "spec": "sdd/specs/meta-llm-client.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -42,8 +42,8 @@
       "parallelism_notes": "Creates clients/meta/client.py, which TASK-2836/2837/2840 all then edit. Must land first.",
       "assigned_to": null,
       "started_at": "2026-09-04T14:09:37+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2834-metaclient-chat-completions.md"
+      "completed_at": "2026-09-04T14:16:23+00:00",
+      "file": "sdd/tasks/completed/TASK-2834-metaclient-chat-completions.md"
     },
     {
       "id": "TASK-2835",

--- a/sdd/tasks/index/meta-llm-client.json
+++ b/sdd/tasks/index/meta-llm-client.json
@@ -92,7 +92,7 @@
       "feature_id": "FEAT-526",
       "feature": "meta-llm-client",
       "spec": "sdd/specs/meta-llm-client.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -102,8 +102,8 @@
       "parallelism_notes": "Edits clients/meta/client.py and builds directly on the Responses path from TASK-2836.",
       "assigned_to": null,
       "started_at": "2026-09-04T14:09:37+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2837-search-grounding-token-counting.md"
+      "completed_at": "2026-09-04T14:36:39+00:00",
+      "file": "sdd/tasks/completed/TASK-2837-search-grounding-token-counting.md"
     },
     {
       "id": "TASK-2838",

--- a/sdd/tasks/index/meta-llm-client.json
+++ b/sdd/tasks/index/meta-llm-client.json
@@ -23,7 +23,8 @@
       "assigned_to": null,
       "started_at": "2026-09-04T14:09:37+00:00",
       "completed_at": "2026-09-04T14:13:26+00:00",
-      "file": "sdd/tasks/completed/TASK-2833-meta-model-catalog.md"
+      "file": "sdd/tasks/completed/TASK-2833-meta-model-catalog.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2834",
@@ -43,7 +44,8 @@
       "assigned_to": null,
       "started_at": "2026-09-04T14:09:37+00:00",
       "completed_at": "2026-09-04T14:16:23+00:00",
-      "file": "sdd/tasks/completed/TASK-2834-metaclient-chat-completions.md"
+      "file": "sdd/tasks/completed/TASK-2834-metaclient-chat-completions.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2835",
@@ -63,7 +65,8 @@
       "assigned_to": null,
       "started_at": "2026-09-04T14:09:37+00:00",
       "completed_at": "2026-09-04T14:19:35+00:00",
-      "file": "sdd/tasks/completed/TASK-2835-factory-registration-and-rosters.md"
+      "file": "sdd/tasks/completed/TASK-2835-factory-registration-and-rosters.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2836",
@@ -83,7 +86,8 @@
       "assigned_to": null,
       "started_at": "2026-09-04T14:09:37+00:00",
       "completed_at": "2026-09-04T14:31:55+00:00",
-      "file": "sdd/tasks/completed/TASK-2836-responses-api-path.md"
+      "file": "sdd/tasks/completed/TASK-2836-responses-api-path.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2837",
@@ -103,7 +107,8 @@
       "assigned_to": null,
       "started_at": "2026-09-04T14:09:37+00:00",
       "completed_at": "2026-09-04T14:36:39+00:00",
-      "file": "sdd/tasks/completed/TASK-2837-search-grounding-token-counting.md"
+      "file": "sdd/tasks/completed/TASK-2837-search-grounding-token-counting.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2838",
@@ -124,7 +129,8 @@
       "assigned_to": null,
       "started_at": "2026-09-04T14:09:37+00:00",
       "completed_at": "2026-09-04T14:49:08+00:00",
-      "file": "sdd/tasks/completed/TASK-2838-live-e2e-suite.md"
+      "file": "sdd/tasks/completed/TASK-2838-live-e2e-suite.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2839",
@@ -144,7 +150,8 @@
       "assigned_to": null,
       "started_at": "2026-09-04T14:09:37+00:00",
       "completed_at": "2026-09-04T14:53:07+00:00",
-      "file": "sdd/tasks/completed/TASK-2839-smoke-script-and-docs.md"
+      "file": "sdd/tasks/completed/TASK-2839-smoke-script-and-docs.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2840",
@@ -153,7 +160,7 @@
       "feature_id": "FEAT-526",
       "feature": "meta-llm-client",
       "spec": "sdd/specs/meta-llm-client.spec.md",
-      "status": "in-progress",
+      "status": "pending",
       "priority": "low",
       "effort": "M",
       "depends_on": [
@@ -162,7 +169,7 @@
       "parallel": false,
       "parallelism_notes": "Edits clients/meta/client.py. D2: last and explicitly droppable - nothing depends on it; intended cut if the phase runs long.",
       "assigned_to": null,
-      "started_at": "2026-09-04T14:09:37+00:00",
+      "started_at": null,
       "completed_at": null,
       "file": "sdd/tasks/active/TASK-2840-tool-search-mapping.md"
     }

--- a/sdd/tasks/index/meta-llm-client.json
+++ b/sdd/tasks/index/meta-llm-client.json
@@ -112,7 +112,7 @@
       "feature_id": "FEAT-526",
       "feature": "meta-llm-client",
       "spec": "sdd/specs/meta-llm-client.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -123,8 +123,8 @@
       "parallelism_notes": "Needs factory registration AND the full capability surface before it can exercise them live.",
       "assigned_to": null,
       "started_at": "2026-09-04T14:09:37+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2838-live-e2e-suite.md"
+      "completed_at": "2026-09-04T14:49:08+00:00",
+      "file": "sdd/tasks/completed/TASK-2838-live-e2e-suite.md"
     },
     {
       "id": "TASK-2839",

--- a/tests/clients/test_meta_client.py
+++ b/tests/clients/test_meta_client.py
@@ -1,0 +1,123 @@
+"""Unit tests for MetaClient (Chat Completions path, credential chain).
+
+No live Meta API calls are made.
+"""
+from pathlib import Path
+
+import pytest
+
+from parrot.clients.meta import CONTRIBUTOR_MODELS, MetaClient, MetaModel
+from parrot.clients.gpt import OpenAIClient
+from parrot.clients.openai_base import OpenAIBaseClient
+
+
+class TestMetaClient:
+    def test_subclasses_openai_base_not_openai_client(self):
+        assert issubclass(MetaClient, OpenAIBaseClient)
+        assert not issubclass(MetaClient, OpenAIClient)
+
+    def test_client_type_and_name(self):
+        assert MetaClient.client_type == "meta"
+        assert MetaClient.client_name == "meta"
+
+    def test_default_model_is_standard_tier(self):
+        assert MetaClient._default_model == "muse-spark-1.3"
+        assert MetaClient._default_model not in CONTRIBUTOR_MODELS
+
+    def test_default_timeout_is_raised(self):
+        assert MetaClient._default_timeout == 120.0
+
+    def test_no_gpt_leak_in_model_attrs(self):
+        for attr in ("_default_model", "_fallback_model", "_lightweight_model"):
+            val = getattr(MetaClient, attr, None)
+            assert val is None or not str(val).startswith("gpt-")
+
+    def test_feat523_discovery_attrs(self):
+        assert MetaClient.provider_keys == ("meta", "muse", "meta-muse")
+        assert MetaClient.models is MetaModel
+
+    def test_package_layout_is_exactly_three_files(self):
+        import parrot.clients.meta as pkg
+        names = {p.name for p in Path(pkg.__file__).parent.glob("*.py")}
+        assert names == {"__init__.py", "client.py", "models.py"}
+
+    def test_base_url(self):
+        assert MetaClient(api_key="k").base_url == "https://api.meta.ai/v1"
+
+    def test_explicit_key_wins(self):
+        assert MetaClient(api_key="explicit").api_key == "explicit"
+
+    def test_prefers_meta_api_key(self, monkeypatch):
+        monkeypatch.setattr(
+            "parrot.clients.meta.config.get",
+            lambda k, *a: {
+                "META_API_KEY": "meta-key",
+                "MODEL_API_KEY": "model-key",
+            }.get(k),
+        )
+        assert MetaClient().api_key == "meta-key"
+
+    def test_falls_back_to_model_api_key(self, monkeypatch):
+        monkeypatch.setattr(
+            "parrot.clients.meta.config.get",
+            lambda k, *a: {"MODEL_API_KEY": "model-key"}.get(k),
+        )
+        assert MetaClient().api_key == "model-key"
+
+    def test_never_falls_back_to_openai_api_key(self, monkeypatch):
+        """Regression: an sk-... key must never be shipped to Meta."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-should-never-be-used")
+        monkeypatch.setattr("parrot.clients.meta.config.get", lambda k, *a: None)
+        assert MetaClient().api_key != "sk-should-never-be-used"
+
+    def test_not_exported_from_clients_init(self):
+        import parrot.clients as clients_pkg
+        assert not hasattr(clients_pkg, "MetaClient")
+
+    @pytest.mark.asyncio
+    async def test_get_client_returns_async_openai(self, monkeypatch):
+        monkeypatch.setattr("parrot.clients.meta.config.get", lambda k, *a: None)
+        client = MetaClient(api_key="k")
+        sdk_client = await client.get_client()
+        from openai import AsyncOpenAI
+        assert isinstance(sdk_client, AsyncOpenAI)
+        assert str(sdk_client.base_url) == "https://api.meta.ai/v1/"
+
+    @pytest.mark.asyncio
+    async def test_list_models_hits_v1_models_endpoint(self, monkeypatch):
+        captured = {}
+
+        class FakeResponse:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            def raise_for_status(self):
+                pass
+
+            async def json(self):
+                return {"data": [{"id": "muse-spark-1.3"}]}
+
+        class FakeSession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            def get(self, url, headers=None):
+                captured["url"] = url
+                captured["headers"] = headers
+                return FakeResponse()
+
+        import parrot.clients.meta.client as client_mod
+        monkeypatch.setattr(client_mod.aiohttp, "ClientSession", FakeSession)
+
+        client = MetaClient(api_key="k")
+        result = await client.list_models()
+
+        assert result == [{"id": "muse-spark-1.3"}]
+        assert captured["url"] == "https://api.meta.ai/v1/models"
+        assert captured["headers"]["Authorization"] == "Bearer k"

--- a/tests/clients/test_meta_client.py
+++ b/tests/clients/test_meta_client.py
@@ -2,6 +2,7 @@
 
 No live Meta API calls are made.
 """
+
 from pathlib import Path
 
 import pytest
@@ -39,6 +40,7 @@ class TestMetaClient:
 
     def test_package_layout_is_exactly_three_files(self):
         import parrot.clients.meta as pkg
+
         names = {p.name for p in Path(pkg.__file__).parent.glob("*.py")}
         assert names == {"__init__.py", "client.py", "models.py"}
 
@@ -73,6 +75,7 @@ class TestMetaClient:
 
     def test_not_exported_from_clients_init(self):
         import parrot.clients as clients_pkg
+
         assert not hasattr(clients_pkg, "MetaClient")
 
     @pytest.mark.asyncio
@@ -81,6 +84,7 @@ class TestMetaClient:
         client = MetaClient(api_key="k")
         sdk_client = await client.get_client()
         from openai import AsyncOpenAI
+
         assert isinstance(sdk_client, AsyncOpenAI)
         assert str(sdk_client.base_url) == "https://api.meta.ai/v1/"
 
@@ -114,6 +118,7 @@ class TestMetaClient:
                 return FakeResponse()
 
         import parrot.clients.meta.client as client_mod
+
         monkeypatch.setattr(client_mod.aiohttp, "ClientSession", FakeSession)
 
         client = MetaClient(api_key="k")
@@ -150,4 +155,5 @@ class TestMetaFactoryRegistration:
     def test_in_both_wire_rosters(self):
         from tests.clients.test_openai_compatible_defaults import WIRE_SUBCLASSES as A
         from tests.clients.test_openai_base_parity import WIRE_SUBCLASSES as B
+
         assert MetaClient in A and MetaClient in B

--- a/tests/clients/test_meta_client.py
+++ b/tests/clients/test_meta_client.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from parrot.clients.meta import CONTRIBUTOR_MODELS, MetaClient, MetaModel
+from parrot.clients.factory import LLMFactory, SUPPORTED_CLIENTS
 from parrot.clients.gpt import OpenAIClient
 from parrot.clients.openai_base import OpenAIBaseClient
 
@@ -121,3 +122,32 @@ class TestMetaClient:
         assert result == [{"id": "muse-spark-1.3"}]
         assert captured["url"] == "https://api.meta.ai/v1/models"
         assert captured["headers"]["Authorization"] == "Bearer k"
+
+
+class TestMetaFactoryRegistration:
+    @pytest.mark.parametrize("alias", ["meta", "muse", "meta-muse"])
+    def test_aliases_resolve(self, alias):
+        assert SUPPORTED_CLIENTS[alias] is MetaClient
+
+    def test_create_with_explicit_model(self):
+        client = LLMFactory.create("meta:muse-spark-1.3")
+        assert isinstance(client, MetaClient)
+        assert client.model == "muse-spark-1.3"
+
+    def test_create_with_default_model(self):
+        client = LLMFactory.create("meta")
+        assert isinstance(client, MetaClient)
+        # No explicit model was passed; the client falls back to its class
+        # default at resolution time (see AbstractClient.default_model /
+        # OpenAIBaseClient._resolve_model) rather than stamping `.model` at
+        # construction — same convention as MoonshotClient's factory tests.
+        assert client.default_model == "muse-spark-1.3"
+
+    def test_registered_keys_match_provider_keys(self):
+        keys = {k for k, v in SUPPORTED_CLIENTS.items() if v is MetaClient}
+        assert keys == set(MetaClient.provider_keys)
+
+    def test_in_both_wire_rosters(self):
+        from tests.clients.test_openai_compatible_defaults import WIRE_SUBCLASSES as A
+        from tests.clients.test_openai_base_parity import WIRE_SUBCLASSES as B
+        assert MetaClient in A and MetaClient in B

--- a/tests/clients/test_meta_grounding.py
+++ b/tests/clients/test_meta_grounding.py
@@ -1,0 +1,156 @@
+"""Unit tests for MetaClient search grounding and count_input_tokens().
+
+No live Meta API calls are made.
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from parrot.clients.meta import MetaClient
+
+GROUNDED = {
+    "status": "completed",
+    "output_text": None,
+    "output": [
+        {"type": "reasoning", "content": []},
+        {"type": "web_search_call", "id": "ws_1"},
+        {
+            "type": "message",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": "Spain won 2026 World Cup",
+                    "annotations": [],
+                }
+            ],
+        },
+    ],
+    "usage": MagicMock(
+        input_tokens=169,
+        input_tokens_details={"cached_tokens": 12},
+        output_tokens=50,
+        prompt_tokens_details=None,
+    ),
+}
+
+
+def _sdk_with_grounded_response():
+    sdk = MagicMock()
+    sdk.responses.create = AsyncMock(return_value=MagicMock(**GROUNDED))
+    return sdk
+
+
+class TestSearchGrounding:
+    @pytest.mark.asyncio
+    async def test_injects_web_search_tool(self, monkeypatch):
+        client = MetaClient(api_key="k", use_responses=True)
+        sdk = _sdk_with_grounded_response()
+        monkeypatch.setattr(client, "get_client", AsyncMock(return_value=sdk))
+
+        await client.ask("Who won the 2026 World Cup?", search_grounding=True)
+
+        _, kwargs = sdk.responses.create.call_args
+        assert {"type": "web_search"} in kwargs["tools"]
+
+    @pytest.mark.asyncio
+    async def test_defaults_to_off(self, monkeypatch):
+        client = MetaClient(api_key="k", use_responses=True)
+        sdk = _sdk_with_grounded_response()
+        monkeypatch.setattr(client, "get_client", AsyncMock(return_value=sdk))
+
+        await client.ask("hi")
+
+        _, kwargs = sdk.responses.create.call_args
+        assert "tools" not in kwargs or {"type": "web_search"} not in (kwargs.get("tools") or [])
+
+    @pytest.mark.asyncio
+    async def test_raises_when_responses_disabled(self):
+        client = MetaClient(api_key="k", use_responses=False)
+        with pytest.raises(ValueError, match="[Rr]esponses"):
+            await client.ask("q", search_grounding=True)
+
+    @pytest.mark.asyncio
+    async def test_surfaces_web_search_call(self, monkeypatch):
+        client = MetaClient(api_key="k", use_responses=True)
+        sdk = _sdk_with_grounded_response()
+        monkeypatch.setattr(client, "get_client", AsyncMock(return_value=sdk))
+
+        result = await client.ask("Who won?", search_grounding=True)
+
+        assert result.metadata["web_search_calls"] == ["ws_1"]
+        assert result.metadata["search_grounded"] is True
+        assert result.output == "Spain won 2026 World Cup"
+
+    @pytest.mark.asyncio
+    async def test_no_grounding_means_no_web_search_metadata(self, monkeypatch):
+        client = MetaClient(api_key="k", use_responses=True)
+        sdk = MagicMock()
+        sdk.responses.create = AsyncMock(
+            return_value=MagicMock(
+                status="completed",
+                output_text=None,
+                output=[{"type": "message", "content": [{"type": "output_text", "text": "hi"}]}],
+                usage=None,
+            )
+        )
+        monkeypatch.setattr(client, "get_client", AsyncMock(return_value=sdk))
+
+        result = await client.ask("hi")
+
+        assert "web_search_calls" not in result.metadata
+        assert "search_grounded" not in result.metadata
+
+
+class TestCachedTokens:
+    def test_extracts_from_responses_shape(self):
+        usage = MagicMock(input_tokens_details={"cached_tokens": 12})
+        del usage.prompt_tokens_details
+        assert MetaClient._extract_cached_tokens(usage) == 12
+
+    def test_extracts_from_chat_completions_shape(self):
+        usage = MagicMock(prompt_tokens_details={"cached_tokens": 7})
+        assert MetaClient._extract_cached_tokens(usage) == 7
+
+    def test_returns_none_when_absent(self):
+        assert MetaClient._extract_cached_tokens(None) is None
+
+    @pytest.mark.asyncio
+    async def test_surfaced_on_ai_message_usage(self, monkeypatch):
+        client = MetaClient(api_key="k", use_responses=True)
+        sdk = _sdk_with_grounded_response()
+        monkeypatch.setattr(client, "get_client", AsyncMock(return_value=sdk))
+
+        result = await client.ask("Who won?")
+
+        assert result.usage.extra_usage["cached_tokens"] == 12
+
+
+class TestCountInputTokens:
+    @pytest.mark.asyncio
+    async def test_returns_positive_int(self, monkeypatch):
+        client = MetaClient(api_key="k")
+        sdk = MagicMock()
+        sdk.responses.input_tokens = AsyncMock(return_value=MagicMock(input_tokens=169))
+        monkeypatch.setattr(client, "get_client", AsyncMock(return_value=sdk))
+        assert await client.count_input_tokens(input="Count these.") == 169
+
+    @pytest.mark.asyncio
+    async def test_works_with_responses_disabled(self, monkeypatch):
+        client = MetaClient(api_key="k", use_responses=False)
+        sdk = MagicMock()
+        sdk.responses.input_tokens = AsyncMock(return_value=MagicMock(input_tokens=42))
+        monkeypatch.setattr(client, "get_client", AsyncMock(return_value=sdk))
+        assert await client.count_input_tokens(input="Count these too.") == 42
+
+    @pytest.mark.asyncio
+    async def test_passes_resolved_model_and_input(self, monkeypatch):
+        client = MetaClient(api_key="k")
+        sdk = MagicMock()
+        sdk.responses.input_tokens = AsyncMock(return_value=MagicMock(input_tokens=5))
+        monkeypatch.setattr(client, "get_client", AsyncMock(return_value=sdk))
+
+        await client.count_input_tokens(input="hi")
+
+        _, kwargs = sdk.responses.input_tokens.call_args
+        assert kwargs["model"] == "muse-spark-1.3"
+        assert kwargs["input"] == "hi"

--- a/tests/clients/test_meta_grounding.py
+++ b/tests/clients/test_meta_grounding.py
@@ -130,7 +130,7 @@ class TestCountInputTokens:
     async def test_returns_positive_int(self, monkeypatch):
         client = MetaClient(api_key="k")
         sdk = MagicMock()
-        sdk.responses.input_tokens = AsyncMock(return_value=MagicMock(input_tokens=169))
+        sdk.responses.input_tokens.count = AsyncMock(return_value=MagicMock(input_tokens=169))
         monkeypatch.setattr(client, "get_client", AsyncMock(return_value=sdk))
         assert await client.count_input_tokens(input="Count these.") == 169
 
@@ -138,7 +138,7 @@ class TestCountInputTokens:
     async def test_works_with_responses_disabled(self, monkeypatch):
         client = MetaClient(api_key="k", use_responses=False)
         sdk = MagicMock()
-        sdk.responses.input_tokens = AsyncMock(return_value=MagicMock(input_tokens=42))
+        sdk.responses.input_tokens.count = AsyncMock(return_value=MagicMock(input_tokens=42))
         monkeypatch.setattr(client, "get_client", AsyncMock(return_value=sdk))
         assert await client.count_input_tokens(input="Count these too.") == 42
 
@@ -146,11 +146,11 @@ class TestCountInputTokens:
     async def test_passes_resolved_model_and_input(self, monkeypatch):
         client = MetaClient(api_key="k")
         sdk = MagicMock()
-        sdk.responses.input_tokens = AsyncMock(return_value=MagicMock(input_tokens=5))
+        sdk.responses.input_tokens.count = AsyncMock(return_value=MagicMock(input_tokens=5))
         monkeypatch.setattr(client, "get_client", AsyncMock(return_value=sdk))
 
         await client.count_input_tokens(input="hi")
 
-        _, kwargs = sdk.responses.input_tokens.call_args
+        _, kwargs = sdk.responses.input_tokens.count.call_args
         assert kwargs["model"] == "muse-spark-1.3"
         assert kwargs["input"] == "hi"

--- a/tests/clients/test_meta_grounding.py
+++ b/tests/clients/test_meta_grounding.py
@@ -2,6 +2,7 @@
 
 No live Meta API calls are made.
 """
+
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest

--- a/tests/clients/test_meta_models.py
+++ b/tests/clients/test_meta_models.py
@@ -3,6 +3,7 @@
 Pure data tests — no I/O, no network. Model ids were verified live
 against ``GET /v1/models`` on 2026-09-04 (FEAT-526 research finding F013).
 """
+
 import pytest
 
 from parrot.clients.meta import (
@@ -14,9 +15,13 @@ from parrot.clients.meta import (
 from parrot.clients.meta.models import MetaModel as MetaModelDirect
 
 LIVE_CATALOG = {
-    "muse-spark-1.3", "muse-spark-1.3-contributor",
-    "muse-spark-1.2", "muse-spark-1.2-contributor",
-    "muse-spark-1.1", "muse-image-1.0", "muse-voice-transcribe-1.0",
+    "muse-spark-1.3",
+    "muse-spark-1.3-contributor",
+    "muse-spark-1.2",
+    "muse-spark-1.2-contributor",
+    "muse-spark-1.1",
+    "muse-image-1.0",
+    "muse-voice-transcribe-1.0",
 }
 
 
@@ -32,13 +37,16 @@ class TestMetaModel:
 
     def test_contributor_frozenset(self):
         assert CONTRIBUTOR_MODELS == {
-            "muse-spark-1.3-contributor", "muse-spark-1.2-contributor",
+            "muse-spark-1.3-contributor",
+            "muse-spark-1.2-contributor",
         }
 
     def test_spark_models_frozenset(self):
         assert SPARK_MODELS == {
-            "muse-spark-1.3", "muse-spark-1.3-contributor",
-            "muse-spark-1.2", "muse-spark-1.2-contributor",
+            "muse-spark-1.3",
+            "muse-spark-1.3-contributor",
+            "muse-spark-1.2",
+            "muse-spark-1.2-contributor",
             "muse-spark-1.1",
         }
 

--- a/tests/clients/test_meta_models.py
+++ b/tests/clients/test_meta_models.py
@@ -1,0 +1,53 @@
+"""Unit tests for the Meta Model API catalog (parrot.clients.meta.models).
+
+Pure data tests — no I/O, no network. Model ids were verified live
+against ``GET /v1/models`` on 2026-09-04 (FEAT-526 research finding F013).
+"""
+import pytest
+
+from parrot.clients.meta import (
+    MetaModel,
+    CONTRIBUTOR_MODELS,
+    SPARK_MODELS,
+    CONTEXT_WINDOW,
+)
+from parrot.clients.meta.models import MetaModel as MetaModelDirect
+
+LIVE_CATALOG = {
+    "muse-spark-1.3", "muse-spark-1.3-contributor",
+    "muse-spark-1.2", "muse-spark-1.2-contributor",
+    "muse-spark-1.1", "muse-image-1.0", "muse-voice-transcribe-1.0",
+}
+
+
+class TestMetaModel:
+    def test_matches_live_catalog_exactly(self):
+        assert {m.value for m in MetaModel} == LIVE_CATALOG
+
+    def test_str_enum_interchanges_with_raw_string(self):
+        assert MetaModel.MUSE_SPARK_1_3 == "muse-spark-1.3"
+
+    def test_muse_spark_1_1_has_no_contributor_variant(self):
+        assert "muse-spark-1.1-contributor" not in {m.value for m in MetaModel}
+
+    def test_contributor_frozenset(self):
+        assert CONTRIBUTOR_MODELS == {
+            "muse-spark-1.3-contributor", "muse-spark-1.2-contributor",
+        }
+
+    def test_spark_models_frozenset(self):
+        assert SPARK_MODELS == {
+            "muse-spark-1.3", "muse-spark-1.3-contributor",
+            "muse-spark-1.2", "muse-spark-1.2-contributor",
+            "muse-spark-1.1",
+        }
+
+    def test_context_window(self):
+        assert CONTEXT_WINDOW == 1_048_576
+
+    def test_package_init_reexports(self):
+        assert MetaModelDirect is MetaModel
+
+    def test_no_enum_left_under_parrot_models(self):
+        with pytest.raises(ImportError):
+            __import__("parrot.models.meta")

--- a/tests/clients/test_meta_responses.py
+++ b/tests/clients/test_meta_responses.py
@@ -3,6 +3,7 @@
 No live Meta API calls are made — the SDK client is mocked via
 ``get_client()``.
 """
+
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -96,9 +97,7 @@ class TestPrepareResponsesArgs:
 
     def test_sends_max_output_tokens_not_max_tokens(self):
         client = MetaClient(api_key="k")
-        req = client._prepare_responses_args(
-            messages=[{"role": "user", "content": "hi"}], args={"max_tokens": 999}
-        )
+        req = client._prepare_responses_args(messages=[{"role": "user", "content": "hi"}], args={"max_tokens": 999})
         assert req["max_output_tokens"] == 999
         assert "max_tokens" not in req
 
@@ -132,12 +131,8 @@ class TestPrepareResponsesArgs:
                 "function": {"name": "f", "description": "d", "parameters": {"type": "object"}},
             }
         ]
-        req = client._prepare_responses_args(
-            messages=[{"role": "user", "content": "hi"}], args={"tools": tools}
-        )
-        assert req["tools"] == [
-            {"type": "function", "name": "f", "description": "d", "parameters": {"type": "object"}}
-        ]
+        req = client._prepare_responses_args(messages=[{"role": "user", "content": "hi"}], args={"tools": tools})
+        assert req["tools"] == [{"type": "function", "name": "f", "description": "d", "parameters": {"type": "object"}}]
 
     def test_forwards_already_flat_tools_unchanged(self):
         """Non-function tools (e.g. web_search) are already flat — passthrough."""
@@ -178,9 +173,7 @@ class TestPrepareResponsesArgs:
             },
         ]
         req = client._prepare_responses_args(messages=messages, args={})
-        assert req["input"] == [
-            {"type": "function_call", "call_id": "call_1", "name": "f", "arguments": "{}"}
-        ]
+        assert req["input"] == [{"type": "function_call", "call_id": "call_1", "name": "f", "arguments": "{}"}]
 
 
 class TestToResponsesTool:
@@ -276,9 +269,7 @@ class TestMetaResponsesRouting:
         round1.output_text = None
         round2 = MagicMock(
             status="completed",
-            output=[
-                {"type": "message", "content": [{"type": "output_text", "text": "It's sunny."}]}
-            ],
+            output=[{"type": "message", "content": [{"type": "output_text", "text": "It's sunny."}]}],
             usage=None,
         )
         round2.output_text = None

--- a/tests/clients/test_meta_responses.py
+++ b/tests/clients/test_meta_responses.py
@@ -1,0 +1,233 @@
+"""Unit tests for MetaClient's Responses API path (MetaClient-local, D1).
+
+No live Meta API calls are made — the SDK client is mocked via
+``get_client()``.
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from parrot.clients.meta import MetaClient
+
+LIVE_SHAPE = {  # captured shape from a real 200 response (spec §6)
+    "status": "completed",
+    "output": [
+        {"type": "reasoning", "content": []},
+        {"type": "message", "content": [{"type": "output_text", "text": "pong"}]},
+    ],
+    "usage": SimpleNamespace(
+        input_tokens=12,
+        output_tokens=153,
+        output_tokens_details={"reasoning_tokens": 142},
+    ),
+}
+
+
+def _sdk_with_response(**overrides):
+    """Build a MagicMock SDK client whose responses.create() returns a
+    MagicMock shaped like a live Responses API result.
+
+    ``output_text`` is pinned to ``None`` explicitly — real Responses JSON
+    has no such wire field (spec §6 "Does NOT Exist"); it is an
+    SDK-computed convenience property. A bare ``MagicMock`` auto-vivifies
+    any unset attribute access into a truthy child mock instead of
+    ``None``, which would silently defeat the ``_fold_output`` fallback
+    path this test suite exercises.
+    """
+    shape = {"output_text": None, **LIVE_SHAPE, **overrides}
+    sdk = MagicMock()
+    sdk.responses.create = AsyncMock(return_value=MagicMock(**shape))
+    return sdk
+
+
+class TestFoldOutput:
+    def test_fold_ignores_reasoning_items(self):
+        client = MetaClient(api_key="k")
+        assert client._fold_output(LIVE_SHAPE["output"]) == "pong"
+
+    def test_fold_concatenates_multiple_message_items(self):
+        client = MetaClient(api_key="k")
+        out = [
+            {"type": "message", "content": [{"type": "output_text", "text": "a"}]},
+            {"type": "message", "content": [{"type": "output_text", "text": "b"}]},
+        ]
+        assert client._fold_output(out) == "ab"
+
+    def test_fold_empty_output_returns_empty_string(self):
+        client = MetaClient(api_key="k")
+        assert client._fold_output([]) == ""
+        assert client._fold_output(None) == ""
+
+
+class TestExtractToolCalls:
+    def test_extracts_function_call_items(self):
+        client = MetaClient(api_key="k")
+        output = [
+            {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "get_weather",
+                "arguments": '{"city": "NYC"}',
+            }
+        ]
+        calls = client._extract_tool_calls(output)
+        assert len(calls) == 1
+        assert calls[0].id == "call_1"
+        assert calls[0].function.name == "get_weather"
+        assert calls[0].function.arguments == '{"city": "NYC"}'
+
+    def test_ignores_non_function_call_items(self):
+        client = MetaClient(api_key="k")
+        assert client._extract_tool_calls(LIVE_SHAPE["output"]) == []
+
+
+class TestPrepareResponsesArgs:
+    def test_lifts_system_message_into_instructions(self):
+        client = MetaClient(api_key="k")
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "hi"},
+        ]
+        req = client._prepare_responses_args(messages=messages, args={})
+        assert req["instructions"] == "You are helpful."
+        assert len(req["input"]) == 1
+        assert req["input"][0]["role"] == "user"
+
+    def test_sends_max_output_tokens_not_max_tokens(self):
+        client = MetaClient(api_key="k")
+        req = client._prepare_responses_args(
+            messages=[{"role": "user", "content": "hi"}], args={"max_tokens": 999}
+        )
+        assert req["max_output_tokens"] == 999
+        assert "max_tokens" not in req
+
+    def test_max_output_tokens_key_wins_over_max_tokens(self):
+        client = MetaClient(api_key="k")
+        req = client._prepare_responses_args(
+            messages=[{"role": "user", "content": "hi"}],
+            args={"max_tokens": 999, "max_output_tokens": 111},
+        )
+        assert req["max_output_tokens"] == 111
+
+    def test_tool_choice_always_forced_to_auto(self):
+        client = MetaClient(api_key="k")
+        req = client._prepare_responses_args(
+            messages=[{"role": "user", "content": "hi"}],
+            args={"tool_choice": "required"},
+        )
+        assert req["tool_choice"] == "auto"
+
+    def test_forwards_tools(self):
+        client = MetaClient(api_key="k")
+        tools = [{"type": "function", "function": {"name": "f"}}]
+        req = client._prepare_responses_args(
+            messages=[{"role": "user", "content": "hi"}], args={"tools": tools}
+        )
+        assert req["tools"] == tools
+
+    def test_tool_role_becomes_tool_output_block(self):
+        client = MetaClient(api_key="k")
+        messages = [
+            {"role": "tool", "tool_call_id": "call_1", "name": "f", "content": "42"},
+        ]
+        req = client._prepare_responses_args(messages=messages, args={})
+        block = req["input"][0]["content"][0]
+        assert block["type"] == "tool_output"
+        assert block["tool_call_id"] == "call_1"
+        assert block["output"] == "42"
+
+
+class TestMetaResponsesRouting:
+    @pytest.mark.asyncio
+    async def test_use_responses_true_calls_responses_create(self, monkeypatch):
+        client = MetaClient(api_key="k", use_responses=True)
+        sdk = _sdk_with_response()
+        monkeypatch.setattr(client, "get_client", AsyncMock(return_value=sdk))
+        await client.ask("ping")
+        sdk.responses.create.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_use_responses_false_uses_chat_funnel(self, monkeypatch):
+        client = MetaClient(api_key="k", use_responses=False)
+
+        class _FakeMessage:
+            content = "hi"
+            tool_calls = None
+
+        class _FakeChoice:
+            message = _FakeMessage()
+            finish_reason = "stop"
+            stop_reason = "stop"
+
+        class _FakeResponse:
+            choices = [_FakeChoice()]
+            usage = None
+
+            def model_dump(self):
+                return {"choices": [{"message": {"content": "hi"}}]}
+
+        funnel = AsyncMock(return_value=_FakeResponse())
+        monkeypatch.setattr(client, "_chat_completion", funnel)
+        await client.ask("ping")
+        funnel.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_ask_returns_folded_text(self, monkeypatch):
+        client = MetaClient(api_key="k", use_responses=True)
+        sdk = _sdk_with_response()
+        monkeypatch.setattr(client, "get_client", AsyncMock(return_value=sdk))
+        result = await client.ask("ping")
+        assert result.output == "pong"
+
+    @pytest.mark.asyncio
+    async def test_sends_max_output_tokens_on_the_wire(self, monkeypatch):
+        client = MetaClient(api_key="k", use_responses=True)
+        sdk = _sdk_with_response()
+        monkeypatch.setattr(client, "get_client", AsyncMock(return_value=sdk))
+        await client.ask("ping", max_tokens=321)
+        _, kwargs = sdk.responses.create.call_args
+        assert kwargs["max_output_tokens"] == 321
+        assert "max_tokens" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_tool_calling_round_trip(self, monkeypatch):
+        """A function_call in round 1 is executed and round 2 answers."""
+        client = MetaClient(api_key="k", use_responses=True)
+        sdk = MagicMock()
+        round1 = MagicMock(
+            status="completed",
+            output=[
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "get_weather",
+                    "arguments": '{"city": "NYC"}',
+                }
+            ],
+            usage=None,
+        )
+        round1.output_text = None
+        round2 = MagicMock(
+            status="completed",
+            output=[
+                {"type": "message", "content": [{"type": "output_text", "text": "It's sunny."}]}
+            ],
+            usage=None,
+        )
+        round2.output_text = None
+        sdk.responses.create = AsyncMock(side_effect=[round1, round2])
+        monkeypatch.setattr(client, "get_client", AsyncMock(return_value=sdk))
+
+        async def fake_execute_tool(name, args):
+            assert name == "get_weather"
+            return "sunny"
+
+        monkeypatch.setattr(client, "_execute_tool", fake_execute_tool)
+
+        result = await client.ask("What's the weather in NYC?")
+
+        assert sdk.responses.create.await_count == 2
+        assert result.output == "It's sunny."
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].name == "get_weather"

--- a/tests/clients/test_meta_responses.py
+++ b/tests/clients/test_meta_responses.py
@@ -118,24 +118,90 @@ class TestPrepareResponsesArgs:
         )
         assert req["tool_choice"] == "auto"
 
-    def test_forwards_tools(self):
+    def test_forwards_tools_flattened_to_responses_shape(self):
+        """Chat-Completions-nested tools are flattened for Responses.
+
+        Sending the nested shape live 400s with
+        `'tools[0]' missing required field 'name'` — this is a regression
+        guard for that live-discovered defect.
+        """
         client = MetaClient(api_key="k")
-        tools = [{"type": "function", "function": {"name": "f"}}]
+        tools = [
+            {
+                "type": "function",
+                "function": {"name": "f", "description": "d", "parameters": {"type": "object"}},
+            }
+        ]
         req = client._prepare_responses_args(
             messages=[{"role": "user", "content": "hi"}], args={"tools": tools}
         )
-        assert req["tools"] == tools
+        assert req["tools"] == [
+            {"type": "function", "name": "f", "description": "d", "parameters": {"type": "object"}}
+        ]
 
-    def test_tool_role_becomes_tool_output_block(self):
+    def test_forwards_already_flat_tools_unchanged(self):
+        """Non-function tools (e.g. web_search) are already flat — passthrough."""
+        client = MetaClient(api_key="k")
+        req = client._prepare_responses_args(
+            messages=[{"role": "user", "content": "hi"}],
+            args={"tools": [{"type": "web_search"}]},
+        )
+        assert req["tools"] == [{"type": "web_search"}]
+
+    def test_tool_role_becomes_function_call_output_item(self):
+        """A `role: tool` message becomes a top-level `function_call_output`
+        item, keyed by `call_id` — NOT a `role`/`content` wrapper.
+
+        Sending the wrapped shape live 400s with `'input[N].content' did
+        not match any supported type` — this is a regression guard for
+        that live-discovered defect.
+        """
         client = MetaClient(api_key="k")
         messages = [
             {"role": "tool", "tool_call_id": "call_1", "name": "f", "content": "42"},
         ]
         req = client._prepare_responses_args(messages=messages, args={})
-        block = req["input"][0]["content"][0]
-        assert block["type"] == "tool_output"
-        assert block["tool_call_id"] == "call_1"
-        assert block["output"] == "42"
+        item = req["input"][0]
+        assert item == {"type": "function_call_output", "call_id": "call_1", "output": "42"}
+
+    def test_assistant_tool_calls_become_function_call_items(self):
+        """An assistant message with `tool_calls` becomes one top-level
+        `function_call` item per call — NOT a `tool_call` content block."""
+        client = MetaClient(api_key="k")
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_1", "function": {"name": "f", "arguments": "{}"}},
+                ],
+            },
+        ]
+        req = client._prepare_responses_args(messages=messages, args={})
+        assert req["input"] == [
+            {"type": "function_call", "call_id": "call_1", "name": "f", "arguments": "{}"}
+        ]
+
+
+class TestToResponsesTool:
+    def test_flattens_function_tool(self):
+        tool = {
+            "type": "function",
+            "function": {"name": "f", "description": "d", "parameters": {"type": "object"}},
+        }
+        assert MetaClient._to_responses_tool(tool) == {
+            "type": "function",
+            "name": "f",
+            "description": "d",
+            "parameters": {"type": "object"},
+        }
+
+    def test_preserves_strict_flag(self):
+        tool = {"type": "function", "function": {"name": "f", "strict": True, "parameters": {}}}
+        assert MetaClient._to_responses_tool(tool)["strict"] is True
+
+    def test_passes_through_non_function_tool(self):
+        assert MetaClient._to_responses_tool({"type": "web_search"}) == {"type": "web_search"}
 
 
 class TestMetaResponsesRouting:

--- a/tests/clients/test_openai_base_parity.py
+++ b/tests/clients/test_openai_base_parity.py
@@ -374,6 +374,14 @@ def _parity_client_kwargs(cls) -> dict:
         return {"api_key": "test-key", "region": "us-east-1"}
     if cls in (LocalLLMClient, vLLMClient):
         return {"api_key": "test-key", "base_url": "http://localhost:8000/v1"}
+    if cls is MetaClient:
+        # FEAT-526: MetaClient defaults to use_responses=True, routing
+        # ask()/ask_stream() to a MetaClient-local Responses override that
+        # bypasses `_chat_completion` entirely (D1). These funnel-parity
+        # sweeps exercise the inherited Chat-Completions funnel, which is
+        # exactly what use_responses=False selects — see
+        # tests/clients/test_meta_responses.py for Responses-path coverage.
+        return {"api_key": "test-key", "use_responses": False}
     return {"api_key": "test-key"}
 
 

--- a/tests/clients/test_openai_base_parity.py
+++ b/tests/clients/test_openai_base_parity.py
@@ -22,6 +22,7 @@ import pytest
 from parrot.clients.gpt import OpenAIClient
 from parrot.clients.groq import GroqClient
 from parrot.clients.localllm import LocalLLMClient
+from parrot.clients.meta import MetaClient
 from parrot.clients.moonshot import MoonshotClient
 from parrot.clients.nova.mantle import BedrockMantleClient
 from parrot.clients.nvidia import NvidiaClient
@@ -337,7 +338,7 @@ async def test_invoke_routes_via_funnel():
 # ---------------------------------------------------------------------------
 
 # Phase 1 wire roster + Phase 2's GroqClient (TASK-2303; ZaiClient joins
-# in TASK-2304).
+# in TASK-2304). FEAT-526: MetaClient added.
 WIRE_SUBCLASSES = [
     OpenRouterClient,
     MoonshotClient,
@@ -347,6 +348,7 @@ WIRE_SUBCLASSES = [
     BedrockMantleClient,
     GroqClient,
     ZaiClient,
+    MetaClient,
 ]
 
 # vLLMClient.ask()/ask_stream() unconditionally forward

--- a/tests/clients/test_openai_compatible_defaults.py
+++ b/tests/clients/test_openai_compatible_defaults.py
@@ -16,6 +16,7 @@ suite: a parametric "no gpt-* leak" check over every Phase-1
 covering class-level defaults, the ``invoke()`` model-resolution chain, and
 a mocked ``ask()`` request payload.
 """
+
 import re
 from types import SimpleNamespace
 from typing import Any
@@ -191,9 +192,7 @@ def test_no_gpt_default_leak(cls):
     """No Phase-1 wire subclass's class-level model attrs are OpenAI ids."""
     for attr in ("_default_model", "_fallback_model", "_lightweight_model", "model"):
         val = getattr(cls, attr, None)
-        assert val is None or not GPT_LEAK.match(str(val)), (
-            f"{cls.__name__}.{attr} leaks an OpenAI model id: {val!r}"
-        )
+        assert val is None or not GPT_LEAK.match(str(val)), f"{cls.__name__}.{attr} leaks an OpenAI model id: {val!r}"
 
 
 @pytest.mark.parametrize("cls", WIRE_SUBCLASSES, ids=lambda c: c.__name__)
@@ -202,9 +201,7 @@ def test_invoke_chain_never_yields_gpt(cls):
     explicitly configured with a provider model id."""
     client = cls(model="provider-model-x", **_client_kwargs(cls))
     resolved = client._resolve_invoke_model(None)
-    assert not GPT_LEAK.match(resolved), (
-        f"{cls.__name__}._resolve_invoke_model() leaked {resolved!r}"
-    )
+    assert not GPT_LEAK.match(resolved), f"{cls.__name__}._resolve_invoke_model() leaked {resolved!r}"
 
 
 class _FakeChoice:
@@ -262,6 +259,6 @@ async def test_ask_payload_model_never_leaks_gpt(cls, monkeypatch):
     await client.ask("hello")
 
     assert "model" in captured
-    assert not GPT_LEAK.match(captured["model"]), (
-        f"{cls.__name__}.ask() sent a gpt-* model on the wire: {captured['model']!r}"
-    )
+    assert not GPT_LEAK.match(
+        captured["model"]
+    ), f"{cls.__name__}.ask() sent a gpt-* model on the wire: {captured['model']!r}"

--- a/tests/clients/test_openai_compatible_defaults.py
+++ b/tests/clients/test_openai_compatible_defaults.py
@@ -25,6 +25,7 @@ from parrot.clients.claude import AnthropicClient
 from parrot.clients.gpt import OpenAIClient
 from parrot.clients.groq import GroqClient
 from parrot.clients.localllm import LocalLLMClient
+from parrot.clients.meta import MetaClient
 from parrot.clients.moonshot import MoonshotClient
 from parrot.clients.nova.mantle import BedrockMantleClient
 from parrot.clients.nvidia import NvidiaClient
@@ -46,6 +47,7 @@ OPENAI_COMPATIBLE = [
 
 # FEAT-438 TASK-2301/2303/2304: every OpenAIBaseClient subclass — Phase 1
 # (six wire clients) + Phase 2 (GroqClient, ZaiClient).
+# FEAT-526: MetaClient added.
 WIRE_SUBCLASSES = [
     OpenRouterClient,
     MoonshotClient,
@@ -55,6 +57,7 @@ WIRE_SUBCLASSES = [
     BedrockMantleClient,
     GroqClient,
     ZaiClient,
+    MetaClient,
 ]
 
 # Matches an OpenAI-the-provider model id (e.g. "gpt-5-mini", "gpt-4.1").

--- a/tests/clients/test_openai_compatible_defaults.py
+++ b/tests/clients/test_openai_compatible_defaults.py
@@ -72,6 +72,13 @@ def _client_kwargs(cls) -> dict:
         return {"api_key": "test-key", "region": "us-east-1"}
     if cls in (LocalLLMClient, vLLMClient):
         return {"api_key": "test-key", "base_url": "http://localhost:8000/v1"}
+    if cls is MetaClient:
+        # FEAT-526: MetaClient defaults to use_responses=True, routing
+        # ask() to a MetaClient-local Responses override that bypasses
+        # `_chat_completion` entirely (D1). These tests mock
+        # `_chat_completion` and exercise the Chat-Completions funnel,
+        # which is exactly what use_responses=False selects.
+        return {"api_key": "test-key", "use_responses": False}
     return {"api_key": "test-key"}
 
 

--- a/tests/e2e/test_meta_live.py
+++ b/tests/e2e/test_meta_live.py
@@ -1,0 +1,164 @@
+"""Live end-to-end tests for MetaClient against the real Meta Model API.
+
+Credential-gated: skips cleanly (not fail) when ``META_API_KEY`` is unset.
+Mirrors the existing live-provider test convention (see
+``tests/clients/test_anthropic_sdk_097.py::test_anthropic_live_smoke``).
+
+.. warning::
+    ``muse-spark-1.3-contributor`` is the Contributor tier: it grants Meta
+    permission to **train on prompts and completions**. All prompts in
+    this suite are deliberately synthetic — never send real user, company,
+    or repository content through it.
+
+Guards F015 (the feature's highest-risk finding): Muse Spark spends most
+of its output budget on private reasoning — 199 of 210 completion tokens
+(Chat Completions) and 142 of 153 output tokens (Responses) were
+``reasoning_tokens`` for a reply whose visible text was the single word
+``pong``. A low ``max_tokens`` therefore returns empty or truncated
+visible text; ``test_live_chat_completion_returns_nonempty_visible_text``
+exists to catch exactly that.
+"""
+import os
+import sys
+
+import pytest
+from navconfig import config
+from pydantic import BaseModel
+
+from parrot.clients.factory import LLMFactory
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.asyncio,
+    pytest.mark.skipif(
+        not config.get("META_API_KEY"),
+        reason="META_API_KEY not configured — live Meta tests skipped",
+    ),
+]
+
+# Contributor tier — synthetic e2e prompts only (spec §7 gotcha 6).
+E2E_MODEL = "meta:muse-spark-1.3-contributor"
+
+# Reuse the shared calculator tool fixture (spec §4 Test Data / Fixtures)
+# rather than defining a second one for this feature.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "examples", "clients", "smoke"))
+from _runner import calculator  # noqa: E402
+
+
+class _Fruit(BaseModel):
+    """Minimal structured-output schema for the live structured-output test."""
+
+    name: str
+    color: str
+
+
+class TestMetaLive:
+    """Live coverage for MetaClient (FEAT-526 Module 5)."""
+
+    async def test_live_chat_completion_returns_nonempty_visible_text(self):
+        """Guards F015: reasoning tokens can swallow the whole output budget."""
+        client = LLMFactory.create(E2E_MODEL, use_responses=False)
+        async with client:
+            result = await client.ask("Reply with exactly: pong")
+        assert result.output.strip(), (
+            "empty visible text — reasoning likely consumed the output budget"
+        )
+
+    async def test_live_tool_calling_roundtrip(self):
+        """A full tool-calling round trip on the (default) Responses path.
+
+        Muse Spark can (and, observed live, sometimes does) answer simple
+        arithmetic without invoking a tool at all, so the prompt must make
+        tool use mandatory rather than merely available — a system prompt
+        instructing it to never compute mentally, per a documented pattern
+        for steering tool-eager vs. tool-reluctant models.
+        """
+        client = LLMFactory.create(E2E_MODEL)
+        client.register_tool(calculator)
+        async with client:
+            result = await client.ask(
+                "What is 87361 + 45213? Compute it using the calculator "
+                "tool and reply with only the final number.",
+                system_prompt=(
+                    "You MUST use the calculator tool for every arithmetic "
+                    "computation, no matter how simple. Never compute "
+                    "mentally — always call the tool first."
+                ),
+                use_tools=True,
+            )
+        assert result.output.strip(), "empty visible text after tool round trip"
+        assert any(tc.name == "calculator" for tc in result.tool_calls), (
+            "calculator tool was never called"
+        )
+
+    async def test_live_structured_output(self):
+        """Structured output on the Chat Completions path (not yet
+        supported on Responses — see MetaClient.ask() docstring)."""
+        client = LLMFactory.create(E2E_MODEL, use_responses=False)
+        async with client:
+            result = await client.ask(
+                "A banana is yellow. Return its name and color.",
+                structured_output=_Fruit,
+            )
+        assert isinstance(result.structured_output, (dict, _Fruit))
+
+    async def test_live_responses_completed(self):
+        """The (default) Responses path returns completed non-empty text."""
+        client = LLMFactory.create(E2E_MODEL)
+        async with client:
+            result = await client.ask("Reply with exactly: pong")
+        assert result.output.strip(), (
+            "empty visible text — reasoning likely consumed the output budget"
+        )
+
+    async def test_live_search_grounding_emits_web_search_call(self):
+        """Search grounding surfaces a web_search_call output item."""
+        client = LLMFactory.create(E2E_MODEL)
+        async with client:
+            result = await client.ask(
+                "Search the web: what year is it right now?",
+                search_grounding=True,
+            )
+        assert result.metadata.get("web_search_calls"), (
+            "no web_search_call output item surfaced for a grounded request"
+        )
+
+    async def test_live_count_input_tokens(self):
+        """count_input_tokens() is standalone and returns a positive int."""
+        client = LLMFactory.create(E2E_MODEL)
+        async with client:
+            count = await client.count_input_tokens(input="Count these tokens.")
+        assert isinstance(count, int)
+        assert count > 0
+
+    async def test_live_tool_choice_required_raises(self):
+        """Meta supports only tool_choice='auto'; anything else is HTTP 400.
+
+        ``ask()`` never exposes a raw ``tool_choice`` override (the base
+        always forces ``"auto"`` when tools are prepared), so this
+        constraint is exercised directly against the wire-protocol funnel.
+        """
+        client = LLMFactory.create(E2E_MODEL, use_responses=False)
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "calculator",
+                    "description": "Evaluate an arithmetic expression.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"expression": {"type": "string"}},
+                        "required": ["expression"],
+                    },
+                },
+            }
+        ]
+        async with client:
+            with pytest.raises(Exception):
+                await client._chat_completion(
+                    model=client._resolve_model(None),
+                    messages=[{"role": "user", "content": "What is 2+2?"}],
+                    use_tools=True,
+                    tools=tools,
+                    tool_choice="required",
+                )

--- a/tests/e2e/test_meta_live.py
+++ b/tests/e2e/test_meta_live.py
@@ -18,6 +18,7 @@ of its output budget on private reasoning — 199 of 210 completion tokens
 visible text; ``test_live_chat_completion_returns_nonempty_visible_text``
 exists to catch exactly that.
 """
+
 import os
 import sys
 
@@ -60,9 +61,7 @@ class TestMetaLive:
         client = LLMFactory.create(E2E_MODEL, use_responses=False)
         async with client:
             result = await client.ask("Reply with exactly: pong")
-        assert result.output.strip(), (
-            "empty visible text — reasoning likely consumed the output budget"
-        )
+        assert result.output.strip(), "empty visible text — reasoning likely consumed the output budget"
 
     async def test_live_tool_calling_roundtrip(self):
         """A full tool-calling round trip on the (default) Responses path.
@@ -77,8 +76,7 @@ class TestMetaLive:
         client.register_tool(calculator)
         async with client:
             result = await client.ask(
-                "What is 87361 + 45213? Compute it using the calculator "
-                "tool and reply with only the final number.",
+                "What is 87361 + 45213? Compute it using the calculator " "tool and reply with only the final number.",
                 system_prompt=(
                     "You MUST use the calculator tool for every arithmetic "
                     "computation, no matter how simple. Never compute "
@@ -87,9 +85,7 @@ class TestMetaLive:
                 use_tools=True,
             )
         assert result.output.strip(), "empty visible text after tool round trip"
-        assert any(tc.name == "calculator" for tc in result.tool_calls), (
-            "calculator tool was never called"
-        )
+        assert any(tc.name == "calculator" for tc in result.tool_calls), "calculator tool was never called"
 
     async def test_live_structured_output(self):
         """Structured output on the Chat Completions path (not yet
@@ -107,9 +103,7 @@ class TestMetaLive:
         client = LLMFactory.create(E2E_MODEL)
         async with client:
             result = await client.ask("Reply with exactly: pong")
-        assert result.output.strip(), (
-            "empty visible text — reasoning likely consumed the output budget"
-        )
+        assert result.output.strip(), "empty visible text — reasoning likely consumed the output budget"
 
     async def test_live_search_grounding_emits_web_search_call(self):
         """Search grounding surfaces a web_search_call output item."""
@@ -119,9 +113,7 @@ class TestMetaLive:
                 "Search the web: what year is it right now?",
                 search_grounding=True,
             )
-        assert result.metadata.get("web_search_calls"), (
-            "no web_search_call output item surfaced for a grounded request"
-        )
+        assert result.metadata.get("web_search_calls"), "no web_search_call output item surfaced for a grounded request"
 
     async def test_live_count_input_tokens(self):
         """count_input_tokens() is standalone and returns a positive int."""


### PR DESCRIPTION
## Summary

Implements `MetaClient` — an `OpenAIBaseClient` subclass for Meta's Model API
(Muse Spark family), following the FEAT-523 `clients/<provider>/` folder
convention. Chat Completions is fully inherited; the Responses API path
(search grounding, `count_input_tokens()`, full tool-calling round trip) is
`MetaClient`-local per design decision D1 — `gpt.py`/`openai_base.py`/`base.py`
are untouched.

## Tasks

7/8 tasks verified and closed:

- ✅ TASK-2833 — Meta model catalog (`parrot/clients/meta/models.py`)
- ✅ TASK-2834 — MetaClient core, Chat Completions path
- ✅ TASK-2835 — Factory registration + wire-subclass test rosters
- ✅ TASK-2836 — Responses API path (MetaClient-local)
- ✅ TASK-2837 — Search grounding + `count_input_tokens()`
- ✅ TASK-2838 — Live end-to-end test suite (7/7 passed live against `muse-spark-1.3-contributor`)
- ✅ TASK-2839 — Smoke script + client documentation
- ⏭️ TASK-2840 — Map `search_tools` onto native `tool_search` — **deferred as a follow-up** (explicitly droppable per spec §3 Module 6 / D2; nothing depends on it)

## Verification

- `pytest tests/clients/` — 560 passed (12 pre-existing, unrelated failures reproduced identically on pre-feature `dev`, confirmed via `git stash`)
- `pytest tests/e2e/test_meta_live.py` — 7/7 passed live against the real Meta API
- `ruff check` clean on all changed files
- `git diff -- gpt.py openai_base.py base.py` — empty (D1 respected)
- Two live-discovered Responses-API wire-shape defects found and fixed with regression-guarded unit tests (tool-definition nesting, tool-call round-trip item shape)

## Code Review

Adversarial review via `code-reviewer` subagent: **✅ Approved**, 0 critical findings.
- 🟠 Important (not fixed, pre-existing/out of scope): `AIMessageFactory.from_openai()` hardcodes `provider="openai"` for every `OpenAIBaseClient` subclass, not just Meta — recommend a follow-up ticket.
- 🟡 Suggestion: `structured_output` is silently ignored on the default Responses path with no runtime warning.
- 💡 Nitpicks: unused `logger` in `client.py`; cosmetic spec/test name mismatch.

External second opinion (`codex`) was unavailable this run (hit its usage quota mid-review, no usable output produced).

---
_Closed by /sdd-done_
