### PR TITLE
fix(voice): live gate must load navconfig before reading credentials

### DIFF
--- a/docs/testing/voicebot-multiroom-live-gate.md
+++ b/docs/testing/voicebot-multiroom-live-gate.md
@@ -40,11 +40,21 @@ exists to surface:
 Run command:
 
 ```bash
+# Credentials are read from env/.env via navconfig — no manual exports.
+# PARROT_LIVEAVATAR_MAX_SESSION_DURATION_S / PARROT_LIVE_MAX_SESSION_DURATION are
+# needed only on an account whose session cap is below the spec's 600 s.
 PARROT_LIVE_BROADCAST_GATE=1 PARROT_LIVEAVATAR_MAX_SESSION_DURATION_S=60 \
 PARROT_LIVE_MAX_SESSION_DURATION=60 \
   pytest packages/ai-parrot-integrations/tests/voice/test_voice_broadcast_live_gate.py
 # 3 passed in 29.18s
 ```
+
+> **Fixed after this report was first written.** The gate used to require the caller to
+> hand-export the five credential variables, because it read `os.environ` at import time
+> and nothing in its import graph loaded `env/.env`. It now imports `navconfig` first, so
+> the command above works as written on any machine that has credentials configured the
+> normal way. The old "export them yourself" instruction was a workaround for a defect in
+> the gate, and it was wrong to document it as the procedure.
 
 ### Measured results
 

--- a/docs/voice/voicebot-multiroom-heygen-avatar.md
+++ b/docs/voice/voicebot-multiroom-heygen-avatar.md
@@ -244,7 +244,7 @@ from `GET …/connection`.
 | `PARROT_BROADCAST_ALLOWED_ORIGINS` | server | Same-origin only. |
 | `PARROT_LIVEAVATAR_MAX_SESSION_DURATION_S` | both | Requests the spec default of 600 s. **Set this on a capped account.** The ceiling is an account property: a sandbox key rejects 600 s with `400 max_session_duration (600s) exceeds the maximum allowed (60s)`, and because avatar startup degrades rather than raises, every broadcast then falls back to `audio_only` with the cause visible only in a warning log. Verified against a live sandbox account (see `docs/testing/voicebot-multiroom-live-gate.md`). |
 | `PARROT_BROADCAST_WORKER_URL` / `PARROT_BROADCAST_WORKER_BIND` | multi-worker | The relay is not served and this worker is not advertised; cross-worker speaking fails closed with `owner_lost`. Single-worker deployments need neither. |
-| `PARROT_LIVE_BROADCAST_GATE` | live gate only | The live vendor probe **skips**. Its skip text mentions credentials, so an unset switch looks like missing credentials — set it to `1` to actually run the gate. |
+| `PARROT_LIVE_BROADCAST_GATE` | live gate only | The live vendor probe **skips**. Set it to `1` to run it; credentials are read from `env/.env` via navconfig, so no manual exports are needed. The skip message now names the specific missing precondition. |
 | `VOICEBOT_DEMO_PARTICIPANTS` | example only | No demo auth; supply real authentication. |
 | `VOICEBOT_BROADCAST_FAILURE_HOOK` | example only | Injection route absent (the default). |
 
@@ -311,8 +311,10 @@ pytest packages/ai-parrot-server/tests/handlers/test_voice_broadcast.py -q
 pytest packages/ai-parrot-integrations/tests/voice/test_voice_demo_broadcast_browser.py -q
 
 # Real-vendor gate — requires credentials and a human observer. Skips otherwise.
-export PARROT_LIVE_BROADCAST_GATE=1
-pytest packages/ai-parrot-integrations/tests/voice/test_voice_broadcast_live_gate.py -q -s
+# Credentials come from env/.env via navconfig; the only thing you set is the switch.
+# On a capped LiveAvatar account, add PARROT_LIVEAVATAR_MAX_SESSION_DURATION_S=60.
+PARROT_LIVE_BROADCAST_GATE=1 \
+  pytest packages/ai-parrot-integrations/tests/voice/test_voice_broadcast_live_gate.py -q -s
 ```
 
 ### Evidence locations

--- a/packages/ai-parrot-integrations/tests/voice/test_voice_broadcast_live_gate.py
+++ b/packages/ai-parrot-integrations/tests/voice/test_voice_broadcast_live_gate.py
@@ -55,6 +55,20 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
 
+# Load the project's configuration layer BEFORE reading os.environ below.
+#
+# The gate's enablement is decided at import time, but credentials live in
+# `env/.env`, which only reaches os.environ when navconfig is imported. Nothing
+# in this module's own import graph pulls navconfig in, so running
+# `PARROT_LIVE_BROADCAST_GATE=1 pytest <this file>` on a machine that HAS
+# credentials still skipped — and the skip text blames "credentials missing",
+# which makes the wrong diagnosis look confirmed. Requiring the caller to
+# hand-export the five variables was a workaround for this, not a fix.
+try:  # pragma: no cover — configuration bootstrap, not logic under test
+    import navconfig  # noqa: F401
+except ImportError:  # navconfig absent: fall back to a bare os.environ read
+    pass
+
 # Every test in this module is a live-vendor probe.
 pytestmark = pytest.mark.live_vendor
 
@@ -72,11 +86,30 @@ _GATE_ENABLED: bool = os.environ.get("PARROT_LIVE_BROADCAST_GATE") == "1" and al
     os.environ.get(name) for name in _REQUIRED_ENV
 )
 
-_SKIP_REASON: str = (
-    "live vendor gate not enabled / credentials missing — NOT VERIFIED "
-    "(set PARROT_LIVE_BROADCAST_GATE=1 plus "
-    f"{', '.join(_REQUIRED_ENV)})"
-)
+
+def _skip_reason() -> str:
+    """Say which precondition is actually unmet.
+
+    A single "not enabled / credentials missing" string cannot distinguish the
+    switch being off from a credential being absent, and reading as though it
+    were the latter sent this feature's own acceptance report down the wrong
+    path for days. Name the specific missing pieces instead.
+
+    Returns:
+        A precise, actionable skip reason.
+    """
+    missing = [name for name in _REQUIRED_ENV if not os.environ.get(name)]
+    if os.environ.get("PARROT_LIVE_BROADCAST_GATE") != "1":
+        return "live vendor gate is OFF — NOT VERIFIED. Set " "PARROT_LIVE_BROADCAST_GATE=1 to run it" + (
+            f" (also missing: {', '.join(missing)})" if missing else " (all five credentials were found)"
+        )
+    return (
+        "live vendor gate is ON but credentials are missing — NOT VERIFIED. "
+        f"Absent from the environment: {', '.join(missing)}"
+    )
+
+
+_SKIP_REASON: str = _skip_reason()
 
 # ── Probe constants ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## The report

> `PARROT_LIVE_BROADCAST_GATE=1 pytest .../test_voice_broadcast_live_gate.py` says
> "no credentials" but the credentials are there in `env/.env`.

Correct, and it is a defect in the gate — not a usage error.

## Cause

The gate decides enablement **at module import time** from `os.environ`, but `env/.env`
only reaches `os.environ` when **navconfig** is imported, and nothing in this module's
import graph pulls navconfig in. So the probe was unrunnable by its own documented command
on exactly the machines that are able to run it.

`examples/clients/voice/server.py` works because it imports the `parrot` stack (and hence
navconfig) before anything reads configuration.

## Fix

1. **Import navconfig before evaluating the precondition** — the way the rest of the
   project reads configuration. The documented "export the five variables yourself" step
   was a workaround for this defect that had been written into the docs as if it were the
   procedure; it is removed.

2. **Make the skip message name what is actually missing.** The old single string could
   not distinguish "switch is off" from "credential absent", and always read as the
   latter. That is precisely what sent this feature's own acceptance report down the wrong
   path — 12 scenarios recorded as blocked on missing credentials that were present the
   whole time. It now reports one of:

   ```
   live vendor gate is OFF — NOT VERIFIED. Set PARROT_LIVE_BROADCAST_GATE=1 to run it
     (all five credentials were found)
   live vendor gate is ON but credentials are missing — NOT VERIFIED.
     Absent from the environment: LIVEKIT_API_SECRET
   ```

## Verified

- With **only** `PARROT_LIVE_BROADCAST_GATE=1` and no exports: **3 passed** against real
  LiveAvatar + LiveKit.
- With the switch unset: still **3 skipped**, cleanly — CI unchanged.
- voice **543**, liveavatar **202**, e2e **15**.

Both skip branches were exercised directly, including one with a credential removed after
navconfig load.