### PR TITLE
fix(wiki): escape ~ in ArangoDB document keys

### DIFF
--- a/packages/ai-parrot/src/parrot/knowledge/wiki/arango_store.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/arango_store.py
@@ -94,7 +94,14 @@ def document_key(identity: str) -> str:
     Returns:
         A string usable directly as an ArangoDB ``_key``.
     """
-    safe = quote(identity, safe=_KEY_SAFE)
+    # ``quote`` never escapes ``~``: it is unreserved in RFC 3986, so it
+    # sits in urllib's own always-safe set and no ``safe`` argument can
+    # take it out. ArangoDB rejects it, and sym_concept_id() puts one in
+    # every repeated-qualname id ("sym:app.py#Foo.handle~2"), so escape it
+    # by hand. Doing it after quote() is unambiguous: a literal ``%`` in
+    # the identity has already become ``%25``, so every ``%`` left is one
+    # this encoding wrote.
+    safe = quote(identity, safe=_KEY_SAFE).replace("~", "%7E")
     if len(safe.encode("utf-8")) <= _KEY_MAX_BYTES:
         return safe
     digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:16]

--- a/packages/ai-parrot/tests/knowledge/wiki/test_arango_document_key.py
+++ b/packages/ai-parrot/tests/knowledge/wiki/test_arango_document_key.py
@@ -1,0 +1,103 @@
+"""Key-encoding contract for the ArangoDB wiki store.
+
+Regression cover for the ``~`` leak: :func:`urllib.parse.quote` treats ``~``
+as unreserved (RFC 3986), so it sits in urllib's own always-safe set and no
+``safe`` argument can take it out. ArangoDB rejects it in a ``_key`` with
+``[ERR 1221] illegal document key``, and :func:`sym_concept_id` puts one in
+every repeated-qualname symbol id — so a repo with two same-named qualnames
+in one file aborted its whole ingest.
+"""
+
+import string
+
+from urllib.parse import unquote
+
+import pytest
+
+from parrot.knowledge.wiki.arango_store import (
+    _KEY_MAX_BYTES,
+    document_key,
+    edge_key,
+)
+from parrot.knowledge.wiki.symbols import sym_concept_id
+
+
+#: Every character ArangoDB accepts in a ``_key``. Percent is legal, which is
+#: what makes percent-encoding a valid encoding here in the first place.
+LEGAL_KEY_CHARS = frozenset(string.ascii_letters + string.digits + "_-:.@()+,=;$!*'%")
+
+
+def illegal_chars(key: str) -> set[str]:
+    """Return the characters in ``key`` ArangoDB would reject."""
+    return set(key) - LEGAL_KEY_CHARS
+
+
+def test_repeated_qualname_symbol_id_has_no_tilde():
+    """The regression: ordinal-suffixed symbol ids must not leak ``~``."""
+    concept_id = sym_concept_id("app.py", "Foo.handle", 2)
+    assert "~" in concept_id, "sym_concept_id no longer uses ~; update this test"
+
+    key = document_key(concept_id)
+
+    assert "~" not in key
+    assert not illegal_chars(key)
+
+
+@pytest.mark.parametrize(
+    "identity",
+    [
+        "file:src/main.py",
+        "dir:packages/ai-parrot",
+        "sym:app.py#Foo.handle",
+        "sym:app.py#Foo.handle~2",
+        "sym:x.py#f~10",
+        "file:a~b/c%d.py",
+        "file:ñandú/áéíóú.py",
+        "file:with space/and+plus.py",
+    ],
+)
+def test_key_uses_only_legal_characters(identity):
+    """No identity shape may produce a character ArangoDB rejects."""
+    assert not illegal_chars(document_key(identity))
+
+
+@pytest.mark.parametrize(
+    "identity",
+    [
+        "file:src/main.py",
+        "sym:app.py#Foo.handle~2",
+        "file:a~b/c%d.py",
+        "file:ñandú/áéíóú.py",
+    ],
+)
+def test_short_keys_round_trip(identity):
+    """Encoding is reversible while the key fits the byte budget."""
+    key = document_key(identity)
+    assert len(key.encode("utf-8")) <= _KEY_MAX_BYTES
+    assert unquote(key) == identity
+
+
+def test_long_identity_is_truncated_within_the_byte_budget():
+    """A path too long to encode keeps a digest and stays under the limit."""
+    identity = "file:" + "muy/largo/" * 40 + "z.py"
+
+    key = document_key(identity)
+
+    assert len(key.encode("utf-8")) <= _KEY_MAX_BYTES
+    assert not illegal_chars(key)
+    assert "$" in key, "truncated keys carry a $<digest> suffix"
+
+
+def test_long_identities_stay_unique_after_truncation():
+    """Two paths sharing a long prefix must not collide."""
+    prefix = "file:" + "muy/largo/" * 40
+    assert document_key(prefix + "a.py") != document_key(prefix + "b.py")
+
+
+def test_edge_key_inherits_the_same_contract():
+    """Edge keys concatenate two identities and must stay legal too."""
+    key = edge_key("file:a~b.py", "sym:c.py#d~2", "references")
+
+    assert "~" not in key
+    assert not illegal_chars(key)
+    assert len(key.encode("utf-8")) <= _KEY_MAX_BYTES


### PR DESCRIPTION
## Problem

`document_key()` percent-encodes wiki identities so they are legal as an ArangoDB `_key`. But `urllib.parse.quote` **never escapes `~`** — it is unreserved in RFC 3986, so it sits in urllib's own `_ALWAYS_SAFE` set and no `safe=` argument can take it out.

ArangoDB rejects `~` in a `_key` with `[ERR 1221] illegal document key`. The module's own comment on `_KEY_DIGEST_SEP` already said so:

```python
#: Separator between a truncated key and its disambiguating digest. Must
#: itself be a legal ``_key`` character and rare in real paths — ``~`` is
#: NOT legal, ``$`` is.
```

`sym_concept_id()` puts a `~` in every repeated-qualname symbol id (`sym:app.py#Foo.handle~2`), which is routine in any large Python codebase — two methods with the same qualname in one file is enough.

## Impact observed

Ingest aborted mid-write on two large Python repositories. Worse than a clean failure: the run had already recorded its sources as synced, so **every later incremental sync skipped them**. The graph looked healthy while its symbol plane was ~97% empty — 421 symbols where a forced re-ingest produced 17,899, and 1,903 where it produced 67,577. Only `--force` recovers it.

## Fix

One line: escape `~` after `quote()`.

Doing it after rather than before is unambiguous — a literal `%` in the identity has already become `%25`, so every `%` left is one this encoding wrote, and `unquote()` still round-trips.

## Tests

New `test_arango_document_key.py` pins the regression and the wider key contract: legal charset across identity shapes (including non-ASCII), round-trip, truncation byte budget, collision resistance after truncation, and the same contract on `edge_key`.

**Mutation-verified**: reverting the one-line change turns 5 of the 16 assertions red.

```
$ pytest packages/ai-parrot/tests/knowledge/wiki/test_arango_document_key.py -q
16 passed
```

Developed with Spec Driven Development