### PR TITLE
fix(voice-demo): show the avatar card in broadcast mode (+ open finding: avatar video never subscribed)

### DIFF
--- a/examples/clients/voice/static/dual_provider.html
+++ b/examples/clients/voice/static/dual_provider.html
@@ -1856,6 +1856,7 @@
                 }
                 const bc = await this.loadBroadcastModule();
                 this.broadcastMode = true;
+                this.updateAvatarCardVisibility();
                 this.broadcastClient = new bc.BroadcastClient({
                     config: cfg,
                     getToken: () => this.demoToken,
@@ -2001,6 +2002,7 @@
                 await this.broadcastAction(() => this.broadcastClient.leave());
                 if (this.avatarController) await this.avatarController.teardown();
                 this.broadcastMode = false;
+                this.updateAvatarCardVisibility();
                 this.broadcastClient = null;
                 this.updateTalkAvailability();
                 this.updateStatusBar('Left the broadcast.');
@@ -2393,7 +2395,15 @@
             }
 
             updateAvatarCardVisibility() {
-                if (this.avatarCard) this.avatarCard.hidden = !this.avatarConfig.enabled;
+                // Broadcast mode always shows the card: the avatar belongs to the
+                // broadcast producer, not to this page's single-user "Enable
+                // avatar" checkbox. Keying visibility solely off avatarConfig
+                // .enabled meant a broadcast participant never saw the avatar
+                // video at all — the element stayed inside a hidden container,
+                // so there was nothing to observe and lip-sync could not be
+                // judged, even though the track was being published.
+                const show = this.avatarConfig.enabled || this.broadcastMode;
+                if (this.avatarCard) this.avatarCard.hidden = !show;
             }
 
             onAvatarSettingChanged() {


### PR DESCRIPTION
Found by driving a **real browser against real LiveKit + LiveAvatar** — the first time
anything had done that. The existing Playwright suites fake the vendor boundary, and the
live gate uses headless Python subscribers, so neither could see this.

## Fixed here: a broadcast participant never saw the avatar

`#avatarVideo` lives inside `#avatarCard`, revealed only when `avatarConfig.enabled` is
true — a flag owned by the **single-user** "Enable avatar" checkbox. In broadcast mode the
avatar belongs to the producer, nothing sets that flag, so the card stayed `hidden` and
the video element was never rendered (`offsetParent === null`).

Visibility now also considers `broadcastMode`, re-evaluated on enter/leave. Single-user
behaviour unchanged.

Verified in a real browser:

| | before entering | after entering |
|---|---|---|
| `avatarCard.hidden` | `true` | **`false`** |
| video element visible | — | **yes** |

Browser suites: **23 passed**.

## ⚠️ Still open (not fixed here): the avatar video track is never subscribed

With the card now visible the picture will **still be blank**, because the browser never
subscribes the avatar's video publication:

```
avatar-bc-xxxxx
  audio 'avatar-audio'  subscribed=True   hasTrack=True     ← attaches, plays
  video 'avatar'        subscribed=False  hasTrack=False    ← never subscribed
```

Established while diagnosing:

- The vendor **does** publish video — the live gate records **195 H264 frames** reaching a
  Python subscriber in the same room.
- Not a token problem: viewer grants are `canSubscribe: true`, no per-kind restriction.
- Not `adaptiveStream` (`false`) and not autoSubscribe (default `true`).
- Forcing `publication.setSubscribed(true)` from the console did not attach it either.

I stopped here rather than keep going, because the remaining work is real WebRTC
debugging and I did not want to fold a speculative change into a fix that is proven. This
is the last thing standing between the demo and the AC1/AC10 human-observer check — audio
is audible today, video is not.