### PR TITLE
fix(voicebot-multiroom-heygen-avatar): two defects that make broadcast unusable (follow-up to #1338)

### DIFF
--- a/docs/testing/voicebot-multiroom-heygen-avatar-acceptance.md
+++ b/docs/testing/voicebot-multiroom-heygen-avatar-acceptance.md
@@ -282,3 +282,54 @@ feature. The comparison now reads: `dev` **189 passed / 0 failed**, this branch 
 passed / 0 failed**, on the same environment.
 
 ---
+
+---
+
+## 8. Running the shipped UI sample against real vendors — 2026-09-09
+
+The example was booted with real LiveKit + LiveAvatar credentials and Redis, and driven
+through its own HTTP API. This is the first time the *service* (as opposed to the vendor
+probe in §7) had been exercised against live infrastructure, and it found **two defects
+that every one of the 543 automated tests missed**, because the fixtures inject a fake
+media session or a `None` bot and so never construct the real objects:
+
+1. **Producer startup crashed on any real bot.** `_build_voice_session` handed the bot to
+   `_AskStreamVoiceClient` without building the bot's lazily-constructed `_llm`, so
+   `voice_capabilities` dereferenced `None`:
+   `AttributeError: 'NoneType' object has no attribute 'voice_capabilities'`. The
+   single-user path in `VoiceChatHandler` already did this construction; the broadcast
+   path simply omitted it. **The moderated broadcast could never start in production.**
+
+2. **The avatar could never start.** The LiveAvatar vendor rejects the publisher token we
+   mint: `422 Bad LiveKit configuration. Input Livekit token needs to grant
+   canPublishData permission.` Because avatar startup *degrades* rather than raises, this
+   surfaced only as every broadcast silently running in `audio_only` with
+   `avatar_control_lost` — the fallback working perfectly and masking a total avatar
+   outage. `mint_publisher_token` now takes `can_publish_data`, granted for the avatar
+   token only; viewer tokens remain subscribe-only (AC3) and the direct publisher keeps
+   least privilege.
+
+Both are covered by regression tests, and the `_llm` one was verified to fail without the
+fix before being committed.
+
+### Result after the fixes — three participants, real vendors
+
+```
+state                avatar
+media_ready          True
+selected_identity    avatar-bc-49c28
+viewer_count         3
+moderator_display_id lease-a7000d7ac5ce4498
+speaker_display_id   lease-a7000d7ac5ce4498
+reason               None
+```
+
+One producer, one LiveKit room, three admitted participants, avatar mode active. This is
+**AC1's backend half** demonstrated end to end. It is still not AC1: no browser rendered
+the media and no human confirmed audible speech or lip-sync.
+
+A third, smaller issue was fixed alongside: a LiveKit `404 room does not exist` during the
+normal window between admission and room creation was logged as "LiveKit unreachable" with
+a full traceback on every reconciler pass, burying the genuine failures above. It is now
+distinguished from an outage and logged at DEBUG.
+

--- a/packages/ai-parrot-integrations/src/parrot/integrations/liveavatar/broadcast/service.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/liveavatar/broadcast/service.py
@@ -163,6 +163,28 @@ def default_principal_resolver(user: Any, agent_id: str, *, tenant_id: str = "de
     )
 
 
+def _is_room_not_found(exc: BaseException) -> bool:
+    """Whether a LiveKit error means "this room does not exist (yet)".
+
+    Distinguished from a genuine outage because the two demand opposite
+    reactions: a missing room during startup is expected and should be quiet,
+    while an unreachable LiveKit must stay loud and fail closed.
+
+    Args:
+        exc: The exception raised by a room-manager call.
+
+    Returns:
+        ``True`` for a not-found/404 response.
+    """
+    code = getattr(exc, "code", None)
+    if code is not None and str(code).lower().endswith("not_found"):
+        return True
+    status = getattr(exc, "status", None)
+    if status == 404:
+        return True
+    return "does not exist" in str(exc).lower()
+
+
 class BroadcastService:
     """Authority, lifecycle and cross-worker routing for moderated broadcasts.
 
@@ -464,8 +486,27 @@ class BroadcastService:
         The conversation key is the broadcast's stable ``voice_session_id`` —
         never the current speaker's — so the floor can move without the agent
         losing the conversation (spec §2).
+
+        Args:
+            descriptor: The broadcast being produced.
+            session: The media session the voice session drives.
+            bot: The broadcast's Nova ``VoiceBot``, or ``None`` in tests.
+
+        Returns:
+            The constructed broadcast voice session.
         """
         from parrot.voice.handler import _AskStreamVoiceClient
+
+        if bot is not None and getattr(bot, "_llm", None) is None:
+            # VoiceBot builds its client lazily, exactly as ask()/ask_stream()
+            # do, and the single-user path in VoiceChatHandler performs this
+            # same construction before building its session. Skipping it here
+            # meant `_AskStreamVoiceClient.voice_capabilities` dereferenced a
+            # None `_llm` and every producer startup with a REAL bot died with
+            # `AttributeError: 'NoneType' object has no attribute
+            # 'voice_capabilities'` — invisible to the tests, which inject a
+            # fake session factory or a None bot.
+            bot._llm = bot._create_llm_client(bot._resolve_llm_config())
 
         client = _AskStreamVoiceClient(bot) if bot is not None else None
         return self._voice_session_factory(
@@ -1067,12 +1108,23 @@ class BroadcastService:
             return 0
         try:
             identities = set(await self.room_manager.list_participant_identities(descriptor.room_name))
-        except Exception:  # noqa: BLE001 — LiveKit unreachable: confirm nothing
-            self.logger.warning(
-                "broadcast %s: could not read the room roster — leaving seats unconfirmed",
-                broadcast_id,
-                exc_info=True,
-            )
+        except Exception as exc:  # noqa: BLE001 — LiveKit unreachable: confirm nothing
+            # A room that does not exist yet is the normal state between
+            # admission and the producer creating it, not an outage. Logging it
+            # at WARNING with a full traceback on every reconciler pass buried
+            # the real failures in this exact scenario, so it is reported once
+            # per pass at DEBUG instead.
+            if _is_room_not_found(exc):
+                self.logger.debug(
+                    "broadcast %s: room not created yet — leaving seats unconfirmed",
+                    broadcast_id,
+                )
+            else:
+                self.logger.warning(
+                    "broadcast %s: could not read the room roster — leaving seats unconfirmed",
+                    broadcast_id,
+                    exc_info=True,
+                )
             return 0
 
         confirmed = 0

--- a/packages/ai-parrot-integrations/src/parrot/integrations/liveavatar/broadcast/session.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/liveavatar/broadcast/session.py
@@ -330,7 +330,10 @@ class BroadcastSession:
         self._start_tasks()
 
         try:
-            avatar_token = self.room_manager.mint_publisher_token(self.room_name, self.avatar_identity)
+            # The vendor requires canPublishData on the token it is given.
+            avatar_token = self.room_manager.mint_publisher_token(
+                self.room_name, self.avatar_identity, can_publish_data=True
+            )
             self._avatar = await self._avatar_factory(
                 agent_id=self.descriptor.agent_id,
                 session_id=self.descriptor.voice_session_id or self.descriptor.broadcast_id,

--- a/packages/ai-parrot-integrations/src/parrot/integrations/liveavatar/room_manager.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/liveavatar/room_manager.py
@@ -200,6 +200,7 @@ class LiveKitRoomManager:
         *,
         ttl_s: int = DEFAULT_PUBLISHER_TOKEN_TTL_S,
         name: Optional[str] = None,
+        can_publish_data: bool = False,
     ) -> str:
         """Mint a server-side publisher token for a caller-chosen identity.
 
@@ -236,7 +237,13 @@ class LiveKitRoomManager:
             room=room,
             can_publish=True,
             can_subscribe=True,
-            can_publish_data=False,
+            # Off by default (least privilege). The LiveAvatar vendor requires
+            # it on the token it is handed and refuses the session outright
+            # without it: `422 Bad LiveKit configuration. Input Livekit token
+            # needs to grant canPublishData permission.` Because avatar startup
+            # degrades instead of raising, that 422 turned every broadcast into
+            # a silent audio_only fallback.
+            can_publish_data=can_publish_data,
         )
         builder = (
             livekit_api.AccessToken(self._key, self._secret)

--- a/packages/ai-parrot-integrations/tests/integrations/liveavatar/test_room_manager.py
+++ b/packages/ai-parrot-integrations/tests/integrations/liveavatar/test_room_manager.py
@@ -300,3 +300,33 @@ async def test_room_admin_closes_the_client_even_on_failure(mgr: LiveKitRoomMana
         await mgr.delete_room("room-x")
     assert _FakeLiveKitAPI.last is not None
     assert _FakeLiveKitAPI.last.closed is True
+
+
+# ── Vendor token grants (live-run regressions) ─────────────────────────────
+
+
+def test_avatar_publisher_token_can_grant_data_publishing(mgr: LiveKitRoomManager) -> None:
+    """LiveAvatar refuses a token without ``canPublishData``.
+
+    Found only by running the demo against the real vendor:
+    ``422 Bad LiveKit configuration. Input Livekit token needs to grant
+    canPublishData permission.`` Avatar startup degrades instead of raising,
+    so this turned every broadcast into a silent audio-only fallback.
+    """
+    token = mgr.mint_publisher_token("room-1", "avatar-x", can_publish_data=True)
+    grants = _jwt_payload(token)["video"]
+    assert grants["canPublishData"] is True
+    assert grants["canPublish"] is True
+
+
+def test_publisher_token_withholds_data_publishing_by_default(mgr: LiveKitRoomManager) -> None:
+    """Least privilege: only the caller that needs it asks for it."""
+    grants = _jwt_payload(mgr.mint_publisher_token("room-1", "direct-x"))["video"]
+    assert grants.get("canPublishData", False) is False
+
+
+def test_viewer_token_never_grants_data_publishing(mgr: LiveKitRoomManager) -> None:
+    """Viewers stay subscribe-only regardless of the publisher change (AC3)."""
+    grants = _jwt_payload(mgr.mint_viewer_token("room-1", "viewer-x"))["video"]
+    assert grants.get("canPublish", False) is False
+    assert grants.get("canPublishData", False) is False

--- a/packages/ai-parrot-integrations/tests/voice/test_voice_broadcast_service.py
+++ b/packages/ai-parrot-integrations/tests/voice/test_voice_broadcast_service.py
@@ -15,6 +15,7 @@ import pytest
 
 from parrot.integrations.liveavatar.broadcast import (
     MAX_VIEWERS,
+    BroadcastDescriptor,
     BroadcastReason,
     BroadcastState,
     InMemoryBroadcastRegistry,
@@ -842,3 +843,51 @@ async def test_media_state_is_only_ever_filled_in_never_erased(
     assert after.room_name == "room-x"
     assert after.avatar_identity == before.avatar_identity
     assert after.direct_identity == before.direct_identity
+
+
+# ── Producer startup with a realistic bot (live-run regression) ────────────
+
+
+async def test_producer_configures_the_bots_llm_before_building_the_session(
+    service: BroadcastService,
+) -> None:
+    """A real ``VoiceBot`` arrives with ``_llm`` unset and must be configured.
+
+    Found only by running the demo against real vendors: every producer
+    startup died with ``AttributeError: 'NoneType' object has no attribute
+    'voice_capabilities'`` because ``_AskStreamVoiceClient`` dereferenced the
+    bot's lazily-built client. The whole suite missed it — the fixtures inject
+    either a fake voice-session factory or a ``None`` bot, so nothing ever
+    exercised the real construction path. ``VoiceChatHandler`` performs this
+    same lazy build for the single-user path.
+    """
+    built: List[str] = []
+
+    class _Llm:
+        voice_capabilities = object()
+
+    class _RealisticBot:
+        """Mirrors VoiceBot's contract: `_llm` is None until asked for."""
+
+        system_prompt = "hi"
+        voice_config = None
+
+        def __init__(self) -> None:
+            self._llm = None
+
+        def _resolve_llm_config(self):
+            built.append("resolve")
+            return {"provider": "nova"}
+
+        def _create_llm_client(self, config):
+            built.append("create")
+            return _Llm()
+
+    bot = _RealisticBot()
+    descriptor = BroadcastDescriptor(broadcast_id="bc-1", tenant_id=TENANT, agent_id=AGENT, creator_user_id="u")
+
+    # Exercise the exact path start_producer uses.
+    service._build_voice_session(descriptor, None, bot)  # noqa: SLF001
+
+    assert built == ["resolve", "create"], "the bot's client must be built exactly once"
+    assert bot._llm is not None


### PR DESCRIPTION
## ⚠️ Follow-up to #1338 — these fixes missed the merge

PR #1338 merged at `df47bb1fc`, one commit before `70ac4ee7c`. **`dev` currently contains
a broadcast feature that cannot start**, so this is not a cosmetic follow-up.

Both defects were found by booting the shipped UI sample against **real LiveKit +
LiveAvatar**, and both were invisible to all 543 automated tests, because every fixture
injects a fake media session or a `None` bot and so never constructs the real objects.

### 1. Producer startup crashes on any real bot

`_build_voice_session` passed the bot to `_AskStreamVoiceClient` without building the
bot's lazily-constructed `_llm`, so `voice_capabilities` dereferenced `None`:

```
AttributeError: 'NoneType' object has no attribute 'voice_capabilities'
```

`VoiceChatHandler`'s single-user path already performs this construction; the broadcast
path simply omitted it. **The moderated broadcast could never start in production.**

### 2. The avatar can never start

LiveAvatar rejects the publisher token we mint:

```
422 Bad LiveKit configuration. Input Livekit token needs to grant canPublishData permission.
```

Because avatar startup *degrades* rather than raises, this surfaced only as every
broadcast quietly running in `audio_only` with `avatar_control_lost` — the fallback
working perfectly and masking a total avatar outage. `mint_publisher_token` now takes
`can_publish_data`, granted for the **avatar token only**; viewer tokens stay
subscribe-only (AC3) and the direct publisher keeps least privilege.

### 3. Misleading log that hid both

A LiveKit `404 room does not exist` — the normal state between admission and room
creation — was logged as "LiveKit unreachable" with a full traceback on every reconciler
pass, burying the two real failures. Now told apart from an outage and logged at DEBUG.

## Verified against real vendors after the fixes

```
state                avatar
media_ready          True
selected_identity    avatar-bc-49c28
viewer_count         3
reason               None
```

One producer, one LiveKit room, three admitted participants, avatar mode active — AC1's
backend half, end to end. Still not AC1 itself: no browser rendered the media and no human
confirmed audible speech or lip-sync.

## Tests

Regression tests for both defects; the `_llm` one was **verified to fail without the fix**
before committing. Suites: voice **543**, liveavatar **202**, e2e **15** — all green.

---
_Follow-up to #1338_