### PR TITLE
feat(a2ui-graph-component): FEAT-529 — A2UI Graph component under the viz-core catalog

### DIFF
--- a/docs/frontend/agentdashboard-a2ui-reference.md
+++ b/docs/frontend/agentdashboard-a2ui-reference.md
@@ -539,12 +539,18 @@ Core defines `RendererCapabilities{interactive, supports_actions, supports_updat
 
 | id | interactive | actions | updates | output | supported components |
 |---|---|---|---|---|---|
-| `interactive-html` | ✓ | ✗ | ✗ | `text/html` | 18 Basic + `Chart`, `DataTable`, `Infographic`, `HtmlDocument` (**FEAT-527**, sandboxed iframe) (+ FilterBar handled via lowering) |
-| `ssr_html` | ✗ | ✗ | ✗ | `text/html` | 18 Basic |
+| `interactive-html` | ✓ | ✗ | ✗ | `text/html` | 18 Basic + `Chart`, `DataTable`, `Infographic`, `HtmlDocument` (**FEAT-527**, sandboxed iframe), `Graph` (**FEAT-529**, viz-core) (+ FilterBar handled via lowering) |
+| `ssr_html` | ✗ | ✗ | ✗ | `text/html` | 18 Basic + `Graph` (**FEAT-529**, viz-core) |
 | `pdf` | ✗ | ✗ | ✗ | `application/pdf` | SSR minus `Video`, `AudioPlayer` |
-| `echarts` | ✗ | ✗ | ✗ | `application/json` | `Chart` |
+| `echarts` | ✗ | ✗ | ✗ | `application/json` | `Chart`, `Graph` (**FEAT-529**, viz-core) |
 | `folium_map` | ✗ | ✗ | ✗ | `text/html` | `Map` |
 | `adaptive_cards` | ✗ | ✓ | ✗ | Adaptive Cards | Text, Image, Row, Column, Card, TextField, CheckBox, ChoicePicker, Slider, DateTimeInput, Button |
+
+`echarts`/`interactive-html`/`ssr_html`/`pdf` additionally declare
+`https://ai-parrot.dev/a2ui/catalogs/viz-core/1.0/catalog.json` in
+`supported_catalog_ids` (**FEAT-529**) — `adaptive_cards`/`folium_map` do
+not, so a `Graph` there always lowers/is skipped with one `degraded` entry
+naming that catalog id (§5.4).
 
 The Svelte renderer will be the first one with `interactive: true, supports_actions: true, supports_updates: true, output: "live"`. Rule inherited from `renderers/degrade.py`: **never throw on an unsupported component** — render a visible notice `Text` (`"[<Component> not supported here: <reason>]"`, `parrot_role: notice`) that **keeps the original id** so references still resolve, and collect `{id, component, reason}` records (`degraded[]`) for telemetry.
 
@@ -563,6 +569,101 @@ The Svelte renderer will be the first one with `interactive: true, supports_acti
 > `Infographic`/`Report` root; a toolbar toggle falls back to the existing
 > HTML iframe view. This is unrelated to (and does not replace)
 > navigator-frontend-next's own Svelte renderer referenced above.
+
+### 5.4 viz-core catalog (FEAT-529)
+
+A THIRD catalog, `catalogId: "https://ai-parrot.dev/a2ui/catalogs/viz-core/1.0/catalog.json"`,
+alongside Basic and Parrot (§5.1/§5.2, still 10 composites — viz-core is
+additive, nothing moved). Its rule: **describe what, never how** — no
+colour, font, pixel size, or renderer-library option on the wire; semantic
+colour roles/formats; `size` is layout intent (`inline`/`tile`/`hero`),
+never pixels; every visual carries `accessibleDescription`; the standard
+`action` is the only interaction primitive. A viz-core component ALWAYS
+carries its own explicit `catalogId` — the surface's default stays
+Parrot's; resolve a component's effective catalog as `component.catalogId
+?? surface.catalogId` (mirrors the backend's `catalog.resolve_catalog`).
+
+#### `Graph` (`catalog/viz_core/graph.py`) — required `nodes`, `edges`
+
+| Prop | Type | Notes |
+|---|---|---|
+| `kind` | `flowchart, state, sequence, dag` | default `flowchart`; `dag` rejects cycles, the others legally allow them (real workflows loop) |
+| `direction` | `TB, LR, BT, RL` | default `TB` |
+| `nodes` | `[{id, label?, shape?, group?, state?, icon?, meta?}]` | `shape ∈ rect (default), rounded, diamond, circle, hexagon, subroutine`; `state ∈ pending, running, completed, failed, skipped, waiting` — DATA, see the status-role table below |
+| `edges` | `[{from, to, label?, kind?, condition?}]` | `kind ∈ solid (default), dashed, thick` |
+| `groups` | `[{id, label?, nodes: [id, ...]}]` | rendered as a bounding box |
+| `layout` | `{engine: layered (default) \| force \| manual, rankSep?, nodeSep?, positions?}` | `positions` (when present) are SERVER-PREPARED — draw them as-is, never recompute; `manual` requires `positions` for every node |
+| `selection` | `{selectable?, selected?}` | |
+| `data` | `{"path": …}` | binding to `{node_id: {state?, label?, meta?}}` — overlays per-node state at render time |
+| `accessibleDescription`, `size` (`inline, tile (default), hero`) | | viz-core common props, same meaning everywhere |
+| `action` | the standard v1.0 `Action` | TOOL origin only (D10b gate, same as everywhere else) — dispatched on node click with `context.nodeId`/`context.nodeLabel` added |
+
+Node `state` → semantic status role → theme token (the SAME five roles
+this app's own `A2UIGraph.svelte` and the backend's `_graph_svg`/`echarts`
+renderers use — only the token NAMES differ per surface, since this app's
+theme schema has no `--accent-*`/`--neutral-muted` of its own):
+
+| `state` | status role | this app's Tailwind/shadcn token |
+|---|---|---|
+| `completed` | `good` | `--chart-2` |
+| `waiting` | `warning` | `--chart-3` |
+| `failed` | `critical` | `--destructive` |
+| `running` | `primary` | `--primary` |
+| `pending`, `skipped` | `neutral` | `--muted-foreground` |
+
+Lowered fallback (any lane without viz-core support, or without a graph
+engine): `Card{Column[Text description, Text title?, Text caption, Column
+edge-list, Text graph-source]}`, `parrot_variant: "graph"` — see
+[`docs/outputs/a2ui-v1.md`](../outputs/a2ui-v1.md#graph--the-viz-core-workflowstate-machine-component-feat-529)
+for the exhaustive lowering-role table, the mermaid codec subset, and the
+layout/degradation contract (force → layered, oversize → truncated edge
+list, both recorded).
+
+**Frontend**: dispatch `Graph` via ECharts' native `graph` series
+(`layout: "none"` from `layout.positions` when present, else `"circular"`)
+— no new graph/diagram npm dependency (no mermaid/dagre/elkjs/@xyflow/
+svelteflow). `A2UIGraph.svelte` (bundled UI reference implementation)
+resolves positions, maps `state` to the token table above, shows a
+tooltip from `meta`, and exposes an `onNodeClick` hook with NO action
+transport wired yet (that ships with the live-workflow-surface follow-up).
+
+```json a2ui-envelope
+{
+  "version": "v1.0",
+  "createSurface": {
+    "surfaceId": "workflow",
+    "catalogId": "https://a2ui.org/specification/v1_0/catalogs/basic/catalog.json",
+    "components": [
+      {"id": "root", "component": "Column", "children": ["graph"]},
+      {
+        "id": "graph",
+        "component": "Graph",
+        "catalogId": "https://ai-parrot.dev/a2ui/catalogs/viz-core/1.0/catalog.json",
+        "kind": "flowchart",
+        "direction": "TB",
+        "nodes": [
+          {"id": "start", "label": "Start", "shape": "circle", "state": "completed"},
+          {"id": "research", "label": "Research", "state": "running"},
+          {"id": "end", "label": "End", "shape": "circle"}
+        ],
+        "edges": [
+          {"from": "start", "to": "research"},
+          {"from": "research", "to": "end", "label": "done"}
+        ],
+        "accessibleDescription": "A tiny research workflow: start, research, end."
+      }
+    ]
+  }
+}
+```
+
+This example is deliberately **mixed-catalog**: the surface's own default
+`catalogId` is the official Basic Catalog (its `root` `Column` resolves
+under it with no override), while `graph` carries its own explicit
+viz-core `catalogId` — exactly the shape `catalog.resolve_catalog`/
+`validate_envelope` are built to handle. Dropping `graph`'s `catalogId`
+here would make it resolve against the Basic surface default instead,
+where `Graph` does not exist — `UNKNOWN_COMPONENT`.
 
 ---
 

--- a/docs/outputs/a2ui-v1.md
+++ b/docs/outputs/a2ui-v1.md
@@ -70,14 +70,15 @@ Every `CreateSurface`'s component list carries exactly one component with
 `id: "root"` (spec G6) — `builders.build_surface` (and everything built on
 it) guarantees this automatically.
 
-## Two catalogs, one resolution rule
+## Three catalogs, one resolution rule
 
 | Catalog | `catalogId` | Contents |
 |---|---|---|
 | **Basic** (official) | `https://a2ui.org/specification/v1_0/catalogs/basic/catalog.json` | 18 primitives + 14 functions, vendored verbatim under `catalog/basic/spec/*.json` (SHA-pinned: `catalog/basic.SPEC_COMMIT`) |
 | **Parrot** (this codebase's presentation layer) | `https://parrot.dev/catalogs/v1` | `InfoCard`, `Chart`, `DataTable`, `Map`, `KPICard`, `Timeline`, `Infographic`, `Report` |
+| **viz-core** (FEAT-529) | `https://ai-parrot.dev/a2ui/catalogs/viz-core/1.0/catalog.json` | `Graph` today; a library-agnostic, "describe what, never how" visualization vocabulary shared with future components (charts, live surfaces) |
 
-`catalog.export_catalog_definition()` produces the Parrot catalog's own
+`catalog.export_catalog_definition()` produces a catalog's own
 `catalog_definition.json`-shaped document (valid against the vendored
 official schema of the same name) — every Basic Catalog component/function
 is included there as a `$ref` (`{"$ref": "<BASIC_CATALOG_ID>#/components/Text"}`)
@@ -85,12 +86,41 @@ rather than duplicated, so **a bare component name resolves under either
 catalog** without an explicit `catalogId` per component
 (`catalog.resolve_catalog`: component's own `catalogId` wins, else the
 surface's default). A component naming neither resolves to
-`CATALOG_UNRESOLVED`.
+`CATALOG_UNRESOLVED`. The registry (`_CATALOG`) is keyed by
+`(catalog_id, name)` — `catalog.get_component(name, catalog_id=None)`
+resolves the unique match when `catalog_id` is omitted and raises
+`CatalogError` (naming the candidates) only once a name is genuinely
+ambiguous across catalogs (not yet the case for any name in this codebase).
 
 A surface's default is always `catalogId: "https://parrot.dev/catalogs/v1"`
 (every public builder sets this) — so `Text`, `Button`, and the rest of the
 Basic Catalog are usable directly inside a Parrot-catalog surface with no
-extra ceremony.
+extra ceremony. A `Graph` component instead carries its OWN explicit
+`catalogId: "https://ai-parrot.dev/a2ui/catalogs/viz-core/1.0/catalog.json"`
+— the surface stays Parrot-default; only the component overrides.
+
+### viz-core principles (FEAT-529)
+
+viz-core's rule is **describe what, never how**: no colour, font, pixel
+size, or renderer-library option ever appears on the wire.
+
+- **Semantic colour roles, not values.** A viz-core component's *data*
+  (e.g. `Graph.nodes[].state`) stays a domain enum; the RENDERER contract
+  (not the schema) maps it to a semantic status role (`good`/`warning`/
+  `critical`/`primary`/`neutral`) and paints that role with its own theme
+  tokens (`DesignSystem` CSS custom properties server-side, this app's own
+  shadcn/Tailwind tokens in the bundled UI).
+- **Semantic formats, never printf strings.**
+- **Size is layout intent, never pixels** — `inline`/`tile`/`hero`, each
+  renderer maps these to its own container class/dimensions.
+- **`accessibleDescription` on every visual** — the screen-reader summary
+  and the lowered fallback's/static SVG's first line.
+- **The standard `action`** is the ONLY interaction primitive — no
+  component-specific `selectAction`/`nodeAction` prop.
+- **Layout is server-side preparation, not styling** — when a viz-core
+  component computes positions (e.g. `Graph.layout.positions`), those
+  travel on the wire so every renderer draws the same picture; a renderer
+  computes them itself only when they are absent.
 
 ### `lower()` — Parrot components become Basic primitives
 
@@ -187,6 +217,139 @@ into `RenderedArtifact.metadata["degraded"]`, via `degrade.degradation_record()`
 For example, `PDFRenderer` inherits `SSRHTMLRenderer`'s primitive set minus
 `Video`/`AudioPlayer` (a rasterized PDF cannot play media — both degrade to a
 link).
+
+## `Graph` — the viz-core workflow/state-machine component (FEAT-529)
+
+`Graph` renders a workflow, state machine, dependency graph, or call
+sequence as TYPED `nodes[]`/`edges[]` — never a mermaid string on the wire
+(mermaid is a pure-Python codec, both ways, for import/export/documentation
+only: `parrot.outputs.a2ui.graph.{to_mermaid,from_mermaid}`).
+
+```python
+# parrot/outputs/a2ui/graph/models.py — GraphSpec (single source of vocabulary)
+kind: "flowchart" | "state" | "sequence" | "dag"   # dag rejects cycles
+direction: "TB" | "LR" | "BT" | "RL"
+title, accessibleDescription, size: "inline" | "tile" | "hero"   # viz-core common props
+nodes: [{id, label?, shape?, group?, state?, icon?, meta?}]
+edges: [{from, to, label?, kind?, condition?}]
+groups: [{id, label?, nodes: [id, ...]}]
+layout: {engine: "layered" | "force" | "manual", rankSep?, nodeSep?, positions?}
+selection: {selectable?, selected?}
+data: {"path": "/pointer"}   # binding descriptor on the wire; overlays state/label/meta per node id
+action: <the standard v1.0 Action>   # TOOL origin only — see below
+```
+
+`GRAPH_SCHEMA` (`catalog/viz_core/graph.py`) is derived from `GraphSpec` via
+`derive_schema` (schema parity by construction, same pattern as `Chart`),
+plus one explicit merge: `action` is not a `GraphSpec` field (nor part of
+the official `common_types.json#/$defs/ComponentCommon`) — it is declared
+as a `$ref` to the vendored `common_types.json#/$defs/Action`.
+
+Node `shape`: `rect` (default), `rounded`, `diamond`, `circle`, `hexagon`,
+`subroutine`. Edge `kind`: `solid` (default), `dashed`, `thick`.
+
+### Node state → semantic status role → theme token
+
+`state` is DATA (a domain enum: `pending`/`running`/`completed`/`failed`/
+`skipped`/`waiting`), never styling. Every renderer maps it to a viz-core
+semantic status role, then paints that role with its own theme:
+
+| `state` | status role | `DesignSystem` token (static/server lanes) |
+|---|---|---|
+| `completed` | `good` | `--accent-green` |
+| `waiting` | `warning` | `--accent-amber` |
+| `failed` | `critical` | `--accent-red` |
+| `running` | `primary` | `--primary` |
+| `pending`, `skipped` | `neutral` | `--neutral-muted` |
+
+(The bundled `ai-parrot-server/ui` SPA maps the same five roles to its own
+shadcn/Tailwind tokens instead — `--chart-2`/`--chart-3`/`--destructive`/
+`--primary`/`--muted-foreground` — since it has no `--accent-*`/
+`--neutral-muted` custom properties of its own.)
+
+### Node click — the standard `action`, not a bespoke prop
+
+A `Graph` may carry the standard component-level `action` (same as
+`Button`), declared explicitly in `GRAPH_SCHEMA` since it is not part of
+the official `ComponentCommon`. The existing D10b gate applies unchanged:
+an LLM-origin envelope carrying a `Graph` with `action` set fails
+`validate_envelope` (`ACTION_NOT_ALLOWED_FOR_LLM`) — only a deterministic
+TOOL producer (`build_graph(action=...)`) may set it. Renderers that
+support actions add `context.nodeId`/`context.nodeLabel` when dispatching
+from a node click. There is no `selectAction`/`nodeAction` — this is the
+one deliberate difference from the original viz-core design draft.
+
+### Lowered fallback
+
+Every lane without a native drawing surface (or without viz-core in its
+`supported_catalog_ids`) still shows something readable and copyable — a
+`Card{Column[...]}` tree of Basic primitives:
+
+| Order | Node | `metadata.extensions.parrot_role` |
+|---|---|---|
+| 1 | `Text` | `description` — `accessibleDescription`, or a generated `"Graph of N nodes and M edges (<kind>)"` |
+| 2 | `Text` (if `title` set) | `title` |
+| 3 | `Text` | `caption` — `"Graph (<kind>, <direction>)"` |
+| 4 | `Column` | `edge-list` — one child `Text` per edge (`parrot_role: edge`, `"<from> → <to> (<label>)"`, plus `parrot_edge_kind`/`parrot_condition` when set); carries `parrot_graph_data` (the UNRESOLVED `data` binding, same convention as `Chart`'s `parrot_series_data`) when `data` is bound |
+| 5 | `Text` | `graph-source` — `to_mermaid(spec)` |
+
+The whole `Card` carries `metadata.extensions.parrot_variant == "graph"`.
+
+### Mermaid codec subset
+
+`parrot.outputs.a2ui.graph.{to_mermaid,from_mermaid}` is a hand-written,
+dependency-free codec (no `mermaid`/`dagre`/`elkjs` package) for exactly
+three dialects, matching `kind`:
+
+- **`flowchart`** (also used for `kind="dag"` on export — a DAG is an
+  acyclic flowchart; `from_mermaid` never infers `"dag"` back from text):
+  all 6 node shapes, all 3 edge kinds, labels via `-- text -->` (parse-only)
+  and `-->|text|` (canonical emit), `subgraph id [label] ... end` groups.
+- **`stateDiagram-v2`**: `[*] --> A` / `A --> [*]` synthetic
+  `__start__`/`__end__` circle nodes, `A --> B : label` transitions,
+  `state "label" as id` aliases, composite `state X { ... }` groups.
+- **`sequenceDiagram`**: `participant A as Label` aliases, `A->>B: msg`
+  (solid) / `A-->>B: msg` (dashed) messages, in `edges[]` order.
+
+Unsupported constructs (`classDef`, `click`, `style`, `linkStyle`,
+`%%{init}` directives, `loop`/`alt`/`par` blocks, other mermaid dialects)
+raise `MermaidCodecError` (a `CatalogValidationError` subclass — the LLM
+producer's existing validate-retry-degrade loop needs no new plumbing)
+naming the offending line. `accessibleDescription`/`size` have no mermaid
+representation and are dropped on export.
+
+### Layout — `graph/layout.py`
+
+`compute_positions(spec, *, rank_sep=80.0, node_sep=40.0) -> LayoutResult`
+is a pure, deterministic layered layout (rank assignment via longest-path
+over a cycle-broken edge set, barycentre crossing reduction, integer
+coordinate assignment scaled at the end) — used by `builders.build_graph`
+at build time (so every renderer, including the bundled UI's `layout:
+"none"` path, draws from the SAME positions) and by any renderer when
+`layout.positions` is absent or incomplete. Graphs above
+`MAX_STATIC_NODES` (200) raise `GraphTooLargeError`; static lanes catch it
+and degrade to a truncated, readable edge list. `layout.engine: "force"` is
+an interactive-renderer-only hint — every static lane degrades it to the
+deterministic layered layout instead, with a recorded `degraded` entry.
+
+### Renderer matrix
+
+| Renderer | viz-core? | Behaviour |
+|---|---|---|
+| `echarts` | ✓ | Native `graph` series, `layout: "none"` with positions (falls back to the option's own layout when absent) |
+| `interactive-html` | ✓ | Inline `<svg>` (shared `_graph_svg.render_graph_svg`) + a collapsed `<details><summary>Mermaid source</summary>` |
+| `ssr_html` | ✓ | Inline `<svg>` |
+| `pdf` | ✓ | Inline `<svg>` (inherited from `ssr_html`; weasyprint rasterizes it, no JS) |
+| `adaptive_cards` | ✗ | Lowers via `GraphComponent.lower()`; records ONE `degraded` entry naming the viz-core catalog id |
+| `folium_map` | ✗ | Not rendered; records ONE `degraded` entry naming the viz-core catalog id (same "single focal component" convention as any other sibling component this Map-only renderer skips) |
+
+The bundled `ai-parrot-server/ui` SPA (behind `features.a2ui`) also
+dispatches `Graph` NATIVELY — but only when the component resolves (its own
+`catalogId`, else the surface default) to the viz-core catalog id; a bare
+`Graph` on a Parrot-default surface falls through to the same unsupported
+placeholder any other unknown component gets. See
+[`docs/frontend/agentdashboard-a2ui-reference.md`](../frontend/agentdashboard-a2ui-reference.md)
+§5.4 for the frontend-facing reference.
 
 ## Infographics: dual emission (FEAT-527)
 

--- a/packages/ai-parrot-server/ui/src/lib/components/agents/canvas/a2ui/A2UIGraph.svelte
+++ b/packages/ai-parrot-server/ui/src/lib/components/agents/canvas/a2ui/A2UIGraph.svelte
@@ -1,0 +1,246 @@
+<script module lang="ts">
+  // ai-parrot (FEAT-529): pure ECharts-option-building logic, exported from
+  // this module block so it is directly unit-testable (no rendering, no
+  // ECharts/canvas involved) — mirrors the backend's
+  // `parrot.outputs.a2ui_renderers.echarts.EChartsRenderer._build_graph_option`
+  // and shares its `STATE_TO_STATUS` role mapping
+  // (`parrot.outputs.a2ui_renderers._graph_svg.STATE_TO_STATUS`), but this
+  // app has no `--accent-green`/`--accent-amber`/`--accent-red`/
+  // `--neutral-muted` CSS custom properties of its own (see
+  // `src/lib/styles/themes/_schema.css`) — the closest existing shadcn/
+  // Tailwind tokens are used instead (`--chart-2`, `--chart-3`,
+  // `--destructive`, `--primary`, `--muted-foreground`).
+
+  export type GraphNodeState =
+    | 'pending'
+    | 'running'
+    | 'completed'
+    | 'failed'
+    | 'skipped'
+    | 'waiting';
+
+  export interface GraphNodeProps {
+    id: string;
+    label?: string;
+    shape?: string;
+    group?: string;
+    state?: GraphNodeState;
+    icon?: string;
+    meta?: Record<string, unknown>;
+  }
+
+  export interface GraphEdgeProps {
+    from: string;
+    to: string;
+    label?: string;
+    kind?: 'solid' | 'dashed' | 'thick';
+    condition?: string;
+  }
+
+  export interface GraphGroupProps {
+    id: string;
+    label?: string;
+    nodes: string[];
+  }
+
+  export interface GraphPosition {
+    x: number;
+    y: number;
+  }
+
+  export interface GraphLayoutProps {
+    engine?: 'layered' | 'force' | 'manual';
+    rankSep?: number;
+    nodeSep?: number;
+    positions?: Record<string, GraphPosition>;
+  }
+
+  export interface GraphSelectionProps {
+    selectable?: boolean;
+    selected?: string;
+  }
+
+  /** The `Graph` component's own (already-resolved) top-level props — never
+   * the wire envelope's `id`/`component`/`catalogId`. */
+  export interface GraphProperties {
+    kind?: string;
+    direction?: string;
+    title?: string;
+    accessibleDescription?: string;
+    size?: 'inline' | 'tile' | 'hero';
+    nodes: GraphNodeProps[];
+    edges: GraphEdgeProps[];
+    groups?: GraphGroupProps[];
+    layout?: GraphLayoutProps;
+    selection?: GraphSelectionProps;
+  }
+
+  /** Node domain `state` -> viz-core semantic status role (spec §2 renderer
+   * contract) — identical mapping to the backend's `STATE_TO_STATUS`. */
+  export const STATE_TO_STATUS: Record<GraphNodeState, string> = {
+    completed: 'good',
+    waiting: 'warning',
+    failed: 'critical',
+    running: 'primary',
+    pending: 'neutral',
+    skipped: 'neutral',
+  };
+
+  const STATUS_ORDER = ['good', 'warning', 'critical', 'primary', 'neutral'] as const;
+
+  /** Status role -> this app's own CSS custom-property NAME (never a
+   * literal colour) — resolved to a concrete value at render time by the
+   * caller (Canvas rendering cannot resolve `var()` itself; see
+   * `resolveColor` below / `AppChart.svelte`'s identical precedent). */
+  const STATUS_TO_TOKEN: Record<string, string> = {
+    good: 'var(--chart-2)',
+    warning: 'var(--chart-3)',
+    critical: 'var(--destructive)',
+    primary: 'var(--primary)',
+    neutral: 'var(--muted-foreground)',
+  };
+
+  /** True when `properties.layout.positions` covers every node — the ONLY
+   * condition under which `layout: "none"` (server-prepared positions) is
+   * used; otherwise ECharts' own `"circular"` layout is the fallback. */
+  export function hasCompletePositions(properties: GraphProperties): boolean {
+    const positions = properties.layout?.positions;
+    if (!positions) return false;
+    return properties.nodes.every((node) => positions[node.id] !== undefined);
+  }
+
+  function statusForNode(node: GraphNodeProps): string {
+    return node.state ? (STATE_TO_STATUS[node.state] ?? 'neutral') : 'neutral';
+  }
+
+  function tooltipText(node: GraphNodeProps): string {
+    const label = node.label ?? node.id;
+    if (!node.meta) return label;
+    const metaLines = Object.entries(node.meta).map(([key, value]) => `${key}: ${String(value)}`);
+    return [label, ...metaLines].join('\n');
+  }
+
+  /**
+   * Build a native ECharts `graph` series option from `Graph` properties.
+   *
+   * @param properties - The (already-resolved) `Graph` component props.
+   * @param resolveColor - Resolves a `var(--token)` string to a concrete
+   *   colour usable by the Canvas renderer; identity by default (tests
+   *   don't need a live DOM to assert on the token names themselves).
+   */
+  export function buildGraphOption(
+    properties: GraphProperties,
+    resolveColor: (token: string) => string = (token) => token,
+  ): Record<string, unknown> {
+    const usePositions = hasCompletePositions(properties);
+    const positions = properties.layout?.positions ?? {};
+
+    const data = properties.nodes.map((node) => {
+      const status = statusForNode(node);
+      const entry: Record<string, unknown> = {
+        id: node.id,
+        name: node.label ?? node.id,
+        category: STATUS_ORDER.indexOf(status as (typeof STATUS_ORDER)[number]),
+        tooltip: { formatter: () => tooltipText(node) },
+        itemStyle: { color: resolveColor(STATUS_TO_TOKEN[status] ?? STATUS_TO_TOKEN.neutral) },
+      };
+      if (node.group) {
+        entry.value = node.group; // groups are represented on the node's own data (spec: "groups ... represented")
+      }
+      if (properties.selection?.selected === node.id) {
+        entry.itemStyle = {
+          ...(entry.itemStyle as Record<string, unknown>),
+          borderColor: resolveColor('var(--ring)'),
+          borderWidth: 3,
+        };
+        entry.symbolSize = 14; // slightly larger — visually distinguishes the selection
+      }
+      if (usePositions) {
+        const position = positions[node.id];
+        entry.x = position.x;
+        entry.y = position.y;
+      }
+      return entry;
+    });
+
+    const links = properties.edges.map((edge) => {
+      const lineStyle: Record<string, unknown> = {};
+      if (edge.kind === 'dashed') lineStyle.type = 'dashed';
+      if (edge.kind === 'thick') lineStyle.width = 3;
+      const link: Record<string, unknown> = { source: edge.from, target: edge.to, lineStyle };
+      if (edge.label) {
+        link.label = { show: true, formatter: edge.label };
+      }
+      return link;
+    });
+
+    return {
+      title: { text: properties.title ?? '' },
+      tooltip: { show: true },
+      series: [
+        {
+          type: 'graph',
+          layout: usePositions ? 'none' : 'circular',
+          roam: true,
+          label: { show: true },
+          edgeSymbol: ['none', 'arrow'],
+          categories: STATUS_ORDER.map((name) => ({ name })),
+          data,
+          links,
+        },
+      ],
+    };
+  }
+</script>
+
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import ECharts from '$lib/components/visualizations/ECharts.svelte';
+
+  interface Props {
+    properties: GraphProperties;
+    dataModel?: Record<string, unknown>;
+    /** Node click hook — NOT wired to any action-dispatch transport yet
+     * (spec §7: that is `a2ui-live-workflow-surface`'s job). Declared so
+     * callers have a stable extension point; a no-op if never invoked. */
+    onNodeClick?: (nodeId: string, nodeLabel?: string) => void;
+  }
+
+  // `dataModel`/`onNodeClick` are accepted for a stable prop surface but
+  // deliberately unused today: `Graph.data` (live overlay) resolution and
+  // node-click action dispatch are both out of scope here (see the Props
+  // doc above and this module's top comment).
+  let { properties }: Props = $props();
+
+  /** Resolve a `var(--token)` string to a concrete rgb value via a probe
+   * element — the Canvas layer's fillStyle cannot resolve CSS variables
+   * (identical precedent: `AppChart.svelte`'s own `resolveColor`). */
+  function resolveColor(color: string): string {
+    if (!browser || !color.includes('var(')) return color;
+    const probe = document.createElement('span');
+    probe.style.color = color;
+    probe.style.display = 'none';
+    document.body.appendChild(probe);
+    const resolved = getComputedStyle(probe).color;
+    probe.remove();
+    return resolved || color;
+  }
+
+  let option = $derived(buildGraphOption(properties, resolveColor));
+
+  let sizeClass = $derived(
+    properties.size === 'inline'
+      ? 'a2ui-graph-inline'
+      : properties.size === 'hero'
+        ? 'a2ui-graph-hero'
+        : 'a2ui-graph-tile',
+  );
+</script>
+
+<div
+  class={`a2ui-graph ${sizeClass}`}
+  role="img"
+  aria-label={properties.accessibleDescription ?? `Graph of ${properties.nodes.length} nodes`}
+>
+  <ECharts options={option} />
+</div>

--- a/packages/ai-parrot-server/ui/src/lib/components/agents/canvas/a2ui/A2UIGraph.test.ts
+++ b/packages/ai-parrot-server/ui/src/lib/components/agents/canvas/a2ui/A2UIGraph.test.ts
@@ -1,0 +1,104 @@
+// ai-parrot (FEAT-529): pure ECharts-option-building logic for the bundled
+// Graph component — no rendering/canvas involved (`buildGraphOption` is
+// exported from `A2UIGraph.svelte`'s `<script module>` block precisely so
+// it is directly unit-testable this way).
+import { describe, expect, it } from 'vitest';
+import { buildGraphOption, hasCompletePositions, type GraphProperties } from './A2UIGraph.svelte';
+
+const identity = (token: string) => token;
+
+describe('A2UIGraph option building', () => {
+  it('builds echarts option from positions', () => {
+    const properties: GraphProperties = {
+      kind: 'flowchart',
+      direction: 'TB',
+      title: 'Demo',
+      nodes: [
+        { id: 'a', label: 'Start', state: 'completed' },
+        { id: 'b', label: 'End', state: 'failed' },
+      ],
+      edges: [{ from: 'a', to: 'b', label: 'go', kind: 'dashed' }],
+      layout: {
+        engine: 'layered',
+        positions: { a: { x: 0, y: 0 }, b: { x: 100, y: 0 } },
+      },
+    };
+
+    expect(hasCompletePositions(properties)).toBe(true);
+
+    const option = buildGraphOption(properties, identity);
+    const series = (option.series as Record<string, unknown>[])[0];
+    expect(series.type).toBe('graph');
+    expect(series.layout).toBe('none');
+
+    const data = series.data as Record<string, unknown>[];
+    expect(data).toHaveLength(2);
+    const byId = Object.fromEntries(data.map((entry) => [entry.id, entry]));
+    expect(byId.a.x).toBe(0);
+    expect(byId.a.y).toBe(0);
+    expect(byId.b.x).toBe(100);
+    expect(byId.b.y).toBe(0);
+
+    const links = series.links as Record<string, unknown>[];
+    expect(links).toHaveLength(1);
+    expect(links[0].source).toBe('a');
+    expect(links[0].target).toBe('b');
+    expect((links[0].lineStyle as Record<string, unknown>).type).toBe('dashed');
+
+    // State -> status role -> resolved token (identity resolver here).
+    expect((byId.a.itemStyle as Record<string, unknown>).color).toBe('var(--chart-2)'); // completed -> good
+    expect((byId.b.itemStyle as Record<string, unknown>).color).toBe('var(--destructive)'); // failed -> critical
+  });
+
+  it('falls back to circular without positions', () => {
+    const properties: GraphProperties = {
+      nodes: [{ id: 'a' }, { id: 'b' }],
+      edges: [{ from: 'a', to: 'b' }],
+    };
+
+    expect(hasCompletePositions(properties)).toBe(false);
+
+    const option = buildGraphOption(properties, identity);
+    const series = (option.series as Record<string, unknown>[])[0];
+    expect(series.layout).toBe('circular');
+
+    const data = series.data as Record<string, unknown>[];
+    expect(data.every((entry) => entry.x === undefined && entry.y === undefined)).toBe(true);
+  });
+
+  it('falls back to circular when positions are incomplete', () => {
+    const properties: GraphProperties = {
+      nodes: [{ id: 'a' }, { id: 'b' }],
+      edges: [{ from: 'a', to: 'b' }],
+      layout: { engine: 'layered', positions: { a: { x: 0, y: 0 } } }, // missing 'b'
+    };
+
+    expect(hasCompletePositions(properties)).toBe(false);
+    const option = buildGraphOption(properties, identity);
+    expect((option.series as Record<string, unknown>[])[0].layout).toBe('circular');
+  });
+
+  it('marks the selected node distinctly', () => {
+    const properties: GraphProperties = {
+      nodes: [{ id: 'a' }, { id: 'b' }],
+      edges: [],
+      selection: { selectable: true, selected: 'b' },
+    };
+    const option = buildGraphOption(properties, identity);
+    const data = (option.series as Record<string, unknown>[])[0].data as Record<string, unknown>[];
+    const selected = data.find((entry) => entry.id === 'b')!;
+    expect((selected.itemStyle as Record<string, unknown>).borderColor).toBe('var(--ring)');
+  });
+
+  it('represents node group membership', () => {
+    const properties: GraphProperties = {
+      nodes: [{ id: 'a', group: 'g1' }, { id: 'b' }],
+      edges: [],
+      groups: [{ id: 'g1', label: 'Group A', nodes: ['a'] }],
+    };
+    const option = buildGraphOption(properties, identity);
+    const data = (option.series as Record<string, unknown>[])[0].data as Record<string, unknown>[];
+    const a = data.find((entry) => entry.id === 'a')!;
+    expect(a.value).toBe('g1');
+  });
+});

--- a/packages/ai-parrot-server/ui/src/lib/components/agents/canvas/a2ui/A2UINode.svelte
+++ b/packages/ai-parrot-server/ui/src/lib/components/agents/canvas/a2ui/A2UINode.svelte
@@ -6,22 +6,44 @@
 	// HtmlDocument/the Basic primitives are rendered inline here.
 	import { resolveProps } from './a2ui-binding';
 	import { toChartBlockData } from './a2ui-chart-adapter';
-	import type { SectionDescriptor } from './a2ui-types';
+	import { VIZ_CORE_CATALOG_ID, type SectionDescriptor } from './a2ui-types';
+	import type { GraphProperties } from './A2UIGraph.svelte';
 	import type { TableBlockData, TimelineBlockData } from '../infographic/infographic-types';
 	import InfographicChartBlock from '../infographic/blocks/InfographicChartBlock.svelte';
 	import InfographicTableBlock from '../infographic/blocks/InfographicTableBlock.svelte';
 	import InfographicTimelineBlock from '../infographic/blocks/InfographicTimelineBlock.svelte';
 	import InfographicHeroCardBlock from '../infographic/blocks/InfographicHeroCardBlock.svelte';
+	import A2UIGraph from './A2UIGraph.svelte';
 	import A2UINode from './A2UINode.svelte';
 
 	let {
 		descriptor,
-		dataModel
-	}: { descriptor: SectionDescriptor; dataModel: Record<string, unknown> } = $props();
+		dataModel,
+		surfaceCatalogId
+	}: {
+		descriptor: SectionDescriptor;
+		dataModel: Record<string, unknown>;
+		/** The owning surface's default `catalogId` (FEAT-529 Module 0/7 v1.0
+		 * resolution rule: a component's OWN `catalogId` wins, else this).
+		 * Optional — omitted call sites simply never resolve to a non-default
+		 * catalog, same as before this prop existed. */
+		surfaceCatalogId?: string;
+	} = $props();
 
 	let component = $derived(descriptor.component);
 	let properties = $derived(descriptor.properties ?? {});
 	let resolved = $derived(resolveProps(properties, dataModel));
+
+	// FEAT-529: a nested authored descriptor carries its OWN `catalogId`
+	// (`{"component": "Graph", "catalogId": VIZ_CORE, "properties": {...}}`);
+	// `A2UISurface.svelte`'s root-dispatch shape instead nests the whole
+	// wire `Component` (which may carry its own `catalogId`) as `properties`
+	// — check both so either call shape resolves correctly.
+	let componentCatalogId = $derived(
+		descriptor.catalogId ?? (properties as { catalogId?: string }).catalogId,
+	);
+	let resolvedCatalogId = $derived(componentCatalogId ?? surfaceCatalogId);
+	let isVizCoreGraph = $derived(component === 'Graph' && resolvedCatalogId === VIZ_CORE_CATALOG_ID);
 
 	// -- DataTable: columns are {name, title?, ...}; resolved rows are
 	// objects keyed by column name — reshape into TableBlockData's
@@ -88,6 +110,13 @@
 		{#if resolved.body}<p class="text-sm text-foreground">{resolved.body}</p>{/if}
 		{#if resolved.footer}<p class="text-xs text-muted-foreground mt-2">{resolved.footer}</p>{/if}
 	</div>
+{:else if isVizCoreGraph}
+	<!-- FEAT-529: dispatched ONLY when this Graph resolves (own catalogId,
+	     else the surface default) to viz-core — a bare "Graph" on a
+	     Parrot-default surface falls through to the unsupported placeholder
+	     below, same as any other unknown component (spec: no $ref from
+	     viz-core to Basic/Parrot). -->
+	<A2UIGraph properties={resolved as unknown as GraphProperties} {dataModel} />
 {:else if component === 'HtmlDocument'}
 	<section class="a2ui-html-document">
 		{#if resolved.title}<h3 class="text-sm font-semibold mb-1">{resolved.title}</h3>{/if}
@@ -127,7 +156,7 @@
 {:else if component === 'List' || component === 'Row' || component === 'Column'}
 	<div class={component === 'Row' ? 'flex flex-row gap-3' : 'flex flex-col gap-2'}>
 		{#each childDescriptors as child, i (i)}
-			<A2UINode descriptor={child} {dataModel} />
+			<A2UINode descriptor={child} {dataModel} {surfaceCatalogId} />
 		{/each}
 	</div>
 {:else if component === 'Tabs'}
@@ -135,7 +164,7 @@
 		{#each tabsData as tab, i (i)}
 			<div>
 				{#if tab.title}<h4 class="text-xs font-semibold text-muted-foreground mb-1">{tab.title}</h4>{/if}
-				<A2UINode descriptor={tab.child} {dataModel} />
+				<A2UINode descriptor={tab.child} {dataModel} {surfaceCatalogId} />
 			</div>
 		{/each}
 	</div>

--- a/packages/ai-parrot-server/ui/src/lib/components/agents/canvas/a2ui/A2UINode.test.ts
+++ b/packages/ai-parrot-server/ui/src/lib/components/agents/canvas/a2ui/A2UINode.test.ts
@@ -20,6 +20,7 @@ const { features } = vi.hoisted(() => ({
 vi.mock('$lib/features', () => ({ features }));
 
 import A2UINode from './A2UINode.svelte';
+import { VIZ_CORE_CATALOG_ID } from './a2ui-types';
 
 describe('A2UINode', () => {
   it('DataTable resolves bound rows into positional cells', () => {
@@ -166,5 +167,52 @@ describe('A2UINode', () => {
     expect(screen.getByText('Revenue')).toBeInTheDocument();
     expect(screen.getByText('By month')).toBeInTheDocument();
     expect(screen.getByText(/chart feature disabled/i)).toBeInTheDocument();
+  });
+
+  // FEAT-529: catalog-aware Graph dispatch.
+  it('dispatches viz-core Graph via its own catalogId', () => {
+    render(A2UINode, {
+      descriptor: {
+        component: 'Graph',
+        catalogId: VIZ_CORE_CATALOG_ID,
+        properties: {
+          nodes: [{ id: 'a' }, { id: 'b' }],
+          edges: [{ from: 'a', to: 'b' }],
+          accessibleDescription: 'Tiny graph',
+        },
+      },
+      dataModel: {},
+    });
+    expect(screen.getByRole('img', { name: 'Tiny graph' })).toBeInTheDocument();
+    expect(screen.queryByText(/not supported/i)).not.toBeInTheDocument();
+  });
+
+  it('dispatches viz-core Graph via the surface default catalogId', () => {
+    render(A2UINode, {
+      descriptor: {
+        component: 'Graph',
+        properties: {
+          nodes: [{ id: 'a' }, { id: 'b' }],
+          edges: [{ from: 'a', to: 'b' }],
+          accessibleDescription: 'Surface-scoped graph',
+        },
+      },
+      dataModel: {},
+      surfaceCatalogId: VIZ_CORE_CATALOG_ID,
+    });
+    expect(screen.getByRole('img', { name: 'Surface-scoped graph' })).toBeInTheDocument();
+  });
+
+  it('rejects a bare Graph on a Parrot-default surface (unsupported placeholder)', () => {
+    render(A2UINode, {
+      descriptor: {
+        component: 'Graph',
+        properties: { nodes: [{ id: 'a' }, { id: 'b' }], edges: [{ from: 'a', to: 'b' }] },
+      },
+      dataModel: {},
+      // No surfaceCatalogId override — resolves to nothing (undefined !==
+      // VIZ_CORE_CATALOG_ID), same as a Parrot-default surface.
+    });
+    expect(screen.getByText(/not supported/i)).toBeInTheDocument();
   });
 });

--- a/packages/ai-parrot-server/ui/src/lib/components/agents/canvas/a2ui/a2ui-types.ts
+++ b/packages/ai-parrot-server/ui/src/lib/components/agents/canvas/a2ui/a2ui-types.ts
@@ -14,12 +14,25 @@ export interface Binding {
   path: string;
 }
 
+/** The viz-core catalog id (FEAT-529 Module 0) — a component whose resolved
+ * `catalogId` (own `catalogId`, else the surface default) equals this value
+ * is a viz-core component (e.g. `Graph`), dispatched by its own
+ * catalog-aware branch in `A2UINode.svelte`, never the legacy bare-name
+ * chain. Mirrors the backend's
+ * `parrot.outputs.a2ui.catalog.viz_core.VIZ_CORE_CATALOG_ID`. */
+export const VIZ_CORE_CATALOG_ID = "https://ai-parrot.dev/a2ui/catalogs/viz-core/1.0/catalog.json";
+
 /** A flat, wire-shaped A2UI component — props live top-level (v1.0), never
  * nested under a "properties" key. `child`/`children` reference OTHER
  * component ids in the same flat list. */
 export interface WireComponent {
   id: string;
   component: string;
+  /** This component's own catalog id, overriding the surface's default
+   * (FEAT-529 Module 0). Already reachable via the index signature below;
+   * declared explicitly so catalog-aware dispatch doesn't read an
+   * untyped prop. */
+  catalogId?: string;
   child?: string;
   children?: string[] | { componentId: string; path: string };
   metadata?: { extensions?: Record<string, unknown> };

--- a/packages/ai-parrot-server/ui/src/lib/components/agents/canvas/a2ui/a2ui-types.ts
+++ b/packages/ai-parrot-server/ui/src/lib/components/agents/canvas/a2ui/a2ui-types.ts
@@ -44,6 +44,11 @@ export interface WireComponent {
  * adapter's own authored-descriptor shape. */
 export interface SectionDescriptor {
   component: string;
+  /** This descriptor's own catalog id (e.g. `VIZ_CORE_CATALOG_ID` for a
+   * `Graph`), overriding the surface default — the authored nested-
+   * descriptor form is `{"component": "Graph", "catalogId": VIZ_CORE, ...}`
+   * (FEAT-529 Module 0/7). */
+  catalogId?: string;
   properties?: Record<string, unknown>;
 }
 

--- a/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/_graph_svg.py
+++ b/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/_graph_svg.py
@@ -1,0 +1,271 @@
+"""Shared static ``Graph`` SVG renderer (FEAT-529 Module 6).
+
+One implementation, shared by every static lane that draws ``Graph``
+inline (interactive-HTML, SSR-HTML, PDF) — spec's "one SVG implementation"
+rule, so geometry, accessibility, semantic status roles, and the
+degradation boundary agree everywhere instead of three renderers each
+hand-rolling their own markup.
+
+**No literal colour anywhere.** Node ``state`` (data) maps to a viz-core
+semantic status role via :data:`STATE_TO_STATUS`, and each role maps to a
+``DesignSystem`` CSS custom-property NAME (``--accent-green``, not
+``#22c55e``) — the SVG references ``var(--token)``, the surrounding page's
+own stylesheet (``DesignSystem.stylesheet()``) supplies the actual value.
+No JavaScript; no external asset references (pure inline ``<svg>``).
+"""
+
+from __future__ import annotations
+
+import html
+from typing import Any
+
+from parrot.outputs.a2ui.graph import GraphEdge, GraphGroup, GraphNode, GraphSpec, Position, compute_positions
+
+__all__ = ["STATE_TO_STATUS", "render_graph_svg"]
+
+#: Node domain ``state`` -> viz-core semantic status role (spec §2 renderer
+#: contract — documented here, not on any core model: state is DATA, the
+#: role/colour mapping is a RENDERER concern).
+STATE_TO_STATUS: dict[str, str] = {
+    "completed": "good",
+    "waiting": "warning",
+    "failed": "critical",
+    "running": "primary",
+    "pending": "neutral",
+    "skipped": "neutral",
+}
+
+#: Status role -> ``DesignSystem`` CSS custom-property NAME (never a
+#: resolved value — the SVG emits ``var(--token)``).
+_STATUS_TO_TOKEN: dict[str, str] = {
+    "good": "--accent-green",
+    "warning": "--accent-amber",
+    "critical": "--accent-red",
+    "primary": "--primary",
+    "neutral": "--neutral-muted",
+}
+
+#: Node box size (SVG user units) and canvas padding — independent from
+#: `compute_positions`'s abstract rank/node separation units; this module
+#: owns its own geometry.
+_NODE_WIDTH = 120.0
+_NODE_HEIGHT = 40.0
+_PADDING = 40.0
+_GROUP_MARGIN = 24.0
+
+
+def render_graph_svg(props: dict[str, Any], *, theme: str | None = None) -> str:
+    """Render a baked ``Graph`` component's props to a static SVG string.
+
+    Args:
+        props: The ``Graph`` component's top-level wire props (camelCase:
+            ``kind``, ``direction``, ``nodes``, ``edges``, ``groups``,
+            ``layout``, ``accessibleDescription``, ...). ``data`` (an
+            unresolved binding descriptor, or already-resolved by an
+            upstream bake pass) is never read as a literal ``GraphSpec.data``
+            value here — callers that need live node-state overlays must
+            apply them to ``nodes``/``edges`` themselves BEFORE calling
+            this function; this renderer draws exactly what ``nodes``/
+            ``edges`` say.
+        theme: Unused placeholder for a future per-call override. Every
+            colour reference here is a ``DesignSystem`` CSS custom
+            property NAME (``var(--accent-green)``), resolved by whatever
+            stylesheet wraps the page — never resolved to a literal value
+            in this function, so no theme value is needed to produce
+            correct markup.
+
+    Returns:
+        A self-contained ``<svg>...</svg>`` string: one shape per node,
+        group bounding boxes, arrow-marked edges styled by ``kind``, a
+        ``<title>`` equal to ``accessibleDescription`` (or a generated
+        summary), and ``data-state``/``data-status`` attributes per node.
+
+    Raises:
+        GraphTooLargeError: When positions must be computed (none were
+            already supplied) and the graph exceeds
+            :data:`~parrot.outputs.a2ui.graph.MAX_STATIC_NODES` — the
+            caller (a renderer module) is expected to catch this and
+            degrade (spec G8).
+    """
+    graph_props = {key: value for key, value in props.items() if key != "data"}
+    spec = GraphSpec.model_validate(graph_props)
+
+    positions = _extract_positions(spec)
+    if positions is None:
+        positions = compute_positions(spec).positions
+
+    half_w, half_h = _NODE_WIDTH / 2, _NODE_HEIGHT / 2
+    offset_x = _PADDING + half_w
+    offset_y = _PADDING + half_h
+    positions = {node_id: Position(x=pos.x + offset_x, y=pos.y + offset_y) for node_id, pos in positions.items()}
+
+    group_boxes = _compute_group_boxes(spec, positions)
+    width, height = _extent(positions)
+
+    accessible_description = spec.accessible_description or (
+        f"Graph of {len(spec.nodes)} nodes and {len(spec.edges)} edges ({spec.kind})"
+    )
+    escaped_description = html.escape(accessible_description)
+
+    body: list[str] = [_defs()]
+    for group in spec.groups or []:
+        box = group_boxes.get(group.id)
+        if box is not None:
+            body.append(_render_group_box(group, box))
+    for edge in spec.edges:
+        if edge.from_ in positions and edge.to in positions:
+            body.append(_render_edge(edge, positions))
+    for node in spec.nodes:
+        body.append(_render_node(node, positions[node.id]))
+
+    return (
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width:.1f} {height:.1f}" '
+        f'role="img" aria-label="{escaped_description}">'
+        f"<title>{escaped_description}</title>"
+        + "".join(body)
+        + "</svg>"
+    )
+
+
+def _extract_positions(spec: GraphSpec) -> dict[str, Position] | None:
+    """``spec.layout.positions`` when it covers every node, else ``None``."""
+    positions = spec.layout.positions if spec.layout else None
+    if positions and all(node.id in positions for node in spec.nodes):
+        return positions
+    return None
+
+
+def _compute_group_boxes(
+    spec: GraphSpec, positions: dict[str, Position]
+) -> dict[str, tuple[float, float, float, float]]:
+    half_w, half_h = _NODE_WIDTH / 2, _NODE_HEIGHT / 2
+    boxes: dict[str, tuple[float, float, float, float]] = {}
+    for group in spec.groups or []:
+        member_positions = [positions[member] for member in group.nodes if member in positions]
+        if not member_positions:
+            continue
+        min_x = min(p.x for p in member_positions) - half_w - _GROUP_MARGIN
+        min_y = min(p.y for p in member_positions) - half_h - _GROUP_MARGIN
+        max_x = max(p.x for p in member_positions) + half_w + _GROUP_MARGIN
+        max_y = max(p.y for p in member_positions) + half_h + _GROUP_MARGIN
+        boxes[group.id] = (min_x, min_y, max_x - min_x, max_y - min_y)
+    return boxes
+
+
+def _extent(positions: dict[str, Position]) -> tuple[float, float]:
+    if not positions:
+        return (_NODE_WIDTH + 2 * _PADDING, _NODE_HEIGHT + 2 * _PADDING)
+    max_x = max(p.x for p in positions.values())
+    max_y = max(p.y for p in positions.values())
+    return (max_x + _NODE_WIDTH / 2 + _PADDING, max_y + _NODE_HEIGHT / 2 + _PADDING)
+
+
+def _defs() -> str:
+    return (
+        "<defs>"
+        '<marker id="graph-arrow" viewBox="0 0 10 10" refX="9" refY="5" '
+        'markerWidth="6" markerHeight="6" orient="auto-start-reverse">'
+        '<path d="M0,0 L10,5 L0,10 z" fill="var(--neutral-muted)"/>'
+        "</marker>"
+        "</defs>"
+    )
+
+
+def _render_group_box(group: GraphGroup, box: tuple[float, float, float, float]) -> str:
+    x, y, w, h = box
+    label_markup = ""
+    if group.label:
+        label_markup = f'<text x="{x + 4:.1f}" y="{y + 14:.1f}" font-size="10">{html.escape(group.label)}</text>'
+    return (
+        f'<rect x="{x:.1f}" y="{y:.1f}" width="{w:.1f}" height="{h:.1f}" '
+        'fill="none" stroke="var(--neutral-muted)" stroke-dasharray="4,4"/>' + label_markup
+    )
+
+
+def _render_edge(edge: GraphEdge, positions: dict[str, Position]) -> str:
+    """Draw ``edge`` in its ORIGINAL ``from`` -> ``to`` direction.
+
+    ``positions`` may come from a layout that internally reversed this
+    edge to break a cycle for RANKING purposes only — this function never
+    consults that; it always draws from the edge's own ``from_``/``to``
+    (spec §7 "Cycles in flowchart/state ... the arrowhead on the original
+    direction").
+    """
+    start = positions[edge.from_]
+    end = positions[edge.to]
+    dash_attr = ' stroke-dasharray="6,4"' if edge.kind == "dashed" else ""
+    stroke_width = 3 if edge.kind == "thick" else 1.5
+    label_markup = ""
+    if edge.label:
+        mid_x, mid_y = (start.x + end.x) / 2, (start.y + end.y) / 2
+        label_markup = (
+            f'<text x="{mid_x:.1f}" y="{mid_y:.1f}" text-anchor="middle" font-size="10">'
+            f"{html.escape(edge.label)}</text>"
+        )
+    return (
+        f'<line x1="{start.x:.1f}" y1="{start.y:.1f}" x2="{end.x:.1f}" y2="{end.y:.1f}" '
+        f'stroke="var(--neutral-muted)" stroke-width="{stroke_width}"{dash_attr} '
+        'marker-end="url(#graph-arrow)"/>' + label_markup
+    )
+
+
+def _render_node(node: GraphNode, position: Position) -> str:
+    status = STATE_TO_STATUS.get(node.state, "neutral") if node.state else "neutral"
+    token = _STATUS_TO_TOKEN[status]
+    label = node.label if node.label is not None else node.id
+    shape = node.shape or "rect"
+    cx, cy = position.x, position.y
+    half_w, half_h = _NODE_WIDTH / 2, _NODE_HEIGHT / 2
+
+    title_markup = ""
+    if node.meta:
+        meta_title = ", ".join(f"{key}={value}" for key, value in node.meta.items())
+        title_markup = f"<title>{html.escape(meta_title)}</title>"
+
+    common_attrs = (
+        f'data-node-id="{html.escape(node.id)}" data-state="{html.escape(node.state or "")}" '
+        f'data-status="{status}" fill="var({token})" stroke="var({token})"'
+    )
+
+    if shape == "circle":
+        radius = min(_NODE_WIDTH, _NODE_HEIGHT) / 2
+        shape_markup = f'<circle cx="{cx:.1f}" cy="{cy:.1f}" r="{radius:.1f}" {common_attrs}/>'
+    elif shape == "diamond":
+        points = (
+            f"{cx:.1f},{cy - half_h:.1f} {cx + half_w:.1f},{cy:.1f} "
+            f"{cx:.1f},{cy + half_h:.1f} {cx - half_w:.1f},{cy:.1f}"
+        )
+        shape_markup = f'<polygon points="{points}" {common_attrs}/>'
+    elif shape == "hexagon":
+        inset = half_w * 0.3
+        points = (
+            f"{cx - half_w + inset:.1f},{cy - half_h:.1f} {cx + half_w - inset:.1f},{cy - half_h:.1f} "
+            f"{cx + half_w:.1f},{cy:.1f} {cx + half_w - inset:.1f},{cy + half_h:.1f} "
+            f"{cx - half_w + inset:.1f},{cy + half_h:.1f} {cx - half_w:.1f},{cy:.1f}"
+        )
+        shape_markup = f'<polygon points="{points}" {common_attrs}/>'
+    elif shape == "subroutine":
+        x, y = cx - half_w, cy - half_h
+        inset = 6.0
+        shape_markup = (
+            f'<rect x="{x:.1f}" y="{y:.1f}" width="{_NODE_WIDTH:.1f}" height="{_NODE_HEIGHT:.1f}" {common_attrs}/>'
+            f'<line x1="{x + inset:.1f}" y1="{y:.1f}" x2="{x + inset:.1f}" y2="{y + _NODE_HEIGHT:.1f}" '
+            f'stroke="var({token})"/>'
+            f'<line x1="{x + _NODE_WIDTH - inset:.1f}" y1="{y:.1f}" x2="{x + _NODE_WIDTH - inset:.1f}" '
+            f'y2="{y + _NODE_HEIGHT:.1f}" stroke="var({token})"/>'
+        )
+    elif shape == "rounded":
+        x, y = cx - half_w, cy - half_h
+        shape_markup = (
+            f'<rect x="{x:.1f}" y="{y:.1f}" width="{_NODE_WIDTH:.1f}" height="{_NODE_HEIGHT:.1f}" '
+            f'rx="10" ry="10" {common_attrs}/>'
+        )
+    else:  # "rect" (also the fallback for an unrecognized shape)
+        x, y = cx - half_w, cy - half_h
+        shape_markup = f'<rect x="{x:.1f}" y="{y:.1f}" width="{_NODE_WIDTH:.1f}" height="{_NODE_HEIGHT:.1f}" {common_attrs}/>'
+
+    text_markup = (
+        f'<text x="{cx:.1f}" y="{cy:.1f}" text-anchor="middle" dominant-baseline="middle">'
+        f"{html.escape(label)}</text>"
+    )
+    return f"<g>{title_markup}{shape_markup}{text_markup}</g>"

--- a/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/_graph_svg.py
+++ b/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/_graph_svg.py
@@ -56,7 +56,19 @@ _GROUP_MARGIN = 24.0
 #: Wire Component-level keys (never part of GraphSpec) to strip from a
 #: whole-component dict before reconstructing a bare GraphSpec.
 _COMPONENT_ONLY_KEYS = frozenset(
-    {"id", "component", "catalogId", "child", "children", "weight", "accessibility", "checks", "action", "metadata", "data"}
+    {
+        "id",
+        "component",
+        "catalogId",
+        "child",
+        "children",
+        "weight",
+        "accessibility",
+        "checks",
+        "action",
+        "metadata",
+        "data",
+    }
 )
 
 
@@ -137,9 +149,7 @@ def render_graph_svg(props: dict[str, Any], *, theme: str | None = None) -> str:
     return (
         f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width:.1f} {height:.1f}" '
         f'role="img" aria-label="{escaped_description}">'
-        f"<title>{escaped_description}</title>"
-        + "".join(body)
-        + "</svg>"
+        f"<title>{escaped_description}</title>" + "".join(body) + "</svg>"
     )
 
 
@@ -278,7 +288,9 @@ def _render_node(node: GraphNode, position: Position) -> str:
         )
     else:  # "rect" (also the fallback for an unrecognized shape)
         x, y = cx - half_w, cy - half_h
-        shape_markup = f'<rect x="{x:.1f}" y="{y:.1f}" width="{_NODE_WIDTH:.1f}" height="{_NODE_HEIGHT:.1f}" {common_attrs}/>'
+        shape_markup = (
+            f'<rect x="{x:.1f}" y="{y:.1f}" width="{_NODE_WIDTH:.1f}" height="{_NODE_HEIGHT:.1f}" {common_attrs}/>'
+        )
 
     text_markup = (
         f'<text x="{cx:.1f}" y="{cy:.1f}" text-anchor="middle" dominant-baseline="middle">'

--- a/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/_graph_svg.py
+++ b/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/_graph_svg.py
@@ -53,14 +53,24 @@ _NODE_HEIGHT = 40.0
 _PADDING = 40.0
 _GROUP_MARGIN = 24.0
 
+#: Wire Component-level keys (never part of GraphSpec) to strip from a
+#: whole-component dict before reconstructing a bare GraphSpec.
+_COMPONENT_ONLY_KEYS = frozenset(
+    {"id", "component", "catalogId", "child", "children", "weight", "accessibility", "checks", "action", "metadata", "data"}
+)
+
 
 def render_graph_svg(props: dict[str, Any], *, theme: str | None = None) -> str:
     """Render a baked ``Graph`` component's props to a static SVG string.
 
     Args:
-        props: The ``Graph`` component's top-level wire props (camelCase:
-            ``kind``, ``direction``, ``nodes``, ``edges``, ``groups``,
-            ``layout``, ``accessibleDescription``, ...). ``data`` (an
+        props: The ``Graph`` component's props — either the bare GraphSpec
+            fields (camelCase: ``kind``, ``direction``, ``nodes``,
+            ``edges``, ``groups``, ``layout``, ``accessibleDescription``,
+            ...) or a whole baked ``Component.model_dump()`` dict (also
+            carrying ``id``/``component``/``catalogId``/``action``/
+            ``metadata``); both shapes work — any wire Component-level key
+            is stripped before reconstructing a ``GraphSpec``. ``data`` (an
             unresolved binding descriptor, or already-resolved by an
             upstream bake pass) is never read as a literal ``GraphSpec.data``
             value here — callers that need live node-state overlays must
@@ -87,7 +97,13 @@ def render_graph_svg(props: dict[str, Any], *, theme: str | None = None) -> str:
             caller (a renderer module) is expected to catch this and
             degrade (spec G8).
     """
-    graph_props = {key: value for key, value in props.items() if key != "data"}
+    # `props` is a whole-component dict — a baked `Component.model_dump()`
+    # (id/component/catalogId/action/metadata/... alongside the actual
+    # GraphSpec fields) — never just `Component.model_extra` (which already
+    # excludes those declared fields). Strip them, plus `data` (an
+    # unresolved/resolved binding), before reconstructing a bare
+    # `GraphSpec` (`extra="forbid"`).
+    graph_props = {key: value for key, value in props.items() if key not in _COMPONENT_ONLY_KEYS}
     spec = GraphSpec.model_validate(graph_props)
 
     positions = _extract_positions(spec)

--- a/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/_intercept.py
+++ b/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/_intercept.py
@@ -1,0 +1,68 @@
+"""Catalog-aware renderer interception helpers (FEAT-529 Module 0).
+
+Every satellite renderer draws a handful of composite components (``Chart``,
+``DataTable``, ``Map``, ...) NATIVELY, intercepting them before the generic
+lowering pass runs (see ``interactive_html.py``'s ``_INTERCEPTED``,
+``ssr_html.py``'s ``_lower_composites``). Until now that interception was
+keyed by bare component NAME alone — safe only because every catalog had a
+disjoint name set. With a second catalog (``viz-core``) registering
+components, interception must resolve the SAME catalog id
+:func:`~parrot.outputs.a2ui.catalog.resolve_catalog` would (component's own
+``catalogId``, else the surface default) and key on the
+``(catalog_id, name)`` pair — so a future viz-core ``Chart`` and the existing
+Parrot ``Chart`` never intercept for each other's renderer branch.
+"""
+
+from __future__ import annotations
+
+from parrot.outputs.a2ui.catalog import resolve_catalog
+from parrot.outputs.a2ui.models import Component
+
+__all__ = ["intercepts", "resolve_component_catalog"]
+
+
+def resolve_component_catalog(comp: Component, surface_catalog_id: str | None) -> str:
+    """Resolve the effective catalog id for a wire ``Component``.
+
+    Thin wrapper over :func:`parrot.outputs.a2ui.catalog.resolve_catalog` so
+    renderers never re-implement the component-vs-surface precedence rule.
+
+    Args:
+        comp: The wire component.
+        surface_catalog_id: The owning surface's default ``catalogId``.
+
+    Returns:
+        The resolved catalog id.
+
+    Raises:
+        CatalogValidationError: If neither the component nor the surface
+            declares a catalog id.
+    """
+    return resolve_catalog(comp.catalog_id, surface_catalog_id)
+
+
+def intercepts(
+    table: frozenset[tuple[str, str]],
+    comp: Component,
+    surface_catalog_id: str | None,
+) -> bool:
+    """Whether ``comp`` should be drawn natively instead of lowered.
+
+    Args:
+        table: A frozenset of ``(catalog_id, name)`` pairs this renderer
+            draws natively — e.g.
+            ``{(DEFAULT_CATALOG_ID, "Chart"), (VIZ_CORE_CATALOG_ID, "Graph")}``.
+        comp: The wire component being considered.
+        surface_catalog_id: The owning surface's default ``catalogId``.
+
+    Returns:
+        ``True`` if ``comp``'s resolved ``(catalog_id, name)`` is in
+        ``table``. ``False`` (never raises) when the catalog id cannot be
+        resolved — an unresolved component is a validation failure caught
+        elsewhere, not this helper's concern.
+    """
+    try:
+        resolved = resolve_component_catalog(comp, surface_catalog_id)
+    except Exception:  # noqa: BLE001 - CatalogValidationError; validation reports it elsewhere
+        return False
+    return (resolved, comp.component) in table

--- a/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/adaptive_cards.py
+++ b/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/adaptive_cards.py
@@ -54,10 +54,11 @@ from typing import Any
 # registered so lowering/dispatch can resolve every component name.
 import parrot.outputs.a2ui.catalog.basic
 import parrot.outputs.a2ui.catalog.parrot  # noqa: F401 — ensure registration
+import parrot.outputs.a2ui.catalog.viz_core  # noqa: F401 — ensure Graph registration (FEAT-529)
 from parrot.outputs.a2ui.artifacts import DeepLink, RenderedArtifact
 from parrot.outputs.a2ui.baking import bake_envelope
-from parrot.outputs.a2ui.catalog import get_component
-from parrot.outputs.a2ui.catalog.base import BasicNode, TabSpec, to_components
+from parrot.outputs.a2ui.catalog import get_component, resolve_catalog
+from parrot.outputs.a2ui.catalog.base import BasicNode, CatalogValidationError, TabSpec, to_components
 from parrot.outputs.a2ui.models import ActionMessage, Component, CreateSurface
 from parrot.outputs.a2ui.renderers import (
     AbstractA2UIRenderer,
@@ -258,7 +259,7 @@ class AdaptiveCardsRenderer(AbstractA2UIRenderer):
         # TASK-2543) — binding-path extraction below must also see the
         # LOWERED (but not yet baked) input primitives, since they are
         # themselves Basic Catalog primitives and lowering never touches them.
-        lowered_envelope = self._lower_composites(envelope)
+        lowered_envelope, graph_degradations = self._lower_composites(envelope)
         binding_paths = self._binding_paths(lowered_envelope.components)
         button_actions = self._button_actions(lowered_envelope.components)
         baked_components = bake_envelope(lowered_envelope)
@@ -271,6 +272,7 @@ class AdaptiveCardsRenderer(AbstractA2UIRenderer):
             button_actions=button_actions,
             data_model=envelope.data_model,
         )
+        state.degradations.extend(graph_degradations)
 
         elements: list[ACElement] = []
         if "root" in by_id:
@@ -299,14 +301,40 @@ class AdaptiveCardsRenderer(AbstractA2UIRenderer):
 
     # -- lowering (composites -> flat primitives, BEFORE baking) -------------
 
-    def _lower_composites(self, envelope: CreateSurface) -> CreateSurface:
+    def _lower_composites(self, envelope: CreateSurface) -> tuple[CreateSurface, list[dict[str, Any]]]:
         """Replace every non-primitive (Parrot composite) component with its
         lowered + flattened primitive equivalents, in place, in the envelope's
         own flat component list. Mirrors
         :meth:`~parrot.outputs.a2ui_renderers.ssr_html.SSRHTMLRenderer._lower_composites`.
+
+        This renderer never declares viz-core support (spec §7 "Adaptive
+        Cards and Folium show the lowered description + edge list + mermaid
+        source with a degraded entry naming the catalog") — a viz-core
+        ``Graph`` always lowers via its own ``GraphComponent.lower()``
+        (already produces readable Text/Column/Card primitives this
+        renderer natively supports), but is ADDITIONALLY recorded as a
+        degradation naming the unsupported catalog id, since otherwise
+        nothing would ever indicate the native component was skipped.
+
+        Returns:
+            The envelope with composites lowered, and any Graph-specific
+            degradation records collected along the way.
         """
         new_components: list[Component] = []
+        degradations: list[dict[str, Any]] = []
         for comp in envelope.components:
+            if comp.component == "Graph":
+                try:
+                    resolved_catalog_id = resolve_catalog(comp.catalog_id, envelope.catalog_id)
+                except CatalogValidationError:
+                    resolved_catalog_id = comp.catalog_id or "unknown"
+                degradations.append(
+                    degradation_record(
+                        BasicNode(id=comp.id, component="Graph"),
+                        f"{_SURFACE_NAME} does not support catalog {resolved_catalog_id!r}; "
+                        "rendered as a lowered summary",
+                    )
+                )
             try:
                 entry = get_component(comp.component)
             except KeyError:
@@ -316,7 +344,7 @@ class AdaptiveCardsRenderer(AbstractA2UIRenderer):
                 new_components.extend(to_components(tree, id_prefix=f"{comp.id}-lc"))
             else:
                 new_components.append(comp)
-        return envelope.model_copy(update={"components": new_components})
+        return envelope.model_copy(update={"components": new_components}), degradations
 
     # -- binding-path extraction (BEFORE baking resolves them away) ----------
 

--- a/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/echarts.py
+++ b/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/echarts.py
@@ -19,20 +19,38 @@ from typing import Any
 
 import parrot.outputs.a2ui.catalog.basic
 import parrot.outputs.a2ui.catalog.parrot  # noqa: F401 — ensure registration
+import parrot.outputs.a2ui.catalog.viz_core  # noqa: F401 — ensure Graph registration (FEAT-529)
 from parrot.outputs.a2ui.artifacts import RenderedArtifact
 from parrot.outputs.a2ui.baking import bake_envelope
-from parrot.outputs.a2ui.catalog.base import BasicNode
-from parrot.outputs.a2ui.models import CreateSurface
+from parrot.outputs.a2ui.catalog.base import DEFAULT_CATALOG_ID, BasicNode
+from parrot.outputs.a2ui.catalog.basic import BASIC_CATALOG_ID
+from parrot.outputs.a2ui.catalog.viz_core import VIZ_CORE_CATALOG_ID
+from parrot.outputs.a2ui.graph import GraphEdge, GraphSpec, compute_positions
+from parrot.outputs.a2ui.models import Component, CreateSurface
 from parrot.outputs.a2ui.renderers import (
     AbstractA2UIRenderer,
     RendererCapabilities,
     register_a2ui_renderer,
 )
 from parrot.outputs.a2ui.renderers.degrade import degradation_record
+from parrot.outputs.a2ui_renderers._graph_svg import STATE_TO_STATUS
+from parrot.outputs.a2ui_renderers._intercept import intercepts
 
 logger = logging.getLogger(__name__)
 
 _SURFACE_NAME = "echarts"
+
+#: The one (catalog_id, name) pair this renderer intercepts as a native
+#: Graph — used with the shared catalog-aware `intercepts()` helper so a
+#: future viz-core `Chart` (a2ui-viz-core-charts) is never confused with
+#: this renderer's existing Parrot `Chart` dispatch.
+_GRAPH_INTERCEPT_TABLE = frozenset({(VIZ_CORE_CATALOG_ID, "Graph")})
+
+#: Wire Component-level keys (never part of GraphSpec) to strip from a
+#: baked whole-component dict before reconstructing a bare GraphSpec.
+_COMPONENT_ONLY_KEYS = frozenset(
+    {"id", "component", "catalogId", "child", "children", "weight", "accessibility", "checks", "action", "metadata", "data"}
+)
 
 # Vendored ECharts bundle (shared with the legacy infographic HTML renderer).
 _ECHARTS_JS_PATH = Path(__file__).parent.parent / "formats" / "assets" / "echarts.min.js"
@@ -65,11 +83,12 @@ _ROW_NATIVE_TYPES = frozenset({"gauge", "funnel", "treemap", "heatmap", "waterfa
         supports_actions=False,
         supports_updates=False,
         output="application/json",
-        supported_components={"Chart"},
+        supported_catalog_ids=[BASIC_CATALOG_ID, DEFAULT_CATALOG_ID, VIZ_CORE_CATALOG_ID],
+        supported_components={"Chart", "Graph"},
     ),
 )
 class EChartsRenderer(AbstractA2UIRenderer):
-    """Chart-component → ECharts option JSON renderer (+ optional vendored HTML wrap)."""
+    """Chart/Graph-component → ECharts option JSON renderer (+ optional vendored HTML wrap)."""
 
     async def render(
         self,
@@ -78,10 +97,16 @@ class EChartsRenderer(AbstractA2UIRenderer):
         bake: bool = True,
         wrap_html: bool = False,
     ) -> RenderedArtifact:
-        """Render the first Chart component to an ECharts option (JSON or HTML wrap).
+        """Render the first Chart or viz-core Graph component to an ECharts option.
+
+        Graph is dispatched BEFORE Chart (spec Implementation Notes): a
+        viz-core ``Graph`` (resolved catalog-aware, via the satellite's
+        shared ``resolve_component_catalog`` helper — spec §7 "sibling spec
+        overlap") wins over a Parrot ``Chart`` if both are somehow present.
 
         Args:
-            envelope: The validated envelope containing a ``Chart`` component.
+            envelope: The validated envelope containing a ``Chart`` or
+                viz-core ``Graph`` component.
             bake: Bindings are always resolved (static output).
             wrap_html: When ``True``, emit a self-contained HTML document inlining the
                 vendored ECharts bundle instead of raw option JSON.
@@ -93,26 +118,37 @@ class EChartsRenderer(AbstractA2UIRenderer):
             never silent).
 
         Raises:
-            ValueError: If the envelope contains no ``Chart`` component.
+            ValueError: If the envelope contains neither a ``Chart`` nor a
+                viz-core ``Graph`` component.
         """
         baked = bake_envelope(envelope)
-        chart = next((c for c in baked if c["component"] == "Chart"), None)
-        if chart is None:
-            raise ValueError("echarts renderer requires a 'Chart' component in the envelope.")
+
+        graph_item = None
+        chart_item = None
+        for item in baked:
+            if item["component"] == "Graph" and graph_item is None:
+                if intercepts(_GRAPH_INTERCEPT_TABLE, Component(**item), envelope.catalog_id):
+                    graph_item = item
+            elif item["component"] == "Chart" and chart_item is None:
+                chart_item = item
+
+        primary = graph_item if graph_item is not None else chart_item
+        if primary is None:
+            raise ValueError("echarts renderer requires a 'Chart' or viz-core 'Graph' component in the envelope.")
 
         degradations = [
             degradation_record(
                 BasicNode(id=item["id"], component=item["component"]),
-                f"{_SURFACE_NAME} renderer only renders a single Chart component per surface",
+                f"{_SURFACE_NAME} renderer only renders a single Chart/Graph component per surface",
             )
             for item in baked
-            if item is not chart
+            if item is not primary
         ]
 
-        option = self._build_option(chart)
+        option = self._build_graph_option(primary) if graph_item is not None else self._build_option(primary)
 
         if wrap_html:
-            document = self._wrap_html(option, chart.get("title", ""))
+            document = self._wrap_html(option, primary.get("title", ""))
             return RenderedArtifact(
                 artifact_id=f"{_SURFACE_NAME}-{envelope.surface_id}",
                 mime_type="text/html",
@@ -286,6 +322,94 @@ class EChartsRenderer(AbstractA2UIRenderer):
                 option["xAxis"] = x_axis
                 option["yAxis"] = y_axis
         return option
+
+    def _build_graph_option(self, props: dict[str, Any]) -> dict[str, Any]:
+        """Build a native ECharts ``graph`` series option from ``Graph`` props (FEAT-529).
+
+        Uses ``layout: "none"`` with server-prepared positions (spec §7 "a
+        layout is server-side preparation") — computed via
+        :func:`~parrot.outputs.a2ui.graph.compute_positions` when
+        ``layout.positions`` is absent or incomplete. Node ``state`` maps to
+        the shared viz-core status role (:data:`~parrot.outputs.
+        a2ui_renderers._graph_svg.STATE_TO_STATUS`) as the ECharts
+        ``category`` — colour/theme is ECharts' own concern (an
+        ``option["categories"]`` entry per role, no literal colour set
+        here); node order/edge from/to are preserved from the input.
+
+        Args:
+            props: The baked ``Graph`` component's top-level wire props.
+                ``data`` (an unresolved/resolved binding) is excluded before
+                reconstructing a :class:`~parrot.outputs.a2ui.graph.GraphSpec`
+                — the same reasoning as ``catalog/viz_core/graph.py``'s
+                ``lower()``.
+
+        Returns:
+            An ECharts option dict: a single ``series[0]`` of
+            ``type: "graph"``.
+        """
+        # `props` here is a BAKED whole-component dict (`component.model_dump()`),
+        # not `Component.model_extra` — so the wire Component-level keys
+        # (id/component/catalogId/action/metadata/...) are present and must
+        # be stripped, alongside `data` (an unresolved/resolved binding),
+        # before reconstructing a bare GraphSpec (`extra="forbid"`).
+        graph_props = {key: value for key, value in props.items() if key not in _COMPONENT_ONLY_KEYS}
+        spec = GraphSpec.model_validate(graph_props)
+
+        positions = spec.layout.positions if spec.layout else None
+        if not positions or not all(node.id in positions for node in spec.nodes):
+            positions = compute_positions(spec).positions
+
+        categories_in_order = ["good", "warning", "critical", "primary", "neutral"]
+        category_index = {name: idx for idx, name in enumerate(categories_in_order)}
+
+        data = []
+        for node in spec.nodes:
+            pos = positions[node.id]
+            status = STATE_TO_STATUS.get(node.state, "neutral") if node.state else "neutral"
+            data.append(
+                {
+                    "id": node.id,
+                    "name": node.label if node.label is not None else node.id,
+                    "x": pos.x,
+                    "y": pos.y,
+                    "category": category_index[status],
+                }
+            )
+
+        links = [
+            {
+                "source": edge.from_,
+                "target": edge.to,
+                "lineStyle": self._graph_edge_line_style(edge),
+                **({"label": {"show": True, "formatter": edge.label}} if edge.label else {}),
+            }
+            for edge in spec.edges
+        ]
+
+        return {
+            "title": {"text": spec.title or ""},
+            "series": [
+                {
+                    "type": "graph",
+                    "layout": "none",
+                    "roam": True,
+                    "label": {"show": True},
+                    "edgeSymbol": ["none", "arrow"],
+                    "categories": [{"name": name} for name in categories_in_order],
+                    "data": data,
+                    "links": links,
+                }
+            ],
+        }
+
+    @staticmethod
+    def _graph_edge_line_style(edge: GraphEdge) -> dict[str, Any]:
+        style: dict[str, Any] = {}
+        if edge.kind == "dashed":
+            style["type"] = "dashed"
+        elif edge.kind == "thick":
+            style["width"] = 3
+        return style
 
     @staticmethod
     def _linear_trend(values: list[Any]) -> list[float]:

--- a/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/echarts.py
+++ b/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/echarts.py
@@ -49,7 +49,19 @@ _GRAPH_INTERCEPT_TABLE = frozenset({(VIZ_CORE_CATALOG_ID, "Graph")})
 #: Wire Component-level keys (never part of GraphSpec) to strip from a
 #: baked whole-component dict before reconstructing a bare GraphSpec.
 _COMPONENT_ONLY_KEYS = frozenset(
-    {"id", "component", "catalogId", "child", "children", "weight", "accessibility", "checks", "action", "metadata", "data"}
+    {
+        "id",
+        "component",
+        "catalogId",
+        "child",
+        "children",
+        "weight",
+        "accessibility",
+        "checks",
+        "action",
+        "metadata",
+        "data",
+    }
 )
 
 # Vendored ECharts bundle (shared with the legacy infographic HTML renderer).
@@ -215,9 +227,7 @@ class EChartsRenderer(AbstractA2UIRenderer):
                 base_option["yAxis"] = {"type": "category", "data": list(y_cols)}
             elif chart_type == "radar":
                 base_option["radar"] = {
-                    "indicator": [
-                        self._radar_indicator(str(c), idx, y_cols, rows) for idx, c in enumerate(categories)
-                    ]
+                    "indicator": [self._radar_indicator(str(c), idx, y_cols, rows) for idx, c in enumerate(categories)]
                 }
             # Code-review fix (FEAT-527): palette/colorBySign used to only be
             # applied in the standard per-y-column path below — the early

--- a/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/folium_map.py
+++ b/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/folium_map.py
@@ -299,14 +299,28 @@ class FoliumMapRenderer(AbstractA2UIRenderer):
         if map_comp is None:
             raise ValueError("folium_map renderer requires a 'Map' component in the envelope.")
 
-        degradations = [
-            degradation_record(
-                BasicNode(id=item["id"], component=item["component"]),
-                f"{_SURFACE_NAME} renderer only renders a single Map component per surface",
+        degradations = []
+        for item in baked:
+            if item is map_comp:
+                continue
+            if item["component"] == "Graph":
+                # FEAT-529: a viz-core Graph gets its own catalog-named
+                # record (spec §7) rather than the generic
+                # "only renders a single Map" message below.
+                resolved_catalog_id = item.get("catalogId") or envelope.catalog_id
+                degradations.append(
+                    degradation_record(
+                        BasicNode(id=item["id"], component="Graph"),
+                        f"{_SURFACE_NAME} does not support catalog {resolved_catalog_id!r}; not rendered",
+                    )
+                )
+                continue
+            degradations.append(
+                degradation_record(
+                    BasicNode(id=item["id"], component=item["component"]),
+                    f"{_SURFACE_NAME} renderer only renders a single Map component per surface",
+                )
             )
-            for item in baked
-            if item is not map_comp
-        ]
 
         document, _ = build_map_document(map_comp, cluster_threshold=DEFAULT_CLUSTER_THRESHOLD)
         return RenderedArtifact(

--- a/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/interactive_html.py
+++ b/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/interactive_html.py
@@ -1342,9 +1342,7 @@ class InteractiveHTMLRenderer(AbstractA2UIRenderer):
             f"<pre>{html.escape(mermaid_source)}</pre></details></div>"
         )
 
-    def _render_graph_truncated_fallback(
-        self, props: dict[str, Any], degradations: list[dict[str, Any]]
-    ) -> str:
+    def _render_graph_truncated_fallback(self, props: dict[str, Any], degradations: list[dict[str, Any]]) -> str:
         """Oversize-graph fallback: ``GraphComponent``'s own lowered tree,
         with its edge-list Column truncated to :data:`MAX_STATIC_NODES` rows.
 

--- a/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/interactive_html.py
+++ b/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/interactive_html.py
@@ -77,10 +77,15 @@ from typing import Any
 # registered so lowering/dispatch can resolve every component name.
 import parrot.outputs.a2ui.catalog.basic
 import parrot.outputs.a2ui.catalog.parrot  # noqa: F401 — ensure registration
+import parrot.outputs.a2ui.catalog.viz_core  # noqa: F401 — ensure Graph registration (FEAT-529)
 from parrot.outputs.a2ui.artifacts import RenderedArtifact
 from parrot.outputs.a2ui.baking import bake_envelope
 from parrot.outputs.a2ui.catalog import get_component
-from parrot.outputs.a2ui.catalog.base import BasicNode, TabSpec, to_components
+from parrot.outputs.a2ui.catalog.base import BasicNode, DEFAULT_CATALOG_ID, TabSpec, to_components
+from parrot.outputs.a2ui.catalog.basic import BASIC_CATALOG_ID
+from parrot.outputs.a2ui.catalog.viz_core import VIZ_CORE_CATALOG_ID
+from parrot.outputs.a2ui.catalog.viz_core.graph import GraphComponent
+from parrot.outputs.a2ui.graph import MAX_STATIC_NODES, GraphSpec, GraphTooLargeError, to_mermaid
 from parrot.outputs.a2ui.models import Component, ComponentMetadata, CreateSurface
 from parrot.outputs.a2ui.renderers import (
     AbstractA2UIRenderer,
@@ -90,6 +95,8 @@ from parrot.outputs.a2ui.renderers import (
 from parrot.outputs.a2ui.renderers.degrade import degradation_record, degrade
 from parrot.outputs.formats.assets.design_system import DesignSystem
 
+from ._graph_svg import render_graph_svg
+from ._intercept import intercepts
 from ._semantics import (
     is_kpi_row,
     kpi_unit_html,
@@ -116,8 +123,15 @@ logger = logging.getLogger(__name__)
 _SURFACE_NAME = "interactive-html"
 
 #: Components intercepted BEFORE lowering — their real (graphics/nested)
-#: rendering is this renderer's own job, not their catalog `lower()`.
+#: rendering is this renderer's own job, not their catalog `lower()`. All
+#: Parrot catalog, bare-name unambiguous (FEAT-529 Module 0: Graph is
+#: viz-core-only and resolved catalog-aware via `_GRAPH_INTERCEPT_TABLE`
+#: below, not this set).
 _INTERCEPTED = {"Chart", "DataTable", "Infographic", "Map", "HtmlDocument"}
+
+#: The one (catalog_id, name) pair intercepted as a native Graph — used
+#: with the shared catalog-aware `intercepts()` helper (FEAT-529).
+_GRAPH_INTERCEPT_TABLE = frozenset({(VIZ_CORE_CATALOG_ID, "Graph")})
 
 
 def _propagate_extensions(parent: Component, lowered: list[Component]) -> list[Component]:
@@ -144,6 +158,39 @@ def _propagate_extensions(parent: Component, lowered: list[Component]) -> list[C
         merged = {**parent_ext, **child_ext}  # child's own key wins on collision
         merged_components.append(child.model_copy(update={"metadata": ComponentMetadata(extensions=merged)}))
     return merged_components
+
+
+#: Wire Component-level keys (never part of GraphSpec) — `data` is
+#: deliberately KEPT out of this set: `GraphComponent.lower()` reads it off
+#: `Component.model_extra` itself for its `parrot_graph_data` pass-through
+#: (FEAT-529).
+_GRAPH_COMPONENT_ONLY_KEYS = frozenset(
+    {"id", "component", "catalogId", "child", "children", "weight", "accessibility", "checks", "action", "metadata"}
+)
+
+
+def _strip_graph_component_keys(props: dict[str, Any]) -> dict[str, Any]:
+    """Strip wire Component-level keys from a baked Graph props dict, keeping ``data``."""
+    return {key: value for key, value in props.items() if key not in _GRAPH_COMPONENT_ONLY_KEYS}
+
+
+def _graph_spec_props(props: dict[str, Any]) -> dict[str, Any]:
+    """``_strip_graph_component_keys`` plus ``data`` — a bare GraphSpec's own props."""
+    return {key: value for key, value in _strip_graph_component_keys(props).items() if key != "data"}
+
+
+def _truncate_graph_edge_list(tree: BasicNode) -> None:
+    """Truncate a lowered ``Graph``'s edge-list ``Column`` children to
+    :data:`~parrot.outputs.a2ui.graph.MAX_STATIC_NODES` rows, in place
+    (FEAT-529 oversize-graph fallback)."""
+    column = tree.child
+    if column is None or not isinstance(column.children, list):
+        return
+    for child in column.children:
+        if isinstance(child, BasicNode) and node_extensions(child).get("parrot_role") == "edge-list":
+            if isinstance(child.children, list) and len(child.children) > MAX_STATIC_NODES:
+                child.children = child.children[:MAX_STATIC_NODES]
+            break
 
 
 #: Vendored Chart.js v4.5.1 UMD bundle (MIT license header preserved in the
@@ -559,6 +606,7 @@ def _esc(value: Any) -> str:
         supports_actions=False,
         supports_updates=False,
         output="text/html",
+        supported_catalog_ids=[BASIC_CATALOG_ID, DEFAULT_CATALOG_ID, VIZ_CORE_CATALOG_ID],
         supported_components={
             "AudioPlayer",
             "Button",
@@ -582,6 +630,7 @@ def _esc(value: Any) -> str:
             "DataTable",
             "Infographic",
             "Map",
+            "Graph",
         },
     ),
 )
@@ -674,6 +723,9 @@ class InteractiveHTMLRenderer(AbstractA2UIRenderer):
             if comp.component in _INTERCEPTED:
                 new_components.append(comp)
                 continue
+            if comp.component == "Graph" and intercepts(_GRAPH_INTERCEPT_TABLE, comp, envelope.catalog_id):
+                new_components.append(comp)
+                continue
             try:
                 entry = get_component(comp.component)
             except KeyError:
@@ -716,6 +768,8 @@ class InteractiveHTMLRenderer(AbstractA2UIRenderer):
             return self._render_map(comp)
         if name == "HtmlDocument":
             return self._render_htmldocument(comp)
+        if name == "Graph":
+            return self._render_graph(comp, degradations)
         node = self._reconstruct(comp["id"], by_id)
         return self._render_basic(node, degradations)
 
@@ -1237,3 +1291,70 @@ class InteractiveHTMLRenderer(AbstractA2UIRenderer):
             )
 
         return f'<section class="a2ui-html-document">{title_html}{iframe}</section>'
+
+    # -- Graph (FEAT-529) ----------------------------------------------------
+
+    def _render_graph(self, props: dict[str, Any], degradations: list[dict[str, Any]]) -> str:
+        """Render a viz-core ``Graph`` as an inline SVG plus its mermaid source.
+
+        Bypasses catalog lowering entirely (``GraphComponent.lower()``
+        intentionally degrades to a text/edge-list summary — real graphics
+        are a renderer concern, same precedent as ``_render_chart``).
+        ``props`` is the baked component's own top-level dict.
+
+        ``layout.engine == "force"`` has no interactive-renderer-specific
+        force-directed drawing here either (spec: force is a hint for
+        interactive renderers "only" in general, but THIS static-SVG path
+        has none) — it degrades to the deterministic layered layout, same
+        as every other static lane. A graph above
+        :data:`~parrot.outputs.a2ui.graph.MAX_STATIC_NODES` degrades to
+        ``GraphComponent``'s own lowered edge list, truncated to the cap.
+        """
+        node_id = props.get("id", "graph")
+        working_props = dict(props)
+        layout = working_props.get("layout") or {}
+        if layout.get("engine") == "force":
+            degradations.append(
+                degradation_record(
+                    BasicNode(id=node_id, component="Graph"),
+                    f"{_SURFACE_NAME} has no force layout; rendered with the deterministic layered layout instead",
+                )
+            )
+            working_props = {key: value for key, value in working_props.items() if key != "layout"}
+
+        try:
+            svg = render_graph_svg(working_props)
+        except GraphTooLargeError:
+            degradations.append(
+                degradation_record(
+                    BasicNode(id=node_id, component="Graph"),
+                    f"{_SURFACE_NAME}: graph exceeds the static node cap ({MAX_STATIC_NODES}); "
+                    "rendered as a truncated edge list",
+                )
+            )
+            return self._render_graph_truncated_fallback(working_props, degradations)
+
+        mermaid_source = to_mermaid(GraphSpec.model_validate(_graph_spec_props(working_props)))
+        return (
+            '<div class="a2ui-card a2ui-graph-wrap">'
+            f"{svg}"
+            '<details class="a2ui-graph-source"><summary>Mermaid source</summary>'
+            f"<pre>{html.escape(mermaid_source)}</pre></details></div>"
+        )
+
+    def _render_graph_truncated_fallback(
+        self, props: dict[str, Any], degradations: list[dict[str, Any]]
+    ) -> str:
+        """Oversize-graph fallback: ``GraphComponent``'s own lowered tree,
+        with its edge-list Column truncated to :data:`MAX_STATIC_NODES` rows.
+
+        ``GraphComponent.lower()`` returns an already self-contained
+        ``BasicNode`` tree (no external id references left to resolve), so
+        it is handed straight to ``_render_basic`` — unlike the flat baked-
+        dict trees ``_reconstruct`` rebuilds elsewhere in this module.
+        """
+        node_id = props.get("id", "graph")
+        component = Component(id=node_id, component="Graph", **_strip_graph_component_keys(props))
+        tree = GraphComponent().lower(component, {})
+        _truncate_graph_edge_list(tree)
+        return self._render_basic(tree, degradations)

--- a/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/pdf.py
+++ b/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/pdf.py
@@ -90,9 +90,11 @@ def _chart_svg(props: dict) -> str:
         supports_actions=False,
         supports_updates=False,
         output="application/pdf",
-        # Inherits SSR's 18-primitive set minus Video/AudioPlayer — a static
-        # rasterized PDF cannot play media; both degrade to a link (spec
-        # Scope: "declara supported_components sin Video/Audio").
+        # Inherits SSR's catalogs (incl. viz-core, FEAT-529) and its
+        # 18-primitive set minus Video/AudioPlayer — a static rasterized
+        # PDF cannot play media; both degrade to a link (spec Scope:
+        # "declara supported_components sin Video/Audio").
+        supported_catalog_ids=list(SSRHTMLRenderer.capabilities.supported_catalog_ids),
         supported_components=SSRHTMLRenderer.capabilities.supported_components - {"Video", "AudioPlayer"},
     ),
 )

--- a/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/ssr_html.py
+++ b/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/ssr_html.py
@@ -94,6 +94,7 @@ _UNSUPPORTED_CHART_TYPES = frozenset({"gauge", "funnel", "waterfall", "heatmap",
 #: with the shared catalog-aware `intercepts()` helper (FEAT-529).
 _GRAPH_INTERCEPT_TABLE = frozenset({(VIZ_CORE_CATALOG_ID, "Graph")})
 
+
 def _truncate_graph_edge_list(tree: BasicNode) -> None:
     """Truncate a lowered ``Graph``'s edge-list ``Column`` children to
     :data:`~parrot.outputs.a2ui.graph.MAX_STATIC_NODES` rows, in place

--- a/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/ssr_html.py
+++ b/packages/ai-parrot-visualizations/src/parrot/outputs/a2ui_renderers/ssr_html.py
@@ -42,10 +42,15 @@ from typing import Any
 # registered so lowering/dispatch can resolve every component name.
 import parrot.outputs.a2ui.catalog.basic
 import parrot.outputs.a2ui.catalog.parrot  # noqa: F401 — ensure registration
+import parrot.outputs.a2ui.catalog.viz_core  # noqa: F401 — ensure Graph registration (FEAT-529)
 from parrot.outputs.a2ui.artifacts import DeepLink, RenderedArtifact
 from parrot.outputs.a2ui.baking import bake_envelope
 from parrot.outputs.a2ui.catalog import get_component
-from parrot.outputs.a2ui.catalog.base import BasicNode, TabSpec, to_components
+from parrot.outputs.a2ui.catalog.base import BasicNode, DEFAULT_CATALOG_ID, TabSpec, to_components
+from parrot.outputs.a2ui.catalog.basic import BASIC_CATALOG_ID
+from parrot.outputs.a2ui.catalog.viz_core import VIZ_CORE_CATALOG_ID
+from parrot.outputs.a2ui.catalog.viz_core.graph import GraphComponent
+from parrot.outputs.a2ui.graph import MAX_STATIC_NODES, GraphTooLargeError
 from parrot.outputs.a2ui.models import Component, ComponentMetadata, CreateSurface
 from parrot.outputs.a2ui.renderers import (
     AbstractA2UIRenderer,
@@ -56,6 +61,8 @@ from parrot.outputs.a2ui.catalog.parrot.htmldocument import parse_html_document_
 from parrot.outputs.a2ui.renderers.degrade import degradation_record, degrade
 from parrot.outputs.formats.assets.design_system import DesignSystem
 
+from ._graph_svg import render_graph_svg
+from ._intercept import intercepts
 from ._semantics import (
     is_kpi_row,
     kpi_unit_html,
@@ -82,6 +89,23 @@ _CONTAINER_COMPONENTS = {"Column": "a2ui-col", "Row": "a2ui-row"}
 #: FEAT-527 the adapter collapsed them to a supported type, so this static
 #: renderer never saw the literal type before.
 _UNSUPPORTED_CHART_TYPES = frozenset({"gauge", "funnel", "waterfall", "heatmap", "treemap"})
+
+#: The one (catalog_id, name) pair intercepted as a native Graph — used
+#: with the shared catalog-aware `intercepts()` helper (FEAT-529).
+_GRAPH_INTERCEPT_TABLE = frozenset({(VIZ_CORE_CATALOG_ID, "Graph")})
+
+def _truncate_graph_edge_list(tree: BasicNode) -> None:
+    """Truncate a lowered ``Graph``'s edge-list ``Column`` children to
+    :data:`~parrot.outputs.a2ui.graph.MAX_STATIC_NODES` rows, in place
+    (FEAT-529 oversize-graph fallback)."""
+    column = tree.child
+    if column is None or not isinstance(column.children, list):
+        return
+    for child in column.children:
+        if isinstance(child, BasicNode) and node_extensions(child).get("parrot_role") == "edge-list":
+            if isinstance(child.children, list) and len(child.children) > MAX_STATIC_NODES:
+                child.children = child.children[:MAX_STATIC_NODES]
+            break
 
 
 def _propagate_extensions(parent: Component, lowered: list[Component]) -> list[Component]:
@@ -126,6 +150,7 @@ def _esc(value: Any) -> str:
         supports_actions=False,
         supports_updates=False,
         output="text/html",
+        supported_catalog_ids=[BASIC_CATALOG_ID, DEFAULT_CATALOG_ID, VIZ_CORE_CATALOG_ID],
         supported_components={
             "AudioPlayer",
             "Button",
@@ -145,6 +170,7 @@ def _esc(value: Any) -> str:
             "Text",
             "TextField",
             "Video",
+            "Graph",
         },
     ),
 )
@@ -273,6 +299,9 @@ class SSRHTMLRenderer(AbstractA2UIRenderer):
         """
         new_components: list[Component] = []
         for comp in envelope.components:
+            if comp.component == "Graph" and intercepts(_GRAPH_INTERCEPT_TABLE, comp, envelope.catalog_id):
+                new_components.extend(self._lower_graph_component(comp, envelope.data_model, degradations))
+                continue
             if comp.component == "Chart":
                 chart_type = (comp.model_extra or {}).get("type")
                 if chart_type in _UNSUPPORTED_CHART_TYPES:
@@ -294,6 +323,52 @@ class SSRHTMLRenderer(AbstractA2UIRenderer):
             else:
                 new_components.append(comp)
         return envelope.model_copy(update={"components": new_components})
+
+    def _lower_graph_component(
+        self, comp: Component, data_model: dict[str, Any], degradations: list[dict[str, Any]]
+    ) -> list[Component]:
+        """Replace an intercepted viz-core ``Graph`` with an inline-SVG
+        ``Text`` marker (FEAT-529), or — if it exceeds the static node cap —
+        ``GraphComponent``'s own lowered edge list, truncated.
+
+        ``layout.engine == "force"`` degrades to the deterministic layered
+        layout (spec: force is an interactive-renderer-only hint; every
+        static lane, this one included, has no force-directed drawing).
+        """
+        props = comp.model_dump(by_alias=True, mode="json", exclude_none=True)
+        working_props = dict(props)
+        layout = working_props.get("layout") or {}
+        if layout.get("engine") == "force":
+            degradations.append(
+                degradation_record(
+                    BasicNode(id=comp.id, component="Graph"),
+                    f"{_SURFACE_NAME} has no force layout; rendered with the deterministic layered layout instead",
+                )
+            )
+            working_props = {key: value for key, value in working_props.items() if key != "layout"}
+
+        try:
+            svg = render_graph_svg(working_props)
+        except GraphTooLargeError:
+            degradations.append(
+                degradation_record(
+                    BasicNode(id=comp.id, component="Graph"),
+                    f"{_SURFACE_NAME}: graph exceeds the static node cap ({MAX_STATIC_NODES}); "
+                    "rendered as a truncated edge list",
+                )
+            )
+            tree = GraphComponent().lower(comp, data_model)
+            _truncate_graph_edge_list(tree)
+            lowered = to_components(tree, id_prefix=f"{comp.id}-lc")
+            return _propagate_extensions(comp, lowered)
+
+        svg_component = Component(
+            id=comp.id,
+            component="Text",
+            text=svg,
+            metadata={"extensions": {"parrot_role": "graph-svg"}},
+        )
+        return [svg_component]
 
     # -- DataTable column type/format re-derivation (TASK-2711) -------------
     # DataTableComponent.lower() cannot carry per-column type/format on its
@@ -432,6 +507,14 @@ class SSRHTMLRenderer(AbstractA2UIRenderer):
         if node.metadata is not None and node.metadata.extensions is not None:
             extensions = node.metadata.extensions.root
             role = extensions.get("parrot_role")
+
+        if role == "graph-svg":
+            # FEAT-529: `_lower_graph_component` stamps this role on a
+            # Text node whose `text` is ALREADY a rendered <svg>...</svg>
+            # string (`_graph_svg.render_graph_svg`'s own output escapes
+            # every data value it embeds) — return it raw, never re-escaped
+            # like an ordinary Text value.
+            return str(props.get("text") or "")
 
         if role == "html_document":
             # FEAT-527: HtmlDocumentComponent.lower() never carries the raw

--- a/packages/ai-parrot-visualizations/src/parrot/outputs/formats/assets/design_system/tailwind.generated.css
+++ b/packages/ai-parrot-visualizations/src/parrot/outputs/formats/assets/design_system/tailwind.generated.css
@@ -127,6 +127,17 @@
   color: var(--neutral-muted);
   font-style: italic;
 }
+.a2ui-graph-source {
+  margin-top: calc(var(--spacing) * 2);
+  font-size: var(--text-xs);
+  line-height: var(--tw-leading, var(--text-xs--line-height));
+  color: var(--neutral-muted);
+}
+.a2ui-graph-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: var(--density-gap);
+}
 .a2ui-heading {
   margin-bottom: var(--spacing);
   font-size: var(--text-base);

--- a/packages/ai-parrot-visualizations/tests/outputs/a2ui_renderers/test_echarts.py
+++ b/packages/ai-parrot-visualizations/tests/outputs/a2ui_renderers/test_echarts.py
@@ -79,7 +79,8 @@ class TestTASK2544:
 
     async def test_echarts_capabilities(self):
         caps = EChartsRenderer.capabilities
-        assert caps.supported_components == {"Chart"}
+        # FEAT-529: Graph (viz-core) joined Chart (Parrot) as of TASK-2888.
+        assert caps.supported_components == {"Chart", "Graph"}
 
     async def test_echarts_reads_top_level_props(self):
         """Chart props (v1.0) live top-level, not nested under "properties"."""

--- a/packages/ai-parrot-visualizations/tests/outputs/a2ui_renderers/test_echarts_graph.py
+++ b/packages/ai-parrot-visualizations/tests/outputs/a2ui_renderers/test_echarts_graph.py
@@ -1,0 +1,125 @@
+"""Tests for native Graph support in the ECharts renderer (FEAT-529 Module 6, TASK-2888)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("jsonpointer")
+
+from parrot.outputs.a2ui.catalog.viz_core import VIZ_CORE_CATALOG_ID
+from parrot.outputs.a2ui.models import Component, CreateSurface
+from parrot.outputs.a2ui.renderers import get_a2ui_renderer
+from parrot.outputs.a2ui_renderers.echarts import EChartsRenderer
+
+pytestmark = pytest.mark.asyncio
+
+
+def _graph_envelope() -> CreateSurface:
+    return CreateSurface(
+        surfaceId="main",
+        catalogId="https://parrot.dev/catalogs/v1",
+        components=[
+            Component(
+                id="root",
+                component="Graph",
+                catalogId=VIZ_CORE_CATALOG_ID,
+                kind="flowchart",
+                direction="TB",
+                nodes=[{"id": "a", "label": "Start"}, {"id": "b", "label": "End"}],
+                edges=[{"from": "a", "to": "b", "label": "go"}],
+                accessibleDescription="A tiny graph.",
+            )
+        ],
+    )
+
+
+class TestEChartsCapabilitiesIncludeVizCore:
+    def test_echarts_capabilities_include_viz_core(self):
+        caps = EChartsRenderer.capabilities
+        assert VIZ_CORE_CATALOG_ID in caps.supported_catalog_ids
+        assert "Graph" in caps.supported_components
+        assert "Chart" in caps.supported_components  # legacy unchanged
+
+    def test_resolves_via_registry(self):
+        assert get_a2ui_renderer("echarts") is EChartsRenderer
+
+
+class TestEChartsGraphOption:
+    async def test_echarts_graph_option(self):
+        env = _graph_envelope()
+        artifact = await EChartsRenderer().render(env)
+        option = json.loads(artifact.content)
+
+        series = option["series"][0]
+        assert series["type"] == "graph"
+        assert series["layout"] == "none"
+        assert len(series["data"]) == 2
+        assert len(series["links"]) == 1
+
+        by_id = {entry["id"]: entry for entry in series["data"]}
+        assert isinstance(by_id["a"]["x"], (int, float))
+        assert isinstance(by_id["a"]["y"], (int, float))
+        assert by_id["a"]["x"] != by_id["b"]["x"] or by_id["a"]["y"] != by_id["b"]["y"]
+
+        link = series["links"][0]
+        assert link["source"] == "a"
+        assert link["target"] == "b"
+
+    async def test_graph_option_deterministic(self):
+        env = _graph_envelope()
+        one = (await EChartsRenderer().render(env)).content
+        two = (await EChartsRenderer().render(env)).content
+        assert one == two
+
+    async def test_graph_dispatch_is_catalog_aware(self):
+        """A `Graph` component WITHOUT a viz-core catalogId does not intercept."""
+        env = CreateSurface(
+            surfaceId="main",
+            catalogId="https://parrot.dev/catalogs/v1",
+            components=[
+                Component(
+                    id="root",
+                    component="Graph",  # no catalogId override -> resolves to Parrot default
+                    nodes=[{"id": "a"}, {"id": "b"}],
+                    edges=[{"from": "a", "to": "b"}],
+                )
+            ],
+        )
+        with pytest.raises(ValueError, match="requires a 'Chart' or viz-core 'Graph'"):
+            await EChartsRenderer().render(env)
+
+    async def test_graph_state_maps_to_category(self):
+        env = CreateSurface(
+            surfaceId="main",
+            catalogId="https://parrot.dev/catalogs/v1",
+            components=[
+                Component(
+                    id="root",
+                    component="Graph",
+                    catalogId=VIZ_CORE_CATALOG_ID,
+                    nodes=[{"id": "a", "state": "failed"}, {"id": "b", "state": "completed"}],
+                    edges=[{"from": "a", "to": "b"}],
+                )
+            ],
+        )
+        option = json.loads((await EChartsRenderer().render(env)).content)
+        categories = option["series"][0]["categories"]
+        by_id = {entry["id"]: entry for entry in option["series"][0]["data"]}
+        assert categories[by_id["a"]["category"]]["name"] == "critical"
+        assert categories[by_id["b"]["category"]]["name"] == "good"
+
+
+class TestLegacyChartUnaffected:
+    async def test_legacy_chart_still_dispatches(self):
+        env = CreateSurface(
+            surfaceId="main",
+            catalogId="https://parrot.dev/catalogs/v1",
+            components=[
+                Component(id="root", component="Chart", type="bar", x="month", y=["rev"], title="Sales"),
+            ],
+        )
+        option = json.loads((await EChartsRenderer().render(env)).content)
+        assert "series" in option
+        assert option["series"][0]["type"] == "bar"

--- a/packages/ai-parrot-visualizations/tests/outputs/a2ui_renderers/test_graph_html.py
+++ b/packages/ai-parrot-visualizations/tests/outputs/a2ui_renderers/test_graph_html.py
@@ -1,0 +1,155 @@
+"""Native/degraded Graph tests across interactive-HTML, SSR-HTML, PDF,
+Adaptive Cards, and Folium (FEAT-529 Module 6, TASK-2889)."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("jsonpointer")
+
+from parrot.outputs.a2ui.catalog.viz_core import VIZ_CORE_CATALOG_ID
+from parrot.outputs.a2ui.graph import MAX_STATIC_NODES
+from parrot.outputs.a2ui.models import Component, CreateSurface
+from parrot.outputs.a2ui.renderers import get_a2ui_renderer
+from parrot.outputs.a2ui_renderers.adaptive_cards import AdaptiveCardsRenderer
+from parrot.outputs.a2ui_renderers.interactive_html import InteractiveHTMLRenderer
+from parrot.outputs.a2ui_renderers.pdf import PDFRenderer
+from parrot.outputs.a2ui_renderers.ssr_html import SSRHTMLRenderer
+
+pytestmark = pytest.mark.asyncio
+
+
+def _graph_envelope(**overrides) -> CreateSurface:
+    props = {
+        "kind": "flowchart",
+        "direction": "TB",
+        "nodes": [{"id": "a", "label": "Start"}, {"id": "b", "label": "End"}],
+        "edges": [{"from": "a", "to": "b", "label": "go"}],
+        "accessibleDescription": "A tiny graph.",
+    }
+    props.update(overrides)
+    return CreateSurface(
+        surfaceId="main",
+        catalogId="https://parrot.dev/catalogs/v1",
+        components=[Component(id="root", component="Graph", catalogId=VIZ_CORE_CATALOG_ID, **props)],
+    )
+
+
+def _oversize_envelope() -> CreateSurface:
+    nodes = [{"id": f"n{i}"} for i in range(MAX_STATIC_NODES + 1)]
+    return CreateSurface(
+        surfaceId="main",
+        catalogId="https://parrot.dev/catalogs/v1",
+        components=[Component(id="root", component="Graph", catalogId=VIZ_CORE_CATALOG_ID, nodes=nodes, edges=[])],
+    )
+
+
+class TestCapabilitiesIncludeVizCore:
+    def test_interactive_html_capabilities(self):
+        caps = InteractiveHTMLRenderer.capabilities
+        assert VIZ_CORE_CATALOG_ID in caps.supported_catalog_ids
+        assert "Graph" in caps.supported_components
+
+    def test_ssr_html_capabilities(self):
+        caps = SSRHTMLRenderer.capabilities
+        assert VIZ_CORE_CATALOG_ID in caps.supported_catalog_ids
+        assert "Graph" in caps.supported_components
+
+    def test_pdf_capabilities(self):
+        caps = PDFRenderer.capabilities
+        assert VIZ_CORE_CATALOG_ID in caps.supported_catalog_ids
+        assert "Graph" in caps.supported_components
+
+
+class TestInteractiveHTMLInterceptsGraph:
+    async def test_interactive_html_intercepts_graph(self):
+        artifact = await InteractiveHTMLRenderer().render(_graph_envelope())
+        doc = artifact.content.decode()
+        assert "<svg" in doc
+        assert "<details" in doc and "Mermaid source" in doc
+        assert "flowchart TB" in doc  # the mermaid source itself
+        assert not artifact.metadata.get("degraded")
+
+    async def test_interactive_html_graph_not_viz_core_falls_through(self):
+        """A Graph WITHOUT a viz-core catalogId does not intercept — it
+        lowers via the standard composite path instead (no SVG emitted)."""
+        env = CreateSurface(
+            surfaceId="main",
+            catalogId="https://parrot.dev/catalogs/v1",
+            components=[
+                Component(
+                    id="root",
+                    component="Graph",
+                    nodes=[{"id": "a"}, {"id": "b"}],
+                    edges=[{"from": "a", "to": "b"}],
+                )
+            ],
+        )
+        artifact = await InteractiveHTMLRenderer().render(env)
+        assert "<svg" not in artifact.content.decode()
+
+    async def test_resolves_via_registry(self):
+        assert get_a2ui_renderer("interactive-html") is InteractiveHTMLRenderer
+
+
+class TestSSRForceLayoutDegradesToLayered:
+    async def test_ssr_force_layout_degrades_to_layered(self):
+        env = _graph_envelope(layout={"engine": "force"})
+        artifact = await SSRHTMLRenderer().render(env)
+        doc = artifact.content.decode()
+        assert "<svg" in doc  # still rendered, just with layered positions
+        degraded = artifact.metadata.get("degraded") or []
+        assert any("force" in d["reason"] for d in degraded)
+
+
+class TestSSRGraphTooLargeDegrades:
+    async def test_ssr_graph_too_large_degrades(self):
+        artifact = await SSRHTMLRenderer().render(_oversize_envelope())
+        doc = artifact.content.decode()
+        assert "<svg" not in doc  # lowered to a truncated edge list instead
+        degraded = artifact.metadata.get("degraded") or []
+        assert any("static node cap" in d["reason"] for d in degraded)
+
+
+class TestPdfGraphRendersSvg:
+    async def test_pdf_graph_renders_svg(self):
+        pytest.importorskip("weasyprint")
+        artifact = await PDFRenderer().render(_graph_envelope())
+        assert artifact.mime_type == "application/pdf"
+        assert artifact.content.startswith(b"%PDF")
+
+
+class TestAdaptiveCardsDegradesUnsupportedCatalog:
+    async def test_adaptive_cards_degrades_unsupported_catalog(self):
+        artifact = await AdaptiveCardsRenderer().render(_graph_envelope())
+        degraded = artifact.metadata.get("degraded") or []
+        assert len(degraded) == 1
+        assert degraded[0]["component"] == "Graph"
+        assert VIZ_CORE_CATALOG_ID in degraded[0]["reason"]
+
+
+class TestFoliumDegradesUnsupportedCatalog:
+    async def test_folium_degrades_graph_with_catalog_name(self):
+        folium = pytest.importorskip("folium")
+        del folium
+        from parrot.outputs.a2ui_renderers.folium_map import FoliumMapRenderer
+
+        env = CreateSurface(
+            surfaceId="main",
+            catalogId="https://parrot.dev/catalogs/v1",
+            components=[
+                Component(id="root", component="Map", layers=[]),
+                Component(
+                    id="graph",
+                    component="Graph",
+                    catalogId=VIZ_CORE_CATALOG_ID,
+                    nodes=[{"id": "a"}, {"id": "b"}],
+                    edges=[{"from": "a", "to": "b"}],
+                ),
+            ],
+        )
+        artifact = await FoliumMapRenderer().render(env)
+        degraded = artifact.metadata.get("degraded") or []
+        graph_records = [d for d in degraded if d["component"] == "Graph"]
+        assert len(graph_records) == 1
+        assert VIZ_CORE_CATALOG_ID in graph_records[0]["reason"]

--- a/packages/ai-parrot-visualizations/tests/outputs/a2ui_renderers/test_graph_svg.py
+++ b/packages/ai-parrot-visualizations/tests/outputs/a2ui_renderers/test_graph_svg.py
@@ -1,0 +1,115 @@
+"""Tests for the shared Graph SVG renderer (FEAT-529 Module 6, TASK-2887)."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from parrot.outputs.a2ui.graph import MAX_STATIC_NODES, GraphTooLargeError
+from parrot.outputs.a2ui_renderers._graph_svg import STATE_TO_STATUS, render_graph_svg
+
+_HEX_COLOR_RE = re.compile(r"#[0-9a-fA-F]{3,8}\b")
+
+
+def _base_props(**overrides) -> dict:
+    props = {
+        "kind": "flowchart",
+        "direction": "TB",
+        "nodes": [
+            {"id": "a", "label": "Start", "shape": "circle", "state": "completed"},
+            {"id": "b", "label": "Work", "state": "running"},
+            {"id": "c", "label": "Failed step", "state": "failed"},
+        ],
+        "edges": [
+            {"from": "a", "to": "b", "kind": "solid"},
+            {"from": "b", "to": "c", "kind": "dashed", "label": "on error"},
+        ],
+        "accessibleDescription": "A tiny sample graph.",
+    }
+    props.update(overrides)
+    return props
+
+
+class TestGraphSvgUsesStatusTokens:
+    def test_graph_svg_uses_status_tokens(self):
+        svg = render_graph_svg(_base_props())
+        assert svg.count("<g>") == 3  # one shape per node
+
+        assert 'data-status="critical"' in svg
+        assert "var(--accent-red)" in svg
+        assert 'data-status="good"' in svg
+        assert "var(--accent-green)" in svg
+        assert 'data-status="primary"' in svg
+        assert "var(--primary)" in svg
+
+        assert _HEX_COLOR_RE.search(svg) is None
+
+    def test_state_to_status_mapping(self):
+        assert STATE_TO_STATUS == {
+            "completed": "good",
+            "waiting": "warning",
+            "failed": "critical",
+            "running": "primary",
+            "pending": "neutral",
+            "skipped": "neutral",
+        }
+
+
+class TestGraphSvgTitleFromDescription:
+    def test_graph_svg_title_from_description(self):
+        svg = render_graph_svg(_base_props())
+        assert "<title>A tiny sample graph.</title>" in svg
+
+    def test_graph_svg_title_generated_when_absent(self):
+        props = _base_props()
+        props["accessibleDescription"] = None
+        svg = render_graph_svg(props)
+        assert "<title>Graph of 3 nodes and 2 edges (flowchart)</title>" in svg
+
+    def test_graph_svg_per_node_title_from_meta(self):
+        props = _base_props()
+        props["nodes"][0]["meta"] = {"owner": "team-a"}
+        svg = render_graph_svg(props)
+        assert "<title>owner=team-a</title>" in svg
+
+
+class TestGraphSvgArrowheadsAndEdgeKinds:
+    def test_graph_svg_arrowheads_and_edge_kinds(self):
+        svg = render_graph_svg(_base_props())
+        assert 'marker-end="url(#graph-arrow)"' in svg
+        assert "stroke-dasharray=" in svg  # the dashed edge
+
+        thick_props = _base_props(edges=[{"from": "a", "to": "b", "kind": "thick"}])
+        thick_svg = render_graph_svg(thick_props)
+        assert 'stroke-width="3"' in thick_svg
+
+
+class TestGraphSvgComputesPositionsWhenAbsent:
+    def test_computes_positions_when_absent(self):
+        svg = render_graph_svg(_base_props())
+        assert svg.count("<line") == 2
+
+    def test_uses_supplied_positions_when_present(self):
+        props = _base_props(
+            layout={
+                "engine": "manual",
+                "positions": {"a": {"x": 0, "y": 0}, "b": {"x": 100, "y": 0}, "c": {"x": 200, "y": 0}},
+            }
+        )
+        svg = render_graph_svg(props)
+        assert svg.count("<g>") == 3
+
+
+class TestGraphSvgGroupBoxes:
+    def test_group_box_rendered(self):
+        props = _base_props(groups=[{"id": "g1", "label": "Group A", "nodes": ["a", "b"]}])
+        svg = render_graph_svg(props)
+        assert "Group A" in svg
+        assert 'stroke-dasharray="4,4"' in svg
+
+
+class TestGraphSvgTooLargeRaises:
+    def test_too_large_raises_when_positions_absent(self):
+        nodes = [{"id": f"n{i}"} for i in range(MAX_STATIC_NODES + 1)]
+        with pytest.raises(GraphTooLargeError):
+            render_graph_svg({"kind": "flowchart", "direction": "TB", "nodes": nodes, "edges": []})

--- a/packages/ai-parrot-visualizations/tests/outputs/a2ui_renderers/test_semantic_classes.py
+++ b/packages/ai-parrot-visualizations/tests/outputs/a2ui_renderers/test_semantic_classes.py
@@ -212,6 +212,9 @@ class TestGoldensUntouched:
         # spec-sanctioned, additive-only changes that rekey `_CATALOG` by
         # `(catalog_id, name)` and scope export/instructions per catalog.
         # No existing `lower()` is touched; no existing golden changes.
+        # TASK-2885 (Module 2) adds the ONE new golden this feature owns:
+        # `golden/graph_lowered.json` — same "new component, new golden"
+        # precedent as `filterbar`/`htmldocument` above.
         _FEAT_529_VIZ_CORE_SHELL_FILES = (
             "catalog/__init__.py",
             "catalog/export.py",
@@ -220,6 +223,7 @@ class TestGoldensUntouched:
             "filterbar" in c
             or "htmldocument" in c
             or "viz_core" in c
+            or "graph_lowered" in c
             or c.endswith("catalog/parrot/__init__.py")
             or c.endswith(_FEAT_527_FROZEN_LOWER_FILES)
             or c.endswith(_FEAT_527_TOOL_ONLY_GATE_FILES)

--- a/packages/ai-parrot-visualizations/tests/outputs/a2ui_renderers/test_semantic_classes.py
+++ b/packages/ai-parrot-visualizations/tests/outputs/a2ui_renderers/test_semantic_classes.py
@@ -208,12 +208,22 @@ class TestGoldensUntouched:
             "catalog/base.py",
             "catalog/__init__.py",
         )
+        # FEAT-529 Module 0 (TASK-2881): the viz-core catalog SHELL —
+        # spec-sanctioned, additive-only changes that rekey `_CATALOG` by
+        # `(catalog_id, name)` and scope export/instructions per catalog.
+        # No existing `lower()` is touched; no existing golden changes.
+        _FEAT_529_VIZ_CORE_SHELL_FILES = (
+            "catalog/__init__.py",
+            "catalog/export.py",
+        )
         assert all(
             "filterbar" in c
             or "htmldocument" in c
+            or "viz_core" in c
             or c.endswith("catalog/parrot/__init__.py")
             or c.endswith(_FEAT_527_FROZEN_LOWER_FILES)
             or c.endswith(_FEAT_527_TOOL_ONLY_GATE_FILES)
+            or c.endswith(_FEAT_529_VIZ_CORE_SHELL_FILES)
             for c in changed
         ), changed
 

--- a/packages/ai-parrot-visualizations/tests/outputs/a2ui_renderers/test_ssr_html.py
+++ b/packages/ai-parrot-visualizations/tests/outputs/a2ui_renderers/test_ssr_html.py
@@ -91,7 +91,9 @@ class TestTASK2543:
         caps = SSRHTMLRenderer.capabilities
         assert "Text" in caps.supported_components
         assert "Video" in caps.supported_components
-        assert len(caps.supported_components) == 18
+        # FEAT-529: Graph (viz-core) joined the 18 Basic primitives as of TASK-2889.
+        assert "Graph" in caps.supported_components
+        assert len(caps.supported_components) == 19
         assert "https://parrot.dev/catalogs/v1" in caps.supported_catalog_ids
 
     async def test_ssr_html_all_primitives(self):

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/adapters/__init__.py
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/adapters/__init__.py
@@ -9,6 +9,7 @@ pure Pydantic model modules under ``parrot.models``. It MUST NEVER import
 ``parrot.bots``, ``parrot.clients`` or ``parrot.tools.dataset_manager``.
 """
 
+from parrot.outputs.a2ui.adapters.flow import flow_definition_to_graph
 from parrot.outputs.a2ui.adapters.infographic import (
     CHART_TYPE_MAP,
     infographic_response_to_envelope,
@@ -33,6 +34,7 @@ __all__ = [
     "SCHEMA_VERSION",
     "chart_to_surface",
     "config_to_component_props",
+    "flow_definition_to_graph",
     "infographic_response_to_envelope",
     "map_to_surface",
     "root_component",

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/adapters/flow.py
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/adapters/flow.py
@@ -100,8 +100,16 @@ def flow_definition_to_graph(
 
     nodes = [
         GraphNode(
+            # Leave label=None (not node_def["id"]) when the node carries no
+            # label of its own — GraphNode.label already documents "defaults
+            # to id on render" (spec §2 Data Models), and the mermaid codec
+            # collapses an explicit label EQUAL to id back to None on
+            # import (graph/mermaid.py's own collapsing convention) — a
+            # redundant explicit id-as-label here would silently break
+            # from_mermaid(to_mermaid(spec)) == spec for every node with no
+            # authored label (caught by TASK-2891's own conformance test).
             id=node_def["id"],
-            label=node_def.get("label") or node_def["id"],
+            label=node_def.get("label") or None,
             shape=_shape_for_node_type(node_def.get("type", "")),
         )
         for node_def in node_defs

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/adapters/flow.py
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/adapters/flow.py
@@ -1,0 +1,129 @@
+"""Map a ``FlowDefinition``-shaped mapping to a ``GraphSpec`` (FEAT-529 Module 5).
+
+One-way import rule (G8): this module accepts ``definition`` as a plain
+``Mapping[str, Any]`` — the caller's own
+``FlowDefinition.model_dump(by_alias=True)`` output (or an equivalent
+already-materialized dict, e.g. loaded from Redis/disk) — and NEVER imports
+``parrot.bots`` (not even under ``TYPE_CHECKING``: the adapters import-rule
+guard is line-text based, so a guarded import still fails it). Callers keep
+their own ``FlowDefinition`` instance; nothing here needs its class.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from parrot.outputs.a2ui.graph import Direction, GraphEdge, GraphKind, GraphNode, GraphSpec
+
+__all__ = ["flow_definition_to_graph"]
+
+#: ``NodeDefinition.type`` -> ``GraphNode.shape`` (spec §2 Overview). Any
+#: type not listed here (``agent``, ``dev_loop.*``, and anything a package
+#: registers via ``@register_node`` that this mapping predates) renders
+#: ``rounded`` — the generic "an agent/step ran here" shape.
+_SHAPE_BY_NODE_TYPE: dict[str, str] = {
+    "start": "circle",
+    "end": "circle",
+    "decision": "diamond",
+    "interactive_decision": "diamond",
+    "synthesis": "hexagon",
+    "tool": "subroutine",
+}
+_DEFAULT_NODE_SHAPE = "rounded"
+
+#: ``EdgeDefinition.condition`` values that render a dashed edge (spec §2 Overview).
+_DASHED_CONDITIONS = frozenset({"on_error", "on_timeout"})
+
+
+def _shape_for_node_type(node_type: str) -> str:
+    return _SHAPE_BY_NODE_TYPE.get(node_type, _DEFAULT_NODE_SHAPE)
+
+
+def _edge_label(edge_def: Mapping[str, Any]) -> str | None:
+    """The edge's display label: an explicit ``label`` wins; otherwise the
+    ``on_condition`` predicate text; otherwise no label (spec §2 Overview:
+    "`on_condition` → the CEL `predicate` text")."""
+    explicit_label = edge_def.get("label")
+    if explicit_label:
+        return explicit_label
+    if edge_def.get("condition") == "on_condition":
+        return edge_def.get("predicate")
+    return None
+
+
+def _edge_kind(edge_def: Mapping[str, Any]) -> str | None:
+    """``on_error``/``on_timeout`` -> ``"dashed"``; every other condition
+    renders the renderer's default (``solid``, i.e. ``None`` here)."""
+    if edge_def.get("condition") in _DASHED_CONDITIONS:
+        return "dashed"
+    return None
+
+
+def flow_definition_to_graph(
+    definition: Mapping[str, Any],
+    *,
+    kind: GraphKind = "flowchart",
+    direction: Direction = "TB",
+    data_binding: str | None = None,
+) -> GraphSpec:
+    """Map a ``FlowDefinition``-shaped mapping to a ``GraphSpec``.
+
+    Args:
+        definition: ``FlowDefinition.model_dump(by_alias=True)``-shaped
+            mapping — top-level ``flow``, ``nodes[]`` (``id``, ``type``,
+            ``label``), ``edges[]`` (``from``, ``to``, ``condition``,
+            ``predicate``, ``label``). Any extra keys (``metadata``,
+            ``version``, ...) are ignored.
+        kind: The output ``GraphSpec.kind``. Defaults to ``"flowchart"``
+            (a flow's nodes/edges are exactly a flowchart's).
+        direction: The output ``GraphSpec.direction``.
+        data_binding: Reserved for a future live-state binding (spec's
+            ``a2ui-live-workflow-surface`` sibling). ``GraphSpec.data`` is
+            typed as the RESOLVED per-node overlay shape
+            (``dict[node_id, {...}]``), never the wire-only ``{"path":
+            ...}`` binding descriptor — so this adapter, which returns a
+            plain ``GraphSpec`` (not a baked wire envelope), has nothing
+            safe to do with a bare pointer string yet. Wire it through
+            ``build_graph(data_binding=...)`` instead once you have a
+            ``CreateSurface`` to build.
+
+    Returns:
+        A :class:`~parrot.outputs.a2ui.graph.GraphSpec` with a generated
+        ``accessible_description`` (``"<flow> workflow: N steps, M
+        transitions"``).
+    """
+    del data_binding  # see docstring — reserved, not yet actionable here.
+
+    node_defs: Sequence[Mapping[str, Any]] = definition.get("nodes") or []
+    edge_defs: Sequence[Mapping[str, Any]] = definition.get("edges") or []
+
+    nodes = [
+        GraphNode(
+            id=node_def["id"],
+            label=node_def.get("label") or node_def["id"],
+            shape=_shape_for_node_type(node_def.get("type", "")),
+        )
+        for node_def in node_defs
+    ]
+
+    edges: list[GraphEdge] = []
+    for edge_def in edge_defs:
+        from_id = edge_def.get("from", edge_def.get("from_"))
+        targets = edge_def.get("to")
+        target_ids = targets if isinstance(targets, list) else [targets]
+        label = _edge_label(edge_def)
+        edge_kind = _edge_kind(edge_def)
+        for target_id in target_ids:
+            edges.append(GraphEdge(**{"from": from_id, "to": target_id, "label": label, "kind": edge_kind}))
+
+    flow_name = definition.get("flow", "flow")
+    accessible_description = f"{flow_name} workflow: {len(nodes)} steps, {len(edges)} transitions"
+
+    return GraphSpec(
+        kind=kind,
+        direction=direction,
+        nodes=nodes,
+        edges=edges,
+        accessible_description=accessible_description,
+    )

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/builders.py
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/builders.py
@@ -21,17 +21,35 @@ from typing import Any
 
 # Ensure the v1 parrot catalog is registered so allowlist validation resolves components.
 import parrot.outputs.a2ui.catalog.parrot  # noqa: F401
+
+# Ensure viz-core (and its Graph registration) is registered too — same
+# reasoning as the parrot import above (FEAT-529).
+import parrot.outputs.a2ui.catalog.viz_core  # noqa: F401
 from parrot.outputs.a2ui.catalog import (
     DEFAULT_CATALOG_ID,
     ProducerOrigin,
     validate_envelope,
 )
-from parrot.outputs.a2ui.models import Component, ComponentMetadata, CreateSurface
+from parrot.outputs.a2ui.catalog.viz_core import VIZ_CORE_CATALOG_ID
+from parrot.outputs.a2ui.graph import (
+    Direction,
+    GraphEdge,
+    GraphGroup,
+    GraphKind,
+    GraphLayout,
+    GraphNode,
+    GraphSelection,
+    GraphSpec,
+    VizSize,
+    compute_positions,
+)
+from parrot.outputs.a2ui.models import Action, Component, ComponentMetadata, CreateSurface
 
 __all__ = [
     "build_card",
     "build_chart",
     "build_datatable",
+    "build_graph",
     "build_html_document",
     "build_infographic",
     "build_kpicard",
@@ -292,4 +310,132 @@ def build_html_document(
         surface_id=surface_id,
         origin=ProducerOrigin.TOOL,
         metadata=metadata,
+    )
+
+
+def build_graph(
+    *,
+    nodes: Sequence[GraphNode | dict[str, Any]],
+    edges: Sequence[GraphEdge | dict[str, Any]],
+    kind: GraphKind = "flowchart",
+    direction: Direction = "TB",
+    title: str | None = None,
+    accessible_description: str | None = None,
+    size: VizSize = "tile",
+    groups: Sequence[GraphGroup | dict[str, Any]] | None = None,
+    layout: GraphLayout | dict[str, Any] | None = None,
+    selection: GraphSelection | dict[str, Any] | None = None,
+    data_binding: str | None = None,
+    data_model: dict[str, Any] | None = None,
+    action: Action | None = None,
+    compute_layout: bool = True,
+    surface_id: str = "graph",
+    origin: ProducerOrigin = ProducerOrigin.TOOL,
+) -> CreateSurface:
+    """Build a display (or action-bearing, TOOL-origin) envelope carrying a
+    single viz-core ``Graph`` component.
+
+    Unlike every other ``build_*`` helper, the emitted ``Graph`` component
+    carries its OWN ``catalogId`` (:data:`~parrot.outputs.a2ui.catalog.
+    viz_core.VIZ_CORE_CATALOG_ID`) — the surface's default ``catalogId``
+    stays the Parrot catalog (every public builder does this, spec §2 New
+    Public Interfaces), so ``Graph`` resolves under viz-core purely via its
+    own component-level override (spec §2 G2 resolution rule).
+
+    Args:
+        nodes: The graph's nodes (:class:`~parrot.outputs.a2ui.graph.
+            GraphNode` instances or equivalent wire-shaped dicts).
+        edges: The graph's edges.
+        kind: ``GraphSpec.kind``.
+        direction: ``GraphSpec.direction``.
+        title: Optional display title.
+        accessible_description: viz-core common prop; also the lowered
+            fallback's first line and the SVG ``<title>`` on static lanes.
+        size: viz-core common prop (layout intent, never pixels).
+        groups: Optional node groupings.
+        layout: Optional layout configuration. When given WITHOUT
+            ``positions`` and ``compute_layout=True`` (default), positions
+            are filled in (see ``compute_layout`` below); its own
+            ``rank_sep``/``node_sep`` (if set) are honoured.
+        selection: Optional selection state.
+        data_binding: Optional data-model pointer (e.g. ``"/nodes"``) —
+            becomes ``{"path": "/nodes"}`` on the wire, overlaying each
+            node's ``state``/``label``/``meta`` at render time.
+        data_model: The envelope's ``dataModel`` (forwarded to
+            :func:`build_surface`).
+        action: Optional component-level action. TOOL origin (this
+            function's default) may carry one; ``origin=ProducerOrigin.LLM``
+            with an ``action`` set is rejected by the existing
+            ``ACTION_NOT_ALLOWED_FOR_LLM`` gate (spec G3 — no new gate).
+        compute_layout: When ``True`` (default) and the (implicit or
+            explicit) layout engine is ``"layered"`` with no ``positions``
+            already given, fills ``layout.positions`` via
+            :func:`~parrot.outputs.a2ui.graph.compute_positions`. ``False``
+            leaves ``layout.positions`` absent (renderers without native
+            layout call ``compute_positions`` themselves at render time).
+        surface_id: Envelope surface id.
+        origin: Producer origin forwarded to :func:`build_surface`'s
+            :func:`~parrot.outputs.a2ui.catalog.validate_envelope` call.
+            Defaults to ``TOOL`` (unlike every other ``build_*`` helper,
+            which default to ``LLM``) since a builder-authored ``Graph`` —
+            positions, `action` — is deterministic tool output by
+            construction (spec's "authoring tiers": the LLM path never
+            calls this builder with positions/`action` set).
+
+    Returns:
+        The validated :class:`~parrot.outputs.a2ui.models.CreateSurface`.
+    """
+
+    def _model(value, model_cls):
+        if value is None or isinstance(value, model_cls):
+            return value
+        return model_cls(**value)
+
+    node_models = [_model(n, GraphNode) for n in nodes]
+    edge_models = [_model(e, GraphEdge) for e in edges]
+    group_models = [_model(g, GraphGroup) for g in groups] if groups else None
+    layout_model = _model(layout, GraphLayout)
+    selection_model = _model(selection, GraphSelection)
+
+    spec = GraphSpec(
+        kind=kind,
+        direction=direction,
+        title=title,
+        accessible_description=accessible_description,
+        size=size,
+        nodes=node_models,
+        edges=edge_models,
+        groups=group_models,
+        layout=layout_model,
+        selection=selection_model,
+    )
+
+    if compute_layout:
+        engine = spec.layout.engine if spec.layout else "layered"
+        positions_present = spec.layout.positions is not None if spec.layout else False
+        if engine == "layered" and not positions_present:
+            layout_kwargs: dict[str, float] = {}
+            if spec.layout and spec.layout.rank_sep is not None:
+                layout_kwargs["rank_sep"] = spec.layout.rank_sep
+            if spec.layout and spec.layout.node_sep is not None:
+                layout_kwargs["node_sep"] = spec.layout.node_sep
+            result = compute_positions(spec, **layout_kwargs)
+            base = spec.layout.model_dump(exclude_none=True) if spec.layout else {}
+            spec = spec.model_copy(update={"layout": GraphLayout(**{**base, "positions": result.positions})})
+
+    props = spec.model_dump(by_alias=True, exclude_none=True)
+    props["catalogId"] = VIZ_CORE_CATALOG_ID
+
+    binding = _binding(data_binding)
+    if binding is not None:
+        props["data"] = binding
+    if action is not None:
+        props["action"] = action
+
+    return build_surface(
+        "Graph",
+        props,
+        surface_id=surface_id,
+        data_model=data_model,
+        origin=origin,
     )

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/catalog/__init__.py
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/catalog/__init__.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import threading
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any
 
 import jsonschema
@@ -76,6 +76,7 @@ __all__ = [
     "FunctionDefinition",
     "ProducerOrigin",
     "RegisteredComponent",
+    "catalog_header_instructions",
     "catalog_instructions",
     "get_component",
     "get_function",
@@ -91,8 +92,10 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
-#: Global component allowlist, keyed by component name.
-_CATALOG: dict[str, RegisteredComponent] = {}
+#: Global component allowlist, keyed by ``(catalog_id, name)`` (FEAT-529 Module 0 —
+#: was bare-name keyed; rekeyed so a second catalog may register the same name,
+#: e.g. a future viz-core ``Chart`` alongside the Parrot ``Chart``).
+_CATALOG: dict[tuple[str, str], RegisteredComponent] = {}
 
 #: Global function allowlist, keyed by function name.
 _FUNCTIONS: dict[str, FunctionDefinition] = {}
@@ -142,6 +145,13 @@ def register_component(
     Raises:
         ComponentContractError: If the decorated class lacks a callable ``lower()``
             and is not registered with ``is_primitive=True``.
+        CatalogError: If ``(catalog_id, name)`` is already registered to a
+            DIFFERENT class (FEAT-529 Module 0 — the SAME name in a
+            DIFFERENT catalog is allowed and does not raise; re-registering
+            the identical ``(catalog_id, name, cls)`` triple is a no-op,
+            preserving the Basic Catalog's idempotent re-registration
+            pattern, e.g. ``basic_components()`` calling
+            ``_register_primitives()`` on every invocation).
     """
 
     def decorator(cls: type) -> type:
@@ -152,6 +162,13 @@ def register_component(
                 "implement a callable lower(self, component, data_model) -> BasicTree "
                 "(spec G4 — lowering is enforced, not conventional), unless "
                 "registered with is_primitive=True."
+            )
+        key = (catalog_id, name)
+        existing = _CATALOG.get(key)
+        if existing is not None and existing.component_cls is not cls:
+            raise CatalogError(
+                f"Component {name!r} is already registered under catalog {catalog_id!r} "
+                f"(by {existing.component_cls.__name__!r})."
             )
         definition = ComponentDefinition(
             name=name,
@@ -164,32 +181,84 @@ def register_component(
             allowed_children=allowed_children,
             tool_only=tool_only,
         )
-        _CATALOG[name] = RegisteredComponent(definition=definition, component_cls=cls)
+        _CATALOG[key] = RegisteredComponent(definition=definition, component_cls=cls)
         # Attach for convenient access from instances / renderers.
         cls.definition = definition  # type: ignore[attr-defined]
-        logger.debug("Registered A2UI catalog component %r (%s)", name, cls.__name__)
+        logger.debug("Registered A2UI catalog component %r under catalog %r (%s)", name, catalog_id, cls.__name__)
         return cls
 
     return decorator
 
 
-def unregister_component(name: str) -> None:
-    """Remove a component from the catalog (primarily for test isolation)."""
-    _CATALOG.pop(name, None)
+def unregister_component(name: str, catalog_id: str = DEFAULT_CATALOG_ID) -> None:
+    """Remove a component from the catalog (primarily for test isolation).
+
+    Args:
+        name: The component name.
+        catalog_id: The catalog it was registered under. Defaults to the
+            Parrot catalog (matches :func:`register_component`'s default),
+            so existing bare ``unregister_component(name)`` call sites keep
+            working unchanged.
+    """
+    _CATALOG.pop((catalog_id, name), None)
 
 
-def get_component(name: str) -> RegisteredComponent:
+def get_component(name: str, catalog_id: str | None = None) -> RegisteredComponent:
     """Return the registered component for ``name``.
 
+    Args:
+        name: The component name.
+        catalog_id: When given, an exact ``(catalog_id, name)`` lookup. When
+            omitted (the default — every pre-FEAT-529 call site), resolves
+            to the unique catalog registering ``name``; if more than one
+            catalog does, raises :class:`CatalogError` naming the candidates
+            (FEAT-529 Module 0 — no name is ambiguous today; the
+            ``a2ui-viz-core-charts`` sibling spec is expected to introduce
+            the first one, at which point its call sites must pass
+            ``catalog_id`` explicitly).
+
     Raises:
-        KeyError: If ``name`` is not registered.
+        KeyError: If ``name`` is not registered under ``catalog_id`` (when
+            given), or not registered under ANY catalog (when omitted).
+        CatalogError: If ``catalog_id`` is omitted and ``name`` is registered
+            under more than one catalog.
     """
-    return _CATALOG[name]
+    if catalog_id is not None:
+        try:
+            return _CATALOG[(catalog_id, name)]
+        except KeyError as exc:
+            raise KeyError(f"No component {name!r} registered under catalog {catalog_id!r}.") from exc
+
+    matches = [(cid, entry) for (cid, nm), entry in _CATALOG.items() if nm == name]
+    if not matches:
+        raise KeyError(name)
+    if len(matches) > 1:
+        candidates = sorted(cid for cid, _ in matches)
+        error = CatalogError(
+            f"Component name {name!r} is ambiguous: registered under multiple "
+            f"catalogs {candidates}. Pass catalog_id= explicitly."
+        )
+        # Set post-construction (not a `CatalogError.__init__` kwarg — that
+        # class is shared, untouched, base-catalog machinery, spec §7 out of
+        # scope for this task) so callers can inspect the candidate ids
+        # without parsing the message.
+        error.candidates = candidates
+        raise error
+    return matches[0][1]
 
 
-def list_components() -> list[ComponentDefinition]:
-    """Return the definitions of all registered components (name-sorted)."""
-    return [entry.definition for _, entry in sorted(_CATALOG.items())]
+def list_components(catalog_id: str | None = None) -> list[ComponentDefinition]:
+    """Return the definitions of registered components (name-sorted).
+
+    Args:
+        catalog_id: When given, only components registered under this
+            catalog. ``None`` (default) returns every registered component
+            across every catalog (today's behavior, preserved).
+    """
+    entries = _CATALOG.values()
+    if catalog_id is not None:
+        entries = [entry for entry in entries if entry.definition.catalog_id == catalog_id]
+    return [entry.definition for entry in sorted(entries, key=lambda e: (e.definition.name, e.definition.catalog_id))]
 
 
 def register_function(definition: FunctionDefinition) -> None:
@@ -216,18 +285,58 @@ def list_functions() -> list[FunctionDefinition]:
     return [d for _, d in sorted(_FUNCTIONS.items())]
 
 
-def catalog_instructions() -> str:
-    """Aggregate every component's embedded ``instructions`` for the LLM producer.
+def catalog_header_instructions(catalog_id: str) -> str | None:
+    """Return ``catalog_id``'s own header-level instructions block, if any.
+
+    Unlike a component's per-name ``instructions`` (folded into
+    :func:`catalog_instructions` as ``"<name>: <instructions>"`` lines), a
+    catalog HEADER is guidance that applies to the whole catalog regardless
+    of which (or how many) of its components are registered — e.g. the
+    viz-core catalog's nine guideline rules (FEAT-529 Module 0). The Parrot
+    and Basic catalogs have no header today.
+
+    Args:
+        catalog_id: The catalog id.
 
     Returns:
-        A newline-joined block of ``<name>: <instructions>`` lines, name-sorted.
+        The header text, or ``None`` if that catalog declares no header.
+    """
+    from parrot.outputs.a2ui.catalog import viz_core  # local: see _component_exists note
+
+    if catalog_id == viz_core.VIZ_CORE_CATALOG_ID:
+        return viz_core.VIZ_CORE_INSTRUCTIONS
+    return None
+
+
+def catalog_instructions(catalog_ids: Sequence[str] | None = None) -> str:
+    """Aggregate registered components' embedded ``instructions`` for the LLM producer.
+
+    Args:
+        catalog_ids: When given, scopes the aggregate to only these catalogs:
+            each catalog's own header block (:func:`catalog_header_instructions`,
+            if any) followed by ``"<name>: <instructions>"`` lines for
+            components registered under one of these ids. ``None`` (default)
+            aggregates every registered catalog (today's behavior), prefixed
+            by the header of every catalog that declares one.
+
+    Returns:
+        A newline-joined instructions block.
     """
     # NOTE (bug fix, TASK-2535): a prior `.rstrip(": ")` here would silently
     # eat a legitimate trailing colon/space from an instructions string that
     # happened to end that way — `list_components()` is already filtered to
     # `d.instructions` truthy, so no stripping is needed at all.
-    lines = [f"{d.name}: {d.instructions}" for d in list_components() if d.instructions]
-    return "\n".join(lines)
+    if catalog_ids is None:
+        defs = list_components()
+        header_ids = sorted({d.catalog_id for d in defs})
+    else:
+        catalog_id_set = set(catalog_ids)
+        defs = [d for d in list_components() if d.catalog_id in catalog_id_set]
+        header_ids = list(catalog_ids)
+
+    headers = [h for h in (catalog_header_instructions(cid) for cid in header_ids) if h]
+    lines = [f"{d.name}: {d.instructions}" for d in defs if d.instructions]
+    return "\n".join([*headers, *lines])
 
 
 def resolve_catalog(component_catalog_id: str | None, surface_catalog_id: str | None) -> str:
@@ -288,10 +397,8 @@ def _component_exists(name: str, resolved_catalog_id: str) -> bool:
     if resolved_catalog_id == DEFAULT_CATALOG_ID:
         if name in _basic_component_names():
             return True
-        entry = _CATALOG.get(name)
-        return entry is not None and entry.definition.catalog_id == DEFAULT_CATALOG_ID
-    entry = _CATALOG.get(name)
-    return entry is not None and entry.definition.catalog_id == resolved_catalog_id
+        return (DEFAULT_CATALOG_ID, name) in _CATALOG
+    return (resolved_catalog_id, name) in _CATALOG
 
 
 #: Serializes access to :func:`_unicode_aware_jsonschema`'s module-global patch
@@ -446,6 +553,12 @@ def validate_envelope(
     issues: list[dict[str, Any]] = []
     unknown_components: list[str] = []
     action_components: list[str] = []
+    #: component id -> its resolved catalog id (FEAT-529 Module 0 — populated
+    #: below as each component's catalog is resolved, so the keyed registry
+    #: lookups later in this function use the SAME resolution instead of a
+    #: bare-name `_CATALOG.get`, which would silently pick whichever catalog
+    #: happened to insert last once names may collide across catalogs).
+    resolved_catalog_by_id: dict[str, str] = {}
 
     if "root" not in ids:
         issues.append(
@@ -477,11 +590,14 @@ def validate_envelope(
                     }
                 )
 
+        resolved_catalog_id: str | None
         try:
             resolved_catalog_id = resolve_catalog(comp.catalog_id, effective_surface_catalog_id)
         except CatalogValidationError as exc:
+            resolved_catalog_id = None
             issues.append({"code": exc.code, "message": str(exc), "path": comp.id})
         else:
+            resolved_catalog_by_id[comp.id] = resolved_catalog_id
             if not _component_exists(comp.component, resolved_catalog_id):
                 unknown_components.append(comp.component)
                 issues.append(
@@ -495,7 +611,10 @@ def validate_envelope(
                     }
                 )
 
-        entry_for_gate = _CATALOG.get(comp.component)
+        # Keyed lookup (FEAT-529 Module 0): resolve against the SAME catalog id
+        # just computed above, not a bare-name `_CATALOG.get` — a name may now
+        # be registered under more than one catalog.
+        entry_for_gate = _CATALOG.get((resolved_catalog_id, comp.component)) if resolved_catalog_id else None
         is_action_bearing = comp.action is not None or (
             entry_for_gate is not None and entry_for_gate.definition.requires_actions
         )
@@ -562,7 +681,8 @@ def validate_envelope(
 
     by_id = {c.id: c for c in components}
     for comp in components:
-        entry = _CATALOG.get(comp.component)
+        resolved = resolved_catalog_by_id.get(comp.id)
+        entry = _CATALOG.get((resolved, comp.component)) if resolved else None
         allowed_children = entry.definition.allowed_children if entry else None
         for child_id in _child_ids(comp):
             child_comp = by_id.get(child_id)
@@ -579,7 +699,8 @@ def validate_envelope(
                         "path": comp.id,
                     }
                 )
-            child_entry = _CATALOG.get(child_comp.component)
+            child_resolved = resolved_catalog_by_id.get(child_comp.id)
+            child_entry = _CATALOG.get((child_resolved, child_comp.component)) if child_resolved else None
             allowed_parents = child_entry.definition.allowed_parents if child_entry else None
             if allowed_parents is not None and comp.component not in allowed_parents:
                 issues.append(

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/catalog/export.py
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/catalog/export.py
@@ -290,18 +290,21 @@ def export_catalog_definition(
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "protocolVersion": "1.0",
         "catalogId": catalog_id,
-        "instructions": catalog_instructions(),
+        "instructions": catalog_instructions(catalog_ids=[catalog_id]),
         "components": components,
         "functions": functions,
     }
 
 
-def write_catalog_definition(path: Path) -> None:
+def write_catalog_definition(path: Path, *, catalog_id: str = DEFAULT_CATALOG_ID) -> None:
     """Write :func:`export_catalog_definition`'s output to ``path`` as JSON.
 
     Args:
         path: The destination file path.
+        catalog_id: The catalog to export. Defaults to the Parrot catalog
+            (FEAT-529 Module 0 — was previously hardcoded to the default;
+            now forwarded so a caller can write the viz-core document too).
     """
     import json
 
-    path.write_text(json.dumps(export_catalog_definition(), indent=2, sort_keys=True) + "\n")
+    path.write_text(json.dumps(export_catalog_definition(catalog_id=catalog_id), indent=2, sort_keys=True) + "\n")

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/catalog/viz_core/__init__.py
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/catalog/viz_core/__init__.py
@@ -1,0 +1,68 @@
+"""The ``viz-core`` A2UI catalog — identity and instructions (FEAT-529 Module 0).
+
+``viz-core`` is the third A2UI catalog (alongside the official Basic Catalog
+and the Parrot catalog): a library-agnostic, "describe what, never how"
+visualization vocabulary. This module carries only the catalog's IDENTITY —
+its id and its header-level LLM instructions (spec §2 Overview) — not any
+registered component. ``Graph`` (FEAT-529 Module 2, ``catalog/viz_core/
+graph.py``) is the first component to register under
+:data:`VIZ_CORE_CATALOG_ID`; importing it here for its registration side
+effect is that module's job, not this one's — this package intentionally
+registers nothing so Module 0 can land and be tested on its own.
+
+:data:`VIZ_CORE_INSTRUCTIONS` is copied VERBATIM from the design artifact's
+own ``instructions`` field (vendored at ``catalog/viz_core/spec/catalog.json``,
+a copy of ``sdd/proposals/assets/a2ui-viz-core/viz-core.catalog.json`` — not
+loaded at runtime by this module; it exists so the ``a2ui-viz-core-charts``
+sibling spec has a drift guard to test against later).
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+__all__ = ["VIZ_CORE_CATALOG_ID", "VIZ_CORE_INSTRUCTIONS"]
+
+#: The viz-core catalog's own ``$id``/``catalogId`` (verified against the
+#: vendored ``spec/catalog.json``, spec §8 open question: kept as authored).
+VIZ_CORE_CATALOG_ID: Final[str] = "https://ai-parrot.dev/a2ui/catalogs/viz-core/1.0/catalog.json"
+
+#: The nine viz-core guideline rules (verbatim from the vendored catalog
+#: draft's ``instructions`` field) — prepended by
+#: :func:`~parrot.outputs.a2ui.catalog.catalog_instructions` whenever a
+#: caller scopes the LLM system prompt to include ``VIZ_CORE_CATALOG_ID``
+#: (:func:`~parrot.outputs.a2ui.catalog.catalog_header_instructions`).
+VIZ_CORE_INSTRUCTIONS: Final[str] = (
+    "## Viz Core Guidelines\n"
+    "\n"
+    "1. Pick the form by the data's job, not by taste: change over time -> "
+    "`line` (or `area` only for a single series or a stacked total); "
+    "magnitude across categories -> `bar` (horizontal when labels are long); "
+    "part-to-whole -> `bar` with `stack: \"percent\"`, or `arc` ONLY with <= 5 "
+    "categories; correlation -> `point`; one headline number -> `Stat`, not a "
+    "chart.\n"
+    "2. ONE y axis per Chart. Never ask for two y scales. Two measures of "
+    "different magnitude -> two Charts side by side (Row) or index both to a "
+    "common base.\n"
+    "3. Bind data with a path to an array of row objects in the data model "
+    '(`"data": {"path": "/sales/rows"}`). Prepare the rows before binding '
+    "(tidy, sorted, aggregated); the renderer does not transform data.\n"
+    "4. Wide data: one `Series` per value column (`field`). Long data (one "
+    "category column, one value column): set `seriesBy` on the Chart to the "
+    "category field and ONE Series with the value `field`.\n"
+    "5. Always give `x.type`: `temporal` for dates/times, `quantitative` for "
+    "numbers, `ordinal` for ordered buckets, `nominal` for names. The "
+    "renderer cannot infer this reliably.\n"
+    "6. Color is semantic. Never send hex. Series get `color.role: "
+    '"categorical"` (default, assigned in fixed slot order by the '
+    'renderer\'s theme) or `"status"` with a `value` (good/warning/serious/'
+    "critical). Use `sequential`/`diverging` only for `rect` (heatmap-like) "
+    "marks.\n"
+    "7. Formats are semantic (`unit`, `format: \"currency\"|\"percent\"|"
+    '"compact"|"integer"`), never printf strings; the renderer applies '
+    "locale.\n"
+    "8. More than 8 series is a design error: fold to \"Other\" before "
+    "binding, or facet into several Charts.\n"
+    "9. Do not set `metadata.extensions` render hints unless a human asked "
+    "for a library-specific override; they are non-portable."
+)

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/catalog/viz_core/__init__.py
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/catalog/viz_core/__init__.py
@@ -38,7 +38,7 @@ VIZ_CORE_INSTRUCTIONS: Final[str] = (
     "1. Pick the form by the data's job, not by taste: change over time -> "
     "`line` (or `area` only for a single series or a stacked total); "
     "magnitude across categories -> `bar` (horizontal when labels are long); "
-    "part-to-whole -> `bar` with `stack: \"percent\"`, or `arc` ONLY with <= 5 "
+    'part-to-whole -> `bar` with `stack: "percent"`, or `arc` ONLY with <= 5 '
     "categories; correlation -> `point`; one headline number -> `Stat`, not a "
     "chart.\n"
     "2. ONE y axis per Chart. Never ask for two y scales. Two measures of "
@@ -58,10 +58,10 @@ VIZ_CORE_INSTRUCTIONS: Final[str] = (
     'renderer\'s theme) or `"status"` with a `value` (good/warning/serious/'
     "critical). Use `sequential`/`diverging` only for `rect` (heatmap-like) "
     "marks.\n"
-    "7. Formats are semantic (`unit`, `format: \"currency\"|\"percent\"|"
+    '7. Formats are semantic (`unit`, `format: "currency"|"percent"|'
     '"compact"|"integer"`), never printf strings; the renderer applies '
     "locale.\n"
-    "8. More than 8 series is a design error: fold to \"Other\" before "
+    '8. More than 8 series is a design error: fold to "Other" before '
     "binding, or facet into several Charts.\n"
     "9. Do not set `metadata.extensions` render hints unless a human asked "
     "for a library-specific override; they are non-portable."

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/catalog/viz_core/__init__.py
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/catalog/viz_core/__init__.py
@@ -1,14 +1,14 @@
-"""The ``viz-core`` A2UI catalog — identity and instructions (FEAT-529 Module 0).
+"""The ``viz-core`` A2UI catalog — identity, instructions, and registrations
+(FEAT-529 Modules 0 and 2).
 
 ``viz-core`` is the third A2UI catalog (alongside the official Basic Catalog
 and the Parrot catalog): a library-agnostic, "describe what, never how"
-visualization vocabulary. This module carries only the catalog's IDENTITY —
-its id and its header-level LLM instructions (spec §2 Overview) — not any
-registered component. ``Graph`` (FEAT-529 Module 2, ``catalog/viz_core/
-graph.py``) is the first component to register under
-:data:`VIZ_CORE_CATALOG_ID`; importing it here for its registration side
-effect is that module's job, not this one's — this package intentionally
-registers nothing so Module 0 can land and be tested on its own.
+visualization vocabulary. This module carries the catalog's IDENTITY — its
+id and its header-level LLM instructions (spec §2 Overview) — and, at the
+bottom (AFTER those constants exist — ``graph.py`` imports
+``VIZ_CORE_CATALOG_ID`` back from this package, so the order matters),
+imports each registered component module for its ``@register_component``
+side effect. ``Graph`` (Module 2) is the first and, so far, only one.
 
 :data:`VIZ_CORE_INSTRUCTIONS` is copied VERBATIM from the design artifact's
 own ``instructions`` field (vendored at ``catalog/viz_core/spec/catalog.json``,
@@ -66,3 +66,10 @@ VIZ_CORE_INSTRUCTIONS: Final[str] = (
     "9. Do not set `metadata.extensions` render hints unless a human asked "
     "for a library-specific override; they are non-portable."
 )
+
+# Imported LAST, after VIZ_CORE_CATALOG_ID/VIZ_CORE_INSTRUCTIONS are defined
+# above — `graph.py` imports VIZ_CORE_CATALOG_ID back from this package at
+# ITS OWN top level, so this package must have already defined it (same
+# forward-reference discipline as `catalog/parrot/__init__.py`'s own
+# registration imports, `catalog/parrot/__init__.py:13-24`).
+from parrot.outputs.a2ui.catalog.viz_core import graph  # noqa: E402,F401

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/catalog/viz_core/graph.py
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/catalog/viz_core/graph.py
@@ -1,0 +1,153 @@
+"""The ``Graph`` viz-core catalog component (FEAT-529 Module 2).
+
+Follows the ``Chart`` composite pattern exactly (``catalog/parrot/chart.py``):
+``GRAPH_SCHEMA`` is derived from :class:`~parrot.outputs.a2ui.graph.models.
+GraphSpec` (schema parity by construction, FEAT-473 G2) via
+:func:`~parrot.outputs.a2ui.catalog.parrot._derive.derive_schema`, plus ONE
+post-derivation merge: ``action`` is not a ``GraphSpec`` field (it's the
+Component-level prop; the official ``common_types.json#/$defs/
+ComponentCommon`` does not define it either — spec §2 Overview), so it is
+declared explicitly as a ``$ref`` to the vendored ``common_types.json#/
+$defs/Action``. ``lower()`` never hand-edits ``GRAPH_SCHEMA`` further.
+
+``Graph`` registers under :data:`~parrot.outputs.a2ui.catalog.viz_core.
+VIZ_CORE_CATALOG_ID`, NOT the Parrot catalog — this is the first
+component to actually populate the viz-core catalog (Module 0 only
+carried its identity/instructions, no registration).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from parrot.outputs.a2ui.catalog import register_component
+from parrot.outputs.a2ui.catalog.base import BasicNode, BasicTree
+from parrot.outputs.a2ui.catalog.parrot._derive import derive_schema
+from parrot.outputs.a2ui.catalog.viz_core import VIZ_CORE_CATALOG_ID
+from parrot.outputs.a2ui.graph import GraphEdge, GraphSpec, to_mermaid
+from parrot.outputs.a2ui.models import Component
+
+#: The official common types document's own ``$id`` (vendored,
+#: ``catalog/basic/spec/common_types.json``) — ``ComponentCommon`` there
+#: has no ``action`` property, so `Graph`'s own schema declares it.
+_COMMON_TYPES_ID = "https://a2ui.org/specification/v1_0/common_types.json"
+
+GRAPH_SCHEMA: dict[str, Any] = derive_schema(
+    GraphSpec,
+    binding_fields=("data",),
+    required=("nodes", "edges"),
+)
+GRAPH_SCHEMA["properties"]["action"] = {"$ref": f"{_COMMON_TYPES_ID}#/$defs/Action"}
+
+GRAPH_INSTRUCTIONS = (
+    "Use Graph to render a workflow, state machine, dependency graph or call "
+    "sequence as TYPED nodes/edges — never author a mermaid string. Set "
+    "`kind` (flowchart/state/sequence/dag — dag rejects cycles), `direction` "
+    "(TB/LR/BT/RL), `nodes[]` (id, label, shape, state, icon, meta) and "
+    "`edges[]` (from, to, label, kind, condition). Always give "
+    "`accessibleDescription`. Bind `data` for live per-node state updates "
+    '(`{"path": "/pointer"}`), never inline positions. Never set `action` — '
+    "only a deterministic tool producer may."
+)
+
+
+def _edge_extensions(edge: GraphEdge) -> dict[str, Any]:
+    extensions: dict[str, Any] = {"parrot_role": "edge"}
+    if edge.kind:
+        extensions["parrot_edge_kind"] = edge.kind
+    if edge.condition:
+        extensions["parrot_condition"] = edge.condition
+    return extensions
+
+
+@register_component("Graph", catalog_id=VIZ_CORE_CATALOG_ID)
+class GraphComponent:
+    """The ``Graph`` viz-core catalog component.
+
+    Display-only by default (``requires_actions=False``) — a component-level
+    ``action`` MAY be attached by a deterministic TOOL producer (rejected for
+    ``ProducerOrigin.LLM`` by the existing ``ACTION_NOT_ALLOWED_FOR_LLM``
+    gate, spec G3 — no new gate is introduced here).
+    """
+
+    SCHEMA = GRAPH_SCHEMA
+    INSTRUCTIONS = GRAPH_INSTRUCTIONS
+
+    def lower(self, component: Component, data_model: dict[str, Any]) -> BasicTree:
+        """Lower a ``Graph`` to a Basic Catalog ``Card{Column[...]}`` tree.
+
+        A graph without a native drawing surface degrades to its
+        accessible description, a caption, an edge list, and its mermaid
+        source (spec §2 Data Models "Lowered tree") — every renderer
+        without viz-core support (or without a graph engine) still shows
+        something readable and copyable. Any ``data`` binding passes
+        through UNRESOLVED under ``metadata.extensions.parrot_graph_data``
+        (same convention as ``Chart``'s ``parrot_series_data``) —
+        resolution happens in the bake pass, never here.
+        """
+        props = component.model_extra or {}
+        # `data` is a binding descriptor ({"path": ...}) when unresolved —
+        # never a literal GraphSpec.data mapping at this point (the bake
+        # pass hasn't run yet); excluding it lets a real GraphSpec model
+        # re-validate the rest of the wire payload (a genuine safety net
+        # `derive_schema`'s JSON-Schema alone cannot express, e.g. dangling
+        # edges) without choking on the binding shape.
+        graph_props = {key: value for key, value in props.items() if key != "data"}
+        spec = GraphSpec.model_validate(graph_props)
+
+        description = spec.accessible_description or (
+            f"Graph of {len(spec.nodes)} nodes and {len(spec.edges)} edges ({spec.kind})"
+        )
+
+        children: list[BasicNode] = [
+            BasicNode(
+                component="Text",
+                text=description,
+                metadata={"extensions": {"parrot_role": "description"}},
+            )
+        ]
+        if spec.title:
+            children.append(
+                BasicNode(component="Text", text=spec.title, metadata={"extensions": {"parrot_role": "title"}})
+            )
+        children.append(
+            BasicNode(
+                component="Text",
+                text=f"Graph ({spec.kind}, {spec.direction})",
+                metadata={"extensions": {"parrot_role": "caption"}},
+            )
+        )
+
+        edge_children = [
+            BasicNode(
+                component="Text",
+                text=f"{edge.from_} → {edge.to}" + (f" ({edge.label})" if edge.label else ""),
+                metadata={"extensions": _edge_extensions(edge)},
+            )
+            for edge in spec.edges
+        ]
+        edge_list_extensions: dict[str, Any] = {"parrot_role": "edge-list"}
+        if "data" in props:
+            edge_list_extensions["parrot_graph_data"] = props["data"]
+        children.append(
+            BasicNode(
+                component="Column",
+                children=edge_children,
+                metadata={"extensions": edge_list_extensions},
+            )
+        )
+
+        children.append(
+            BasicNode(
+                component="Text",
+                text=to_mermaid(spec),
+                metadata={"extensions": {"parrot_role": "graph-source"}},
+            )
+        )
+
+        return BasicNode(
+            id=component.id,
+            component="Card",
+            child=BasicNode(component="Column", children=children),
+            metadata={"extensions": {"parrot_variant": "graph"}},
+        )

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/catalog/viz_core/spec/catalog.json
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/catalog/viz_core/spec/catalog.json
@@ -1,0 +1,392 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ai-parrot.dev/a2ui/catalogs/viz-core/1.0/catalog.json",
+  "protocolVersion": "1.0",
+  "title": "A2UI Viz Core Catalog (draft 0.1)",
+  "description": "Library-agnostic chart components for A2UI v1.0. The agent describes WHAT to plot (data, fields, scale types, marks, semantic color roles); the renderer decides HOW to paint it with its own chart library and theme. No colors, fonts, sizes or library options travel on the wire.",
+  "catalogId": "https://ai-parrot.dev/a2ui/catalogs/viz-core/1.0/catalog.json",
+  "instructions": "## Viz Core Guidelines\n\n1. Pick the form by the data's job, not by taste: change over time -> `line` (or `area` only for a single series or a stacked total); magnitude across categories -> `bar` (horizontal when labels are long); part-to-whole -> `bar` with `stack: \"percent\"`, or `arc` ONLY with <= 5 categories; correlation -> `point`; one headline number -> `Stat`, not a chart.\n2. ONE y axis per Chart. Never ask for two y scales. Two measures of different magnitude -> two Charts side by side (Row) or index both to a common base.\n3. Bind data with a path to an array of row objects in the data model (`\"data\": {\"path\": \"/sales/rows\"}`). Prepare the rows before binding (tidy, sorted, aggregated); the renderer does not transform data.\n4. Wide data: one `Series` per value column (`field`). Long data (one category column, one value column): set `seriesBy` on the Chart to the category field and ONE Series with the value `field`.\n5. Always give `x.type`: `temporal` for dates/times, `quantitative` for numbers, `ordinal` for ordered buckets, `nominal` for names. The renderer cannot infer this reliably.\n6. Color is semantic. Never send hex. Series get `color.role: \"categorical\"` (default, assigned in fixed slot order by the renderer's theme) or `\"status\"` with a `value` (good/warning/serious/critical). Use `sequential`/`diverging` only for `rect` (heatmap-like) marks.\n7. Formats are semantic (`unit`, `format: \"currency\"|\"percent\"|\"compact\"|\"integer\"`), never printf strings; the renderer applies locale.\n8. More than 8 series is a design error: fold to \"Other\" before binding, or facet into several Charts.\n9. Do not set `metadata.extensions` render hints unless a human asked for a library-specific override; they are non-portable.",
+  "components": {
+    "Chart": {
+      "type": "object",
+      "description": "A single-frame chart: one x axis, one y axis, one or more Series drawn in the same frame (layered). Series are child components so they can be added or replaced incrementally with updateComponents, or generated from the data model via a ChildList template.",
+      "properties": {
+        "component": {
+          "const": "Chart"
+        },
+        "title": {
+          "$ref": "https://a2ui.org/specification/v1_0/common_types.json#/$defs/DynamicString",
+          "description": "Chart title. State the takeaway when there is one ('Ventas crecen 12% en Q2'), not the axis names."
+        },
+        "subtitle": {
+          "$ref": "https://a2ui.org/specification/v1_0/common_types.json#/$defs/DynamicString"
+        },
+        "data": {
+          "$ref": "https://a2ui.org/specification/v1_0/common_types.json#/$defs/DynamicValue",
+          "description": "Path to an array of row objects in the data model, e.g. {\"path\": \"/sales/rows\"}. Each row is a flat object; Series `field` and axis `field` name its keys."
+        },
+        "x": {
+          "type": "object",
+          "description": "The x (independent) axis.",
+          "properties": {
+            "field": {
+              "type": "string",
+              "description": "Row key for x."
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "temporal",
+                "quantitative",
+                "ordinal",
+                "nominal"
+              ],
+              "description": "Scale type. Drives the renderer's choice of time/linear/category scale."
+            },
+            "title": {
+              "$ref": "https://a2ui.org/specification/v1_0/common_types.json#/$defs/DynamicString"
+            },
+            "format": {
+              "type": "string",
+              "enum": [
+                "auto",
+                "date",
+                "month",
+                "year",
+                "integer",
+                "compact",
+                "percent",
+                "currency"
+              ],
+              "default": "auto"
+            },
+            "unit": {
+              "type": "string",
+              "description": "Semantic unit hint (ISO 4217 code for currency, 'ms', 'km', ...)."
+            },
+            "sort": {
+              "type": "string",
+              "enum": [
+                "natural",
+                "ascending",
+                "descending",
+                "byValue"
+              ],
+              "default": "natural"
+            }
+          },
+          "required": [
+            "field",
+            "type"
+          ],
+          "additionalProperties": false
+        },
+        "y": {
+          "type": "object",
+          "description": "The single y (dependent) axis shared by every Series.",
+          "properties": {
+            "title": {
+              "$ref": "https://a2ui.org/specification/v1_0/common_types.json#/$defs/DynamicString"
+            },
+            "format": {
+              "type": "string",
+              "enum": [
+                "auto",
+                "integer",
+                "compact",
+                "percent",
+                "currency"
+              ],
+              "default": "auto"
+            },
+            "unit": {
+              "type": "string"
+            },
+            "zeroBased": {
+              "type": "boolean",
+              "description": "Force the axis to include zero. Renderers default to true for bar/area and false for line/point.",
+              "default": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "series": {
+          "$ref": "https://a2ui.org/specification/v1_0/common_types.json#/$defs/ChildList",
+          "description": "IDs of Series components drawn in this frame (static list), or a template object {componentId, path} to generate one Series per item of a list in the data model."
+        },
+        "seriesBy": {
+          "type": "string",
+          "description": "For long-format rows: the row key whose distinct values become series. The Chart then has exactly ONE Series whose `field` is the value column."
+        },
+        "orientation": {
+          "type": "string",
+          "enum": [
+            "vertical",
+            "horizontal"
+          ],
+          "default": "vertical",
+          "description": "horizontal swaps the axes (bars grow to the right). Use for long category labels."
+        },
+        "stack": {
+          "type": "string",
+          "enum": [
+            "none",
+            "normal",
+            "percent"
+          ],
+          "default": "none",
+          "description": "Stack all stackable Series (bar, area)."
+        },
+        "legend": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "hidden"
+          ],
+          "default": "auto",
+          "description": "auto: the renderer shows a legend when there are >= 2 series."
+        },
+        "size": {
+          "type": "string",
+          "enum": [
+            "inline",
+            "tile",
+            "hero"
+          ],
+          "default": "tile",
+          "description": "Layout intent, not pixels: inline (sparkline-like, in a row of text), tile (dashboard cell), hero (full-width figure)."
+        },
+        "selectAction": {
+          "$ref": "https://a2ui.org/specification/v1_0/common_types.json#/$defs/Action",
+          "description": "Fired when the user selects a mark. The renderer adds {seriesId, x, y} to the event context."
+        },
+        "accessibleDescription": {
+          "$ref": "https://a2ui.org/specification/v1_0/common_types.json#/$defs/DynamicString",
+          "description": "Plain-language summary of what the chart shows, for screen readers and for the table fallback."
+        },
+        "weight": {
+          "type": "number",
+          "description": "Relative weight within a Row or Column (flex-grow)."
+        }
+      },
+      "required": [
+        "component",
+        "data",
+        "x",
+        "series"
+      ]
+    },
+    "Series": {
+      "type": "object",
+      "description": "One layer of marks in a Chart: which value column to draw, with which mark, in which semantic color role. Must be referenced from a Chart's `series`.",
+      "properties": {
+        "component": {
+          "const": "Series"
+        },
+        "field": {
+          "type": "string",
+          "description": "Row key holding the y value."
+        },
+        "label": {
+          "$ref": "https://a2ui.org/specification/v1_0/common_types.json#/$defs/DynamicString",
+          "description": "Legend / tooltip name. Defaults to `field`."
+        },
+        "mark": {
+          "type": "string",
+          "enum": [
+            "line",
+            "bar",
+            "area",
+            "point",
+            "arc",
+            "rect"
+          ],
+          "description": "arc = pie/donut slice (x is the category, field the value). rect = matrix cell (x, field and colorField)."
+        },
+        "color": {
+          "type": "object",
+          "description": "Semantic color assignment resolved by the renderer's theme.",
+          "properties": {
+            "role": {
+              "type": "string",
+              "enum": [
+                "categorical",
+                "status",
+                "sequential",
+                "diverging",
+                "neutral"
+              ],
+              "default": "categorical"
+            },
+            "slot": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 8,
+              "description": "Fixed categorical slot; when omitted the renderer assigns slots in Series order and keeps them stable across updates."
+            },
+            "value": {
+              "type": "string",
+              "enum": [
+                "good",
+                "warning",
+                "serious",
+                "critical"
+              ],
+              "description": "Only with role=status."
+            },
+            "field": {
+              "type": "string",
+              "description": "Only with role=sequential|diverging: the row key whose value drives the ramp (rect marks)."
+            }
+          },
+          "additionalProperties": false
+        },
+        "emphasis": {
+          "type": "string",
+          "enum": [
+            "normal",
+            "primary",
+            "muted"
+          ],
+          "default": "normal",
+          "description": "primary: the one series the story is about; muted: context (e.g. previous period)."
+        },
+        "labels": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "ends",
+            "all",
+            "none"
+          ],
+          "default": "auto",
+          "description": "Direct value labels. auto lets the renderer's policy decide (typically ends for lines, none past 4 series)."
+        },
+        "weight": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "component",
+        "field",
+        "mark"
+      ]
+    },
+    "Stat": {
+      "type": "object",
+      "description": "A headline number (KPI tile). Use instead of a chart when the message is one value.",
+      "properties": {
+        "component": {
+          "const": "Stat"
+        },
+        "label": {
+          "$ref": "https://a2ui.org/specification/v1_0/common_types.json#/$defs/DynamicString"
+        },
+        "value": {
+          "$ref": "https://a2ui.org/specification/v1_0/common_types.json#/$defs/DynamicNumber"
+        },
+        "format": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "integer",
+            "compact",
+            "percent",
+            "currency"
+          ],
+          "default": "auto"
+        },
+        "unit": {
+          "type": "string"
+        },
+        "delta": {
+          "type": "object",
+          "description": "Change versus a reference, shown with direction and sentiment.",
+          "properties": {
+            "value": {
+              "$ref": "https://a2ui.org/specification/v1_0/common_types.json#/$defs/DynamicNumber"
+            },
+            "format": {
+              "type": "string",
+              "enum": [
+                "auto",
+                "percent",
+                "absolute"
+              ],
+              "default": "auto"
+            },
+            "sentiment": {
+              "type": "string",
+              "enum": [
+                "auto",
+                "positiveIsGood",
+                "negativeIsGood",
+                "neutral"
+              ],
+              "default": "positiveIsGood"
+            },
+            "reference": {
+              "$ref": "https://a2ui.org/specification/v1_0/common_types.json#/$defs/DynamicString",
+              "description": "e.g. 'vs. mes anterior'."
+            }
+          },
+          "required": [
+            "value"
+          ],
+          "additionalProperties": false
+        },
+        "trend": {
+          "type": "object",
+          "description": "Optional sparkline drawn from rows in the data model.",
+          "properties": {
+            "data": {
+              "$ref": "https://a2ui.org/specification/v1_0/common_types.json#/$defs/DynamicValue"
+            },
+            "x": {
+              "type": "string"
+            },
+            "field": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "data",
+            "field"
+          ],
+          "additionalProperties": false
+        },
+        "weight": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "component",
+        "label",
+        "value"
+      ]
+    }
+  },
+  "functions": {},
+  "$defs": {
+    "anyComponent": {
+      "oneOf": [
+        {
+          "$ref": "#/components/Chart"
+        },
+        {
+          "$ref": "#/components/Series"
+        },
+        {
+          "$ref": "#/components/Stat"
+        }
+      ],
+      "discriminator": {
+        "propertyName": "component"
+      }
+    },
+    "anyFunction": {
+      "description": "This catalog defines no functions.",
+      "not": {}
+    }
+  }
+}

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/graph/__init__.py
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/graph/__init__.py
@@ -1,14 +1,14 @@
 """``parrot.outputs.a2ui.graph`` — the ``Graph`` viz-core composite's core vocabulary.
 
 Pure, synchronous modules shared by every renderer and the catalog layer
-(FEAT-529): :mod:`.models` (the Pydantic ``GraphSpec`` family — this
-package's only module so far). ``.mermaid`` (the mermaid codec, Module 3)
-and ``.layout`` (the layered layout, Module 4) add their own exports here
-once they land.
+(FEAT-529): :mod:`.models` (the Pydantic ``GraphSpec`` family) and
+:mod:`.mermaid` (the mermaid codec, Module 3). ``.layout`` (the layered
+layout, Module 4) adds its own exports here once it lands.
 """
 
 from __future__ import annotations
 
+from .mermaid import MermaidCodecError, from_mermaid, to_mermaid
 from .models import (
     Direction,
     EdgeKind,
@@ -37,8 +37,11 @@ __all__ = [
     "GraphSelection",
     "GraphSpec",
     "LayoutEngine",
+    "MermaidCodecError",
     "NodeShape",
     "NodeState",
     "Position",
     "VizSize",
+    "from_mermaid",
+    "to_mermaid",
 ]

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/graph/__init__.py
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/graph/__init__.py
@@ -1,0 +1,44 @@
+"""``parrot.outputs.a2ui.graph`` — the ``Graph`` viz-core composite's core vocabulary.
+
+Pure, synchronous modules shared by every renderer and the catalog layer
+(FEAT-529): :mod:`.models` (the Pydantic ``GraphSpec`` family — this
+package's only module so far). ``.mermaid`` (the mermaid codec, Module 3)
+and ``.layout`` (the layered layout, Module 4) add their own exports here
+once they land.
+"""
+
+from __future__ import annotations
+
+from .models import (
+    Direction,
+    EdgeKind,
+    GraphEdge,
+    GraphGroup,
+    GraphKind,
+    GraphLayout,
+    GraphNode,
+    GraphSelection,
+    GraphSpec,
+    LayoutEngine,
+    NodeShape,
+    NodeState,
+    Position,
+    VizSize,
+)
+
+__all__ = [
+    "Direction",
+    "EdgeKind",
+    "GraphEdge",
+    "GraphGroup",
+    "GraphKind",
+    "GraphLayout",
+    "GraphNode",
+    "GraphSelection",
+    "GraphSpec",
+    "LayoutEngine",
+    "NodeShape",
+    "NodeState",
+    "Position",
+    "VizSize",
+]

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/graph/__init__.py
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/graph/__init__.py
@@ -1,13 +1,14 @@
 """``parrot.outputs.a2ui.graph`` — the ``Graph`` viz-core composite's core vocabulary.
 
 Pure, synchronous modules shared by every renderer and the catalog layer
-(FEAT-529): :mod:`.models` (the Pydantic ``GraphSpec`` family) and
-:mod:`.mermaid` (the mermaid codec, Module 3). ``.layout`` (the layered
-layout, Module 4) adds its own exports here once it lands.
+(FEAT-529): :mod:`.models` (the Pydantic ``GraphSpec`` family),
+:mod:`.mermaid` (the mermaid codec, Module 3), and :mod:`.layout` (the
+layered layout, Module 4).
 """
 
 from __future__ import annotations
 
+from .layout import MAX_STATIC_NODES, GraphTooLargeError, LayoutResult, compute_positions
 from .mermaid import MermaidCodecError, from_mermaid, to_mermaid
 from .models import (
     Direction,
@@ -27,6 +28,7 @@ from .models import (
 )
 
 __all__ = [
+    "MAX_STATIC_NODES",
     "Direction",
     "EdgeKind",
     "GraphEdge",
@@ -36,12 +38,15 @@ __all__ = [
     "GraphNode",
     "GraphSelection",
     "GraphSpec",
+    "GraphTooLargeError",
     "LayoutEngine",
+    "LayoutResult",
     "MermaidCodecError",
     "NodeShape",
     "NodeState",
     "Position",
     "VizSize",
+    "compute_positions",
     "from_mermaid",
     "to_mermaid",
 ]

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/graph/layout.py
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/graph/layout.py
@@ -78,9 +78,7 @@ class GraphTooLargeError(CatalogValidationError):
     """
 
     def __init__(self, node_count: int) -> None:
-        super().__init__(
-            f"Graph has {node_count} nodes, exceeding the static layout cap of {MAX_STATIC_NODES}."
-        )
+        super().__init__(f"Graph has {node_count} nodes, exceeding the static layout cap of {MAX_STATIC_NODES}.")
         self.node_count = node_count
 
 
@@ -109,9 +107,9 @@ class LayoutResult(BaseModel):
     reversed_edges: list[tuple[str, str]]
 
 
-def _break_cycles(node_ids: list[str], edge_pairs: list[tuple[str, str]]) -> tuple[
-    list[tuple[str, str]], list[tuple[str, str]]
-]:
+def _break_cycles(
+    node_ids: list[str], edge_pairs: list[tuple[str, str]]
+) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
     """Stable DFS (3-colour) feedback-arc-set: flips every back edge.
 
     Args:
@@ -336,9 +334,7 @@ def _extent(
     return (max_x + _LAYOUT_PADDING * 2, max_y + _LAYOUT_PADDING * 2)
 
 
-def _group_boxes(
-    spec: GraphSpec, positions: dict[str, Position]
-) -> dict[str, tuple[float, float, float, float]]:
+def _group_boxes(spec: GraphSpec, positions: dict[str, Position]) -> dict[str, tuple[float, float, float, float]]:
     boxes: dict[str, tuple[float, float, float, float]] = {}
     for group in spec.groups or []:
         member_positions = [positions[member_id] for member_id in group.nodes]

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/graph/layout.py
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/graph/layout.py
@@ -1,0 +1,352 @@
+"""Deterministic layered layout for the ``Graph`` vocabulary (FEAT-529 Module 4).
+
+Layout is SERVER-SIDE PREPARATION, not styling (spec §2 Overview rule 3):
+positions computed here travel on the wire (``GraphLayout.positions``) so
+every renderer — the bundled UI, ECharts, and the static SVG lanes — draws
+the same picture from the same numbers, with ``layout: "none"`` where the
+renderer supports native layout. Positions are emitted ALREADY oriented for
+the requested ``direction`` — renderers read ``direction`` only for
+arrow/label placement hints, never to re-transform a position (spec §7
+"Positions and direction").
+
+Algorithm (a hand-written, dependency-light layered/Sugiyama-style layout,
+not a full crossing-minimization implementation):
+
+1. **Cycle breaking** — a stable DFS (3-colour, input node order) finds
+   every back edge; each is logically reversed for ranking purposes only
+   and recorded in :attr:`LayoutResult.reversed_edges` (the ORIGINAL
+   ``(from, to)`` pair — renderers draw the arrowhead on the original
+   direction and flip it, per spec §7). Cycles are legal for every
+   ``kind`` except ``"dag"`` (rejected earlier, at the model level).
+2. **Rank assignment** — longest-path layering over the now-acyclic edge
+   set, via :func:`networkx.topological_sort` (the one place
+   ``networkx``, already a core hard dependency, is used — spec §3
+   Module 4 permits it for "topological generations / cycle detection
+   only").
+3. **Crossing reduction** — four barycentre sweeps (down/up/down/up),
+   stable-sorting each rank's nodes by the mean cross-axis position of
+   their neighbours in the adjacent rank, falling back to the current
+   position when a node has none.
+4. **Coordinate assignment** — integer rank/slot indices scaled by
+   ``rank_sep``/``node_sep`` (abstract units) only at the very end, so the
+   algorithm itself is exact-integer and platform-independent; axes are
+   swapped/placed per ``direction`` (``TB``/``BT``: rank axis is Y;
+   ``LR``/``RL``: rank axis is X; ``BT``/``RL`` mirror the rank axis).
+5. **Group bounding boxes** — the padded min/max of each group's member
+   positions.
+
+Pure and synchronous: no I/O beyond ``logging.getLogger(__name__)`` at
+debug (per spec §7 "Patterns to Follow").
+"""
+
+from __future__ import annotations
+
+import logging
+
+import networkx as nx
+from pydantic import BaseModel, ConfigDict
+
+from parrot.outputs.a2ui.catalog.base import CatalogValidationError
+from parrot.outputs.a2ui.graph.models import Direction, GraphSpec, Position
+
+__all__ = ["MAX_STATIC_NODES", "GraphTooLargeError", "LayoutResult", "compute_positions"]
+
+logger = logging.getLogger(__name__)
+
+#: Above this many nodes, static renderers (SVG/SSR-HTML/PDF) degrade
+#: rather than lay out and draw a graph (spec §8 open question — default
+#: 200, pending Jesus Lara's confirmation after measuring a 200-node
+#: fixture). ECharts and the bundled UI have no cap (spec §7).
+MAX_STATIC_NODES = 200
+
+#: Padding (abstract units) around a group's member bounding box, and
+#: around the overall layout's extent for `LayoutResult.width`/`.height`.
+_GROUP_PADDING = 20.0
+_LAYOUT_PADDING = 20.0
+
+
+class GraphTooLargeError(CatalogValidationError):
+    """Raised by :func:`compute_positions` above :data:`MAX_STATIC_NODES`.
+
+    Subclasses :class:`~parrot.outputs.a2ui.catalog.base.CatalogValidationError`
+    (same reasoning as ``MermaidCodecError``) so the LLM producer's
+    validate-retry-degrade loop needs no new plumbing; static renderers
+    catch it explicitly to degrade instead (Module 6).
+
+    Attributes:
+        node_count: The offending node count.
+    """
+
+    def __init__(self, node_count: int) -> None:
+        super().__init__(
+            f"Graph has {node_count} nodes, exceeding the static layout cap of {MAX_STATIC_NODES}."
+        )
+        self.node_count = node_count
+
+
+class LayoutResult(BaseModel):
+    """The output of :func:`compute_positions`.
+
+    Attributes:
+        positions: Final, direction-oriented positions, keyed by node id.
+            Abstract units, origin top-left.
+        width: Overall layout width (abstract units), including padding.
+        height: Overall layout height (abstract units), including padding.
+        group_boxes: Per-group ``(x, y, w, h)`` bounding box, padded around
+            its members' positions.
+        reversed_edges: The ORIGINAL ``(from, to)`` pairs that were
+            logically reversed to break a cycle for ranking purposes —
+            renderers draw the arrowhead on the original direction and
+            flip it (spec §7).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    positions: dict[str, Position]
+    width: float
+    height: float
+    group_boxes: dict[str, tuple[float, float, float, float]]
+    reversed_edges: list[tuple[str, str]]
+
+
+def _break_cycles(node_ids: list[str], edge_pairs: list[tuple[str, str]]) -> tuple[
+    list[tuple[str, str]], list[tuple[str, str]]
+]:
+    """Stable DFS (3-colour) feedback-arc-set: flips every back edge.
+
+    Args:
+        node_ids: Node ids in stable input order (DFS root order).
+        edge_pairs: ``(from, to)`` pairs in input order.
+
+    Returns:
+        ``(dag_edges, reversed_edges)`` — ``dag_edges`` is ``edge_pairs``
+        with every back edge flipped to ``(to, from)`` (an acyclic edge
+        set for ranking); ``reversed_edges`` lists the ORIGINAL ``(from,
+        to)`` pairs that were flipped, in encounter order.
+    """
+    adjacency: dict[str, list[str]] = {node_id: [] for node_id in node_ids}
+    for from_id, to_id in edge_pairs:
+        adjacency[from_id].append(to_id)
+
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color = {node_id: WHITE for node_id in node_ids}
+    back_edges: set[tuple[str, str]] = set()
+
+    def _visit(start: str) -> None:
+        stack: list[tuple[str, int]] = [(start, 0)]
+        color[start] = GRAY
+        while stack:
+            node_id, child_index = stack[-1]
+            neighbours = adjacency[node_id]
+            if child_index < len(neighbours):
+                stack[-1] = (node_id, child_index + 1)
+                neighbour = neighbours[child_index]
+                if color[neighbour] == WHITE:
+                    color[neighbour] = GRAY
+                    stack.append((neighbour, 0))
+                elif color[neighbour] == GRAY:
+                    back_edges.add((node_id, neighbour))
+            else:
+                color[node_id] = BLACK
+                stack.pop()
+
+    for node_id in node_ids:
+        if color[node_id] == WHITE:
+            _visit(node_id)
+
+    dag_edges: list[tuple[str, str]] = []
+    reversed_edges: list[tuple[str, str]] = []
+    for from_id, to_id in edge_pairs:
+        if (from_id, to_id) in back_edges:
+            dag_edges.append((to_id, from_id))
+            reversed_edges.append((from_id, to_id))
+        else:
+            dag_edges.append((from_id, to_id))
+    return dag_edges, reversed_edges
+
+
+def _assign_ranks(node_ids: list[str], dag_edges: list[tuple[str, str]]) -> dict[str, int]:
+    """Longest-path rank assignment over the acyclic ``dag_edges``."""
+    graph: nx.DiGraph = nx.DiGraph()
+    graph.add_nodes_from(node_ids)
+    graph.add_edges_from((u, v) for u, v in dag_edges if u != v)
+
+    rank = dict.fromkeys(node_ids, 0)
+    for node_id in nx.topological_sort(graph):
+        for successor in graph.successors(node_id):
+            candidate = rank[node_id] + 1
+            if candidate > rank[successor]:
+                rank[successor] = candidate
+    return rank
+
+
+def _order_within_ranks(
+    node_ids: list[str], rank: dict[str, int], dag_edges: list[tuple[str, str]]
+) -> dict[int, list[str]]:
+    """Four barycentre sweeps; returns each rank's nodes in slot order."""
+    by_rank: dict[int, list[str]] = {}
+    for node_id in node_ids:
+        by_rank.setdefault(rank[node_id], []).append(node_id)
+
+    if not by_rank:
+        return by_rank
+    max_rank = max(by_rank)
+
+    down_adjacency: dict[str, list[str]] = {}
+    up_adjacency: dict[str, list[str]] = {}
+    for u, v in dag_edges:
+        if u == v:
+            continue
+        down_adjacency.setdefault(u, []).append(v)
+        up_adjacency.setdefault(v, []).append(u)
+
+    slot: dict[str, int] = {}
+    for nodes in by_rank.values():
+        for index, node_id in enumerate(nodes):
+            slot[node_id] = index
+
+    for sweep in range(4):
+        downward = sweep % 2 == 0
+        rank_sequence = range(1, max_rank + 1) if downward else range(max_rank - 1, -1, -1)
+        neighbours_of = up_adjacency if downward else down_adjacency
+        for current_rank in rank_sequence:
+            nodes = by_rank.get(current_rank)
+            if not nodes:
+                continue
+
+            def _barycentre(node_id: str) -> float:
+                neighbours = neighbours_of.get(node_id, [])
+                if not neighbours:
+                    return float(slot[node_id])
+                return sum(slot[n] for n in neighbours) / len(neighbours)
+
+            nodes.sort(key=lambda node_id: (_barycentre(node_id), slot[node_id]))
+            for index, node_id in enumerate(nodes):
+                slot[node_id] = index
+
+    return by_rank
+
+
+def compute_positions(
+    spec: GraphSpec,
+    *,
+    rank_sep: float = 80.0,
+    node_sep: float = 40.0,
+) -> LayoutResult:
+    """Compute a deterministic layered layout for ``spec``.
+
+    Args:
+        spec: The graph to lay out. Its own ``layout.rank_sep``/
+            ``layout.node_sep`` are NOT read here — callers (the builder)
+            pass them explicitly if they want to override the defaults.
+        rank_sep: Abstract-unit spacing between consecutive ranks.
+        node_sep: Abstract-unit spacing between consecutive nodes within
+            the same rank.
+
+    Returns:
+        A :class:`LayoutResult` with positions for every node, overall
+        dimensions, per-group bounding boxes, and any reversed edges.
+
+    Raises:
+        GraphTooLargeError: If ``len(spec.nodes) > MAX_STATIC_NODES``.
+    """
+    node_count = len(spec.nodes)
+    if node_count > MAX_STATIC_NODES:
+        raise GraphTooLargeError(node_count)
+
+    node_ids = [node.id for node in spec.nodes]
+    edge_pairs = [(edge.from_, edge.to) for edge in spec.edges]
+
+    dag_edges, reversed_edges = _break_cycles(node_ids, edge_pairs)
+    rank = _assign_ranks(node_ids, dag_edges)
+    by_rank = _order_within_ranks(node_ids, rank, dag_edges)
+
+    slot: dict[str, int] = {}
+    for nodes in by_rank.values():
+        for index, node_id in enumerate(nodes):
+            slot[node_id] = index
+
+    max_rank = max(by_rank) if by_rank else 0
+    positions: dict[str, Position] = {}
+    for node_id in node_ids:
+        rank_coord = rank[node_id] * rank_sep
+        cross_coord = slot[node_id] * node_sep
+        positions[node_id] = _oriented_position(rank_coord, cross_coord, spec.direction)
+
+    width, height = _extent(positions, max_rank, rank_sep, node_sep, spec.direction, by_rank)
+    group_boxes = _group_boxes(spec, positions)
+
+    logger.debug(
+        "compute_positions: %d nodes, %d ranks, %d reversed edge(s)",
+        node_count,
+        max_rank + 1 if by_rank else 0,
+        len(reversed_edges),
+    )
+
+    return LayoutResult(
+        positions=positions,
+        width=width,
+        height=height,
+        group_boxes=group_boxes,
+        reversed_edges=reversed_edges,
+    )
+
+
+def _oriented_position(rank_coord: float, cross_coord: float, direction: Direction) -> Position:
+    """Place ``(rank_coord, cross_coord)`` on the axes ``direction`` implies.
+
+    ``TB``/``BT``: the rank axis is Y (vertical); ``LR``/``RL``: the rank
+    axis is X (horizontal) — i.e. ``LR`` positions are the ``TB``
+    positions with X/Y swapped (spec test: "LR == transposed TB"). ``BT``/
+    ``RL`` additionally mirror their rank axis (reversed_edges are still
+    reported on the ORIGINAL direction; only the coordinate is mirrored).
+    """
+    if direction in ("TB", "BT"):
+        # BT mirrors the rank axis; the caller passes the UN-mirrored
+        # rank_coord (0 at the first rank) — mirroring happens afterwards,
+        # in `_extent`, once `max_rank` is known (see `compute_positions`).
+        return Position(x=cross_coord, y=rank_coord)
+    return Position(x=rank_coord, y=cross_coord)  # LR, RL (RL mirrored in `_extent`)
+
+
+def _extent(
+    positions: dict[str, Position],
+    max_rank: int,
+    rank_sep: float,
+    node_sep: float,
+    direction: Direction,
+    by_rank: dict[int, list[str]],
+) -> tuple[float, float]:
+    """Mirror BT/RL in place (rank axis reversed) and return (width, height)."""
+    if direction in ("BT", "RL"):
+        rank_extent = max_rank * rank_sep
+        for nodes in by_rank.values():
+            for node_id in nodes:
+                pos = positions[node_id]
+                if direction == "BT":
+                    positions[node_id] = Position(x=pos.x, y=rank_extent - pos.y)
+                else:  # RL
+                    positions[node_id] = Position(x=rank_extent - pos.x, y=pos.y)
+
+    if not positions:
+        return (_LAYOUT_PADDING * 2, _LAYOUT_PADDING * 2)
+
+    max_x = max(pos.x for pos in positions.values())
+    max_y = max(pos.y for pos in positions.values())
+    return (max_x + _LAYOUT_PADDING * 2, max_y + _LAYOUT_PADDING * 2)
+
+
+def _group_boxes(
+    spec: GraphSpec, positions: dict[str, Position]
+) -> dict[str, tuple[float, float, float, float]]:
+    boxes: dict[str, tuple[float, float, float, float]] = {}
+    for group in spec.groups or []:
+        member_positions = [positions[member_id] for member_id in group.nodes]
+        if not member_positions:
+            continue
+        min_x = min(p.x for p in member_positions) - _GROUP_PADDING
+        min_y = min(p.y for p in member_positions) - _GROUP_PADDING
+        max_x = max(p.x for p in member_positions) + _GROUP_PADDING
+        max_y = max(p.y for p in member_positions) + _GROUP_PADDING
+        boxes[group.id] = (min_x, min_y, max_x - min_x, max_y - min_y)
+    return boxes

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/graph/mermaid.py
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/graph/mermaid.py
@@ -117,9 +117,7 @@ _FLOWCHART_EDGE_OP_SEARCH_RE = re.compile(r"-->|-\.->|==>")
 
 _STATE_ALIAS_RE = re.compile(rf'^state\s+"(?P<label>.*)"\s+as\s+(?P<id>{_IDENT})$')
 _STATE_COMPOSITE_OPEN_RE = re.compile(rf"^state\s+(?P<id>{_IDENT})\s*\{{$")
-_STATE_EDGE_RE = re.compile(
-    rf"^(?P<from>\[\*\]|{_IDENT})\s*-->\s*(?P<to>\[\*\]|{_IDENT})(\s*:\s*(?P<label>.+))?$"
-)
+_STATE_EDGE_RE = re.compile(rf"^(?P<from>\[\*\]|{_IDENT})\s*-->\s*(?P<to>\[\*\]|{_IDENT})(\s*:\s*(?P<label>.+))?$")
 _BARE_IDENT_RE = re.compile(rf"^{_IDENT}$")
 
 _SEQ_PARTICIPANT_RE = re.compile(rf"^participant\s+(?P<id>{_IDENT})(\s+as\s+(?P<label>.+))?$")
@@ -356,9 +354,7 @@ def from_mermaid(text: str) -> GraphSpec:
 def _parse_flowchart_node_decl(stripped: str) -> Optional[GraphNode]:
     for shape in _NODE_SHAPE_ORDER:
         open_bracket, close_bracket = _SHAPE_BRACKETS[shape]
-        pattern = re.compile(
-            rf"^(?P<id>{_IDENT}){re.escape(open_bracket)}(?P<label>.*){re.escape(close_bracket)}$"
-        )
+        pattern = re.compile(rf"^(?P<id>{_IDENT}){re.escape(open_bracket)}(?P<label>.*){re.escape(close_bracket)}$")
         match = pattern.match(stripped)
         if match:
             node_id = match.group("id")
@@ -441,9 +437,7 @@ def _parse_flowchart(lines: list[tuple[int, str]]) -> GraphSpec:
         if stripped == "end":
             if current_group_members is None:
                 raise MermaidCodecError(line_no, content, "'end' with no open subgraph")
-            groups.append(
-                GraphGroup(id=current_group_id, label=current_group_label, nodes=list(current_group_members))
-            )
+            groups.append(GraphGroup(id=current_group_id, label=current_group_label, nodes=list(current_group_members)))
             current_group_id = None
             current_group_label = None
             current_group_members = None
@@ -532,9 +526,7 @@ def _parse_state(lines: list[tuple[int, str]]) -> GraphSpec:
             to_id = _END if to_raw == "[*]" else to_raw
             _ensure_node(from_id)
             _ensure_node(to_id)
-            edges.append(
-                GraphEdge(**{"from": from_id, "to": to_id, "label": edge_match.group("label")})
-            )
+            edges.append(GraphEdge(**{"from": from_id, "to": to_id, "label": edge_match.group("label")}))
             continue
 
         bare_match = _BARE_IDENT_RE.match(stripped)

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/graph/mermaid.py
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/graph/mermaid.py
@@ -1,0 +1,604 @@
+"""Pure-Python Mermaid codec for the ``Graph`` vocabulary (FEAT-529 Module 3).
+
+Mermaid is a deterministic IMPORT/EXPORT codec only — :class:`~parrot.
+outputs.a2ui.graph.models.GraphSpec` stays the single wire vocabulary
+(spec §7 "Patterns to Follow"). This module hand-writes a tokenizer/parser
+for a deliberately small subset of three mermaid dialects (``flowchart``,
+``stateDiagram-v2``, ``sequenceDiagram``); no external parsing dependency
+is introduced (spec Non-Goals — no ``mermaid``/``lark``/``pyparsing``, etc.).
+
+Supported subset (spec §3 Module 3):
+
+* **flowchart**: 6 node shapes (``[rect]``, ``(rounded)``, ``{diamond}``,
+  ``((circle))``, ``{{hexagon}}``, ``[[subroutine]]``), 3 edge kinds
+  (``-->`` solid, ``-.->`` dashed, ``==>`` thick), labels via
+  ``-- text -->`` (parse-only) and ``-->|text|`` (canonical emit),
+  ``subgraph id [label] ... end`` groups.
+* **stateDiagram-v2**: ``[*] --> A`` / ``A --> [*]`` synthetic
+  ``__start__``/``__end__`` circle nodes, ``A --> B : label`` transitions,
+  ``state "label" as id`` aliases, composite ``state X { ... }`` groups.
+* **sequenceDiagram**: ``participant A as Label`` aliases, ``A->>B: msg``
+  (solid) / ``A-->>B: msg`` (dashed) messages, in encountered order
+  (``GraphSpec.edges`` is already an ordered list — no separate ordering
+  field is needed or exists on :class:`~parrot.outputs.a2ui.graph.models.
+  GraphEdge`).
+
+``%%`` lines are comments (ignored); ``%%{...`` init directives,
+``classDef``/``click``/``style``/``linkStyle``, and sequence
+``loop``/``alt``/``par``/``note`` blocks are explicitly OUT of the
+supported subset and raise :class:`MermaidCodecError` naming the
+offending line (spec Non-Goals).
+
+**Object round-trip, not textual round-trip.** ``from_mermaid(to_mermaid(
+spec)) == spec`` (modulo ``accessible_description``/``size``, which have
+no mermaid representation) is the contract — NOT that re-serializing
+preserves the exact original source text. Two collapsing conventions make
+this practical without extra wire fields:
+
+* A node's ``label`` is omitted on export (and re-inferred as ``None`` on
+  import) whenever it is exactly the node's ``id`` — the common "no
+  explicit label" case.
+* A node's ``shape`` is omitted on export (and re-inferred as ``None`` on
+  import) whenever it equals the dialect's DEFAULT shape (``rect`` for
+  flowchart, ``rounded`` for state) — an explicit shape matching the
+  default is indistinguishable from "no shape given" once round-tripped
+  through text, which is harmless: both render identically.
+
+``kind="dag"`` reuses the ``flowchart`` mermaid dialect on export (a DAG
+IS an acyclic flowchart); ``from_mermaid`` never infers ``kind="dag"``
+back from text — that semantic promise cannot be recovered from syntax
+alone, so a flowchart-dialect text always parses to ``kind="flowchart"``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from parrot.outputs.a2ui.catalog.base import CatalogValidationError
+from parrot.outputs.a2ui.graph.models import (
+    Direction,
+    GraphEdge,
+    GraphGroup,
+    GraphNode,
+    GraphSpec,
+)
+
+__all__ = ["MermaidCodecError", "from_mermaid", "to_mermaid"]
+
+#: Synthetic node ids for stateDiagram-v2's ``[*]`` start/end pseudo-state.
+_START = "__start__"
+_END = "__end__"
+
+_RESERVED_LABEL_CHARS = frozenset('[](){}|"#')
+
+#: Constructs explicitly excluded from the supported subset (spec Non-Goals).
+#: Checked as a line PREFIX (after stripping leading whitespace).
+_UNSUPPORTED_PREFIXES = (
+    "classDef",
+    "click",
+    "style",
+    "linkStyle",
+    "loop",
+    "alt",
+    "par",
+    "note",
+    "Note",
+)
+
+_SHAPE_BRACKETS: dict[str, tuple[str, str]] = {
+    "circle": ("((", "))"),
+    "hexagon": ("{{", "}}"),
+    "subroutine": ("[[", "]]"),
+    "rect": ("[", "]"),
+    "rounded": ("(", ")"),
+    "diamond": ("{", "}"),
+}
+#: Tried in this order so multi-char brackets are matched before their
+#: single-char prefixes/suffixes could greedily mismatch them (e.g. a
+#: `((circle))` must be tried before `(rounded)` would swallow one pair).
+_NODE_SHAPE_ORDER = ("circle", "hexagon", "subroutine", "rect", "rounded", "diamond")
+_DEFAULT_FLOWCHART_SHAPE = "rect"
+_DEFAULT_STATE_SHAPE = "rounded"
+
+_EDGE_OPS: dict[str, str] = {"solid": "-->", "dashed": "-.->", "thick": "==>"}
+_OPS_TO_KIND: dict[str, str] = {v: k for k, v in _EDGE_OPS.items()}
+_DEFAULT_EDGE_KIND = "solid"
+
+_IDENT = r"[A-Za-z_][A-Za-z0-9_]*"
+
+_FLOWCHART_HEADER_RE = re.compile(r"^flowchart\s+(TB|LR|BT|RL)$")
+_SUBGRAPH_HEADER_RE = re.compile(rf"^(?P<id>{_IDENT})(\s*\[(?P<label>.*)\])?$")
+_FLOWCHART_MID_LABEL_RE = re.compile(rf"^(?P<from>{_IDENT})\s+--\s+(?P<label>.+?)\s+-->\s+(?P<to>{_IDENT})$")
+_FLOWCHART_EDGE_RE = re.compile(
+    rf"^(?P<from>{_IDENT})\s+(?P<op>-->|-\.->|==>)(\|(?P<label>[^|]*)\|)?\s+(?P<to>{_IDENT})$"
+)
+_FLOWCHART_EDGE_OP_SEARCH_RE = re.compile(r"-->|-\.->|==>")
+
+_STATE_ALIAS_RE = re.compile(rf'^state\s+"(?P<label>.*)"\s+as\s+(?P<id>{_IDENT})$')
+_STATE_COMPOSITE_OPEN_RE = re.compile(rf"^state\s+(?P<id>{_IDENT})\s*\{{$")
+_STATE_EDGE_RE = re.compile(
+    rf"^(?P<from>\[\*\]|{_IDENT})\s*-->\s*(?P<to>\[\*\]|{_IDENT})(\s*:\s*(?P<label>.+))?$"
+)
+_BARE_IDENT_RE = re.compile(rf"^{_IDENT}$")
+
+_SEQ_PARTICIPANT_RE = re.compile(rf"^participant\s+(?P<id>{_IDENT})(\s+as\s+(?P<label>.+))?$")
+_SEQ_MESSAGE_RE = re.compile(rf"^(?P<from>{_IDENT})(?P<arrow>-->>|->>)(?P<to>{_IDENT})(:\s*(?P<label>.+))?$")
+
+
+class MermaidCodecError(CatalogValidationError):
+    """A mermaid source line falls outside the supported subset (spec §2 G4).
+
+    Subclasses :class:`~parrot.outputs.a2ui.catalog.base.CatalogValidationError`
+    so the LLM producer's existing validate-retry-degrade loop handles a
+    codec failure without any new plumbing.
+
+    Attributes:
+        line_no: 1-based source line number of the offending line.
+        line: The offending line's raw text.
+        reason: Human-readable explanation.
+    """
+
+    def __init__(self, line_no: int, line: str, reason: str) -> None:
+        super().__init__(f"Mermaid parse error at line {line_no}: {reason} ({line!r})")
+        self.line_no = line_no
+        self.line = line
+        self.reason = reason
+
+
+def _escape_label(label: str) -> str:
+    """Quote ``label`` if it contains any reserved mermaid character."""
+    if any(ch in _RESERVED_LABEL_CHARS for ch in label):
+        return '"' + label.replace('"', "#quot;") + '"'
+    return label
+
+
+def _unescape_label(token: Optional[str]) -> Optional[str]:
+    """Inverse of :func:`_escape_label`; ``None`` passes through unchanged."""
+    if token is None:
+        return None
+    token = token.strip()
+    if len(token) >= 2 and token.startswith('"') and token.endswith('"'):
+        return token[1:-1].replace("#quot;", '"')
+    return token
+
+
+def _check_unsupported(line_no: int, content: str) -> None:
+    stripped = content.strip()
+    for keyword in _UNSUPPORTED_PREFIXES:
+        # Word-boundary match — `startswith` alone would also flag
+        # "participant" (contains "par") or "alt_path" (contains "alt").
+        if re.match(rf"^{re.escape(keyword)}(\s|$)", stripped):
+            raise MermaidCodecError(
+                line_no, content, f"unsupported construct: {keyword!r} is not in the supported subset"
+            )
+
+
+def _prepare_lines(text: str) -> list[tuple[int, str]]:
+    """Strip comments/blank lines; reject ``%%{init}``-style directives.
+
+    Returns:
+        ``(line_no, content)`` pairs, 1-based, blank lines and plain ``%%``
+        comments removed.
+
+    Raises:
+        MermaidCodecError: On a ``%%{`` init directive (excluded — spec
+            Non-Goals; NOT the same as a plain ``%%`` comment, which is
+            silently ignored).
+    """
+    out: list[tuple[int, str]] = []
+    for line_no, raw in enumerate(text.splitlines(), start=1):
+        stripped = raw.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("%%{"):
+            raise MermaidCodecError(
+                line_no, raw, "unsupported construct: '%%{init}' directives are not in the supported subset"
+            )
+        if stripped.startswith("%%"):
+            continue
+        out.append((line_no, raw.rstrip()))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# to_mermaid
+# ---------------------------------------------------------------------------
+
+
+def to_mermaid(spec: GraphSpec) -> str:
+    """Emit ``spec`` as canonical mermaid source text.
+
+    Deterministic: the same spec always produces the same text (stable,
+    input-preserving order for nodes/edges/groups).
+
+    Args:
+        spec: The graph to serialize.
+
+    Returns:
+        Mermaid source text (trailing newline included).
+    """
+    if spec.kind == "sequence":
+        return _emit_sequence(spec)
+    if spec.kind == "state":
+        return _emit_state(spec)
+    # "flowchart" and "dag" share the flowchart dialect (a DAG is an
+    # acyclic flowchart) — see this module's docstring.
+    return _emit_flowchart(spec)
+
+
+def _emit_flowchart_node_decl(node: GraphNode) -> str:
+    shape = node.shape or _DEFAULT_FLOWCHART_SHAPE
+    open_bracket, close_bracket = _SHAPE_BRACKETS[shape]
+    label_text = node.label if node.label is not None else node.id
+    return f"{node.id}{open_bracket}{_escape_label(label_text)}{close_bracket}"
+
+
+def _emit_flowchart_edge(edge: GraphEdge) -> str:
+    op = _EDGE_OPS[edge.kind or _DEFAULT_EDGE_KIND]
+    if edge.label:
+        return f"{edge.from_} {op}|{_escape_label(edge.label)}| {edge.to}"
+    return f"{edge.from_} {op} {edge.to}"
+
+
+def _emit_flowchart(spec: GraphSpec) -> str:
+    # Every node is declared ONCE at top level, in input order (spec §3
+    # Module 3: "nodes declared once, in input order") — a subgraph block
+    # only BARE-references its members' ids afterwards. This is what keeps
+    # `from_mermaid(to_mermaid(spec))`'s `nodes` list in the SAME order as
+    # `spec.nodes`: declaring (a subset of) nodes only inside the subgraph
+    # block would reorder them to wherever their group happens to sort.
+    lines = [f"flowchart {spec.direction}"]
+
+    for node in spec.nodes:
+        lines.append(_emit_flowchart_node_decl(node))
+
+    for group in spec.groups or []:
+        header = f"subgraph {group.id}"
+        if group.label and group.label != group.id:
+            header += f" [{_escape_label(group.label)}]"
+        lines.append(header)
+        for member_id in group.nodes:
+            lines.append(member_id)
+        lines.append("end")
+
+    for edge in spec.edges:
+        lines.append(_emit_flowchart_edge(edge))
+
+    return "\n".join(lines) + "\n"
+
+
+def _emit_state(spec: GraphSpec) -> str:
+    # Same "declare once at top, group blocks bare-reference members"
+    # ordering discipline as `_emit_flowchart` (see its comment) — keeps
+    # `nodes` list order stable through a round-trip. `__start__`/`__end__`
+    # have no top-level declaration (they exist only via `[*]` edge
+    # endpoints), so they inevitably land at the END of the parsed node
+    # order regardless of their position in `spec.nodes`.
+    lines = ["stateDiagram-v2"]
+
+    for node in spec.nodes:
+        if node.id in (_START, _END):
+            continue
+        if node.label and node.label != node.id:
+            lines.append(f'state "{_escape_label(node.label)}" as {node.id}')
+
+    for group in spec.groups or []:
+        lines.append(f"state {group.id} {{")
+        for member_id in group.nodes:
+            lines.append(f"    {member_id}")
+        lines.append("}")
+
+    for edge in spec.edges:
+        from_token = "[*]" if edge.from_ == _START else edge.from_
+        to_token = "[*]" if edge.to == _END else edge.to
+        if edge.label:
+            lines.append(f"{from_token} --> {to_token} : {edge.label}")
+        else:
+            lines.append(f"{from_token} --> {to_token}")
+
+    return "\n".join(lines) + "\n"
+
+
+def _emit_sequence(spec: GraphSpec) -> str:
+    lines = ["sequenceDiagram"]
+    for node in spec.nodes:
+        if node.label and node.label != node.id:
+            lines.append(f"participant {node.id} as {_escape_label(node.label)}")
+        else:
+            lines.append(f"participant {node.id}")
+
+    for edge in spec.edges:
+        arrow = "-->>" if edge.kind == "dashed" else "->>"
+        if edge.label:
+            lines.append(f"{edge.from_}{arrow}{edge.to}: {edge.label}")
+        else:
+            lines.append(f"{edge.from_}{arrow}{edge.to}")
+
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# from_mermaid
+# ---------------------------------------------------------------------------
+
+
+def from_mermaid(text: str) -> GraphSpec:
+    """Parse mermaid source text into a :class:`GraphSpec`.
+
+    Args:
+        text: Mermaid source (flowchart / stateDiagram-v2 / sequenceDiagram).
+
+    Returns:
+        The parsed :class:`GraphSpec` (``accessible_description``/``size``
+        stay at their defaults — mermaid has no representation for them).
+
+    Raises:
+        MermaidCodecError: For an empty source, an unrecognized diagram
+            header, or any line outside the supported subset — names the
+            offending line and a reason.
+    """
+    lines = _prepare_lines(text)
+    if not lines:
+        raise MermaidCodecError(1, "", "empty mermaid source")
+
+    header_no, header = lines[0]
+    stripped_header = header.strip()
+    if stripped_header.startswith("flowchart"):
+        return _parse_flowchart(lines)
+    if stripped_header.startswith("stateDiagram-v2"):
+        return _parse_state(lines)
+    if stripped_header.startswith("sequenceDiagram"):
+        return _parse_sequence(lines)
+    raise MermaidCodecError(header_no, header, "unrecognized or unsupported diagram header")
+
+
+def _parse_flowchart_node_decl(stripped: str) -> Optional[GraphNode]:
+    for shape in _NODE_SHAPE_ORDER:
+        open_bracket, close_bracket = _SHAPE_BRACKETS[shape]
+        pattern = re.compile(
+            rf"^(?P<id>{_IDENT}){re.escape(open_bracket)}(?P<label>.*){re.escape(close_bracket)}$"
+        )
+        match = pattern.match(stripped)
+        if match:
+            node_id = match.group("id")
+            label = _unescape_label(match.group("label"))
+            return GraphNode(
+                id=node_id,
+                label=None if label == node_id else label,
+                shape=None if shape == _DEFAULT_FLOWCHART_SHAPE else shape,
+            )
+    if _BARE_IDENT_RE.match(stripped):
+        return GraphNode(id=stripped)
+    return None
+
+
+def _parse_flowchart_edge_line(line_no: int, content: str, stripped: str) -> GraphEdge:
+    mid_match = _FLOWCHART_MID_LABEL_RE.match(stripped)
+    if mid_match:
+        return GraphEdge(
+            **{
+                "from": mid_match.group("from"),
+                "to": mid_match.group("to"),
+                "label": _unescape_label(mid_match.group("label")),
+                "kind": "solid",
+            }
+        )
+
+    match = _FLOWCHART_EDGE_RE.match(stripped)
+    if match:
+        return GraphEdge(
+            **{
+                "from": match.group("from"),
+                "to": match.group("to"),
+                "label": _unescape_label(match.group("label")),
+                "kind": _OPS_TO_KIND[match.group("op")],
+            }
+        )
+
+    raise MermaidCodecError(line_no, content, "malformed flowchart edge declaration")
+
+
+def _parse_flowchart(lines: list[tuple[int, str]]) -> GraphSpec:
+    header_no, header = lines[0]
+    direction_match = _FLOWCHART_HEADER_RE.match(header.strip())
+    if not direction_match:
+        raise MermaidCodecError(header_no, header, "flowchart header must be 'flowchart <TB|LR|BT|RL>'")
+    direction: Direction = direction_match.group(1)  # type: ignore[assignment]
+
+    nodes: dict[str, GraphNode] = {}
+    node_order: list[str] = []
+    edges: list[GraphEdge] = []
+    groups: list[GraphGroup] = []
+
+    current_group_id: Optional[str] = None
+    current_group_label: Optional[str] = None
+    current_group_members: Optional[list[str]] = None
+
+    def _register(node: GraphNode) -> None:
+        if node.id not in nodes:
+            nodes[node.id] = node
+            node_order.append(node.id)
+        if current_group_members is not None:
+            current_group_members.append(node.id)
+
+    for line_no, content in lines[1:]:
+        stripped = content.strip()
+        _check_unsupported(line_no, content)
+
+        if stripped.startswith("subgraph"):
+            if current_group_members is not None:
+                raise MermaidCodecError(line_no, content, "nested 'subgraph' is not supported")
+            rest = stripped[len("subgraph") :].strip()
+            match = _SUBGRAPH_HEADER_RE.match(rest)
+            if not match:
+                raise MermaidCodecError(line_no, content, "malformed subgraph header")
+            current_group_id = match.group("id")
+            current_group_label = _unescape_label(match.group("label"))
+            current_group_members = []
+            continue
+
+        if stripped == "end":
+            if current_group_members is None:
+                raise MermaidCodecError(line_no, content, "'end' with no open subgraph")
+            groups.append(
+                GraphGroup(id=current_group_id, label=current_group_label, nodes=list(current_group_members))
+            )
+            current_group_id = None
+            current_group_label = None
+            current_group_members = None
+            continue
+
+        if _FLOWCHART_EDGE_OP_SEARCH_RE.search(stripped):
+            edges.append(_parse_flowchart_edge_line(line_no, content, stripped))
+            continue
+
+        node = _parse_flowchart_node_decl(stripped)
+        if node is None:
+            raise MermaidCodecError(line_no, content, "unrecognized flowchart statement")
+        _register(node)
+
+    if current_group_members is not None:
+        last_no, last_line = lines[-1]
+        raise MermaidCodecError(last_no, last_line, "subgraph missing closing 'end'")
+
+    ordered_nodes = [nodes[node_id] for node_id in node_order]
+    return GraphSpec(kind="flowchart", direction=direction, nodes=ordered_nodes, edges=edges, groups=groups or None)
+
+
+def _parse_state(lines: list[tuple[int, str]]) -> GraphSpec:
+    nodes: dict[str, GraphNode] = {}
+    node_order: list[str] = []
+    edges: list[GraphEdge] = []
+    groups: list[GraphGroup] = []
+
+    current_group_id: Optional[str] = None
+    current_group_members: Optional[list[str]] = None
+
+    def _ensure_node(node_id: str, label: Optional[str] = None, shape: Optional[str] = None) -> None:
+        if node_id not in nodes:
+            # Synthetic start/end states are always circles (spec §2 Data
+            # Models) — there is no textual declaration for them to carry a
+            # shape, so it is filled in here, at first reference.
+            if node_id in (_START, _END) and shape is None:
+                shape = "circle"
+            nodes[node_id] = GraphNode(id=node_id, label=label, shape=shape)
+            node_order.append(node_id)
+        elif label is not None:
+            nodes[node_id] = nodes[node_id].model_copy(update={"label": label})
+        if current_group_members is not None and node_id not in (_START, _END):
+            current_group_members.append(node_id)
+
+    def _reject_reserved(line_no: int, content: str, *ids: str) -> None:
+        for candidate in ids:
+            if candidate in (_START, _END):
+                raise MermaidCodecError(
+                    line_no, content, f"{candidate!r} is reserved for the synthetic start/end state"
+                )
+
+    for line_no, content in lines[1:]:
+        stripped = content.strip()
+        _check_unsupported(line_no, content)
+
+        alias_match = _STATE_ALIAS_RE.match(stripped)
+        if alias_match:
+            node_id = alias_match.group("id")
+            _reject_reserved(line_no, content, node_id)
+            _ensure_node(node_id, label=_unescape_label(alias_match.group("label")))
+            continue
+
+        composite_match = _STATE_COMPOSITE_OPEN_RE.match(stripped)
+        if composite_match:
+            if current_group_members is not None:
+                raise MermaidCodecError(line_no, content, "nested composite state is not supported")
+            current_group_id = composite_match.group("id")
+            current_group_members = []
+            continue
+
+        if stripped == "}":
+            if current_group_members is None:
+                raise MermaidCodecError(line_no, content, "'}' with no open composite state")
+            groups.append(GraphGroup(id=current_group_id, nodes=list(current_group_members)))
+            current_group_id = None
+            current_group_members = None
+            continue
+
+        edge_match = _STATE_EDGE_RE.match(stripped)
+        if edge_match:
+            from_raw = edge_match.group("from")
+            to_raw = edge_match.group("to")
+            _reject_reserved(line_no, content, from_raw, to_raw)
+            from_id = _START if from_raw == "[*]" else from_raw
+            to_id = _END if to_raw == "[*]" else to_raw
+            _ensure_node(from_id)
+            _ensure_node(to_id)
+            edges.append(
+                GraphEdge(**{"from": from_id, "to": to_id, "label": edge_match.group("label")})
+            )
+            continue
+
+        bare_match = _BARE_IDENT_RE.match(stripped)
+        if bare_match:
+            _reject_reserved(line_no, content, stripped)
+            _ensure_node(stripped)
+            continue
+
+        raise MermaidCodecError(line_no, content, "unrecognized stateDiagram-v2 statement")
+
+    if current_group_members is not None:
+        last_no, last_line = lines[-1]
+        raise MermaidCodecError(last_no, last_line, "composite state missing closing '}'")
+
+    # __start__/__end__ (if referenced) were already registered by
+    # `_ensure_node` the first time an edge mentioned `[*]` — they have no
+    # top-level textual declaration of their own to parse separately.
+    ordered_nodes = [nodes[node_id] for node_id in node_order]
+    return GraphSpec(kind="state", direction="TB", nodes=ordered_nodes, edges=edges, groups=groups or None)
+
+
+def _parse_sequence(lines: list[tuple[int, str]]) -> GraphSpec:
+    nodes: dict[str, GraphNode] = {}
+    node_order: list[str] = []
+    edges: list[GraphEdge] = []
+
+    def _ensure_node(node_id: str, label: Optional[str] = None) -> None:
+        if node_id not in nodes:
+            nodes[node_id] = GraphNode(id=node_id, label=label)
+            node_order.append(node_id)
+        elif label is not None:
+            nodes[node_id] = nodes[node_id].model_copy(update={"label": label})
+
+    for line_no, content in lines[1:]:
+        stripped = content.strip()
+        _check_unsupported(line_no, content)
+
+        participant_match = _SEQ_PARTICIPANT_RE.match(stripped)
+        if participant_match:
+            node_id = participant_match.group("id")
+            label = _unescape_label(participant_match.group("label"))
+            _ensure_node(node_id, label=label)
+            continue
+
+        message_match = _SEQ_MESSAGE_RE.match(stripped)
+        if message_match:
+            from_id = message_match.group("from")
+            to_id = message_match.group("to")
+            _ensure_node(from_id)
+            _ensure_node(to_id)
+            kind = "dashed" if message_match.group("arrow") == "-->>" else "solid"
+            edges.append(
+                GraphEdge(
+                    **{
+                        "from": from_id,
+                        "to": to_id,
+                        "label": message_match.group("label"),
+                        "kind": kind,
+                    }
+                )
+            )
+            continue
+
+        raise MermaidCodecError(line_no, content, "unrecognized sequenceDiagram statement")
+
+    ordered_nodes = [nodes[node_id] for node_id in node_order]
+    return GraphSpec(kind="sequence", direction="TB", nodes=ordered_nodes, edges=edges)

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/graph/models.py
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/graph/models.py
@@ -1,0 +1,306 @@
+"""The ``Graph`` viz-core composite's wire vocabulary (FEAT-529 Module 1).
+
+:class:`GraphSpec` (and its child models) is the SINGLE source of vocabulary
+for the ``Graph`` component — the mermaid codec (``graph/mermaid.py``), the
+layered layout (``graph/layout.py``), the builder (``builders.build_graph``),
+the ``FlowDefinition`` adapter (``adapters/flow.py``), the derived
+``GRAPH_SCHEMA`` (``catalog/viz_core/graph.py``), and every renderer all
+consume or produce a :class:`GraphSpec`; nothing else defines a parallel
+shape (spec §7 "Patterns to Follow").
+
+**What, never how** (spec §2 Overview, §7): no field on any model here may
+carry a colour, a font, a pixel size or a renderer-library option.
+``rankSep``/``nodeSep`` are ABSTRACT layout units, not pixels; node ``state``
+is DATA (a domain enum) — the renderer contract (documented, not modelled
+here) maps it to a viz-core semantic status role and paints that role with
+its own theme. This invariant is enforced mechanically by
+``test_graph_schema_has_no_colour_vocabulary`` (Module 2) against the
+DERIVED wire schema, not against this module directly.
+
+This module is pure and synchronous: no I/O, no catalog registration, no
+import from ``parrot.bots``/``parrot.clients`` (core A2UI invariant, spec G9).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+__all__ = [
+    "Direction",
+    "EdgeKind",
+    "GraphEdge",
+    "GraphGroup",
+    "GraphKind",
+    "GraphLayout",
+    "GraphNode",
+    "GraphSelection",
+    "GraphSpec",
+    "LayoutEngine",
+    "NodeShape",
+    "NodeState",
+    "Position",
+    "VizSize",
+]
+
+GraphKind = Literal["flowchart", "state", "sequence", "dag"]
+Direction = Literal["TB", "LR", "BT", "RL"]
+NodeShape = Literal["rect", "rounded", "diamond", "circle", "hexagon", "subroutine"]
+NodeState = Literal["pending", "running", "completed", "failed", "skipped", "waiting"]
+EdgeKind = Literal["solid", "dashed", "thick"]
+LayoutEngine = Literal["layered", "force", "manual"]
+#: viz-core common prop (spec §2 Overview: size is intent, never pixels).
+VizSize = Literal["inline", "tile", "hero"]
+
+
+class GraphNode(BaseModel):
+    """A single node in a :class:`GraphSpec`.
+
+    Attributes:
+        id: Unique node identifier (unique within the owning ``GraphSpec``).
+        label: Display label. Renderers default to ``id`` when omitted.
+        shape: Node shape hint. Renderer default is ``rect`` (``rounded`` for
+            ``kind="state"`` graphs).
+        group: The :class:`GraphGroup.id` this node belongs to, if any.
+        state: DATA, not styling — the domain state of whatever this node
+            represents. The renderer contract maps it to a viz-core semantic
+            status role (documented in ``catalog/viz_core/graph.py``/the
+            renderer modules, not here).
+        icon: A free-form icon name hint (``parrot_icon`` semantics per
+            ``KPICard.icon``, FEAT-527) — never an asset path or pixel size.
+        meta: Opaque data surfaced by renderers as a tooltip. Never
+            interpreted by this module.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    label: Optional[str] = None
+    shape: Optional[NodeShape] = None
+    group: Optional[str] = None
+    state: Optional[NodeState] = None
+    icon: Optional[str] = None
+    meta: Optional[dict[str, Any]] = None
+
+
+class GraphEdge(BaseModel):
+    """A directed edge between two :class:`GraphNode` ids.
+
+    Attributes:
+        from_: Source node id (wire alias ``from`` — ``from`` is a Python
+            keyword, hence the trailing underscore).
+        to: Target node id.
+        label: Display label (e.g. a mermaid edge label, or a CEL predicate
+            summary from ``flow_definition_to_graph``).
+        kind: Edge stroke kind. Renderer default is ``solid``.
+        condition: Free text (e.g. ``"on_error"``, a CEL predicate) — never
+            interpreted here; carried through for renderers/tooltips.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    from_: str = Field(alias="from")
+    to: str
+    label: Optional[str] = None
+    kind: Optional[EdgeKind] = None
+    condition: Optional[str] = None
+
+
+class GraphGroup(BaseModel):
+    """A named grouping of node ids (rendered as a bounding box).
+
+    Attributes:
+        id: Unique group identifier.
+        label: Display label for the group.
+        nodes: Member node ids. Every id must exist in the owning
+            :class:`GraphSpec` and belong to at most one group.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    label: Optional[str] = None
+    nodes: list[str]
+
+
+class Position(BaseModel):
+    """An abstract-unit 2D coordinate (origin top-left, never pixels).
+
+    Attributes:
+        x: Horizontal coordinate, abstract units.
+        y: Vertical coordinate, abstract units.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    x: float
+    y: float
+
+
+class GraphLayout(BaseModel):
+    """Layout configuration and (optionally) precomputed node positions.
+
+    Attributes:
+        engine: The layout engine hint. ``"layered"`` (default) is computed
+            server-side (``graph/layout.py``); ``"force"`` is an interactive-
+            renderer-only hint (static lanes degrade to layered); ``"manual"``
+            requires ``positions`` to cover every node.
+        rank_sep: Abstract rank-axis spacing unit (wire alias ``rankSep``) —
+            NOT pixels.
+        node_sep: Abstract cross-axis spacing unit (wire alias ``nodeSep``) —
+            NOT pixels.
+        positions: Precomputed node positions, keyed by node id. Required
+            (and must cover every node) when ``engine == "manual"``.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    engine: LayoutEngine = "layered"
+    rank_sep: Optional[float] = Field(default=None, alias="rankSep")
+    node_sep: Optional[float] = Field(default=None, alias="nodeSep")
+    positions: Optional[dict[str, Position]] = None
+
+
+class GraphSelection(BaseModel):
+    """Node selection state.
+
+    Attributes:
+        selectable: Whether nodes may be selected (renderer hint).
+        selected: The currently selected node id, if any.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    selectable: bool = False
+    selected: Optional[str] = None
+
+
+class GraphSpec(BaseModel):
+    """Wire vocabulary of the viz-core ``Graph`` composite (camelCase aliases).
+
+    This is the SINGLE source of vocabulary for ``Graph`` — see this
+    module's docstring. ``action`` is deliberately NOT a field here: it is
+    the component-level prop the catalog layer (``catalog/viz_core/
+    graph.py``) declares explicitly in ``GRAPH_SCHEMA`` (a ``$ref`` to
+    ``common_types.json#/$defs/Action``), because ``action`` is not part of
+    the official ``ComponentCommon`` (spec §2 Overview).
+
+    Attributes:
+        kind: The graph's semantic kind. ``kind="dag"`` enforces
+            acyclicity; ``"flowchart"``/``"state"``/``"sequence"`` legally
+            allow cycles (real workflows loop).
+        direction: Layout direction hint honoured by ``compute_positions``.
+        title: Optional display title.
+        accessible_description: viz-core common prop (wire alias
+            ``accessibleDescription``) — plain-language summary used as the
+            lowered fallback's first line and the SVG ``<title>``.
+        size: viz-core common prop — layout INTENT (``inline``/``tile``/
+            ``hero``), never pixels.
+        nodes: The graph's nodes.
+        edges: The graph's edges. Every endpoint must reference an existing
+            node id.
+        groups: Optional node groupings. Every member must exist and belong
+            to at most one group.
+        layout: Optional layout configuration/precomputed positions.
+        selection: Optional selection state.
+        data: INPUT-ONLY — a data-model binding descriptor replaces this
+            field in the DERIVED wire schema (``GRAPH_SCHEMA``, Module 2).
+            Resolves to ``{node_id: {"state"?: NodeState, "label"?: str,
+            "meta"?: dict}}``, overlaying the matching node's ``state``/
+            ``label``/``meta`` at render time.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    kind: GraphKind = "flowchart"
+    direction: Direction = "TB"
+    title: Optional[str] = None
+    accessible_description: Optional[str] = Field(default=None, alias="accessibleDescription")
+    size: VizSize = "tile"
+    nodes: list[GraphNode]
+    edges: list[GraphEdge]
+    groups: Optional[list[GraphGroup]] = None
+    layout: Optional[GraphLayout] = None
+    selection: Optional[GraphSelection] = None
+    data: Optional[dict[str, dict[str, Any]]] = None
+
+    @model_validator(mode="after")
+    def _validate_graph(self) -> GraphSpec:
+        """Enforce the spec §2 Data Models invariants (all reported via ``ValueError``).
+
+        * Node ids are unique.
+        * Every edge endpoint (``from``/``to``) references an existing node.
+        * Every group member exists and belongs to at most one group.
+        * ``kind == "dag"`` implies the edge graph is acyclic (cycles are
+          legal for every other ``kind`` — real workflows loop).
+        * ``layout.engine == "manual"`` implies ``layout.positions`` covers
+          every node.
+        """
+        node_ids = [node.id for node in self.nodes]
+        id_set = set(node_ids)
+        if len(node_ids) != len(id_set):
+            seen: set[str] = set()
+            dupes: set[str] = set()
+            for node_id in node_ids:
+                if node_id in seen:
+                    dupes.add(node_id)
+                seen.add(node_id)
+            raise ValueError(f"Duplicate GraphNode id(s): {sorted(dupes)}")
+
+        for edge in self.edges:
+            if edge.from_ not in id_set:
+                raise ValueError(f"GraphEdge.from {edge.from_!r} does not reference an existing node")
+            if edge.to not in id_set:
+                raise ValueError(f"GraphEdge.to {edge.to!r} does not reference an existing node")
+
+        if self.groups:
+            node_group: dict[str, str] = {}
+            for group in self.groups:
+                for member in group.nodes:
+                    if member not in id_set:
+                        raise ValueError(f"GraphGroup {group.id!r} references unknown node {member!r}")
+                    if member in node_group:
+                        raise ValueError(
+                            f"Node {member!r} belongs to more than one group "
+                            f"({node_group[member]!r} and {group.id!r})"
+                        )
+                    node_group[member] = group.id
+
+        if self.kind == "dag" and self._has_cycle():
+            raise ValueError("kind='dag' requires an acyclic graph, but a cycle was found")
+
+        if self.layout is not None and self.layout.engine == "manual":
+            positions = self.layout.positions or {}
+            missing = id_set - set(positions)
+            if missing:
+                raise ValueError(
+                    "layout.engine='manual' requires a position for every node; "
+                    f"missing: {sorted(missing)}"
+                )
+
+        return self
+
+    def _has_cycle(self) -> bool:
+        """Whether the (directed) edge graph contains a cycle (DFS, 3-colour)."""
+        adjacency: dict[str, list[str]] = {}
+        for edge in self.edges:
+            adjacency.setdefault(edge.from_, []).append(edge.to)
+
+        visiting: set[str] = set()
+        visited: set[str] = set()
+
+        def _walk(node_id: str) -> bool:
+            if node_id in visiting:
+                return True
+            if node_id in visited:
+                return False
+            visiting.add(node_id)
+            for neighbor in adjacency.get(node_id, ()):
+                if _walk(neighbor):
+                    return True
+            visiting.discard(node_id)
+            visited.add(node_id)
+            return False
+
+        return any(node.id not in visited and _walk(node.id) for node in self.nodes)

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/graph/models.py
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/graph/models.py
@@ -281,25 +281,44 @@ class GraphSpec(BaseModel):
         return self
 
     def _has_cycle(self) -> bool:
-        """Whether the (directed) edge graph contains a cycle (DFS, 3-colour)."""
+        """Whether the (directed) edge graph contains a cycle.
+
+        Iterative 3-colour DFS with an explicit stack (mirrors
+        ``graph/layout.py``'s ``_break_cycles``) — deliberately NOT recursive
+        Python-call-stack DFS, so an adversarially large or long-chained
+        ``dag`` candidate raises the intended ``ValidationError`` via the
+        caller's ``kind == "dag"`` check rather than crashing the process
+        with an unhandled ``RecursionError``.
+        """
         adjacency: dict[str, list[str]] = {}
         for edge in self.edges:
             adjacency.setdefault(edge.from_, []).append(edge.to)
 
-        visiting: set[str] = set()
-        visited: set[str] = set()
+        WHITE, GRAY, BLACK = 0, 1, 2
+        color: dict[str, int] = {node.id: WHITE for node in self.nodes}
 
-        def _walk(node_id: str) -> bool:
-            if node_id in visiting:
-                return True
-            if node_id in visited:
-                return False
-            visiting.add(node_id)
-            for neighbor in adjacency.get(node_id, ()):
-                if _walk(neighbor):
-                    return True
-            visiting.discard(node_id)
-            visited.add(node_id)
-            return False
+        for start in color:
+            if color[start] != WHITE:
+                continue
+            stack: list[tuple[str, int]] = [(start, 0)]
+            color[start] = GRAY
+            while stack:
+                node_id, child_index = stack[-1]
+                neighbours = adjacency.get(node_id, [])
+                if child_index < len(neighbours):
+                    stack[-1] = (node_id, child_index + 1)
+                    neighbour = neighbours[child_index]
+                    if neighbour not in color:
+                        # Dangling edge target — already rejected earlier in
+                        # _validate_graph; defensively skip rather than KeyError.
+                        continue
+                    if color[neighbour] == WHITE:
+                        color[neighbour] = GRAY
+                        stack.append((neighbour, 0))
+                    elif color[neighbour] == GRAY:
+                        return True
+                else:
+                    color[node_id] = BLACK
+                    stack.pop()
 
-        return any(node.id not in visited and _walk(node.id) for node in self.nodes)
+        return False

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/graph/models.py
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/graph/models.py
@@ -275,8 +275,7 @@ class GraphSpec(BaseModel):
             missing = id_set - set(positions)
             if missing:
                 raise ValueError(
-                    "layout.engine='manual' requires a position for every node; "
-                    f"missing: {sorted(missing)}"
+                    "layout.engine='manual' requires a position for every node; " f"missing: {sorted(missing)}"
                 )
 
         return self

--- a/packages/ai-parrot/src/parrot/outputs/a2ui/producer.py
+++ b/packages/ai-parrot/src/parrot/outputs/a2ui/producer.py
@@ -175,9 +175,17 @@ def _ensure_catalogs_registered() -> None:
     bodies). Calling this before :func:`catalog_instructions` guarantees the
     system prompt covers BOTH catalogs regardless of what else has run first in
     the process (spec Module 9: "instructions básico + parrot").
+
+    Also imports ``catalog.viz_core`` (FEAT-529 Module 0) — a no-op today
+    (that package registers no component yet), kept alongside so a future
+    ``catalog=VIZ_CORE_CATALOG_ID`` caller's header instructions
+    (:func:`~parrot.outputs.a2ui.catalog.catalog_header_instructions`) are
+    available regardless of import order, same reasoning as the two lines
+    above.
     """
     import parrot.outputs.a2ui.catalog.basic
     import parrot.outputs.a2ui.catalog.parrot  # noqa: F401
+    import parrot.outputs.a2ui.catalog.viz_core  # noqa: F401
 
 
 async def generate_envelope(
@@ -199,7 +207,11 @@ async def generate_envelope(
             ``surface_catalog_id`` (v1.0 catalog resolution, spec §2 G2). When
             omitted, resolution falls back to each component's own
             ``catalogId`` (the structured-output ``CreateSurface`` the LLM
-            returns normally carries its own ``catalogId`` already).
+            returns normally carries its own ``catalogId`` already). ALSO
+            scopes the system prompt's catalog instructions (FEAT-529
+            Module 0): when given, only that catalog's components/header are
+            listed; when omitted, every registered catalog is (today's
+            behavior, unchanged).
         max_attempts: Total ``ask()`` attempts (default from SPK-3: 3).
         model: Model id forwarded to ``client.ask``.
         system_prompt: Optional base system prompt; the catalog instructions are appended.
@@ -208,7 +220,7 @@ async def generate_envelope(
         A :class:`ProducerResult` — either a validated envelope or a plain-text degradation.
     """
     _ensure_catalogs_registered()
-    instructions = catalog_instructions()
+    instructions = catalog_instructions(catalog_ids=[catalog] if catalog else None)
     system = (
         (system_prompt + "\n\n" if system_prompt else "")
         + "You produce ONLY an A2UI v1.0 createSurface envelope for the requested "

--- a/packages/ai-parrot/tests/integration/test_frontend_guide_examples.py
+++ b/packages/ai-parrot/tests/integration/test_frontend_guide_examples.py
@@ -21,11 +21,15 @@ import parrot.outputs.a2ui.catalog.parrot  # noqa: F401 — ensure Chart/DataTab
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 _GUIDE_PATH = _REPO_ROOT / "docs" / "frontend" / "structured-artifacts-frontend-guide.md"
+#: FEAT-529 Module 8: the AgentDashboard/navigator-frontend-next TECHNICAL
+#: reference (a separate doc from the guide above) gains its own Graph
+#: example, §5.4 — same ```json a2ui-envelope``` fence convention.
+_REFERENCE_GUIDE_PATH = _REPO_ROOT / "docs" / "frontend" / "agentdashboard-a2ui-reference.md"
 _FENCE_RE = re.compile(r"```json a2ui-envelope\n(.*?)```", re.DOTALL)
 
 
-def _extract_a2ui_envelope_examples() -> list[dict]:
-    text = _GUIDE_PATH.read_text(encoding="utf-8")
+def _extract_a2ui_envelope_examples(path: Path = _GUIDE_PATH) -> list[dict]:
+    text = path.read_text(encoding="utf-8")
     return [json.loads(block) for block in _FENCE_RE.findall(text)]
 
 
@@ -57,6 +61,36 @@ def test_frontend_guide_examples_validate(index):
 
     examples = _extract_a2ui_envelope_examples()
     envelope_dict = examples[index]
+    assert envelope_dict["version"] == "v1.0"
+
+    message = A2UIAgentMessage.model_validate(envelope_dict)
+    surface = message.create_surface
+    validate_envelope(surface, origin=ProducerOrigin.TOOL)
+
+    lowered_surface = surface.model_copy(update={"components": _lower_to_basic_components(surface)})
+    lowered_message = A2UIAgentMessage(version="v1.0", create_surface=lowered_surface)
+    validate_message(lowered_message)
+
+
+def test_frontend_guide_graph_example_validates():
+    """FEAT-529 Module 8: the Graph example added to
+    docs/frontend/agentdashboard-a2ui-reference.md §5.4 validates — same
+    two-layer conformance check as the guide's own examples above, just
+    against a different (frontend TECHNICAL reference) document."""
+    import parrot.outputs.a2ui.catalog.viz_core  # noqa: F401 — ensure Graph registration
+    from parrot.outputs.a2ui.catalog import validate_envelope, validate_message
+    from parrot.outputs.a2ui.catalog.base import ProducerOrigin
+    from parrot.outputs.a2ui.models import A2UIAgentMessage
+
+    examples = _extract_a2ui_envelope_examples(_REFERENCE_GUIDE_PATH)
+    graph_examples = [
+        example
+        for example in examples
+        if any(comp.get("component") == "Graph" for comp in example["createSurface"]["components"])
+    ]
+    assert len(graph_examples) == 1, "expected exactly one Graph example in the reference doc"
+
+    envelope_dict = graph_examples[0]
     assert envelope_dict["version"] == "v1.0"
 
     message = A2UIAgentMessage.model_validate(envelope_dict)

--- a/packages/ai-parrot/tests/outputs/a2ui/adapters/test_import_rule.py
+++ b/packages/ai-parrot/tests/outputs/a2ui/adapters/test_import_rule.py
@@ -138,6 +138,16 @@ def test_adapters_subpackage_importable_without_agents_or_clients():
     )
 
 
+def test_adapters_flow_has_no_bots_import():
+    """FEAT-529 Module 5: adapters/flow.py accepts a mapping, never a live
+    FlowDefinition instance — importing it must never pull in parrot.bots."""
+    _run_import_probe(
+        _ADAPTERS_DIR.parents[3],  # .../src
+        "from parrot.outputs.a2ui.adapters.flow import flow_definition_to_graph",
+        "assert flow_definition_to_graph is not None",
+    )
+
+
 def test_catalog_basic_has_no_forbidden_imports():
     assert _CATALOG_BASIC_DIR.is_dir(), f"expected catalog/basic subpackage at {_CATALOG_BASIC_DIR}"
     offenders = _forbidden_import_offenders(_CATALOG_BASIC_DIR.rglob("*.py"))

--- a/packages/ai-parrot/tests/outputs/a2ui/catalog/test_export.py
+++ b/packages/ai-parrot/tests/outputs/a2ui/catalog/test_export.py
@@ -3,16 +3,22 @@
 from __future__ import annotations
 
 import jsonschema
+import pytest
+from parrot.outputs.a2ui.catalog import (
+    register_component,
+    unregister_component,
+)
 from parrot.outputs.a2ui.catalog import (
     parrot as _register_parrot_components,  # noqa: F401
 )
-from parrot.outputs.a2ui.catalog.base import DEFAULT_CATALOG_ID
+from parrot.outputs.a2ui.catalog.base import DEFAULT_CATALOG_ID, BasicNode
 from parrot.outputs.a2ui.catalog.basic import (
     BASIC_CATALOG_ID,
     load_spec,
     schema_registry,
 )
-from parrot.outputs.a2ui.catalog.export import export_catalog_definition
+from parrot.outputs.a2ui.catalog.export import export_catalog_definition, write_catalog_definition
+from parrot.outputs.a2ui.catalog.viz_core import VIZ_CORE_CATALOG_ID, VIZ_CORE_INSTRUCTIONS
 
 
 class TestExportCatalogDefinitionValid:
@@ -46,3 +52,47 @@ class TestExportIncludesBasicRefsAndInstructions:
     def test_export_parrot_components_carry_allowed_parents(self):
         doc = export_catalog_definition()
         assert doc["components"]["Report"].get("allowedParents") == ["root", "Column"]
+
+
+@pytest.fixture
+def viz_core_probe():
+    """Register a throwaway viz-core component for the export tests below."""
+
+    @register_component("VizCoreExportProbe", catalog_id=VIZ_CORE_CATALOG_ID)
+    class VizCoreExportProbe:
+        SCHEMA = {"type": "object", "properties": {"kind": {"type": "string"}}}
+        INSTRUCTIONS = "Use VizCoreExportProbe for probing exports."
+
+        def lower(self, component, data_model):
+            return BasicNode(component="Column")
+
+    yield "VizCoreExportProbe"
+    unregister_component("VizCoreExportProbe", VIZ_CORE_CATALOG_ID)
+
+
+class TestExportScopedToVizCore:
+    """FEAT-529 Module 0: catalog-scoped export."""
+
+    def test_export_viz_core_catalog_validates(self, viz_core_probe):
+        doc = export_catalog_definition(catalog_id=VIZ_CORE_CATALOG_ID)
+        schema = load_spec("catalog_definition")
+        registry = schema_registry()
+        validator_cls = jsonschema.validators.validator_for(schema)
+        validator_cls(schema, registry=registry).validate(doc)  # raises on failure
+
+        assert doc["catalogId"] == VIZ_CORE_CATALOG_ID
+        assert "VizCoreExportProbe" in doc["components"]
+        # include_basic=True (default) still $ref's the Basic Catalog primitives.
+        assert doc["components"]["Text"] == {"$ref": f"{BASIC_CATALOG_ID}#/components/Text"}
+        assert doc["instructions"].startswith(VIZ_CORE_INSTRUCTIONS)
+        assert "InfoCard" not in doc["instructions"]
+
+    def test_write_catalog_definition_catalog_id(self, tmp_path, viz_core_probe):
+        path = tmp_path / "viz_core_catalog_definition.json"
+        write_catalog_definition(path, catalog_id=VIZ_CORE_CATALOG_ID)
+
+        import json
+
+        doc = json.loads(path.read_text())
+        assert doc["catalogId"] == VIZ_CORE_CATALOG_ID
+        assert "VizCoreExportProbe" in doc["components"]

--- a/packages/ai-parrot/tests/outputs/a2ui/catalog/test_validation_v1.py
+++ b/packages/ai-parrot/tests/outputs/a2ui/catalog/test_validation_v1.py
@@ -7,7 +7,9 @@ import pytest
 from parrot.outputs.a2ui.catalog import (
     DEFAULT_CATALOG_ID,
     ProducerOrigin,
+    catalog_header_instructions,
     catalog_instructions,
+    get_component,
     register_component,
     resolve_catalog,
     unregister_component,
@@ -26,6 +28,7 @@ from parrot.outputs.a2ui.catalog.base import (
     CatalogValidationError,
 )
 from parrot.outputs.a2ui.catalog.basic import BASIC_CATALOG_ID
+from parrot.outputs.a2ui.catalog.viz_core import VIZ_CORE_CATALOG_ID, VIZ_CORE_INSTRUCTIONS
 from parrot.outputs.a2ui.models import A2UIAgentMessage, Component, CreateSurface
 
 
@@ -243,3 +246,76 @@ class TestCatalogInstructionsNoRstripBug:
 
         cleanup_catalog.append("TrailingColon")
         assert "TrailingColon: Always end with a colon:" in catalog_instructions()
+
+
+class TestCatalogInstructionsScoped:
+    """FEAT-529 Module 0."""
+
+    def test_catalog_instructions_scoped(self, cleanup_catalog):
+        @register_component("GraphProbeScoped", catalog_id=VIZ_CORE_CATALOG_ID)
+        class GraphProbeScoped:
+            INSTRUCTIONS = "Use GraphProbeScoped for probes."
+
+            def lower(self, component, data_model):
+                return None
+
+        try:
+            scoped = catalog_instructions([VIZ_CORE_CATALOG_ID])
+            assert scoped.startswith(VIZ_CORE_INSTRUCTIONS)
+            assert "GraphProbeScoped: Use GraphProbeScoped for probes." in scoped
+            assert "InfoCard" not in scoped
+
+            unscoped = catalog_instructions()
+            assert VIZ_CORE_INSTRUCTIONS in unscoped
+            assert "GraphProbeScoped: Use GraphProbeScoped for probes." in unscoped
+        finally:
+            unregister_component("GraphProbeScoped", VIZ_CORE_CATALOG_ID)
+
+    def test_catalog_header_instructions(self):
+        assert catalog_header_instructions(VIZ_CORE_CATALOG_ID) == VIZ_CORE_INSTRUCTIONS
+        assert catalog_header_instructions(DEFAULT_CATALOG_ID) is None
+        assert catalog_header_instructions(BASIC_CATALOG_ID) is None
+
+
+class TestIntercepts:
+    """FEAT-529 Module 0/6: the satellite's catalog-aware interception helper."""
+
+    def test_intercepts_resolves_catalog(self):
+        from parrot.outputs.a2ui_renderers._intercept import intercepts
+
+        # Deliberately fake, never-registered names — this Module 0 test only
+        # exercises the resolution/membership logic, not real catalog content
+        # (real components would collide with whatever Module 2+ registers
+        # elsewhere in the same test session).
+        table = frozenset(
+            {
+                (DEFAULT_CATALOG_ID, "FakeParrotComposite"),
+                (VIZ_CORE_CATALOG_ID, "FakeVizComposite"),
+            }
+        )
+
+        parrot_no_own_catalog = Component(id="c0", component="FakeParrotComposite")
+        assert intercepts(table, parrot_no_own_catalog, DEFAULT_CATALOG_ID) is True
+
+        viz_with_catalog = Component(id="g0", component="FakeVizComposite", catalogId=VIZ_CORE_CATALOG_ID)
+        assert intercepts(table, viz_with_catalog, DEFAULT_CATALOG_ID) is True
+
+        viz_no_catalog = Component(id="g1", component="FakeVizComposite")
+        assert intercepts(table, viz_no_catalog, DEFAULT_CATALOG_ID) is False
+
+
+class TestGetComponentAmbiguity:
+    """FEAT-529 Module 0: ``get_component`` catalog-aware resolution."""
+
+    def test_get_component_explicit_catalog_id(self, cleanup_catalog):
+        @register_component("ExplicitProbe", catalog_id=VIZ_CORE_CATALOG_ID)
+        class ExplicitProbe:
+            def lower(self, component, data_model):
+                return None
+
+        try:
+            assert get_component("ExplicitProbe", VIZ_CORE_CATALOG_ID).component_cls is ExplicitProbe
+            with pytest.raises(KeyError):
+                get_component("ExplicitProbe", DEFAULT_CATALOG_ID)
+        finally:
+            unregister_component("ExplicitProbe", VIZ_CORE_CATALOG_ID)

--- a/packages/ai-parrot/tests/outputs/a2ui/conformance/test_all_emitters.py
+++ b/packages/ai-parrot/tests/outputs/a2ui/conformance/test_all_emitters.py
@@ -56,15 +56,18 @@ expected to — validate against it directly. So ``_assert_conformant`` checks:
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 from parrot.models.infographic import InfographicResponse
 from parrot.outputs.a2ui.adapters import infographic_response_to_envelope
+from parrot.outputs.a2ui.adapters.flow import flow_definition_to_graph
 from parrot.outputs.a2ui.baking import bake_envelope
 from parrot.outputs.a2ui.builders import (
     build_card,
     build_chart,
     build_datatable,
+    build_graph,
     build_infographic,
     build_kpicard,
     build_surface,
@@ -75,14 +78,18 @@ from parrot.outputs.a2ui.catalog import (
     validate_envelope,
     validate_message,
 )
-from parrot.outputs.a2ui.catalog.base import to_components
+from parrot.outputs.a2ui.catalog.base import CatalogValidationError, to_components
 from parrot.outputs.a2ui.catalog.parrot.form import FormField, FormSubmit, build_form
+from parrot.outputs.a2ui.catalog.viz_core import VIZ_CORE_CATALOG_ID
+from parrot.outputs.a2ui.graph import from_mermaid, to_mermaid
 from parrot.outputs.a2ui.models import A2UIAgentMessage, Component, CreateSurface
 from parrot.outputs.a2ui.recipes import SUPPORTED_SCHEMA_VERSION
 from parrot.outputs.a2ui.recipes.migrate import migrate_layout
 from parrot.outputs.a2ui.recipes.models import LayoutSpec
 
 from .._v1 import DEFAULT_CATALOG_ID
+
+_FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures"
 
 
 def _lower_to_basic_components(envelope: CreateSurface) -> list[Component]:
@@ -158,6 +165,17 @@ class TestBuildersConformance:
             title="Q1 Overview",
             sections=[{"heading": "Summary", "text": "Revenue grew."}],
         )
+        _assert_conformant(envelope)
+
+    def test_build_graph(self):
+        """FEAT-529: build_graph()'s output validates against the wire
+        schema (lowered — GraphComponent.lower() is a Basic-only tree)."""
+        envelope = build_graph(
+            nodes=[{"id": "a", "label": "Start"}, {"id": "b", "label": "End"}],
+            edges=[{"from": "a", "to": "b", "label": "go"}],
+            accessible_description="Tiny graph",
+        )
+        assert envelope.components[0].catalog_id == VIZ_CORE_CATALOG_ID
         _assert_conformant(envelope)
 
 
@@ -429,3 +447,144 @@ class TestRendererConformance:
         # vocabulary, not an A2UI envelope (see module docstring).
         card = json.loads(artifact.content)
         assert card.get("type") == "AdaptiveCard" or "body" in card
+
+
+# ---------------------------------------------------------------------------
+# FEAT-529: viz-core Graph — cross-cutting acceptance (Module 8, TASK-2891).
+# ---------------------------------------------------------------------------
+
+
+def _graph_envelope() -> CreateSurface:
+    return build_graph(
+        nodes=[{"id": "a", "label": "Start"}, {"id": "b", "label": "End"}],
+        edges=[{"from": "a", "to": "b", "label": "go"}],
+        accessible_description="Tiny graph",
+    )
+
+
+class TestFlowToGraphToMermaidRoundtrip:
+    """The dev-loop FlowDefinition fixture -> Graph -> mermaid -> Graph
+    round-trips (modulo accessibleDescription/size, per the codec's own
+    contract), and the adapter's own build_graph() output is conformant."""
+
+    def test_flow_to_graph_to_mermaid_roundtrip(self):
+        definition = json.loads((_FIXTURES_DIR / "dev_loop_flow.json").read_text())
+        spec = flow_definition_to_graph(definition)
+
+        envelope = build_graph(
+            nodes=spec.nodes,
+            edges=spec.edges,
+            accessible_description=spec.accessible_description,
+        )
+        _assert_conformant(envelope)
+
+        mermaid_text = to_mermaid(spec)
+        roundtripped = from_mermaid(mermaid_text)
+
+        def _normalize(graph_spec):
+            dumped = graph_spec.model_dump(by_alias=True, exclude={"accessible_description", "size"})
+            # The mermaid codec never collapses an edge's `kind` back to
+            # `None` (an edge operator is always unambiguously explicit in
+            # text) — normalize the two equivalent representations before
+            # comparing (documented in graph/mermaid.py's module docstring;
+            # flow_definition_to_graph legitimately leaves `kind=None` on
+            # every non-on_error/on_timeout edge).
+            for edge in dumped.get("edges", []):
+                if edge.get("kind") is None:
+                    edge["kind"] = "solid"
+            return dumped
+
+        assert _normalize(roundtripped) == _normalize(spec)
+
+
+class TestGraphRendersOnEveryRegisteredRenderer:
+    """A viz-core Graph envelope renders (natively, or via exactly one
+    recorded, readable degradation) on every registered satellite renderer."""
+
+    @pytest.mark.asyncio
+    async def test_graph_renders_on_every_registered_renderer(self):
+        from parrot.outputs.a2ui_renderers.adaptive_cards import AdaptiveCardsRenderer
+        from parrot.outputs.a2ui_renderers.echarts import EChartsRenderer
+        from parrot.outputs.a2ui_renderers.interactive_html import InteractiveHTMLRenderer
+        from parrot.outputs.a2ui_renderers.ssr_html import SSRHTMLRenderer
+
+        envelope = _graph_envelope()
+        _assert_conformant(envelope)
+
+        for renderer in (SSRHTMLRenderer(), InteractiveHTMLRenderer(), EChartsRenderer()):
+            artifact = await renderer.render(envelope)
+            assert not artifact.metadata.get("degraded"), type(renderer).__name__
+
+        try:
+            import weasyprint  # noqa: F401
+        except ImportError:
+            pass
+        else:
+            from parrot.outputs.a2ui_renderers.pdf import PDFRenderer
+
+            pdf_artifact = await PDFRenderer().render(envelope)
+            assert not pdf_artifact.metadata.get("degraded")
+
+        ac_artifact = await AdaptiveCardsRenderer().render(envelope)
+        ac_degraded = ac_artifact.metadata.get("degraded") or []
+        assert len(ac_degraded) == 1
+        assert VIZ_CORE_CATALOG_ID in ac_degraded[0]["reason"]
+
+        try:
+            import folium  # noqa: F401
+        except ImportError:
+            pass
+        else:
+            from parrot.outputs.a2ui_renderers.folium_map import FoliumMapRenderer
+
+            map_and_graph = build_surface(
+                "Map",
+                {"layers": [{"layer": "base"}]},
+                surface_id="map",
+            )
+            graph_component = envelope.components[0].model_copy(update={"id": "graph"})
+            combined = map_and_graph.model_copy(
+                update={"components": [*map_and_graph.components, graph_component]}
+            )
+            map_artifact = await FoliumMapRenderer().render(combined)
+            map_degraded = map_artifact.metadata.get("degraded") or []
+            graph_records = [record for record in map_degraded if record["component"] == "Graph"]
+            assert len(graph_records) == 1
+            assert VIZ_CORE_CATALOG_ID in graph_records[0]["reason"]
+
+
+class TestCatalogDefinitionIncludesGraph:
+    def test_catalog_definition_includes_graph(self):
+        from parrot.outputs.a2ui.catalog.export import export_catalog_definition
+
+        viz_core_doc = export_catalog_definition(catalog_id=VIZ_CORE_CATALOG_ID)
+        assert "Graph" in viz_core_doc["components"]
+
+        parrot_doc = export_catalog_definition()  # DEFAULT_CATALOG_ID
+        assert "Graph" not in parrot_doc["components"]
+
+
+class TestMixedCatalogSurfaceValidates:
+    def test_mixed_catalog_surface_validates(self):
+        from parrot.outputs.a2ui.catalog.basic import BASIC_CATALOG_ID
+
+        graph_component = Component(
+            id="graph",
+            component="Graph",
+            catalogId=VIZ_CORE_CATALOG_ID,
+            nodes=[{"id": "a"}, {"id": "b"}],
+            edges=[{"from": "a", "to": "b"}],
+        )
+        root = Component(id="root", component="Column", children=["graph"])
+        surface = CreateSurface(
+            surfaceId="s",
+            catalogId=BASIC_CATALOG_ID,
+            components=[root, graph_component],
+        )
+        validate_envelope(surface)  # must not raise — mixed-catalog shape
+
+        graph_without_catalog_id = graph_component.model_copy(update={"catalog_id": None})
+        bad_surface = surface.model_copy(update={"components": [root, graph_without_catalog_id]})
+        with pytest.raises(CatalogValidationError) as exc:
+            validate_envelope(bad_surface)
+        assert "Graph" in exc.value.unknown_components

--- a/packages/ai-parrot/tests/outputs/a2ui/conformance/test_all_emitters.py
+++ b/packages/ai-parrot/tests/outputs/a2ui/conformance/test_all_emitters.py
@@ -543,9 +543,7 @@ class TestGraphRendersOnEveryRegisteredRenderer:
                 surface_id="map",
             )
             graph_component = envelope.components[0].model_copy(update={"id": "graph"})
-            combined = map_and_graph.model_copy(
-                update={"components": [*map_and_graph.components, graph_component]}
-            )
+            combined = map_and_graph.model_copy(update={"components": [*map_and_graph.components, graph_component]})
             map_artifact = await FoliumMapRenderer().render(combined)
             map_degraded = map_artifact.metadata.get("degraded") or []
             graph_records = [record for record in map_degraded if record["component"] == "Graph"]

--- a/packages/ai-parrot/tests/outputs/a2ui/fixtures/dev_loop_flow.json
+++ b/packages/ai-parrot/tests/outputs/a2ui/fixtures/dev_loop_flow.json
@@ -1,0 +1,26 @@
+{
+  "flow": "dev_loop",
+  "version": "1.0",
+  "description": "FEAT-529 test fixture: a FlowDefinition.model_dump(by_alias=True)-shaped mapping — never imports parrot.bots.",
+  "nodes": [
+    {"id": "start", "type": "start"},
+    {"id": "research", "type": "agent", "label": "Research"},
+    {"id": "decision", "type": "decision", "label": "Ready?"},
+    {"id": "development", "type": "agent", "label": "Development"},
+    {"id": "qa", "type": "agent", "label": "QA"},
+    {"id": "docs", "type": "agent", "label": "Docs"},
+    {"id": "close", "type": "agent", "label": "Close"},
+    {"id": "failure_handler", "type": "agent", "label": "Failure Handler"},
+    {"id": "end", "type": "end"}
+  ],
+  "edges": [
+    {"from": "start", "to": "research", "condition": "always"},
+    {"from": "research", "to": "decision", "condition": "on_success"},
+    {"from": "decision", "to": "development", "condition": "on_condition", "predicate": "ready == true"},
+    {"from": "development", "to": ["qa", "docs"], "condition": "on_success"},
+    {"from": "development", "to": "failure_handler", "condition": "on_error"},
+    {"from": "qa", "to": "close", "condition": "always"},
+    {"from": "docs", "to": "close", "condition": "always"},
+    {"from": "close", "to": "end", "condition": "always"}
+  ]
+}

--- a/packages/ai-parrot/tests/outputs/a2ui/fixtures/mermaid/flowchart_mid_label.json
+++ b/packages/ai-parrot/tests/outputs/a2ui/fixtures/mermaid/flowchart_mid_label.json
@@ -1,0 +1,11 @@
+{
+  "kind": "flowchart",
+  "direction": "TB",
+  "nodes": [
+    {"id": "n1", "label": "Start"},
+    {"id": "n2", "label": "Finish"}
+  ],
+  "edges": [
+    {"from": "n1", "to": "n2", "label": "go", "kind": "solid"}
+  ]
+}

--- a/packages/ai-parrot/tests/outputs/a2ui/fixtures/mermaid/flowchart_mid_label.mmd
+++ b/packages/ai-parrot/tests/outputs/a2ui/fixtures/mermaid/flowchart_mid_label.mmd
@@ -1,0 +1,7 @@
+%% Fixture: mid-label edge syntax ("-- text -->"), parse-only (FEAT-529 TASK-2883).
+%% to_mermaid() always emits the pipe form ("-->|text|"); this fixture exists
+%% to prove from_mermaid() also accepts the alternate syntax on import.
+flowchart TB
+n1[Start]
+n2[Finish]
+n1 -- go --> n2

--- a/packages/ai-parrot/tests/outputs/a2ui/golden/graph_lowered.json
+++ b/packages/ai-parrot/tests/outputs/a2ui/golden/graph_lowered.json
@@ -1,0 +1,60 @@
+{
+  "child": {
+    "children": [
+      {
+        "component": "Text",
+        "metadata": {
+          "extensions": {
+            "parrot_role": "description"
+          }
+        },
+        "text": "A tiny two-node graph."
+      },
+      {
+        "component": "Text",
+        "metadata": {
+          "extensions": {
+            "parrot_role": "caption"
+          }
+        },
+        "text": "Graph (flowchart, TB)"
+      },
+      {
+        "children": [
+          {
+            "component": "Text",
+            "metadata": {
+              "extensions": {
+                "parrot_role": "edge"
+              }
+            },
+            "text": "a \u2192 b (go)"
+          }
+        ],
+        "component": "Column",
+        "metadata": {
+          "extensions": {
+            "parrot_role": "edge-list"
+          }
+        }
+      },
+      {
+        "component": "Text",
+        "metadata": {
+          "extensions": {
+            "parrot_role": "graph-source"
+          }
+        },
+        "text": "flowchart TB\na[Start]\nb[End]\na -->|go| b\n"
+      }
+    ],
+    "component": "Column"
+  },
+  "component": "Card",
+  "id": "blk-000",
+  "metadata": {
+    "extensions": {
+      "parrot_variant": "graph"
+    }
+  }
+}

--- a/packages/ai-parrot/tests/outputs/a2ui/graph/test_layout.py
+++ b/packages/ai-parrot/tests/outputs/a2ui/graph/test_layout.py
@@ -1,0 +1,133 @@
+"""Unit tests for the deterministic layered layout (FEAT-529 Module 4, TASK-2884)."""
+
+from __future__ import annotations
+
+import pytest
+from parrot.outputs.a2ui.graph import (
+    MAX_STATIC_NODES,
+    GraphEdge,
+    GraphGroup,
+    GraphNode,
+    GraphSpec,
+    GraphTooLargeError,
+    compute_positions,
+)
+
+
+def _linear_spec(direction: str = "TB") -> GraphSpec:
+    return GraphSpec(
+        direction=direction,
+        nodes=[GraphNode(id="a"), GraphNode(id="b"), GraphNode(id="c")],
+        edges=[
+            GraphEdge(**{"from": "a", "to": "b"}),
+            GraphEdge(**{"from": "b", "to": "c"}),
+        ],
+    )
+
+
+class TestLayoutRanksFollowEdges:
+    def test_layout_ranks_follow_edges(self):
+        spec = GraphSpec(
+            nodes=[GraphNode(id="a"), GraphNode(id="b"), GraphNode(id="c"), GraphNode(id="d")],
+            edges=[
+                GraphEdge(**{"from": "a", "to": "b"}),
+                GraphEdge(**{"from": "a", "to": "c"}),
+                GraphEdge(**{"from": "b", "to": "d"}),
+                GraphEdge(**{"from": "c", "to": "d"}),
+            ],
+        )
+        result = compute_positions(spec)
+        reversed_pairs = set(result.reversed_edges)
+        for edge in spec.edges:
+            if (edge.from_, edge.to) in reversed_pairs:
+                continue
+            # TB: rank axis is Y — every non-reversed edge must advance Y.
+            assert result.positions[edge.to].y > result.positions[edge.from_].y
+
+
+class TestLayoutDeterministic:
+    def test_layout_deterministic(self):
+        spec = _linear_spec()
+        first = compute_positions(spec)
+        second = compute_positions(spec)
+        assert first == second
+
+
+class TestLayoutBreaksCycles:
+    def test_layout_breaks_cycles(self):
+        spec = GraphSpec(
+            nodes=[GraphNode(id="a"), GraphNode(id="b"), GraphNode(id="c")],
+            edges=[
+                GraphEdge(**{"from": "a", "to": "b"}),
+                GraphEdge(**{"from": "b", "to": "c"}),
+                GraphEdge(**{"from": "c", "to": "a"}),  # closes the cycle
+            ],
+        )
+        result = compute_positions(spec)
+        assert result.reversed_edges  # at least one back edge reported
+        assert set(result.positions) == {"a", "b", "c"}  # every node still positioned
+
+
+class TestLayoutDirectionLrSwapsAxes:
+    def test_layout_direction_lr_swaps_axes(self):
+        tb = compute_positions(_linear_spec("TB"))
+        lr = compute_positions(_linear_spec("LR"))
+        for node_id in ("a", "b", "c"):
+            tb_pos = tb.positions[node_id]
+            lr_pos = lr.positions[node_id]
+            assert lr_pos.x == tb_pos.y
+            assert lr_pos.y == tb_pos.x
+
+
+class TestLayoutGroupBoxesContainMembers:
+    def test_layout_group_boxes_contain_members(self):
+        spec = GraphSpec(
+            nodes=[GraphNode(id="a"), GraphNode(id="b"), GraphNode(id="c")],
+            edges=[
+                GraphEdge(**{"from": "a", "to": "b"}),
+                GraphEdge(**{"from": "b", "to": "c"}),
+            ],
+            groups=[GraphGroup(id="g1", nodes=["a", "b"])],
+        )
+        result = compute_positions(spec)
+        box_x, box_y, box_w, box_h = result.group_boxes["g1"]
+        for member_id in ("a", "b"):
+            pos = result.positions[member_id]
+            assert box_x <= pos.x <= box_x + box_w
+            assert box_y <= pos.y <= box_y + box_h
+
+
+class TestLayoutTooLargeRaises:
+    def test_layout_too_large_raises(self):
+        nodes = [GraphNode(id=f"n{i}") for i in range(MAX_STATIC_NODES + 1)]
+        spec = GraphSpec(nodes=nodes, edges=[])
+        with pytest.raises(GraphTooLargeError) as exc:
+            compute_positions(spec)
+        assert exc.value.node_count == MAX_STATIC_NODES + 1
+
+    def test_layout_at_cap_does_not_raise(self):
+        nodes = [GraphNode(id=f"n{i}") for i in range(MAX_STATIC_NODES)]
+        spec = GraphSpec(nodes=nodes, edges=[])
+        compute_positions(spec)  # must not raise
+
+
+class TestLayoutMiscInvariants:
+    def test_every_node_gets_a_position(self):
+        spec = _linear_spec()
+        result = compute_positions(spec)
+        assert set(result.positions) == {"a", "b", "c"}
+
+    def test_isolated_node_gets_a_position(self):
+        spec = GraphSpec(nodes=[GraphNode(id="lonely")], edges=[])
+        result = compute_positions(spec)
+        assert "lonely" in result.positions
+        assert result.width > 0
+        assert result.height > 0
+
+    def test_bt_and_rl_mirror_the_rank_axis(self):
+        tb = compute_positions(_linear_spec("TB"))
+        bt = compute_positions(_linear_spec("BT"))
+        # Same cross-axis (x), mirrored rank-axis (y): a is first in TB
+        # (smallest y) and last in BT (largest y).
+        assert bt.positions["a"].y > bt.positions["c"].y
+        assert tb.positions["a"].y < tb.positions["c"].y

--- a/packages/ai-parrot/tests/outputs/a2ui/graph/test_mermaid.py
+++ b/packages/ai-parrot/tests/outputs/a2ui/graph/test_mermaid.py
@@ -133,9 +133,7 @@ class TestMermaidRoundtripSequence:
         # separate ordering field — spec §2 Data Models is authoritative).
         text = to_mermaid(spec)
         restored = from_mermaid(text)
-        assert [(e.from_, e.to, e.label) for e in restored.edges] == [
-            (e.from_, e.to, e.label) for e in spec.edges
-        ]
+        assert [(e.from_, e.to, e.label) for e in restored.edges] == [(e.from_, e.to, e.label) for e in spec.edges]
 
 
 class TestMermaidQuotesReservedLabels:

--- a/packages/ai-parrot/tests/outputs/a2ui/graph/test_mermaid.py
+++ b/packages/ai-parrot/tests/outputs/a2ui/graph/test_mermaid.py
@@ -1,0 +1,215 @@
+"""Unit tests for the Mermaid Graph codec (FEAT-529 Module 3, TASK-2883)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from parrot.outputs.a2ui.catalog.base import CatalogValidationError
+from parrot.outputs.a2ui.graph import (
+    GraphEdge,
+    GraphGroup,
+    GraphNode,
+    GraphSpec,
+    MermaidCodecError,
+    from_mermaid,
+    to_mermaid,
+)
+
+_FIXTURES_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "mermaid"
+
+
+def _assert_roundtrip_equal(spec: GraphSpec) -> None:
+    """``from_mermaid(to_mermaid(spec)) == spec`` modulo accessibleDescription/size."""
+    text = to_mermaid(spec)
+    restored = from_mermaid(text)
+    original = spec.model_dump(by_alias=True, exclude={"accessible_description", "size"})
+    round_tripped = restored.model_dump(by_alias=True, exclude={"accessible_description", "size"})
+    assert round_tripped == original, text
+
+
+class TestMermaidRoundtripFlowchart:
+    def test_mermaid_roundtrip_flowchart(self):
+        spec = GraphSpec(
+            kind="flowchart",
+            direction="LR",
+            nodes=[
+                GraphNode(id="n1", label="Start", shape="circle"),
+                # shape=None exercises the "rect" DEFAULT (flowchart's
+                # implicit shape) — an explicit "rect" would collapse to
+                # None on round-trip too (see mermaid.py's module
+                # docstring), so this is the more informative of the two.
+                GraphNode(id="n2", label="Do work"),
+                GraphNode(id="n3", label="Decide?", shape="diamond"),
+                GraphNode(id="n4", label="Cleanup", shape="rounded"),
+                GraphNode(id="n5", label="Sub routine", shape="subroutine"),
+                GraphNode(id="n6", label="Hex", shape="hexagon"),
+                GraphNode(id="n7", label="End", shape="circle"),
+            ],
+            edges=[
+                GraphEdge(**{"from": "n1", "to": "n2", "kind": "solid"}),
+                GraphEdge(**{"from": "n2", "to": "n3", "label": "check", "kind": "solid"}),
+                GraphEdge(**{"from": "n3", "to": "n4", "label": "no", "kind": "dashed"}),
+                GraphEdge(**{"from": "n4", "to": "n5", "kind": "thick"}),
+                GraphEdge(**{"from": "n5", "to": "n6", "kind": "solid"}),
+                GraphEdge(**{"from": "n6", "to": "n7", "kind": "solid"}),
+            ],
+            groups=[GraphGroup(id="grp", label="Middle steps", nodes=["n3", "n4"])],
+        )
+        _assert_roundtrip_equal(spec)
+
+    def test_mermaid_roundtrip_flowchart_default_shape_and_label(self):
+        """A node with no explicit shape/label round-trips to shape=None/label=None.
+
+        The edge's ``kind`` is set explicitly (``"solid"``) — unlike shape/
+        label, ``kind`` is never collapsed to ``None`` on parse (an edge
+        operator is always unambiguously explicit in mermaid text, so
+        parsing one always yields a concrete kind; callers who want a
+        round-trippable spec set ``kind`` explicitly, same as this fixture).
+        """
+        spec = GraphSpec(
+            nodes=[GraphNode(id="a"), GraphNode(id="b")],
+            edges=[GraphEdge(**{"from": "a", "to": "b", "kind": "solid"})],
+        )
+        _assert_roundtrip_equal(spec)
+
+    def test_mermaid_supports_mid_label_syntax_on_parse(self):
+        """from_mermaid() also accepts the '-- text -->' mid-label syntax."""
+        text = (_FIXTURES_DIR / "flowchart_mid_label.mmd").read_text()
+        expected = json.loads((_FIXTURES_DIR / "flowchart_mid_label.json").read_text())
+
+        spec = from_mermaid(text)
+        dumped = spec.model_dump(by_alias=True, exclude_none=True, exclude={"accessible_description", "size"})
+        assert dumped == expected
+
+
+class TestMermaidRoundtripState:
+    def test_mermaid_roundtrip_state(self):
+        # Node order: `__start__`/`__end__` are placed LAST because they have
+        # no top-level textual declaration of their own — they only exist
+        # via a `[*]` edge endpoint, so from_mermaid() can only register them
+        # the first time an edge references one, which is necessarily after
+        # every alias/composite-state declaration has been parsed. Placing
+        # them last here keeps this a genuine object round-trip (see
+        # `_emit_state`'s docstring comment for the full reasoning).
+        spec = GraphSpec(
+            kind="state",
+            nodes=[
+                GraphNode(id="idle", label="Idle State"),
+                GraphNode(id="running"),
+                GraphNode(id="failed"),
+                GraphNode(id="__start__", shape="circle"),
+                GraphNode(id="__end__", shape="circle"),
+            ],
+            edges=[
+                GraphEdge(**{"from": "__start__", "to": "idle"}),
+                GraphEdge(**{"from": "idle", "to": "running", "label": "start"}),
+                GraphEdge(**{"from": "running", "to": "failed", "label": "error"}),
+                GraphEdge(**{"from": "running", "to": "__end__"}),
+            ],
+            groups=[GraphGroup(id="composite", nodes=["running", "failed"])],
+        )
+        _assert_roundtrip_equal(spec)
+
+
+class TestMermaidRoundtripSequence:
+    def test_mermaid_roundtrip_sequence(self):
+        spec = GraphSpec(
+            kind="sequence",
+            nodes=[
+                GraphNode(id="alice", label="Alice"),
+                GraphNode(id="bob"),
+            ],
+            edges=[
+                GraphEdge(**{"from": "alice", "to": "bob", "label": "hello", "kind": "solid"}),
+                GraphEdge(**{"from": "bob", "to": "alice", "label": "hi back", "kind": "dashed"}),
+                GraphEdge(**{"from": "alice", "to": "bob", "label": "bye", "kind": "solid"}),
+            ],
+        )
+        _assert_roundtrip_equal(spec)
+
+        # Order is preserved via the ordered edges list (GraphEdge carries no
+        # separate ordering field — spec §2 Data Models is authoritative).
+        text = to_mermaid(spec)
+        restored = from_mermaid(text)
+        assert [(e.from_, e.to, e.label) for e in restored.edges] == [
+            (e.from_, e.to, e.label) for e in spec.edges
+        ]
+
+
+class TestMermaidQuotesReservedLabels:
+    def test_mermaid_quotes_reserved_labels(self):
+        tricky_label = 'Has [brackets], (parens), {braces}, "quotes" and # hash'
+        spec = GraphSpec(
+            nodes=[GraphNode(id="a", label=tricky_label), GraphNode(id="b")],
+            edges=[GraphEdge(**{"from": "a", "to": "b", "label": tricky_label})],
+        )
+        text = to_mermaid(spec)
+        assert '"' in text  # the label got quoted
+        assert "#quot;" in text  # embedded quotes escaped
+
+        restored = from_mermaid(text)
+        assert restored.nodes[0].label == tricky_label
+        assert restored.edges[0].label == tricky_label
+
+
+class TestMermaidRejectsUnsupportedConstruct:
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "classDef someClass fill:#f9f",
+            "click n1 callback",
+            "style n1 fill:#fff",
+            "linkStyle 0 stroke:#333",
+            "%%{init: {'theme': 'dark'}}%%",
+        ],
+    )
+    def test_mermaid_rejects_unsupported_construct(self, line):
+        text = f"flowchart TB\nn1[A]\nn2[B]\n{line}\nn1 --> n2\n"
+        with pytest.raises(MermaidCodecError) as exc:
+            from_mermaid(text)
+        assert exc.value.line_no == 4
+        assert line in exc.value.line
+
+    def test_mermaid_rejects_sequence_loop_block(self):
+        text = "sequenceDiagram\nparticipant a\nparticipant b\nloop every day\na->>b: hi\nend\n"
+        with pytest.raises(MermaidCodecError) as exc:
+            from_mermaid(text)
+        assert exc.value.line_no == 4
+
+
+class TestMermaidIgnoresCommentsAndBlankLines:
+    def test_mermaid_ignores_comments_and_blank_lines(self):
+        text = "flowchart TB\n%% a comment\n\nn1[A]\n\n%% another\nn2[B]\nn1 --> n2\n"
+        spec = from_mermaid(text)
+        assert [n.id for n in spec.nodes] == ["n1", "n2"]
+        assert len(spec.edges) == 1
+
+
+class TestMermaidErrorIsCatalogValidationError:
+    def test_mermaid_error_is_catalog_validation_error(self):
+        assert isinstance(MermaidCodecError(1, "x", "reason"), CatalogValidationError)
+
+    def test_mermaid_error_raised_carries_line_info(self):
+        with pytest.raises(MermaidCodecError) as exc:
+            from_mermaid("not a real diagram header\n")
+        assert exc.value.line_no == 1
+        assert exc.value.reason
+
+
+class TestMermaidReservedStateIdCollision:
+    def test_user_authored_start_id_collides(self):
+        text = "stateDiagram-v2\n__start__ --> idle\n"
+        with pytest.raises(MermaidCodecError, match="reserved"):
+            from_mermaid(text)
+
+
+class TestMermaidEmptySource:
+    def test_empty_source_raises(self):
+        with pytest.raises(MermaidCodecError):
+            from_mermaid("")
+
+    def test_only_comments_raises(self):
+        with pytest.raises(MermaidCodecError):
+            from_mermaid("%% just a comment\n")

--- a/packages/ai-parrot/tests/outputs/a2ui/graph/test_models.py
+++ b/packages/ai-parrot/tests/outputs/a2ui/graph/test_models.py
@@ -1,0 +1,140 @@
+"""Unit tests for the ``GraphSpec`` vocabulary (FEAT-529 Module 1, TASK-2882)."""
+
+from __future__ import annotations
+
+import pytest
+from parrot.outputs.a2ui.graph import (
+    GraphEdge,
+    GraphGroup,
+    GraphLayout,
+    GraphNode,
+    GraphSpec,
+    Position,
+)
+from pydantic import ValidationError
+
+
+def _spec(**overrides):
+    defaults = {
+        "nodes": [GraphNode(id="a"), GraphNode(id="b")],
+        "edges": [GraphEdge(**{"from": "a", "to": "b"})],
+    }
+    defaults.update(overrides)
+    return GraphSpec(**defaults)
+
+
+class TestGraphSpecRejectsDanglingEdge:
+    def test_graphspec_rejects_dangling_edge(self):
+        with pytest.raises(ValidationError, match="does not reference an existing node"):
+            _spec(edges=[GraphEdge(**{"from": "a", "to": "ghost"})])
+
+
+class TestGraphSpecRejectsDuplicateNodeIds:
+    def test_graphspec_rejects_duplicate_node_ids(self):
+        with pytest.raises(ValidationError, match="Duplicate GraphNode id"):
+            _spec(nodes=[GraphNode(id="a"), GraphNode(id="a")], edges=[])
+
+
+class TestGraphSpecDagRejectsCycle:
+    def test_graphspec_dag_rejects_cycle(self):
+        cyclic_edges = [
+            GraphEdge(**{"from": "a", "to": "b"}),
+            GraphEdge(**{"from": "b", "to": "a"}),
+        ]
+        with pytest.raises(ValidationError, match="acyclic"):
+            _spec(kind="dag", edges=cyclic_edges)
+
+        # The SAME cyclic shape is legal for the default kind (flowchart).
+        _spec(edges=cyclic_edges)  # must not raise
+
+    def test_graphspec_dag_accepts_acyclic(self):
+        _spec(kind="dag")  # a -> b only, must not raise
+
+
+class TestGraphSpecManualRequiresPositions:
+    def test_graphspec_manual_requires_positions(self):
+        with pytest.raises(ValidationError, match="requires a position for every node"):
+            _spec(layout=GraphLayout(engine="manual", positions={"a": Position(x=0, y=0)}))
+
+    def test_graphspec_manual_with_full_positions_passes(self):
+        _spec(
+            layout=GraphLayout(
+                engine="manual",
+                positions={"a": Position(x=0, y=0), "b": Position(x=10, y=10)},
+            )
+        )  # must not raise
+
+
+class TestGraphSpecSizeAndDescription:
+    def test_graphspec_size_and_description(self):
+        spec = _spec()
+        assert spec.size == "tile"
+
+        with pytest.raises(ValidationError):
+            _spec(size="320px")
+
+        described = _spec(accessible_description="A tiny graph.")
+        assert described.accessible_description == "A tiny graph."
+        dumped = described.model_dump(by_alias=True)
+        assert dumped["accessibleDescription"] == "A tiny graph."
+
+        # Round-trips via the wire alias too (populate_by_name=True keeps
+        # the snake_case constructor kwarg working above).
+        from_wire = GraphSpec.model_validate(
+            {
+                "nodes": [{"id": "a"}, {"id": "b"}],
+                "edges": [{"from": "a", "to": "b"}],
+                "accessibleDescription": "Wire round-trip.",
+            }
+        )
+        assert from_wire.accessible_description == "Wire round-trip."
+
+
+class TestGraphGroupInvariants:
+    def test_group_member_must_exist(self):
+        with pytest.raises(ValidationError, match="references unknown node"):
+            _spec(groups=[GraphGroup(id="g1", nodes=["ghost"])])
+
+    def test_group_member_at_most_one_group(self):
+        with pytest.raises(ValidationError, match="belongs to more than one group"):
+            _spec(
+                groups=[
+                    GraphGroup(id="g1", nodes=["a"]),
+                    GraphGroup(id="g2", nodes=["a"]),
+                ]
+            )
+
+    def test_group_valid_passes(self):
+        _spec(groups=[GraphGroup(id="g1", nodes=["a", "b"])])  # must not raise
+
+
+class TestGraphEdgeAliasAndExtraForbid:
+    def test_edge_from_alias(self):
+        edge = GraphEdge(**{"from": "a", "to": "b"})
+        assert edge.from_ == "a"
+        assert edge.model_dump(by_alias=True)["from"] == "a"
+
+    def test_edge_populate_by_name(self):
+        edge = GraphEdge(from_="a", to="b")
+        assert edge.from_ == "a"
+
+    def test_extra_forbidden_on_node(self):
+        with pytest.raises(ValidationError):
+            GraphNode(id="a", color="red")  # type: ignore[call-arg]
+
+    def test_extra_forbidden_on_spec(self):
+        with pytest.raises(ValidationError):
+            _spec(fontSize=12)  # type: ignore[call-arg]
+
+
+class TestNoColourFontPixelVocabulary:
+    """Mechanical guard mirroring the spec's schema-level invariant (G9)."""
+
+    def test_no_forbidden_field_names_on_any_graph_model(self):
+        forbidden_substrings = ("color", "colour", "font", "px")
+        for model in (GraphNode, GraphEdge, GraphGroup, Position, GraphLayout, GraphSpec):
+            for field_name in model.model_fields:
+                lowered = field_name.lower()
+                assert not any(bad in lowered for bad in forbidden_substrings), (
+                    f"{model.__name__}.{field_name} looks like styling vocabulary"
+                )

--- a/packages/ai-parrot/tests/outputs/a2ui/graph/test_models.py
+++ b/packages/ai-parrot/tests/outputs/a2ui/graph/test_models.py
@@ -135,6 +135,6 @@ class TestNoColourFontPixelVocabulary:
         for model in (GraphNode, GraphEdge, GraphGroup, Position, GraphLayout, GraphSpec):
             for field_name in model.model_fields:
                 lowered = field_name.lower()
-                assert not any(bad in lowered for bad in forbidden_substrings), (
-                    f"{model.__name__}.{field_name} looks like styling vocabulary"
-                )
+                assert not any(
+                    bad in lowered for bad in forbidden_substrings
+                ), f"{model.__name__}.{field_name} looks like styling vocabulary"

--- a/packages/ai-parrot/tests/outputs/a2ui/graph/test_models.py
+++ b/packages/ai-parrot/tests/outputs/a2ui/graph/test_models.py
@@ -50,6 +50,28 @@ class TestGraphSpecDagRejectsCycle:
     def test_graphspec_dag_accepts_acyclic(self):
         _spec(kind="dag")  # a -> b only, must not raise
 
+    def test_graphspec_dag_large_acyclic_chain_does_not_recurse(self):
+        """Regression: ``_has_cycle`` must be iterative, not recursive.
+
+        A long (but genuinely acyclic) chain used to blow Python's call
+        stack (``RecursionError``) instead of validating cleanly, because
+        the original ``_has_cycle`` DFS recursed once per edge. Found by
+        adversarial code review during FEAT-529.
+        """
+        n = 3000
+        nodes = [GraphNode(id=f"n{i}") for i in range(n)]
+        edges = [GraphEdge(**{"from": f"n{i}", "to": f"n{i + 1}"}) for i in range(n - 1)]
+        GraphSpec(kind="dag", nodes=nodes, edges=edges)  # must not raise RecursionError
+
+    def test_graphspec_dag_large_cyclic_chain_raises_validation_error(self):
+        """The same large-graph path still raises a clean ``ValidationError``
+        (not ``RecursionError``) when a cycle genuinely exists."""
+        n = 3000
+        nodes = [GraphNode(id=f"n{i}") for i in range(n)]
+        edges = [GraphEdge(**{"from": f"n{i}", "to": f"n{(i + 1) % n}"}) for i in range(n)]
+        with pytest.raises(ValidationError, match="acyclic"):
+            GraphSpec(kind="dag", nodes=nodes, edges=edges)
+
 
 class TestGraphSpecManualRequiresPositions:
     def test_graphspec_manual_requires_positions(self):

--- a/packages/ai-parrot/tests/outputs/a2ui/test_builders_graph.py
+++ b/packages/ai-parrot/tests/outputs/a2ui/test_builders_graph.py
@@ -105,9 +105,7 @@ class TestFlowDefinitionToGraphShapesAndEdges:
         assert condition_edge.label == "score > 0.5"
 
         # Default accessibleDescription generated.
-        assert spec.accessible_description == (
-            f"demo workflow: {len(spec.nodes)} steps, {len(spec.edges)} transitions"
-        )
+        assert spec.accessible_description == (f"demo workflow: {len(spec.nodes)} steps, {len(spec.edges)} transitions")
 
     def test_flow_definition_to_graph_builds_a_valid_envelope(self):
         """Integration: the adapter's output builds through build_graph unmodified."""

--- a/packages/ai-parrot/tests/outputs/a2ui/test_builders_graph.py
+++ b/packages/ai-parrot/tests/outputs/a2ui/test_builders_graph.py
@@ -1,0 +1,120 @@
+"""Tests for build_graph / flow_definition_to_graph (FEAT-529 Module 5, TASK-2886)."""
+
+from __future__ import annotations
+
+import pytest
+from parrot.outputs.a2ui.adapters.flow import flow_definition_to_graph
+from parrot.outputs.a2ui.builders import build_graph
+from parrot.outputs.a2ui.catalog import DEFAULT_CATALOG_ID, ProducerOrigin
+from parrot.outputs.a2ui.catalog.base import CatalogValidationError
+from parrot.outputs.a2ui.catalog.viz_core import VIZ_CORE_CATALOG_ID
+from parrot.outputs.a2ui.models import Action, EventAction
+
+
+def _nodes():
+    return [{"id": "a", "label": "Start"}, {"id": "b", "label": "End"}]
+
+
+def _edges():
+    return [{"from": "a", "to": "b"}]
+
+
+class TestBuildGraphFillsPositions:
+    def test_build_graph_fills_positions(self):
+        envelope = build_graph(nodes=_nodes(), edges=_edges())
+        comp = envelope.components[0]
+        assert comp.model_extra["layout"]["positions"]["a"] is not None
+        assert comp.model_extra["layout"]["positions"]["b"] is not None
+
+    def test_compute_layout_false_leaves_positions_absent(self):
+        envelope = build_graph(nodes=_nodes(), edges=_edges(), compute_layout=False)
+        comp = envelope.components[0]
+        assert "layout" not in comp.model_extra
+
+
+class TestBuildGraphSetsVizCoreCatalogId:
+    def test_build_graph_sets_viz_core_catalog_id(self):
+        envelope = build_graph(nodes=_nodes(), edges=_edges())
+        comp = envelope.components[0]
+        assert comp.catalog_id == VIZ_CORE_CATALOG_ID
+        assert envelope.catalog_id == DEFAULT_CATALOG_ID
+
+
+class TestBuildGraphActionToolOriginOnly:
+    def test_build_graph_action_tool_origin_only(self):
+        action = Action(event=EventAction(name="select"))
+        envelope = build_graph(nodes=_nodes(), edges=_edges(), action=action)  # default origin=TOOL, must not raise
+        assert envelope.components[0].action is not None
+
+        with pytest.raises(CatalogValidationError):
+            build_graph(nodes=_nodes(), edges=_edges(), action=action, origin=ProducerOrigin.LLM)
+
+
+class TestBuildGraphListedInAll:
+    def test_build_graph_in_all(self):
+        import parrot.outputs.a2ui.builders as builders_mod
+
+        assert "build_graph" in builders_mod.__all__
+
+
+class TestFlowDefinitionToGraphShapesAndEdges:
+    def _flow_mapping(self) -> dict:
+        return {
+            "flow": "demo",
+            "nodes": [
+                {"id": "start", "type": "start"},
+                {"id": "research", "type": "agent", "label": "Research"},
+                {"id": "gate", "type": "decision"},
+                {"id": "run_tool", "type": "tool"},
+                {"id": "qa", "type": "agent"},
+                {"id": "docs", "type": "agent"},
+                {"id": "failure_handler", "type": "agent"},
+                {"id": "end", "type": "end"},
+            ],
+            "edges": [
+                {"from": "start", "to": "research", "condition": "always"},
+                {"from": "research", "to": "gate", "condition": "on_success"},
+                {"from": "gate", "to": "run_tool", "condition": "on_condition", "predicate": "score > 0.5"},
+                {"from": "run_tool", "to": ["qa", "docs"], "condition": "on_success"},
+                {"from": "run_tool", "to": "failure_handler", "condition": "on_error"},
+                {"from": "qa", "to": "end", "condition": "always"},
+                {"from": "docs", "to": "end", "condition": "always"},
+            ],
+        }
+
+    def test_flow_definition_to_graph_shapes_and_edges(self):
+        spec = flow_definition_to_graph(self._flow_mapping())
+
+        shapes = {node.id: node.shape for node in spec.nodes}
+        assert shapes["start"] == "circle"
+        assert shapes["end"] == "circle"
+        assert shapes["gate"] == "diamond"
+        assert shapes["run_tool"] == "subroutine"
+        assert shapes["research"] == "rounded"  # agent -> generic rounded
+
+        # Fan-out: one edge per target.
+        fan_out_edges = [e for e in spec.edges if e.from_ == "run_tool" and e.to in ("qa", "docs")]
+        assert len(fan_out_edges) == 2
+
+        # on_error -> dashed.
+        error_edge = next(e for e in spec.edges if e.from_ == "run_tool" and e.to == "failure_handler")
+        assert error_edge.kind == "dashed"
+
+        # on_condition -> label == predicate.
+        condition_edge = next(e for e in spec.edges if e.from_ == "gate" and e.to == "run_tool")
+        assert condition_edge.label == "score > 0.5"
+
+        # Default accessibleDescription generated.
+        assert spec.accessible_description == (
+            f"demo workflow: {len(spec.nodes)} steps, {len(spec.edges)} transitions"
+        )
+
+    def test_flow_definition_to_graph_builds_a_valid_envelope(self):
+        """Integration: the adapter's output builds through build_graph unmodified."""
+        spec = flow_definition_to_graph(self._flow_mapping())
+        envelope = build_graph(
+            nodes=spec.nodes,
+            edges=spec.edges,
+            accessible_description=spec.accessible_description,
+        )
+        assert envelope.components[0].catalog_id == VIZ_CORE_CATALOG_ID

--- a/packages/ai-parrot/tests/outputs/a2ui/test_catalog.py
+++ b/packages/ai-parrot/tests/outputs/a2ui/test_catalog.py
@@ -1,4 +1,8 @@
-"""Unit tests for the A2UI component catalog (TASK-1721 / Module 2, updated FEAT-470)."""
+"""Unit tests for the A2UI component catalog (TASK-1721 / Module 2, updated FEAT-470).
+
+FEAT-529 Module 0 adds the keyed-registry (``(catalog_id, name)``) regression
+tests at the bottom of this file.
+"""
 
 from typing import ClassVar
 
@@ -6,15 +10,18 @@ import pytest
 from parrot.outputs.a2ui.catalog import (
     DEFAULT_CATALOG_ID,
     BasicNode,
+    CatalogError,
     CatalogValidationError,
     ComponentContractError,
     ComponentDefinition,
     ProducerOrigin,
     get_component,
+    list_components,
     register_component,
     unregister_component,
     validate_envelope,
 )
+from parrot.outputs.a2ui.catalog.viz_core import VIZ_CORE_CATALOG_ID
 from parrot.outputs.a2ui.models import Component, CreateSurface
 
 
@@ -146,3 +153,64 @@ class TestEnvelopeValidation:
 
         cleanup_catalog.append("DisplayOnlyDummy")
         validate_envelope(_surface("DisplayOnlyDummy"), origin=ProducerOrigin.LLM)
+
+
+class TestKeyedRegistry:
+    """FEAT-529 Module 0: ``_CATALOG`` keyed by ``(catalog_id, name)``."""
+
+    def test_registry_keyed_by_catalog_and_name(self):
+        @register_component("KeyedProbe", catalog_id=DEFAULT_CATALOG_ID)
+        class KeyedProbeDefault:
+            def lower(self, component, data_model):
+                return BasicNode(component="Column")
+
+        @register_component("KeyedProbe", catalog_id=VIZ_CORE_CATALOG_ID)
+        class KeyedProbeVizCore:
+            def lower(self, component, data_model):
+                return BasicNode(component="Column")
+
+        try:
+            with pytest.raises(CatalogError) as exc:
+                get_component("KeyedProbe")
+            assert set(exc.value.candidates) == {DEFAULT_CATALOG_ID, VIZ_CORE_CATALOG_ID}
+
+            assert get_component("KeyedProbe", DEFAULT_CATALOG_ID).component_cls is KeyedProbeDefault
+            assert get_component("KeyedProbe", VIZ_CORE_CATALOG_ID).component_cls is KeyedProbeVizCore
+        finally:
+            unregister_component("KeyedProbe", DEFAULT_CATALOG_ID)
+            unregister_component("KeyedProbe", VIZ_CORE_CATALOG_ID)
+
+    def test_registry_rejects_duplicate_pair(self, cleanup_catalog):
+        @register_component("DupPair")
+        class DupPair:
+            def lower(self, component, data_model):
+                return BasicNode(component="Column")
+
+        cleanup_catalog.append("DupPair")
+
+        with pytest.raises(CatalogError):
+
+            @register_component("DupPair")
+            class DupPairAgain:
+                def lower(self, component, data_model):
+                    return BasicNode(component="Column")
+
+    def test_bare_name_lookup_stays_unique_today(self):
+        """Pins that no registered name is ambiguous until the charts spec."""
+        for definition in list_components():
+            get_component(definition.name)  # must not raise CatalogError
+
+    def test_component_exists_third_catalog(self, cleanup_catalog):
+        from parrot.outputs.a2ui.catalog import _component_exists
+
+        @register_component("VizCoreExistsProbe", catalog_id=VIZ_CORE_CATALOG_ID)
+        class VizCoreExistsProbe:
+            def lower(self, component, data_model):
+                return BasicNode(component="Column")
+
+        try:
+            assert _component_exists("VizCoreExistsProbe", VIZ_CORE_CATALOG_ID) is True
+            assert _component_exists("VizCoreExistsProbe", DEFAULT_CATALOG_ID) is False
+            assert _component_exists("Text", VIZ_CORE_CATALOG_ID) is False
+        finally:
+            unregister_component("VizCoreExistsProbe", VIZ_CORE_CATALOG_ID)

--- a/packages/ai-parrot/tests/outputs/a2ui/test_catalog_parity.py
+++ b/packages/ai-parrot/tests/outputs/a2ui/test_catalog_parity.py
@@ -16,6 +16,8 @@ from parrot.outputs.a2ui.catalog.export import export_catalog_definition
 from parrot.outputs.a2ui.catalog.parrot import chart as chart_mod
 from parrot.outputs.a2ui.catalog.parrot import datatable as datatable_mod
 from parrot.outputs.a2ui.catalog.parrot import map as map_mod
+from parrot.outputs.a2ui.catalog.viz_core import graph as graph_mod
+from parrot.outputs.a2ui.graph import GraphSpec
 from parrot.outputs.a2ui.models import Component, CreateSurface
 
 
@@ -57,6 +59,32 @@ def test_datatable_schema_parity_unchanged():
     """
     previous_hand_written = {"columns", "totalRows", "truncated", "data"}
     assert previous_hand_written <= set(datatable_mod.DATATABLE_SCHEMA["properties"])
+
+
+def test_graph_schema_has_all_spec_fields():
+    """FEAT-529: every GraphSpec alias (plus `action`) is a GRAPH_SCHEMA property."""
+    aliases = {field.alias or name for name, field in GraphSpec.model_fields.items()} - {"data"}
+    assert aliases <= set(graph_mod.GRAPH_SCHEMA["properties"])
+    assert "action" in graph_mod.GRAPH_SCHEMA["properties"]
+    assert graph_mod.GRAPH_SCHEMA["properties"]["action"] == {
+        "$ref": "https://a2ui.org/specification/v1_0/common_types.json#/$defs/Action"
+    }
+    # `data` is the binding descriptor, not the raw GraphSpec.data shape.
+    assert "path" not in graph_mod.GRAPH_SCHEMA["properties"]["data"].get("properties", {})
+
+
+def test_graph_schema_has_no_colour_vocabulary():
+    """FEAT-529 G9: no property name or enum value looks like styling vocabulary."""
+    import json
+    import re
+
+    blob = json.dumps(graph_mod.GRAPH_SCHEMA).lower()
+    for forbidden in ("color", "colour", "palette", "font"):
+        assert forbidden not in blob
+    # Word-boundary match for "hex" (would otherwise flag the legitimate
+    # "hexagon" node shape) and "px" (would otherwise flag "expression").
+    assert re.search(r"\bhex\b", blob) is None
+    assert re.search(r"\bpx\b", blob) is None
 
 
 def _surface(component: Component) -> CreateSurface:

--- a/packages/ai-parrot/tests/outputs/a2ui/test_components_graph.py
+++ b/packages/ai-parrot/tests/outputs/a2ui/test_components_graph.py
@@ -1,0 +1,125 @@
+"""Golden + contract tests for the viz-core ``Graph`` component (FEAT-529 Module 2, TASK-2885)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from parrot.outputs.a2ui.catalog import ProducerOrigin, get_component, validate_envelope
+from parrot.outputs.a2ui.catalog.base import CatalogValidationError, to_components
+from parrot.outputs.a2ui.catalog.parrot import infographic as infographic_mod
+from parrot.outputs.a2ui.catalog.viz_core import VIZ_CORE_CATALOG_ID
+from parrot.outputs.a2ui.catalog.viz_core import graph as graph_mod
+from parrot.outputs.a2ui.models import Action, Component, CreateSurface, EventAction
+
+GOLDEN_DIR = Path(__file__).parent / "golden"
+
+
+def _dump(tree) -> bytes:
+    return json.dumps(tree.model_dump(mode="json", exclude_none=True), sort_keys=True, indent=2).encode() + b"\n"
+
+
+def _graph_component(**extra) -> Component:
+    base = dict(
+        id="blk-000",
+        component="Graph",
+        catalogId=VIZ_CORE_CATALOG_ID,
+        kind="flowchart",
+        direction="TB",
+        nodes=[{"id": "a", "label": "Start"}, {"id": "b", "label": "End"}],
+        edges=[{"from": "a", "to": "b", "label": "go"}],
+        accessibleDescription="A tiny two-node graph.",
+    )
+    base.update(extra)
+    return Component(**base)
+
+
+class TestGraphSchema:
+    def test_graph_registered_under_viz_core(self):
+        entry = get_component("Graph", VIZ_CORE_CATALOG_ID)
+        assert entry.definition.catalog_id == VIZ_CORE_CATALOG_ID
+        assert entry.definition.requires_actions is False
+        assert entry.definition.tool_only is False
+        assert entry.definition.allowed_parents is None
+
+        # Unique bare-name lookup still resolves (no ambiguity introduced).
+        assert get_component("Graph").definition.catalog_id == VIZ_CORE_CATALOG_ID
+
+
+class TestGraphLowerGolden:
+    def test_graph_lower_golden(self):
+        comp = _graph_component()
+        one = _dump(graph_mod.GraphComponent().lower(comp, {}))
+        two = _dump(graph_mod.GraphComponent().lower(comp, {}))
+        assert one == two
+        assert one == (GOLDEN_DIR / "graph_lowered.json").read_bytes()
+
+    def test_graph_lower_first_child_is_description(self):
+        tree = graph_mod.GraphComponent().lower(_graph_component(), {})
+        first_child = tree.child.children[0]
+        assert first_child.component == "Text"
+        assert first_child.metadata.extensions.root["parrot_role"] == "description"
+
+    def test_graph_lower_generates_description_when_absent(self):
+        comp = _graph_component(accessibleDescription=None)
+        tree = graph_mod.GraphComponent().lower(comp, {})
+        description_node = tree.child.children[0]
+        assert description_node.text == "Graph of 2 nodes and 1 edges (flowchart)"
+
+    def test_graph_lower_passes_data_binding_through(self):
+        comp = _graph_component(data={"path": "/nodes"})
+        tree = graph_mod.GraphComponent().lower(comp, {})
+        edge_list = next(c for c in tree.child.children if c.metadata.extensions.root.get("parrot_role") == "edge-list")
+        assert edge_list.metadata.extensions.root["parrot_graph_data"] == {"path": "/nodes"}
+
+    def test_graph_lower_emits_only_basic_primitives(self):
+        tree = graph_mod.GraphComponent().lower(_graph_component(), {})
+        blob = json.dumps(tree.model_dump(mode="json"))
+        assert '"option"' not in blob
+
+
+class TestGraphActionGate:
+    """The surface stays Parrot-default (so the Basic ``Column`` root
+    resolves); ``Graph`` carries its OWN ``catalogId=VIZ_CORE_CATALOG_ID``
+    (spec §7: "the surface default vs component catalog")."""
+
+    def test_graph_llm_origin_rejects_action(self):
+        comp = _graph_component(action=Action(event=EventAction(name="select")))
+        root = Component(id="root", component="Column", children=[comp.id])
+        surface = CreateSurface(surfaceId="s", catalogId="https://parrot.dev/catalogs/v1", components=[root, comp])
+        with pytest.raises(CatalogValidationError) as exc:
+            validate_envelope(surface, origin=ProducerOrigin.LLM)
+        assert "Graph" in exc.value.action_components
+
+    def test_graph_tool_origin_allows_action(self):
+        comp = _graph_component(action=Action(event=EventAction(name="select")))
+        root = Component(id="root", component="Column", children=[comp.id])
+        surface = CreateSurface(surfaceId="s", catalogId="https://parrot.dev/catalogs/v1", components=[root, comp])
+        validate_envelope(surface, origin=ProducerOrigin.TOOL)  # must not raise
+
+
+class TestGraphEmitsV1Primitives:
+    def test_graph_emits_v1_primitives(self):
+        tree = graph_mod.GraphComponent().lower(_graph_component(), {})
+        flat = to_components(tree)
+        root = Component(id="root", component="Column", children=[c.id for c in flat])
+        surface = CreateSurface(surfaceId="s", catalogId="https://parrot.dev/catalogs/v1", components=[root, *flat])
+        validate_envelope(surface)  # must not raise
+
+
+class TestGraphInInfographicSection:
+    def test_graph_in_infographic_section_lowers(self):
+        descriptor = {
+            "component": "Graph",
+            "properties": {
+                "kind": "flowchart",
+                "direction": "TB",
+                "nodes": [{"id": "a"}, {"id": "b"}],
+                "edges": [{"from": "a", "to": "b"}],
+                "accessibleDescription": "Nested graph.",
+            },
+        }
+        node = infographic_mod._lower_child(descriptor, {}, "child-0")
+        assert node.component == "Card"
+        assert node.metadata.extensions.root["parrot_variant"] == "graph"

--- a/packages/ai-parrot/tests/outputs/a2ui/test_producer.py
+++ b/packages/ai-parrot/tests/outputs/a2ui/test_producer.py
@@ -207,6 +207,24 @@ class TestProducerUsesV1StructuredOutput:
         system = client.system_prompts[0]
         assert "root" in system.lower()
 
+    async def test_producer_passes_surface_catalogs(self):
+        """FEAT-529 Module 0: `catalog=` scopes the system prompt's instructions."""
+        from parrot.outputs.a2ui.catalog.viz_core import (
+            VIZ_CORE_CATALOG_ID,
+            VIZ_CORE_INSTRUCTIONS,
+        )
+
+        client = FakeClient([_valid_envelope()])
+        # max_attempts=1 with a mismatched surface catalog will degrade (the
+        # fake envelope's components resolve under DEFAULT_CATALOG_ID), but
+        # generate_envelope still sends its FIRST system prompt scoped to the
+        # requested catalog before validation ever runs.
+        await generate_envelope(client, "make a graph", model="m", max_attempts=1, catalog=VIZ_CORE_CATALOG_ID)
+        system = client.system_prompts[0]
+        assert VIZ_CORE_INSTRUCTIONS in system
+        assert "Chart:" not in system
+        assert "InfoCard:" not in system
+
 
 class TestRepairPromptIncludesCode:
     """TASK-2547 Test Specification: ``test_repair_prompt_includes_code``."""

--- a/scripts/generate_a2ui_css.py
+++ b/scripts/generate_a2ui_css.py
@@ -97,6 +97,8 @@ SELECTOR_UTILITIES: dict[str, str] = {
     "a2ui-field-label": "text-xs uppercase tracking-wide text-[var(--neutral-muted)]",
     "a2ui-field-value": "text-sm font-medium text-[var(--neutral-text)]",
     "a2ui-filter-empty": "py-2 text-sm italic text-[var(--neutral-muted)]",
+    "a2ui-graph-source": "mt-2 text-xs text-[var(--neutral-muted)]",
+    "a2ui-graph-wrap": "flex flex-col gap-[var(--density-gap)]",
     "a2ui-label": "text-xs uppercase tracking-wide text-[var(--neutral-muted)]",
     "a2ui-heading": "mb-1 text-base font-semibold text-[var(--neutral-text)]",
     "a2ui-icon": "inline-flex h-4 w-4 items-center justify-center",

--- a/sdd/tasks/completed/TASK-2881-viz-core-catalog-shell.md
+++ b/sdd/tasks/completed/TASK-2881-viz-core-catalog-shell.md
@@ -117,3 +117,58 @@ renderers, UI rendering, or feature documentation.
 2. Run the catalog test suite after the registry rekey.
 3. Keep this task as the first implementation commit in the feature.
 4. Do not register Graph in this task.
+
+### Completion Note
+
+Implemented as specified. `_CATALOG` is now keyed by `(catalog_id, name)`;
+`register_component` allows idempotent re-registration of the SAME class
+under an existing `(catalog_id, name)` pair (needed by the Basic Catalog's
+existing `_register_primitives()` idempotency pattern) but raises
+`CatalogError` for a genuinely different class claiming the same pair.
+`get_component(name, catalog_id=None)` resolves uniquely or raises
+`CatalogError` with `.candidates` (set post-construction — `CatalogError`
+itself, in `catalog/base.py`, was intentionally left untouched; it is not
+in this task's file list). `list_components`, `catalog_instructions`
+(+ new `catalog_header_instructions`), `_component_exists`, and
+`export_catalog_definition`/`write_catalog_definition` are all catalog-id
+scoped now. `validate_envelope`'s action/tool-only gate and
+allowed-parent/child checks resolve each component's catalog once and
+reuse it (a `resolved_catalog_by_id` map) instead of a bare-name
+`_CATALOG.get`. The producer scopes its system-prompt instructions to
+`catalog=` when given (unscoped/aggregate when omitted — unchanged
+default). Added `catalog/viz_core/__init__.py` (`VIZ_CORE_CATALOG_ID`,
+`VIZ_CORE_INSTRUCTIONS`, verified byte-for-byte against the vendored
+draft) and its vendored `spec/catalog.json`; no component registered here
+(Module 2/TASK-2885 owns `Graph`). Added the satellite's
+`_intercept.py` (`resolve_component_catalog`, `intercepts`). Extended
+`a2ui-types.ts` with an explicit `catalogId` field and the
+`VIZ_CORE_CATALOG_ID` constant.
+
+**One file outside the task's table was touched to keep an existing
+acceptance criterion ("Existing A2UI catalog and validation tests remain
+green") true**: `packages/ai-parrot-visualizations/tests/outputs/
+a2ui_renderers/test_semantic_classes.py::TestGoldensUntouched::
+test_no_catalog_file_modified` is a FEAT-527-era diff guard that
+allowlists specific historical file touches under `catalog/`; it does not
+anticipate ANY future catalog work, and unconditionally failed against
+this task's mandated `catalog/__init__.py`/`catalog/export.py` edits and
+new `catalog/viz_core/` files. Extended its allowlist with an explicit,
+commented FEAT-529 Module 0 entry, following the file's own established
+per-feature-block convention.
+
+Verification: `pytest packages/ai-parrot/tests/outputs/a2ui
+packages/ai-parrot-visualizations/tests -q` → 948 passed, 1 skipped;
+`ruff check` clean on every touched Python file. Frontend `a2ui-types.ts`
+change is additive-only (new const + one explicit interface field
+already covered by the existing index signature) — no `npm test` run
+needed to validate it (no runtime logic added), deferred to a task that
+touches `.svelte`/`.test.ts` files.
+
+**Worktree note**: this worktree's `packages/ai-parrot/src/parrot/utils/
+types.cpython-312-x86_64-linux-gnu.so` and `.../parsers/toml.cpython-312-
+x86_64-linux-gnu.so` were copied from the main checkout's `.venv`-matching
+build (gitignored, not committed) purely to run the test suite locally —
+the editable install resolves `parrot.*`/`parrot_*` to the MAIN repo
+checkout by default, so a `PYTHONPATH` prefix of this worktree's `packages/
+*/src` dirs was used ahead of site-packages for every test run in this
+task, to exercise the worktree's own source instead of the main repo's.

--- a/sdd/tasks/completed/TASK-2882-graph-vocabulary-models.md
+++ b/sdd/tasks/completed/TASK-2882-graph-vocabulary-models.md
@@ -90,3 +90,32 @@ specified in the feature spec sections 2 and 3.
 1. Verify the Pydantic version and current catalog validation exception before coding.
 2. Keep this package independent of parrot.bots and renderer packages.
 3. Do not add schema or catalog side effects to model imports.
+
+### Completion Note
+
+Implemented as specified: `GraphNode`/`GraphEdge`/`GraphGroup`/`Position`/
+`GraphLayout`/`GraphSelection`/`GraphSpec` in `graph/models.py`, all
+`extra="forbid"`, `GraphEdge`/`GraphLayout`/`GraphSpec` with
+`populate_by_name=True` for their camelCase aliases (`from`,
+`accessibleDescription`, `rankSep`, `nodeSep`). A single `@model_validator
+(mode="after")` on `GraphSpec` enforces unique node ids, edge-endpoint
+existence, group-membership invariants, `kind="dag"` acyclicity (DFS
+3-colour cycle check via a private `_has_cycle()` helper — cycles stay
+legal for every other `kind`), and `layout.engine="manual"` positions
+completeness. 15 tests in `test_models.py`, including the five named in
+the Test Specification plus group-invariant, alias/extra-forbid, and a
+mechanical no-colour/font/pixel field-name guard (a model-level pre-echo
+of the spec's later schema-level `test_graph_schema_has_no_colour_
+vocabulary`).
+
+Deliberately did NOT export `GraphTooLargeError` from `graph/__init__.py`
+despite the task's Scope bullet mentioning "the graph-size exception" —
+the Codebase Contract's own "Does NOT Exist" list states it doesn't exist
+yet, and it belongs to `graph/layout.py` (Module 4 / TASK-2884, not yet
+implemented at this point in the sequence). `graph/__init__.py` exports
+only what `models.py` defines here; TASK-2883/2884 are expected to extend
+it once `mermaid.py`/`layout.py` land.
+
+Verification: `pytest packages/ai-parrot/tests/outputs/a2ui -q` → 678
+passed (663 pre-existing + 15 new), 1 skipped; `ruff check` clean on all
+three touched/created files.

--- a/sdd/tasks/completed/TASK-2883-mermaid-graph-codec.md
+++ b/sdd/tasks/completed/TASK-2883-mermaid-graph-codec.md
@@ -92,3 +92,61 @@ or support for excluded dialects/directives.
 1. Verify TASK-2882 is available and its public model exports are unchanged.
 2. Keep the parser restricted to the documented subset; do not silently accept syntax.
 3. Make canonical output deterministic across runs and platforms.
+
+### Completion Note
+
+Implemented as specified: hand-written regex-based tokenizer/parser (no
+external dependency) for `flowchart`/`stateDiagram-v2`/`sequenceDiagram`,
+plus a deterministic canonical emitter. `MermaidCodecError(line_no, line,
+reason)` subclasses `CatalogValidationError`.
+
+Two design decisions worth flagging for reviewers, both driven by the
+spec's own contract — "`from_mermaid(to_mermaid(spec)) == spec` (modulo
+`accessibleDescription`/`size`)" is an OBJECT round-trip, not a textual
+one:
+
+1. **Collapsing conventions.** A node's `label`/`shape` collapse to
+   `None` on parse whenever they equal the id / the dialect's default
+   shape (`rect` for flowchart, `rounded` for state) — the inverse of
+   what `to_mermaid` does when those fields are `None`. This is
+   documented in the module docstring and in `test_mermaid_roundtrip_
+   flowchart_default_shape_and_label`. `GraphEdge.kind` is NOT collapsed
+   this way (an edge operator is always unambiguously explicit in text,
+   unlike "no shape/label given"); callers who want an edge's `kind` to
+   round-trip must set it explicitly, which every edge in this task's
+   fixtures does.
+2. **Declare-once-at-top ordering.** Both `_emit_flowchart` and
+   `_emit_state` declare EVERY node once, at top level, in `spec.nodes`
+   order; `subgraph`/composite-`state` blocks only bare-reference member
+   ids afterwards (never re-declare shape/label there). This was a
+   necessary fix during implementation — an earlier draft declared
+   grouped nodes only inside their group block, which reordered them in
+   the parsed result and broke the round-trip's list-order equality.
+   `__start__`/`__end__` are the one unavoidable exception: they have no
+   top-level textual form (they exist only via a `[*]` edge endpoint), so
+   they always land at the END of the parsed `nodes` list regardless of
+   their position in the original spec — the state round-trip fixture's
+   node order is deliberately arranged to match this (commented in the
+   test).
+
+`_check_unsupported` matches keywords on a WORD BOUNDARY (not bare
+`startswith`) — an earlier draft flagged `sequenceDiagram`'s own
+`participant` keyword as the excluded `par` (sequence "par" block)
+construct.
+
+`kind="dag"` reuses the flowchart dialect for `to_mermaid`; `from_mermaid`
+never infers `"dag"` back (unrecoverable from syntax alone) — matches the
+Test Specification, which only requires flowchart/state/sequence
+round-trips, not dag.
+
+19 tests in `test_mermaid.py` (7 named in the Test Specification plus
+default-shape/mid-label-syntax/reserved-id-collision/empty-source
+coverage), plus a fixture pair (`fixtures/mermaid/flowchart_mid_label.
+{mmd,json}`) proving `from_mermaid` accepts the `-- text -->` mid-label
+syntax even though `to_mermaid` only ever emits the pipe form.
+
+Verification: `pytest packages/ai-parrot/tests/outputs/a2ui -q` → 696
+passed (678 pre-existing + 18 new — one of the 19 new tests is a second
+assertion block inside an existing test function, not a separate
+collected test), 1 skipped; `ruff check` clean on all three touched/
+created Python files.

--- a/sdd/tasks/completed/TASK-2884-layered-graph-layout.md
+++ b/sdd/tasks/completed/TASK-2884-layered-graph-layout.md
@@ -89,3 +89,27 @@ force-directed server layout.
 1. Verify TASK-2882 model aliases and validation behavior first.
 2. Keep the implementation synchronous, deterministic, and dependency-light.
 3. Do not add renderer-specific colors, dimensions, or library options to GraphSpec.
+
+### Completion Note
+
+Implemented as specified: `compute_positions(spec, *, rank_sep=80.0,
+node_sep=40.0) -> LayoutResult`. Cycle breaking is an iterative (no
+recursion — avoids stack-depth limits on a 200-node fixture), stable,
+3-colour DFS feedback-arc-set over the edges in input order; rank
+assignment is a single topological-order pass over the resulting acyclic
+edge set (via `networkx.topological_sort`, the only networkx usage);
+crossing reduction is 4 barycentre sweeps; coordinates scale integer
+rank/slot indices by `rank_sep`/`node_sep` only at the very end.
+`TB`/`LR` share the exact same coordinate computation with axes swapped
+(satisfies "LR == transposed TB" literally); `BT`/`RL` additionally mirror
+the rank axis in a second pass once `max_rank` is known. Group boxes are
+the padded min/max of member positions; `GraphTooLargeError` subclasses
+`CatalogValidationError` (same pattern as `MermaidCodecError`, TASK-2883).
+
+10 tests in `test_layout.py`: the six named in the Test Specification plus
+isolated-node, at-cap (`MAX_STATIC_NODES` exactly, must NOT raise), and an
+explicit BT/RL axis-mirroring check.
+
+Verification: `pytest packages/ai-parrot/tests/outputs/a2ui -q` → 706
+passed (696 pre-existing + 10 new), 1 skipped; `ruff check` clean on all
+three touched/created files.

--- a/sdd/tasks/completed/TASK-2885-graph-catalog-composite.md
+++ b/sdd/tasks/completed/TASK-2885-graph-catalog-composite.md
@@ -102,3 +102,47 @@ builders/adapters, native renderers, UI, or docs.
 1. Verify TASK-2881, TASK-2882, and TASK-2883 contracts before implementation.
 2. Keep schema derivation as the source of truth; only merge the explicit Action property.
 3. Do not modify legacy Parrot Chart/KPICard definitions.
+
+### Completion Note
+
+Implemented as specified. `catalog/viz_core/graph.py` derives `GRAPH_SCHEMA`
+from `GraphSpec` via the existing `derive_schema` (Chart's exact pattern)
+and merges in `action` as a `$ref` to the vendored `common_types.json#/
+$defs/Action` post-derivation — no other hand-edits. `@register_component
+("Graph", catalog_id=VIZ_CORE_CATALOG_ID)` registers with default
+`requires_actions=False`/`tool_only=False`/`allowed_parents=None`, so the
+existing `ACTION_NOT_ALLOWED_FOR_LLM` gate handles TOOL-vs-LLM action
+rejection with no new code.
+
+`catalog/viz_core/__init__.py`'s bottom-of-file `from parrot.outputs.
+a2ui.catalog.viz_core import graph` closes a genuine (if intentional)
+circular-import shape — `graph.py` imports `VIZ_CORE_CATALOG_ID` back from
+its own parent package — safe ONLY because the constant is already bound
+by the time that import line executes (same discipline as `catalog/
+parrot/__init__.py`'s registration imports).
+
+`lower()` reconstructs a real `GraphSpec` (with `data` stripped, since an
+unresolved binding descriptor like `{"path": ...}` cannot validate against
+`GraphSpec.data`'s literal shape) rather than reading each field off the
+raw `props` dict the way `Chart`'s `lower()` does — this buys the mermaid
+source and node/edge counts a genuine re-validation pass (dangling edges,
+etc.) that `GRAPH_SCHEMA`'s JSON-Schema alone can't express, at the cost
+of one deliberate, documented deviation from the literal "copy the Chart
+pattern" instruction.
+
+**Test fixture note**: the two action-gate tests build their surface with
+`catalogId="https://parrot.dev/catalogs/v1"` (Parrot default, so the
+`Column` root resolves via the Basic `$ref`), while `Graph` itself
+carries its own explicit `catalogId=VIZ_CORE_CATALOG_ID` — a bare
+viz-core surface can't host a `Column` root (viz-core doesn't `$ref`
+Basic, spec §2 Overview), so this is the only valid shape for that test,
+matching spec §7's own "surface default vs component catalog" guidance.
+
+Verification: `pytest packages/ai-parrot/tests/outputs/a2ui
+packages/ai-parrot-visualizations/tests -q -k a2ui` → 718 + 218 passed (36
+new across both files), 1 skipped; `ruff check` clean on all
+touched/created files. The FEAT-527-era catalog-diff guard test
+(`test_semantic_classes.py::test_no_catalog_file_modified`) already
+allowed this task's new `catalog/viz_core/graph.py` and `golden/
+graph_lowered.json` via the `"viz_core" in c"` branch added in TASK-2881
+— no further change needed there.

--- a/sdd/tasks/completed/TASK-2886-graph-builder-flow-adapter.md
+++ b/sdd/tasks/completed/TASK-2886-graph-builder-flow-adapter.md
@@ -101,3 +101,43 @@ renderers, or live workflow updates.
 1. Verify the builder signature and FlowDefinition mapping shape before coding.
 2. Keep the adapter independent from bot implementation modules, including under TYPE_CHECKING.
 3. Validate emitted envelopes against the existing conformance helper.
+
+### Completion Note
+
+Implemented as specified. `build_graph` folds `catalogId=VIZ_CORE_CATALOG_ID`
+into the `properties` dict passed to the EXISTING `build_surface` (Component's
+`catalog_id` field populates via its `catalogId` alias like any other prop) —
+`build_surface`'s own signature/body is completely untouched, matching "the
+surface catalogId stays DEFAULT_CATALOG_ID; the Graph component carries
+catalogId: viz-core explicitly" without adding a new parameter anywhere.
+`action` flows through the same properties dict so `build_surface`'s single
+`validate_envelope(origin=...)` call is the only gate.
+
+`flow_definition_to_graph`'s `data_binding` parameter is accepted (per the
+Codebase Contract's exact signature) but documented as presently a no-op:
+`GraphSpec.data` (TASK-2882) is typed as the RESOLVED per-node overlay shape
+(`dict[node_id, {...}]`), never the wire-only `{"path": ...}` binding
+descriptor, so there is nothing safe to do with a bare pointer string on a
+plain `GraphSpec` return value — a caller wires live-state binding through
+`build_graph(data_binding=...)` once they have something to build. This is a
+deliberate scope decision, not an oversight; flagging for the human reviewer
+since the Codebase Contract didn't call it out explicitly.
+
+`_edge_label`/`_edge_kind` interpret the spec's compact "`EdgeDefinition.
+condition` becomes the edge label" clause narrowly: only `on_condition`
+(→ predicate text) and an edge's own explicit `label` field produce a
+label; `on_error`/`on_timeout` affect `kind` (dashed), not the label; a
+default `on_success`/`always` edge gets neither — avoiding literal
+"on_success" text cluttering every ordinary transition. Only the two
+concretely-tested behaviors (`on_error → dashed`, `on_condition label ==
+predicate`) are asserted by the Test Specification, so this reading isn't
+contradicted by anything testable.
+
+Verification: `pytest packages/ai-parrot/tests/outputs/a2ui -q` → 730
+passed (718 pre-existing + 16 new — one extra beyond the five named tests
+covers `compute_layout=False`, TOOL-origin action attach, `build_graph` in
+`__all__`, and an end-to-end adapter→builder integration check), 1
+skipped; `ruff check` clean on all five touched/created files. A
+pre-existing, unrelated collection error in `tests/integration/
+observability/test_multiround_usage.py` was confirmed present in complete
+isolation (no a2ui import in the chain) — not a regression from this task.

--- a/sdd/tasks/completed/TASK-2887-shared-graph-svg-contract.md
+++ b/sdd/tasks/completed/TASK-2887-shared-graph-svg-contract.md
@@ -87,3 +87,38 @@ bundled UI, or changing the core Graph schema.
 1. Verify the graph package and DesignSystem APIs after dependency tasks land.
 2. Keep the SVG renderer pure apart from reading supplied props/theme.
 3. Do not add JavaScript or an SVG/graph dependency.
+
+### Completion Note
+
+Implemented as specified. `render_graph_svg` draws all six shapes, group
+boxes, arrow-marked/labeled edges, and per-node/graph titles; `STATE_TO_
+STATUS` maps node domain state to the viz-core status role, and a private
+`_STATUS_TO_TOKEN` maps that role to a `DesignSystem` CSS custom-property
+NAME only — every `fill`/`stroke` in the SVG is `var(--token)`, never a
+literal colour. Positions come from `spec.layout.positions` when they
+cover every node, else `compute_positions()` — `GraphTooLargeError`
+propagates uncaught (the owning renderer, not this module, decides how to
+degrade). Edges always draw in their ORIGINAL `from`/`to` direction; since
+this module never reads `LayoutResult.reversed_edges` at all (only
+`.positions`), preserving the original direction required no special-case
+logic — it's simply what iterating `spec.edges` and drawing `from_` →
+`to` already does.
+
+**Path correction**: the task's file table names `tests/a2ui_renderers/
+test_graph_svg.py`; the satellite's actual test root is `tests/outputs/
+a2ui_renderers/` (every sibling test file lives there). Created at the
+real path instead of introducing a second, inconsistent test tree.
+
+**Also fixed** (found during this task's own full-suite verification, not
+introduced by it): TASK-2885's new `golden/graph_lowered.json` was never
+actually covered by the FEAT-527-era catalog-diff guard test
+(`test_no_catalog_file_modified`)'s allowlist — TASK-2885's own
+verification ran `pytest ... -k a2ui`, and that keyword filter happened to
+DESELECT this specific test (its name has no "a2ui" substring), so the gap
+went unnoticed until this task's unfiltered `pytest packages/
+ai-parrot-visualizations/tests -q` run caught it. Added a `"graph_lowered"
+in c` branch alongside the existing `"viz_core" in c` one.
+
+Verification: `pytest packages/ai-parrot-visualizations/tests -q`
+(UNFILTERED this time) → 295 passed; `ruff check` clean on all three
+touched/created files.

--- a/sdd/tasks/completed/TASK-2888-echarts-graph-renderer.md
+++ b/sdd/tasks/completed/TASK-2888-echarts-graph-renderer.md
@@ -86,3 +86,28 @@ Folium, bundled UI, or changes to legacy Chart options.
 1. Verify the shared SVG/status contract and current ECharts option shape before coding.
 2. Keep this task limited to the ECharts satellite module and its tests.
 3. Run existing visualization ECharts tests alongside the new tests.
+
+### Completion Note
+
+Implemented as specified. Dispatch uses the shared `_intercept.intercepts()`
+helper (not a raw `resolve_component_catalog` call) so a malformed/
+ambiguous catalog id never raises mid-render — it just fails to intercept,
+falling through exactly like "no Graph present." `_build_graph_option`
+strips BOTH `data` and the wire Component-level keys (`id`, `component`,
+`catalogId`, `action`, `metadata`, ...) before reconstructing a bare
+`GraphSpec` — `props` here is a baked WHOLE-COMPONENT dict
+(`component.model_dump()`), unlike `catalog/viz_core/graph.py`'s `lower()`
+which only ever sees `component.model_extra` (declared fields already
+excluded there); this distinction cost one failed test run before the fix.
+
+**One pre-existing legacy test was also fixed**, a direct and foreseeable
+casualty of this task's own acceptance criterion ("ECharts capabilities
+include viz-core and Graph"): `test_echarts.py::TestTASK2544::
+test_echarts_capabilities` asserted `supported_components == {"Chart"}`
+exhaustively (not a subset check) — updated to `{"Chart", "Graph"}`.
+
+Verification: `pytest packages/ai-parrot-visualizations/tests -q` → 302
+passed (295 pre-existing + 7 new); `pytest packages/ai-parrot/tests/
+outputs/a2ui -q` → 726 passed, 1 skipped (core untouched by this
+satellite-only task); `ruff check` clean on all three touched/created
+files.

--- a/sdd/tasks/completed/TASK-2889-html-ssr-pdf-graph-renderers.md
+++ b/sdd/tasks/completed/TASK-2889-html-ssr-pdf-graph-renderers.md
@@ -104,3 +104,43 @@ or live action transport.
 1. Verify TASK-2887 SVG API and current degradation record shape first.
 2. Keep interception before lowering and preserve all legacy non-viz-core dispatch.
 3. Run the full visualization renderer test suite after implementation.
+
+### Completion Note
+
+Implemented as specified across all five renderer modules, plus PDF gets
+Graph support "for free" by inheriting `SSRHTMLRenderer._lower_composites`/
+`_render_Text` unchanged (only its own `RendererCapabilities` needed
+updating) — matching "PDF inherits SSR behavior" literally, no PDF-specific
+Graph code was needed.
+
+**A real bug in TASK-2887's shared contract was found and fixed here**:
+`_graph_svg.render_graph_svg` only stripped `data` before reconstructing a
+bare `GraphSpec`, never the other wire Component-level keys (`id`,
+`component`, `catalogId`, ...). TASK-2887's own unit tests never caught
+this because its fixtures passed bare GraphSpec-shaped dicts, never a
+realistic whole-baked-component dict — every ACTUAL caller in this task
+does exactly that, and hit `ValidationError: extra_forbidden` immediately
+during smoke-testing (before the pytest suite was even written). Fixed by
+introducing `_COMPONENT_ONLY_KEYS` in `_graph_svg.py` (mirroring the same
+fix independently made in `echarts.py`, TASK-2888) and re-verified
+TASK-2887's own `test_graph_svg.py` suite still green afterward.
+
+**Two pre-existing artifacts needed updating**, both direct, foreseeable
+casualties of this task's own acceptance criteria:
+1. `test_ssr_html.py::test_renderer_capabilities_declared` asserted
+   `len(supported_components) == 18` exactly — bumped to 19 (`Graph` added).
+2. `tailwind.generated.css` — this task's new interactive-HTML markup
+   introduces two literal CSS classes (`a2ui-graph-wrap`, `a2ui-graph-
+   source`); the EXISTING `test_all_a2ui_classes_have_css_rule` coverage
+   guard correctly caught their absence. Added curated Tailwind utility
+   mappings to `scripts/generate_a2ui_css.py`'s `SELECTOR_UTILITIES` and
+   regenerated the CSS via the script itself (confirmed `npx`/Tailwind CLI
+   available and working in this environment) — not hand-edited.
+
+Verification: `pytest packages/ai-parrot-visualizations/tests -q` → 313
+passed; `pytest packages/ai-parrot/tests/outputs/a2ui packages/ai-parrot/
+tests/integration/test_frontend_guide_examples.py -q` → 730 passed, 1
+skipped (core untouched by this satellite-only task); `ruff check` clean
+on all nine touched/created Python files. Every degradation path (force
+layout, oversize, unsupported-catalog on Adaptive Cards/Folium) was also
+manually smoke-tested end-to-end before the pytest suite was written.

--- a/sdd/tasks/completed/TASK-2890-bundled-ui-graph-component.md
+++ b/sdd/tasks/completed/TASK-2890-bundled-ui-graph-component.md
@@ -90,3 +90,40 @@ dependencies, Graph schema changes, or editing user-moved positions.
 1. Verify existing Svelte component props and ECharts wrapper API before coding.
 2. Keep existing dispatch branches and feature flag intact.
 3. Run the UI Vitest suite and avoid adding a graph library.
+
+### Completion Note
+
+Implemented as specified. `A2UIGraph.svelte` uses a Svelte 5 `<script
+module>` block to export `buildGraphOption`/`hasCompletePositions`/
+`STATE_TO_STATUS` as plain, directly-importable functions — tested in
+`A2UIGraph.test.ts` with ZERO rendering/canvas involved, exactly the two
+named behaviors (positions -> `layout:"none"`, missing/incomplete
+positions -> `"circular"`) plus selection/group coverage.
+
+**Token mapping deviation (documented, not a divergence from spec
+intent)**: this app's own theme schema (`src/lib/styles/themes/
+_schema.css`) has NO `--accent-green`/`--accent-amber`/`--accent-red`/
+`--neutral-muted` tokens — those are server-side `DesignSystem` names only.
+Mapped the SAME five status roles to this app's own EXISTING shadcn/
+Tailwind tokens instead (`--chart-2`/`--chart-3`/`--destructive`/
+`--primary`/`--muted-foreground`), resolved to a concrete colour at render
+time via the identical `getComputedStyle` probe pattern already
+established by `AppChart.svelte` (Canvas rendering cannot resolve `var()`).
+
+**Catalog resolution gap (documented, out of this task's file list)**:
+`A2UISurface.svelte` — the true root dispatcher — is NOT in this task's
+Files table and was not modified. It does not yet pass its own surface
+`catalogId` down as `surfaceCatalogId`, so today only a Graph carrying its
+OWN explicit `catalogId` (which `build_graph`/the LLM producer always set,
+per spec) resolves correctly from the true root; the `surfaceCatalogId`
+prop and its resolution precedence are fully implemented and tested at the
+`A2UINode`/nested-descriptor level (both the `descriptor.catalogId` and
+`A2UISurface`'s `properties.catalogId` nesting shapes are handled). Wiring
+`A2UISurface.svelte`'s own default through is a small, obvious follow-up.
+
+Verification: `pnpm install` (fresh, no lockfile changes) then `vitest run`
+→ 294 passed across 45 files (the full UI suite, not just the new tests) —
+`A2UIGraph.test.ts` (5), `A2UINode.test.ts` (18, 15 pre-existing + 3 new).
+`svelte-check` shows 22 pre-existing errors in UNRELATED files (AppChart.svelte,
+AgentChat.svelte, TabsAI.svelte, slider.svelte, ...) and ZERO in any file
+this task touched or created.

--- a/sdd/tasks/completed/TASK-2891-a2ui-graph-docs-conformance.md
+++ b/sdd/tasks/completed/TASK-2891-a2ui-graph-docs-conformance.md
@@ -92,3 +92,51 @@ sibling chart/live-workflow specifications.
 1. Verify all implementation dependencies are complete before changing docs/tests.
 2. Keep this task additive and do not edit sibling feature specifications.
 3. Run the complete acceptance commands from spec AC-14 and capture failures clearly.
+
+### Completion Note
+
+Implemented as specified. Both docs updated (three-catalog resolution rule
++ full `Graph` section in `a2ui-v1.md`; a new additive §5.4 in the frontend
+reference, renderer table updated, Parrot composite count unchanged at 10).
+
+**A real, genuinely-introduced-by-an-earlier-task bug was found and fixed
+by this task's own `test_flow_to_graph_to_mermaid_roundtrip`**:
+`flow_definition_to_graph` (TASK-2886) defaulted every label-less node's
+`label` to its own `id` explicitly. `GraphNode.label` documents "defaults
+to id on render" (i.e. `None` is the correct "no label given" value), and
+the mermaid codec (TASK-2883) collapses an explicit label EQUAL to id back
+to `None` on import — so the adapter's redundant explicit default silently
+broke `from_mermaid(to_mermaid(spec)) == spec` for every node without an
+authored label. Fixed at the source (`adapters/flow.py`), re-verified
+TASK-2886's own `test_builders_graph.py` suite unaffected (it never
+asserted on `.label` values).
+
+**Path correction, not a divergence**: `test_frontend_guide_examples.py`
+(named in the Codebase Contract as validating "every envelope example in
+the frontend guide") actually only ever scanned `docs/frontend/
+structured-artifacts-frontend-guide.md` — a DIFFERENT document from
+`agentdashboard-a2ui-reference.md`, which is the one this task's own Files
+table requires the Graph example be added to. Generalized the existing
+fence-scanner helper to accept a path (default unchanged, so the existing
+"expected 3 Chart/Table/Map examples" assertion on the OTHER file stays
+untouched) and added a new, additive test scanning the reference doc
+specifically.
+
+`test_catalog_parity.py` needed no changes — TASK-2885 already added
+`test_graph_schema_has_all_spec_fields`, which is the "final Graph parity
+assertion" this task's Scope calls for "if needed"; adding a second,
+overlapping assertion would have been redundant.
+
+Verification: `pytest packages/ai-parrot/tests/outputs/a2ui packages/
+ai-parrot/tests/integration/test_frontend_guide_examples.py -q` → 736
+passed, 1 skipped; `pytest packages/ai-parrot-visualizations/tests -q` →
+313 passed (run SEPARATELY — combining both package roots in one `pytest`
+invocation trips a rootdir/module-identity collision across their
+identically-named `tests.outputs.*` packages; confirmed this is a
+pre-existing invocation-order artifact, not a regression, by running each
+package alone). `ruff check` clean on all five touched/created Python
+files. The bundled UI's full Vitest suite (294 passed) was already
+verified in TASK-2890 and is untouched by this docs/conformance-only task.
+
+**This closes FEAT-529** — all 11 tasks (TASK-2881 through TASK-2891) are
+now complete.

--- a/sdd/tasks/index/a2ui-graph-component.json
+++ b/sdd/tasks/index/a2ui-graph-component.json
@@ -144,7 +144,7 @@
       "feature_id": "FEAT-529",
       "feature": "a2ui-graph-component",
       "spec": "sdd/specs/a2ui-graph-component.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "depends_on": [
@@ -158,8 +158,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-06T01:13:07+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2887-shared-graph-svg-contract.md"
+      "completed_at": "2026-09-06T02:10:34+00:00",
+      "file": "sdd/tasks/completed/TASK-2887-shared-graph-svg-contract.md"
     },
     {
       "id": "TASK-2888",

--- a/sdd/tasks/index/a2ui-graph-component.json
+++ b/sdd/tasks/index/a2ui-graph-component.json
@@ -5,7 +5,7 @@
   "type": "feature",
   "base_branch": "dev",
   "created_at": "2026-09-06T00:09:29+00:00",
-  "completed_at": null,
+  "completed_at": "2026-09-06T02:50:32+00:00",
   "parallelism_notes": "TASK-2881 is the foundational catalog-shell task and must land first. TASK-2882 can proceed after the shell; TASK-2883 and TASK-2884 are parallel pure graph tasks after TASK-2882. TASK-2885 depends on the shell, models, and codec. TASK-2886 depends on the composite and layout. TASK-2887 is the shared renderer contract; TASK-2888 and TASK-2889 can run in parallel after it. TASK-2890 can run after the composite and in parallel with renderer tasks. TASK-2891 waits for all implementation lanes and owns final docs/conformance.",
   "tasks": [
     {
@@ -231,7 +231,7 @@
       "feature_id": "FEAT-529",
       "feature": "a2ui-graph-component",
       "spec": "sdd/specs/a2ui-graph-component.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "M",
       "depends_on": [
@@ -245,8 +245,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-06T01:13:07+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2891-a2ui-graph-docs-conformance.md"
+      "completed_at": "2026-09-06T02:50:32+00:00",
+      "file": "sdd/tasks/completed/TASK-2891-a2ui-graph-docs-conformance.md"
     }
   ]
 }

--- a/sdd/tasks/index/a2ui-graph-component.json
+++ b/sdd/tasks/index/a2ui-graph-component.json
@@ -34,7 +34,7 @@
       "feature_id": "FEAT-529",
       "feature": "a2ui-graph-component",
       "spec": "sdd/specs/a2ui-graph-component.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -45,8 +45,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-06T01:13:07+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2882-graph-vocabulary-models.md"
+      "completed_at": "2026-09-06T01:35:49+00:00",
+      "file": "sdd/tasks/completed/TASK-2882-graph-vocabulary-models.md"
     },
     {
       "id": "TASK-2883",

--- a/sdd/tasks/index/a2ui-graph-component.json
+++ b/sdd/tasks/index/a2ui-graph-component.json
@@ -168,7 +168,7 @@
       "feature_id": "FEAT-529",
       "feature": "a2ui-graph-component",
       "spec": "sdd/specs/a2ui-graph-component.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -179,8 +179,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-06T01:13:07+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2888-echarts-graph-renderer.md"
+      "completed_at": "2026-09-06T02:16:09+00:00",
+      "file": "sdd/tasks/completed/TASK-2888-echarts-graph-renderer.md"
     },
     {
       "id": "TASK-2889",

--- a/sdd/tasks/index/a2ui-graph-component.json
+++ b/sdd/tasks/index/a2ui-graph-component.json
@@ -15,7 +15,7 @@
       "feature_id": "FEAT-529",
       "feature": "a2ui-graph-component",
       "spec": "sdd/specs/a2ui-graph-component.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "depends_on": [],
@@ -24,8 +24,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-06T01:13:07+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2881-viz-core-catalog-shell.md"
+      "completed_at": "2026-09-06T01:32:19+00:00",
+      "file": "sdd/tasks/completed/TASK-2881-viz-core-catalog-shell.md"
     },
     {
       "id": "TASK-2882",

--- a/sdd/tasks/index/a2ui-graph-component.json
+++ b/sdd/tasks/index/a2ui-graph-component.json
@@ -76,7 +76,7 @@
       "feature_id": "FEAT-529",
       "feature": "a2ui-graph-component",
       "spec": "sdd/specs/a2ui-graph-component.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -87,8 +87,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-06T01:13:07+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2884-layered-graph-layout.md"
+      "completed_at": "2026-09-06T01:53:30+00:00",
+      "file": "sdd/tasks/completed/TASK-2884-layered-graph-layout.md"
     },
     {
       "id": "TASK-2885",

--- a/sdd/tasks/index/a2ui-graph-component.json
+++ b/sdd/tasks/index/a2ui-graph-component.json
@@ -5,7 +5,7 @@
   "type": "feature",
   "base_branch": "dev",
   "created_at": "2026-09-06T00:09:29+00:00",
-  "completed_at": "2026-09-06T02:50:32+00:00",
+  "completed_at": "2026-09-06T03:10:46+00:00",
   "parallelism_notes": "TASK-2881 is the foundational catalog-shell task and must land first. TASK-2882 can proceed after the shell; TASK-2883 and TASK-2884 are parallel pure graph tasks after TASK-2882. TASK-2885 depends on the shell, models, and codec. TASK-2886 depends on the composite and layout. TASK-2887 is the shared renderer contract; TASK-2888 and TASK-2889 can run in parallel after it. TASK-2890 can run after the composite and in parallel with renderer tasks. TASK-2891 waits for all implementation lanes and owns final docs/conformance.",
   "tasks": [
     {
@@ -25,7 +25,8 @@
       "assigned_at": null,
       "started_at": "2026-09-06T01:13:07+00:00",
       "completed_at": "2026-09-06T01:32:19+00:00",
-      "file": "sdd/tasks/completed/TASK-2881-viz-core-catalog-shell.md"
+      "file": "sdd/tasks/completed/TASK-2881-viz-core-catalog-shell.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2882",
@@ -46,7 +47,8 @@
       "assigned_at": null,
       "started_at": "2026-09-06T01:13:07+00:00",
       "completed_at": "2026-09-06T01:35:49+00:00",
-      "file": "sdd/tasks/completed/TASK-2882-graph-vocabulary-models.md"
+      "file": "sdd/tasks/completed/TASK-2882-graph-vocabulary-models.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2883",
@@ -67,7 +69,8 @@
       "assigned_at": null,
       "started_at": "2026-09-06T01:13:07+00:00",
       "completed_at": "2026-09-06T01:49:29+00:00",
-      "file": "sdd/tasks/completed/TASK-2883-mermaid-graph-codec.md"
+      "file": "sdd/tasks/completed/TASK-2883-mermaid-graph-codec.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2884",
@@ -88,7 +91,8 @@
       "assigned_at": null,
       "started_at": "2026-09-06T01:13:07+00:00",
       "completed_at": "2026-09-06T01:53:30+00:00",
-      "file": "sdd/tasks/completed/TASK-2884-layered-graph-layout.md"
+      "file": "sdd/tasks/completed/TASK-2884-layered-graph-layout.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2885",
@@ -111,7 +115,8 @@
       "assigned_at": null,
       "started_at": "2026-09-06T01:13:07+00:00",
       "completed_at": "2026-09-06T02:00:05+00:00",
-      "file": "sdd/tasks/completed/TASK-2885-graph-catalog-composite.md"
+      "file": "sdd/tasks/completed/TASK-2885-graph-catalog-composite.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2886",
@@ -135,7 +140,8 @@
       "assigned_at": null,
       "started_at": "2026-09-06T01:13:07+00:00",
       "completed_at": "2026-09-06T02:05:49+00:00",
-      "file": "sdd/tasks/completed/TASK-2886-graph-builder-flow-adapter.md"
+      "file": "sdd/tasks/completed/TASK-2886-graph-builder-flow-adapter.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2887",
@@ -159,7 +165,8 @@
       "assigned_at": null,
       "started_at": "2026-09-06T01:13:07+00:00",
       "completed_at": "2026-09-06T02:10:34+00:00",
-      "file": "sdd/tasks/completed/TASK-2887-shared-graph-svg-contract.md"
+      "file": "sdd/tasks/completed/TASK-2887-shared-graph-svg-contract.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2888",
@@ -180,7 +187,8 @@
       "assigned_at": null,
       "started_at": "2026-09-06T01:13:07+00:00",
       "completed_at": "2026-09-06T02:16:09+00:00",
-      "file": "sdd/tasks/completed/TASK-2888-echarts-graph-renderer.md"
+      "file": "sdd/tasks/completed/TASK-2888-echarts-graph-renderer.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2889",
@@ -201,7 +209,8 @@
       "assigned_at": null,
       "started_at": "2026-09-06T01:13:07+00:00",
       "completed_at": "2026-09-06T02:31:54+00:00",
-      "file": "sdd/tasks/completed/TASK-2889-html-ssr-pdf-graph-renderers.md"
+      "file": "sdd/tasks/completed/TASK-2889-html-ssr-pdf-graph-renderers.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2890",
@@ -222,7 +231,8 @@
       "assigned_at": null,
       "started_at": "2026-09-06T01:13:07+00:00",
       "completed_at": "2026-09-06T02:40:15+00:00",
-      "file": "sdd/tasks/completed/TASK-2890-bundled-ui-graph-component.md"
+      "file": "sdd/tasks/completed/TASK-2890-bundled-ui-graph-component.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-2891",
@@ -246,7 +256,8 @@
       "assigned_at": null,
       "started_at": "2026-09-06T01:13:07+00:00",
       "completed_at": "2026-09-06T02:50:32+00:00",
-      "file": "sdd/tasks/completed/TASK-2891-a2ui-graph-docs-conformance.md"
+      "file": "sdd/tasks/completed/TASK-2891-a2ui-graph-docs-conformance.md",
+      "verification": "verified"
     }
   ]
 }

--- a/sdd/tasks/index/a2ui-graph-component.json
+++ b/sdd/tasks/index/a2ui-graph-component.json
@@ -97,7 +97,7 @@
       "feature_id": "FEAT-529",
       "feature": "a2ui-graph-component",
       "spec": "sdd/specs/a2ui-graph-component.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "depends_on": [
@@ -110,8 +110,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-06T01:13:07+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2885-graph-catalog-composite.md"
+      "completed_at": "2026-09-06T02:00:05+00:00",
+      "file": "sdd/tasks/completed/TASK-2885-graph-catalog-composite.md"
     },
     {
       "id": "TASK-2886",

--- a/sdd/tasks/index/a2ui-graph-component.json
+++ b/sdd/tasks/index/a2ui-graph-component.json
@@ -189,7 +189,7 @@
       "feature_id": "FEAT-529",
       "feature": "a2ui-graph-component",
       "spec": "sdd/specs/a2ui-graph-component.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "depends_on": [
@@ -200,8 +200,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-06T01:13:07+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2889-html-ssr-pdf-graph-renderers.md"
+      "completed_at": "2026-09-06T02:31:54+00:00",
+      "file": "sdd/tasks/completed/TASK-2889-html-ssr-pdf-graph-renderers.md"
     },
     {
       "id": "TASK-2890",

--- a/sdd/tasks/index/a2ui-graph-component.json
+++ b/sdd/tasks/index/a2ui-graph-component.json
@@ -210,7 +210,7 @@
       "feature_id": "FEAT-529",
       "feature": "a2ui-graph-component",
       "spec": "sdd/specs/a2ui-graph-component.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -221,8 +221,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-06T01:13:07+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2890-bundled-ui-graph-component.md"
+      "completed_at": "2026-09-06T02:40:15+00:00",
+      "file": "sdd/tasks/completed/TASK-2890-bundled-ui-graph-component.md"
     },
     {
       "id": "TASK-2891",

--- a/sdd/tasks/index/a2ui-graph-component.json
+++ b/sdd/tasks/index/a2ui-graph-component.json
@@ -120,7 +120,7 @@
       "feature_id": "FEAT-529",
       "feature": "a2ui-graph-component",
       "spec": "sdd/specs/a2ui-graph-component.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -134,8 +134,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-06T01:13:07+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2886-graph-builder-flow-adapter.md"
+      "completed_at": "2026-09-06T02:05:49+00:00",
+      "file": "sdd/tasks/completed/TASK-2886-graph-builder-flow-adapter.md"
     },
     {
       "id": "TASK-2887",

--- a/sdd/tasks/index/a2ui-graph-component.json
+++ b/sdd/tasks/index/a2ui-graph-component.json
@@ -55,7 +55,7 @@
       "feature_id": "FEAT-529",
       "feature": "a2ui-graph-component",
       "spec": "sdd/specs/a2ui-graph-component.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "depends_on": [
@@ -66,8 +66,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-06T01:13:07+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-2883-mermaid-graph-codec.md"
+      "completed_at": "2026-09-06T01:49:29+00:00",
+      "file": "sdd/tasks/completed/TASK-2883-mermaid-graph-codec.md"
     },
     {
       "id": "TASK-2884",


### PR DESCRIPTION
## Summary

Adds the A2UI `Graph` component under a new third catalog (`viz-core`) —
workflow/state-machine visualization with a Mermaid codec, deterministic
layered layout, and native/degraded support across every registered
renderer (ECharts, interactive HTML, SSR HTML, PDF, Adaptive Cards,
Folium) plus a bundled Svelte UI component.

11/11 tasks verified (TASK-2881 through TASK-2891):

- TASK-2881 — viz-core catalog shell + `_CATALOG` rekeyed to `(catalog_id, name)`
- TASK-2882 — `GraphSpec` vocabulary and validation
- TASK-2883 — Mermaid codec (flowchart / stateDiagram-v2 / sequenceDiagram)
- TASK-2884 — Deterministic layered graph layout
- TASK-2885 — `Graph` catalog composite + `lower()`
- TASK-2886 — `build_graph` builder + `flow_definition_to_graph` adapter
- TASK-2887 — Shared SVG renderer contract
- TASK-2888 — Native ECharts `graph` series support
- TASK-2889 — Interactive HTML / SSR HTML / PDF / degradation support
- TASK-2890 — Bundled `A2UIGraph.svelte` + catalog-aware dispatch
- TASK-2891 — Docs (`a2ui-v1.md`, frontend reference) + conformance suite

Plus a post-review fix: `GraphSpec._has_cycle` was rewritten from a
recursive to an iterative 3-colour DFS (mirrors `layout.py`'s existing
`_break_cycles` pattern) after adversarial code review found it could
raise an unhandled `RecursionError` on a long acyclic `kind="dag"` chain
instead of validating cleanly.

## Verification

- `pytest packages/ai-parrot/tests/outputs/a2ui packages/ai-parrot/tests/integration/test_frontend_guide_examples.py -q` → 738 passed, 1 skipped
- `pytest packages/ai-parrot-visualizations/tests -q` → 313 passed (run separately — pre-existing cross-package `tests` rootdir collision, predates this branch)
- `ruff check` clean on all touched files
- `npm test` (vitest) in `packages/ai-parrot-server/ui` → 294 passed / 45 files
- Adversarial code review (code-reviewer agent): 0 critical, 2 important (1 fixed — the recursion bug above; 1 noted as an already-documented, deliberately out-of-scope follow-up — `A2UISurface.svelte`'s own `catalogId` default isn't wired through yet), 3 suggestions, 1 nitpick — none blocking.

## Tasks

11/11 tasks verified.

---
_Closed by /sdd-done_