### PR TITLE
fix(voicebot-multiroom): a departed participant must not strand its seat

### DIFF
--- a/packages/ai-parrot-integrations/src/parrot/integrations/liveavatar/broadcast/service.py
+++ b/packages/ai-parrot-integrations/src/parrot/integrations/liveavatar/broadcast/service.py
@@ -163,6 +163,29 @@ def default_principal_resolver(user: Any, agent_id: str, *, tenant_id: str = "de
     )
 
 
+def _is_not_found(exc: BaseException) -> bool:
+    """Whether a LiveKit error means "the thing is not there".
+
+    Covers both a room that does not exist yet and a participant that has
+    already left. Both are *expected* states, not outages, and conflating them
+    with an unreachable LiveKit has opposite consequences: an outage must fail
+    closed and retain the seat, whereas an already-departed participant must
+    let the seat be released.
+
+    Args:
+        exc: The exception raised by a room-manager call.
+
+    Returns:
+        ``True`` for a not-found/404 response.
+    """
+    code = getattr(exc, "code", None)
+    if code is not None and str(code).lower().endswith("not_found"):
+        return True
+    if getattr(exc, "status", None) == 404:
+        return True
+    return "does not exist" in str(exc).lower()
+
+
 def _is_room_not_found(exc: BaseException) -> bool:
     """Whether a LiveKit error means "this room does not exist (yet)".
 
@@ -1303,15 +1326,28 @@ class BroadcastService:
             try:
                 await self.room_manager.remove_participant(room, lease.livekit_identity)
                 report.removed_participants.append((room, lease.livekit_identity))
-            except Exception:  # noqa: BLE001 — retain the seat, retry next pass
-                report.uncertain.append(broadcast_id)
-                self.logger.warning(
-                    "broadcast %s: could not remove %s — retaining its seat",
-                    broadcast_id,
-                    lease_id,
-                    exc_info=True,
-                )
-                return
+            except Exception as exc:  # noqa: BLE001
+                if _is_not_found(exc):
+                    # Already gone — which is the outcome we wanted. Treating
+                    # `404 participant does not exist` as an outage retained
+                    # the seat forever: the participant can never come back to
+                    # be removed, so no later pass could ever release it, and
+                    # the broadcast leaked a seat out of its ten every time
+                    # somebody disconnected before the reconciler noticed.
+                    self.logger.debug(
+                        "broadcast %s: %s already left the room — releasing its seat",
+                        broadcast_id,
+                        lease_id,
+                    )
+                else:
+                    report.uncertain.append(broadcast_id)
+                    self.logger.warning(
+                        "broadcast %s: could not remove %s — retaining its seat",
+                        broadcast_id,
+                        lease_id,
+                        exc_info=True,
+                    )
+                    return
 
         outcome = await self.registry.release_viewer(tenant_id, broadcast_id, lease_id)
         report.released_leases.append(lease_id)

--- a/packages/ai-parrot-integrations/tests/voice/test_voice_broadcast_service.py
+++ b/packages/ai-parrot-integrations/tests/voice/test_voice_broadcast_service.py
@@ -25,6 +25,7 @@ from parrot.integrations.liveavatar.broadcast import (
 from parrot.integrations.liveavatar.broadcast.service import (
     BroadcastNotReady,
     BroadcastService,
+    ReconcileReport,
     default_principal_resolver,
 )
 
@@ -891,3 +892,71 @@ async def test_producer_configures_the_bots_llm_before_building_the_session(
 
     assert built == ["resolve", "create"], "the bot's client must be built exactly once"
     assert bot._llm is not None
+
+
+# ── Eviction vs a participant that already left (live-run regression) ──────
+
+
+class _GoneError(Exception):
+    """LiveKit's `404 participant does not exist`."""
+
+    code = "not_found"
+    status = 404
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return "participant does not exist"
+
+
+async def test_eviction_releases_the_seat_when_the_participant_already_left(
+    service: BroadcastService, room_manager: FakeRoomManager, clock: FakeClock
+) -> None:
+    """`404 participant does not exist` is the outcome we wanted, not an outage.
+
+    Reported from real use: disconnecting and re-joining raised
+    `ServerError(code=not_found, message=participant does not exist, 404)` and
+    the reconciler logged "retaining its seat". Because that participant can
+    never come back to be removed, no later pass could release it either — the
+    broadcast leaked one of its ten seats on every such disconnect.
+    """
+    descriptor, broadcast_id = await _create(service)
+    principal = await _principal(service, "creator")
+    admission = await service.join(principal, AGENT, broadcast_id)
+    lease_id = admission.lease.lease_id
+
+    async def _gone(room: str, identity: str) -> None:
+        raise _GoneError()
+
+    room_manager.remove_participant = _gone  # type: ignore[assignment]
+
+    report = ReconcileReport()
+    await service._evict_expired_lease(  # noqa: SLF001
+        TENANT, broadcast_id, lease_id, report
+    )
+
+    leases = await service.registry.list_leases(TENANT, broadcast_id)
+    assert all(lease.lease_id != lease_id for lease in leases), "the seat must be freed"
+    assert broadcast_id not in report.uncertain
+
+
+async def test_eviction_retains_the_seat_when_livekit_is_unreachable(
+    service: BroadcastService, room_manager: FakeRoomManager
+) -> None:
+    """A genuine outage must still fail closed (spec §7)."""
+    descriptor, broadcast_id = await _create(service)
+    principal = await _principal(service, "creator")
+    admission = await service.join(principal, AGENT, broadcast_id)
+    lease_id = admission.lease.lease_id
+
+    async def _down(room: str, identity: str) -> None:
+        raise ConnectionError("livekit unreachable")
+
+    room_manager.remove_participant = _down  # type: ignore[assignment]
+
+    report = ReconcileReport()
+    await service._evict_expired_lease(  # noqa: SLF001
+        TENANT, broadcast_id, lease_id, report
+    )
+
+    leases = await service.registry.list_leases(TENANT, broadcast_id)
+    assert any(lease.lease_id == lease_id for lease in leases), "seat must be retained"
+    assert broadcast_id in report.uncertain


### PR DESCRIPTION
## Reported from real use

Disconnect, then re-add a participant:

```
ServerError(code=not_found, message=participant does not exist, status=404)
broadcast bc-0a8025f5…: could not remove lease-3ba94e3f… — retaining its seat
```

**Retaining is the wrong reaction.** A `404` means the participant has *already left* —
which is exactly what the removal was trying to achieve. Worse, it can never come back to
be removed, so no later reconciler pass could release the seat either: every disconnect
that beat the reconciler **permanently leaked one of the broadcast's ten seats**.

## Fix

Not-found is now distinguished from an outage:

| Situation | Before | After |
|---|---|---|
| `404 participant does not exist` | seat retained **forever** | seat released |
| LiveKit unreachable | seat retained | seat retained (unchanged, spec §7) |

The same distinction already existed for `room does not exist`; the predicate is
generalised rather than duplicated.

## Tests

Both branches pinned:

- `test_eviction_releases_the_seat_when_the_participant_already_left`
- `test_eviction_retains_the_seat_when_livekit_is_unreachable`

The release path was **verified to fail against the unpatched code** before committing.
Suites: voice **545**, e2e **15**, liveavatar **202**.

## Note on the FFI warnings in the same log

`Attempted to drop unknown FFI handle: 16/17` came after `^C` — that is the livekit Rust
FFI unwinding on interrupt, not a leak in this path.