### PR TITLE
feat(tool-optimizations): FEAT-543 — Claude Code and Codex tool optimizations

### DIFF
--- a/.agents/skills/sdd-spec/SKILL.md
+++ b/.agents/skills/sdd-spec/SKILL.md
@@ -24,9 +24,18 @@ feature or hotfix.
 - Never re-ask brainstorm questions marked `[x]`; carry answers forward
   verbatim and route them into the correct spec sections.
 - Build a verified Codebase Contract with file paths and line numbers.
+- Identify delegation-eligible modules (see the workflow note below).
 - Commit only the spec file.
 
 ## Workflow
+
+#### Identify delegation-eligible modules
+
+While writing §3 Module Breakdown, fill the "Delegation-eligible modules"
+sub-table: for each module state whether its design is complete enough that
+implementing it is mechanical, and record the decided patterns and exact
+contracts (signatures, error codes, file layout). Architecture decisions
+stay with the thinking model — eligibility never delegates a design choice.
 
 1. Parse:
    - feature slug

--- a/.agents/skills/sdd-start/SKILL.md
+++ b/.agents/skills/sdd-start/SKILL.md
@@ -64,6 +64,30 @@ validate it, and close it in the same branch/worktree.
    - edit/create only task-scoped files
    - use specified classes, methods, signatures, and patterns
    - follow repo instructions in `AGENTS.md` and `.agent/CONTEXT.md`
+
+#### Delegated implementation (only when the task has `## Delegation Contract`)
+
+Use this branch ONLY when the task file contains a `## Delegation Contract`
+section AND the `parrot-targeted-writer` MCP server is available. Otherwise
+implement the task yourself — the normal route is the default.
+
+1. Call MCP tool `writer_generate` (server `parrot-targeted-writer`) with `task_path`.
+2. On `status: error` with a contract code (`stale_target`, `missing_block`,
+   `placeholder_code`, `underspecified_create`, …): fix the packet in the task file
+   (refresh hashes with `sha256sum`, complete the design) and retry once, or implement
+   the task yourself. The workflow **never silently invokes another coder** — no other
+   coding tool is substituted when delegation fails.
+3. On `ok`: read `data.patch_path` with `source_read` in ranges of at most 350 lines and
+   review EVERY hunk against the task's Codebase Contract. Never apply a patch you have
+   not fully read. If a hunk is wrong, do not apply: fix the packet/blocks and regenerate
+   at most once more, else implement normally.
+4. Call `writer_apply` with `artifact_id` and `reviewed_sha256 = data.patch_sha256`
+   (verify it equals `sha256sum artifacts/tool-optimizations/<id>/patch.diff`).
+5. Run the task's acceptance tests yourself. The writer never runs tests; a model's claim
+   that tests passed is not execution evidence.
+6. Continue with the normal validate → commit → SDD state steps. SDD files
+   (`sdd/tasks/index/*.json`, task files) are never edited by the writer.
+
 9. Validate:
    - run task-specified tests
    - run task-specified lint/format checks

--- a/.agents/skills/sdd-task/SKILL.md
+++ b/.agents/skills/sdd-task/SKILL.md
@@ -61,6 +61,27 @@ them to the spec's base branch before creating a worktree.
    - re-read each referenced file to verify freshness
    - add task-specific references for touched files
    - include "Does NOT Exist" entries
+
+#### Delegation Contract (optional, per task)
+
+Emit a `## Delegation Contract` packet ONLY for a task whose design is
+complete. `design_complete: true` is a declaration the task author signs.
+
+- List every target file with its `action` (`create`/`modify`), and give each
+  `modify` target a REAL `expected_sha256` — compute it, never guess:
+  `sha256sum <path>` or
+  `python -c "import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" <path>`.
+- Every `create` target needs a block tagged `path=<target>` holding the new
+  file's full content; every referenced block id must exist in the task file.
+- Never leave placeholders (`...`, `TODO`, `FIXME`, `XXX`, `<angle>`,
+  `raise NotImplementedError`) in an implementation block — the validator
+  rejects them and the packet is not delegated.
+- Hashes are re-validated at execution time, after dependencies land. If they
+  are stale then, the executor refreshes the packet in the task file FIRST and
+  only then re-runs `writer_generate`.
+- Omit the section entirely when the task is not eligible. Most tasks are not,
+  and that is the normal, expected route.
+
 7. Reserve task IDs:
    - For `type: feature`, run:
      `python -m scripts.sdd.reserve_ids --kind task --count <N> --base-branch <base_branch> --label <feature-slug>`.

--- a/.claude/agents/sdd-worker.md
+++ b/.claude/agents/sdd-worker.md
@@ -226,6 +226,30 @@ Before writing ANY code, verify the task's `## Codebase Contract` section:
 - **NEVER guess an import, attribute, or method. If it's not in the contract
   and you're unsure, verify with `grep` or `read` before using it.**
 
+### b2) Delegated implementation (ONLY when a Delegation Contract exists)
+
+Skip this entire step unless the task file contains a `## Delegation Contract`
+section AND the `parrot-targeted-writer` MCP server is available. A task
+without one takes the normal route in step (c) — that is the default, not a
+failure.
+
+1. Call MCP tool `writer_generate` (server `parrot-targeted-writer`) with `task_path`.
+2. On `status: error` with a contract code (`stale_target`, `missing_block`,
+   `placeholder_code`, `underspecified_create`, …): fix the packet in the task file
+   (refresh hashes with `sha256sum`, complete the design) and retry once, or implement
+   the task yourself in step (c). **Never silently invokes another coder** — no other
+   coding tool is substituted when delegation fails.
+3. On `ok`: read `data.patch_path` with `source_read` in ranges of at most 350 lines and
+   review EVERY hunk against the task's Codebase Contract. Never apply a patch you have
+   not fully read. If a hunk is wrong, do not apply: fix the packet/blocks and regenerate
+   at most once more, else implement normally.
+4. Call `writer_apply` with `artifact_id` and `reviewed_sha256 = data.patch_sha256`
+   (verify it equals `sha256sum artifacts/tool-optimizations/<id>/patch.diff`).
+5. Run the task's acceptance tests yourself in step (e). The writer never runs tests, and
+   a model's claim that tests passed is not execution evidence.
+6. SDD state is never delegated: the index and task files are edited only by you,
+   in step (g).
+
 ### c) Implement — EXACTLY as specified (in worktree)
 - Create/modify ONLY the files listed in the task.
 - Use ONLY the class names, method signatures, and patterns specified.
@@ -240,6 +264,7 @@ VERIFICATION CHECKLIST for TASK-<NNN>:
 □ No files were created that are NOT listed in the task?
 □ Class/interface names match the task specification?
 □ No unrelated changes were made?
+□ Delegated patch hunks were all reviewed before writer_apply?
 ```
 If ANY check fails, fix or STOP.
 

--- a/.claude/commands/sdd-spec.md
+++ b/.claude/commands/sdd-spec.md
@@ -2,6 +2,7 @@
 
 Scaffold a new Feature Specification using the SDD methodology.
 
+
 ## Usage
 ```
 /sdd-spec <feature-name> [--type feature|hotfix] [--base-branch <branch>] [-- free-form description and notes]
@@ -250,6 +251,14 @@ This step prevents AI hallucinations during implementation. You MUST:
    implementing agents what NOT to reference.
 5. **Include user-provided code**: if the user or brainstorm provided code snippets,
    preserve them as verified references in the contract.
+
+#### Identify delegation-eligible modules
+
+While writing §3 Module Breakdown, fill the "Delegation-eligible modules"
+sub-table: for each module state whether its design is complete enough that
+implementing it is mechanical, and record the decided patterns and exact
+contracts (signatures, error codes, file layout). Architecture decisions
+stay with the thinking model — eligibility never delegates a design choice.
 
 ### 5. Scaffold the Spec
 1. Read the template at `sdd/templates/spec.md`. The template already contains

--- a/.claude/commands/sdd-start.md
+++ b/.claude/commands/sdd-start.md
@@ -166,6 +166,30 @@ Follow the **Agent Instructions** section in the task file:
 
 Otherwise, keep going until the task is **done**.
 
+
+#### Delegated implementation (only when the task has `## Delegation Contract`)
+
+Use this branch ONLY when the task file contains a `## Delegation Contract`
+section AND the `parrot-targeted-writer` MCP server is available. Otherwise
+implement the task yourself — the normal route is the default.
+
+1. Call MCP tool `writer_generate` (server `parrot-targeted-writer`) with `task_path`.
+2. On `status: error` with a contract code (`stale_target`, `missing_block`,
+   `placeholder_code`, `underspecified_create`, …): fix the packet in the task file
+   (refresh hashes with `sha256sum`, complete the design) and retry once, or implement
+   the task yourself. The workflow **never silently invokes another coder** — no other
+   coding tool is substituted when delegation fails.
+3. On `ok`: read `data.patch_path` with `source_read` in ranges of at most 350 lines and
+   review EVERY hunk against the task's Codebase Contract. Never apply a patch you have
+   not fully read. If a hunk is wrong, do not apply: fix the packet/blocks and regenerate
+   at most once more, else implement normally.
+4. Call `writer_apply` with `artifact_id` and `reviewed_sha256 = data.patch_sha256`
+   (verify it equals `sha256sum artifacts/tool-optimizations/<id>/patch.diff`).
+5. Run the task's acceptance tests yourself. The writer never runs tests; a model's claim
+   that tests passed is not execution evidence.
+6. Continue with the normal validate → commit → SDD state steps. SDD files
+   (`sdd/tasks/index/*.json`, task files) are never edited by the writer.
+
 ### 8. Mark Done (in place)
 
 After the code is committed, update the per-spec index in the same branch

--- a/.claude/commands/sdd-task.md
+++ b/.claude/commands/sdd-task.md
@@ -2,6 +2,7 @@
 
 Decompose an approved Feature Specification into atomic, assignable implementation tasks.
 
+
 ## Usage
 ```
 /sdd-task sdd/specs/<feature-name>.spec.md
@@ -223,6 +224,26 @@ mkdir -p "$(dirname "$INDEX")"
   **`null` for a hotfix** (FEAT-466 — no id reserved); use `jira_issue_key`
   as the identity instead.
 - `feature`: Kebab-case slug (e.g., `"videoreel-visual-changes"`).
+
+#### Delegation Contract (optional, per task)
+
+Emit a `## Delegation Contract` packet ONLY for a task whose design is
+complete. `design_complete: true` is a declaration the task author signs.
+
+- List every target file with its `action` (`create`/`modify`), and give each
+  `modify` target a REAL `expected_sha256` — compute it, never guess:
+  `sha256sum <path>` or
+  `python -c "import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" <path>`.
+- Every `create` target needs a block tagged `path=<target>` holding the new
+  file's full content; every referenced block id must exist in the task file.
+- Never leave placeholders (`...`, `TODO`, `FIXME`, `XXX`, `<angle>`,
+  `raise NotImplementedError`) in an implementation block — the validator
+  rejects them and the packet is not delegated.
+- Hashes are re-validated at execution time, after dependencies land. If they
+  are stale then, the executor refreshes the packet in the task file FIRST and
+  only then re-runs `writer_generate`.
+- Omit the section entirely when the task is not eligible. Most tasks are not,
+  and that is the normal, expected route.
 
 ### 5. Commit Tasks and Per-Spec Index to `<BASE>`
 

--- a/benchmarks/tool_optimizations/README.md
+++ b/benchmarks/tool_optimizations/README.md
@@ -1,0 +1,65 @@
+# Tool optimizations benchmark (FEAT-543)
+
+Measures the three optimized workflows against the baseline a coding host
+would otherwise use, reporting **primary tokens, delegate tokens, total
+tokens, latency and correctness separately**.
+
+## Run it
+
+```bash
+source .venv/bin/activate
+python -m benchmarks.tool_optimizations --scenario all --runs 1
+```
+
+Offline by default: the delegate is a scripted fake, so the run is free and
+deterministic. Reports land in `artifacts/tool-optimizations/benchmarks/`
+as a JSON/Markdown pair (`artifacts/` is gitignored — copy a report
+elsewhere if you need to share it).
+
+A live comparison against the configured provider costs money and requires
+at least five runs per scenario:
+
+```bash
+python -m benchmarks.tool_optimizations --scenario all --runs 5 --live
+```
+
+## Scenarios
+
+| Name | Baseline | Optimized |
+|---|---|---|
+| `git_prepare` | The three shell commands from the spec's user-provided code | `git_fetch` + `git_preflight` + `git_prepare_files` |
+| `targeted_read` | Whole-file `Read` of a 2,000-line module | `source_info` + one bounded `source_read` |
+| `decided_task` | Primary model writes both files itself | `writer_generate` → bounded review → `writer_apply` → `pytest` |
+
+## What the exit code means
+
+Non-zero means an **optimized scenario failed its real acceptance test**.
+Correctness parity is the only pass/fail criterion; token and latency
+figures are informational.
+
+## What is measured, and what is not claimed
+
+- Baseline token counts are **estimates** (`estimate:chars_div_4`) — a
+  host's real tokenizer will differ. They are labelled as estimates in
+  every report.
+- Delegate token counts come from provider usage. A missing count is
+  reported as `null`, never as `0`: unknown is not zero.
+- Cost is `unknown` until you fill in `prices.yaml` with sourced prices
+  (each row records its provenance and `as_of` date).
+- **No savings percentage is claimed anywhere.** Numeric token/cost/latency
+  targets are an owner decision (spec §8). The harness reports what it
+  measured.
+
+## Reading the results honestly
+
+Fewer primary tokens is not fewer total tokens. Planning, review and repair
+are accounted as their own stages precisely so that work moved out of the
+primary model does not disappear from the total.
+
+The offline numbers are also shaped by the fixtures: the `git_prepare`
+baseline runs against a two-file temporary repository, where terse git
+stdout is genuinely smaller than the structured JSON results. On a real
+repository — where `git status` output is long and a failed step has to be
+diagnosed from raw text — that comparison changes. Draw conclusions from
+`--live` runs on representative repositories, not from the offline smoke
+run.

--- a/benchmarks/tool_optimizations/__init__.py
+++ b/benchmarks/tool_optimizations/__init__.py
@@ -1,0 +1,13 @@
+"""Reproducible benchmarks for the FEAT-543 tool optimizations.
+
+The harness measures primary-model tokens, delegate tokens, latency and
+correctness **separately**, and claims no savings percentage: fewer primary
+tokens is not the same as fewer total tokens, and this package exists to
+keep those two numbers visibly distinct.
+
+Run offline (the default, free) with::
+
+    python -m benchmarks.tool_optimizations --scenario all --runs 1
+"""
+
+__all__ = ()

--- a/benchmarks/tool_optimizations/__main__.py
+++ b/benchmarks/tool_optimizations/__main__.py
@@ -1,0 +1,121 @@
+"""CLI entry point for the FEAT-543 benchmark harness.
+
+Offline by default and free. ``--live`` is the only path that spends money
+and it requires at least five runs per scenario, per the spec's measurement
+protocol.
+
+Exit code is driven by **correctness only**: an optimized scenario whose
+acceptance test fails exits non-zero. Token and latency figures are
+informational — this harness reports numbers, it does not claim savings.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+from typing import Optional
+
+from .accounting import CostModel
+from .runner import MIN_LIVE_RUNS, RunReport, run, summarize, write_reports
+from .scenarios import SCENARIOS
+
+DEFAULT_OUT = Path("artifacts") / "tool-optimizations" / "benchmarks"
+
+
+def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    """Parse the harness command line."""
+    parser = argparse.ArgumentParser(prog="benchmarks.tool_optimizations", description=__doc__)
+    parser.add_argument("--scenario", default="all", help="Scenario name, or 'all'.")
+    parser.add_argument("--runs", type=int, default=5, help="Repetitions per scenario and mode.")
+    parser.add_argument("--live", action="store_true", help="Use a real provider (spends money).")
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT, help="Report output directory.")
+    parser.add_argument("--stamp", default=None, help="Report file stem (defaults to a UTC timestamp).")
+    return parser.parse_args(argv)
+
+
+def _live_client_factory():
+    """Build a real client from the shipped example configuration."""
+    from parrot.clients.factory import LLMFactory
+    from parrot.mcp.toolkit_config import load_toolkits_config
+
+    example = Path("examples") / "tool-optimizations-mcp.yaml"
+    config = load_toolkits_config(example.parent, config_path=example)
+    section = config.toolkits["targeted-writer"]
+
+    def factory():
+        return LLMFactory.create(section.llm, **section.llm_kwargs)
+
+    return factory
+
+
+async def _main_async(args: argparse.Namespace) -> int:
+    """Run the selected scenarios and write the reports."""
+    selected = SCENARIOS if args.scenario == "all" else [s for s in SCENARIOS if s.name == args.scenario]
+    if not selected:
+        print(
+            f"unknown scenario {args.scenario!r}; choose from: {', '.join(s.name for s in SCENARIOS)}", file=sys.stderr
+        )
+        return 2
+
+    client_factory = _live_client_factory() if args.live else None
+    reports: list[RunReport] = []
+    for scenario in selected:
+        for mode in ("baseline", "optimized"):
+            reports.extend(await run(scenario, mode, runs=args.runs, client_factory=client_factory))
+
+    summary = summarize(reports, live=args.live, prices=CostModel.load())
+    json_path, md_path = write_reports(summary, args.out, stamp=args.stamp)
+    print(f"wrote {json_path}")
+    print(f"wrote {md_path}")
+
+    # Correctness parity is mandatory; the numbers are informational.
+    failures = [
+        entry["name"]
+        for entry in summary.scenarios
+        if entry["optimized"]["pass_rate"] is not None and entry["optimized"]["pass_rate"] < 1.0
+    ]
+    if failures:
+        print(f"acceptance FAILED for: {', '.join(failures)}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def _preload_toolkits() -> None:
+    """Import the toolkits BEFORE the event loop is created.
+
+    Importing `parrot` installs uvloop's event-loop policy as a side effect.
+    If that happens lazily *inside* a running stdlib loop, the loop and the
+    policy disagree: `asyncio.create_subprocess_exec` then asks uvloop's
+    policy for a child watcher, which it does not implement, and every git
+    call dies with `NotImplementedError`. Importing up front makes
+    `asyncio.run()` build a loop that matches whatever policy is installed.
+    """
+    import parrot_tools.tool_optimizations.git  # noqa: F401
+    import parrot_tools.tool_optimizations.reader  # noqa: F401
+    import parrot_tools.tool_optimizations.writer  # noqa: F401
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """Entry point.
+
+    Args:
+        argv: Command-line arguments.
+
+    Returns:
+        The process exit code.
+    """
+    args = _parse_args(argv)
+    _preload_toolkits()
+    if args.live and args.runs < MIN_LIVE_RUNS:
+        print(
+            f"--live requires --runs >= {MIN_LIVE_RUNS} (spec measurement protocol); got {args.runs}",
+            file=sys.stderr,
+        )
+        return 2
+    return asyncio.run(_main_async(args))
+
+
+if __name__ == "__main__":  # pragma: no cover — process entry point
+    sys.exit(main())

--- a/benchmarks/tool_optimizations/accounting.py
+++ b/benchmarks/tool_optimizations/accounting.py
@@ -1,0 +1,213 @@
+"""Token, latency and cost accounting for the FEAT-543 benchmarks.
+
+Two rules drive the design:
+
+* **Unknown is never zero.** A provider that reports no usage yields
+  ``tokens=None``, which propagates to ``cost_usd=None``. Coercing a missing
+  measurement to 0 would silently flatter the optimized side.
+* **Every number carries its provenance.** Provider-reported counts are
+  labelled ``provider_usage``; anything the harness estimates is labelled
+  ``estimate:<method>`` so a reader can tell measurement from arithmetic.
+"""
+
+from __future__ import annotations
+
+import statistics
+from pathlib import Path
+from typing import Any, Literal, Optional
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = (
+    "PRICES_PATH",
+    "CostModel",
+    "PriceRow",
+    "Stage",
+    "UsageRecord",
+    "cost_usd",
+    "estimate_tokens",
+    "percentile",
+)
+
+PRICES_PATH = Path(__file__).with_name("prices.yaml")
+
+#: Accounting stages. Keeping planning/review/repair separate from the raw
+#: model calls is what prevents "savings" that merely moved work elsewhere.
+Stage = Literal[
+    "tool_schema_overhead",
+    "planning_packet",
+    "primary_input",
+    "primary_output",
+    "delegate_input",
+    "delegate_output",
+    "review",
+    "repair",
+]
+
+#: Stages attributable to the delegate rather than the primary model.
+DELEGATE_STAGES = frozenset({"delegate_input", "delegate_output", "repair"})
+
+#: A crude but honest character-based estimator, always labelled as such.
+ESTIMATE_METHOD = "estimate:chars_div_4"
+
+
+def estimate_tokens(text: str) -> int:
+    """Estimate a token count from raw text.
+
+    Args:
+        text: The text to estimate.
+
+    Returns:
+        An approximate token count (``len // 4``). Always report this with
+        the :data:`ESTIMATE_METHOD` source label — it is not a measurement.
+    """
+    return len(text) // 4
+
+
+class UsageRecord(BaseModel):
+    """One accounted quantity in a benchmark run.
+
+    Attributes:
+        stage: Which part of the workflow this belongs to.
+        tokens: The token count, or None when genuinely unknown.
+        source: ``provider_usage`` or ``estimate:<method>``.
+        elapsed_ms: Wall-clock time attributable to this stage.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    stage: Stage
+    tokens: Optional[int] = None
+    source: str
+    elapsed_ms: int = 0
+
+
+class PriceRow(BaseModel):
+    """A per-model price, with the provenance that makes it auditable.
+
+    Attributes:
+        input_usd_per_1k: USD per 1,000 input tokens.
+        output_usd_per_1k: USD per 1,000 output tokens.
+        provenance: Where the figure came from (URL, contract, console).
+        as_of: The date the price was read.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    input_usd_per_1k: float = Field(..., ge=0)
+    output_usd_per_1k: float = Field(..., ge=0)
+    provenance: str = Field(..., min_length=1)
+    as_of: str = Field(..., min_length=1)
+
+
+class CostModel(BaseModel):
+    """The configured price table.
+
+    Ships empty on purpose: an invented price is worse than no price, so
+    cost is reported as ``unknown`` until an operator fills this in.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    rows: dict[str, PriceRow] = Field(default_factory=dict)
+
+    @classmethod
+    def load(cls, path: Optional[Path] = None) -> "CostModel":
+        """Load the price table, tolerating an absent or empty file.
+
+        Args:
+            path: The YAML file; defaults to the shipped ``prices.yaml``.
+
+        Returns:
+            The parsed cost model, possibly with no rows.
+        """
+        target = path or PRICES_PATH
+        if not target.is_file():
+            return cls()
+        data = yaml.safe_load(target.read_text(encoding="utf-8")) or {}
+        rows = data.get("models") or {}
+        return cls(rows={name: PriceRow.model_validate(row) for name, row in rows.items()})
+
+
+def cost_usd(records: list[UsageRecord], model: str, prices: CostModel) -> Optional[float]:
+    """Compute the USD cost of a set of usage records.
+
+    Args:
+        records: The accounted usage.
+        model: The model identity to price.
+        prices: The configured price table.
+
+    Returns:
+        The cost, or None when the price is unknown or any input token count
+        is unknown. Never returns 0 to stand in for "we do not know".
+    """
+    row = prices.rows.get(model)
+    if row is None:
+        return None
+    if any(record.tokens is None for record in records):
+        return None
+    total = 0.0
+    for record in records:
+        rate = row.output_usd_per_1k if record.stage.endswith("_output") else row.input_usd_per_1k
+        total += (record.tokens or 0) / 1000.0 * rate
+    return round(total, 6)
+
+
+def percentile(values: list[float], fraction: float) -> Optional[float]:
+    """Return a percentile using nearest-rank, safe for tiny samples.
+
+    Args:
+        values: The observations.
+        fraction: The percentile as a fraction (e.g. 0.95).
+
+    Returns:
+        The percentile value, or None for an empty sample.
+    """
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = max(0, min(len(ordered) - 1, int(round(fraction * len(ordered) + 0.5)) - 1))
+    return ordered[index]
+
+
+def median(values: list[float]) -> Optional[float]:
+    """Return the median, or None for an empty sample.
+
+    Args:
+        values: The observations.
+
+    Returns:
+        The median, or None.
+    """
+    return statistics.median(values) if values else None
+
+
+def totals_by_kind(records: list[UsageRecord]) -> dict[str, Any]:
+    """Split token totals into primary, delegate and overall.
+
+    Fewer primary tokens is not fewer total tokens — reporting both is the
+    entire point of this function.
+
+    Args:
+        records: The accounted usage.
+
+    Returns:
+        A mapping with ``primary_tokens``, ``delegate_tokens`` and
+        ``total_tokens``; a member is None when any contributing record's
+        count is unknown.
+    """
+
+    def _sum(subset: list[UsageRecord]) -> Optional[int]:
+        if not subset:
+            return 0
+        if any(record.tokens is None for record in subset):
+            return None
+        return sum(record.tokens or 0 for record in subset)
+
+    delegate = [record for record in records if record.stage in DELEGATE_STAGES]
+    primary = [record for record in records if record.stage not in DELEGATE_STAGES]
+    primary_total = _sum(primary)
+    delegate_total = _sum(delegate)
+    overall = None if primary_total is None or delegate_total is None else primary_total + delegate_total
+    return {"primary_tokens": primary_total, "delegate_tokens": delegate_total, "total_tokens": overall}

--- a/benchmarks/tool_optimizations/prices.yaml
+++ b/benchmarks/tool_optimizations/prices.yaml
@@ -1,0 +1,16 @@
+# Model prices for the FEAT-543 benchmark harness.
+#
+# This file ships EMPTY on purpose. An invented price is worse than no
+# price: cost is reported as `unknown` (null) until an operator fills in
+# real figures, and every row must record where its numbers came from.
+#
+# Fill in like this, then re-run the harness:
+#
+# models:
+#   bedrock-converse:qwen3-coder-480b-a35b:
+#     input_usd_per_1k: 0.0
+#     output_usd_per_1k: 0.0
+#     provenance: "AWS Bedrock pricing page, us-east-1, on-demand"
+#     as_of: "2026-09-10"
+
+models: {}

--- a/benchmarks/tool_optimizations/runner.py
+++ b/benchmarks/tool_optimizations/runner.py
@@ -1,0 +1,457 @@
+"""Execute benchmark scenarios and summarize them (FEAT-543).
+
+Offline by default: the delegate is a scripted fake, so a run costs nothing
+and is deterministic. ``--live`` swaps in a real client built from
+``examples/tool-optimizations-mcp.yaml`` and is the only path that spends
+money; it requires at least five runs per scenario, per the spec's
+measurement protocol.
+
+Correctness is measured separately from tokens and latency, and it is the
+only thing the harness treats as pass/fail. A scenario that is faster and
+cheaper but no longer passes its acceptance test has not been optimized.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .accounting import (
+    ESTIMATE_METHOD,
+    CostModel,
+    UsageRecord,
+    cost_usd,
+    estimate_tokens,
+    median,
+    percentile,
+    totals_by_kind,
+)
+from .scenarios import Scenario, build_git_repo, build_large_file_repo
+
+__all__ = ("RunReport", "ScenarioSummary", "Summary", "run", "summarize", "write_reports")
+
+GIT_ENV = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "bench",
+    "GIT_AUTHOR_EMAIL": "bench@example.com",
+    "GIT_COMMITTER_NAME": "bench",
+    "GIT_COMMITTER_EMAIL": "bench@example.com",
+    "GIT_CONFIG_GLOBAL": "/dev/null",
+    "GIT_CONFIG_SYSTEM": "/dev/null",
+    "LC_ALL": "C",
+}
+
+#: Minimum runs required for a live comparison (spec §4).
+MIN_LIVE_RUNS = 5
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+    """Run a git command with the deterministic benchmark environment."""
+    return subprocess.run(["git", *args], cwd=cwd, env=GIT_ENV, capture_output=True, text=True, check=True)
+
+
+class RunReport(BaseModel):
+    """The result of one scenario executed once in one mode.
+
+    Attributes:
+        scenario: The scenario name.
+        mode: ``baseline`` or ``optimized``.
+        run_index: 0-based index within the repetition set.
+        warm: True for the second and later runs (cache/context warm).
+        elapsed_ms: Wall-clock duration.
+        usage: Accounted token usage.
+        acceptance_passed: Real acceptance outcome, or None when the
+            scenario has no executable acceptance test.
+        retries: Repair/retry count reported by the tooling.
+        model: The model identity involved, if any.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    scenario: str
+    mode: str
+    run_index: int
+    warm: bool
+    elapsed_ms: int
+    usage: list[UsageRecord] = Field(default_factory=list)
+    acceptance_passed: Optional[bool] = None
+    retries: int = 0
+    model: Optional[str] = None
+
+
+class ScenarioSummary(BaseModel):
+    """Aggregated statistics for one scenario/mode pair."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    primary_tokens: Optional[int] = None
+    delegate_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
+    latency_median_ms: Optional[float] = None
+    latency_p95_ms: Optional[float] = None
+    pass_rate: Optional[float] = None
+    cost_usd: Optional[float] = None
+    runs: int = 0
+    sources: list[str] = Field(default_factory=list)
+
+
+class Summary(BaseModel):
+    """The full comparison across scenarios."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    created_at: str
+    live: bool
+    scenarios: list[dict[str, Any]] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)
+
+
+# --------------------------------------------------------------------------- #
+# Scenario execution
+# --------------------------------------------------------------------------- #
+async def _run_git_scenario(mode: str, workdir: Path) -> tuple[list[UsageRecord], Optional[bool], int]:
+    """Execute the Git scenario in one mode."""
+    from parrot_tools.tool_optimizations.git import LocalGitToolkit
+
+    repo, _remote = build_git_repo(workdir, _git)
+    records: list[UsageRecord] = []
+
+    if mode == "baseline":
+        # What a host issues without the tools: three shell commands whose
+        # full stdout lands in the context window.
+        output = ""
+        for args in (["fetch", "origin", "dev"], ["status", "--short"], ["diff", "--check"]):
+            output += subprocess.run(["git", *args], cwd=repo, env=GIT_ENV, capture_output=True, text=True).stdout
+        output += subprocess.run(
+            ["git", "add", "--", "feature.py"], cwd=repo, env=GIT_ENV, capture_output=True, text=True
+        ).stdout
+        output += subprocess.run(
+            ["git", "diff", "--cached", "--name-only"], cwd=repo, env=GIT_ENV, capture_output=True, text=True
+        ).stdout
+        records.append(UsageRecord(stage="primary_input", tokens=estimate_tokens(output), source=ESTIMATE_METHOD))
+        return records, None, 0
+
+    toolkit = LocalGitToolkit(repo_root=repo)
+    payload = ""
+    for result in (
+        await toolkit.git_fetch(remote="origin", branch="dev", recent=3),
+        await toolkit.git_preflight(),
+        await toolkit.git_prepare_files(["feature.py"]),
+    ):
+        payload += json.dumps(result.model_dump(mode="json"), ensure_ascii=False)
+    records.append(UsageRecord(stage="primary_input", tokens=estimate_tokens(payload), source=ESTIMATE_METHOD))
+    return records, None, 0
+
+
+async def _run_read_scenario(mode: str, workdir: Path) -> tuple[list[UsageRecord], Optional[bool], int]:
+    """Execute the bounded-read scenario in one mode."""
+    from parrot_tools.tool_optimizations.reader import BoundedSourceToolkit
+
+    repo = build_large_file_repo(workdir)
+    records: list[UsageRecord] = []
+
+    if mode == "baseline":
+        # The whole file enters the context window.
+        text = (repo / "big_module.py").read_text()
+        records.append(UsageRecord(stage="primary_input", tokens=estimate_tokens(text), source=ESTIMATE_METHOD))
+        return records, None, 0
+
+    toolkit = BoundedSourceToolkit(repo_root=repo)
+    info = await toolkit.source_info("big_module.py")
+    chunk = await toolkit.source_read("big_module.py", 1, 350)
+    payload = json.dumps(info.model_dump(mode="json"), ensure_ascii=False) + json.dumps(
+        chunk.model_dump(mode="json"), ensure_ascii=False
+    )
+    records.append(UsageRecord(stage="primary_input", tokens=estimate_tokens(payload), source=ESTIMATE_METHOD))
+    return records, None, 0
+
+
+async def _run_task_scenario(mode: str, workdir: Path, client_factory) -> tuple[list[UsageRecord], Optional[bool], int]:
+    """Execute the decided-TASK scenario in one mode."""
+    sys.path.insert(0, str(_repo_root() / "packages" / "ai-parrot-tools" / "tests"))
+    from tool_optimizations.fixtures import GOOD_PATCH, make_repo_with_target, make_valid_task
+
+    from parrot_tools.tool_optimizations.reader import BoundedSourceToolkit
+    from parrot_tools.tool_optimizations.writer import TargetedWriterToolkit
+
+    repo = make_repo_with_target(workdir)
+    tests_dir = repo / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_greeter.py").write_text(
+        "from pkg.greeter import greet\n\n\ndef test_greet():\n    assert greet('world') == 'hello world'\n"
+    )
+    # `writer_apply` re-checks that no target is already staged, so it needs a
+    # real repository — the same precondition a host would have in practice.
+    _git(repo, "init", "-q", "-b", "dev")
+    _git(repo, "config", "commit.gpgsign", "false")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", "base")
+    task = make_valid_task(repo)
+    task_path = task.relative_to(repo).as_posix()
+    records: list[UsageRecord] = []
+
+    if mode == "baseline":
+        # The primary model reads the TASK and writes both files itself.
+        prompt = task.read_text()
+        records.append(UsageRecord(stage="primary_input", tokens=estimate_tokens(prompt), source=ESTIMATE_METHOD))
+        records.append(UsageRecord(stage="primary_output", tokens=estimate_tokens(GOOD_PATCH), source=ESTIMATE_METHOD))
+        # Simulate the same end state so the acceptance test is comparable.
+        (repo / "pkg" / "greeter.py").write_text(
+            'def greet(name: str) -> str:\n    """Return a greeting."""\n    return f"hello {name}"\n'
+        )
+        passed = _run_acceptance(repo)
+        return records, passed, 0
+
+    client = client_factory()
+    writer = TargetedWriterToolkit(repo_root=repo, llm_client=client)
+    generated = await writer.writer_generate(task_path)
+    if generated.status != "ok":
+        return records, False, 0
+
+    # Planning + the delegate's own usage, kept apart.
+    records.append(
+        UsageRecord(stage="planning_packet", tokens=estimate_tokens(task.read_text()), source=ESTIMATE_METHOD)
+    )
+    usage = generated.data.get("usage") or {}
+    records.append(UsageRecord(stage="delegate_input", tokens=usage.get("prompt_tokens"), source="provider_usage"))
+    records.append(UsageRecord(stage="delegate_output", tokens=usage.get("completion_tokens"), source="provider_usage"))
+
+    # The primary model reviews every hunk through the bounded reader.
+    reader = BoundedSourceToolkit(repo_root=repo)
+    reviewed = ""
+    cursor = 1
+    while cursor is not None:
+        chunk = await reader.source_read(generated.data["patch_path"], cursor, cursor + 349)
+        if getattr(chunk, "content", None) is None:
+            break
+        reviewed += chunk.content
+        cursor = chunk.next_line
+    records.append(UsageRecord(stage="review", tokens=estimate_tokens(reviewed), source=ESTIMATE_METHOD))
+
+    applied = await writer.writer_apply(generated.data["artifact_id"], generated.data["patch_sha256"])
+    if applied.status != "ok":
+        return records, False, int(generated.data.get("repairs", 0))
+
+    passed = _run_acceptance(repo)
+    return records, passed, int(generated.data.get("repairs", 0))
+
+
+def _repo_root() -> Path:
+    """Return the repository root (this file lives at benchmarks/<pkg>/)."""
+    return Path(__file__).resolve().parents[2]
+
+
+def _run_acceptance(repo: Path) -> bool:
+    """Run the scenario's real acceptance test and report its exit code."""
+    env = dict(os.environ)
+    root = _repo_root()
+    env["PYTHONPATH"] = os.pathsep.join(
+        [
+            str(root / "packages" / "ai-parrot" / "src"),
+            str(root / "packages" / "ai-parrot-tools" / "src"),
+            env.get("PYTHONPATH", ""),
+        ]
+    ).rstrip(os.pathsep)
+    completed = subprocess.run(
+        [sys.executable, "-m", "pytest", "tests/test_greeter.py", "-q"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        timeout=180,
+        env=env,
+    )
+    return completed.returncode == 0
+
+
+def _default_client_factory():
+    """Return the offline scripted delegate."""
+    sys.path.insert(0, str(_repo_root() / "packages" / "ai-parrot-tools" / "tests"))
+    from tool_optimizations.fixtures import GOOD_PATCH
+    from tool_optimizations.test_writer import FakeClient
+
+    return FakeClient([GOOD_PATCH])
+
+
+async def run(
+    scenario: Scenario,
+    mode: str,
+    *,
+    runs: int = 5,
+    workdir: Optional[Path] = None,
+    client_factory=None,
+) -> list[RunReport]:
+    """Execute one scenario in one mode, ``runs`` times.
+
+    Args:
+        scenario: The scenario to execute.
+        mode: ``baseline`` or ``optimized``.
+        runs: Repetitions.
+        workdir: Directory for scratch repositories.
+        client_factory: Callable returning the delegate client.
+
+    Returns:
+        One :class:`RunReport` per repetition.
+    """
+    import tempfile
+
+    factory = client_factory or _default_client_factory
+    base = Path(workdir or tempfile.mkdtemp())
+    reports: list[RunReport] = []
+
+    for index in range(runs):
+        attempt_dir = base / f"{scenario.name}-{mode}-{index}"
+        attempt_dir.mkdir(parents=True, exist_ok=True)
+        started = time.perf_counter()
+
+        if scenario.kind == "git_fetch_preflight_prepare":
+            records, passed, retries = await _run_git_scenario(mode, attempt_dir)
+        elif scenario.kind == "targeted_read_large_file":
+            records, passed, retries = await _run_read_scenario(mode, attempt_dir)
+        else:
+            records, passed, retries = await _run_task_scenario(mode, attempt_dir, factory)
+
+        reports.append(
+            RunReport(
+                scenario=scenario.name,
+                mode=mode,
+                run_index=index,
+                warm=index > 0,
+                elapsed_ms=int((time.perf_counter() - started) * 1000),
+                usage=records,
+                acceptance_passed=passed,
+                retries=retries,
+                model=None,
+            )
+        )
+    return reports
+
+
+# --------------------------------------------------------------------------- #
+# Summarizing and reporting
+# --------------------------------------------------------------------------- #
+def _summarize_mode(reports: list[RunReport], prices: CostModel) -> ScenarioSummary:
+    """Aggregate the repetitions of one scenario/mode pair."""
+    if not reports:
+        return ScenarioSummary()
+
+    records = [record for report in reports for record in report.usage]
+    latencies = [float(report.elapsed_ms) for report in reports]
+    outcomes = [report.acceptance_passed for report in reports if report.acceptance_passed is not None]
+
+    totals = totals_by_kind(records)
+    return ScenarioSummary(
+        **totals,
+        latency_median_ms=median(latencies),
+        latency_p95_ms=percentile(latencies, 0.95),
+        pass_rate=(sum(1 for value in outcomes if value) / len(outcomes)) if outcomes else None,
+        cost_usd=cost_usd(records, reports[0].model or "", prices),
+        runs=len(reports),
+        sources=sorted({record.source for record in records}),
+    )
+
+
+def summarize(reports: list[RunReport], *, live: bool = False, prices: Optional[CostModel] = None) -> Summary:
+    """Build the comparison summary from raw run reports.
+
+    Args:
+        reports: All run reports, any scenario and mode.
+        live: Whether a real provider was used.
+        prices: The price table; loaded from disk when omitted.
+
+    Returns:
+        The populated summary.
+    """
+    table = prices or CostModel.load()
+    names = []
+    for report in reports:
+        if report.scenario not in names:
+            names.append(report.scenario)
+
+    scenarios: list[dict[str, Any]] = []
+    for name in names:
+        entry: dict[str, Any] = {"name": name}
+        for mode in ("baseline", "optimized"):
+            subset = [report for report in reports if report.scenario == name and report.mode == mode]
+            entry[mode] = _summarize_mode(subset, table).model_dump(mode="json")
+        scenarios.append(entry)
+
+    notes = [
+        "Baseline token counts are estimates (estimate:chars_div_4), not provider measurements.",
+        "Delegate token counts come from provider usage; `null` means the provider reported nothing "
+        "— it never means zero.",
+        "Cost is `unknown` until benchmarks/tool_optimizations/prices.yaml is filled in with sourced prices.",
+        "Primary and total tokens are reported separately: fewer primary tokens is NOT fewer total tokens.",
+        "No savings percentage is claimed. Numeric targets are an owner decision (spec section 8).",
+    ]
+    if not live:
+        notes.append("Offline run: the delegate was a scripted fake, so delegate latency is not representative.")
+    return Summary(created_at=datetime.now(timezone.utc).isoformat(), live=live, scenarios=scenarios, notes=notes)
+
+
+def _fmt(value: Any) -> str:
+    """Render a possibly-unknown number for the Markdown table."""
+    if value is None:
+        return "unknown"
+    if isinstance(value, float):
+        return f"{value:.1f}"
+    return str(value)
+
+
+def render_markdown(summary: Summary) -> str:
+    """Render the summary as a Markdown report.
+
+    Args:
+        summary: The summary to render.
+
+    Returns:
+        The Markdown text.
+    """
+    lines = [
+        "# Tool optimizations benchmark",
+        "",
+        f"- Generated: {summary.created_at}",
+        f"- Mode: {'LIVE (real provider)' if summary.live else 'offline (scripted delegate)'}",
+        "",
+        "| Scenario | Mode | primary tokens | delegate tokens | total tokens | latency median ms | latency p95 ms "
+        "| pass rate | cost USD | sources |",
+        "|---|---|---|---|---|---|---|---|---|---|",
+    ]
+    for entry in summary.scenarios:
+        for mode in ("baseline", "optimized"):
+            data = entry[mode]
+            lines.append(
+                f"| {entry['name']} | {mode} | {_fmt(data['primary_tokens'])} | {_fmt(data['delegate_tokens'])} "
+                f"| {_fmt(data['total_tokens'])} | {_fmt(data['latency_median_ms'])} | {_fmt(data['latency_p95_ms'])} "
+                f"| {_fmt(data['pass_rate'])} | {_fmt(data['cost_usd'])} | {', '.join(data['sources']) or 'n/a'} |"
+            )
+    lines += ["", "## Notes", ""]
+    lines += [f"- {note}" for note in summary.notes]
+    return "\n".join(lines) + "\n"
+
+
+def write_reports(summary: Summary, directory: Path, *, stamp: Optional[str] = None) -> tuple[Path, Path]:
+    """Write the JSON and Markdown reports side by side.
+
+    Args:
+        summary: The summary to persist.
+        directory: Output directory (created if needed).
+        stamp: File stem; defaults to a UTC timestamp.
+
+    Returns:
+        A ``(json_path, markdown_path)`` tuple.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    name = stamp or datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    json_path = directory / f"{name}.json"
+    md_path = directory / f"{name}.md"
+    json_path.write_text(json.dumps(summary.model_dump(mode="json"), indent=2) + "\n", encoding="utf-8")
+    md_path.write_text(render_markdown(summary), encoding="utf-8")
+    return json_path, md_path

--- a/benchmarks/tool_optimizations/scenarios.py
+++ b/benchmarks/tool_optimizations/scenarios.py
@@ -1,0 +1,123 @@
+"""Benchmark scenarios: the same work, done the baseline and optimized way.
+
+Each scenario names a task a coding host actually performs, and supplies two
+recipes for it:
+
+* ``baseline`` — what a host does *without* these tools (the shell lines
+  from the spec's user-provided code, a whole-file read, a hand-written
+  implementation prompt).
+* ``optimized`` — the equivalent tool calls.
+
+Both sides run against the same fixtures at the same repository revision, so
+the comparison is like-for-like.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ("SCENARIOS", "Scenario", "ScenarioKind", "build_git_repo", "build_large_file_repo")
+
+ScenarioKind = Literal["git_fetch_preflight_prepare", "targeted_read_large_file", "decided_create_modify_task"]
+
+
+class Scenario(BaseModel):
+    """One benchmarked unit of work.
+
+    Attributes:
+        name: Stable identifier used in reports.
+        kind: Which workflow this exercises.
+        description: What a host is trying to achieve.
+        baseline_recipe: The commands/reads a host issues without the tools.
+        optimized_recipe: The equivalent tool calls.
+        has_acceptance: Whether a real acceptance test can be executed.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    kind: ScenarioKind
+    description: str
+    baseline_recipe: list[str] = Field(default_factory=list)
+    optimized_recipe: list[str] = Field(default_factory=list)
+    has_acceptance: bool = False
+
+
+#: The three fixed scenarios (spec §4 Measurement Protocol).
+SCENARIOS: list[Scenario] = [
+    Scenario(
+        name="git_prepare",
+        kind="git_fetch_preflight_prepare",
+        description="Fetch the branch, inspect the tree, and stage exactly one file.",
+        # The user-provided commands preserved in spec §6.
+        baseline_recipe=[
+            "git fetch origin dev",
+            "git status --short && git diff --check && git diff --cached --name-only",
+            "git reset HEAD && git add -- {filename} && git diff --cached --name-only && git diff --cached --check",
+        ],
+        optimized_recipe=["git_fetch", "git_preflight", "git_prepare_files"],
+        has_acceptance=False,
+    ),
+    Scenario(
+        name="targeted_read",
+        kind="targeted_read_large_file",
+        description="Read the region of interest from a 2,000-line module.",
+        baseline_recipe=["Read(file_path=big_module.py)  # whole file into context"],
+        optimized_recipe=["source_info", "source_read(start_line, end_line)"],
+        has_acceptance=False,
+    ),
+    Scenario(
+        name="decided_task",
+        kind="decided_create_modify_task",
+        description="Implement an already-decided TASK: one file created, one modified.",
+        baseline_recipe=["primary model writes both files from the TASK description"],
+        optimized_recipe=["writer_generate", "source_read(patch)", "writer_apply", "pytest"],
+        has_acceptance=True,
+    ),
+]
+
+
+def build_git_repo(workdir: Path, git_run) -> tuple[Path, Path]:
+    """Create a repo with a bare remote for the Git scenario.
+
+    Args:
+        workdir: Directory to build in.
+        git_run: A callable running git in a given cwd.
+
+    Returns:
+        A ``(repo, remote)`` tuple.
+    """
+    repo = workdir / "git_repo"
+    repo.mkdir(parents=True)
+    git_run(repo, "init", "-q", "-b", "dev")
+    git_run(repo, "config", "commit.gpgsign", "false")
+    (repo / "a.py").write_text("print('a')\n")
+    git_run(repo, "add", "a.py")
+    git_run(repo, "commit", "-q", "-m", "base")
+
+    remote = workdir / "remote.git"
+    git_run(workdir, "init", "-q", "--bare", str(remote))
+    git_run(repo, "remote", "add", "origin", str(remote))
+    git_run(repo, "push", "-q", "-u", "origin", "dev")
+    (repo / "feature.py").write_text("value = 1\n")
+    return repo, remote
+
+
+def build_large_file_repo(workdir: Path, lines: int = 2000) -> Path:
+    """Create a repo containing one large module.
+
+    Args:
+        workdir: Directory to build in.
+        lines: How many lines the module should have.
+
+    Returns:
+        The repository root.
+    """
+    repo = workdir / "read_repo"
+    repo.mkdir(parents=True)
+    body = "".join(f"def function_{index}():\n    return {index}\n\n" for index in range(1, lines // 3 + 1))
+    (repo / "big_module.py").write_text(body)
+    return repo

--- a/docs/mcp-local-toolkits.md
+++ b/docs/mcp-local-toolkits.md
@@ -186,6 +186,10 @@ MCP host's caller (the model) must pass `confirm: true` explicitly.
 
 ## Related
 
+- [Tool optimizations (FEAT-543)](tool-optimizations.md) — the
+  `local-git`, `bounded-source` and `targeted-writer` toolkits configured
+  through this machinery, including the `llm_kwargs` example and the
+  opt-in host read guards.
 - [FEAT-403 — `wikitoolkit mcp`](../sdd/specs/) — the pattern this feature
   generalizes; `StdioMCPServer`/`LocalServerConfig`/`MCPToolAdapter` are
   shared, unmodified core machinery.

--- a/docs/mcp-local-toolkits.md
+++ b/docs/mcp-local-toolkits.md
@@ -67,6 +67,7 @@ toolkits:
     include: null                                      # optional whitelist of tool names
     exclude: null                                      # optional blacklist of tool names
     llm: null                                          # optional "provider:model" string
+    llm_kwargs: {}                                     # optional extra kwargs for LLMFactory.create (requires llm)
     env: {}                                            # env vars written into installer entries
 ```
 
@@ -78,6 +79,7 @@ toolkits:
 | `include` | `list[str] \| null` | Whitelist of tool names to expose. When set, only these are exposed. |
 | `exclude` | `list[str] \| null` | Blacklist of tool names to exclude. Only consulted when `include` is unset. |
 | `llm` | `str \| null` | A `"provider:model"` string (e.g. `"openai:gpt-4o-mini"`, `"anthropic:claude-3-5-haiku-latest"`). When set, `LLMFactory.create()` builds a client passed to the toolkit's constructor as `llm_client`. |
+| `llm_kwargs` | `dict` | Extra keyword arguments forwarded verbatim to `LLMFactory.create(llm, **llm_kwargs)`, so they reach the client constructor unchanged — e.g. `fallback_model: null`, `max_retries`, `read_timeout`. This is **trusted server configuration**, never an LLM-callable argument. Requires `llm` to be set, and may not contain an `llm` key (it would collide with the factory's first argument). See `examples/tool-optimizations-mcp.yaml`, where `fallback_model: null` is required so the Bedrock client cannot silently answer with its default fallback model. |
 | `env` | `dict[str, str]` | Environment variables written into the generated `.mcp.json` / `.codex/config.toml` server entry (e.g. API keys the toolkit reads from its process env at runtime). **Not** passed as constructor kwargs. |
 
 ### The include/exclude/llm-dependent rules

--- a/docs/tool-optimizations.md
+++ b/docs/tool-optimizations.md
@@ -1,0 +1,357 @@
+# Tool optimizations for Claude Code and Codex (FEAT-543)
+
+Three locally installed MCP capabilities that replace token-expensive,
+predictable work: deterministic Git workflows, bounded source reading, and
+delegated implementation of work whose design is already decided.
+
+They are ordinary AI-Parrot tools (`AbstractToolkit` subclasses) exposed
+through the existing local stdio MCP machinery. Each is an independent,
+opt-in configuration section — none is a globally enabled built-in.
+
+## Overview
+
+| Toolkit | Tools | Model calls |
+|---|---|---|
+| `LocalGitToolkit` | `git_recent`, `git_fetch`, `git_preflight`, `git_prepare_files`, `git_pull`, `git_push` | none |
+| `BoundedSourceToolkit` | `source_info`, `source_read` | none |
+| `TargetedWriterToolkit` | `writer_generate`, `writer_apply` | one configured client |
+
+### Non-goals
+
+- Not an autonomous coding agent: the writer never explores the repository
+  and never chooses a design.
+- Not a guarantee that every shell read is intercepted — see
+  [Host guards](#host-guards).
+- No automatic commits, force pushes, resets, stashes or history rewriting.
+- No claimed token-saving percentage. See [Release checklist](#release-checklist).
+
+## Installation
+
+Copy the example configuration and adjust `repo_root`:
+
+```bash
+cp examples/tool-optimizations-mcp.yaml .parrot/mcp-toolkits.yaml
+parrot mcp-local --list
+```
+
+Serve one toolkit:
+
+```bash
+parrot mcp-local local-git --config .parrot/mcp-toolkits.yaml
+```
+
+Install the opt-in read guards (off by default):
+
+```bash
+parrot claude install --tool-guards
+parrot codex install --tool-guards
+parrot claude status --json      # includes a `tool_guards` block
+```
+
+Uninstall removes only the entries these commands created:
+
+```bash
+parrot claude uninstall
+```
+
+## Tool reference
+
+### Git
+
+| Tool | Arguments | Notes |
+|---|---|---|
+| `git_recent` | `ref="HEAD"`, `limit=3` (1–50) | Bounded structured history. |
+| `git_fetch` | `remote="origin"`, `branch="dev"`, `recent=3` | Explicit refspec, no `+`; reports the fetched commit and freshness. |
+| `git_preflight` | — | Runs every check independently and reports each one. |
+| `git_prepare_files` | `paths: list[str]` | Stages exactly these files via an isolated index. Requires `confirm`. |
+| `git_pull` | `remote="origin"`, `branch=None` | Fast-forward only. Requires `confirm`. |
+| `git_push` | `remote="origin"`, `branch=None` | Never forced, never creates a commit. Requires `confirm`. |
+
+Mutating tools carry a required `confirm` boolean over MCP. That flag is
+the host's record that a human approved the operation — it is not
+authorization a model can grant itself.
+
+#### Git refusal codes
+
+`bare_repository`, `not_a_repository`, `root_mismatch`, `git_too_old`,
+`invalid_ref`, `unknown_ref`, `unknown_remote`, `invalid_branch`,
+`fetch_failed`, `fetch_rejected`, `fetch_timeout`, `tracking_ref_stale`,
+`preflight_failed`, `unmerged_index`, `unrelated_staged`,
+`partially_staged`, `index_unsupported`, `index_changed`, `index_locked`,
+`staged_mismatch`, `whitespace_errors`, `path_not_found`,
+`submodule_rejected`, `symlink_rejected`, `secret_file`,
+`path_outside_root`, `directory_rejected`, `glob_rejected`,
+`pathspec_magic`, `duplicate_path`, `detached_head`, `unborn_head`,
+`staged_changes`, `dirty_worktree`, `missing_upstream`,
+`upstream_remote_mismatch`, `branch_mismatch`, `diverged`,
+`untracked_conflict`, `fast_forward_failed`, `push_rejected`,
+`push_timeout`, `worktree_busy`.
+
+**`git_prepare_files` never unstages anything.** If unrelated paths are
+already staged it refuses with `unrelated_staged` rather than resetting the
+index. Staging happens in a private copy of the index and is published only
+after every check passes and Git's own `index.lock` is acquired; a refusal
+leaves the index byte-identical.
+
+### Bounded reader
+
+A file is *large* when it exceeds **350 lines or 64,000 bytes** (either
+threshold, both configurable). A large file cannot be read without an
+explicit inclusive 1-based range.
+
+```text
+source_info(path)                       -> size, sha256, is_large, range_required
+source_read(path, start_line, end_line, expected_sha256=None)
+```
+
+Continue through a file with the returned cursor:
+
+```text
+1. info = source_info("big.py")
+2. chunk = source_read("big.py", 1, 350, expected_sha256=info.sha256)
+3. while chunk.next_line: chunk = source_read("big.py", chunk.next_line,
+                                              chunk.next_line + 349,
+                                              expected_sha256=info.sha256)
+```
+
+`expected_sha256` makes continuation safe: if the file changed underneath
+you, the read is refused with `stale_revision` instead of returning a
+mixture of two revisions.
+
+Reader error codes: `not_found`, `not_a_file`, `symlink_rejected`,
+`secret_file`, `path_outside_root`, `binary_file`, `invalid_encoding`,
+`range_required`, `range_too_large`, `range_out_of_bounds`,
+`line_too_large`, `stale_revision`, `concurrent_modification`,
+`hash_timeout`.
+
+Only complete lines are ever returned. A single line that cannot fit the
+byte budget is reported as `line_too_large` with its number — never
+silently cut.
+
+### Delegation workflow
+
+A TASK file is eligible when it contains exactly one `## Delegation
+Contract` section holding one `json` block that validates as a
+`DelegationPacket`, and every implementation block it references exists in
+the same file, is placeholder-free, and matches the recorded revisions.
+
+```text
+writer_generate(task_path)   -> artifact_id, patch_path, patch_sha256, usage, repairs
+  read the patch with source_read, review EVERY hunk
+writer_apply(artifact_id, reviewed_sha256)
+  then run the acceptance tests yourself
+```
+
+Rules that matter:
+
+- An incomplete or stale contract costs **zero** model calls.
+- The delegate gets only the packet, its approved reference slices and its
+  decided implementation blocks — never whole repository files, never host
+  conversation history, and no tools.
+- At most **one** repair attempt, and none at all for a substituted model
+  or an unexpected tool call.
+- Generation never modifies a target file.
+- `writer_apply` re-checks the reviewed hash, the packet identity, the
+  contract, staged targets and every target revision before writing
+  anything. It never stages, commits or pushes, and it requires a git
+  repository (it must be able to see the staged file list).
+
+Contract error codes: `task_not_found`, `task_outside_root`,
+`no_delegation_section`, `duplicate_delegation_section`, `no_packet_block`,
+`duplicate_packet_block`, `invalid_packet_json`, `invalid_packet`,
+`duplicate_block_id`, `missing_block`, `placeholder_code`,
+`scope_path_invalid`, `target_exists_for_create`,
+`target_missing_for_modify`, `stale_target`, `stale_reference`,
+`reference_range_invalid`, `underspecified_create`,
+`invalid_validation_command`, `context_budget_exceeded`,
+`packet_too_large`.
+
+Patch/apply codes: `not_a_patch`, `absolute_path`, `path_escape`,
+`path_outside_scope`, `duplicate_target`, `deletion_rejected`,
+`rename_rejected`, `mode_change_rejected`, `binary_rejected`,
+`submodule_rejected`, `malformed_hunk`, `context_mismatch`,
+`create_needs_dev_null`, `patch_too_large`, `artifact_tampered`,
+`artifact_not_found`, `invalid_artifact_id`, `review_hash_mismatch`,
+`packet_mismatch`, `staged_target`, `target_changed`, `create_collision`,
+`after_hash_mismatch`, `recovery_pending`, `recovery_required`,
+`model_substituted`, `unexpected_tool_call`, `deadline_exceeded`,
+`no_client`.
+
+#### Recovery
+
+Multi-file filesystem mutation is **not globally atomic**. Applying writes
+each file through an adjacent temporary file and records a journal of
+before/after hashes.
+
+- On failure, only files still matching exactly what this operation wrote
+  are restored; the journal state becomes `rolled_back`.
+- A file a concurrent editor has changed is **never overwritten**. It is
+  marked unrecoverable, the operation returns `recovery_required`, and the
+  journal is retained at
+  `artifacts/tool-optimizations/<artifact-id>/journal.json`.
+- A later apply of the same artifact returns `recovery_pending` until a
+  human resolves it.
+- Re-applying a fully applied artifact returns `already_applied` and writes
+  nothing.
+
+## Client configuration
+
+Only the writer needs a model. Configure it through the existing
+`LLMFactory`:
+
+```yaml
+targeted-writer:
+  class: parrot_tools.tool_optimizations.writer.TargetedWriterToolkit
+  llm: bedrock-converse:qwen3-coder-480b-a35b
+  llm_kwargs:
+    fallback_model: null      # REQUIRED
+    max_retries: 1
+    read_timeout: 120
+  kwargs:
+    repo_root: .
+    expected_model_ids: ["qwen.qwen3-coder-480b-a35b-v1:0"]
+```
+
+- **`fallback_model: null` is required.** `BedrockConverseClient` declares
+  `_fallback_model = "claude-haiku-4-5"` and applies it via `setdefault`,
+  so without the explicit null the provider may answer with a different
+  model. The writer's constructor **refuses** a client that still permits a
+  fallback.
+- Bedrock reports the *translated* model id
+  (`qwen3-coder-480b-a35b` → `qwen.qwen3-coder-480b-a35b-v1:0`), so list
+  the reported id in `expected_model_ids` for the identity check.
+- Credentials come from the standard AWS chain. No secret ever belongs in
+  this file.
+- `llm_kwargs` is trusted server configuration, never an LLM-callable
+  argument.
+
+## Host guards
+
+An opt-in `PreToolUse` hook that denies unbounded reads of large files and
+replies with the exact bounded-reader call to make instead. It uses the
+same thresholds as the reader, read from `.parrot/tool-guards.json`.
+
+**The guard is a convenience, not an enforcement boundary.** The reader's
+own limits hold whether or not the hook is installed, and the hook makes no
+decision at all for anything outside the documented subset.
+
+### Tested host versions
+
+| Host | Version tested | Notes |
+|---|---|---|
+| Claude Code | 2.1.267 | Denial keyword `deny`. |
+| Codex CLI | 0.154.0 | Denial keyword `block` — its `PreToolUseDecisionWire` enum is `approve\|block\|allow` and it rejects `deny` as an unsupported decision. |
+
+Coverage was verified against **those versions only**. Re-test after a host
+upgrade; a host that silently changes its decision enum will fail open.
+
+### Coverage matrix
+
+<!-- coverage-matrix:begin -->
+
+| Form | Covered | Note |
+|---|---|---|
+| `Claude Read (file_path)` | yes | Structured tool input; honours a limit <= max_lines. |
+| `cat FILE` | yes | Literal operand; denied when the file is large. |
+| `head -n N FILE / head -N FILE` | yes | Allowed when N <= max_lines. |
+| `tail -c N FILE` | yes | Allowed when N <= large_file_bytes. |
+| `bare head FILE / tail FILE` | yes | Defaults to 10 lines, so bounded. |
+| `less FILE / more FILE` | yes | Treated as a whole-file read. |
+| `cat FILE | head -20` | yes | The reading segment decides; a pipe is not safe. |
+| `cat FILE; other` | no | Compound statement — outside the parsed subset. |
+| `cat $(echo FILE)` | no | Command substitution is never evaluated. |
+| `cat *.py` | no | Glob expansion is the shell's, not ours. |
+| `cat < FILE` | no | Redirection is outside the subset. |
+| `sed -n '1,500p' FILE` | no | sed is not an intercepted program. |
+| `awk 'NR<500' FILE` | no | awk is not an intercepted program. |
+| `python -c "open('FILE').read()"` | no | Arbitrary interpreters are not parsed. |
+| `xargs cat` | no | Operands arrive on stdin, not in the argv we can see. |
+| `heredoc (<<EOF)` | no | Outside the subset. |
+| `Codex write_stdin` | no | Documented host gap: it does not re-run PreToolUse. |
+| `Codex hosted tools` | no | Not hookable by the host. |
+| `Grep / Glob` | no | Out of scope; the guard matcher is Read|Bash. |
+| `WebFetch` | no | Not a local file read. |
+| `Interactive shell session input` | no | Not mediated by PreToolUse. |
+
+<!-- coverage-matrix:end -->
+
+Everything marked `no` keeps normal host behaviour. Notable documented
+bypasses: compound statements, command substitution, globs, redirection,
+`sed`/`awk`/arbitrary interpreters, `xargs`, heredocs, Codex `write_stdin`
+(which does not re-run `PreToolUse`), hosted tools, and interactive shell
+input.
+
+## Measurement protocol
+
+```bash
+python -m benchmarks.tool_optimizations --scenario all --runs 1          # offline, free
+python -m benchmarks.tool_optimizations --scenario all --runs 5 --live   # spends money
+```
+
+Primary tokens, delegate tokens and total tokens are reported separately;
+median and p95 latency are both reported; correctness is measured by
+executing the real acceptance test. Cost is `unknown` until
+`benchmarks/tool_optimizations/prices.yaml` is filled in with sourced
+prices. See `benchmarks/tool_optimizations/README.md`.
+
+## Limitations and security notes
+
+- Multi-file application is not globally atomic; see [Recovery](#recovery).
+- The worktree lock is advisory (`fcntl.flock`). External Git processes do
+  not honour it, which is why Git's own locks and revision checks are still
+  used. The lock file is never deleted — flock is released by the kernel on
+  process death, so a stale lock is impossible.
+- Artifacts are stored under `artifacts/tool-optimizations/<id>/` with
+  `0o700` directories and `0o600` files, and are opaque data — never
+  executable commands. `artifacts/` is gitignored.
+- Only approved packet slices are sent to the provider; whole repository
+  files are never included in a prompt.
+- `validation_commands` in a packet are data, never an execution path. No
+  command from a model response is ever run.
+- Secret files are refused by the same deny-list the read-only repo toolkit
+  uses; `*.example` / `*.sample` / `*.template` / `*.dist` remain readable.
+
+## Release checklist
+
+- [ ] `pytest packages/ai-parrot-tools/tests/tool_optimizations` green.
+- [ ] `pytest tests/mcp` shows no regressions against the base branch.
+- [ ] `ruff check` and `black --check` clean.
+- [ ] An offline benchmark report is attached, and a `--live` report if the
+      deployment has provider access.
+- [ ] `prices.yaml` filled in if cost figures are required.
+- [ ] **Codex guard installation verified end to end.** The installer
+      currently writes a Claude-shaped `.codex/hooks.json`, while
+      codex-cli 0.154.0 exposes `eventName` / `timeoutSec` fields. See
+      `artifacts/logs/host-smoke.json`.
+- [ ] Host versions re-confirmed against the deployment's installed hosts.
+
+**Numeric token, cost and latency targets are an owner decision** (spec
+§8). This feature ships with correctness parity enforced by the benchmark
+harness and reports the numbers it measured. No percentage saving is
+claimed anywhere in this repository.
+
+## Acceptance criteria traceability
+
+| AC | Covered by |
+|---|---|
+| AC1 | `integration/test_stdio_protocol.py` |
+| AC2 | `test_git.py`, `integration/test_git_lifecycle.py` |
+| AC3 | `test_git.py` (`unrelated_staged`, `partially_staged`, index-byte assertions) |
+| AC4 | `test_git.py` (pull/push), `integration/test_git_lifecycle.py` |
+| AC5 | `test_reader.py` (thresholds, budget), `test_policy.py` (`fit_to_budget`) |
+| AC6 | `test_reader.py` (bounded allocation, continuation, stale revision) |
+| AC7 | `test_contracts.py`, `test_writer.py` (`fake.calls == []`) |
+| AC8 | `tests/mcp/test_toolkit_config.py`, `tests/mcp/test_toolkit_server.py`, `integration/test_client_configuration.py` |
+| AC9 | `test_writer.py`, `test_apply.py`, `test_patches.py` |
+| AC10 | `test_apply.py` (rollback, recovery, idempotency), `integration/test_cross_process.py` |
+| AC11 | `test_writer.py` (one repair, deadline, usage recording) |
+| AC12 | `test_sdd_contracts.py` |
+| AC13 | `test_hooks.py`, `test_installation.py`, `integration/test_host_smoke.py` |
+| AC14 | `artifacts/logs/TASK-3091-regression.log`, ruff/black checks |
+| AC15 | `docs/tool-optimizations.md`, `benchmarks/tool_optimizations/`, `test_benchmark_harness.py` |
+
+## Related
+
+- [Local MCP toolkits](mcp-local-toolkits.md) — the configuration and
+  serving machinery this feature plugs into.
+- `sdd/specs/tool-optimizations.spec.md` — the authoritative specification.

--- a/docs/tool-optimizations.md
+++ b/docs/tool-optimizations.md
@@ -65,7 +65,7 @@ parrot claude uninstall
 | `git_preflight` | — | Runs every check independently and reports each one. |
 | `git_prepare_files` | `paths: list[str]` | Stages exactly these files via an isolated index. Requires `confirm`. |
 | `git_pull` | `remote="origin"`, `branch=None` | Fast-forward only. Requires `confirm`. |
-| `git_push` | `remote="origin"`, `branch=None` | Never forced, never creates a commit. Requires `confirm`. |
+| `git_push` | `remote="origin"`, `branch=None` | Never forced, never creates a commit, never publishes tags. Pushes the **currently checked-out** branch to the resolved remote branch; the result reports both as `branch` and `remote_branch`. Requires `confirm`. |
 
 Mutating tools carry a required `confirm` boolean over MCP. That flag is
 the host's record that a human approved the operation — it is not
@@ -86,6 +86,12 @@ authorization a model can grant itself.
 `upstream_remote_mismatch`, `branch_mismatch`, `diverged`,
 `untracked_conflict`, `fast_forward_failed`, `push_rejected`,
 `push_timeout`, `worktree_busy`.
+
+**`git_push` publishes the branch you are on.** When a branch tracks a
+differently-named upstream (`feature` -> `origin/dev`), the source ref is
+always the current branch and the destination is the resolved remote branch.
+The result reports `branch` (local) and `remote_branch` (remote) separately,
+so what was published is never ambiguous.
 
 **`git_prepare_files` never unstages anything.** If unrelated paths are
 already staged it refuses with `unrelated_staged` rather than resetting the

--- a/examples/tool-optimizations-mcp.yaml
+++ b/examples/tool-optimizations-mcp.yaml
@@ -1,0 +1,65 @@
+# FEAT-543 — Claude Code / Codex tool optimizations, as local MCP toolkits.
+#
+# Serve with:
+#     parrot mcp-local <name> --config examples/tool-optimizations-mcp.yaml
+#
+# The three toolkits are independent, opt-in sections — none of them is a
+# globally enabled built-in. Only `targeted-writer` needs a model; the Git
+# and reader toolkits are fully deterministic and make no LLM calls, so a
+# server for them never even imports the client factory.
+#
+# NOTE ON `repo_root: .`
+#   Paths are resolved relative to the *MCP host's* working directory, which
+#   is not always the repository you think it is — hosts frequently start
+#   servers from their own cwd. Prefer an absolute path in a real
+#   installation, or start the server from the repository root.
+#
+# NOTE ON CREDENTIALS
+#   No secrets appear here. The Bedrock client uses the standard AWS
+#   credential/profile/environment chain; region and model access are
+#   deployment settings. This file names a model alias, which is not a claim
+#   that a given account or region can invoke it.
+
+toolkits:
+  # Deterministic Git workflows: bounded history, fetch with an explicit
+  # refspec, preflight checks, isolated-index staging, fast-forward-only
+  # pull and non-forced push. No LLM, no model configuration.
+  local-git:
+    class: parrot_tools.tool_optimizations.git.LocalGitToolkit
+    kwargs:
+      repo_root: .
+
+  # Bounded source reading: files above 350 lines or 64,000 bytes require an
+  # explicit inclusive line range; every result carries a SHA-256 revision
+  # and a continuation cursor.
+  bounded-source:
+    class: parrot_tools.tool_optimizations.reader.BoundedSourceToolkit
+    kwargs:
+      repo_root: .
+      # Both thresholds are configurable; these are the defaults.
+      # max_lines: 350
+      # large_file_bytes: 64000
+
+  # Patch generation for work whose design is ALREADY DECIDED in a TASK
+  # file's `## Delegation Contract`. The delegate never explores the
+  # repository and never resolves a design gap.
+  targeted-writer:
+    class: parrot_tools.tool_optimizations.writer.TargetedWriterToolkit
+    llm: bedrock-converse:qwen3-coder-480b-a35b
+    llm_kwargs:
+      # REQUIRED. BedrockConverseClient declares
+      # `_fallback_model = "claude-haiku-4-5"`
+      # (ai-parrot-client-amazon/.../bedrock.py:1669) and its constructor
+      # applies that default via `setdefault`, so without this explicit null
+      # the provider may silently answer with a different model. The writer's
+      # constructor REFUSES a client that still permits a fallback.
+      fallback_model: null
+      max_retries: 1
+      read_timeout: 120
+    kwargs:
+      repo_root: .
+      # Bedrock reports the *translated* model id rather than the alias
+      # (`qwen3-coder-480b-a35b` -> `qwen.qwen3-coder-480b-a35b-v1:0`,
+      # ai-parrot-client-amazon/.../models.py:130), so the identity check
+      # must be told which reported ids are legitimate.
+      expected_model_ids: ["qwen.qwen3-coder-480b-a35b-v1:0"]

--- a/packages/ai-parrot-tools/src/parrot_tools/__init__.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/__init__.py
@@ -79,6 +79,7 @@ TOOL_REGISTRY: dict[str, str] = {
     "lyria": "parrot_tools.google.lyria.LyriaToolkit",
     "graph_index": "parrot_tools.graphindex.toolkit.GraphIndexToolkit",
     "local_git": "parrot_tools.tool_optimizations.git.LocalGitToolkit",
+    "bounded_source": "parrot_tools.tool_optimizations.reader.BoundedSourceToolkit",
     "google_voice": "parrot_tools.gvoice.GoogleVoiceTool",
     "ibis_world": "parrot_tools.ibisworld.tool.IBISWorldTool",
     "jira": "parrot_tools.jiratoolkit.JiraToolkit",

--- a/packages/ai-parrot-tools/src/parrot_tools/__init__.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/__init__.py
@@ -80,6 +80,7 @@ TOOL_REGISTRY: dict[str, str] = {
     "graph_index": "parrot_tools.graphindex.toolkit.GraphIndexToolkit",
     "local_git": "parrot_tools.tool_optimizations.git.LocalGitToolkit",
     "bounded_source": "parrot_tools.tool_optimizations.reader.BoundedSourceToolkit",
+    "targeted_writer": "parrot_tools.tool_optimizations.writer.TargetedWriterToolkit",
     "google_voice": "parrot_tools.gvoice.GoogleVoiceTool",
     "ibis_world": "parrot_tools.ibisworld.tool.IBISWorldTool",
     "jira": "parrot_tools.jiratoolkit.JiraToolkit",

--- a/packages/ai-parrot-tools/src/parrot_tools/__init__.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/__init__.py
@@ -78,6 +78,7 @@ TOOL_REGISTRY: dict[str, str] = {
     "google_lyria": "parrot_tools.google.lyria.LyriaToolkit",
     "lyria": "parrot_tools.google.lyria.LyriaToolkit",
     "graph_index": "parrot_tools.graphindex.toolkit.GraphIndexToolkit",
+    "local_git": "parrot_tools.tool_optimizations.git.LocalGitToolkit",
     "google_voice": "parrot_tools.gvoice.GoogleVoiceTool",
     "ibis_world": "parrot_tools.ibisworld.tool.IBISWorldTool",
     "jira": "parrot_tools.jiratoolkit.JiraToolkit",

--- a/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/__init__.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/__init__.py
@@ -1,0 +1,102 @@
+"""Claude Code / Codex tool optimizations (FEAT-543).
+
+Three focused ``AbstractToolkit`` subclasses, exposed as ordinary AI-Parrot
+tools and installable as local stdio MCP capabilities:
+
+* ``LocalGitToolkit`` — deterministic Git workflows, no LLM calls.
+* ``BoundedSourceToolkit`` — bounded reads with hashes and continuation.
+* ``TargetedWriterToolkit`` — patch generation for *already-decided* TASK work.
+
+Importing this package is deliberately cheap: names are resolved lazily via
+:pep:`562` ``__getattr__`` so that ``import parrot_tools.tool_optimizations``
+pulls in neither ``pydantic`` nor any toolkit machinery. The host read-guard
+runtime depends on that — it must stay stdlib-light on import.
+"""
+
+from typing import Any
+
+__all__ = (
+    # models
+    "OperationError",
+    "StepResult",
+    "OperationResult",
+    "SourceInfo",
+    "SourceResult",
+    "WriterLimits",
+    "ReferenceSlice",
+    "TargetFile",
+    "DelegationPacket",
+    "PatchManifest",
+    # policy
+    "MIN_RESULT_BYTES",
+    "OptimizationPolicy",
+    "PolicyError",
+    "SymlinkRejectedError",
+    "LockTimeoutError",
+    "BudgetError",
+    "WorktreeLock",
+    "compact_json",
+    "measure_json_bytes",
+    "fit_to_budget",
+    "relative_posix",
+    "check_no_symlink_components",
+    "resolve_operand",
+    # base
+    "OptimizationToolkitBase",
+)
+
+#: Public name -> defining submodule. Kept explicit so a typo surfaces as an
+#: AttributeError here rather than as a confusing ImportError downstream.
+_EXPORTS: dict[str, str] = {
+    "OperationError": "models",
+    "StepResult": "models",
+    "OperationResult": "models",
+    "SourceInfo": "models",
+    "SourceResult": "models",
+    "WriterLimits": "models",
+    "ReferenceSlice": "models",
+    "TargetFile": "models",
+    "DelegationPacket": "models",
+    "PatchManifest": "models",
+    "MIN_RESULT_BYTES": "policy",
+    "OptimizationPolicy": "policy",
+    "PolicyError": "policy",
+    "SymlinkRejectedError": "policy",
+    "LockTimeoutError": "policy",
+    "BudgetError": "policy",
+    "WorktreeLock": "policy",
+    "compact_json": "policy",
+    "measure_json_bytes": "policy",
+    "fit_to_budget": "policy",
+    "relative_posix": "policy",
+    "check_no_symlink_components": "policy",
+    "resolve_operand": "policy",
+    "OptimizationToolkitBase": "base",
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily import a public name from its defining submodule.
+
+    Args:
+        name: The attribute being accessed on this package.
+
+    Returns:
+        The resolved object.
+
+    Raises:
+        AttributeError: ``name`` is not a public export of this package.
+    """
+    module_name = _EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from importlib import import_module
+
+    value = getattr(import_module(f".{module_name}", __name__), name)
+    globals()[name] = value  # cache: subsequent lookups skip __getattr__
+    return value
+
+
+def __dir__() -> list[str]:
+    """Return the public export names for interactive completion."""
+    return sorted(__all__)

--- a/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/base.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/base.py
@@ -1,0 +1,231 @@
+"""Shared toolkit base for the tool-optimizations toolkits (FEAT-543).
+
+:class:`OptimizationToolkitBase` is the single validation seam for all three
+toolkits. It exists because MCP input does **not** pass through
+``AbstractTool.execute()``: ``MCPToolAdapter.execute()`` calls
+``tool._execute(**arguments)`` directly, so schema validation never runs.
+``ToolkitTool._execute()`` does still invoke ``toolkit._pre_execute()`` with
+the *raw* kwargs, before unknown keys are stripped — which makes
+:meth:`OptimizationToolkitBase._pre_execute` the enforcement point for
+untrusted ``tools/call`` arguments.
+
+Direct Python calls must be safe too, so the public toolkit methods validate
+their own arguments as well; this seam is defence in depth, not a substitute.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from time import perf_counter
+from typing import Any, Optional
+
+from parrot.tools.abstract import ToolResult
+from parrot.tools.toolkit import AbstractToolkit
+from pydantic import BaseModel, ValidationError
+
+from .models import OperationError, OperationResult, StepResult
+from .policy import OptimizationPolicy, fit_to_budget, relative_posix, resolve_operand
+
+__all__ = ("OptimizationToolkitBase",)
+
+
+class OptimizationToolkitBase(AbstractToolkit):
+    """Common policy, validation and result-shaping for optimization toolkits.
+
+    Subclasses declare :attr:`arg_models`, mapping each public method name to
+    its Pydantic argument model, and implement public ``async`` methods that
+    return Pydantic models.
+
+    Attributes:
+        arg_models: Method name -> argument model. Every exposed tool must
+            have an entry; an unmapped tool name is rejected outright.
+    """
+
+    arg_models: dict[str, type[BaseModel]] = {}
+
+    def __init__(
+        self,
+        *,
+        repo_root: str | Path,
+        policy: Optional[OptimizationPolicy] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the toolkit and build its policy.
+
+        Any :class:`OptimizationPolicy` field passed as a keyword argument is
+        consumed as a policy override; everything else is forwarded to
+        ``AbstractToolkit.__init__``.
+
+        Args:
+            repo_root: The repository checkout this toolkit is confined to.
+            policy: A fully built policy, overriding per-field keyword
+                arguments when supplied.
+            **kwargs: Policy overrides plus normal toolkit keyword arguments.
+        """
+        overrides = {key: kwargs.pop(key) for key in list(kwargs) if key in OptimizationPolicy.model_fields}
+        overrides.pop("repo_root", None)
+        super().__init__(**kwargs)
+        self.policy = policy or OptimizationPolicy(repo_root=Path(repo_root), **overrides)
+        # Capture the serializable constructor kwargs so build_envelope_from_tool
+        # can reconstruct this toolkit for remote/off-process execution.
+        self._init_kwargs.update(
+            {
+                "repo_root": str(self.policy.repo_root),
+                **self.policy.model_dump(mode="json", exclude={"repo_root"}),
+            }
+        )
+        self.logger = logging.getLogger(__name__)
+
+    # ----------------------------------------------------------------- #
+    # Lifecycle hooks
+    # ----------------------------------------------------------------- #
+    async def _pre_execute(self, tool_name: str, /, **kwargs: Any) -> None:
+        """Validate raw tool arguments before any subprocess, model or write.
+
+        Args:
+            tool_name: The tool being invoked. Equal to the method name,
+                because these toolkits never set ``tool_prefix``.
+            **kwargs: The raw arguments, plus the injected permission context.
+
+        Raises:
+            ValueError: The tool is unknown or its arguments are invalid.
+        """
+        assert self.tool_prefix is None, "optimization toolkits must not set tool_prefix"
+        kwargs.pop("_permission_context", None)
+        model = self.arg_models.get(tool_name)
+        if model is None:
+            raise ValueError(f"unknown tool {tool_name!r}")
+        try:
+            model.model_validate(kwargs)
+        except ValidationError as exc:
+            first = exc.errors()[0]
+            location = ".".join(str(part) for part in first.get("loc", ())) or "<root>"
+            raise ValueError(f"invalid arguments for {tool_name}: {location}: {first['msg']}") from exc
+
+    async def _post_execute(self, tool_name: str, result: Any, /, **kwargs: Any) -> Any:
+        """Serialize a Pydantic result into a JSON-safe ``ToolResult``.
+
+        A domain failure is still ``status="success"`` at the ``ToolResult``
+        level, carrying ``result["status"] == "error"`` — the MCP ``isError``
+        flag is reserved for argument rejection and crashes. ``metadata`` stays
+        empty so the adapter does not append a "Metadata:" text block.
+
+        Args:
+            tool_name: The tool that produced the result.
+            result: The value returned by the toolkit method.
+            **kwargs: The (filtered) tool arguments; unused.
+
+        Returns:
+            A ``ToolResult`` wrapping a JSON-compatible dict, or ``result``
+            unchanged when it is already a ``ToolResult`` or a plain dict.
+        """
+        if isinstance(result, ToolResult):
+            return result
+        if isinstance(result, BaseModel):
+            return ToolResult(status="success", result=result.model_dump(mode="json"), metadata={})
+        return result
+
+    # ----------------------------------------------------------------- #
+    # Result helpers
+    # ----------------------------------------------------------------- #
+    def _ok(
+        self,
+        operation: str,
+        data: Optional[dict[str, Any]] = None,
+        steps: Optional[list[StepResult]] = None,
+        started: Optional[float] = None,
+        truncated: bool = False,
+    ) -> OperationResult:
+        """Build a bounded successful :class:`OperationResult`.
+
+        Args:
+            operation: The tool/method name.
+            data: The operation payload.
+            steps: Per-step outcomes, in execution order.
+            started: A ``perf_counter()`` reading taken at operation start.
+            truncated: True when the caller already dropped content.
+
+        Returns:
+            A result guaranteed to fit ``policy.max_result_bytes``.
+        """
+        return fit_to_budget(
+            OperationResult(
+                status="ok",
+                operation=operation,
+                data=data or {},
+                steps=steps or [],
+                truncated=truncated,
+                elapsed_ms=self._elapsed_ms(started),
+            ),
+            self.policy.max_result_bytes,
+        )
+
+    def _error(
+        self,
+        operation: str,
+        code: str,
+        message: str,
+        details: Optional[dict[str, Any]] = None,
+        steps: Optional[list[StepResult]] = None,
+        started: Optional[float] = None,
+        status: str = "error",
+    ) -> OperationResult:
+        """Build a bounded failed (or uncertain) :class:`OperationResult`.
+
+        Args:
+            operation: The tool/method name.
+            code: A snake_case error code.
+            message: A short human-readable explanation.
+            details: Structured context for the caller.
+            steps: Per-step outcomes recorded before the failure.
+            started: A ``perf_counter()`` reading taken at operation start.
+            status: ``error`` (default) or ``uncertain`` when the outcome of a
+                remote effect is genuinely unknown.
+
+        Returns:
+            A result guaranteed to fit ``policy.max_result_bytes``.
+        """
+        return fit_to_budget(
+            OperationResult(
+                status="uncertain" if status == "uncertain" else "error",
+                operation=operation,
+                error=OperationError(code=code, message=message, details=details or {}),
+                steps=steps or [],
+                elapsed_ms=self._elapsed_ms(started),
+            ),
+            self.policy.max_result_bytes,
+        )
+
+    @staticmethod
+    def _elapsed_ms(started: Optional[float]) -> int:
+        """Return elapsed milliseconds since ``started``.
+
+        Args:
+            started: A ``perf_counter()`` reading, or None.
+
+        Returns:
+            The elapsed milliseconds, or 0 when ``started`` is None.
+        """
+        if started is None:
+            return 0
+        return max(0, int((perf_counter() - started) * 1000))
+
+    def _repo_relative(self, candidate: str, *, readable: bool) -> str:
+        """Resolve ``candidate`` under policy and return its relative path.
+
+        Args:
+            candidate: A caller-supplied path.
+            readable: When True, the path must already exist.
+
+        Returns:
+            The repo-relative POSIX path.
+
+        Raises:
+            PathOutsideRootError: The path escapes the repository root.
+            SecretFileError: The path matches the secret deny-list.
+            SymlinkRejectedError: A component below the root is a symlink.
+            PolicyError: ``readable`` is True and the path does not exist.
+        """
+        target = resolve_operand(self.policy, candidate, must_exist=readable)
+        return relative_posix(self.policy.repo_root, target)

--- a/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/contracts.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/contracts.py
@@ -1,0 +1,713 @@
+"""Delegation-contract parsing and validation (FEAT-543).
+
+This module decides — **entirely offline, before any model call** — whether
+a TASK file is eligible for delegation. A stale or incomplete contract is
+returned to the thinking model with a precise, actionable error; the
+delegate never explores the repository and never resolves a design gap.
+
+A TASK file is eligible when it contains exactly one ``## Delegation
+Contract`` section holding exactly one ``json`` fenced block that validates
+as a :class:`DelegationPacket`, and every implementation block that packet
+references exists in the same file, is free of placeholders, and matches
+the recorded revisions on disk.
+
+``design_complete: true`` is an *eligibility declaration*, not proof of
+correctness: this module checks structural completeness, while the thinking
+model verifies semantics.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any, Optional
+
+from parrot.tools.repo.confinement import PathOutsideRootError, SecretFileError
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from .models import DelegationPacket, ReferenceSlice, WriterLimits
+from .policy import (
+    OptimizationPolicy,
+    PolicyError,
+    SymlinkRejectedError,
+    compact_json,
+    measure_json_bytes,
+    resolve_operand,
+)
+from .reader import (
+    InvalidEncodingError,
+    LineTooLargeError,
+    RangeOutOfBoundsError,
+    read_line_range,
+    sha256_stream,
+    stat_regular,
+)
+
+__all__ = (
+    "ALLOWED_VALIDATION_PROGRAMS",
+    "CodeBlock",
+    "ContractError",
+    "ResolvedReference",
+    "ValidatedContract",
+    "extract_packet",
+    "find_placeholders",
+    "parse_task_file",
+    "render_prompt_sections",
+    "validate_contract",
+)
+
+#: The only programs a packet may name in `validation_commands`. Commands are
+#: never executed here — the SDD workflow owns authorized validation — but an
+#: unrecognized program means the packet was not authored by that workflow.
+ALLOWED_VALIDATION_PROGRAMS = frozenset({"pytest", "ruff", "black", "mypy", "python", "python3"})
+
+#: The heading that opens the delegation section.
+DELEGATION_HEADING = "## Delegation Contract"
+
+#: Maximum number of TASK-file lines scanned.
+_MAX_TASK_LINES = 200_000
+
+_FENCE = re.compile(r"^(?P<fence>`{3,})(?P<info>.*)$")
+_BLOCK_ID = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+
+#: Line-anchored placeholder patterns. A bare ellipsis *line* is a
+#: placeholder; the string "..." inside an expression is not.
+_PLACEHOLDERS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("bare_ellipsis", re.compile(r"^\s*\.\.\.\s*$")),
+    ("todo", re.compile(r"\bTODO\b")),
+    ("fixme", re.compile(r"\bFIXME\b")),
+    ("xxx", re.compile(r"\bXXX\b")),
+    ("angle_placeholder", re.compile(r"<[A-Za-z][A-Za-z0-9 _-]*>")),
+    ("not_implemented", re.compile(r"raise NotImplementedError")),
+    ("pass_implement", re.compile(r"pass\s+#\s*implement")),
+)
+
+
+class ContractError(ValueError):
+    """A delegation contract is missing, malformed, stale or underspecified.
+
+    Attributes:
+        code: A stable snake_case code identifying the failure.
+        details: Structured context telling the thinking model what to fix.
+    """
+
+    def __init__(self, code: str, message: str = "", details: Optional[dict[str, Any]] = None) -> None:
+        """Initialize the error.
+
+        Args:
+            code: The stable failure code.
+            message: A human-readable explanation.
+            details: Structured context (block ids, paths, expected vs current).
+        """
+        super().__init__(message or code)
+        self.code = code
+        self.details = details or {}
+
+
+class CodeBlock(BaseModel):
+    """A labelled fenced code block inside a TASK file.
+
+    Attributes:
+        block_id: The `id=` attribute from the fence info string.
+        language: The fence's language token, if any.
+        text: The block's literal content.
+        start_line: The 1-based line of the opening fence.
+        path: The `path=` attribute, when the block *is* a file's content.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    block_id: str
+    language: str = ""
+    text: str = ""
+    start_line: int
+    path: Optional[str] = None
+
+
+class ResolvedReference(BaseModel):
+    """A reference slice loaded from disk and checked for freshness.
+
+    Attributes:
+        slice: The packet's declared reference.
+        content: The bounded excerpt actually read.
+        current_sha256: The referenced file's current digest.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    slice: ReferenceSlice
+    content: str
+    current_sha256: str
+
+
+class ValidatedContract(BaseModel):
+    """A TASK file proven eligible for delegation.
+
+    Attributes:
+        task_path: The repo-relative TASK file path.
+        packet: The validated delegation packet.
+        packet_sha256: The packet's canonical identity.
+        blocks: Only the implementation blocks the packet references.
+        references: The loaded, freshness-checked reference slices.
+        targets_state: Target path -> current digest, or None when absent.
+        context_bytes: The measured size of everything sent to the delegate.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    task_path: str
+    packet: DelegationPacket
+    packet_sha256: str
+    blocks: dict[str, CodeBlock]
+    references: list[ResolvedReference]
+    targets_state: dict[str, Optional[str]]
+    context_bytes: int
+
+
+# --------------------------------------------------------------------------- #
+# Parsing
+# --------------------------------------------------------------------------- #
+def _parse_info(info: str) -> dict[str, str]:
+    """Parse a fence info string into a language plus ``key=value`` tokens.
+
+    Args:
+        info: The text following the opening backticks.
+
+    Returns:
+        A mapping with ``language`` plus any attributes found.
+    """
+    parsed: dict[str, str] = {"language": ""}
+    tokens = info.strip().split()
+    for index, token in enumerate(tokens):
+        if "=" in token:
+            key, _, value = token.partition("=")
+            parsed[key] = value
+        elif index == 0:
+            parsed["language"] = token
+        else:
+            parsed.setdefault("modifier", token)
+    return parsed
+
+
+def parse_task_file(text: str) -> tuple[str, dict[str, CodeBlock]]:
+    """Extract the packet JSON and every labelled code block from a TASK file.
+
+    The fence scanner is hand-written on purpose (no markdown dependency)
+    and tracks fence length, so a shorter fence nested inside a block is
+    preserved literally.
+
+    Args:
+        text: The TASK file's full text.
+
+    Returns:
+        A ``(packet_json, blocks)`` tuple keyed by block id.
+
+    Raises:
+        ContractError: The delegation section or packet block is missing,
+            duplicated, or a block id is duplicated or malformed.
+    """
+    packets: list[str] = []
+    blocks: dict[str, CodeBlock] = {}
+    current: Optional[dict[str, Any]] = None
+    fence_len = 0
+    buffer: list[str] = []
+    section_count = 0
+    in_section = False
+
+    for lineno, line in enumerate(text.splitlines(), 1):
+        match = _FENCE.match(line)
+
+        if current is None:
+            if line.startswith("## "):
+                in_section = line.strip() == DELEGATION_HEADING
+                if in_section:
+                    section_count += 1
+                continue
+            if match:
+                current = _parse_info(match.group("info"))
+                current["start_line"] = lineno
+                current["in_section"] = in_section
+                fence_len = len(match.group("fence"))
+                buffer = []
+            continue
+
+        # Inside a block: only a bare fence at least as long closes it.
+        if match and len(match.group("fence")) >= fence_len and not match.group("info").strip():
+            _close_block(current, buffer, packets, blocks)
+            current = None
+            continue
+        buffer.append(line)
+
+    if section_count == 0:
+        raise ContractError("no_delegation_section", f"no {DELEGATION_HEADING!r} section in the TASK file")
+    if section_count > 1:
+        raise ContractError(
+            "duplicate_delegation_section",
+            f"{section_count} {DELEGATION_HEADING!r} sections; exactly one is allowed",
+            {"count": section_count},
+        )
+    if not packets:
+        raise ContractError("no_packet_block", "the delegation section contains no json fenced block")
+    if len(packets) > 1:
+        raise ContractError(
+            "duplicate_packet_block",
+            f"the delegation section contains {len(packets)} json blocks; exactly one is allowed",
+            {"count": len(packets)},
+        )
+    return packets[0], blocks
+
+
+def _close_block(info: dict[str, Any], buffer: list[str], packets: list[str], blocks: dict[str, CodeBlock]) -> None:
+    """Record a finished fenced block as the packet or a labelled block.
+
+    Args:
+        info: The parsed fence info string plus positional metadata.
+        buffer: The block's literal lines.
+        packets: Accumulator for packet JSON blocks.
+        blocks: Accumulator for labelled implementation blocks.
+
+    Raises:
+        ContractError: A block id is malformed or duplicated.
+    """
+    body = "\n".join(buffer)
+    if info.get("in_section") and info.get("language") == "json" and "id" not in info:
+        packets.append(body)
+        return
+
+    block_id = info.get("id")
+    if not block_id:
+        return
+    if not _BLOCK_ID.match(block_id):
+        raise ContractError("duplicate_block_id", f"malformed block id {block_id!r}", {"block_id": block_id})
+    if block_id in blocks:
+        raise ContractError(
+            "duplicate_block_id", f"block id {block_id!r} appears more than once", {"block_id": block_id}
+        )
+    blocks[block_id] = CodeBlock(
+        block_id=block_id,
+        language=info.get("language", ""),
+        text=body,
+        start_line=int(info["start_line"]),
+        path=info.get("path"),
+    )
+
+
+def extract_packet(json_text: str) -> DelegationPacket:
+    """Parse and validate the packet JSON block.
+
+    Args:
+        json_text: The raw contents of the packet fenced block.
+
+    Returns:
+        The validated packet.
+
+    Raises:
+        ContractError: The JSON is malformed or the packet is invalid.
+    """
+    try:
+        payload = json.loads(json_text)
+    except json.JSONDecodeError as exc:
+        raise ContractError(
+            "invalid_packet_json", f"the packet block is not valid JSON: {exc}", {"error": str(exc)}
+        ) from exc
+    try:
+        return DelegationPacket.model_validate(payload)
+    except ValidationError as exc:
+        errors = [
+            {"loc": ".".join(str(part) for part in item.get("loc", ())), "msg": item["msg"]}
+            for item in exc.errors()[:10]
+        ]
+        raise ContractError(
+            "invalid_packet", "the packet does not satisfy the delegation schema", {"errors": errors}
+        ) from exc
+
+
+def find_placeholders(block: CodeBlock) -> list[tuple[int, str]]:
+    """Find unresolved placeholder code inside an implementation block.
+
+    Args:
+        block: The block to scan.
+
+    Returns:
+        A list of ``(line_number, pattern_name)`` tuples, relative to the
+        block's own first line.
+    """
+    found: list[tuple[int, str]] = []
+    for offset, line in enumerate(block.text.splitlines(), 1):
+        for name, pattern in _PLACEHOLDERS:
+            if pattern.search(line):
+                found.append((offset, name))
+                break
+    return found
+
+
+# --------------------------------------------------------------------------- #
+# Validation
+# --------------------------------------------------------------------------- #
+def _resolve_scope_path(policy: OptimizationPolicy, candidate: str, *, must_exist: bool) -> Path:
+    """Resolve a packet-declared path under the repository policy.
+
+    Args:
+        policy: The active policy.
+        candidate: The declared repo-relative path.
+        must_exist: Whether the path is required to exist.
+
+    Returns:
+        The resolved absolute path.
+
+    Raises:
+        ContractError: The path is absolute, escapes the root, traverses a
+            symlink, matches the secret deny-list, or is required and absent.
+    """
+    if not candidate or candidate.startswith("/") or Path(candidate).is_absolute():
+        raise ContractError("scope_path_invalid", f"{candidate!r} must be repository-relative", {"path": candidate})
+    if any(segment in ("", ".", "..") for segment in candidate.split("/")):
+        raise ContractError("scope_path_invalid", f"{candidate!r} contains a traversal segment", {"path": candidate})
+    try:
+        return resolve_operand(policy, candidate, must_exist=must_exist)
+    except (SymlinkRejectedError, SecretFileError, PathOutsideRootError, PolicyError) as exc:
+        raise ContractError("scope_path_invalid", str(exc), {"path": candidate}) from exc
+
+
+def _read_text_bounded(policy: OptimizationPolicy, path: Path) -> str:
+    """Read a whole text file through the bounded reader.
+
+    ``Path.read_text`` is deliberately avoided so this module obeys the same
+    allocation rules as the bounded reader.
+
+    Args:
+        policy: The active policy, supplying the per-line byte bound.
+        path: The file to read.
+
+    Returns:
+        The file's text, or ``""`` when it is empty.
+
+    Raises:
+        ContractError: The file has an oversized line or invalid encoding.
+    """
+    if stat_regular(path).size == 0:
+        return ""
+    try:
+        span = read_line_range(path, 1, _MAX_TASK_LINES, max_line_bytes=policy.max_result_bytes)
+    except LineTooLargeError as exc:
+        raise ContractError("packet_too_large", str(exc), {"line": exc.line_no}) from exc
+    except InvalidEncodingError as exc:
+        raise ContractError(
+            "invalid_packet_json", f"the file is not valid UTF-8 at line {exc.line_no}", {"line": exc.line_no}
+        ) from exc
+    except RangeOutOfBoundsError:
+        return ""
+    return "".join(span.lines)
+
+
+def _validate_commands(packet: DelegationPacket) -> None:
+    """Check that every validation command is a safe, recognized argv list.
+
+    Commands are **never executed** here; this only proves the packet came
+    from the SDD workflow rather than from a model response.
+
+    Args:
+        packet: The validated packet.
+
+    Raises:
+        ContractError: A command is empty, option-shaped, or names a program
+            outside the allow-list.
+    """
+    for argv in packet.validation_commands:
+        if not argv:
+            raise ContractError("invalid_validation_command", "empty argv list", {"argv": argv})
+        program = argv[0]
+        if not isinstance(program, str) or program.startswith("-"):
+            raise ContractError("invalid_validation_command", f"option-shaped program {program!r}", {"argv": argv})
+        if Path(program).name not in ALLOWED_VALIDATION_PROGRAMS:
+            raise ContractError(
+                "invalid_validation_command",
+                f"{program!r} is not an allowed validation program",
+                {"argv": argv, "allowed": sorted(ALLOWED_VALIDATION_PROGRAMS)},
+            )
+
+
+def _validate_blocks(packet: DelegationPacket, blocks: dict[str, CodeBlock]) -> dict[str, CodeBlock]:
+    """Resolve every referenced block and reject placeholder code.
+
+    Args:
+        packet: The validated packet.
+        blocks: Every labelled block found in the TASK file.
+
+    Returns:
+        Only the blocks the packet actually references.
+
+    Raises:
+        ContractError: A referenced block is missing or contains a placeholder.
+    """
+    needed: list[str] = list(packet.implementation_blocks)
+    for target in packet.targets:
+        needed.extend(target.blocks)
+
+    resolved: dict[str, CodeBlock] = {}
+    for block_id in needed:
+        block = blocks.get(block_id)
+        if block is None:
+            raise ContractError(
+                "missing_block",
+                f"the TASK file has no code block with id={block_id!r}",
+                {"block_id": block_id, "available": sorted(blocks)},
+            )
+        placeholders = find_placeholders(block)
+        if placeholders:
+            line, name = placeholders[0]
+            raise ContractError(
+                "placeholder_code",
+                f"block {block_id!r} still contains unresolved placeholder code",
+                {"block_id": block_id, "line": line, "pattern": name},
+            )
+        resolved[block_id] = block
+    return resolved
+
+
+def _validate_targets(
+    policy: OptimizationPolicy, packet: DelegationPacket, blocks: dict[str, CodeBlock]
+) -> dict[str, Optional[str]]:
+    """Check every target's precondition and record its current revision.
+
+    Args:
+        policy: The active policy.
+        packet: The validated packet.
+        blocks: The resolved implementation blocks.
+
+    Returns:
+        Target path -> current digest, or None when the file is absent.
+
+    Raises:
+        ContractError: A precondition fails or a CREATE is underspecified.
+    """
+    state: dict[str, Optional[str]] = {}
+    for target in packet.targets:
+        resolved = _resolve_scope_path(policy, target.path, must_exist=False)
+        exists = resolved.exists()
+
+        if target.action == "create":
+            if exists:
+                raise ContractError(
+                    "target_exists_for_create",
+                    f"{target.path!r} already exists but is declared as a create",
+                    {"path": target.path},
+                )
+            if not any(blocks[block_id].path == target.path for block_id in target.blocks):
+                raise ContractError(
+                    "underspecified_create",
+                    f"no block tagged path={target.path} supplies the new file's content",
+                    {"path": target.path, "blocks": target.blocks},
+                )
+            state[target.path] = None
+            continue
+
+        if not exists:
+            raise ContractError(
+                "target_missing_for_modify",
+                f"{target.path!r} does not exist but is declared as a modify",
+                {"path": target.path},
+            )
+        current = sha256_stream(resolved, deadline_seconds=policy.command_timeout_seconds)
+        if current != target.expected_sha256:
+            raise ContractError(
+                "stale_target",
+                f"{target.path!r} changed since the packet was written",
+                {"path": target.path, "expected": target.expected_sha256, "current": current},
+            )
+        state[target.path] = current
+    return state
+
+
+def _load_references(policy: OptimizationPolicy, packet: DelegationPacket) -> list[ResolvedReference]:
+    """Load and freshness-check every reference slice.
+
+    Args:
+        policy: The active policy.
+        packet: The validated packet.
+
+    Returns:
+        The loaded references, in packet order.
+
+    Raises:
+        ContractError: A reference is stale or its range is invalid.
+    """
+    loaded: list[ResolvedReference] = []
+    for slice_ in packet.references:
+        resolved = _resolve_scope_path(policy, slice_.path, must_exist=True)
+        current = sha256_stream(resolved, deadline_seconds=policy.command_timeout_seconds)
+        if current != slice_.sha256:
+            raise ContractError(
+                "stale_reference",
+                f"{slice_.path!r} changed since the packet was written",
+                {"path": slice_.path, "expected": slice_.sha256, "current": current},
+            )
+        span_length = slice_.end_line - slice_.start_line + 1
+        if span_length > policy.max_lines:
+            raise ContractError(
+                "reference_range_invalid",
+                f"reference to {slice_.path!r} spans {span_length} lines, above the {policy.max_lines}-line maximum",
+                {"path": slice_.path, "lines": span_length, "max_lines": policy.max_lines},
+            )
+        try:
+            span = read_line_range(resolved, slice_.start_line, slice_.end_line, max_line_bytes=policy.max_result_bytes)
+        except (RangeOutOfBoundsError, LineTooLargeError, InvalidEncodingError) as exc:
+            raise ContractError(
+                "reference_range_invalid",
+                f"cannot read the declared range of {slice_.path!r}: {exc}",
+                {"path": slice_.path},
+            ) from exc
+        loaded.append(ResolvedReference(slice=slice_, content="".join(span.lines), current_sha256=current))
+    return loaded
+
+
+def _validate_blocking(
+    policy: OptimizationPolicy, task_path: str, limits_override: Optional[WriterLimits]
+) -> ValidatedContract:
+    """Run the whole validation off the event loop.
+
+    Args:
+        policy: The active policy.
+        task_path: The repo-relative TASK file path.
+        limits_override: Limits replacing the packet's own, when supplied.
+
+    Returns:
+        The validated contract.
+
+    Raises:
+        ContractError: Any eligibility rule failed.
+    """
+    try:
+        resolved_task = resolve_operand(policy, task_path, must_exist=True)
+    except (SymlinkRejectedError, SecretFileError, PathOutsideRootError) as exc:
+        raise ContractError("task_outside_root", str(exc), {"path": task_path}) from exc
+    except PolicyError as exc:
+        raise ContractError("task_not_found", str(exc), {"path": task_path}) from exc
+
+    pre_limits = limits_override or WriterLimits()
+    if stat_regular(resolved_task).size > pre_limits.max_packet_bytes:
+        raise ContractError(
+            "packet_too_large",
+            f"{task_path!r} is larger than the {pre_limits.max_packet_bytes}-byte packet budget",
+            {"path": task_path, "max_packet_bytes": pre_limits.max_packet_bytes},
+        )
+
+    text = _read_text_bounded(policy, resolved_task)
+    packet_json, blocks = parse_task_file(text)
+    packet = extract_packet(packet_json)
+
+    limits = limits_override or packet.limits
+    _validate_commands(packet)
+    resolved_blocks = _validate_blocks(packet, blocks)
+
+    packet_dump = packet.model_dump(mode="json")
+    packet_bytes = measure_json_bytes(packet_dump)
+    if packet_bytes > limits.max_packet_bytes:
+        raise ContractError(
+            "packet_too_large",
+            f"the packet is {packet_bytes} bytes, above the {limits.max_packet_bytes}-byte budget",
+            {"bytes": packet_bytes, "max_packet_bytes": limits.max_packet_bytes},
+        )
+
+    # Blocks alone can exceed the context budget; check that before any
+    # hashing or reference loading, which are the expensive steps.
+    block_bytes = sum(len(block.text.encode("utf-8")) for block in resolved_blocks.values())
+    if packet_bytes + block_bytes > limits.max_context_bytes:
+        raise ContractError(
+            "context_budget_exceeded",
+            f"packet plus implementation blocks is {packet_bytes + block_bytes} bytes, above the "
+            f"{limits.max_context_bytes}-byte context budget",
+            {"bytes": packet_bytes + block_bytes, "max_context_bytes": limits.max_context_bytes},
+        )
+
+    targets_state = _validate_targets(policy, packet, resolved_blocks)
+    references = _load_references(policy, packet)
+
+    context_bytes = packet_bytes + block_bytes + sum(len(ref.content.encode("utf-8")) for ref in references)
+    if context_bytes > limits.max_context_bytes:
+        raise ContractError(
+            "context_budget_exceeded",
+            f"the delegation context is {context_bytes} bytes, above the {limits.max_context_bytes}-byte budget",
+            {"bytes": context_bytes, "max_context_bytes": limits.max_context_bytes},
+        )
+
+    return ValidatedContract(
+        task_path=resolved_task.relative_to(policy.repo_root).as_posix(),
+        packet=packet,
+        packet_sha256=hashlib.sha256(compact_json(packet_dump).encode("utf-8")).hexdigest(),
+        blocks=resolved_blocks,
+        references=references,
+        targets_state=targets_state,
+        context_bytes=context_bytes,
+    )
+
+
+async def validate_contract(
+    policy: OptimizationPolicy, task_path: str, *, limits_override: Optional[WriterLimits] = None
+) -> ValidatedContract:
+    """Prove a TASK file is eligible for delegation, or explain why it is not.
+
+    Everything here is deterministic and offline: no network, no model, and
+    no command is ever executed.
+
+    Args:
+        policy: The active policy, supplying the repository root and limits.
+        task_path: The repo-relative TASK file path.
+        limits_override: Limits replacing the packet's own, when supplied.
+
+    Returns:
+        The validated contract, ready for prompt rendering.
+
+    Raises:
+        ContractError: Any eligibility rule failed.
+    """
+    return await asyncio.to_thread(_validate_blocking, policy, task_path, limits_override)
+
+
+# --------------------------------------------------------------------------- #
+# Prompt rendering
+# --------------------------------------------------------------------------- #
+def render_prompt_sections(contract: ValidatedContract) -> dict[str, str]:
+    """Render the deterministic prompt sections for a validated contract.
+
+    The output contains only the approved packet and its approved excerpts —
+    never whole repository files and never host conversation history.
+
+    Args:
+        contract: The validated contract.
+
+    Returns:
+        A mapping with ``packet``, ``references``, ``blocks`` and
+        ``acceptance`` sections, each a Markdown heading plus fenced content.
+    """
+    packet_section = "## Packet\n\n```json\n" + compact_json(contract.packet.model_dump(mode="json")) + "\n```"
+
+    reference_parts = ["## References"]
+    for reference in contract.references:
+        slice_ = reference.slice
+        reference_parts.append(
+            f"\n### {slice_.path} @ {slice_.sha256[:12]} lines {slice_.start_line}-{slice_.end_line} — {slice_.purpose}\n\n"
+            f"```\n{reference.content}\n```"
+        )
+    if len(reference_parts) == 1:
+        reference_parts.append("\n(none)")
+
+    block_parts = ["## Implementation blocks"]
+    for block_id in sorted(contract.blocks):
+        block = contract.blocks[block_id]
+        target = f" (file: {block.path})" if block.path else ""
+        block_parts.append(f"\n### {block_id}{target}\n\n```{block.language}\n{block.text}\n```")
+
+    acceptance_parts = ["## Acceptance criteria\n"]
+    for criterion in contract.packet.acceptance_criteria:
+        acceptance_parts.append(f"\n- {criterion}")
+
+    return {
+        "packet": packet_section,
+        "references": "".join(reference_parts),
+        "blocks": "".join(block_parts),
+        "acceptance": "".join(acceptance_parts),
+    }

--- a/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/git.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/git.py
@@ -1346,7 +1346,20 @@ class LocalGitToolkit(OptimizationToolkitBase):
             )
 
         merge_step, _ = await self._run_git(
-            ["-c", "merge.autoStash=false", "merge", "--ff-only", "--no-autostash", "--end-of-options", fetched]
+            [
+                "-c",
+                "merge.autoStash=false",
+                "merge",
+                "--ff-only",
+                "--no-autostash",
+                # Git's DEFAULT is to overwrite ignored files. A fast-forward
+                # that starts tracking a path currently occupied by an ignored
+                # local file would destroy it, despite this tool's promise to
+                # preserve untracked/ignored content.
+                "--no-overwrite-ignore",
+                "--end-of-options",
+                fetched,
+            ]
         )
         merge_step.name = "merge --ff-only"
         steps.append(merge_step)

--- a/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/git.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/git.py
@@ -1,0 +1,797 @@
+"""Deterministic local Git operations for Claude Code / Codex (FEAT-543).
+
+:class:`LocalGitToolkit` replaces the predictable Git command sequences a
+coding host would otherwise construct token by token. It performs **no LLM
+calls** and returns bounded :class:`OperationResult` models carrying one
+:class:`StepResult` per Git command actually executed, so a caller can always
+see which step failed instead of inferring success from the last command.
+
+Safety properties (spec §2 "Git Contract"):
+
+* Every invocation is an argv list — never a shell string, never a
+  caller-interpolated option. ``--end-of-options`` precedes refs and ``--``
+  precedes paths.
+* Output is drained concurrently with a memory cap, but reading continues to
+  EOF so a child never blocks on a full pipe. Truncation never turns a
+  failure into a success.
+* Remote and branch names are validated against allow-lists; refspecs and
+  revision expressions are rejected where a branch name is required.
+* A fetch failure stops dependent history lookup, and freshness is verified
+  against the actually fetched commit rather than assumed.
+
+This module owns the read-only and fetch-only half of the toolkit;
+``git_prepare_files`` / ``git_pull`` / ``git_push`` are added by TASK-3081.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any, Optional, Sequence
+
+from parrot.tools.decorators import tool_schema
+from parrot.tools.repo.git_tools import LOG_FORMAT, InvalidRefError, parse_log, validate_ref
+from pydantic import BaseModel, ConfigDict
+
+from .base import OptimizationToolkitBase
+from .models import (
+    GitFetchArgs,
+    GitPreflightArgs,
+    GitRecentArgs,
+    OperationResult,
+    StepResult,
+)
+
+__all__ = ("GIT_ENV", "MIN_GIT_VERSION", "RepoLayout", "LocalGitToolkit")
+
+#: Environment forced onto every Git invocation.
+#:
+#: ``GIT_CONFIG_NOSYSTEM`` is deliberately **not** set: user and system config
+#: must still apply so remotes, credential helpers and transport settings work.
+GIT_ENV: dict[str, str] = {
+    "GIT_TERMINAL_PROMPT": "0",
+    "GIT_EDITOR": ":",
+    "GIT_SEQUENCE_EDITOR": ":",
+    "GIT_PAGER": "cat",
+    "GIT_OPTIONAL_LOCKS": "0",
+    "LC_ALL": "C",
+    "LANG": "C",
+    "GIT_LITERAL_PATHSPECS": "1",
+}
+
+#: ``--end-of-options`` and ``--absolute-git-dir`` both require git >= 2.24.
+MIN_GIT_VERSION = (2, 24)
+
+#: Remote names: no leading dash, no path or option characters.
+_REMOTE_OK = re.compile(r"^[A-Za-z0-9._][A-Za-z0-9._-]*$")
+
+#: Branch names: conservative subset. Refspecs (':'), revision expressions
+#: ('~', '^', '@{') and option-shaped values cannot match.
+_BRANCH_OK = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,254}$")
+
+_GIT_VERSION_RE = re.compile(r"git version (\d+)\.(\d+)")
+
+
+class RepoLayout(BaseModel):
+    """The discovered layout of the repository this toolkit operates on.
+
+    Attributes:
+        toplevel: The work-tree root (equals the configured ``repo_root``).
+        git_dir: The **per-worktree** git directory, absolute. For a linked
+            worktree this is ``<main>/.git/worktrees/<name>``.
+        common_dir: The shared git directory holding refs and objects.
+        is_linked_worktree: True when ``git_dir`` differs from ``common_dir``.
+        index_path: The per-worktree index file.
+        lock_path: The toolkit's advisory lock, scoped to this worktree.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    toplevel: Path
+    git_dir: Path
+    common_dir: Path
+    is_linked_worktree: bool
+    index_path: Path
+    lock_path: Path
+
+
+async def _drain(stream: asyncio.StreamReader, cap: int) -> tuple[bytes, bool]:
+    """Read ``stream`` to EOF, retaining at most ``cap`` bytes.
+
+    Reading continues past the cap and the excess is discarded, so the child
+    process can never block writing into a full pipe (which would deadlock a
+    naive capped reader).
+
+    Args:
+        stream: The subprocess stream to drain.
+        cap: Maximum number of bytes to retain.
+
+    Returns:
+        A ``(retained_bytes, truncated)`` tuple.
+    """
+    buf = bytearray()
+    truncated = False
+    while True:
+        chunk = await stream.read(65536)
+        if not chunk:
+            return bytes(buf), truncated
+        if len(buf) < cap:
+            room = cap - len(buf)
+            buf += chunk[:room]
+            if len(chunk) > room:
+                truncated = True
+        else:
+            truncated = True
+
+
+class LocalGitToolkit(OptimizationToolkitBase):
+    """Bounded, deterministic Git operations confined to one repository.
+
+    All paths and refs are validated before any subprocess starts. No method
+    here invokes an LLM.
+
+    Example:
+        >>> toolkit = LocalGitToolkit(repo_root="/path/to/repo")
+        >>> result = await toolkit.git_preflight()
+        >>> result.status
+        'ok'
+    """
+
+    arg_models: dict[str, type[BaseModel]] = {
+        "git_recent": GitRecentArgs,
+        "git_fetch": GitFetchArgs,
+        "git_preflight": GitPreflightArgs,
+    }
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize the toolkit.
+
+        Args:
+            **kwargs: Forwarded to
+                :class:`~parrot_tools.tool_optimizations.base.OptimizationToolkitBase`
+                (``repo_root`` is required).
+        """
+        super().__init__(**kwargs)
+        self._layout: Optional[RepoLayout] = None
+        self._git_version: Optional[tuple[int, int]] = None
+
+    # ----------------------------------------------------------------- #
+    # Subprocess runner
+    # ----------------------------------------------------------------- #
+    async def _run_git(
+        self,
+        args: Sequence[str],
+        *,
+        timeout: Optional[float] = None,
+        cwd: Optional[Path] = None,
+        extra_env: Optional[dict[str, str]] = None,
+        stdin_bytes: Optional[bytes] = None,
+        max_capture: int = 1_048_576,
+    ) -> tuple[StepResult, bytes]:
+        """Run one Git command, bounded, non-interactive and kill-safe.
+
+        Args:
+            args: Git arguments (without the leading ``git``).
+            timeout: Seconds; defaults to ``policy.command_timeout_seconds``.
+            cwd: Working directory; defaults to the configured repo root.
+            extra_env: Extra environment entries layered over :data:`GIT_ENV`.
+            stdin_bytes: Bytes to write to the child's stdin, if any.
+            max_capture: Maximum stdout bytes retained.
+
+        Returns:
+            A ``(StepResult, raw_stdout)`` tuple. The raw bytes let callers
+            split NUL-delimited (``-z``) output without a decode round-trip.
+            ``state_changed`` is always False here — only the caller knows
+            whether a command mutated state.
+
+        Raises:
+            asyncio.CancelledError: Re-raised after killing the child, so a
+                cancelled dispatch leaves no orphan process.
+        """
+        name = args[0] if args else "git"
+        env = {**os.environ, **GIT_ENV, **(extra_env or {})}
+        limit = timeout if timeout is not None else self.policy.command_timeout_seconds
+        self.logger.debug("running git %s", " ".join(args))
+
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            *args,
+            cwd=str(cwd or self.policy.repo_root),
+            env=env,
+            stdin=asyncio.subprocess.PIPE if stdin_bytes is not None else asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            async with asyncio.timeout(limit):
+                if stdin_bytes is not None and proc.stdin is not None:
+                    proc.stdin.write(stdin_bytes)
+                    await proc.stdin.drain()
+                    proc.stdin.close()
+                (out, out_trunc), (err, err_trunc) = await asyncio.gather(
+                    _drain(proc.stdout, max_capture),
+                    _drain(proc.stderr, 65536),
+                )
+                code = await proc.wait()
+        except (TimeoutError, asyncio.TimeoutError):
+            self._kill(proc)
+            await proc.wait()
+            return (
+                StepResult(name=name, exit_code=None, timed_out=True, state_changed=False, stderr="timeout"),
+                b"",
+            )
+        except asyncio.CancelledError:
+            self._kill(proc)
+            raise
+
+        return (
+            StepResult(
+                name=name,
+                exit_code=code,
+                timed_out=False,
+                state_changed=False,
+                stdout=out.decode("utf-8", "replace"),
+                stderr=err.decode("utf-8", "replace")[:4096],
+                truncated=out_trunc or err_trunc,
+            ),
+            out,
+        )
+
+    @staticmethod
+    def _kill(proc: asyncio.subprocess.Process) -> None:
+        """Best-effort terminate; an already-exited child is not an error."""
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
+
+    # ----------------------------------------------------------------- #
+    # Discovery and validation
+    # ----------------------------------------------------------------- #
+    async def _check_git_version(self, operation: str, started: float) -> Optional[OperationResult]:
+        """Verify the git binary is new enough for the flags this module uses.
+
+        Args:
+            operation: The calling operation name, for the error result.
+            started: A ``perf_counter()`` reading taken at operation start.
+
+        Returns:
+            None when the version is acceptable, else an error result.
+        """
+        if self._git_version is not None:
+            return None
+        step, _ = await self._run_git(["--version"])
+        match = _GIT_VERSION_RE.search(step.stdout or "")
+        if step.exit_code != 0 or match is None:
+            return self._error(
+                operation, "git_unavailable", "could not determine the git version", steps=[step], started=started
+            )
+        version = (int(match.group(1)), int(match.group(2)))
+        if version < MIN_GIT_VERSION:
+            return self._error(
+                operation,
+                "git_too_old",
+                f"git {version[0]}.{version[1]} is older than the required {MIN_GIT_VERSION[0]}.{MIN_GIT_VERSION[1]}",
+                steps=[step],
+                started=started,
+            )
+        self._git_version = version
+        return None
+
+    async def _discover(
+        self, operation: str = "discover", started: Optional[float] = None
+    ) -> RepoLayout | OperationResult:
+        """Discover the repository layout, supporting linked worktrees.
+
+        ``.git`` may be a *file* in a linked worktree, so the layout is
+        obtained from Git itself rather than by probing the filesystem.
+
+        Args:
+            operation: The calling operation name, for any error result.
+            started: A ``perf_counter()`` reading taken at operation start.
+
+        Returns:
+            The cached :class:`RepoLayout`, or an :class:`OperationResult`
+            describing why discovery failed.
+        """
+        if self._layout is not None:
+            return self._layout
+        started = started if started is not None else time.perf_counter()
+
+        version_error = await self._check_git_version(operation, started)
+        if version_error is not None:
+            return version_error
+
+        step, _ = await self._run_git(
+            ["rev-parse", "--is-bare-repository", "--show-toplevel", "--absolute-git-dir", "--git-common-dir"]
+        )
+        lines = step.stdout.splitlines()
+        # A bare repository answers "true" and then dies on --show-toplevel,
+        # so the bare check must precede the exit-code check.
+        if lines and lines[0].strip() == "true":
+            return self._error(
+                operation,
+                "bare_repository",
+                "worktree operations require a non-bare repository",
+                steps=[step],
+                started=started,
+            )
+        if step.exit_code != 0 or len(lines) < 4:
+            return self._error(
+                operation,
+                "not_a_repository",
+                f"{str(self.policy.repo_root)!r} is not inside a git work tree",
+                steps=[step],
+                started=started,
+            )
+
+        toplevel = Path(lines[1].strip()).resolve()
+        git_dir = Path(lines[2].strip()).resolve()
+        common_raw = lines[3].strip()
+        common_dir = Path(common_raw)
+        if not common_dir.is_absolute():
+            common_dir = (self.policy.repo_root / common_raw).resolve()
+        else:
+            common_dir = common_dir.resolve()
+
+        if toplevel != self.policy.repo_root:
+            return self._error(
+                operation,
+                "root_mismatch",
+                "repo_root is not the work-tree toplevel",
+                details={"repo_root": str(self.policy.repo_root), "toplevel": str(toplevel)},
+                steps=[step],
+                started=started,
+            )
+
+        self._layout = RepoLayout(
+            toplevel=toplevel,
+            git_dir=git_dir,
+            common_dir=common_dir,
+            is_linked_worktree=git_dir != common_dir,
+            index_path=git_dir / "index",
+            lock_path=git_dir / "parrot-tool-optimizations.lock",
+        )
+        return self._layout
+
+    async def _remote_names(self) -> tuple[list[str], StepResult]:
+        """List the configured remote names.
+
+        Returns:
+            A ``(names, step)`` tuple.
+        """
+        step, _ = await self._run_git(["remote"])
+        names = [line.strip() for line in step.stdout.splitlines() if line.strip()] if step.exit_code == 0 else []
+        return names, step
+
+    @staticmethod
+    def _validate_remote(remote: str, remotes: Sequence[str]) -> str:
+        """Validate a remote name against shape rules and the configured set.
+
+        Args:
+            remote: The caller-supplied remote name.
+            remotes: The names Git reports as configured.
+
+        Returns:
+            The remote name, unchanged.
+
+        Raises:
+            ValueError: The name is option-shaped, malformed, or unknown.
+        """
+        if not _REMOTE_OK.match(remote):
+            raise ValueError(f"malformed remote name: {remote!r}")
+        if remote not in remotes:
+            raise ValueError(f"unknown remote: {remote!r}")
+        return remote
+
+    async def _validate_branch(self, branch: str) -> str:
+        """Validate that ``branch`` is a real branch name, not a revision.
+
+        A refspec, a revision expression or an option-shaped value must never
+        reach ``git fetch``/``pull``/``push``, where they change the meaning
+        of the operation.
+
+        Args:
+            branch: The caller-supplied branch name.
+
+        Returns:
+            The branch name, unchanged.
+
+        Raises:
+            ValueError: The name is malformed or Git rejects its ref format.
+        """
+        if not _BRANCH_OK.match(branch):
+            raise ValueError(f"malformed branch name: {branch!r}")
+        if ".." in branch or "@{" in branch or branch.endswith((".lock", "/", ".")):
+            raise ValueError(f"malformed branch name: {branch!r}")
+        # The regex already forbids a leading '-', so this cannot be an option.
+        step, _ = await self._run_git(["check-ref-format", "--branch", branch])
+        if step.exit_code != 0:
+            raise ValueError(f"git rejected the branch name: {branch!r}")
+        return branch
+
+    async def _resolve_commit(self, ref: str) -> tuple[Optional[str], StepResult]:
+        """Resolve ``ref`` to a concrete commit sha.
+
+        Args:
+            ref: A caller-supplied ref.
+
+        Returns:
+            A ``(sha_or_None, step)`` tuple.
+
+        Raises:
+            InvalidRefError: The ref is option-shaped or malformed.
+        """
+        safe = validate_ref(ref)
+        step, _ = await self._run_git(["rev-parse", "--verify", "--quiet", "--end-of-options", f"{safe}^{{commit}}"])
+        sha = step.stdout.strip()
+        if step.exit_code != 0 or len(sha) != 40:
+            return None, step
+        return sha, step
+
+    async def _log_step(self, sha: str, limit: int) -> tuple[list[dict[str, str]], StepResult]:
+        """Read bounded commit history starting at ``sha``.
+
+        Args:
+            sha: A resolved 40-hex commit sha.
+            limit: Maximum number of commits.
+
+        Returns:
+            A ``(commits, step)`` tuple.
+        """
+        step, _ = await self._run_git(
+            ["log", f"--max-count={int(limit)}", f"--format={LOG_FORMAT}", "--end-of-options", sha, "--"]
+        )
+        commits = parse_log(step.stdout) if step.exit_code == 0 else []
+        return commits, step
+
+    # ----------------------------------------------------------------- #
+    # Public tools
+    # ----------------------------------------------------------------- #
+    @tool_schema(GitRecentArgs)
+    async def git_recent(self, ref: str = "HEAD", limit: int = 3) -> OperationResult:
+        """Show recent commits for a ref, as compact structured records.
+
+        Args:
+            ref: The ref to read history from. Defaults to ``HEAD``.
+            limit: How many commits to return, between 1 and 50.
+
+        Returns:
+            An operation result whose ``data`` carries ``ref``, the resolved
+            ``commit`` and a ``commits`` list of
+            ``{sha, author, date, subject}`` records.
+        """
+        started = time.perf_counter()
+        try:
+            args = GitRecentArgs(ref=ref, limit=limit)
+        except Exception as exc:  # pydantic ValidationError
+            return self._error("git_recent", "invalid_arguments", str(exc), started=started)
+
+        layout = await self._discover("git_recent", started)
+        if isinstance(layout, OperationResult):
+            return layout
+
+        try:
+            sha, resolve_step = await self._resolve_commit(args.ref)
+        except InvalidRefError as exc:
+            # Rejected before any git process is spawned.
+            return self._error("git_recent", "invalid_ref", str(exc), started=started)
+        if sha is None:
+            return self._error(
+                "git_recent",
+                "unknown_ref",
+                f"could not resolve {args.ref!r} to a commit",
+                steps=[resolve_step],
+                started=started,
+            )
+
+        commits, log_step = await self._log_step(sha, args.limit)
+        steps = [resolve_step, log_step]
+        if log_step.exit_code != 0:
+            return self._error("git_recent", "log_failed", "git log failed", steps=steps, started=started)
+        return self._ok("git_recent", {"ref": args.ref, "commit": sha, "commits": commits}, steps, started)
+
+    @tool_schema(GitFetchArgs)
+    async def git_fetch(self, remote: str = "origin", branch: str = "dev", recent: int = 3) -> OperationResult:
+        """Fetch one branch from a configured remote and report what arrived.
+
+        The explicit destination refspec is required: a bare
+        ``git fetch <remote> <branch>`` only guarantees ``FETCH_HEAD``. No
+        leading ``+`` is used, so a non-fast-forward remote-tracking update is
+        reported as a rejection rather than silently forced.
+
+        Args:
+            remote: A configured remote name. Defaults to ``origin``.
+            branch: The branch to fetch. Must be a branch name, not a refspec
+                or revision expression.
+            recent: How many recent commits to report, between 1 and 50.
+
+        Returns:
+            An operation result whose ``data`` carries ``remote``, ``branch``,
+            ``fetched_commit``, ``tracking_ref``, ``tracking_commit``,
+            ``fresh`` and ``commits``. Status is ``uncertain`` when the
+            remote-tracking ref does not match the fetched commit.
+        """
+        started = time.perf_counter()
+        try:
+            args = GitFetchArgs(remote=remote, branch=branch, recent=recent)
+        except Exception as exc:  # pydantic ValidationError
+            return self._error("git_fetch", "invalid_arguments", str(exc), started=started)
+
+        layout = await self._discover("git_fetch", started)
+        if isinstance(layout, OperationResult):
+            return layout
+
+        remotes, remote_step = await self._remote_names()
+        try:
+            safe_remote = self._validate_remote(args.remote, remotes)
+        except ValueError as exc:
+            return self._error("git_fetch", "unknown_remote", str(exc), steps=[remote_step], started=started)
+        try:
+            safe_branch = await self._validate_branch(args.branch)
+        except ValueError as exc:
+            return self._error("git_fetch", "invalid_branch", str(exc), started=started)
+
+        tracking_ref = f"refs/remotes/{safe_remote}/{safe_branch}"
+        refspec = f"refs/heads/{safe_branch}:{tracking_ref}"
+        fetch_step, _ = await self._run_git(
+            ["fetch", "--no-tags", "--no-recurse-submodules", "--end-of-options", safe_remote, refspec],
+            timeout=self.policy.network_timeout_seconds,
+        )
+        fetch_step.state_changed = fetch_step.exit_code == 0
+        fetch_step.name = "fetch"
+
+        if fetch_step.timed_out:
+            return self._error(
+                "git_fetch",
+                "fetch_timeout",
+                "the fetch timed out",
+                steps=[fetch_step],
+                started=started,
+                status="uncertain",
+            )
+        if fetch_step.exit_code != 0:
+            # A fetch failure must not fall through to a history lookup.
+            rejected = "rejected" in fetch_step.stderr or "non-fast-forward" in fetch_step.stderr
+            return self._error(
+                "git_fetch",
+                "fetch_rejected" if rejected else "fetch_failed",
+                "the fetch did not complete",
+                details={"remote": safe_remote, "branch": safe_branch},
+                steps=[fetch_step],
+                started=started,
+            )
+
+        fetched_step, _ = await self._run_git(
+            ["rev-parse", "--verify", "--quiet", "--end-of-options", "FETCH_HEAD^{commit}"]
+        )
+        fetched = fetched_step.stdout.strip()
+        tracking_step, _ = await self._run_git(
+            ["rev-parse", "--verify", "--quiet", "--end-of-options", f"{tracking_ref}^{{commit}}"]
+        )
+        tracking = tracking_step.stdout.strip()
+        steps = [remote_step, fetch_step, fetched_step, tracking_step]
+
+        if len(fetched) != 40:
+            return self._error(
+                "git_fetch", "fetch_head_unresolved", "could not read the fetched commit", steps=steps, started=started
+            )
+
+        fresh = bool(tracking) and tracking == fetched
+        commits, log_step = await self._log_step(fetched, args.recent)
+        steps.append(log_step)
+
+        data: dict[str, Any] = {
+            "remote": safe_remote,
+            "branch": safe_branch,
+            "fetched_commit": fetched,
+            "tracking_ref": tracking_ref,
+            "tracking_commit": tracking or None,
+            "fresh": fresh,
+            "commits": commits,
+        }
+        if not fresh:
+            # Report the identity we actually fetched; never assume the
+            # remote-tracking ref moved.
+            result = self._error(
+                "git_fetch",
+                "tracking_ref_stale",
+                "the remote-tracking ref does not match the fetched commit",
+                details={"fetched_commit": fetched, "tracking_commit": tracking or None},
+                steps=steps,
+                started=started,
+                status="uncertain",
+            )
+            result.data = data
+            return result
+        return self._ok("git_fetch", data, steps, started)
+
+    @tool_schema(GitPreflightArgs)
+    async def git_preflight(self) -> OperationResult:
+        """Report working-tree status, whitespace errors and staged files.
+
+        Every check runs independently, even when an earlier one fails, so a
+        single report describes the whole state of the tree.
+
+        Returns:
+            An operation result whose ``data`` carries ``checks`` (per-check
+            ``{ok, exit_code, detail}``), the parsed ``status`` summary and
+            the ``staged`` file list. Status is ``error`` with code
+            ``preflight_failed`` when any check failed.
+        """
+        started = time.perf_counter()
+        layout = await self._discover("git_preflight", started)
+        if isinstance(layout, OperationResult):
+            return layout
+
+        status_step, status_raw = await self._run_git(
+            ["status", "--porcelain=v2", "-z", "--branch", "--untracked-files=normal"]
+        )
+        diff_step, _ = await self._run_git(["diff", "--check"])
+        cached_step, _ = await self._run_git(["diff", "--cached", "--check"])
+        staged_step, staged_raw = await self._run_git(["diff", "--cached", "--name-only", "-z"])
+
+        status_step.name = "status"
+        diff_step.name = "diff_check"
+        cached_step.name = "cached_check"
+        staged_step.name = "staged_names"
+
+        summary = _parse_status_v2(status_raw) if status_step.exit_code == 0 else {}
+        staged_names = _split_nul(staged_raw) if staged_step.exit_code == 0 else []
+
+        checks = {
+            "status": {
+                "ok": status_step.exit_code == 0,
+                "exit_code": status_step.exit_code,
+                "detail": "" if status_step.exit_code == 0 else status_step.stderr[:512],
+            },
+            "diff_check": {
+                "ok": diff_step.exit_code == 0,
+                "exit_code": diff_step.exit_code,
+                "detail": _bounded_lines(diff_step.stdout, 50),
+            },
+            "cached_check": {
+                "ok": cached_step.exit_code == 0,
+                "exit_code": cached_step.exit_code,
+                "detail": _bounded_lines(cached_step.stdout, 50),
+            },
+            "staged_names": {
+                "ok": staged_step.exit_code == 0,
+                "exit_code": staged_step.exit_code,
+                "detail": "" if staged_step.exit_code == 0 else staged_step.stderr[:512],
+            },
+        }
+
+        steps = [status_step, diff_step, cached_step, staged_step]
+        data: dict[str, Any] = {"checks": checks, "staged": staged_names[:50], **summary}
+        failed = [name for name, check in checks.items() if not check["ok"]]
+        if failed:
+            result = self._error(
+                "git_preflight",
+                "preflight_failed",
+                "one or more preflight checks failed",
+                details={"failed": failed},
+                steps=steps,
+                started=started,
+            )
+            result.data = data
+            return result
+        return self._ok("git_preflight", data, steps, started)
+
+
+# --------------------------------------------------------------------------- #
+# Output parsing helpers (module level so _generate_tools never sees them)
+# --------------------------------------------------------------------------- #
+def _split_nul(raw: bytes) -> list[str]:
+    """Split a NUL-delimited git ``-z`` stream into records.
+
+    Args:
+        raw: The raw stdout bytes.
+
+    Returns:
+        The non-empty records, decoded permissively.
+    """
+    return [item.decode("utf-8", "replace") for item in raw.split(b"\x00") if item]
+
+
+def _bounded_lines(text: str, limit: int) -> str:
+    """Return at most ``limit`` lines of ``text``.
+
+    Args:
+        text: The text to bound.
+        limit: Maximum number of lines to keep.
+
+    Returns:
+        The retained lines joined by newlines.
+    """
+    lines = text.splitlines()
+    return "\n".join(lines[:limit])
+
+
+def _parse_status_v2(raw: bytes) -> dict[str, Any]:
+    """Parse ``git status --porcelain=v2 -z --branch`` output.
+
+    Args:
+        raw: The raw NUL-delimited stdout bytes.
+
+    Returns:
+        A summary with branch identity, ahead/behind counts, per-category
+        counts and up to 50 paths per category.
+    """
+    records = raw.split(b"\x00")
+    branch: Optional[str] = None
+    oid: Optional[str] = None
+    upstream: Optional[str] = None
+    ahead = behind = 0
+    staged: list[str] = []
+    unstaged: list[str] = []
+    untracked: list[str] = []
+    unmerged: list[str] = []
+    ignored: list[str] = []
+
+    index = 0
+    while index < len(records):
+        record = records[index].decode("utf-8", "replace")
+        index += 1
+        if not record:
+            continue
+        if record.startswith("# "):
+            key, _, value = record[2:].partition(" ")
+            if key == "branch.oid":
+                oid = value
+            elif key == "branch.head":
+                branch = value
+            elif key == "branch.upstream":
+                upstream = value
+            elif key == "branch.ab":
+                for token in value.split():
+                    if token.startswith("+"):
+                        ahead = int(token[1:] or 0)
+                    elif token.startswith("-"):
+                        behind = int(token[1:] or 0)
+            continue
+
+        kind = record[0]
+        if kind in ("1", "2"):
+            fields = record.split(" ", 8) if kind == "1" else record.split(" ", 9)
+            xy = fields[1]
+            path = fields[-1]
+            if kind == "2" and index < len(records):
+                # A rename entry is followed by its original path record.
+                index += 1
+            if xy[0] != ".":
+                staged.append(path)
+            if len(xy) > 1 and xy[1] != ".":
+                unstaged.append(path)
+        elif kind == "u":
+            unmerged.append(record.split(" ", 10)[-1])
+        elif kind == "?":
+            untracked.append(record[2:])
+        elif kind == "!":
+            ignored.append(record[2:])
+
+    return {
+        "branch": None if branch in (None, "(detached)") else branch,
+        "detached": branch == "(detached)",
+        "unborn": oid == "(initial)",
+        "head_commit": None if oid in (None, "(initial)") else oid,
+        "upstream": upstream,
+        "ahead": ahead,
+        "behind": behind,
+        "counts": {
+            "staged": len(staged),
+            "unstaged": len(unstaged),
+            "untracked": len(untracked),
+            "unmerged": len(unmerged),
+            "ignored": len(ignored),
+        },
+        "paths": {
+            "staged": staged[:50],
+            "unstaged": unstaged[:50],
+            "untracked": untracked[:50],
+            "unmerged": unmerged[:50],
+        },
+    }

--- a/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/git.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/git.py
@@ -1438,20 +1438,37 @@ class LocalGitToolkit(OptimizationToolkitBase):
             return error
         try:
             safe_branch = await self._validate_branch(branch or "")
+            # The SOURCE ref is always the branch actually checked out.
+            # Resolving the upstream can yield a DIFFERENT name (a branch may
+            # track origin/<other>); using that name on both sides of the
+            # refspec publishes an unrelated local branch's history while
+            # reporting the current branch's commit.
+            local_branch = await self._validate_branch(str(summary.get("branch") or ""))
         except ValueError as exc:
             return self._error(operation, "invalid_branch", str(exc), steps=steps, started=started)
 
         local_commit = summary.get("head_commit")
-        refspec = f"refs/heads/{safe_branch}:refs/heads/{safe_branch}"
+        refspec = f"refs/heads/{local_branch}:refs/heads/{safe_branch}"
         push_step, _ = await self._run_git(
-            ["push", "--porcelain", "--no-force-with-lease", "--end-of-options", safe_remote, refspec],
+            [
+                "push",
+                "--porcelain",
+                "--no-force-with-lease",
+                # Never publish tags as a side effect, even when the user's
+                # config sets push.followTags=true.
+                "--no-follow-tags",
+                "--end-of-options",
+                safe_remote,
+                refspec,
+            ],
             timeout=self.policy.network_timeout_seconds,
         )
         push_step.name = "push"
         steps.append(push_step)
 
         data: dict[str, Any] = {
-            "branch": safe_branch,
+            "branch": local_branch,
+            "remote_branch": safe_branch,
             "remote": safe_remote,
             "local_commit": local_commit,
             "remote_commit_before": None,

--- a/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/git.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/git.py
@@ -26,24 +26,33 @@ This module owns the read-only and fetch-only half of the toolkit;
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import hashlib
 import os
 import re
+import shutil
+import tempfile
 import time
 from pathlib import Path
 from typing import Any, Optional, Sequence
 
 from parrot.tools.decorators import tool_schema
+from parrot.tools.repo.confinement import PathOutsideRootError, SecretFileError
 from parrot.tools.repo.git_tools import LOG_FORMAT, InvalidRefError, parse_log, validate_ref
 from pydantic import BaseModel, ConfigDict
 
 from .base import OptimizationToolkitBase
 from .models import (
     GitFetchArgs,
+    GitPrepareFilesArgs,
     GitPreflightArgs,
+    GitPullArgs,
+    GitPushArgs,
     GitRecentArgs,
     OperationResult,
     StepResult,
 )
+from .policy import LockTimeoutError, SymlinkRejectedError, WorktreeLock, resolve_operand
 
 __all__ = ("GIT_ENV", "MIN_GIT_VERSION", "RepoLayout", "LocalGitToolkit")
 
@@ -144,7 +153,16 @@ class LocalGitToolkit(OptimizationToolkitBase):
         "git_recent": GitRecentArgs,
         "git_fetch": GitFetchArgs,
         "git_preflight": GitPreflightArgs,
+        "git_prepare_files": GitPrepareFilesArgs,
+        "git_pull": GitPullArgs,
+        "git_push": GitPushArgs,
     }
+
+    #: Mutating tools. The MCP adapter injects a required ``confirm`` boolean
+    #: for these and rejects the call unless it is true. ``confirm`` is the
+    #: host-side record that a human approved the operation — it is never
+    #: authorization a model can grant itself (spec Git Contract 12).
+    confirming_tools: frozenset = frozenset({"git_prepare_files", "git_pull", "git_push"})
 
     def __init__(self, **kwargs: Any) -> None:
         """Initialize the toolkit.
@@ -681,6 +699,860 @@ class LocalGitToolkit(OptimizationToolkitBase):
             return result
         return self._ok("git_preflight", data, steps, started)
 
+    # ----------------------------------------------------------------- #
+    # Staging helpers
+    # ----------------------------------------------------------------- #
+    def _normalise_literal_paths(
+        self, paths: Sequence[str]
+    ) -> tuple[list[str], Optional[tuple[str, str, dict[str, Any]]]]:
+        """Validate caller paths as literal, in-root, non-magic file paths.
+
+        Pathspec magic, globs, directories, symlinks and traversal are all
+        rejected here — before any Git process runs — so a refusal can never
+        have touched the repository.
+
+        Args:
+            paths: The caller-supplied paths.
+
+        Returns:
+            A ``(relative_paths, error)`` tuple, where ``error`` is
+            ``(code, message, details)`` or None.
+        """
+        seen: list[str] = []
+        for raw in paths:
+            candidate = raw
+            if not candidate or candidate != candidate.strip():
+                return [], ("invalid_path", f"{raw!r} is empty or padded with whitespace", {"path": raw})
+            if candidate.startswith(":"):
+                return [], ("pathspec_magic", f"{raw!r} uses git pathspec magic", {"path": raw})
+            if any(char in candidate for char in "*?[]"):
+                return [], ("glob_rejected", f"{raw!r} looks like a glob; pass literal paths", {"path": raw})
+            if "\\" in candidate:
+                return [], ("invalid_path", f"{raw!r} contains a backslash", {"path": raw})
+            if candidate.endswith("/"):
+                return [], ("invalid_path", f"{raw!r} has a trailing slash", {"path": raw})
+            if Path(candidate).is_absolute():
+                return [], ("invalid_path", f"{raw!r} must be repository-relative", {"path": raw})
+            segments = candidate.split("/")
+            if any(segment in ("", ".", "..") for segment in segments):
+                return [], ("invalid_path", f"{raw!r} contains an empty or traversal segment", {"path": raw})
+
+            try:
+                target = resolve_operand(self.policy, candidate, must_exist=False)
+            except SymlinkRejectedError as exc:
+                return [], ("symlink_rejected", str(exc), {"path": raw})
+            except SecretFileError as exc:
+                return [], ("secret_file", str(exc), {"path": raw})
+            except PathOutsideRootError as exc:
+                return [], ("path_outside_root", str(exc), {"path": raw})
+            except ValueError as exc:
+                return [], ("invalid_path", str(exc), {"path": raw})
+
+            if target.is_dir():
+                return [], ("directory_rejected", f"{raw!r} is a directory; pass individual files", {"path": raw})
+            if target.is_symlink():
+                return [], ("symlink_rejected", f"{raw!r} is a symlink", {"path": raw})
+
+            relative = target.relative_to(self.policy.repo_root).as_posix()
+            if relative in seen:
+                return [], ("duplicate_path", f"{relative!r} was supplied more than once", {"path": relative})
+            seen.append(relative)
+        return seen, None
+
+    @staticmethod
+    def _fingerprint(index_path: Path) -> Optional[tuple[int, int, str]]:
+        """Fingerprint the index file so a concurrent change is detectable.
+
+        Args:
+            index_path: The per-worktree index path.
+
+        Returns:
+            A ``(size, mtime_ns, sha256)`` tuple, or None when the index does
+            not exist yet (a repository with an unborn HEAD).
+        """
+        try:
+            stat_result = index_path.stat()
+        except FileNotFoundError:
+            return None
+        digest = hashlib.sha256()
+        with open(index_path, "rb") as handle:
+            for chunk in iter(lambda: handle.read(1 << 20), b""):
+                digest.update(chunk)
+        return (stat_result.st_size, stat_result.st_mtime_ns, digest.hexdigest())
+
+    async def _index_features_supported(self) -> tuple[bool, list[StepResult]]:
+        """Check that the index is a plain, fully readable index file.
+
+        A split or sparse index cannot be safely copied and republished as a
+        whole file, so those configurations are refused rather than corrupted.
+
+        Returns:
+            A ``(supported, steps)`` tuple.
+        """
+        steps: list[StepResult] = []
+        for key in ("core.splitIndex", "index.sparse"):
+            step, _ = await self._run_git(["config", "--get", key])
+            step.name = f"config {key}"
+            steps.append(step)
+            if step.exit_code == 0 and step.stdout.strip().lower() == "true":
+                return False, steps
+        return True, steps
+
+    # ----------------------------------------------------------------- #
+    # Mutating tools
+    # ----------------------------------------------------------------- #
+    @tool_schema(GitPrepareFilesArgs)
+    async def git_prepare_files(self, paths: list[str]) -> OperationResult:
+        """Stage exactly the listed files, refusing to disturb unrelated staging.
+
+        Staging happens in a private copy of the index; the copy is published
+        only after every check passes, the real index is byte-identical to
+        what it was at the start, and Git's own ``index.lock`` was acquired.
+        A refusal or a failed check therefore leaves the index and the working
+        files untouched. Unrelated already-staged paths cause a refusal — this
+        operation never unstages anything.
+
+        The ``confirm`` argument added over MCP records that a human approved
+        this mutation; it is not authorization a model can grant itself.
+
+        Args:
+            paths: Literal, repository-relative file paths. Tracked files that
+                have been deleted on disk are staged as removals.
+
+        Returns:
+            An operation result whose ``data`` carries the exact ``staged``
+            names, any ``deleted`` ones, ``whitespace_ok`` and
+            ``index_published``.
+        """
+        started = time.perf_counter()
+        operation = "git_prepare_files"
+        try:
+            args = GitPrepareFilesArgs(paths=paths)
+        except Exception as exc:  # pydantic ValidationError
+            return self._error(operation, "invalid_arguments", str(exc), started=started)
+
+        layout = await self._discover(operation, started)
+        if isinstance(layout, OperationResult):
+            return layout
+
+        selected, path_error = self._normalise_literal_paths(args.paths)
+        if path_error is not None:
+            code, message, details = path_error
+            return self._error(operation, code, message, details=details, started=started)
+
+        try:
+            async with WorktreeLock(layout.lock_path, self.policy.command_timeout_seconds):
+                return await self._prepare_locked(layout, selected, started)
+        except LockTimeoutError as exc:
+            return self._error(operation, "worktree_busy", str(exc), started=started)
+
+    async def _prepare_locked(self, layout: RepoLayout, selected: list[str], started: float) -> OperationResult:
+        """Run the staging transaction while holding the worktree lock.
+
+        Args:
+            layout: The discovered repository layout.
+            selected: Validated repo-relative paths.
+            started: A ``perf_counter()`` reading taken at operation start.
+
+        Returns:
+            The bounded operation result.
+        """
+        operation = "git_prepare_files"
+        steps: list[StepResult] = []
+
+        # --- Per-path git-level checks (submodule / tracked-deletion) ------
+        ls_step, ls_raw = await self._run_git(["ls-files", "-s", "-z", "--", *selected])
+        ls_step.name = "ls-files"
+        steps.append(ls_step)
+        if ls_step.exit_code != 0:
+            return self._error(
+                operation, "ls_files_failed", "could not read index entries", steps=steps, started=started
+            )
+        for record in _split_nul(ls_raw):
+            mode, _, remainder = record.partition(" ")
+            if mode == "160000":
+                path = remainder.split("\t", 1)[-1]
+                return self._error(
+                    operation,
+                    "submodule_rejected",
+                    f"{path!r} is a submodule",
+                    details={"path": path},
+                    steps=steps,
+                    started=started,
+                )
+
+        deleted: list[str] = []
+        for relative in selected:
+            absolute = self.policy.repo_root / relative
+            if absolute.exists():
+                continue
+            tracked_step, _ = await self._run_git(["ls-files", "--error-unmatch", "-z", "--", relative])
+            tracked_step.name = "ls-files --error-unmatch"
+            steps.append(tracked_step)
+            if tracked_step.exit_code != 0:
+                return self._error(
+                    operation,
+                    "path_not_found",
+                    f"{relative!r} does not exist and is not tracked",
+                    details={"path": relative},
+                    steps=steps,
+                    started=started,
+                )
+            deleted.append(relative)
+
+        # --- Index-state pre-checks ---------------------------------------
+        unmerged_step, unmerged_raw = await self._run_git(["ls-files", "-u", "-z"])
+        unmerged_step.name = "ls-files -u"
+        steps.append(unmerged_step)
+        if unmerged_step.exit_code != 0 or _split_nul(unmerged_raw):
+            return self._error(
+                operation,
+                "unmerged_index",
+                "the index has unmerged entries; resolve the conflict first",
+                steps=steps,
+                started=started,
+            )
+
+        staged_step, staged_raw = await self._run_git(["diff", "--cached", "--name-only", "-z"])
+        staged_step.name = "diff --cached --name-only"
+        steps.append(staged_step)
+        unstaged_step, unstaged_raw = await self._run_git(["diff", "--name-only", "-z"])
+        unstaged_step.name = "diff --name-only"
+        steps.append(unstaged_step)
+        if staged_step.exit_code != 0 or unstaged_step.exit_code != 0:
+            return self._error(
+                operation, "status_failed", "could not read the current staging state", steps=steps, started=started
+            )
+
+        staged_now = set(_split_nul(staged_raw))
+        unstaged_now = set(_split_nul(unstaged_raw))
+        chosen = set(selected)
+
+        unrelated = sorted(staged_now - chosen)
+        if unrelated:
+            return self._error(
+                operation,
+                "unrelated_staged",
+                "unrelated paths are already staged; this operation never unstages",
+                details={"unrelated": unrelated[:50]},
+                steps=steps,
+                started=started,
+            )
+        partial = sorted(chosen & staged_now & unstaged_now)
+        if partial:
+            return self._error(
+                operation,
+                "partially_staged",
+                "selected paths have partially staged content that whole-file staging would replace",
+                details={"partial": partial[:50]},
+                steps=steps,
+                started=started,
+            )
+
+        supported, config_steps = await self._index_features_supported()
+        steps.extend(config_steps)
+        if not supported:
+            return self._error(
+                operation,
+                "index_unsupported",
+                "split or sparse index is not supported by this operation",
+                steps=steps,
+                started=started,
+            )
+
+        # --- Transaction ---------------------------------------------------
+        fingerprint_before = self._fingerprint(layout.index_path)
+        handle = tempfile.NamedTemporaryFile(dir=layout.git_dir, prefix="parrot-index-", delete=False)
+        handle.close()
+        temp_index = Path(handle.name)
+        try:
+            if layout.index_path.exists():
+                # copy2, NOT copyfile: git decides an index entry is "racily
+                # clean" by comparing the entry's mtime against the *index
+                # file's* mtime, and re-hashes the file when it is. A copy
+                # with a fresh mtime silently turns those entries into
+                # trusted-clean ones, so a same-size edit made within the
+                # same clock tick as the last `git add` would not be staged
+                # (measured: ~3% of same-size edits). Preserving the index's
+                # mtime makes the private copy behave exactly like the real
+                # index.
+                shutil.copy2(layout.index_path, temp_index)
+            env = {"GIT_INDEX_FILE": str(temp_index.resolve())}
+
+            # NOTE: `--end-of-options` must NOT be combined with `--` here —
+            # git would then read `--` as a literal pathspec and fail. The
+            # `--` separator alone already protects an option-shaped path.
+            add_step, _ = await self._run_git(["add", "--", *selected], extra_env=env)
+            add_step.name = "add"
+            steps.append(add_step)
+            if add_step.exit_code != 0:
+                return self._error(
+                    operation, "add_failed", "git add rejected the selection", steps=steps, started=started
+                )
+
+            verify_step, verify_raw = await self._run_git(["diff", "--cached", "--name-only", "-z"], extra_env=env)
+            verify_step.name = "verify staged names"
+            steps.append(verify_step)
+            staged_after = sorted(_split_nul(verify_raw))
+            if verify_step.exit_code != 0 or staged_after != sorted(chosen):
+                return self._error(
+                    operation,
+                    "staged_mismatch",
+                    "the prepared index does not contain exactly the selected paths",
+                    details={"expected": sorted(chosen)[:50], "actual": staged_after[:50]},
+                    steps=steps,
+                    started=started,
+                )
+
+            check_step, _ = await self._run_git(["diff", "--cached", "--check"], extra_env=env)
+            check_step.name = "verify whitespace"
+            steps.append(check_step)
+            if check_step.exit_code != 0:
+                return self._error(
+                    operation,
+                    "whitespace_errors",
+                    "the selection introduces whitespace errors",
+                    details={"lines": _bounded_lines(check_step.stdout, 50)},
+                    steps=steps,
+                    started=started,
+                )
+
+            if self._fingerprint(layout.index_path) != fingerprint_before:
+                return self._error(
+                    operation,
+                    "index_changed",
+                    "the index changed while it was being prepared",
+                    steps=steps,
+                    started=started,
+                )
+
+            publish_step = self._publish_index(layout, temp_index)
+            steps.append(publish_step)
+            if publish_step.exit_code != 0:
+                code = "index_locked" if publish_step.stderr.startswith("index_locked") else "publish_failed"
+                return self._error(
+                    operation, code, publish_step.stderr or "could not publish the index", steps=steps, started=started
+                )
+        finally:
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(temp_index)
+
+        data = {
+            "staged": sorted(chosen),
+            "deleted": sorted(deleted),
+            "whitespace_ok": True,
+            "index_published": True,
+        }
+        return self._ok(operation, data, steps, started)
+
+    def _publish_index(self, layout: RepoLayout, temp_index: Path) -> StepResult:
+        """Publish the prepared index through Git's own ``index.lock``.
+
+        This is exactly how Git itself commits an index: write the new
+        content into ``index.lock`` and atomically rename it over ``index``.
+        A pre-existing lock belongs to another Git process and is never
+        removed.
+
+        Args:
+            layout: The discovered repository layout.
+            temp_index: The prepared private index file.
+
+        Returns:
+            A step describing the publish attempt. ``exit_code`` 0 means the
+            index was replaced.
+        """
+        lock_path = layout.index_path.with_name("index.lock")
+        try:
+            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        except FileExistsError:
+            return StepResult(
+                name="publish index",
+                exit_code=1,
+                timed_out=False,
+                state_changed=False,
+                stderr="index_locked: another git process holds the index lock",
+            )
+        try:
+            with os.fdopen(fd, "wb") as destination, open(temp_index, "rb") as source:
+                shutil.copyfileobj(source, destination)
+                destination.flush()
+                os.fsync(destination.fileno())
+            os.replace(lock_path, layout.index_path)
+        except BaseException as exc:  # noqa: BLE001 — cleanup then report
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(lock_path)
+            return StepResult(
+                name="publish index",
+                exit_code=1,
+                timed_out=False,
+                state_changed=False,
+                stderr=f"publish failed: {exc}"[:4096],
+            )
+        return StepResult(name="publish index", exit_code=0, timed_out=False, state_changed=True)
+
+    # ----------------------------------------------------------------- #
+    # Publication
+    # ----------------------------------------------------------------- #
+    async def _status_summary(self) -> tuple[dict[str, Any], StepResult]:
+        """Read and parse the porcelain-v2 status with branch headers.
+
+        Returns:
+            A ``(summary, step)`` tuple; ``summary`` is empty when the
+            command failed.
+        """
+        step, raw = await self._run_git(["status", "--porcelain=v2", "-z", "--branch", "--untracked-files=normal"])
+        step.name = "status"
+        return (_parse_status_v2(raw) if step.exit_code == 0 else {}), step
+
+    async def _resolve_publication_branch(
+        self,
+        operation: str,
+        summary: dict[str, Any],
+        remote: str,
+        branch: Optional[str],
+        steps: list[StepResult],
+        started: float,
+    ) -> tuple[Optional[str], Optional[OperationResult]]:
+        """Resolve which branch a pull/push acts on, refusing unsafe states.
+
+        Args:
+            operation: The calling operation name.
+            summary: The parsed status summary.
+            remote: The validated remote name.
+            branch: The caller-supplied branch, or None to use the upstream.
+            steps: Steps recorded so far, for the error result.
+            started: A ``perf_counter()`` reading taken at operation start.
+
+        Returns:
+            A ``(branch, error_result)`` tuple; exactly one is not None.
+        """
+        if summary.get("detached"):
+            return None, self._error(operation, "detached_head", "HEAD is detached", steps=steps, started=started)
+        if summary.get("unborn"):
+            return None, self._error(
+                operation, "unborn_head", "the current branch has no commits yet", steps=steps, started=started
+            )
+
+        current = summary.get("branch")
+        if not current:
+            return None, self._error(
+                operation, "unknown_branch", "could not determine the current branch", steps=steps, started=started
+            )
+
+        if branch is None:
+            upstream = summary.get("upstream")
+            if not upstream:
+                return None, self._error(
+                    operation,
+                    "missing_upstream",
+                    f"branch {current!r} has no upstream; pass an explicit branch",
+                    steps=steps,
+                    started=started,
+                )
+            upstream_remote, _, upstream_branch = upstream.partition("/")
+            if upstream_remote != remote:
+                return None, self._error(
+                    operation,
+                    "upstream_remote_mismatch",
+                    f"upstream {upstream!r} does not belong to remote {remote!r}",
+                    details={"upstream": upstream, "remote": remote},
+                    steps=steps,
+                    started=started,
+                )
+            return upstream_branch or current, None
+
+        if branch != current:
+            return None, self._error(
+                operation,
+                "branch_mismatch",
+                f"requested branch {branch!r} is not the current branch {current!r}",
+                details={"requested": branch, "current": current},
+                steps=steps,
+                started=started,
+            )
+        return branch, None
+
+    async def _fetch_branch(self, remote: str, branch: str) -> tuple[Optional[str], StepResult]:
+        """Fetch one branch with an explicit, non-forced destination refspec.
+
+        Args:
+            remote: A validated remote name.
+            branch: A validated branch name.
+
+        Returns:
+            A ``(fetched_sha_or_None, step)`` tuple.
+        """
+        refspec = f"refs/heads/{branch}:refs/remotes/{remote}/{branch}"
+        step, _ = await self._run_git(
+            ["fetch", "--no-tags", "--no-recurse-submodules", "--end-of-options", remote, refspec],
+            timeout=self.policy.network_timeout_seconds,
+        )
+        step.name = "fetch"
+        step.state_changed = step.exit_code == 0
+        if step.exit_code != 0:
+            return None, step
+        head_step, _ = await self._run_git(
+            ["rev-parse", "--verify", "--quiet", "--end-of-options", "FETCH_HEAD^{commit}"]
+        )
+        sha = head_step.stdout.strip()
+        return (sha if len(sha) == 40 else None), step
+
+    @tool_schema(GitPullArgs)
+    async def git_pull(self, remote: str = "origin", branch: Optional[str] = None) -> OperationResult:
+        """Fast-forward the current branch from its remote, or refuse.
+
+        Only a fast-forward is ever performed: there is no stash, no rebase
+        and no merge commit. A dirty or partially staged tree, a detached or
+        unborn HEAD, or a diverged history all cause a refusal that changes
+        nothing. Untracked files are preserved — Git itself refuses a
+        fast-forward that would overwrite one.
+
+        The ``confirm`` argument added over MCP records that a human approved
+        this mutation; it is not authorization a model can grant itself.
+
+        Args:
+            remote: A configured remote name. Defaults to ``origin``.
+            branch: The branch to pull. Defaults to the current branch's
+                upstream, and must equal the current branch when supplied.
+
+        Returns:
+            An operation result whose ``data`` carries ``branch``, ``remote``,
+            ``before``, ``after`` and ``updated``.
+        """
+        started = time.perf_counter()
+        operation = "git_pull"
+        try:
+            args = GitPullArgs(remote=remote, branch=branch)
+        except Exception as exc:  # pydantic ValidationError
+            return self._error(operation, "invalid_arguments", str(exc), started=started)
+
+        layout = await self._discover(operation, started)
+        if isinstance(layout, OperationResult):
+            return layout
+
+        try:
+            async with WorktreeLock(layout.lock_path, self.policy.command_timeout_seconds):
+                return await self._pull_locked(operation, args, started)
+        except LockTimeoutError as exc:
+            return self._error(operation, "worktree_busy", str(exc), started=started)
+
+    async def _pull_locked(self, operation: str, args: GitPullArgs, started: float) -> OperationResult:
+        """Perform the fast-forward-only pull while holding the worktree lock.
+
+        Args:
+            operation: The operation name.
+            args: The validated arguments.
+            started: A ``perf_counter()`` reading taken at operation start.
+
+        Returns:
+            The bounded operation result.
+        """
+        remotes, remote_step = await self._remote_names()
+        steps: list[StepResult] = [remote_step]
+        try:
+            safe_remote = self._validate_remote(args.remote, remotes)
+        except ValueError as exc:
+            return self._error(operation, "unknown_remote", str(exc), steps=steps, started=started)
+
+        summary, status_step = await self._status_summary()
+        steps.append(status_step)
+        if status_step.exit_code != 0:
+            return self._error(
+                operation, "status_failed", "could not read the working tree state", steps=steps, started=started
+            )
+
+        counts = summary.get("counts", {})
+        if counts.get("unmerged"):
+            return self._error(
+                operation, "unmerged_index", "the index has unmerged entries", steps=steps, started=started
+            )
+        if counts.get("staged"):
+            return self._error(
+                operation,
+                "staged_changes",
+                "the index has staged changes; publish or reset them yourself",
+                steps=steps,
+                started=started,
+            )
+        if counts.get("unstaged"):
+            return self._error(
+                operation,
+                "dirty_worktree",
+                "tracked files have uncommitted modifications",
+                steps=steps,
+                started=started,
+            )
+
+        branch, error = await self._resolve_publication_branch(
+            operation, summary, safe_remote, args.branch, steps, started
+        )
+        if error is not None:
+            return error
+        try:
+            safe_branch = await self._validate_branch(branch or "")
+        except ValueError as exc:
+            return self._error(operation, "invalid_branch", str(exc), steps=steps, started=started)
+
+        before = summary.get("head_commit")
+        fetched, fetch_step = await self._fetch_branch(safe_remote, safe_branch)
+        steps.append(fetch_step)
+        if fetch_step.timed_out:
+            return self._error(
+                operation, "fetch_timeout", "the fetch timed out", steps=steps, started=started, status="uncertain"
+            )
+        if fetch_step.exit_code != 0:
+            rejected = "rejected" in fetch_step.stderr or "non-fast-forward" in fetch_step.stderr
+            return self._error(
+                operation,
+                "fetch_rejected" if rejected else "fetch_failed",
+                "the fetch did not complete",
+                steps=steps,
+                started=started,
+            )
+        if fetched is None:
+            return self._error(
+                operation, "fetch_head_unresolved", "could not read the fetched commit", steps=steps, started=started
+            )
+
+        up_to_date_step, _ = await self._run_git(["merge-base", "--is-ancestor", "--end-of-options", fetched, "HEAD"])
+        up_to_date_step.name = "merge-base"
+        steps.append(up_to_date_step)
+        if up_to_date_step.exit_code == 0:
+            data = {"branch": safe_branch, "remote": safe_remote, "before": before, "after": before, "updated": False}
+            return self._ok(operation, data, steps, started)
+
+        ancestor_step, _ = await self._run_git(["merge-base", "--is-ancestor", "--end-of-options", "HEAD", fetched])
+        ancestor_step.name = "merge-base"
+        steps.append(ancestor_step)
+        if ancestor_step.exit_code != 0:
+            count_step, _ = await self._run_git(
+                ["rev-list", "--left-right", "--count", "--end-of-options", f"HEAD...{fetched}"]
+            )
+            count_step.name = "rev-list"
+            steps.append(count_step)
+            ahead_behind = count_step.stdout.split()
+            return self._error(
+                operation,
+                "diverged",
+                "the local branch and the remote branch have diverged",
+                details={
+                    "local": before,
+                    "remote": fetched,
+                    "ahead": int(ahead_behind[0]) if len(ahead_behind) == 2 else None,
+                    "behind": int(ahead_behind[1]) if len(ahead_behind) == 2 else None,
+                },
+                steps=steps,
+                started=started,
+            )
+
+        merge_step, _ = await self._run_git(
+            ["-c", "merge.autoStash=false", "merge", "--ff-only", "--no-autostash", "--end-of-options", fetched]
+        )
+        merge_step.name = "merge --ff-only"
+        steps.append(merge_step)
+        if merge_step.exit_code != 0:
+            untracked = (
+                "untracked working tree files" in merge_step.stderr or "would be overwritten" in merge_step.stderr
+            )
+            return self._error(
+                operation,
+                "untracked_conflict" if untracked else "fast_forward_failed",
+                "the fast-forward did not complete; nothing was changed",
+                details={"stderr": merge_step.stderr[:1024]},
+                steps=steps,
+                started=started,
+            )
+        merge_step.state_changed = True
+        data = {"branch": safe_branch, "remote": safe_remote, "before": before, "after": fetched, "updated": True}
+        return self._ok(operation, data, steps, started)
+
+    @tool_schema(GitPushArgs)
+    async def git_push(self, remote: str = "origin", branch: Optional[str] = None) -> OperationResult:
+        """Push the current branch to the same branch name on a remote.
+
+        The push is never forced, never pushes all refs and never creates a
+        commit. A rejection is reported with the remote's reason. If the push
+        times out after transmission its outcome is genuinely unknown, so the
+        result is ``uncertain`` and a single read-only ``ls-remote`` is used
+        to resolve it — the push is never blindly retried.
+
+        The ``confirm`` argument added over MCP records that a human approved
+        this mutation; it is not authorization a model can grant itself.
+
+        Args:
+            remote: A configured remote name. Defaults to ``origin``.
+            branch: The branch to push. Defaults to the current branch, and
+                must equal it when supplied.
+
+        Returns:
+            An operation result whose ``data`` carries ``branch``, ``remote``,
+            ``local_commit``, ``remote_commit_before``, ``remote_commit_after``
+            and ``summary``.
+        """
+        started = time.perf_counter()
+        operation = "git_push"
+        try:
+            args = GitPushArgs(remote=remote, branch=branch)
+        except Exception as exc:  # pydantic ValidationError
+            return self._error(operation, "invalid_arguments", str(exc), started=started)
+
+        layout = await self._discover(operation, started)
+        if isinstance(layout, OperationResult):
+            return layout
+
+        try:
+            async with WorktreeLock(layout.lock_path, self.policy.command_timeout_seconds):
+                return await self._push_locked(operation, args, started)
+        except LockTimeoutError as exc:
+            return self._error(operation, "worktree_busy", str(exc), started=started)
+
+    async def _push_locked(self, operation: str, args: GitPushArgs, started: float) -> OperationResult:
+        """Perform the non-forced push while holding the worktree lock.
+
+        Args:
+            operation: The operation name.
+            args: The validated arguments.
+            started: A ``perf_counter()`` reading taken at operation start.
+
+        Returns:
+            The bounded operation result.
+        """
+        remotes, remote_step = await self._remote_names()
+        steps: list[StepResult] = [remote_step]
+        try:
+            safe_remote = self._validate_remote(args.remote, remotes)
+        except ValueError as exc:
+            return self._error(operation, "unknown_remote", str(exc), steps=steps, started=started)
+
+        summary, status_step = await self._status_summary()
+        steps.append(status_step)
+        if status_step.exit_code != 0:
+            return self._error(
+                operation, "status_failed", "could not read the working tree state", steps=steps, started=started
+            )
+
+        branch, error = await self._resolve_publication_branch(
+            operation, summary, safe_remote, args.branch, steps, started
+        )
+        if error is not None:
+            return error
+        try:
+            safe_branch = await self._validate_branch(branch or "")
+        except ValueError as exc:
+            return self._error(operation, "invalid_branch", str(exc), steps=steps, started=started)
+
+        local_commit = summary.get("head_commit")
+        refspec = f"refs/heads/{safe_branch}:refs/heads/{safe_branch}"
+        push_step, _ = await self._run_git(
+            ["push", "--porcelain", "--no-force-with-lease", "--end-of-options", safe_remote, refspec],
+            timeout=self.policy.network_timeout_seconds,
+        )
+        push_step.name = "push"
+        steps.append(push_step)
+
+        data: dict[str, Any] = {
+            "branch": safe_branch,
+            "remote": safe_remote,
+            "local_commit": local_commit,
+            "remote_commit_before": None,
+            "remote_commit_after": None,
+            "summary": "",
+        }
+
+        if push_step.timed_out:
+            return await self._resolve_push_timeout(
+                operation, safe_remote, safe_branch, local_commit, data, steps, started
+            )
+
+        flag, refs, message = _parse_push_porcelain(push_step.stdout)
+        data["summary"] = message
+        before, _abbreviated_after = _parse_push_range(message)
+        # Git reports abbreviated shas in the porcelain range. On a successful
+        # non-forced push of <b>:<b> the remote ref is exactly our local
+        # commit, so report that full identity rather than the abbreviation.
+        data["remote_commit_before"] = before
+        if push_step.exit_code == 0 and flag in (" ", "*", "="):
+            data["remote_commit_after"] = local_commit
+
+        if push_step.exit_code != 0 or flag == "!":
+            return self._error(
+                operation,
+                "push_rejected",
+                "the remote rejected the push",
+                details={"summary": message, "refs": refs, "stderr": push_step.stderr[:1024]},
+                steps=steps,
+                started=started,
+            )
+        if flag in ("-", "+"):
+            # A deletion or a forced update must never come out of this tool.
+            return self._error(
+                operation,
+                "unexpected_push_effect",
+                f"the push reported an unexpected effect ({flag!r})",
+                details={"summary": message},
+                steps=steps,
+                started=started,
+            )
+        push_step.state_changed = flag != "="
+        return self._ok(operation, data, steps, started)
+
+    async def _resolve_push_timeout(
+        self,
+        operation: str,
+        remote: str,
+        branch: str,
+        local_commit: Optional[str],
+        data: dict[str, Any],
+        steps: list[StepResult],
+        started: float,
+    ) -> OperationResult:
+        """Resolve a push whose outcome is unknown, without retrying it.
+
+        A timeout after transmission may or may not have updated the remote.
+        Exactly one read-only ``ls-remote`` is used to find out; anything
+        else leaves the result ``uncertain``.
+
+        Args:
+            operation: The operation name.
+            remote: The validated remote name.
+            branch: The validated branch name.
+            local_commit: The local HEAD commit.
+            data: The partially built result payload.
+            steps: Steps recorded so far.
+            started: A ``perf_counter()`` reading taken at operation start.
+
+        Returns:
+            An ``ok`` result when the remote demonstrably matches the local
+            commit, otherwise an ``uncertain`` one.
+        """
+        probe_step, _ = await self._run_git(
+            ["ls-remote", "--heads", "--end-of-options", remote, f"refs/heads/{branch}"],
+            timeout=self.policy.network_timeout_seconds,
+        )
+        probe_step.name = "ls-remote"
+        steps.append(probe_step)
+        remote_sha = probe_step.stdout.split("\t")[0].strip() if probe_step.exit_code == 0 else ""
+
+        if remote_sha and local_commit and remote_sha == local_commit:
+            data["remote_commit_after"] = remote_sha
+            data["summary"] = "resolved after timeout"
+            data["resolved_after_timeout"] = True
+            return self._ok(operation, data, steps, started)
+
+        result = self._error(
+            operation,
+            "push_timeout",
+            "the push timed out; the remote state could not be confirmed",
+            details={"remote_commit": remote_sha or None, "local_commit": local_commit},
+            steps=steps,
+            started=started,
+            status="uncertain",
+        )
+        data["remote_commit_after"] = remote_sha or None
+        data["resolved_after_timeout"] = False
+        result.data = data
+        return result
+
 
 # --------------------------------------------------------------------------- #
 # Output parsing helpers (module level so _generate_tools never sees them)
@@ -795,3 +1667,42 @@ def _parse_status_v2(raw: bytes) -> dict[str, Any]:
             "unmerged": unmerged[:50],
         },
     }
+
+
+def _parse_push_porcelain(stdout: str) -> tuple[str, str, str]:
+    """Parse ``git push --porcelain`` output into flag, refs and summary.
+
+    Args:
+        stdout: The raw porcelain stdout.
+
+    Returns:
+        A ``(flag, refs, summary)`` tuple; empty strings when no ref line was
+        emitted.
+    """
+    for line in stdout.splitlines():
+        if not line or line.startswith("To ") or line.startswith("Done"):
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        flag = parts[0][:1] or " "
+        refs = parts[1]
+        summary = parts[2] if len(parts) > 2 else ""
+        return flag, refs, summary
+    return "", "", ""
+
+
+def _parse_push_range(summary: str) -> tuple[Optional[str], Optional[str]]:
+    """Extract ``<old>..<new>`` commit identities from a push summary.
+
+    Args:
+        summary: The porcelain summary field.
+
+    Returns:
+        An ``(old, new)`` tuple; ``(None, None)`` when the summary is not a
+        commit range (e.g. ``[new branch]`` or ``[rejected]``).
+    """
+    match = re.match(r"^([0-9a-f]{7,40})\.\.([0-9a-f]{7,40})$", summary.strip())
+    if match is None:
+        return None, None
+    return match.group(1), match.group(2)

--- a/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/hooks.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/hooks.py
@@ -1,0 +1,529 @@
+"""Opt-in host read guards for Claude Code and Codex (FEAT-543).
+
+A ``PreToolUse`` hook that denies *unbounded* reads of large files and
+replies with the exact bounded-reader call to make instead. It uses the same
+thresholds as the MCP reader, and it is a convenience, not an enforcement
+boundary: the reader's own limits hold regardless of whether this hook is
+installed.
+
+Scope is deliberately narrow and honestly documented (see
+:func:`coverage_matrix`). v1 understands Claude's structured ``Read`` tool
+and a small literal shell subset (``cat``, ``head``, ``tail``, ``less``,
+``more``). Anything else — command substitution, redirection, globs,
+compound statements, other interpreters — produces **no decision**, and the
+host behaves normally. A pipe never makes a large read safe: the reading
+segment decides.
+
+Two invariants:
+
+* **This module never breaks a host session.** Any exception, malformed
+  payload, or unreadable file results in exit 0 with no output.
+* **This module is stdlib-only at import.** No pydantic, no ``parrot.*``.
+  A hook runs on every tool call, so its import cost must stay negligible.
+
+Run as::
+
+    python -m parrot_tools.tool_optimizations.hooks --host claude
+    python -m parrot_tools.tool_optimizations.hooks --host codex
+"""
+
+import argparse
+import json
+import os
+import re
+import shlex
+import stat
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+__all__ = (
+    "GuardDecision",
+    "GuardPolicy",
+    "build_reason",
+    "count_lines_bounded",
+    "coverage_matrix",
+    "evaluate_read",
+    "evaluate_shell",
+    "is_large",
+    "main",
+    "parse_shell_subset",
+    "render_output",
+)
+
+#: Programs whose default behaviour is to emit a whole file.
+_READERS = frozenset({"cat", "less", "more"})
+
+#: Programs that read a *bounded* prefix/suffix by default (10 lines).
+_BOUNDED_READERS = frozenset({"head", "tail"})
+
+#: Shell metacharacters that put a command outside the documented subset.
+#: A match means "no decision" — never a denial, and never an approval.
+_UNSAFE = re.compile(r"[;&<>`$*?\[\]{}~\n()!]")
+
+_CHUNK = 1 << 16
+
+
+@dataclass(frozen=True)
+class GuardPolicy:
+    """Thresholds and reader identity used by the guard.
+
+    Attributes:
+        max_lines: Line threshold above which a read must be bounded.
+        large_file_bytes: Byte threshold above which a read must be bounded.
+        reader_server: MCP server name to recommend in a denial.
+        tool: Bounded-reader tool name to recommend in a denial.
+    """
+
+    max_lines: int = 350
+    large_file_bytes: int = 64_000
+    reader_server: str = "parrot-bounded-source"
+    tool: str = "source_read"
+
+    @classmethod
+    def load(cls, root: Path) -> "GuardPolicy":
+        """Load thresholds from ``<root>/.parrot/tool-guards.json``.
+
+        Any problem — missing file, bad JSON, wrong types — falls back to
+        the defaults rather than failing the host's tool call.
+
+        Args:
+            root: The repository root reported by the host.
+
+        Returns:
+            The effective policy.
+        """
+        try:
+            raw = json.loads((root / ".parrot" / "tool-guards.json").read_text(encoding="utf-8"))
+            return cls(
+                max_lines=int(raw.get("max_lines", cls.max_lines)),
+                large_file_bytes=int(raw.get("large_file_bytes", cls.large_file_bytes)),
+                reader_server=str(raw.get("reader_server", cls.reader_server)),
+                tool=str(raw.get("tool", cls.tool)),
+            )
+        except Exception:  # noqa: BLE001 — defaults are always acceptable
+            return cls()
+
+
+@dataclass
+class GuardDecision:
+    """The guard's verdict for one tool call.
+
+    Attributes:
+        deny: True when the call should be blocked.
+        reason: The message shown to the assistant.
+        path: The file the decision is about, if any.
+        lines: The file's line count, when it was counted.
+        size: The file's size in bytes.
+        coverage: Which rule produced the verdict — ``structured``,
+            ``shell``, ``unrecognized`` or ``not_applicable``.
+    """
+
+    deny: bool = False
+    reason: str = ""
+    path: Optional[str] = None
+    lines: Optional[int] = None
+    size: Optional[int] = None
+    coverage: str = "not_applicable"
+
+
+def count_lines_bounded(path: Path, stop_after: int) -> tuple[int, bool]:
+    """Count logical lines, stopping early once the bound is exceeded.
+
+    This intentionally duplicates
+    :func:`parrot_tools.tool_optimizations.reader.count_lines_bounded`.
+    Importing the reader would pull pydantic into a hook that runs on every
+    tool call; twenty stdlib lines are cheaper than that. A test asserts the
+    two implementations agree.
+
+    Args:
+        path: The file to count.
+        stop_after: The threshold to compare against.
+
+    Returns:
+        A ``(count, exceeded)`` tuple; when ``exceeded`` the exact count is
+        unknown and ``count`` is ``stop_after + 1``.
+    """
+    count = 0
+    ended_with_newline = True
+    saw_any = False
+    with open(path, "rb") as handle:
+        while True:
+            chunk = handle.read(_CHUNK)
+            if not chunk:
+                break
+            saw_any = True
+            count += chunk.count(b"\n")
+            ended_with_newline = chunk.endswith(b"\n")
+            if count > stop_after:
+                return stop_after + 1, True
+    if saw_any and not ended_with_newline:
+        count += 1
+        if count > stop_after:
+            return stop_after + 1, True
+    return count, False
+
+
+def is_large(path: Path, policy: GuardPolicy) -> tuple[bool, Optional[int], int]:
+    """Decide whether a file exceeds either configured threshold.
+
+    Only file metadata and newline counts are inspected; contents are never
+    loaded.
+
+    Args:
+        path: The file to inspect.
+        policy: The active policy.
+
+    Returns:
+        A ``(large, line_count_or_None, size_bytes)`` tuple. ``line_count``
+        is None when counting stopped early.
+
+    Raises:
+        OSError: The path is unreadable.
+        ValueError: The path is not a regular file.
+    """
+    info = os.stat(path)
+    if not stat.S_ISREG(info.st_mode):
+        raise ValueError(f"{path} is not a regular file")
+    if info.st_size > policy.large_file_bytes:
+        return True, None, info.st_size
+    count, exceeded = count_lines_bounded(path, policy.max_lines)
+    return exceeded, (None if exceeded else count), info.st_size
+
+
+def _resolve(candidate: str, cwd: Path) -> Path:
+    """Resolve a caller path against the host's working directory."""
+    path = Path(candidate).expanduser()
+    return path if path.is_absolute() else (cwd / path)
+
+
+def _decide_for_path(candidate: str, cwd: Path, policy: GuardPolicy, coverage: str) -> GuardDecision:
+    """Build a decision for one file operand.
+
+    Args:
+        candidate: The path as written by the caller.
+        cwd: The host's working directory.
+        policy: The active policy.
+        coverage: The rule that produced this decision.
+
+    Returns:
+        A denial when the file is large, otherwise a non-applicable verdict.
+    """
+    target = _resolve(candidate, cwd)
+    try:
+        large, lines, size = is_large(target, policy)
+    except (OSError, ValueError):
+        return GuardDecision(coverage="not_applicable")
+    if not large:
+        return GuardDecision(coverage=coverage, path=str(target), lines=lines, size=size)
+
+    decision = GuardDecision(deny=True, coverage=coverage, path=str(target), lines=lines, size=size)
+    decision.reason = build_reason(decision, policy, cwd)
+    return decision
+
+
+def evaluate_read(tool_input: dict[str, Any], cwd: Path, policy: GuardPolicy) -> GuardDecision:
+    """Evaluate Claude Code's structured ``Read`` tool.
+
+    Args:
+        tool_input: The host's ``tool_input`` mapping.
+        cwd: The host's working directory.
+        policy: The active policy.
+
+    Returns:
+        The guard's verdict.
+    """
+    candidate = tool_input.get("file_path")
+    if not isinstance(candidate, str) or not candidate:
+        return GuardDecision(coverage="not_applicable")
+
+    limit = tool_input.get("limit")
+    if isinstance(limit, int) and 0 < limit <= policy.max_lines:
+        # Already an explicitly bounded read.
+        return GuardDecision(coverage="structured", path=candidate)
+
+    return _decide_for_path(candidate, cwd, policy, "structured")
+
+
+def parse_shell_subset(command: str) -> Optional[list[list[str]]]:
+    """Parse a command if — and only if — it is in the documented subset.
+
+    Args:
+        command: The raw shell command.
+
+    Returns:
+        Pipeline segments as argv lists, or None when the command uses any
+        construct outside the subset (in which case the guard makes no
+        decision at all).
+    """
+    if not command or not command.strip():
+        return None
+    if _UNSAFE.search(command):
+        return None
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        return None
+    if not tokens:
+        return None
+
+    segments: list[list[str]] = []
+    current: list[str] = []
+    for token in tokens:
+        if token == "|":
+            segments.append(current)
+            current = []
+            continue
+        if "|" in token:
+            # `||` (and any other pipe-bearing token) survives shlex as a
+            # single token rather than a separator. Treating it as a plain
+            # operand would silently swallow a compound statement.
+            return None
+        current.append(token)
+    segments.append(current)
+    return segments if all(segments) else None
+
+
+def _is_bounded_invocation(argv: list[str], policy: GuardPolicy) -> bool:
+    """Decide whether a head/tail invocation is explicitly bounded.
+
+    A bare ``head file`` / ``tail file`` defaults to 10 lines and is
+    therefore bounded.
+
+    Args:
+        argv: The segment's argv.
+        policy: The active policy.
+
+    Returns:
+        True when the invocation cannot produce more than the thresholds.
+    """
+    if os.path.basename(argv[0]) not in _BOUNDED_READERS:
+        return False
+    index = 1
+    while index < len(argv):
+        token = argv[index]
+        match = re.fullmatch(r"-(\d+)", token)
+        if match:
+            return int(match.group(1)) <= policy.max_lines
+        if token in ("-n", "--lines") and index + 1 < len(argv) and argv[index + 1].lstrip("+-").isdigit():
+            return int(argv[index + 1].lstrip("+-")) <= policy.max_lines
+        if token in ("-c", "--bytes") and index + 1 < len(argv) and argv[index + 1].lstrip("+-").isdigit():
+            return int(argv[index + 1].lstrip("+-")) <= policy.large_file_bytes
+        index += 1
+    return True  # bare head/tail: 10 lines by default
+
+
+def _file_operands(argv: list[str]) -> Optional[list[str]]:
+    """Extract literal file operands from a reader invocation.
+
+    Args:
+        argv: The segment's argv.
+
+    Returns:
+        The operands, or None when stdin is used or a flag takes a value we
+        would otherwise mistake for a file.
+    """
+    operands: list[str] = []
+    index = 1
+    while index < len(argv):
+        token = argv[index]
+        if token == "-":
+            return None  # explicit stdin
+        if token in ("-n", "--lines", "-c", "--bytes"):
+            index += 2
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        operands.append(token)
+        index += 1
+    return operands
+
+
+def evaluate_shell(command: str, cwd: Path, policy: GuardPolicy) -> GuardDecision:
+    """Evaluate a shell command against the documented reader subset.
+
+    Args:
+        command: The raw shell command.
+        cwd: The host's working directory.
+        policy: The active policy.
+
+    Returns:
+        The guard's verdict. Unrecognised commands yield ``unrecognized``,
+        which renders no output.
+    """
+    segments = parse_shell_subset(command)
+    if segments is None:
+        return GuardDecision(coverage="unrecognized")
+
+    for argv in segments:
+        program = os.path.basename(argv[0])
+        if program not in _READERS and program not in _BOUNDED_READERS:
+            continue
+        if program in _BOUNDED_READERS and _is_bounded_invocation(argv, policy):
+            continue
+        operands = _file_operands(argv)
+        if operands is None:
+            return GuardDecision(coverage="not_applicable")
+        for operand in operands:
+            decision = _decide_for_path(operand, cwd, policy, "shell")
+            if decision.deny:
+                return decision
+    return GuardDecision(coverage="shell")
+
+
+def build_reason(decision: GuardDecision, policy: GuardPolicy, cwd: Optional[Path] = None) -> str:
+    """Build the denial message, naming the exact call to make instead.
+
+    Args:
+        decision: The denial being explained.
+        policy: The active policy.
+        cwd: The host's working directory, used to relativize the path.
+
+    Returns:
+        A concise, actionable reason.
+    """
+    path = Path(decision.path or "")
+    display = str(path)
+    if cwd is not None:
+        try:
+            display = str(path.relative_to(cwd))
+        except ValueError:
+            display = str(path)
+
+    measured = f"{decision.lines} lines" if decision.lines is not None else f"more than {policy.max_lines} lines"
+    arguments = json.dumps({"path": display, "start_line": 1, "end_line": policy.max_lines}, ensure_ascii=False)
+    return (
+        f"{display} is {measured} / {decision.size} bytes "
+        f"(> {policy.max_lines} lines or {policy.large_file_bytes:,} bytes). "
+        f"Use the bounded reader instead: MCP server '{policy.reader_server}' tool '{policy.tool}' "
+        f"with {arguments}; continue with the returned next_line and expected_sha256."
+    )
+
+
+def render_output(decision: Optional[GuardDecision], host: str) -> Optional[str]:
+    """Render a host-appropriate hook response.
+
+    Both hosts accept the ``hookSpecificOutput`` shape, so one renderer
+    serves both.
+
+    Args:
+        decision: The guard's verdict, if any.
+        host: ``claude`` or ``codex``.
+
+    Returns:
+        The JSON to print, or None when there is no decision to report.
+    """
+    if decision is None or not decision.deny:
+        return None
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": decision.reason,
+        }
+    }
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def coverage_matrix() -> list[dict[str, Any]]:
+    """Return the honest, machine-readable coverage table.
+
+    Publishing what the guard does **not** intercept is deliberate: a guard
+    that appears total but is not creates a false sense of enforcement.
+
+    Returns:
+        Rows of ``{"form", "covered", "note"}``.
+    """
+    return [
+        {
+            "form": "Claude Read (file_path)",
+            "covered": True,
+            "note": "Structured tool input; honours a limit <= max_lines.",
+        },
+        {"form": "cat FILE", "covered": True, "note": "Literal operand; denied when the file is large."},
+        {"form": "head -n N FILE / head -N FILE", "covered": True, "note": "Allowed when N <= max_lines."},
+        {"form": "tail -c N FILE", "covered": True, "note": "Allowed when N <= large_file_bytes."},
+        {"form": "bare head FILE / tail FILE", "covered": True, "note": "Defaults to 10 lines, so bounded."},
+        {"form": "less FILE / more FILE", "covered": True, "note": "Treated as a whole-file read."},
+        {"form": "cat FILE | head -20", "covered": True, "note": "The reading segment decides; a pipe is not safe."},
+        {"form": "cat FILE; other", "covered": False, "note": "Compound statement — outside the parsed subset."},
+        {"form": "cat $(echo FILE)", "covered": False, "note": "Command substitution is never evaluated."},
+        {"form": "cat *.py", "covered": False, "note": "Glob expansion is the shell's, not ours."},
+        {"form": "cat < FILE", "covered": False, "note": "Redirection is outside the subset."},
+        {"form": "sed -n '1,500p' FILE", "covered": False, "note": "sed is not an intercepted program."},
+        {"form": "awk 'NR<500' FILE", "covered": False, "note": "awk is not an intercepted program."},
+        {
+            "form": "python -c \"open('FILE').read()\"",
+            "covered": False,
+            "note": "Arbitrary interpreters are not parsed.",
+        },
+        {"form": "xargs cat", "covered": False, "note": "Operands arrive on stdin, not in the argv we can see."},
+        {"form": "heredoc (<<EOF)", "covered": False, "note": "Outside the subset."},
+        {"form": "Codex write_stdin", "covered": False, "note": "Documented host gap: it does not re-run PreToolUse."},
+        {"form": "Codex hosted tools", "covered": False, "note": "Not hookable by the host."},
+        {"form": "Grep / Glob", "covered": False, "note": "Out of scope; the guard matcher is Read|Bash."},
+        {"form": "WebFetch", "covered": False, "note": "Not a local file read."},
+        {"form": "Interactive shell session input", "covered": False, "note": "Not mediated by PreToolUse."},
+    ]
+
+
+def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    """Parse the hook's command line.
+
+    Args:
+        argv: Argument list, or None for ``sys.argv``.
+
+    Returns:
+        The parsed arguments.
+    """
+    parser = argparse.ArgumentParser(prog="parrot-tool-guard", description="PreToolUse read guard.")
+    parser.add_argument("--host", choices=("claude", "codex"), default="claude")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None, stdin: Any = None, stdout: Any = None) -> int:
+    """Run the guard over one hook payload.
+
+    Always returns 0. A denial is communicated by the printed JSON, never by
+    the exit code, and any internal failure results in silence — a broken
+    guard must not break the host session.
+
+    Args:
+        argv: Command-line arguments.
+        stdin: Input stream carrying the hook JSON.
+        stdout: Output stream for the decision.
+
+    Returns:
+        Always 0.
+    """
+    stream_in = stdin if stdin is not None else sys.stdin
+    stream_out = stdout if stdout is not None else sys.stdout
+    try:
+        args = _parse_args(argv)
+        payload = json.load(stream_in)
+        cwd = Path(payload.get("cwd") or os.getcwd())
+        policy = GuardPolicy.load(cwd)
+        tool_name = payload.get("tool_name")
+        tool_input = payload.get("tool_input") or {}
+
+        decision: Optional[GuardDecision]
+        if tool_name == "Read":
+            decision = evaluate_read(tool_input, cwd, policy)
+        elif tool_name == "Bash":
+            decision = evaluate_shell(str(tool_input.get("command", "")), cwd, policy)
+        else:
+            decision = None
+
+        rendered = render_output(decision, args.host)
+        if rendered:
+            stream_out.write(rendered)
+            stream_out.flush()
+    except Exception:  # noqa: BLE001 — never break the host session
+        pass
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover — process entry point
+    sys.exit(main())

--- a/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/hooks.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/hooks.py
@@ -289,52 +289,107 @@ def parse_shell_subset(command: str) -> Optional[list[list[str]]]:
 def _is_bounded_invocation(argv: list[str], policy: GuardPolicy) -> bool:
     """Decide whether a head/tail invocation is explicitly bounded.
 
-    A bare ``head file`` / ``tail file`` defaults to 10 lines and is
-    therefore bounded.
+    Conservative by construction: anything this function cannot fully
+    reason about is reported as **not** bounded, so the caller falls
+    through to the size check instead of waving the command past.
+
+    Three ways a naive reading fails open, all rejected here:
+
+    * A **signed** count changes the meaning from "N lines" to "from/until
+      line N" — ``tail -n +1 f`` and ``head -n -1 f`` both read essentially
+      the whole file.
+    * The ``--lines=N`` / ``-n=N`` *equals* form is a single token and is
+      missed by a two-token-only parser.
+    * ``tail -f`` (and any other unrecognized flag) is not a bounded read
+      at all.
+
+    A bare ``head file`` / ``tail file`` really does default to 10 lines
+    and is the only case that is bounded without an explicit count.
 
     Args:
         argv: The segment's argv.
         policy: The active policy.
 
     Returns:
-        True when the invocation cannot produce more than the thresholds.
+        True only when the invocation provably cannot exceed the thresholds.
     """
     if os.path.basename(argv[0]) not in _BOUNDED_READERS:
         return False
+
     index = 1
     while index < len(argv):
         token = argv[index]
-        match = re.fullmatch(r"-(\d+)", token)
-        if match:
-            return int(match.group(1)) <= policy.max_lines
-        if token in ("-n", "--lines") and index + 1 < len(argv) and argv[index + 1].lstrip("+-").isdigit():
-            return int(argv[index + 1].lstrip("+-")) <= policy.max_lines
-        if token in ("-c", "--bytes") and index + 1 < len(argv) and argv[index + 1].lstrip("+-").isdigit():
-            return int(argv[index + 1].lstrip("+-")) <= policy.large_file_bytes
-        index += 1
+        if token == "--":
+            break  # everything after this is a file operand
+        if not token.startswith("-") or token == "-":
+            index += 1
+            continue
+
+        plain_count = re.fullmatch(r"-(\d+)", token)
+        if plain_count:
+            if int(plain_count.group(1)) > policy.max_lines:
+                return False
+            index += 1
+            continue
+
+        name, separator, inline = token.partition("=")
+        if name in ("-n", "--lines", "-c", "--bytes"):
+            if separator:
+                value, step = inline, 1
+            elif index + 1 < len(argv):
+                value, step = argv[index + 1], 2
+            else:
+                return False
+            # `isdigit()` rejects '+1' and '-1' — a signed count is not a bound.
+            if not value.isdigit():
+                return False
+            limit = policy.max_lines if name in ("-n", "--lines") else policy.large_file_bytes
+            if int(value) > limit:
+                return False
+            index += step
+            continue
+
+        if name in ("-q", "--quiet", "--silent", "-v", "--verbose", "-z", "--zero-terminated"):
+            index += 1
+            continue
+
+        # Unrecognized flag (-f/--follow, --retry, ...): not reasoned about,
+        # therefore not bounded.
+        return False
+
     return True  # bare head/tail: 10 lines by default
 
 
-def _file_operands(argv: list[str]) -> Optional[list[str]]:
+def _file_operands(argv: list[str], program: str) -> Optional[list[str]]:
     """Extract literal file operands from a reader invocation.
+
+    Only ``head`` and ``tail`` take a *value* after ``-n``/``-c``. For
+    ``cat``, ``less`` and ``more``, ``-n`` is a valueless flag (``cat -n``
+    numbers output lines), so treating it as value-consuming would swallow
+    the filename and leave no operand to size-check — a silent fail-open.
 
     Args:
         argv: The segment's argv.
+        program: The basename of ``argv[0]``.
 
     Returns:
-        The operands, or None when stdin is used or a flag takes a value we
-        would otherwise mistake for a file.
+        The operands, or None when stdin is used (nothing to check).
     """
+    consumes_value = program in _BOUNDED_READERS
     operands: list[str] = []
     index = 1
     while index < len(argv):
         token = argv[index]
+        if token == "--":
+            operands.extend(argv[index + 1 :])
+            break
         if token == "-":
             return None  # explicit stdin
-        if token in ("-n", "--lines", "-c", "--bytes"):
-            index += 2
-            continue
         if token.startswith("-"):
+            name, separator, _inline = token.partition("=")
+            if consumes_value and not separator and name in ("-n", "--lines", "-c", "--bytes"):
+                index += 2
+                continue
             index += 1
             continue
         operands.append(token)
@@ -364,7 +419,7 @@ def evaluate_shell(command: str, cwd: Path, policy: GuardPolicy) -> GuardDecisio
             continue
         if program in _BOUNDED_READERS and _is_bounded_invocation(argv, policy):
             continue
-        operands = _file_operands(argv)
+        operands = _file_operands(argv, program)
         if operands is None:
             return GuardDecision(coverage="not_applicable")
         for operand in operands:

--- a/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/hooks.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/hooks.py
@@ -41,6 +41,7 @@ from typing import Any, Optional
 __all__ = (
     "GuardDecision",
     "GuardPolicy",
+    "DENY_VALUE",
     "build_reason",
     "count_lines_bounded",
     "coverage_matrix",
@@ -402,11 +403,21 @@ def build_reason(decision: GuardDecision, policy: GuardPolicy, cwd: Optional[Pat
     )
 
 
+#: The refusal value each host's PreToolUse decision enum accepts.
+#:
+#: Claude Code documents ``deny``. Codex 0.154.0 does NOT accept it: its
+#: ``PreToolUseDecisionWire`` enum is ``approve | block | allow`` (verified
+#: against the shipped binary), and it rejects anything else with
+#: "PreToolUse hook returned unsupported decision" — i.e. sending ``deny``
+#: to Codex silently fails open and the large read proceeds.
+DENY_VALUE = {"claude": "deny", "codex": "block"}
+
+
 def render_output(decision: Optional[GuardDecision], host: str) -> Optional[str]:
     """Render a host-appropriate hook response.
 
-    Both hosts accept the ``hookSpecificOutput`` shape, so one renderer
-    serves both.
+    Both hosts use the ``hookSpecificOutput`` envelope, but they do **not**
+    share the refusal keyword — see :data:`DENY_VALUE`.
 
     Args:
         decision: The guard's verdict, if any.
@@ -420,7 +431,7 @@ def render_output(decision: Optional[GuardDecision], host: str) -> Optional[str]
     payload = {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
-            "permissionDecision": "deny",
+            "permissionDecision": DENY_VALUE.get(host, "deny"),
             "permissionDecisionReason": decision.reason,
         }
     }

--- a/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/installation.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/installation.py
@@ -1,0 +1,427 @@
+"""Managed installation of the host read guards (FEAT-543).
+
+Installs, reports on, and removes the opt-in ``PreToolUse`` guard for
+Claude Code and Codex, following the same "touch only what we own"
+discipline as the existing wiki installers:
+
+* **Idempotent.** Installing twice produces identical bytes and an
+  "already installed" message.
+* **Foreign configuration is preserved.** Other hook entries, other
+  matchers and unknown keys are never rewritten or dropped.
+* **A malformed config is never clobbered.** It raises an actionable
+  error and leaves the file untouched.
+* **Uninstall removes only owned entries**, identified by the hook module
+  name in the command string, and only collapses containers it emptied.
+
+The user's home directory is never touched: Codex hooks are written to
+``<root>/.codex/hooks.json``, project scope only.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess  # noqa: S404 — used only to read `--version` from a host binary
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+__all__ = (
+    "CLAUDE_MATCHER",
+    "CODEX_MATCHER",
+    "HOOK_MODULE",
+    "guard_status",
+    "guard_thresholds",
+    "hook_command",
+    "install_guards",
+    "resolve_python",
+    "uninstall_guards",
+)
+
+#: Ownership marker: any hook command mentioning this module is ours.
+HOOK_MODULE = "parrot_tools.tool_optimizations.hooks"
+
+#: Claude Code intercepts both the structured Read tool and shell reads.
+CLAUDE_MATCHER = "Read|Bash"
+
+#: Codex reads through the shell only.
+CODEX_MATCHER = "Bash"
+
+#: Default thresholds, matching the bounded reader's own defaults.
+_DEFAULT_MAX_LINES = 350
+_DEFAULT_LARGE_FILE_BYTES = 64_000
+_DEFAULT_READER_SERVER = "parrot-bounded-source"
+_READER_CLASS = "parrot_tools.tool_optimizations.reader.BoundedSourceToolkit"
+
+#: Minimum host versions known to support the hook contract used here.
+_MIN_VERSIONS = {"claude": (2, 1), "codex": (0, 150)}
+
+_HOSTS = {
+    "claude": (Path(".claude") / "settings.json", CLAUDE_MATCHER),
+    "codex": (Path(".codex") / "hooks.json", CODEX_MATCHER),
+}
+
+
+def resolve_python(root: Path) -> str:
+    """Return an absolute interpreter path for the hook command.
+
+    Hooks run without the virtualenv on ``$PATH`` — notably inside git
+    worktrees — so the command must name the interpreter absolutely.
+
+    Args:
+        root: The repository root.
+
+    Returns:
+        An absolute path to a Python interpreter.
+    """
+    candidate = root / ".venv" / "bin" / "python"
+    if candidate.exists():
+        return str(candidate.resolve())
+    return sys.executable
+
+
+def hook_command(root: Path, host: str) -> str:
+    """Build the guard's hook command for a host.
+
+    Args:
+        root: The repository root.
+        host: ``claude`` or ``codex``.
+
+    Returns:
+        The full command string.
+
+    Raises:
+        ValueError: The host is not supported.
+    """
+    if host not in _HOSTS:
+        raise ValueError(f"unsupported host {host!r}")
+    return f"{resolve_python(root)} -m {HOOK_MODULE} --host {host}"
+
+
+def guard_thresholds(root: Path) -> dict[str, Any]:
+    """Derive guard thresholds from the configured bounded-source toolkit.
+
+    The guard must use the same limits as the MCP reader it points at;
+    reading them from the same configuration is what keeps them aligned.
+
+    Args:
+        root: The repository root.
+
+    Returns:
+        The thresholds mapping written to ``.parrot/tool-guards.json``.
+    """
+    thresholds: dict[str, Any] = {
+        "max_lines": _DEFAULT_MAX_LINES,
+        "large_file_bytes": _DEFAULT_LARGE_FILE_BYTES,
+        "reader_server": _DEFAULT_READER_SERVER,
+        "tool": "source_read",
+    }
+    try:
+        from parrot.mcp.toolkit_config import load_toolkits_config
+
+        config = load_toolkits_config(root)
+    except Exception:  # noqa: BLE001 — defaults are a valid outcome
+        return thresholds
+
+    for name, section in config.toolkits.items():
+        if section.class_path != _READER_CLASS:
+            continue
+        kwargs = section.kwargs or {}
+        thresholds["max_lines"] = int(kwargs.get("max_lines", _DEFAULT_MAX_LINES))
+        thresholds["large_file_bytes"] = int(kwargs.get("large_file_bytes", _DEFAULT_LARGE_FILE_BYTES))
+        thresholds["reader_server"] = f"parrot-{name}"
+        break
+    return thresholds
+
+
+def _load_json_object(path: Path) -> Optional[dict[str, Any]]:
+    """Read a JSON object, refusing to proceed on malformed content.
+
+    Args:
+        path: The file to read.
+
+    Returns:
+        The parsed object, or None when the file does not exist.
+
+    Raises:
+        RuntimeError: The file exists but is not a JSON object.
+    """
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise RuntimeError(f"Cannot parse {path} — fix or remove it first: {exc}") from exc
+    if not isinstance(data, dict):
+        raise RuntimeError(f"{path} is not a JSON object")
+    return data
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> None:
+    """Persist a JSON object as pretty JSON with a trailing newline."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def _is_guard_entry(entry: Any) -> bool:
+    """Whether a PreToolUse entry was installed by this module.
+
+    Args:
+        entry: A candidate hook entry.
+
+    Returns:
+        True when any of its commands names our hook module.
+    """
+    if not isinstance(entry, dict):
+        return False
+    return any(HOOK_MODULE in str(hook.get("command", "")) for hook in entry.get("hooks", []) if isinstance(hook, dict))
+
+
+def _guard_entry(matcher: str, command: str) -> dict[str, Any]:
+    """Build the guard's PreToolUse entry."""
+    return {"matcher": matcher, "hooks": [{"type": "command", "command": command, "timeout": 10}]}
+
+
+def _pre_tool_use_list(data: dict[str, Any], path: Path, *, create: bool) -> Optional[list[Any]]:
+    """Return the ``hooks.PreToolUse`` list, validating the containers.
+
+    Args:
+        data: The parsed config object.
+        path: The file, for error messages.
+        create: Whether to create missing containers.
+
+    Returns:
+        The list, or None when absent and ``create`` is False.
+
+    Raises:
+        RuntimeError: A container exists with the wrong type.
+    """
+    hooks = data.get("hooks")
+    if hooks is None:
+        if not create:
+            return None
+        hooks = {}
+        data["hooks"] = hooks
+    if not isinstance(hooks, dict):
+        raise RuntimeError(f"{path}: 'hooks' is not a JSON object")
+
+    entries = hooks.get("PreToolUse")
+    if entries is None:
+        if not create:
+            return None
+        entries = []
+        hooks["PreToolUse"] = entries
+    if not isinstance(entries, list):
+        raise RuntimeError(f"{path}: 'hooks.PreToolUse' is not a list")
+    return entries
+
+
+def install_guards(root: Path, host: str) -> list[str]:
+    """Install the read guard for a host, idempotently.
+
+    Args:
+        root: The repository root.
+        host: ``claude`` or ``codex``.
+
+    Returns:
+        Human-readable action strings.
+
+    Raises:
+        ValueError: The host is not supported.
+        RuntimeError: A target config file is malformed; nothing is written.
+    """
+    if host not in _HOSTS:
+        raise ValueError(f"unsupported host {host!r}")
+    relative, matcher = _HOSTS[host]
+    actions: list[str] = []
+
+    thresholds = guard_thresholds(root)
+    thresholds_path = root / ".parrot" / "tool-guards.json"
+    desired = json.dumps(thresholds, indent=2) + "\n"
+    if not thresholds_path.exists() or thresholds_path.read_text(encoding="utf-8") != desired:
+        thresholds_path.parent.mkdir(parents=True, exist_ok=True)
+        thresholds_path.write_text(desired, encoding="utf-8")
+        actions.append(f".parrot/tool-guards.json — thresholds written ({thresholds['max_lines']} lines)")
+    else:
+        actions.append(".parrot/tool-guards.json — thresholds already current")
+    if thresholds["reader_server"] == _DEFAULT_READER_SERVER:
+        actions.append("reader MCP not configured — guard denials will reference " f"'{_DEFAULT_READER_SERVER}'")
+
+    path = root / relative
+    data = _load_json_object(path) or {}
+    entries = _pre_tool_use_list(data, path, create=True)
+    assert entries is not None  # create=True always returns a list
+
+    command = hook_command(root, host)
+    entry = _guard_entry(matcher, command)
+    existing = next((item for item in entries if _is_guard_entry(item)), None)
+
+    if existing == entry:
+        actions.append(f"{relative.as_posix()} — tool guard already installed")
+        return actions
+    if existing is None:
+        entries.append(entry)
+        verb = "installed"
+    else:
+        existing.clear()
+        existing.update(entry)
+        verb = "updated"
+    _write_json(path, data)
+    actions.append(f"{relative.as_posix()} — tool guard {verb}")
+    return actions
+
+
+def uninstall_guards(root: Path, host: str) -> list[str]:
+    """Remove only the guard entries this module installed.
+
+    Args:
+        root: The repository root.
+        host: ``claude`` or ``codex``.
+
+    Returns:
+        Human-readable action strings.
+
+    Raises:
+        ValueError: The host is not supported.
+        RuntimeError: The target config file is malformed; it is left alone.
+    """
+    if host not in _HOSTS:
+        raise ValueError(f"unsupported host {host!r}")
+    relative, _matcher = _HOSTS[host]
+    path = root / relative
+    actions: list[str] = []
+
+    data = _load_json_object(path)
+    if data is None:
+        actions.append(f"{relative.as_posix()} — nothing to remove")
+    else:
+        entries = _pre_tool_use_list(data, path, create=False)
+        if entries is None:
+            actions.append(f"{relative.as_posix()} — nothing to remove")
+        else:
+            kept = [item for item in entries if not _is_guard_entry(item)]
+            if len(kept) == len(entries):
+                actions.append(f"{relative.as_posix()} — nothing to remove")
+            else:
+                hooks = data["hooks"]
+                if kept:
+                    hooks["PreToolUse"] = kept
+                else:
+                    # Only collapse containers we emptied ourselves.
+                    hooks.pop("PreToolUse", None)
+                    if not hooks:
+                        data.pop("hooks", None)
+                _write_json(path, data)
+                actions.append(f"{relative.as_posix()} — tool guard removed")
+
+    # The thresholds file is shared; drop it only when no host still uses it.
+    if not any(_is_installed(root, other) for other in _HOSTS):
+        thresholds_path = root / ".parrot" / "tool-guards.json"
+        if thresholds_path.exists():
+            thresholds_path.unlink()
+            actions.append(".parrot/tool-guards.json — removed")
+    return actions
+
+
+def _is_installed(root: Path, host: str) -> bool:
+    """Whether a host currently has our guard entry.
+
+    Args:
+        root: The repository root.
+        host: The host name.
+
+    Returns:
+        True when an owned entry is present. A malformed file reads as
+        "not installed" rather than raising, so status never crashes.
+    """
+    relative, _matcher = _HOSTS[host]
+    try:
+        data = _load_json_object(root / relative)
+    except RuntimeError:
+        return False
+    if data is None:
+        return False
+    try:
+        entries = _pre_tool_use_list(data, root / relative, create=False)
+    except RuntimeError:
+        return False
+    return bool(entries) and any(_is_guard_entry(item) for item in entries)
+
+
+def _host_version(host: str) -> Optional[str]:
+    """Read a host binary's reported version, tolerating any failure.
+
+    Args:
+        host: ``claude`` or ``codex``.
+
+    Returns:
+        The version string, or None when the binary is missing or silent.
+    """
+    binary = shutil.which(host)
+    if not binary:
+        return None
+    try:
+        result = subprocess.run(  # noqa: S603 — fixed argv, no shell
+            [binary, "--version"], capture_output=True, text=True, timeout=5, check=False
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    output = (result.stdout or result.stderr or "").strip()
+    return output.splitlines()[0] if output else None
+
+
+def _supported(host: str, version: Optional[str]) -> Optional[bool]:
+    """Decide whether a reported host version supports the guard contract.
+
+    Args:
+        host: The host name.
+        version: The reported version string.
+
+    Returns:
+        True/False when the version can be parsed, None when unknown — an
+        unknown version is reported as unknown, never as supported.
+    """
+    if not version:
+        return None
+    import re
+
+    match = re.search(r"(\d+)\.(\d+)", version)
+    if not match:
+        return None
+    return (int(match.group(1)), int(match.group(2))) >= _MIN_VERSIONS[host]
+
+
+def guard_status(root: Path, host: str) -> dict[str, Any]:
+    """Report whether the guard is installed and whether the host supports it.
+
+    Args:
+        root: The repository root.
+        host: ``claude`` or ``codex``.
+
+    Returns:
+        A mapping with ``installed``, ``supported``, ``hook_path``,
+        ``thresholds`` and ``host_version``. Never raises.
+
+    Raises:
+        ValueError: The host is not supported.
+    """
+    if host not in _HOSTS:
+        raise ValueError(f"unsupported host {host!r}")
+    relative, _matcher = _HOSTS[host]
+    version = _host_version(host)
+
+    thresholds: Optional[dict[str, Any]] = None
+    thresholds_path = root / ".parrot" / "tool-guards.json"
+    if thresholds_path.exists():
+        try:
+            thresholds = json.loads(thresholds_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            thresholds = None
+
+    return {
+        "installed": _is_installed(root, host),
+        "supported": _supported(host, version),
+        "hook_path": str(root / relative),
+        "thresholds": thresholds,
+        "host_version": version,
+    }

--- a/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/installation.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/installation.py
@@ -163,18 +163,46 @@ def _write_json(path: Path, data: dict[str, Any]) -> None:
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 
 
+def _is_our_hook(hook: Any) -> bool:
+    """Whether a single hook handler was installed by this module.
+
+    Ownership is decided per *hook*, not per entry: a user may legitimately
+    add their own command alongside ours under the same matcher, and that
+    command is not ours to rewrite or delete.
+
+    Args:
+        hook: A candidate hook handler.
+
+    Returns:
+        True when its command names our hook module.
+    """
+    return isinstance(hook, dict) and HOOK_MODULE in str(hook.get("command", ""))
+
+
 def _is_guard_entry(entry: Any) -> bool:
-    """Whether a PreToolUse entry was installed by this module.
+    """Whether a PreToolUse entry contains any hook installed by this module.
 
     Args:
         entry: A candidate hook entry.
 
     Returns:
-        True when any of its commands names our hook module.
+        True when at least one of its handlers is ours.
     """
     if not isinstance(entry, dict):
         return False
-    return any(HOOK_MODULE in str(hook.get("command", "")) for hook in entry.get("hooks", []) if isinstance(hook, dict))
+    return any(_is_our_hook(hook) for hook in entry.get("hooks", []))
+
+
+def _foreign_hooks(entry: dict[str, Any]) -> list[Any]:
+    """Return the handlers in ``entry`` that are not ours.
+
+    Args:
+        entry: A PreToolUse entry.
+
+    Returns:
+        The handlers this module must never modify or remove.
+    """
+    return [hook for hook in entry.get("hooks", []) if not _is_our_hook(hook)]
 
 
 def _guard_entry(matcher: str, command: str) -> dict[str, Any]:
@@ -254,17 +282,31 @@ def install_guards(root: Path, host: str) -> list[str]:
 
     command = hook_command(root, host)
     entry = _guard_entry(matcher, command)
-    existing = next((item for item in entries if _is_guard_entry(item)), None)
 
-    if existing == entry:
+    # Detach our handler from any entry it shares with a foreign one, so the
+    # foreign handler keeps its own matcher and settings untouched.
+    detached = False
+    exclusive: Optional[dict[str, Any]] = None
+    for item in list(entries):
+        if not _is_guard_entry(item):
+            continue
+        foreign = _foreign_hooks(item)
+        if foreign:
+            item["hooks"] = foreign
+            detached = True
+        else:
+            exclusive = item
+
+    if exclusive == entry and not detached:
         actions.append(f"{relative.as_posix()} — tool guard already installed")
         return actions
-    if existing is None:
+    if exclusive is None:
         entries.append(entry)
         verb = "installed"
     else:
-        existing.clear()
-        existing.update(entry)
+        # Safe to replace wholesale: this entry holds only our handler.
+        exclusive.clear()
+        exclusive.update(entry)
         verb = "updated"
     _write_json(path, data)
     actions.append(f"{relative.as_posix()} — tool guard {verb}")
@@ -299,8 +341,19 @@ def uninstall_guards(root: Path, host: str) -> list[str]:
         if entries is None:
             actions.append(f"{relative.as_posix()} — nothing to remove")
         else:
-            kept = [item for item in entries if not _is_guard_entry(item)]
-            if len(kept) == len(entries):
+            kept: list[Any] = []
+            removed = False
+            for item in entries:
+                if not _is_guard_entry(item):
+                    kept.append(item)
+                    continue
+                removed = True
+                foreign = _foreign_hooks(item)
+                if foreign:
+                    # Someone else's handler shares this entry: keep it.
+                    item["hooks"] = foreign
+                    kept.append(item)
+            if not removed:
                 actions.append(f"{relative.as_posix()} — nothing to remove")
             else:
                 hooks = data["hooks"]

--- a/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/models.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/models.py
@@ -347,6 +347,8 @@ class PatchManifest(_StrictModel):
     Attributes:
         artifact_id: Opaque identifier of the stored artifact directory.
         task_id: The originating task identifier.
+        task_path: Repo-relative path of the TASK file, so an apply can
+            re-validate the very same contract this patch came from.
         packet_sha256: Hash of the canonical delegation packet.
         patch_sha256: Hash of the normalized unified patch.
         before_hashes: Per-target baseline hash; ``None`` means "must be absent".
@@ -365,6 +367,7 @@ class PatchManifest(_StrictModel):
 
     artifact_id: ArtifactIdStr
     task_id: str = Field(..., pattern=r"^TASK-\d{3,}$")
+    task_path: ShortStr
     packet_sha256: Sha256Str
     patch_sha256: Sha256Str
     before_hashes: Dict[str, Optional[str]] = Field(default_factory=dict)

--- a/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/models.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/models.py
@@ -1,0 +1,485 @@
+"""Pydantic contracts for the tool-optimizations toolkits (FEAT-543).
+
+This module holds every typed contract shared by :class:`LocalGitToolkit`,
+:class:`BoundedSourceToolkit` and :class:`TargetedWriterToolkit`:
+
+* Operation results (:class:`StepResult`, :class:`OperationError`,
+  :class:`OperationResult`).
+* Bounded-reader results (:class:`SourceInfo`, :class:`SourceResult`).
+* Delegation contracts (:class:`ReferenceSlice`, :class:`TargetFile`,
+  :class:`DelegationPacket`, :class:`WriterLimits`, :class:`PatchManifest`).
+* Per-tool argument models, used both as ``@tool_schema`` schemas and as the
+  raw-argument validation seam in
+  :meth:`~parrot_tools.tool_optimizations.base.OptimizationToolkitBase._pre_execute`.
+
+Every model sets ``extra="forbid"``: the argument models see *raw* MCP input
+(``MCPToolAdapter.execute`` calls ``tool._execute(**arguments)`` directly), so
+unknown keys must be rejected rather than silently dropped.
+
+Note:
+    ``from __future__ import annotations`` is deliberately **not** used here.
+    ``ToolkitTool`` reads ``func._args_schema`` and calls ``model_json_schema()``
+    on these classes; keeping annotations eager avoids any string-annotation
+    resolution surprises at schema-generation time.
+"""
+
+import re
+from typing import Annotated, Any, Dict, List, Literal, Optional
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
+
+__all__ = (
+    "OperationError",
+    "StepResult",
+    "OperationResult",
+    "SourceInfo",
+    "SourceResult",
+    "WriterLimits",
+    "ReferenceSlice",
+    "TargetFile",
+    "DelegationPacket",
+    "PatchManifest",
+    "GitRecentArgs",
+    "GitFetchArgs",
+    "GitPreflightArgs",
+    "GitPrepareFilesArgs",
+    "GitPullArgs",
+    "GitPushArgs",
+    "SourceInfoArgs",
+    "SourceReadArgs",
+    "WriterGenerateArgs",
+    "WriterApplyArgs",
+)
+
+#: Bounded string used by every caller-supplied string argument.
+ShortStr = Annotated[str, StringConstraints(min_length=1, max_length=4096)]
+
+#: A lowercase hex SHA-256 digest.
+Sha256Str = Annotated[str, StringConstraints(pattern=r"^[0-9a-f]{64}$")]
+
+#: An opaque artifact identifier (32 lowercase hex characters).
+ArtifactIdStr = Annotated[str, StringConstraints(pattern=r"^[0-9a-f]{32}$")]
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class _StrictModel(BaseModel):
+    """Base class applying ``extra='forbid'`` to every contract."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+# --------------------------------------------------------------------------- #
+# Operation results
+# --------------------------------------------------------------------------- #
+class OperationError(_StrictModel):
+    """A structured, machine-readable operation failure.
+
+    Attributes:
+        code: A snake_case error code (e.g. ``range_required``,
+            ``path_outside_root``, ``secret_file``, ``unrelated_staged``).
+        message: A short human-readable explanation.
+        details: Optional structured context for the caller.
+    """
+
+    code: str = Field(..., min_length=1, max_length=128)
+    message: str = Field(..., max_length=4096)
+    details: Dict[str, Any] = Field(default_factory=dict)
+
+
+class StepResult(_StrictModel):
+    """The outcome of one independent step inside a composite operation.
+
+    Success is never inferred from the last command alone: every step records
+    its own exit code, timeout flag and whether it changed state.
+
+    Attributes:
+        name: The step identifier (e.g. ``git_status``).
+        exit_code: The process exit code, or ``None`` when it never ran or
+            timed out.
+        timed_out: True when the step exceeded its timeout.
+        state_changed: True when the step mutated repository or index state.
+        stdout: Bounded standard output.
+        stderr: Bounded standard error.
+        truncated: True when ``stdout``/``stderr`` were clipped to fit a budget.
+    """
+
+    name: str = Field(..., min_length=1, max_length=128)
+    exit_code: Optional[int] = None
+    timed_out: bool = False
+    state_changed: bool = False
+    stdout: str = ""
+    stderr: str = ""
+    truncated: bool = False
+
+
+class OperationResult(_StrictModel):
+    """The bounded domain result returned by every optimization tool.
+
+    ``status`` is the *domain* outcome; the MCP ``isError`` flag is reserved
+    for argument rejection and crashes.
+
+    Attributes:
+        status: ``ok``, ``error`` or ``uncertain`` (e.g. a push that timed out
+            after transmission, whose remote effect is unknown).
+        operation: The tool/method name that produced this result.
+        data: The bounded operation payload.
+        error: Structured failure details when ``status`` is not ``ok``.
+        steps: Per-step outcomes, in execution order.
+        truncated: True when content was reduced to fit the byte budget.
+        diagnostic_path: Optional repo-relative path to a retained diagnostic.
+        elapsed_ms: Wall-clock duration of the operation, in milliseconds.
+    """
+
+    status: Literal["ok", "error", "uncertain"]
+    operation: str = Field(..., min_length=1, max_length=128)
+    data: Dict[str, Any] = Field(default_factory=dict)
+    error: Optional[OperationError] = None
+    steps: List[StepResult] = Field(default_factory=list)
+    truncated: bool = False
+    diagnostic_path: Optional[str] = None
+    elapsed_ms: int = Field(..., ge=0)
+
+
+# --------------------------------------------------------------------------- #
+# Bounded reader results
+# --------------------------------------------------------------------------- #
+class SourceInfo(_StrictModel):
+    """Bounded metadata about a source file, with no file content.
+
+    Attributes:
+        path: Repo-relative POSIX path.
+        sha256: SHA-256 of the on-disk bytes.
+        size_bytes: On-disk size in bytes.
+        line_count: Exact logical line count, or ``None`` when only threshold
+            detection ran (large files short-circuit exact counting).
+        is_large: True when either configured threshold is exceeded.
+        max_lines: The configured line threshold in effect.
+        large_file_bytes: The configured byte threshold in effect.
+        range_required: True when a read must supply both range ends.
+    """
+
+    path: str = Field(..., min_length=1)
+    sha256: Sha256Str
+    size_bytes: int = Field(..., ge=0)
+    line_count: Optional[int] = Field(default=None, ge=0)
+    is_large: bool
+    max_lines: int = Field(..., ge=1)
+    large_file_bytes: int = Field(..., ge=1)
+    range_required: bool
+
+
+class SourceResult(_StrictModel):
+    """A bounded slice of a source file with an explicit continuation cursor.
+
+    Attributes:
+        path: Repo-relative POSIX path.
+        sha256: SHA-256 of the whole file's on-disk bytes (the revision).
+        size_bytes: On-disk size in bytes.
+        start_line: First returned line, 1-based inclusive.
+        end_line: Last returned line, 1-based inclusive. ``0`` with an empty
+            ``content`` denotes an empty file.
+        content: The returned complete lines.
+        truncated: True when fewer lines were returned than requested because
+            of the serialized byte budget.
+        next_line: The line to request next, or ``None`` at EOF.
+        eof: True when the returned range reaches the end of the file.
+    """
+
+    path: str = Field(..., min_length=1)
+    sha256: Sha256Str
+    size_bytes: int = Field(..., ge=0)
+    start_line: int = Field(..., ge=0)
+    end_line: int = Field(..., ge=0)
+    content: str = ""
+    truncated: bool = False
+    next_line: Optional[int] = Field(default=None, ge=1)
+    eof: bool = False
+
+
+# --------------------------------------------------------------------------- #
+# Delegation contracts
+# --------------------------------------------------------------------------- #
+class WriterLimits(_StrictModel):
+    """Hard budgets applied to one delegated generation operation.
+
+    Attributes:
+        max_packet_bytes: Maximum serialized delegation-packet size.
+        max_context_bytes: Maximum size of the locally built prompt context.
+        max_patch_bytes: Maximum size of the generated unified patch.
+        max_output_tokens: Maximum model output tokens.
+        generation_deadline_seconds: Overall deadline for the operation,
+            covering transport retries and the optional repair call.
+        max_repairs: At most one repair attempt for a valid packet.
+    """
+
+    max_packet_bytes: int = Field(default=128_000, gt=0)
+    max_context_bytes: int = Field(default=128_000, gt=0)
+    max_patch_bytes: int = Field(default=128_000, gt=0)
+    max_output_tokens: int = Field(default=8_192, gt=0)
+    generation_deadline_seconds: int = Field(default=180, gt=0)
+    max_repairs: Literal[0, 1] = 1
+
+
+class ReferenceSlice(_StrictModel):
+    """A hashed, bounded excerpt of an existing file included as context.
+
+    Attributes:
+        path: Repo-relative POSIX path of the referenced file.
+        sha256: SHA-256 of the referenced file's bytes, checked for freshness.
+        start_line: First referenced line, 1-based inclusive.
+        end_line: Last referenced line, 1-based inclusive.
+        purpose: Why the delegate needs this excerpt.
+    """
+
+    path: ShortStr
+    sha256: Sha256Str
+    start_line: int = Field(..., ge=1)
+    end_line: int = Field(..., ge=1)
+    purpose: str = Field(..., min_length=1, max_length=4096)
+
+    @model_validator(mode="after")
+    def _check_range(self) -> "ReferenceSlice":
+        """Reject an inverted line range."""
+        if self.start_line > self.end_line:
+            raise ValueError("start_line must be <= end_line")
+        return self
+
+
+class TargetFile(_StrictModel):
+    """One file the delegate is allowed to create or modify.
+
+    Attributes:
+        path: Repo-relative POSIX path.
+        action: ``create`` (the file must be absent) or ``modify``.
+        expected_sha256: Required for ``modify`` (the baseline revision);
+            must be ``None`` for ``create``, whose precondition is absence.
+        planned_changes: The already-decided change description.
+        blocks: Identifiers of the labelled TASK code blocks that specify
+            this file's implementation. At least one is required.
+    """
+
+    path: ShortStr
+    action: Literal["create", "modify"]
+    expected_sha256: Optional[Sha256Str] = None
+    planned_changes: str = Field(..., min_length=1, max_length=65_536)
+    blocks: List[ShortStr] = Field(..., min_length=1)
+
+    @model_validator(mode="after")
+    def _check_action_hash(self) -> "TargetFile":
+        """Bind the expected hash to the declared action."""
+        if self.action == "modify" and self.expected_sha256 is None:
+            raise ValueError("action 'modify' requires expected_sha256")
+        if self.action == "create" and self.expected_sha256 is not None:
+            raise ValueError("action 'create' must not set expected_sha256 (its precondition is absence)")
+        return self
+
+
+class DelegationPacket(_StrictModel):
+    """The complete, already-decided implementation contract for one TASK.
+
+    ``design_complete`` is an eligibility *declaration*, not proof of
+    correctness: this model checks structural completeness, while the
+    thinking model verifies semantics.
+
+    Attributes:
+        schema_version: Always ``1`` in v1.
+        task_id: The owning task identifier (``TASK-<NNN>``).
+        spec_path: Repo-relative path of the governing spec.
+        design_complete: Must be ``True``; a packet is otherwise ineligible.
+        targets: The approved file scope (at least one, unique paths).
+        references: Hashed bounded excerpts supplied as read-only context.
+        implementation_blocks: Labels of the decided code blocks in the TASK.
+        acceptance_criteria: The criteria the change must satisfy.
+        validation_commands: argv lists owned by the SDD workflow. No command
+            from a model response is ever executed.
+        limits: The budgets for this delegation.
+    """
+
+    schema_version: Literal[1]
+    task_id: str = Field(..., pattern=r"^TASK-\d{3,}$")
+    spec_path: ShortStr
+    design_complete: Literal[True]
+    targets: List[TargetFile] = Field(..., min_length=1)
+    references: List[ReferenceSlice] = Field(default_factory=list)
+    implementation_blocks: List[ShortStr] = Field(..., min_length=1)
+    acceptance_criteria: List[ShortStr] = Field(..., min_length=1)
+    validation_commands: List[List[ShortStr]] = Field(default_factory=list)
+    limits: WriterLimits = Field(default_factory=WriterLimits)
+
+    @field_validator("targets")
+    @classmethod
+    def _unique_targets(cls, value: List[TargetFile]) -> List[TargetFile]:
+        """Reject duplicate target paths."""
+        paths = [target.path for target in value]
+        if len(set(paths)) != len(paths):
+            raise ValueError("target paths must be unique")
+        return value
+
+    @field_validator("implementation_blocks")
+    @classmethod
+    def _unique_blocks(cls, value: List[str]) -> List[str]:
+        """Reject duplicate implementation-block labels."""
+        if len(set(value)) != len(value):
+            raise ValueError("implementation_blocks must be unique")
+        return value
+
+    @field_validator("validation_commands")
+    @classmethod
+    def _non_empty_argv(cls, value: List[List[str]]) -> List[List[str]]:
+        """Reject an empty argv list."""
+        for argv in value:
+            if not argv:
+                raise ValueError("each validation command must be a non-empty argv list")
+        return value
+
+
+class PatchManifest(_StrictModel):
+    """Provenance and validation state for one generated patch artifact.
+
+    Attributes:
+        artifact_id: Opaque identifier of the stored artifact directory.
+        task_id: The originating task identifier.
+        packet_sha256: Hash of the canonical delegation packet.
+        patch_sha256: Hash of the normalized unified patch.
+        before_hashes: Per-target baseline hash; ``None`` means "must be absent".
+        after_hashes: Per-target hash after staged application.
+        allowed_paths: The approved target scope.
+        configured_model: The model identity requested by configuration.
+        actual_model: The model identity reported by the provider, if known.
+        used_fallback: True when the provider reported a model substitution.
+        usage: Token usage; ``None`` values mean the provider reported nothing
+            (unknown is never recorded as zero).
+        repairs: Number of repair calls consumed (0 or 1).
+        elapsed_ms: Wall-clock duration of generation.
+        validation_state: ``validated`` or ``rejected``.
+        created_at: ISO-8601 UTC creation timestamp.
+    """
+
+    artifact_id: ArtifactIdStr
+    task_id: str = Field(..., pattern=r"^TASK-\d{3,}$")
+    packet_sha256: Sha256Str
+    patch_sha256: Sha256Str
+    before_hashes: Dict[str, Optional[str]] = Field(default_factory=dict)
+    after_hashes: Dict[str, str] = Field(default_factory=dict)
+    allowed_paths: List[str] = Field(default_factory=list)
+    configured_model: str = Field(..., min_length=1, max_length=512)
+    actual_model: Optional[str] = Field(default=None, max_length=512)
+    used_fallback: bool = False
+    usage: Dict[str, Optional[int]] = Field(default_factory=dict)
+    repairs: int = Field(default=0, ge=0, le=1)
+    elapsed_ms: int = Field(..., ge=0)
+    validation_state: Literal["validated", "rejected"]
+    created_at: str = Field(..., min_length=1, max_length=64)
+
+    @field_validator("before_hashes")
+    @classmethod
+    def _check_before(cls, value: Dict[str, Optional[str]]) -> Dict[str, Optional[str]]:
+        """Allow only a SHA-256 digest or an explicit ``None`` (absence)."""
+        for path, digest in value.items():
+            if digest is not None and not _SHA256_RE.match(digest):
+                raise ValueError(f"before_hashes[{path!r}] must be a sha256 digest or null")
+        return value
+
+    @field_validator("after_hashes")
+    @classmethod
+    def _check_after(cls, value: Dict[str, str]) -> Dict[str, str]:
+        """Require a SHA-256 digest for every written target."""
+        for path, digest in value.items():
+            if not _SHA256_RE.match(digest):
+                raise ValueError(f"after_hashes[{path!r}] must be a sha256 digest")
+        return value
+
+
+# --------------------------------------------------------------------------- #
+# Per-tool argument models
+#
+# These are both the ``@tool_schema`` schemas AND the raw-argument validation
+# seam used by ``OptimizationToolkitBase._pre_execute``. They must therefore
+# reject unknown keys and out-of-range values on their own.
+# --------------------------------------------------------------------------- #
+class GitRecentArgs(_StrictModel):
+    """Arguments for ``git_recent``."""
+
+    ref: ShortStr = "HEAD"
+    limit: int = Field(default=3, ge=1, le=50)
+
+
+class GitFetchArgs(_StrictModel):
+    """Arguments for ``git_fetch``."""
+
+    remote: ShortStr = "origin"
+    branch: ShortStr = "dev"
+    recent: int = Field(default=3, ge=1, le=50)
+
+
+class GitPreflightArgs(_StrictModel):
+    """Arguments for ``git_preflight`` (none)."""
+
+
+class GitPrepareFilesArgs(_StrictModel):
+    """Arguments for ``git_prepare_files``."""
+
+    paths: List[ShortStr] = Field(..., min_length=1)
+
+
+class GitPullArgs(_StrictModel):
+    """Arguments for ``git_pull``."""
+
+    remote: ShortStr = "origin"
+    branch: Optional[ShortStr] = None
+
+
+class GitPushArgs(_StrictModel):
+    """Arguments for ``git_push``."""
+
+    remote: ShortStr = "origin"
+    branch: Optional[ShortStr] = None
+
+
+class SourceInfoArgs(_StrictModel):
+    """Arguments for ``source_info``."""
+
+    path: ShortStr
+
+
+class SourceReadArgs(_StrictModel):
+    """Arguments for ``source_read``.
+
+    Both range ends are required together: one coordinate system (1-based
+    inclusive lines) and no offset/limit aliases.
+    """
+
+    path: ShortStr
+    start_line: Optional[int] = Field(default=None, ge=1)
+    end_line: Optional[int] = Field(default=None, ge=1)
+    expected_sha256: Optional[Sha256Str] = None
+
+    @model_validator(mode="after")
+    def _check_range(self) -> "SourceReadArgs":
+        """Require both range ends or neither, and a non-inverted range."""
+        if (self.start_line is None) != (self.end_line is None):
+            raise ValueError("start_line and end_line must be supplied together")
+        if self.start_line is not None and self.end_line is not None and self.start_line > self.end_line:
+            raise ValueError("start_line must be <= end_line")
+        return self
+
+
+class WriterGenerateArgs(_StrictModel):
+    """Arguments for ``writer_generate``."""
+
+    task_path: ShortStr
+
+
+class WriterApplyArgs(_StrictModel):
+    """Arguments for ``writer_apply``."""
+
+    artifact_id: ArtifactIdStr
+    reviewed_sha256: Sha256Str

--- a/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/patches.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/patches.py
@@ -639,13 +639,20 @@ class ArtifactStore:
             return
         cutoff = time.time() - _TMP_TTL_SECONDS
         for entry in self.root.iterdir():
+            # NEVER follow a symlink here. `is_dir()` and `stat()` both follow
+            # links, so a `.tmp-*` symlink pointing outside the repository
+            # would pass every check and we would delete the *target's*
+            # contents. Only real directories we created are swept.
+            if entry.is_symlink():
+                continue
             if not entry.name.startswith(".tmp-") or not entry.is_dir():
                 continue
             try:
-                if entry.stat().st_mtime > cutoff:
+                if entry.lstat().st_mtime > cutoff:
                     continue
                 for child in entry.iterdir():
-                    child.unlink()
+                    if child.is_symlink() or child.is_file():
+                        child.unlink()
                 entry.rmdir()
             except OSError:  # pragma: no cover — best-effort housekeeping
                 continue

--- a/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/patches.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/patches.py
@@ -131,6 +131,8 @@ class JournalEntry(BaseModel):
         before_sha256: The file's digest before, or None when it was absent.
         after_sha256: The digest this operation intended to write.
         before_index: Index of the saved ``before/<n>.bin`` payload.
+        before_mode: The file's original permission bits, so a rollback
+            restores them instead of silently normalizing to 0644.
         state: How far this file got.
     """
 
@@ -140,6 +142,7 @@ class JournalEntry(BaseModel):
     before_sha256: Optional[str] = None
     after_sha256: str
     before_index: int = Field(..., ge=0)
+    before_mode: Optional[int] = None
     state: Literal["pending", "written", "verified", "restored", "unrecoverable"] = "pending"
 
 
@@ -388,8 +391,12 @@ def _parse_hunk(lines: list[str], index: int, path: str) -> tuple[Hunk, int]:
                 no_newline_new = no_newline_new or (body and body[-1][0] == " ")
             cursor += 1
             continue
-        if raw.startswith("@@") or raw.startswith("--- ") or raw.startswith("diff --git "):
-            break
+        # While the declared counts are not yet satisfied, a line starting with
+        # ' ', '-' or '+' is hunk BODY even when it looks like a header:
+        # removing a source line that begins with '-- ' (an email signature
+        # marker, a SQL comment, ...) is legitimate. Unified diff resolves that
+        # ambiguity with the counts, exactly as git itself does — treating
+        # '--- signature' as a file header rejected valid patches.
         marker = raw[0] if raw else " "
         if marker not in (" ", "-", "+"):
             break

--- a/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/patches.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/patches.py
@@ -1,0 +1,812 @@
+"""Unified-diff parsing, in-memory application and artifact storage (FEAT-543).
+
+This module is pure Python, stdlib-only and model-free. It takes the
+unified diff a delegate returned and decides — deterministically — whether
+it is a legal, in-scope CREATE/MODIFY patch, then applies it *in memory*
+against the expected source bytes so nothing is written until the caller
+has verified the outcome.
+
+Two deliberate design choices:
+
+* **Patches are applied in pure Python with exact context matching and zero
+  fuzz.** No external diff tool is invoked, so a model-written path can
+  never reach an external command's argument list, and a mismatch is a
+  clean rejection returned to the thinking model rather than a guess.
+* **v1 supports CREATE and MODIFY only.** Deletions, renames, copies, mode
+  changes, binary payloads and submodule updates are each rejected with
+  their own code, so the refusal is explainable.
+
+Artifacts live under ``<repo_root>/artifacts/tool-optimizations/<id>/``,
+which is gitignored (`.gitignore:283`), with ``0o700`` directories and
+``0o600`` files.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import stat
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .models import PatchManifest
+from .policy import compact_json
+
+__all__ = (
+    "ApplyJournal",
+    "ArtifactStore",
+    "FilePatch",
+    "Hunk",
+    "JournalEntry",
+    "PatchError",
+    "apply_file_patch",
+    "apply_in_memory",
+    "check_scope",
+    "normalize_patch",
+    "parse_patch",
+)
+
+_HUNK = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+_ARTIFACT_ID = re.compile(r"^[0-9a-f]{32}$")
+_NO_NEWLINE = "\\ No newline at end of file"
+
+#: Sweep abandoned temp directories older than this (seconds).
+_TMP_TTL_SECONDS = 3600
+
+
+class PatchError(ValueError):
+    """A patch is malformed, out of scope, or does not match its source.
+
+    Attributes:
+        code: A stable snake_case code identifying the rejection.
+        details: Structured context for the thinking model.
+    """
+
+    def __init__(self, code: str, message: str = "", details: Optional[dict[str, Any]] = None) -> None:
+        """Initialize the error.
+
+        Args:
+            code: The stable rejection code.
+            message: A human-readable explanation.
+            details: Structured context (path, hunk index, expected vs actual).
+        """
+        super().__init__(message or code)
+        self.code = code
+        self.details = details or {}
+
+
+class Hunk(BaseModel):
+    """One ``@@`` hunk of a unified diff.
+
+    Attributes:
+        old_start: 1-based start line in the original file (0 for a create).
+        old_count: Number of original lines the hunk covers.
+        new_start: 1-based start line in the resulting file.
+        new_count: Number of resulting lines the hunk produces.
+        lines: Body lines with their leading ``' '``, ``'-'`` or ``'+'``
+            marker preserved.
+        no_newline_old: The original file had no trailing newline.
+        no_newline_new: The resulting file has no trailing newline.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    old_start: int = Field(..., ge=0)
+    old_count: int = Field(..., ge=0)
+    new_start: int = Field(..., ge=0)
+    new_count: int = Field(..., ge=0)
+    lines: list[str] = Field(default_factory=list)
+    no_newline_old: bool = False
+    no_newline_new: bool = False
+
+
+class FilePatch(BaseModel):
+    """All hunks that apply to one file.
+
+    Attributes:
+        path: The repo-relative POSIX path, with any ``a/``/``b/`` prefix
+            stripped.
+        is_create: True when the patch creates the file (``--- /dev/null``).
+        hunks: The hunks, in file order.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    path: str
+    is_create: bool = False
+    hunks: list[Hunk] = Field(default_factory=list)
+
+
+class JournalEntry(BaseModel):
+    """The recorded state of one file during an apply operation.
+
+    Attributes:
+        path: The repo-relative path.
+        before_sha256: The file's digest before, or None when it was absent.
+        after_sha256: The digest this operation intended to write.
+        before_index: Index of the saved ``before/<n>.bin`` payload.
+        state: How far this file got.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    path: str
+    before_sha256: Optional[str] = None
+    after_sha256: str
+    before_index: int = Field(..., ge=0)
+    state: Literal["pending", "written", "verified", "restored", "unrecoverable"] = "pending"
+
+
+class ApplyJournal(BaseModel):
+    """A recovery journal for one multi-file apply operation.
+
+    Multi-file filesystem mutation is not globally atomic, so the journal
+    records what was intended and what was achieved, allowing a targeted
+    rollback that never overwrites a concurrent edit.
+
+    Attributes:
+        artifact_id: The artifact being applied.
+        started_at: ISO-8601 UTC start time.
+        entries: One entry per target file.
+        state: The operation's overall outcome.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    artifact_id: str
+    started_at: str
+    entries: list[JournalEntry] = Field(default_factory=list)
+    state: Literal["pending", "applied", "rolled_back", "recovery_required"] = "pending"
+
+
+# --------------------------------------------------------------------------- #
+# Normalization and parsing
+# --------------------------------------------------------------------------- #
+def normalize_patch(text: str) -> str:
+    """Canonicalize patch text and reject prose or fenced output.
+
+    The returned text is what gets hashed and stored, so this function is
+    idempotent: ``normalize_patch(normalize_patch(x)) == normalize_patch(x)``.
+
+    Args:
+        text: The raw model output.
+
+    Returns:
+        The canonical patch text, ending in a single newline.
+
+    Raises:
+        PatchError: The text is fenced, contains prose before the first
+            header, or has no diff header at all (``not_a_patch``).
+    """
+    lines = text.split("\n")
+    while lines and not lines[0].strip():
+        lines.pop(0)
+    while lines and not lines[-1].strip():
+        lines.pop()
+    if not lines:
+        raise PatchError("not_a_patch", "the response contains no patch")
+
+    for line in lines:
+        if line.startswith("```"):
+            raise PatchError("not_a_patch", "the response is fenced; return a bare unified diff")
+        if line.startswith("--- ") or line.startswith("diff --git "):
+            break
+        if line.strip():
+            raise PatchError(
+                "not_a_patch",
+                "the response contains prose before the first diff header",
+                {"first_line": line[:200]},
+            )
+    else:
+        raise PatchError("not_a_patch", "no unified-diff header was found")
+
+    return "\n".join(lines) + "\n"
+
+
+def _scan_forbidden(lines: list[str]) -> None:
+    """Reject diff features that v1 does not support.
+
+    Args:
+        lines: The normalized patch lines.
+
+    Raises:
+        PatchError: A binary, rename, copy, deletion, mode change or
+            submodule update was requested.
+    """
+    for line in lines:
+        if line.startswith("GIT binary patch") or line.startswith("Binary files "):
+            raise PatchError("binary_rejected", "binary patches are not supported", {"line": line[:200]})
+        if line.startswith(("rename from ", "rename to ", "similarity index ", "copy from ", "copy to ")):
+            raise PatchError("rename_rejected", "renames and copies are not supported", {"line": line[:200]})
+        if line.startswith("deleted file mode"):
+            raise PatchError("deletion_rejected", "deletions are not supported", {"line": line[:200]})
+        if line.startswith(("old mode ", "new mode ")):
+            raise PatchError("mode_change_rejected", "mode changes are not supported", {"line": line[:200]})
+        if line.startswith("new file mode ") and line.split()[-1] not in {"100644", "100755"}:
+            raise PatchError("mode_change_rejected", "only regular files are supported", {"line": line[:200]})
+        if line[1:].startswith("Subproject commit ") and line[:1] in {" ", "-", "+"}:
+            raise PatchError("submodule_rejected", "submodule updates are not supported", {"line": line[:200]})
+
+
+def _strip_prefix(raw: str) -> str:
+    """Strip a diff header's ``a/``/``b/`` prefix and trailing metadata.
+
+    Args:
+        raw: The path portion of a ``---``/``+++`` header.
+
+    Returns:
+        The bare path.
+    """
+    path = raw.split("\t", 1)[0].strip()
+    if path.startswith(("a/", "b/")):
+        path = path[2:]
+    return path
+
+
+def _validate_patch_path(path: str) -> str:
+    """Validate a path taken from a diff header.
+
+    Args:
+        path: The prefix-stripped path.
+
+    Returns:
+        The path, unchanged.
+
+    Raises:
+        PatchError: The path is absolute, escapes the root, or is malformed.
+    """
+    if not path:
+        raise PatchError("not_a_patch", "a diff header has an empty path")
+    if path.startswith("/") or (len(path) > 1 and path[1] == ":"):
+        raise PatchError("absolute_path", f"{path!r} is absolute", {"path": path})
+    if "\\" in path:
+        raise PatchError("path_escape", f"{path!r} contains a backslash", {"path": path})
+    if any(segment in ("", ".", "..") for segment in path.split("/")):
+        raise PatchError("path_escape", f"{path!r} contains a traversal segment", {"path": path})
+    return path
+
+
+def parse_patch(text: str, *, max_bytes: int) -> list[FilePatch]:
+    """Parse a normalized unified diff into per-file patches.
+
+    Args:
+        text: Normalized patch text (see :func:`normalize_patch`).
+        max_bytes: The largest patch accepted.
+
+    Returns:
+        One :class:`FilePatch` per target file, in patch order.
+
+    Raises:
+        PatchError: The patch is too large, uses an unsupported feature, has
+            an invalid path, targets a file twice, or has a malformed hunk.
+    """
+    encoded = text.encode("utf-8")
+    if len(encoded) > max_bytes:
+        raise PatchError(
+            "patch_too_large",
+            f"the patch is {len(encoded)} bytes, above the {max_bytes}-byte budget",
+            {"bytes": len(encoded), "max_bytes": max_bytes},
+        )
+
+    lines = text.split("\n")
+    if lines and lines[-1] == "":
+        lines.pop()
+    _scan_forbidden(lines)
+
+    patches: list[FilePatch] = []
+    seen: set[str] = set()
+    index = 0
+    current: Optional[FilePatch] = None
+
+    while index < len(lines):
+        line = lines[index]
+
+        if line.startswith("diff --git ") or line.startswith("index ") or line.startswith("new file mode "):
+            index += 1
+            continue
+
+        if line.startswith("--- "):
+            old_raw = line[4:]
+            if index + 1 >= len(lines) or not lines[index + 1].startswith("+++ "):
+                raise PatchError("not_a_patch", "a '---' header is not followed by '+++'", {"line": line[:200]})
+            new_raw = lines[index + 1][4:]
+            if _strip_prefix(new_raw) == "/dev/null" or new_raw.split("\t", 1)[0].strip() == "/dev/null":
+                raise PatchError("deletion_rejected", "deletions are not supported", {"line": lines[index + 1][:200]})
+
+            is_create = old_raw.split("\t", 1)[0].strip() == "/dev/null"
+            path = _validate_patch_path(_strip_prefix(new_raw))
+            if path in seen:
+                raise PatchError("duplicate_target", f"{path!r} is patched more than once", {"path": path})
+            seen.add(path)
+            current = FilePatch(path=path, is_create=is_create, hunks=[])
+            patches.append(current)
+            index += 2
+            continue
+
+        if line.startswith("@@"):
+            if current is None:
+                raise PatchError("not_a_patch", "a hunk appears before any file header", {"line": line[:200]})
+            hunk, index = _parse_hunk(lines, index, current.path)
+            current.hunks.append(hunk)
+            continue
+
+        if not line.strip():
+            index += 1
+            continue
+
+        raise PatchError("not_a_patch", "unexpected line outside the diff grammar", {"line": line[:200]})
+
+    if not patches:
+        raise PatchError("not_a_patch", "no file headers were found")
+    for patch in patches:
+        if not patch.hunks:
+            raise PatchError("malformed_hunk", f"{patch.path!r} has no hunks", {"path": patch.path})
+    return patches
+
+
+def _parse_hunk(lines: list[str], index: int, path: str) -> tuple[Hunk, int]:
+    """Parse one hunk starting at ``lines[index]``.
+
+    Args:
+        lines: The patch lines.
+        index: Index of the ``@@`` header.
+        path: The file this hunk belongs to, for error details.
+
+    Returns:
+        A ``(hunk, next_index)`` tuple.
+
+    Raises:
+        PatchError: The header is malformed or the body does not match the
+            declared line counts.
+    """
+    match = _HUNK.match(lines[index])
+    if match is None:
+        raise PatchError("malformed_hunk", "malformed @@ header", {"path": path, "line": lines[index][:200]})
+    old_start = int(match.group(1))
+    old_count = int(match.group(2)) if match.group(2) is not None else 1
+    new_start = int(match.group(3))
+    new_count = int(match.group(4)) if match.group(4) is not None else 1
+
+    body: list[str] = []
+    old_seen = new_seen = 0
+    no_newline_old = no_newline_new = False
+    cursor = index + 1
+
+    while cursor < len(lines) and (old_seen < old_count or new_seen < new_count):
+        raw = lines[cursor]
+        if raw == _NO_NEWLINE:
+            if body and body[-1][0] == "+":
+                no_newline_new = True
+            else:
+                no_newline_old = True
+                no_newline_new = no_newline_new or (body and body[-1][0] == " ")
+            cursor += 1
+            continue
+        if raw.startswith("@@") or raw.startswith("--- ") or raw.startswith("diff --git "):
+            break
+        marker = raw[0] if raw else " "
+        if marker not in (" ", "-", "+"):
+            break
+        body.append(raw if raw else " ")
+        if marker in (" ", "-"):
+            old_seen += 1
+        if marker in (" ", "+"):
+            new_seen += 1
+        cursor += 1
+
+    if cursor < len(lines) and lines[cursor] == _NO_NEWLINE:
+        if body and body[-1][0] == "+":
+            no_newline_new = True
+        else:
+            no_newline_old = True
+            no_newline_new = no_newline_new or bool(body and body[-1][0] == " ")
+        cursor += 1
+
+    if old_seen != old_count or new_seen != new_count:
+        raise PatchError(
+            "malformed_hunk",
+            "the hunk body does not match its declared line counts",
+            {
+                "path": path,
+                "declared_old": old_count,
+                "actual_old": old_seen,
+                "declared_new": new_count,
+                "actual_new": new_seen,
+            },
+        )
+
+    return (
+        Hunk(
+            old_start=old_start,
+            old_count=old_count,
+            new_start=new_start,
+            new_count=new_count,
+            lines=body,
+            no_newline_old=no_newline_old,
+            no_newline_new=no_newline_new,
+        ),
+        cursor,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Scope
+# --------------------------------------------------------------------------- #
+def check_scope(patches: list[FilePatch], allowed: dict[str, str]) -> None:
+    """Verify every patched path is approved with matching create semantics.
+
+    Args:
+        patches: The parsed patches.
+        allowed: Approved path -> ``"create"`` or ``"modify"``.
+
+    Raises:
+        PatchError: A path is outside the approved scope, or its create /
+            modify semantics disagree with the packet.
+    """
+    for patch in patches:
+        action = allowed.get(patch.path)
+        if action is None:
+            raise PatchError(
+                "path_outside_scope",
+                f"{patch.path!r} is not an approved target",
+                {"path": patch.path, "allowed": sorted(allowed)},
+            )
+        if action == "create" and not patch.is_create:
+            raise PatchError(
+                "create_needs_dev_null",
+                f"{patch.path!r} is declared as a create, so its patch must start from /dev/null",
+                {"path": patch.path},
+            )
+        if action == "modify" and patch.is_create:
+            raise PatchError(
+                "path_outside_scope",
+                f"{patch.path!r} is declared as a modify but the patch creates it",
+                {"path": patch.path, "declared": action},
+            )
+
+
+# --------------------------------------------------------------------------- #
+# Application
+# --------------------------------------------------------------------------- #
+def _newline_for(source_lines: list[str]) -> str:
+    """Infer the newline an added line should use.
+
+    Args:
+        source_lines: The original file's lines, with endings preserved.
+
+    Returns:
+        ``"\\r\\n"`` when the file consistently uses CRLF, else ``"\\n"``.
+    """
+    terminated = [line for line in source_lines if line.endswith("\n")]
+    if terminated and all(line.endswith("\r\n") for line in terminated):
+        return "\r\n"
+    return "\n"
+
+
+def apply_file_patch(before: Optional[bytes], patch: FilePatch) -> bytes:
+    """Apply one file's hunks in memory, with exact context matching.
+
+    There is no fuzz factor and no offset search: a context line that does
+    not match the source exactly is a rejection, not a guess.
+
+    Args:
+        before: The original file bytes, or None for a create.
+        patch: The parsed patch for this file.
+
+    Returns:
+        The resulting file bytes.
+
+    Raises:
+        PatchError: The source does not decode as UTF-8, a hunk is out of
+            order, or a context/removed line does not match the source.
+    """
+    try:
+        source = (before or b"").decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise PatchError("binary_rejected", f"{patch.path!r} is not valid UTF-8 text", {"path": patch.path}) from exc
+
+    source_lines = source.splitlines(keepends=True)
+    newline = _newline_for(source_lines)
+    out: list[str] = []
+    cursor = 0
+
+    for hunk_index, hunk in enumerate(patch.hunks):
+        target = hunk.old_start - 1 if hunk.old_count else hunk.old_start
+        if target < cursor or target > len(source_lines):
+            raise PatchError(
+                "malformed_hunk",
+                "hunks are out of order or start past the end of the file",
+                {"path": patch.path, "hunk_index": hunk_index, "start": hunk.old_start, "lines": len(source_lines)},
+            )
+        out.extend(source_lines[cursor:target])
+        cursor = target
+
+        for body in hunk.lines:
+            marker, content = body[0], body[1:]
+            if marker in (" ", "-"):
+                actual = source_lines[cursor].rstrip("\r\n") if cursor < len(source_lines) else None
+                if actual != content:
+                    raise PatchError(
+                        "context_mismatch",
+                        f"{patch.path!r} does not match the patch context",
+                        {
+                            "path": patch.path,
+                            "hunk_index": hunk_index,
+                            "line_no": cursor + 1,
+                            "expected": content,
+                            "expected_line": content,
+                            "actual": actual,
+                            "actual_line": actual,
+                        },
+                    )
+                if marker == " ":
+                    out.append(source_lines[cursor])
+                cursor += 1
+            elif marker == "+":
+                out.append(content + newline)
+
+    out.extend(source_lines[cursor:])
+    result = "".join(out)
+
+    last_hunk = patch.hunks[-1] if patch.hunks else None
+    if last_hunk is not None and last_hunk.no_newline_new and cursor >= len(source_lines):
+        result = result.rstrip("\r\n")
+    return result.encode("utf-8")
+
+
+def apply_in_memory(patches: list[FilePatch], sources: dict[str, Optional[bytes]]) -> dict[str, bytes]:
+    """Apply every file patch against its expected source bytes.
+
+    Args:
+        patches: The parsed, scope-checked patches.
+        sources: Path -> current bytes, or None when the file is absent.
+
+    Returns:
+        Path -> resulting bytes, for every patched path.
+
+    Raises:
+        PatchError: A modify target is missing, or a hunk does not match.
+    """
+    result: dict[str, bytes] = {}
+    for patch in patches:
+        before = sources.get(patch.path)
+        if not patch.is_create and before is None:
+            raise PatchError(
+                "context_mismatch",
+                f"{patch.path!r} does not exist but the patch modifies it",
+                {"path": patch.path, "hunk_index": 0, "line_no": 1, "expected": None, "actual": None},
+            )
+        result[patch.path] = apply_file_patch(None if patch.is_create else before, patch)
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# Artifact store
+# --------------------------------------------------------------------------- #
+class ArtifactStore:
+    """Durable, restrictive storage for generated patch artifacts.
+
+    Artifacts are opaque data, never executable commands: ids are random
+    hex, directories are ``0o700`` and files are ``0o600``.
+    """
+
+    def __init__(self, repo_root: Path) -> None:
+        """Initialize the store.
+
+        Args:
+            repo_root: The repository root; artifacts live beneath it.
+        """
+        self.repo_root = Path(repo_root)
+        self.root = self.repo_root / "artifacts" / "tool-optimizations"
+
+    @staticmethod
+    def new_id() -> str:
+        """Return a fresh opaque artifact id.
+
+        Returns:
+            32 lowercase hex characters.
+        """
+        return uuid.uuid4().hex
+
+    def _artifact_dir(self, artifact_id: str) -> Path:
+        """Resolve and validate an artifact directory.
+
+        Args:
+            artifact_id: The artifact identifier.
+
+        Returns:
+            The artifact directory path.
+
+        Raises:
+            PatchError: The id is malformed or the directory is a symlink.
+        """
+        if not _ARTIFACT_ID.match(artifact_id):
+            raise PatchError("invalid_artifact_id", f"{artifact_id!r} is not a valid artifact id")
+        target = self.root / artifact_id
+        if target.is_symlink() or (target.parent.exists() and target.parent.is_symlink()):
+            raise PatchError("artifact_tampered", "the artifact directory is a symlink", {"artifact_id": artifact_id})
+        return target
+
+    def _sweep_stale_temp_dirs(self) -> None:
+        """Remove abandoned temp directories left by a crashed generation."""
+        if not self.root.exists():
+            return
+        cutoff = time.time() - _TMP_TTL_SECONDS
+        for entry in self.root.iterdir():
+            if not entry.name.startswith(".tmp-") or not entry.is_dir():
+                continue
+            try:
+                if entry.stat().st_mtime > cutoff:
+                    continue
+                for child in entry.iterdir():
+                    child.unlink()
+                entry.rmdir()
+            except OSError:  # pragma: no cover — best-effort housekeeping
+                continue
+
+    @staticmethod
+    def _write_private(path: Path, text: str) -> None:
+        """Write ``text`` to a new ``0o600`` file, flushed to disk.
+
+        Args:
+            path: The file to create; it must not already exist.
+            text: The contents.
+        """
+        handle = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(handle, "w", encoding="utf-8") as stream:
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+
+    def write_generation(self, artifact_id: str, *, manifest: PatchManifest, patch_text: str, packet_json: str) -> Path:
+        """Store a generated artifact atomically.
+
+        Everything is written into a private temp directory and published
+        with a single rename, so a crash can never leave a half-written
+        artifact that :meth:`load` would accept.
+
+        Args:
+            artifact_id: The artifact identifier.
+            manifest: The provenance manifest.
+            patch_text: The normalized patch.
+            packet_json: The canonical packet JSON.
+
+        Returns:
+            The published artifact directory.
+
+        Raises:
+            PatchError: The id is malformed.
+        """
+        final = self._artifact_dir(artifact_id)
+        self.root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        self._sweep_stale_temp_dirs()
+
+        temp = self.root / f".tmp-{artifact_id}"
+        temp.mkdir(mode=0o700, parents=True)
+        self._write_private(temp / "manifest.json", compact_json(manifest.model_dump(mode="json")))
+        self._write_private(temp / "patch.diff", patch_text)
+        self._write_private(temp / "packet.json", packet_json)
+        os.rename(temp, final)
+        return final
+
+    def load(self, artifact_id: str) -> tuple[PatchManifest, str, str]:
+        """Load an artifact, verifying it has not been edited.
+
+        Args:
+            artifact_id: The artifact identifier.
+
+        Returns:
+            A ``(manifest, patch_text, packet_json)`` tuple.
+
+        Raises:
+            PatchError: The artifact is missing, or its stored patch or
+                packet no longer hashes to the manifest's recorded value.
+        """
+        directory = self._artifact_dir(artifact_id)
+        if not directory.is_dir():
+            raise PatchError("artifact_not_found", f"no artifact {artifact_id!r}", {"artifact_id": artifact_id})
+
+        try:
+            manifest = PatchManifest.model_validate_json((directory / "manifest.json").read_text(encoding="utf-8"))
+            patch_text = (directory / "patch.diff").read_text(encoding="utf-8")
+            packet_json = (directory / "packet.json").read_text(encoding="utf-8")
+        except (OSError, ValueError) as exc:
+            raise PatchError(
+                "artifact_tampered", f"artifact {artifact_id!r} is unreadable", {"artifact_id": artifact_id}
+            ) from exc
+
+        if hashlib.sha256(patch_text.encode("utf-8")).hexdigest() != manifest.patch_sha256:
+            raise PatchError(
+                "artifact_tampered", "the stored patch does not match its manifest hash", {"artifact_id": artifact_id}
+            )
+        if hashlib.sha256(packet_json.encode("utf-8")).hexdigest() != manifest.packet_sha256:
+            raise PatchError(
+                "artifact_tampered", "the stored packet does not match its manifest hash", {"artifact_id": artifact_id}
+            )
+        return manifest, patch_text, packet_json
+
+    def write_journal(self, artifact_id: str, journal: ApplyJournal) -> None:
+        """Persist the recovery journal for an apply operation.
+
+        Args:
+            artifact_id: The artifact identifier.
+            journal: The journal to write.
+        """
+        directory = self._artifact_dir(artifact_id)
+        directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        path = directory / "journal.json"
+        temp = directory / ".journal.json.tmp"
+        if temp.exists():
+            temp.unlink()
+        self._write_private(temp, compact_json(journal.model_dump(mode="json")))
+        os.replace(temp, path)
+
+    def read_journal(self, artifact_id: str) -> Optional[ApplyJournal]:
+        """Read the recovery journal, if one exists.
+
+        Args:
+            artifact_id: The artifact identifier.
+
+        Returns:
+            The journal, or None when the artifact has never been applied.
+        """
+        path = self._artifact_dir(artifact_id) / "journal.json"
+        if not path.is_file():
+            return None
+        return ApplyJournal.model_validate(json.loads(path.read_text(encoding="utf-8")))
+
+    def save_before(self, artifact_id: str, index: int, data: Optional[bytes]) -> None:
+        """Save a file's pre-application bytes for rollback.
+
+        Args:
+            artifact_id: The artifact identifier.
+            index: The journal entry index.
+            data: The original bytes, or None when the file did not exist
+                (in which case nothing is stored and rollback means delete).
+        """
+        directory = self._artifact_dir(artifact_id) / "before"
+        directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        target = directory / f"{index}.bin"
+        if data is None:
+            if target.exists():
+                target.unlink()
+            return
+        if target.exists():
+            target.unlink()
+        handle = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(handle, "wb") as stream:
+            stream.write(data)
+            stream.flush()
+            os.fsync(stream.fileno())
+
+    def load_before(self, artifact_id: str, index: int) -> Optional[bytes]:
+        """Load a file's saved pre-application bytes.
+
+        Args:
+            artifact_id: The artifact identifier.
+            index: The journal entry index.
+
+        Returns:
+            The original bytes, or None when the file did not exist.
+        """
+        target = self._artifact_dir(artifact_id) / "before" / f"{index}.bin"
+        if not target.is_file():
+            return None
+        return target.read_bytes()
+
+    def directory_mode(self, artifact_id: str) -> int:
+        """Return the artifact directory's permission bits.
+
+        Args:
+            artifact_id: The artifact identifier.
+
+        Returns:
+            The mode bits, e.g. ``0o700``.
+        """
+        return stat.S_IMODE(self._artifact_dir(artifact_id).stat().st_mode)

--- a/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/policy.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/policy.py
@@ -1,0 +1,390 @@
+"""Operation policy, result budget, path checks and worktree lock (FEAT-543).
+
+This module owns the *deterministic* safety layer shared by the three
+tool-optimizations toolkits:
+
+* :class:`OptimizationPolicy` — the configured limits (line/byte thresholds,
+  serialized result budget, subprocess timeouts).
+* Byte-budget helpers — :func:`compact_json`, :func:`measure_json_bytes` and
+  :func:`fit_to_budget`, which shrink *content* and re-serialize rather than
+  slicing JSON text into something unparseable.
+* Path policy — :func:`resolve_operand` composes the existing confinement
+  helpers (containment + secret deny-list) with a new symlink-component
+  rejection pass.
+* :class:`WorktreeLock` — a cross-process advisory ``fcntl.flock`` used to
+  serialize cooperating mutations per worktree.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import fcntl
+import json
+import os
+import stat
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from parrot.tools.repo.confinement import (
+    PathOutsideRootError,
+    resolve_readable_path,
+    resolve_within_root,
+)
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from .models import OperationError, OperationResult
+
+__all__ = (
+    "MIN_RESULT_BYTES",
+    "PolicyError",
+    "SymlinkRejectedError",
+    "LockTimeoutError",
+    "BudgetError",
+    "OptimizationPolicy",
+    "compact_json",
+    "measure_json_bytes",
+    "fit_to_budget",
+    "relative_posix",
+    "check_no_symlink_components",
+    "resolve_operand",
+    "WorktreeLock",
+)
+
+#: The smallest configurable serialized result budget, so errors stay useful.
+MIN_RESULT_BYTES = 4096
+
+
+class PolicyError(ValueError):
+    """Base class for every policy violation raised by this module."""
+
+
+class SymlinkRejectedError(PolicyError):
+    """Raised when a path traverses a symlinked component below the root."""
+
+
+class LockTimeoutError(PolicyError):
+    """Raised when a :class:`WorktreeLock` could not be acquired in time."""
+
+
+class BudgetError(PolicyError):
+    """Raised when a configured byte budget is unusable."""
+
+
+class OptimizationPolicy(BaseModel):
+    """Configured limits shared by every tool-optimizations toolkit.
+
+    Attributes:
+        repo_root: The repository checkout every operand is confined to.
+            Resolved at construction; must be an existing directory.
+        max_lines: Line threshold above which a read requires explicit ranges.
+        large_file_bytes: Byte threshold above which a read requires ranges.
+        max_result_bytes: Budget applied to the serialized domain result.
+        command_timeout_seconds: Timeout for a local subprocess.
+        network_timeout_seconds: Timeout for a network-bound subprocess.
+        deny_secret_files: When True, the existing secret deny-list applies.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    repo_root: Path
+    max_lines: int = Field(default=350, ge=1)
+    large_file_bytes: int = Field(default=64_000, ge=1)
+    max_result_bytes: int = Field(default=64_000, ge=MIN_RESULT_BYTES)
+    command_timeout_seconds: float = Field(default=30.0, gt=0)
+    network_timeout_seconds: float = Field(default=120.0, gt=0)
+    deny_secret_files: bool = True
+
+    @field_validator("repo_root")
+    @classmethod
+    def _resolve_root(cls, value: Path) -> Path:
+        """Resolve the root and require an existing directory."""
+        resolved = Path(value).resolve()
+        if not resolved.is_dir():
+            raise ValueError(f"repo_root {str(value)!r} is not an existing directory")
+        return resolved
+
+
+# --------------------------------------------------------------------------- #
+# Byte budget
+# --------------------------------------------------------------------------- #
+def compact_json(obj: Any) -> str:
+    """Serialize ``obj`` with the canonical compact encoding.
+
+    This exact encoding defines what ``max_result_bytes`` measures: the UTF-8
+    encoding of the compact JSON domain result, including metadata and
+    escaped content, before any MCP transport wrapping.
+
+    Args:
+        obj: Any JSON-compatible object.
+
+    Returns:
+        The compact JSON text.
+    """
+    return json.dumps(obj, ensure_ascii=False, separators=(",", ":"), default=str)
+
+
+def measure_json_bytes(obj: Any) -> int:
+    """Return the UTF-8 byte length of :func:`compact_json` for ``obj``.
+
+    Args:
+        obj: Any JSON-compatible object.
+
+    Returns:
+        The measured byte count.
+    """
+    return len(compact_json(obj).encode("utf-8"))
+
+
+def _drop_trailing_lines(text: str) -> str:
+    """Drop roughly the last half of ``text``'s lines, keeping whole lines.
+
+    Args:
+        text: The text to shrink.
+
+    Returns:
+        The retained prefix; ``""`` when nothing can be kept.
+    """
+    if not text:
+        return ""
+    lines = text.splitlines()
+    keep = len(lines) // 2
+    if keep <= 0:
+        return ""
+    return "\n".join(lines[:keep])
+
+
+def _fits(result: OperationResult, budget: int) -> bool:
+    """True when ``result`` serializes within ``budget`` bytes."""
+    return measure_json_bytes(result.model_dump(mode="json")) <= budget
+
+
+def fit_to_budget(result: OperationResult, budget: int) -> OperationResult:
+    """Shrink ``result`` until its serialized form fits ``budget`` bytes.
+
+    Content is reduced and re-serialized; JSON text is never sliced, so the
+    returned object always parses. The reduction order is deliberate — step
+    diagnostics first, then payload records, then the payload as a whole, so
+    that status/error identity survives to the very last stage.
+
+    Args:
+        result: The domain result to bound.
+        budget: The serialized byte budget (at least :data:`MIN_RESULT_BYTES`).
+
+    Returns:
+        A result whose ``model_dump(mode="json")`` measures at most ``budget``
+        bytes. ``truncated`` is set whenever anything was dropped.
+
+    Raises:
+        BudgetError: ``budget`` is below :data:`MIN_RESULT_BYTES`.
+    """
+    if budget < MIN_RESULT_BYTES:
+        raise BudgetError(f"result budget {budget} is below the minimum {MIN_RESULT_BYTES}")
+    if _fits(result, budget):
+        return result
+
+    working = result.model_copy(deep=True)
+    working.truncated = True
+
+    # Stage 1 — clip step diagnostics, largest stream first, whole lines only.
+    while not _fits(working, budget):
+        candidates = [(len(step.stdout), "stdout", step) for step in working.steps if step.stdout]
+        candidates += [(len(step.stderr), "stderr", step) for step in working.steps if step.stderr]
+        if not candidates:
+            break
+        _, attr, step = max(candidates, key=lambda item: item[0])
+        setattr(step, attr, _drop_trailing_lines(getattr(step, attr)))
+        step.truncated = True
+
+    # Stage 2 — drop payload list records from the end, longest list first.
+    while not _fits(working, budget):
+        lists = [(len(v), k) for k, v in working.data.items() if isinstance(v, list) and v]
+        if not lists:
+            break
+        _, key = max(lists, key=lambda item: item[0])
+        working.data[key] = working.data[key][:-1]
+
+    # Stage 3 — drop the payload entirely.
+    if not _fits(working, budget):
+        working.data = {"omitted": True}
+
+    # Stage 4 — drop step records entirely.
+    if not _fits(working, budget):
+        working.steps = []
+
+    # Stage 5 — last resort: a minimal, still-truthful result.
+    if not _fits(working, budget):
+        working = OperationResult(
+            status=result.status,
+            operation=result.operation[:128],
+            data={"omitted": True},
+            error=OperationError(
+                code=result.error.code if result.error else "result_truncated",
+                message="result omitted: exceeded the configured byte budget",
+            ),
+            steps=[],
+            truncated=True,
+            elapsed_ms=result.elapsed_ms,
+        )
+    return working
+
+
+# --------------------------------------------------------------------------- #
+# Path policy
+# --------------------------------------------------------------------------- #
+def relative_posix(root: Path, target: Path) -> str:
+    """Return ``target`` as a repo-relative POSIX path.
+
+    Args:
+        root: The repository root.
+        target: An absolute path inside ``root``.
+
+    Returns:
+        The repo-relative POSIX path (``"."`` for the root itself).
+
+    Raises:
+        PathOutsideRootError: ``target`` is not inside ``root``.
+    """
+    try:
+        return target.relative_to(root).as_posix()
+    except ValueError as exc:
+        raise PathOutsideRootError(f"{str(target)!r} is not inside {str(root)!r}") from exc
+
+
+def check_no_symlink_components(root: Path, candidate: str) -> Path:
+    """Reject a path any of whose components below ``root`` is a symlink.
+
+    The candidate is *normalized*, not resolved, so the returned path keeps
+    the caller's spelling; each existing component below the root is then
+    ``lstat``-ed. This closes the gap left by containment checks, which
+    legitimately follow symlinks and therefore accept a link that happens to
+    point back inside the root.
+
+    Args:
+        root: The (already resolved) repository root.
+        candidate: A caller-supplied relative or absolute path.
+
+    Returns:
+        The normalized absolute path, with no symlinked component.
+
+    Raises:
+        PathOutsideRootError: The normalized path escapes ``root``.
+        SymlinkRejectedError: A component below ``root`` is a symlink.
+    """
+    normalized = Path(os.path.normpath(os.path.join(str(root), candidate)))
+    if normalized != root and not normalized.is_relative_to(root):
+        raise PathOutsideRootError(f"{candidate!r} normalizes outside the repository root")
+
+    current = root
+    for part in normalized.relative_to(root).parts:
+        current = current / part
+        try:
+            mode = os.lstat(current).st_mode
+        except FileNotFoundError:
+            # Nothing below an absent component can be a symlink.
+            break
+        if stat.S_ISLNK(mode):
+            raise SymlinkRejectedError(f"{relative_posix(root, current)!r} is a symlink; symlinks are not followed")
+    return normalized
+
+
+def resolve_operand(policy: OptimizationPolicy, candidate: str, *, must_exist: bool) -> Path:
+    """Resolve one caller-supplied path under the configured policy.
+
+    Checks run in a deliberate order: containment first (and the secret
+    deny-list when enabled), then symlink-component rejection, then existence.
+    Running containment first means an escaping path is reported as such even
+    when it also happens to be a symlink.
+
+    Args:
+        policy: The active policy supplying the root and secret setting.
+        candidate: A caller-supplied relative or absolute path.
+        must_exist: When True, a missing path is an error.
+
+    Returns:
+        The normalized absolute path, guaranteed inside the root and free of
+        symlinked components.
+
+    Raises:
+        PathOutsideRootError: The path escapes the repository root.
+        SecretFileError: The path matches the secret deny-list.
+        SymlinkRejectedError: A component below the root is a symlink.
+        PolicyError: ``must_exist`` is True and the path does not exist.
+    """
+    root = policy.repo_root
+    if policy.deny_secret_files:
+        resolve_readable_path(root, candidate)
+    else:
+        resolve_within_root(root, candidate)
+
+    target = check_no_symlink_components(root, candidate)
+    if must_exist and not target.exists():
+        raise PolicyError(f"{candidate!r} does not exist")
+    return target
+
+
+# --------------------------------------------------------------------------- #
+# Cross-process advisory lock
+# --------------------------------------------------------------------------- #
+class WorktreeLock:
+    """A cross-process advisory lock serializing mutations per worktree.
+
+    Built on ``fcntl.flock(LOCK_EX)``. flock is advisory and is released by
+    the kernel when the owning process dies, so a stale lock file is never
+    possible and the lock file is therefore **never** unlinked — deleting it
+    would break the mutual exclusion of processes already holding it.
+
+    External Git processes do not honor this lock, so Git's own index lock
+    and the toolkit's revision checks remain necessary.
+
+    Example:
+        >>> async with WorktreeLock(git_dir / "parrot-tool-optimizations.lock", 30.0):
+        ...     ...  # serialized section
+    """
+
+    def __init__(self, lock_path: Path, timeout_seconds: float) -> None:
+        """Initialize the lock.
+
+        Args:
+            lock_path: The lock file path. Created if absent, never removed.
+            timeout_seconds: How long to wait for the lock before failing.
+        """
+        self._path = Path(lock_path)
+        self._timeout = float(timeout_seconds)
+        self._fd: Optional[int] = None
+
+    async def __aenter__(self) -> "WorktreeLock":
+        """Acquire the exclusive lock, polling until the timeout expires.
+
+        Returns:
+            This lock instance.
+
+        Raises:
+            LockTimeoutError: The lock was still held when the timeout expired.
+        """
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(self._path, os.O_CREAT | os.O_RDWR, 0o600)
+        deadline = time.monotonic() + self._timeout
+        while True:
+            try:
+                await asyncio.to_thread(fcntl.flock, fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                self._fd = fd
+                return self
+            except BlockingIOError:
+                if time.monotonic() >= deadline:
+                    os.close(fd)
+                    raise LockTimeoutError(f"timed out acquiring {str(self._path)!r}") from None
+                await asyncio.sleep(0.05)
+            except BaseException:
+                os.close(fd)
+                raise
+
+    async def __aexit__(self, *exc_info: Any) -> None:
+        """Release the lock, leaving the lock file in place."""
+        if self._fd is None:
+            return
+        try:
+            fcntl.flock(self._fd, fcntl.LOCK_UN)
+        finally:
+            os.close(self._fd)
+            self._fd = None

--- a/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/reader.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/reader.py
@@ -1,0 +1,665 @@
+"""Bounded, streaming source reading for Claude Code / Codex (FEAT-543).
+
+:class:`BoundedSourceToolkit` replaces "read the whole file into the
+context window" with an explicitly bounded read. A file above **350 logical
+lines or 64,000 on-disk bytes** (either threshold, both configurable)
+requires an explicit inclusive 1-based range; every result carries the
+file's SHA-256 revision and a continuation cursor so the caller can page
+through it safely.
+
+The reader never holds a whole file in memory and never returns a partial
+line. ``ReadOnlyRepoToolkit.read_file`` is deliberately *not* reused: it
+reads the entire file and then slices it (`repo/toolkit.py:227-243`). That
+API is preserved untouched; this is a separate toolkit.
+
+The helpers above the toolkit class are pure, synchronous and stdlib-only
+so they can be reused for reference slices (TASK-3083) and host-side
+threshold detection (TASK-3088) without dragging in toolkit state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import stat
+import time
+from pathlib import Path
+from typing import Any, NamedTuple, Optional
+
+from parrot.tools.decorators import tool_schema
+from parrot.tools.repo.confinement import PathOutsideRootError, SecretFileError
+from pydantic import BaseModel
+
+from .base import OptimizationToolkitBase
+from .models import OperationResult, SourceInfo, SourceInfoArgs, SourceReadArgs, SourceResult
+from .policy import PolicyError, SymlinkRejectedError, measure_json_bytes, resolve_operand
+
+__all__ = (
+    "FileIdentity",
+    "RangeRead",
+    "ReaderError",
+    "NotRegularFileError",
+    "LineTooLargeError",
+    "InvalidEncodingError",
+    "RangeOutOfBoundsError",
+    "ConcurrentModificationError",
+    "HashTimeoutError",
+    "stat_regular",
+    "sniff_binary",
+    "count_lines_bounded",
+    "sha256_stream",
+    "read_line_range",
+    "check_identity_unchanged",
+    "BoundedSourceToolkit",
+)
+
+#: Chunk size for line counting and binary sniffing.
+_CHUNK = 1 << 16
+#: Chunk size for hashing.
+_HASH_CHUNK = 1 << 20
+
+
+class ReaderError(Exception):
+    """Base class for bounded-reader failures."""
+
+
+class NotRegularFileError(ReaderError):
+    """Raised for a device, FIFO, socket or directory."""
+
+
+class LineTooLargeError(ReaderError):
+    """Raised when one line alone exceeds the caller's byte bound."""
+
+    def __init__(self, line_no: int, at_least_bytes: int) -> None:
+        """Initialize the error.
+
+        Args:
+            line_no: The 1-based line number.
+            at_least_bytes: A lower bound on the line's size in bytes.
+        """
+        super().__init__(f"line {line_no} is at least {at_least_bytes} bytes")
+        self.line_no = line_no
+        self.at_least_bytes = at_least_bytes
+
+
+class InvalidEncodingError(ReaderError):
+    """Raised when a line is not valid UTF-8 (decoding is strict)."""
+
+    def __init__(self, line_no: int) -> None:
+        """Initialize the error.
+
+        Args:
+            line_no: The 1-based line number that failed to decode.
+        """
+        super().__init__(f"line {line_no} is not valid UTF-8")
+        self.line_no = line_no
+
+
+class RangeOutOfBoundsError(ReaderError):
+    """Raised when the requested start line is past the end of the file."""
+
+    def __init__(self, start_line: int, total_lines: int) -> None:
+        """Initialize the error.
+
+        Args:
+            start_line: The requested start line.
+            total_lines: The number of lines the file actually has.
+        """
+        super().__init__(f"start_line {start_line} is past the last line ({total_lines})")
+        self.start_line = start_line
+        self.total_lines = total_lines
+
+
+class ConcurrentModificationError(ReaderError):
+    """Raised when the file changed identity while it was being scanned."""
+
+
+class HashTimeoutError(ReaderError):
+    """Raised when hashing a very large file exceeded its deadline."""
+
+
+class FileIdentity(NamedTuple):
+    """A file's identity for concurrent-modification detection.
+
+    Attributes:
+        inode: The inode number.
+        size: The on-disk size in bytes.
+        mtime_ns: The modification time in nanoseconds.
+    """
+
+    inode: int
+    size: int
+    mtime_ns: int
+
+
+class RangeRead(NamedTuple):
+    """The outcome of reading an inclusive line range.
+
+    Attributes:
+        lines: The complete lines read, with their line endings preserved.
+        actual_end: The last line number actually returned.
+        eof: True when the file ended at or before the requested end.
+    """
+
+    lines: list[str]
+    actual_end: int
+    eof: bool
+
+
+def stat_regular(path: Path) -> FileIdentity:
+    """Stat ``path``, rejecting symlinks and anything but a regular file.
+
+    ``os.lstat`` is used so a symlink is detected rather than followed.
+
+    Args:
+        path: The file to stat.
+
+    Returns:
+        The file's identity.
+
+    Raises:
+        FileNotFoundError: The path does not exist.
+        SymlinkRejectedError: The path is a symlink.
+        NotRegularFileError: The path is a device, FIFO, socket or directory.
+    """
+    info = os.lstat(path)
+    if stat.S_ISLNK(info.st_mode):
+        raise SymlinkRejectedError(f"{str(path)!r} is a symlink; symlinks are not followed")
+    if not stat.S_ISREG(info.st_mode):
+        raise NotRegularFileError(f"{str(path)!r} is not a regular file")
+    return FileIdentity(inode=info.st_ino, size=info.st_size, mtime_ns=info.st_mtime_ns)
+
+
+def check_identity_unchanged(before: FileIdentity, path: Path) -> None:
+    """Verify the file has not changed identity since ``before`` was taken.
+
+    Args:
+        before: The identity captured before the scan.
+        path: The file to re-stat.
+
+    Raises:
+        ConcurrentModificationError: The file changed while being scanned.
+    """
+    try:
+        current = stat_regular(path)
+    except (OSError, ReaderError) as exc:
+        raise ConcurrentModificationError(f"{str(path)!r} changed while it was being read") from exc
+    if current != before:
+        raise ConcurrentModificationError(f"{str(path)!r} changed while it was being read")
+
+
+def sniff_binary(path: Path, probe: int = 8192) -> bool:
+    """Detect a binary file by looking for a NUL byte in its first bytes.
+
+    Args:
+        path: The file to sniff.
+        probe: How many leading bytes to inspect.
+
+    Returns:
+        True when the probe contains a NUL byte.
+    """
+    with open(path, "rb") as handle:
+        return b"\x00" in handle.read(probe)
+
+
+def count_lines_bounded(path: Path, stop_after: int) -> tuple[int, bool]:
+    """Count logical lines, stopping early once the bound is exceeded.
+
+    A final line without a trailing newline still counts as a line.
+
+    Args:
+        path: The file to count.
+        stop_after: The threshold to compare against.
+
+    Returns:
+        A ``(count, exceeded)`` tuple. When ``exceeded`` is True the exact
+        count is unknown and ``count`` is ``stop_after + 1``.
+    """
+    count = 0
+    ended_with_newline = True
+    saw_any = False
+    with open(path, "rb", buffering=_CHUNK) as handle:
+        while True:
+            chunk = handle.read(_CHUNK)
+            if not chunk:
+                break
+            saw_any = True
+            count += chunk.count(b"\n")
+            ended_with_newline = chunk.endswith(b"\n")
+            if count > stop_after:
+                return stop_after + 1, True
+    if saw_any and not ended_with_newline:
+        count += 1
+        if count > stop_after:
+            return stop_after + 1, True
+    return count, False
+
+
+def sha256_stream(path: Path, *, deadline_seconds: float) -> str:
+    """Hash a file's bytes in bounded memory, under a wall-clock deadline.
+
+    Args:
+        path: The file to hash.
+        deadline_seconds: Maximum time to spend hashing.
+
+    Returns:
+        The lowercase hex SHA-256 digest.
+
+    Raises:
+        HashTimeoutError: Hashing exceeded the deadline.
+    """
+    deadline = time.monotonic() + deadline_seconds
+    digest = hashlib.sha256()
+    with open(path, "rb", buffering=_HASH_CHUNK) as handle:
+        while True:
+            chunk = handle.read(_HASH_CHUNK)
+            if not chunk:
+                break
+            digest.update(chunk)
+            if time.monotonic() > deadline:
+                raise HashTimeoutError(f"hashing {str(path)!r} exceeded {deadline_seconds}s")
+    return digest.hexdigest()
+
+
+def read_line_range(path: Path, start_line: int, end_line: int, *, max_line_bytes: int) -> RangeRead:
+    """Read an inclusive 1-based line range without loading the whole file.
+
+    Memory is bounded by ``max_line_bytes`` plus the buffer size, never by
+    the file's length: an oversized line is reported by number and size
+    rather than being read into memory or silently cut.
+
+    Args:
+        path: The file to read.
+        start_line: First line to return, 1-based inclusive.
+        end_line: Last line to return, 1-based inclusive.
+        max_line_bytes: The largest single line that may be materialized.
+
+    Returns:
+        The lines read, the last line number returned, and whether the file
+        ended at or before ``end_line``.
+
+    Raises:
+        LineTooLargeError: A line exceeds ``max_line_bytes``.
+        InvalidEncodingError: A line is not valid UTF-8.
+        RangeOutOfBoundsError: ``start_line`` is past the last line.
+    """
+    lines: list[str] = []
+    line_no = 0
+    eof = False
+    with open(path, "rb", buffering=_CHUNK) as handle:
+        while True:
+            raw = handle.readline(max_line_bytes + 1)
+            if not raw:
+                eof = True
+                break
+            line_no += 1
+            if len(raw) > max_line_bytes and not raw.endswith(b"\n"):
+                raise LineTooLargeError(line_no, len(raw))
+            if line_no < start_line:
+                continue
+            try:
+                lines.append(raw.decode("utf-8"))
+            except UnicodeDecodeError as exc:
+                raise InvalidEncodingError(line_no) from exc
+            if line_no >= end_line:
+                eof = handle.peek(1) == b""
+                break
+    if line_no < start_line:
+        raise RangeOutOfBoundsError(start_line, line_no)
+    return RangeRead(lines=lines, actual_end=min(end_line, line_no), eof=eof)
+
+
+def _escaped_length(text: str) -> int:
+    """Return the JSON-escaped UTF-8 byte cost of ``text``, without quotes.
+
+    Args:
+        text: The string to measure.
+
+    Returns:
+        The number of bytes the string contributes inside a JSON document.
+    """
+    return len(json.dumps(text, ensure_ascii=False).encode("utf-8")) - 2
+
+
+class BoundedSourceToolkit(OptimizationToolkitBase):
+    """Read source files under explicit line, byte and revision bounds.
+
+    Example:
+        >>> toolkit = BoundedSourceToolkit(repo_root="/path/to/repo")
+        >>> info = await toolkit.source_info("src/big_module.py")
+        >>> info.range_required
+        True
+    """
+
+    arg_models: dict[str, type[BaseModel]] = {
+        "source_info": SourceInfoArgs,
+        "source_read": SourceReadArgs,
+    }
+
+    def _resolve(self, path: str) -> tuple[Path, str]:
+        """Resolve a caller path under policy and require a regular file.
+
+        Args:
+            path: The caller-supplied path.
+
+        Returns:
+            A ``(absolute_path, relative_posix)`` tuple.
+
+        Raises:
+            PathOutsideRootError: The path escapes the repository root.
+            SecretFileError: The path matches the secret deny-list.
+            SymlinkRejectedError: The path or a parent is a symlink.
+            NotRegularFileError: The path is not a regular file.
+            PolicyError: The path does not exist.
+        """
+        target = resolve_operand(self.policy, path, must_exist=True)
+        stat_regular(target)
+        return target, target.relative_to(self.policy.repo_root).as_posix()
+
+    def _path_error(self, operation: str, exc: Exception, started: float) -> OperationResult:
+        """Map a path/identity exception onto a stable error code.
+
+        Args:
+            operation: The operation name.
+            exc: The raised exception.
+            started: A ``perf_counter()`` reading taken at operation start.
+
+        Returns:
+            The bounded error result.
+        """
+        mapping: list[tuple[type[Exception], str]] = [
+            (SymlinkRejectedError, "symlink_rejected"),
+            (SecretFileError, "secret_file"),
+            (PathOutsideRootError, "path_outside_root"),
+            (NotRegularFileError, "not_a_file"),
+            (FileNotFoundError, "not_found"),
+            (ConcurrentModificationError, "concurrent_modification"),
+            (HashTimeoutError, "hash_timeout"),
+            (PolicyError, "not_found"),
+        ]
+        for exc_type, code in mapping:
+            if isinstance(exc, exc_type):
+                return self._error(operation, code, str(exc), started=started)
+        return self._error(operation, "read_failed", str(exc), started=started)
+
+    @tool_schema(SourceInfoArgs)
+    async def source_info(self, path: str) -> SourceInfo | OperationResult:
+        """Report a file's size, revision and whether a read needs a range.
+
+        No file content is ever returned by this tool.
+
+        Args:
+            path: A repository-relative file path.
+
+        Returns:
+            The file's bounded metadata, or an error result.
+        """
+        started = time.perf_counter()
+        operation = "source_info"
+        try:
+            args = SourceInfoArgs(path=path)
+        except Exception as exc:  # pydantic ValidationError
+            return self._error(operation, "invalid_arguments", str(exc), started=started)
+
+        try:
+            return await asyncio.to_thread(self._info_blocking, args.path)
+        except Exception as exc:  # noqa: BLE001 — mapped to a domain error
+            return self._path_error(operation, exc, started)
+
+    def _info_blocking(self, path: str) -> SourceInfo:
+        """Collect file metadata off the event loop.
+
+        Args:
+            path: A repository-relative file path.
+
+        Returns:
+            The file's bounded metadata.
+
+        Raises:
+            ReaderError: The file is unreadable under the reader's rules.
+        """
+        target, relative = self._resolve(path)
+        identity = stat_regular(target)
+        if sniff_binary(target):
+            raise InvalidEncodingError(0)
+        count, exceeded = count_lines_bounded(target, self.policy.max_lines)
+        is_large = exceeded or identity.size > self.policy.large_file_bytes
+        digest = sha256_stream(target, deadline_seconds=self.policy.command_timeout_seconds)
+        check_identity_unchanged(identity, target)
+        return SourceInfo(
+            path=relative,
+            sha256=digest,
+            size_bytes=identity.size,
+            line_count=None if exceeded else count,
+            is_large=is_large,
+            max_lines=self.policy.max_lines,
+            large_file_bytes=self.policy.large_file_bytes,
+            range_required=is_large,
+        )
+
+    @tool_schema(SourceReadArgs)
+    async def source_read(
+        self,
+        path: str,
+        start_line: Optional[int] = None,
+        end_line: Optional[int] = None,
+        expected_sha256: Optional[str] = None,
+    ) -> SourceResult | OperationResult:
+        """Read a small file whole, or an explicit inclusive line range.
+
+        Files above either configured threshold require both range ends.
+        Only complete lines are returned; continue with ``next_line`` and
+        ``expected_sha256`` to page through a file safely.
+
+        Args:
+            path: A repository-relative file path.
+            start_line: First line to read, 1-based inclusive.
+            end_line: Last line to read, 1-based inclusive.
+            expected_sha256: The revision the caller expects; the read is
+                refused when the file has changed since.
+
+        Returns:
+            The bounded slice, or an error result.
+        """
+        started = time.perf_counter()
+        operation = "source_read"
+        try:
+            args = SourceReadArgs(path=path, start_line=start_line, end_line=end_line, expected_sha256=expected_sha256)
+        except Exception as exc:  # pydantic ValidationError
+            return self._error(operation, "invalid_arguments", str(exc), started=started)
+
+        if args.start_line is not None and args.end_line is not None:
+            span = args.end_line - args.start_line + 1
+            if span > self.policy.max_lines:
+                return self._error(
+                    operation,
+                    "range_too_large",
+                    f"a range of {span} lines exceeds the {self.policy.max_lines}-line maximum",
+                    details={"max_lines": self.policy.max_lines, "requested": span},
+                    started=started,
+                )
+
+        try:
+            return await asyncio.to_thread(self._read_blocking, args, started)
+        except LineTooLargeError as exc:
+            return self._error(
+                operation,
+                "line_too_large",
+                str(exc),
+                details={"line": exc.line_no, "bytes": exc.at_least_bytes},
+                started=started,
+            )
+        except InvalidEncodingError as exc:
+            return self._error(operation, "invalid_encoding", str(exc), details={"line": exc.line_no}, started=started)
+        except RangeOutOfBoundsError as exc:
+            return self._error(
+                operation,
+                "range_out_of_bounds",
+                str(exc),
+                details={"start_line": exc.start_line, "total_lines": exc.total_lines},
+                started=started,
+            )
+        except _RangeRequired as exc:
+            return self._error(operation, "range_required", str(exc), details=exc.details, started=started)
+        except _StaleRevision as exc:
+            return self._error(
+                operation, "stale_revision", str(exc), details={"current_sha256": exc.current}, started=started
+            )
+        except _BinaryFile as exc:
+            return self._error(operation, "binary_file", str(exc), started=started)
+        except Exception as exc:  # noqa: BLE001 — mapped to a domain error
+            return self._path_error(operation, exc, started)
+
+    def _read_blocking(self, args: SourceReadArgs, started: float) -> SourceResult:
+        """Perform the bounded read off the event loop.
+
+        Args:
+            args: The validated arguments.
+            started: A ``perf_counter()`` reading taken at operation start.
+
+        Returns:
+            The bounded slice.
+
+        Raises:
+            ReaderError: The file is unreadable under the reader's rules.
+            _RangeRequired: The file is large and no range was supplied.
+            _StaleRevision: The file no longer matches ``expected_sha256``.
+            _BinaryFile: The file is binary.
+        """
+        target, relative = self._resolve(args.path)
+        identity = stat_regular(target)
+        if sniff_binary(target):
+            raise _BinaryFile(f"{relative!r} looks like a binary file")
+
+        _count, exceeded = count_lines_bounded(target, self.policy.max_lines)
+        is_large = exceeded or identity.size > self.policy.large_file_bytes
+        if is_large and args.start_line is None:
+            raise _RangeRequired(
+                f"{relative!r} is large; supply both start_line and end_line",
+                {
+                    "max_lines": self.policy.max_lines,
+                    "large_file_bytes": self.policy.large_file_bytes,
+                    "size_bytes": identity.size,
+                    "example": {"start_line": 1, "end_line": self.policy.max_lines},
+                },
+            )
+
+        digest = sha256_stream(target, deadline_seconds=self.policy.command_timeout_seconds)
+        if args.expected_sha256 is not None and args.expected_sha256 != digest:
+            raise _StaleRevision(f"{relative!r} has changed since it was last read", digest)
+
+        if identity.size == 0:
+            check_identity_unchanged(identity, target)
+            return SourceResult(
+                path=relative,
+                sha256=digest,
+                size_bytes=0,
+                start_line=1,
+                end_line=0,
+                content="",
+                truncated=False,
+                next_line=None,
+                eof=True,
+            )
+
+        start = args.start_line if args.start_line is not None else 1
+        end = args.end_line if args.end_line is not None else self.policy.max_lines
+        span = read_line_range(target, start, end, max_line_bytes=self.policy.max_result_bytes)
+
+        kept, used, envelope_budget = self._fit_lines(relative, digest, identity.size, start, span.lines)
+        if not kept:
+            first = span.lines[0]
+            raise LineTooLargeError(start, len(first.encode("utf-8")))
+
+        returned_end = start + len(kept) - 1
+        all_requested_returned = returned_end >= span.actual_end
+        eof = span.eof and all_requested_returned
+        truncated = not all_requested_returned
+        del used, envelope_budget
+
+        check_identity_unchanged(identity, target)
+        return SourceResult(
+            path=relative,
+            sha256=digest,
+            size_bytes=identity.size,
+            start_line=start,
+            end_line=returned_end,
+            content="".join(kept),
+            truncated=truncated,
+            next_line=None if eof else returned_end + 1,
+            eof=eof,
+        )
+
+    def _fit_lines(
+        self, relative: str, digest: str, size: int, start: int, lines: list[str]
+    ) -> tuple[list[str], int, int]:
+        """Select the complete lines that fit the serialized byte budget.
+
+        Args:
+            relative: The repo-relative path.
+            digest: The file's SHA-256 revision.
+            size: The file's size in bytes.
+            start: The first line number.
+            lines: The candidate lines.
+
+        Returns:
+            A ``(kept_lines, bytes_used, budget)`` tuple. ``kept_lines`` is
+            empty when even the first line does not fit.
+        """
+        envelope = measure_json_bytes(
+            SourceResult(
+                path=relative,
+                sha256=digest,
+                size_bytes=size,
+                start_line=start,
+                end_line=start + max(0, len(lines) - 1),
+                content="",
+                truncated=True,
+                next_line=start + len(lines),
+                eof=False,
+            ).model_dump(mode="json")
+        )
+        budget = self.policy.max_result_bytes - envelope
+        kept: list[str] = []
+        used = 0
+        for line in lines:
+            cost = _escaped_length(line)
+            if used + cost > budget:
+                break
+            kept.append(line)
+            used += cost
+        return kept, used, budget
+
+
+class _RangeRequired(ReaderError):
+    """Internal signal: a large file was read without an explicit range."""
+
+    def __init__(self, message: str, details: dict[str, Any]) -> None:
+        """Initialize the signal.
+
+        Args:
+            message: The human-readable explanation.
+            details: Structured guidance, including an example range.
+        """
+        super().__init__(message)
+        self.details = details
+
+
+class _StaleRevision(ReaderError):
+    """Internal signal: the file no longer matches the expected revision."""
+
+    def __init__(self, message: str, current: str) -> None:
+        """Initialize the signal.
+
+        Args:
+            message: The human-readable explanation.
+            current: The file's current SHA-256 digest.
+        """
+        super().__init__(message)
+        self.current = current
+
+
+class _BinaryFile(ReaderError):
+    """Internal signal: the file is binary and has no text representation."""

--- a/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/writer.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/writer.py
@@ -65,7 +65,13 @@ from .reader import sha256_stream, stat_regular
 if TYPE_CHECKING:  # pragma: no cover — typing only, keeps provider imports lazy
     from parrot.clients.base import AbstractClient
 
-__all__ = ("SYSTEM_PROMPT", "TargetedWriterToolkit", "build_prompt", "build_repair_prompt")
+__all__ = (
+    "SYSTEM_PROMPT",
+    "TargetedWriterToolkit",
+    "build_prompt",
+    "build_repair_prompt",
+    "redact_local_content",
+)
 
 #: Default permissions for a newly created file.
 _CREATE_MODE = 0o644
@@ -123,12 +129,46 @@ def build_prompt(contract: ValidatedContract) -> str:
     )
 
 
+#: Diagnostic keys that carry LOCAL file content rather than the model's own
+#: output. A `context_mismatch` reports the source line it actually found —
+#: which is repository content the delegate was never approved to see, and on
+#: an unapproved line at that. These must never reach the provider.
+_LOCAL_CONTENT_KEYS = frozenset({"actual", "actual_line", "current", "before", "source"})
+
+#: Placeholder substituted for redacted diagnostic values.
+_REDACTED = "<redacted: local file content>"
+
+
+def redact_local_content(details: dict[str, Any]) -> dict[str, Any]:
+    """Strip local file content from a diagnostic before it leaves the machine.
+
+    The thinking model sees the full, unredacted diagnostic — it runs locally.
+    The *delegate* does not: only the approved packet slices may be sent to
+    the provider, so a mismatch diagnostic reports that a line differed, never
+    what the local line said.
+
+    Args:
+        details: The raw error details.
+
+    Returns:
+        A copy safe to place in a provider prompt.
+    """
+    return {
+        key: (_REDACTED if key in _LOCAL_CONTENT_KEYS and value is not None else value)
+        for key, value in details.items()
+    }
+
+
 def build_repair_prompt(contract: ValidatedContract, previous_patch: str, error: PatchError) -> str:
     """Build the single permitted repair prompt.
 
     The delegate gets the same approved context plus a bounded diagnostic —
     never additional repository content, and never a second chance at a
     contract that was itself invalid.
+
+    The diagnostic is redacted (see :func:`redact_local_content`): the
+    rejected patch is the model's own output and may be echoed back, but the
+    local source it failed to match may not.
 
     Args:
         contract: The validated contract.
@@ -144,7 +184,7 @@ def build_repair_prompt(contract: ValidatedContract, previous_patch: str, error:
             build_prompt(contract),
             "## Your previous attempt was rejected",
             f"Rejection code: {error.code}",
-            f"Details: {compact_json(error.details)}",
+            f"Details: {compact_json(redact_local_content(error.details))}",
             "Rejected output (truncated):\n\n```\n" + excerpt + "\n```",
             "Return a corrected unified diff. Output only the diff.",
         ]
@@ -413,6 +453,14 @@ class TargetedWriterToolkit(OptimizationToolkitBase):
                         if repairs < limits.max_repairs:
                             repairs += 1
                             prompt = build_repair_prompt(contract, text, exc)
+                            if len(prompt.encode("utf-8")) > limits.max_context_bytes:
+                                return self._error(
+                                    operation,
+                                    "context_budget_exceeded",
+                                    "the repair prompt exceeds the configured context budget",
+                                    details={"bytes": len(prompt.encode("utf-8")), "repairs": repairs},
+                                    started=started,
+                                )
                             continue
                         return self._error(
                             operation,
@@ -748,6 +796,7 @@ class TargetedWriterToolkit(OptimizationToolkitBase):
                     before_sha256=manifest.before_hashes.get(target.path),
                     after_sha256=manifest.after_hashes[target.path],
                     before_index=index,
+                    before_mode=_mode_or_none(root / target.path),
                 )
                 for index, target in enumerate(packet.targets)
             ],
@@ -841,7 +890,9 @@ class TargetedWriterToolkit(OptimizationToolkitBase):
                 if original is None:
                     await asyncio.to_thread(destination.unlink)
                 else:
-                    await asyncio.to_thread(_write_atomic, destination, original, _CREATE_MODE)
+                    # Restore the ORIGINAL mode: normalizing to 0644 would strip
+                    # an executable bit or widen a 0600 file.
+                    await asyncio.to_thread(_write_atomic, destination, original, entry.before_mode or _CREATE_MODE)
                 entry.state = "restored"
             except OSError:
                 entry.state = "unrecoverable"
@@ -1004,3 +1055,18 @@ def _write_atomic(path: Path, data: bytes, mode: int) -> None:
         with contextlib.suppress(FileNotFoundError):
             os.unlink(temp)
         raise
+
+
+def _mode_or_none(path: Path) -> Optional[int]:
+    """Return a file's permission bits, or None when it does not exist.
+
+    Args:
+        path: The file to stat.
+
+    Returns:
+        The mode bits, or None.
+    """
+    try:
+        return os.stat(path).st_mode & 0o777
+    except OSError:
+        return None

--- a/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/writer.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/writer.py
@@ -27,7 +27,9 @@ Provider satellites stay lazy: importing this module pulls in no AWS SDK.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
+import os
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -38,21 +40,35 @@ from pydantic import BaseModel
 
 from .base import OptimizationToolkitBase
 from .contracts import ContractError, ValidatedContract, render_prompt_sections, validate_contract
+from .git import LocalGitToolkit
 from .models import (
+    DelegationPacket,
     OperationResult,
     PatchManifest,
     WriterApplyArgs,
     WriterGenerateArgs,
     WriterLimits,
 )
-from .patches import ArtifactStore, PatchError, apply_in_memory, check_scope, normalize_patch, parse_patch
-from .policy import compact_json
-from .reader import stat_regular
+from .patches import (
+    ApplyJournal,
+    ArtifactStore,
+    JournalEntry,
+    PatchError,
+    apply_in_memory,
+    check_scope,
+    normalize_patch,
+    parse_patch,
+)
+from .policy import LockTimeoutError, WorktreeLock, compact_json
+from .reader import sha256_stream, stat_regular
 
 if TYPE_CHECKING:  # pragma: no cover — typing only, keeps provider imports lazy
     from parrot.clients.base import AbstractClient
 
 __all__ = ("SYSTEM_PROMPT", "TargetedWriterToolkit", "build_prompt", "build_repair_prompt")
+
+#: Default permissions for a newly created file.
+_CREATE_MODE = 0o644
 
 #: Instructions for the delegate. It implements decisions that are already
 #: made; it does not design, explore, or choose files.
@@ -475,6 +491,7 @@ class TargetedWriterToolkit(OptimizationToolkitBase):
         manifest = PatchManifest(
             artifact_id=artifact_id,
             task_id=contract.packet.task_id,
+            task_path=contract.task_path,
             packet_sha256=hashlib.sha256(packet_json.encode("utf-8")).hexdigest(),
             patch_sha256=hashlib.sha256(patch_text.encode("utf-8")).hexdigest(),
             before_hashes=dict(contract.targets_state),
@@ -513,11 +530,24 @@ class TargetedWriterToolkit(OptimizationToolkitBase):
         )
 
     # ----------------------------------------------------------------- #
-    # Application (TASK-3086)
+    # Application
     # ----------------------------------------------------------------- #
     @tool_schema(WriterApplyArgs)
     async def writer_apply(self, artifact_id: str, reviewed_sha256: str) -> OperationResult:
         """Apply a reviewed patch artifact to the worktree.
+
+        Every precondition is re-checked before anything is written: the
+        reviewed patch hash, the packet identity, the delegation contract,
+        the absence of staged targets, and each target's current revision.
+        Files are then replaced one at a time through adjacent temporary
+        files, with a recovery journal recording what was intended.
+
+        Multi-file mutation is not globally atomic. On failure, only files
+        that still match exactly what this operation wrote are restored; a
+        file a concurrent editor has touched is never overwritten, and the
+        operation reports ``recovery_required`` instead.
+
+        Applying never stages, commits or pushes anything.
 
         The ``confirm`` argument added over MCP records that a human approved
         this mutation; it is not authorization a model can grant itself.
@@ -527,12 +557,428 @@ class TargetedWriterToolkit(OptimizationToolkitBase):
             reviewed_sha256: The hash of the patch the caller actually read.
 
         Returns:
-            An operation result describing the application.
+            An operation result whose ``data`` carries ``applied``,
+            ``artifact_id`` and ``journal_path``, or ``already_applied``.
         """
         started = time.perf_counter()
-        return self._error(
-            "writer_apply",
-            "not_implemented",
-            "writer_apply is implemented by TASK-3086",
+        operation = "writer_apply"
+        try:
+            args = WriterApplyArgs(artifact_id=artifact_id, reviewed_sha256=reviewed_sha256)
+        except Exception as exc:  # pydantic ValidationError
+            return self._error(operation, "invalid_arguments", str(exc), started=started)
+
+        try:
+            manifest, patch_text, packet_json = self._store.load(args.artifact_id)
+        except PatchError as exc:
+            return self._error(operation, exc.code, str(exc), details=exc.details, started=started)
+
+        # The hash proves artifact identity — that the caller reviewed THIS
+        # patch. It is not, and cannot be, proof of semantic review.
+        if args.reviewed_sha256 != manifest.patch_sha256:
+            return self._error(
+                operation,
+                "review_hash_mismatch",
+                "the reviewed hash does not match the stored patch; read the patch and pass its hash",
+                details={"expected": manifest.patch_sha256, "supplied": args.reviewed_sha256},
+                started=started,
+            )
+
+        try:
+            packet = DelegationPacket.model_validate_json(packet_json)
+        except Exception as exc:  # pydantic ValidationError
+            return self._error(operation, "packet_mismatch", f"the stored packet is unusable: {exc}", started=started)
+        recomputed = hashlib.sha256(compact_json(packet.model_dump(mode="json")).encode("utf-8")).hexdigest()
+        if recomputed != manifest.packet_sha256:
+            return self._error(
+                operation,
+                "packet_mismatch",
+                "the stored packet does not round-trip to its recorded identity",
+                details={"expected": manifest.packet_sha256, "actual": recomputed},
+                started=started,
+            )
+
+        git = LocalGitToolkit(repo_root=self.policy.repo_root, policy=self.policy)
+        layout = await git._discover(operation, started)
+        if isinstance(layout, OperationResult):
+            return layout
+
+        try:
+            async with WorktreeLock(layout.lock_path, self.policy.command_timeout_seconds):
+                return await self._apply_locked(operation, git, manifest, packet, patch_text, started)
+        except LockTimeoutError as exc:
+            return self._error(operation, "worktree_busy", str(exc), started=started)
+
+    async def _apply_locked(
+        self,
+        operation: str,
+        git: LocalGitToolkit,
+        manifest: PatchManifest,
+        packet: DelegationPacket,
+        patch_text: str,
+        started: float,
+    ) -> OperationResult:
+        """Re-check every precondition, then write, under the worktree lock.
+
+        Args:
+            operation: The operation name.
+            git: A private Git toolkit used only to read staged names.
+            manifest: The artifact's manifest.
+            packet: The artifact's packet.
+            patch_text: The stored, normalized patch.
+            started: A ``perf_counter()`` reading taken at operation start.
+
+        Returns:
+            The bounded operation result.
+        """
+        root = self.policy.repo_root
+        artifact_id = manifest.artifact_id
+        targets = {target.path: target.action for target in packet.targets}
+
+        # Idempotent re-run: if every target already equals what this
+        # artifact produces, report that instead of re-writing.
+        current = await asyncio.to_thread(self._current_hashes, sorted(targets))
+        if all(current.get(path) == manifest.after_hashes.get(path) for path in targets):
+            return self._ok(
+                operation,
+                {"already_applied": True, "artifact_id": artifact_id, "applied": sorted(targets)},
+                started=started,
+            )
+
+        journal = self._store.read_journal(artifact_id)
+        if journal is not None and journal.state == "recovery_required":
+            return self._error(
+                operation,
+                "recovery_pending",
+                "a previous apply needs manual recovery; resolve it before retrying",
+                details={
+                    "journal_path": self._journal_path(artifact_id),
+                    "unrecoverable": [entry.path for entry in journal.entries if entry.state == "unrecoverable"],
+                },
+                started=started,
+            )
+
+        staged_step, staged_raw = await git._run_git(["diff", "--cached", "--name-only", "-z"])
+        if staged_step.exit_code != 0:
+            return self._error(operation, "status_failed", "could not read the staged file list", started=started)
+        staged = {item for item in staged_raw.decode("utf-8", "replace").split("\x00") if item}
+        conflicting = sorted(staged & set(targets))
+        if conflicting:
+            return self._error(
+                operation,
+                "staged_target",
+                "a target file is already staged; publish or unstage it yourself first",
+                details={"staged": conflicting},
+                started=started,
+            )
+
+        for path, action in sorted(targets.items()):
+            expected = manifest.before_hashes.get(path)
+            actual = current.get(path)
+            if action == "create" and actual is not None:
+                return self._error(
+                    operation,
+                    "create_collision",
+                    f"{path!r} was created since the patch was generated",
+                    details={"path": path},
+                    started=started,
+                )
+            if action == "modify" and actual != expected:
+                return self._error(
+                    operation,
+                    "target_changed",
+                    f"{path!r} changed since the patch was generated",
+                    details={"path": path, "expected": expected, "actual": actual},
+                    started=started,
+                )
+
+        try:
+            await validate_contract(self.policy, manifest.task_path, limits_override=self._limits)
+        except ContractError as exc:
+            return self._error(operation, exc.code, str(exc), details=exc.details, started=started)
+
+        try:
+            sources = await asyncio.to_thread(self._read_sources_for_packet, packet)
+            patches = parse_patch(patch_text, max_bytes=self._limits.max_patch_bytes)
+            check_scope(patches, targets)
+            after = apply_in_memory(patches, sources)
+        except PatchError as exc:
+            return self._error(operation, exc.code, str(exc), details=exc.details, started=started)
+        except OSError as exc:
+            return self._error(operation, "source_unreadable", str(exc), started=started)
+
+        for path, data in after.items():
+            digest = hashlib.sha256(data).hexdigest()
+            if digest != manifest.after_hashes.get(path):
+                return self._error(
+                    operation,
+                    "after_hash_mismatch",
+                    f"re-applying the patch to {path!r} no longer reproduces the recorded result",
+                    details={"path": path, "expected": manifest.after_hashes.get(path), "actual": digest},
+                    started=started,
+                )
+
+        journal = ApplyJournal(
+            artifact_id=artifact_id,
+            started_at=datetime.now(timezone.utc).isoformat(),
+            entries=[
+                JournalEntry(
+                    path=target.path,
+                    before_sha256=manifest.before_hashes.get(target.path),
+                    after_sha256=manifest.after_hashes[target.path],
+                    before_index=index,
+                )
+                for index, target in enumerate(packet.targets)
+            ],
+            state="pending",
+        )
+        for index, target in enumerate(packet.targets):
+            self._store.save_before(artifact_id, index, sources.get(target.path))
+        self._store.write_journal(artifact_id, journal)
+
+        created_dirs: list[Path] = []
+        try:
+            for index, target in enumerate(packet.targets):
+                destination = root / target.path
+                data = after[target.path]
+                if target.action == "create":
+                    mode = _CREATE_MODE
+                    if not destination.parent.exists():
+                        created_dirs.extend(_missing_parents(root, destination.parent))
+                        await asyncio.to_thread(destination.parent.mkdir, 0o755, True, True)
+                else:
+                    # Preserve the existing file's permissions across the replace.
+                    mode = os.stat(destination).st_mode & 0o777
+                await asyncio.to_thread(_write_atomic, destination, data, mode)
+                journal.entries[index].state = "written"
+                self._store.write_journal(artifact_id, journal)
+        except BaseException as exc:  # noqa: BLE001 — rollback then report
+            return await self._rollback(operation, journal, created_dirs, exc, started)
+
+        for entry in journal.entries:
+            digest = await asyncio.to_thread(_sha_or_none, root / entry.path)
+            if digest != entry.after_sha256:
+                return await self._rollback(
+                    operation,
+                    journal,
+                    created_dirs,
+                    PatchError("verification_failed", f"{entry.path!r} does not match the expected result"),
+                    started,
+                )
+            entry.state = "verified"
+        journal.state = "applied"
+        self._store.write_journal(artifact_id, journal)
+
+        self.logger.info("writer_apply applied artifact %s to %d file(s)", artifact_id, len(journal.entries))
+        return self._ok(
+            operation,
+            {
+                "applied": [entry.path for entry in journal.entries],
+                "artifact_id": artifact_id,
+                "journal_path": self._journal_path(artifact_id),
+                "already_applied": False,
+            },
             started=started,
         )
+
+    async def _rollback(
+        self,
+        operation: str,
+        journal: ApplyJournal,
+        created_dirs: list[Path],
+        error: BaseException,
+        started: float,
+    ) -> OperationResult:
+        """Restore only the files that still match exactly what we wrote.
+
+        A file a concurrent editor has since changed is left untouched and
+        marked unrecoverable — overwriting it would destroy their work.
+
+        Args:
+            operation: The operation name.
+            journal: The journal to update in place.
+            created_dirs: Directories this operation created, for cleanup.
+            error: The failure that triggered the rollback.
+            started: A ``perf_counter()`` reading taken at operation start.
+
+        Returns:
+            The bounded error result.
+        """
+        root = self.policy.repo_root
+        artifact_id = journal.artifact_id
+        for index in range(len(journal.entries) - 1, -1, -1):
+            entry = journal.entries[index]
+            if entry.state != "written":
+                continue
+            destination = root / entry.path
+            digest = await asyncio.to_thread(_sha_or_none, destination)
+            if digest != entry.after_sha256:
+                entry.state = "unrecoverable"
+                continue
+            original = self._store.load_before(artifact_id, entry.before_index)
+            try:
+                if original is None:
+                    await asyncio.to_thread(destination.unlink)
+                else:
+                    await asyncio.to_thread(_write_atomic, destination, original, _CREATE_MODE)
+                entry.state = "restored"
+            except OSError:
+                entry.state = "unrecoverable"
+
+        for directory in reversed(created_dirs):
+            with contextlib.suppress(OSError):
+                directory.rmdir()
+
+        unrecoverable = [entry.path for entry in journal.entries if entry.state == "unrecoverable"]
+        journal.state = "recovery_required" if unrecoverable else "rolled_back"
+        self._store.write_journal(artifact_id, journal)
+
+        if unrecoverable:
+            return self._error(
+                operation,
+                "recovery_required",
+                "the apply failed and some files could not be safely restored",
+                details={
+                    "unrecoverable": unrecoverable,
+                    "journal_path": self._journal_path(artifact_id),
+                    "cause": str(error),
+                },
+                started=started,
+            )
+        code = getattr(error, "code", None) or "write_failed"
+        return self._error(
+            operation,
+            code,
+            f"the apply failed and was rolled back: {error}",
+            details={"journal_path": self._journal_path(artifact_id), "errno": getattr(error, "errno", None)},
+            started=started,
+        )
+
+    def _current_hashes(self, paths: Sequence[str]) -> dict[str, Optional[str]]:
+        """Hash each path that currently exists.
+
+        Args:
+            paths: Repo-relative paths.
+
+        Returns:
+            Path -> digest, or None when the file is absent.
+        """
+        return {path: _sha_or_none(self.policy.repo_root / path) for path in paths}
+
+    def _read_sources_for_packet(self, packet: DelegationPacket) -> dict[str, Optional[bytes]]:
+        """Read the current bytes of every modify target in a packet.
+
+        Args:
+            packet: The delegation packet.
+
+        Returns:
+            Target path -> current bytes, or None for a create.
+        """
+        sources: dict[str, Optional[bytes]] = {}
+        for target in packet.targets:
+            if target.action == "create":
+                sources[target.path] = None
+                continue
+            path = self.policy.repo_root / target.path
+            size = stat_regular(path).size
+            with open(path, "rb") as handle:
+                sources[target.path] = handle.read(size + 1)
+        return sources
+
+    @staticmethod
+    def _journal_path(artifact_id: str) -> str:
+        """Return the repo-relative path of an artifact's journal."""
+        return f"artifacts/tool-optimizations/{artifact_id}/journal.json"
+
+    async def _recovery_report(self, artifact_id: str) -> OperationResult:
+        """Report an artifact's journal state (not exposed as a tool).
+
+        Args:
+            artifact_id: The artifact identifier.
+
+        Returns:
+            An operation result describing each journal entry.
+        """
+        started = time.perf_counter()
+        operation = "recovery_report"
+        try:
+            journal = self._store.read_journal(artifact_id)
+        except PatchError as exc:
+            return self._error(operation, exc.code, str(exc), started=started)
+        if journal is None:
+            return self._error(
+                operation, "no_journal", f"artifact {artifact_id!r} has never been applied", started=started
+            )
+        return self._ok(
+            operation,
+            {
+                "artifact_id": artifact_id,
+                "state": journal.state,
+                "journal_path": self._journal_path(artifact_id),
+                "entries": [{"path": entry.path, "state": entry.state} for entry in journal.entries],
+            },
+            started=started,
+        )
+
+
+def _sha_or_none(path: Path) -> Optional[str]:
+    """Return a file's SHA-256, or None when it does not exist.
+
+    Args:
+        path: The file to hash.
+
+    Returns:
+        The digest, or None.
+    """
+    try:
+        return sha256_stream(path, deadline_seconds=60)
+    except (FileNotFoundError, OSError):
+        return None
+
+
+def _missing_parents(root: Path, target: Path) -> list[Path]:
+    """List the directories that would have to be created under ``root``.
+
+    Args:
+        root: The repository root.
+        target: The deepest directory needed.
+
+    Returns:
+        The missing directories, outermost first.
+    """
+    missing: list[Path] = []
+    current = target
+    while current != root and root in current.parents and not current.exists():
+        missing.append(current)
+        current = current.parent
+    return list(reversed(missing))
+
+
+def _write_atomic(path: Path, data: bytes, mode: int) -> None:
+    """Replace ``path`` with ``data`` via an adjacent temporary file.
+
+    The temporary file is adjacent to the destination so the rename stays
+    within one filesystem, which is what makes the replacement atomic.
+
+    Args:
+        path: The destination file.
+        data: The bytes to write.
+        mode: Permission bits for the new file.
+
+    Raises:
+        OSError: The write or replacement failed; the temp file is removed.
+    """
+    temp = path.parent / f".{path.name}.parrot-tmp"
+    if temp.exists():
+        temp.unlink()
+    handle = os.open(temp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
+    try:
+        with os.fdopen(handle, "wb") as stream:
+            stream.write(data)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.chmod(temp, mode)
+        os.replace(temp, path)
+    except BaseException:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(temp)
+        raise

--- a/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/writer.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/writer.py
@@ -1,0 +1,538 @@
+"""Targeted patch generation for already-decided TASK work (FEAT-543).
+
+:class:`TargetedWriterToolkit` delegates *implementation*, never *design*.
+It accepts a TASK file whose ``## Delegation Contract`` proves the design is
+already complete, builds a bounded prompt from that packet alone, asks a
+configured :class:`~parrot.clients.base.AbstractClient` for a unified diff,
+validates the diff against the approved scope and the expected source bytes,
+and stores it as an artifact.
+
+Safety properties:
+
+* **No repository exploration and no design mode.** The delegate sees only
+  the packet, its approved reference slices and its decided implementation
+  blocks — never whole files and never host conversation history.
+* **An incomplete or stale contract costs zero model calls.** Validation
+  runs first; a `ContractError` returns to the thinking model unchanged.
+* **No silent model switching.** A client whose fallback model is enabled is
+  refused at construction, and a response reporting a substituted model
+  aborts the operation with no repair attempt.
+* **Generation never touches a target file.** The result is an artifact id
+  plus a patch path; the thinking model reviews the hunks with the bounded
+  reader and only then calls ``writer_apply``.
+
+Provider satellites stay lazy: importing this module pulls in no AWS SDK.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional, Sequence
+
+from parrot.tools.decorators import tool_schema
+from pydantic import BaseModel
+
+from .base import OptimizationToolkitBase
+from .contracts import ContractError, ValidatedContract, render_prompt_sections, validate_contract
+from .models import (
+    OperationResult,
+    PatchManifest,
+    WriterApplyArgs,
+    WriterGenerateArgs,
+    WriterLimits,
+)
+from .patches import ArtifactStore, PatchError, apply_in_memory, check_scope, normalize_patch, parse_patch
+from .policy import compact_json
+from .reader import stat_regular
+
+if TYPE_CHECKING:  # pragma: no cover — typing only, keeps provider imports lazy
+    from parrot.clients.base import AbstractClient
+
+__all__ = ("SYSTEM_PROMPT", "TargetedWriterToolkit", "build_prompt", "build_repair_prompt")
+
+#: Instructions for the delegate. It implements decisions that are already
+#: made; it does not design, explore, or choose files.
+SYSTEM_PROMPT = """You are a code-writing delegate operating under a strict contract.
+
+The design is ALREADY DECIDED. Your only job is to express the decided
+implementation as a unified diff. You must not design, explore, or improve
+anything.
+
+Rules:
+1. Output ONLY a unified diff. No prose, no explanation, no markdown fences,
+   no commentary before or after the diff.
+2. Use exactly this header form:
+       --- a/<path>
+       +++ b/<path>
+   and for a new file:
+       --- /dev/null
+       +++ b/<path>
+3. Patch ONLY the target paths listed in the packet. Never touch any other
+   file, for any reason.
+4. Where an implementation block is the complete content of a new file, use
+   it verbatim.
+5. Context lines must match the provided source excerpts EXACTLY, including
+   indentation and blank lines. There is no fuzzy matching.
+6. Never emit a deletion, rename, copy, mode change, binary payload or
+   submodule update. Only file creation and modification are supported.
+7. Never invent an API, import, or behaviour that is not already specified.
+   If something is genuinely underspecified, emit no diff at all.
+8. Never include shell commands, test invocations, or instructions."""
+
+
+def build_prompt(contract: ValidatedContract) -> str:
+    """Build the delegation prompt from approved content only.
+
+    Args:
+        contract: The validated contract.
+
+    Returns:
+        The prompt text: packet, references, implementation blocks and
+        acceptance criteria, and nothing else.
+    """
+    sections = render_prompt_sections(contract)
+    return "\n\n".join(
+        [
+            f"# Implement {contract.packet.task_id}",
+            sections["packet"],
+            sections["references"],
+            sections["blocks"],
+            sections["acceptance"],
+            "## Output\n\nReturn only the unified diff implementing the packet's targets.",
+        ]
+    )
+
+
+def build_repair_prompt(contract: ValidatedContract, previous_patch: str, error: PatchError) -> str:
+    """Build the single permitted repair prompt.
+
+    The delegate gets the same approved context plus a bounded diagnostic —
+    never additional repository content, and never a second chance at a
+    contract that was itself invalid.
+
+    Args:
+        contract: The validated contract.
+        previous_patch: The rejected patch text.
+        error: The rejection.
+
+    Returns:
+        The repair prompt text.
+    """
+    excerpt = previous_patch[:2000]
+    return "\n\n".join(
+        [
+            build_prompt(contract),
+            "## Your previous attempt was rejected",
+            f"Rejection code: {error.code}",
+            f"Details: {compact_json(error.details)}",
+            "Rejected output (truncated):\n\n```\n" + excerpt + "\n```",
+            "Return a corrected unified diff. Output only the diff.",
+        ]
+    )
+
+
+class TargetedWriterToolkit(OptimizationToolkitBase):
+    """Generate and apply validated patches for already-decided TASK work.
+
+    Example:
+        >>> toolkit = TargetedWriterToolkit(repo_root="/repo", llm_client=client)
+        >>> result = await toolkit.writer_generate("sdd/tasks/active/TASK-1-x.md")
+        >>> result.data["artifact_id"]
+        '...'
+    """
+
+    arg_models: dict[str, type[BaseModel]] = {
+        "writer_generate": WriterGenerateArgs,
+        "writer_apply": WriterApplyArgs,
+    }
+
+    #: Only generation needs a model; a server configured without `llm:`
+    #: exposes `writer_apply` alone.
+    llm_dependent_tools: frozenset = frozenset({"writer_generate"})
+
+    #: Applying mutates the worktree and therefore requires host approval.
+    confirming_tools: frozenset = frozenset({"writer_apply"})
+
+    #: Acquire the client lazily on first use, and release it deterministically.
+    auto_open: bool = True
+
+    def __init__(
+        self,
+        *,
+        repo_root: str | Path,
+        llm_client: Optional["AbstractClient"] = None,
+        limits: Optional[WriterLimits] = None,
+        expected_model_ids: Sequence[str] = (),
+        owns_client: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the toolkit and refuse a client that may switch models.
+
+        Args:
+            repo_root: The repository checkout this toolkit is confined to.
+            llm_client: The configured client, injected by MCP config.
+            limits: Budgets for one generation.
+            expected_model_ids: Additional model identities the provider may
+                legitimately report (e.g. Bedrock's translated model id).
+            owns_client: When True, this toolkit opens and closes the client.
+            **kwargs: Policy overrides and toolkit keyword arguments.
+
+        Raises:
+            ValueError: The client permits a fallback model, which would let
+                the provider silently answer with a different model.
+        """
+        super().__init__(repo_root=repo_root, **kwargs)
+        fallback = getattr(llm_client, "_fallback_model", None) if llm_client is not None else None
+        if fallback:
+            raise ValueError(
+                "TargetedWriterToolkit requires a client with fallback disabled "
+                "(configure llm_kwargs: {fallback_model: null}); "
+                f"got fallback_model={fallback!r}"
+            )
+        self._client = llm_client
+        self._owns_client = bool(owns_client and llm_client is not None)
+        self._limits = limits or WriterLimits()
+        self._expected_models = tuple(expected_model_ids)
+        self._client_lock = asyncio.Lock()
+        self._store = ArtifactStore(self.policy.repo_root)
+
+    # ----------------------------------------------------------------- #
+    # Lifecycle
+    # ----------------------------------------------------------------- #
+    async def _open(self) -> None:
+        """Enter the client's context so its resources are acquired once."""
+        if self._owns_client and self._client is not None:
+            await self._client.__aenter__()
+
+    async def _close(self) -> None:
+        """Release the client's resources; MCP shutdown is not assumed to."""
+        try:
+            if self._owns_client and self._client is not None:
+                await self._client.__aexit__(None, None, None)
+                await self._client.close()
+        finally:
+            await super()._close()
+
+    # ----------------------------------------------------------------- #
+    # Generation
+    # ----------------------------------------------------------------- #
+    @tool_schema(WriterGenerateArgs)
+    async def writer_generate(self, task_path: str) -> OperationResult:
+        """Generate a reviewed-patch artifact for an eligible TASK file.
+
+        Validates the TASK's delegation contract, calls the configured model
+        with no tools and no history, validates the returned unified diff
+        against the approved scope and current source bytes, and stores it.
+        **No target file is modified.** The result carries an artifact id and
+        a patch path for the thinking model to review before applying.
+
+        Args:
+            task_path: Repository-relative path of the TASK file.
+
+        Returns:
+            An operation result whose ``data`` carries ``artifact_id``,
+            ``patch_path``, ``patch_sha256``, ``targets``, ``usage``,
+            ``repairs``, ``configured_model`` and ``actual_model``.
+        """
+        started = time.perf_counter()
+        operation = "writer_generate"
+        try:
+            args = WriterGenerateArgs(task_path=task_path)
+        except Exception as exc:  # pydantic ValidationError
+            return self._error(operation, "invalid_arguments", str(exc), started=started)
+
+        if self._client is None:
+            return self._error(
+                operation, "no_client", "this toolkit was configured without a model client", started=started
+            )
+
+        try:
+            contract = await validate_contract(self.policy, args.task_path, limits_override=self._limits)
+        except ContractError as exc:
+            # No model call has happened, and none will.
+            return self._error(operation, exc.code, str(exc), details=exc.details, started=started)
+
+        allowed = {target.path: target.action for target in contract.packet.targets}
+        try:
+            sources = await asyncio.to_thread(self._read_sources, contract)
+        except OSError as exc:
+            return self._error(operation, "source_unreadable", str(exc), started=started)
+
+        try:
+            return await self._generate_locked(contract, allowed, sources, started)
+        except (TimeoutError, asyncio.TimeoutError):
+            return self._error(
+                operation,
+                "deadline_exceeded",
+                f"generation exceeded {self._limits.generation_deadline_seconds}s",
+                details={"deadline_seconds": self._limits.generation_deadline_seconds},
+                started=started,
+            )
+
+    def _read_sources(self, contract: ValidatedContract) -> dict[str, Optional[bytes]]:
+        """Read the current bytes of every modify target.
+
+        The size is taken from an already-verified stat, and one extra byte
+        is requested so a file that grew mid-read is detected rather than
+        silently truncated.
+
+        Args:
+            contract: The validated contract.
+
+        Returns:
+            Target path -> current bytes, or None for a create.
+
+        Raises:
+            OSError: A target could not be read.
+        """
+        sources: dict[str, Optional[bytes]] = {}
+        for target in contract.packet.targets:
+            if target.action == "create":
+                sources[target.path] = None
+                continue
+            path = self.policy.repo_root / target.path
+            size = stat_regular(path).size
+            with open(path, "rb") as handle:
+                sources[target.path] = handle.read(size + 1)
+        return sources
+
+    async def _generate_locked(
+        self,
+        contract: ValidatedContract,
+        allowed: dict[str, str],
+        sources: dict[str, Optional[bytes]],
+        started: float,
+    ) -> OperationResult:
+        """Run the model attempts under the lock and the overall deadline.
+
+        Args:
+            contract: The validated contract.
+            allowed: Approved path -> create/modify.
+            sources: Current bytes per target.
+            started: A ``perf_counter()`` reading taken at operation start.
+
+        Returns:
+            The bounded operation result.
+        """
+        operation = "writer_generate"
+        limits = self._limits
+        configured_model = str(getattr(self._client, "model", "") or "")
+        usage_total = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+        saw_usage = False
+        actual_model: Optional[str] = None
+        prompt = build_prompt(contract)
+        if len(prompt.encode("utf-8")) > limits.max_context_bytes:
+            return self._error(
+                operation,
+                "context_budget_exceeded",
+                "the rendered prompt exceeds the configured context budget",
+                details={"bytes": len(prompt.encode("utf-8")), "max_context_bytes": limits.max_context_bytes},
+                started=started,
+            )
+
+        repairs = 0
+        async with self._client_lock:
+            async with asyncio.timeout(limits.generation_deadline_seconds):
+                while True:
+                    message = await self._client.ask(
+                        prompt=prompt,
+                        system_prompt=SYSTEM_PROMPT,
+                        max_tokens=limits.max_output_tokens,
+                        temperature=0.0,
+                        use_tools=False,
+                        history=None,
+                    )
+
+                    metadata = getattr(message, "metadata", None) or {}
+                    usage = getattr(message, "usage", None)
+                    if usage is not None:
+                        for field in usage_total:
+                            value = getattr(usage, field, None)
+                            if value:
+                                usage_total[field] += int(value)
+                                saw_usage = True
+                    actual_model = getattr(message, "model", None)
+
+                    if metadata.get("used_fallback_model"):
+                        return self._error(
+                            operation,
+                            "model_substituted",
+                            "the provider answered with a fallback model",
+                            details={"configured": configured_model, "actual": actual_model},
+                            started=started,
+                        )
+                    if self._expected_models and actual_model not in {configured_model, *self._expected_models}:
+                        return self._error(
+                            operation,
+                            "model_substituted",
+                            "the provider reported an unexpected model identity",
+                            details={"configured": configured_model, "actual": actual_model},
+                            started=started,
+                        )
+                    if metadata.get("tool_calls"):
+                        return self._error(
+                            operation, "unexpected_tool_call", "the delegate attempted a tool call", started=started
+                        )
+
+                    text = self._response_text(message)
+                    if text is None:
+                        return self._error(
+                            operation,
+                            "unexpected_tool_call",
+                            "the delegate returned a structured response instead of a patch",
+                            started=started,
+                        )
+
+                    try:
+                        normalized = normalize_patch(text)
+                        patches = parse_patch(normalized, max_bytes=limits.max_patch_bytes)
+                        check_scope(patches, allowed)
+                        after = apply_in_memory(patches, sources)
+                        break
+                    except PatchError as exc:
+                        if repairs < limits.max_repairs:
+                            repairs += 1
+                            prompt = build_repair_prompt(contract, text, exc)
+                            continue
+                        return self._error(
+                            operation,
+                            exc.code,
+                            str(exc),
+                            details={**exc.details, "repairs": repairs},
+                            started=started,
+                        )
+
+        recorded_usage: dict[str, Optional[int]] = (
+            {field: value for field, value in usage_total.items()}
+            if saw_usage
+            else {field: None for field in usage_total}
+        )
+        return self._store_artifact(
+            contract=contract,
+            patch_text=normalized,
+            after=after,
+            allowed=allowed,
+            configured_model=configured_model,
+            actual_model=actual_model,
+            usage=recorded_usage,
+            repairs=repairs,
+            started=started,
+        )
+
+    @staticmethod
+    def _response_text(message: Any) -> Optional[str]:
+        """Extract patch text from a model response.
+
+        Args:
+            message: The provider's response object.
+
+        Returns:
+            The text, or None when the response was not plain text.
+        """
+        response = getattr(message, "response", None)
+        if isinstance(response, str) and response:
+            return response
+        output = getattr(message, "output", None)
+        if isinstance(output, str):
+            return output
+        return None
+
+    def _store_artifact(
+        self,
+        *,
+        contract: ValidatedContract,
+        patch_text: str,
+        after: dict[str, bytes],
+        allowed: dict[str, str],
+        configured_model: str,
+        actual_model: Optional[str],
+        usage: dict[str, Optional[int]],
+        repairs: int,
+        started: float,
+    ) -> OperationResult:
+        """Persist the validated patch and return its manifest summary.
+
+        Args:
+            contract: The validated contract.
+            patch_text: The normalized, validated patch.
+            after: Path -> resulting bytes, from the in-memory application.
+            allowed: Approved path -> create/modify.
+            configured_model: The model identity configuration requested.
+            actual_model: The model identity the provider reported.
+            usage: Recorded token usage; None means the provider reported none.
+            repairs: How many repair calls were consumed.
+            started: A ``perf_counter()`` reading taken at operation start.
+
+        Returns:
+            The bounded operation result.
+        """
+        artifact_id = self._store.new_id()
+        packet_json = compact_json(contract.packet.model_dump(mode="json"))
+        manifest = PatchManifest(
+            artifact_id=artifact_id,
+            task_id=contract.packet.task_id,
+            packet_sha256=hashlib.sha256(packet_json.encode("utf-8")).hexdigest(),
+            patch_sha256=hashlib.sha256(patch_text.encode("utf-8")).hexdigest(),
+            before_hashes=dict(contract.targets_state),
+            after_hashes={path: hashlib.sha256(data).hexdigest() for path, data in after.items()},
+            allowed_paths=sorted(allowed),
+            configured_model=configured_model or "unknown",
+            actual_model=actual_model,
+            used_fallback=False,
+            usage=usage,
+            repairs=repairs,
+            elapsed_ms=self._elapsed_ms(started),
+            validation_state="validated",
+            created_at=datetime.now(timezone.utc).isoformat(),
+        )
+        self._store.write_generation(artifact_id, manifest=manifest, patch_text=patch_text, packet_json=packet_json)
+        self.logger.info(
+            "writer_generate produced artifact %s for %s (model=%s, repairs=%d)",
+            artifact_id,
+            contract.packet.task_id,
+            actual_model,
+            repairs,
+        )
+        return self._ok(
+            "writer_generate",
+            {
+                "artifact_id": artifact_id,
+                "patch_path": f"artifacts/tool-optimizations/{artifact_id}/patch.diff",
+                "patch_sha256": manifest.patch_sha256,
+                "targets": sorted(allowed),
+                "usage": usage,
+                "repairs": repairs,
+                "configured_model": manifest.configured_model,
+                "actual_model": actual_model,
+            },
+            started=started,
+        )
+
+    # ----------------------------------------------------------------- #
+    # Application (TASK-3086)
+    # ----------------------------------------------------------------- #
+    @tool_schema(WriterApplyArgs)
+    async def writer_apply(self, artifact_id: str, reviewed_sha256: str) -> OperationResult:
+        """Apply a reviewed patch artifact to the worktree.
+
+        The ``confirm`` argument added over MCP records that a human approved
+        this mutation; it is not authorization a model can grant itself.
+
+        Args:
+            artifact_id: The artifact returned by ``writer_generate``.
+            reviewed_sha256: The hash of the patch the caller actually read.
+
+        Returns:
+            An operation result describing the application.
+        """
+        started = time.perf_counter()
+        return self._error(
+            "writer_apply",
+            "not_implemented",
+            "writer_apply is implemented by TASK-3086",
+            started=started,
+        )

--- a/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/writer.py
+++ b/packages/ai-parrot-tools/src/parrot_tools/tool_optimizations/writer.py
@@ -660,6 +660,15 @@ class TargetedWriterToolkit(OptimizationToolkitBase):
         staged_step, staged_raw = await git._run_git(["diff", "--cached", "--name-only", "-z"])
         if staged_step.exit_code != 0:
             return self._error(operation, "status_failed", "could not read the staged file list", started=started)
+        if staged_step.truncated:
+            # A clipped list could omit a genuinely conflicting staged target,
+            # so it must not be read as "nothing is staged".
+            return self._error(
+                operation,
+                "status_failed",
+                "the staged file list was truncated; cannot prove no target is staged",
+                started=started,
+            )
         staged = {item for item in staged_raw.decode("utf-8", "replace").split("\x00") if item}
         conflicting = sorted(staged & set(targets))
         if conflicting:
@@ -692,9 +701,22 @@ class TargetedWriterToolkit(OptimizationToolkitBase):
                 )
 
         try:
-            await validate_contract(self.policy, manifest.task_path, limits_override=self._limits)
+            revalidated = await validate_contract(self.policy, manifest.task_path, limits_override=self._limits)
         except ContractError as exc:
             return self._error(operation, exc.code, str(exc), details=exc.details, started=started)
+
+        # Re-validating proves the TASK is still *valid*; this proves it is
+        # still the *same* contract this artifact was generated and reviewed
+        # from. Without it, a TASK edited between review and apply (different
+        # targets, different decided code) would sail through.
+        if revalidated.packet_sha256 != manifest.packet_sha256:
+            return self._error(
+                operation,
+                "packet_mismatch",
+                "the TASK file changed since this patch was generated; regenerate it",
+                details={"expected": manifest.packet_sha256, "actual": revalidated.packet_sha256},
+                started=started,
+            )
 
         try:
             sources = await asyncio.to_thread(self._read_sources_for_packet, packet)
@@ -807,7 +829,7 @@ class TargetedWriterToolkit(OptimizationToolkitBase):
         artifact_id = journal.artifact_id
         for index in range(len(journal.entries) - 1, -1, -1):
             entry = journal.entries[index]
-            if entry.state != "written":
+            if entry.state not in ("written", "verified"):
                 continue
             destination = root / entry.path
             digest = await asyncio.to_thread(_sha_or_none, destination)

--- a/packages/ai-parrot-tools/tests/tool_optimizations/conftest.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/conftest.py
@@ -1,0 +1,73 @@
+"""Deterministic Git fixtures for the tool-optimizations tests (FEAT-543).
+
+Every repository is created with pinned identity, pinned dates and no
+signing, so commit shas are stable and the suite never touches the
+developer's global Git configuration.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+#: Environment used for every fixture Git command. Global/system config are
+#: neutralized so a developer's settings cannot change fixture behavior.
+ENV = {
+    **os.environ,
+    "GIT_AUTHOR_DATE": "2026-01-01T00:00:00Z",
+    "GIT_COMMITTER_DATE": "2026-01-01T00:00:00Z",
+    "GIT_AUTHOR_NAME": "t",
+    "GIT_AUTHOR_EMAIL": "t@example.com",
+    "GIT_COMMITTER_NAME": "t",
+    "GIT_COMMITTER_EMAIL": "t@example.com",
+    "GIT_CONFIG_GLOBAL": "/dev/null",
+    "GIT_CONFIG_SYSTEM": "/dev/null",
+    "LC_ALL": "C",
+    "LANG": "C",
+}
+
+
+def git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    """Run a Git command in ``cwd`` with the deterministic fixture environment.
+
+    Args:
+        cwd: Working directory for the command.
+        *args: Git arguments, without the leading ``git``.
+        check: Raise on a non-zero exit code.
+
+    Returns:
+        The completed process.
+    """
+    return subprocess.run(["git", *args], cwd=cwd, env=ENV, capture_output=True, text=True, check=check)
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    """A repository on branch ``dev`` with a single commit."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git(repo, "init", "-q", "-b", "dev")
+    git(repo, "config", "commit.gpgsign", "false")
+    (repo / "a.py").write_text("print('a')\n")
+    git(repo, "add", "a.py")
+    git(repo, "commit", "-q", "-m", "init")
+    return repo
+
+
+@pytest.fixture
+def bare_remote(git_repo: Path, tmp_path: Path) -> Path:
+    """A local bare remote registered as ``origin`` with ``dev`` pushed."""
+    remote = tmp_path / "remote.git"
+    git(tmp_path, "init", "-q", "--bare", str(remote))
+    git(git_repo, "remote", "add", "origin", str(remote))
+    git(git_repo, "push", "-q", "origin", "dev")
+    return remote
+
+
+@pytest.fixture
+def linked_worktree(git_repo: Path, tmp_path: Path) -> Path:
+    """A linked worktree of ``git_repo`` (its ``.git`` is a file, not a dir)."""
+    worktree = tmp_path / "wt"
+    git(git_repo, "worktree", "add", "-q", "-b", "feat", str(worktree))
+    return worktree

--- a/packages/ai-parrot-tools/tests/tool_optimizations/fixtures.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/fixtures.py
@@ -1,0 +1,120 @@
+"""Shared TASK-file fixtures for the delegation-contract tests (FEAT-543).
+
+`make_valid_task` produces the canonical COMPLETE eligible TASK file used by
+TASK-3083, TASK-3085 and TASK-3090, with real SHA-256 digests computed from
+the repository the fixture just built — so it stays valid rather than
+carrying hard-coded hashes that rot.
+"""
+
+import hashlib
+import json
+from pathlib import Path
+
+__all__ = ("make_repo_with_target", "make_valid_task", "sha256_of", "PACKET_TASK_ID")
+
+#: The task id used by the canonical fixture packet.
+PACKET_TASK_ID = "TASK-9999"
+
+
+def sha256_of(path: Path) -> str:
+    """Return the lowercase hex SHA-256 of a file's bytes.
+
+    Args:
+        path: The file to hash.
+
+    Returns:
+        The digest.
+    """
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def make_repo_with_target(tmp_path: Path) -> Path:
+    """Create a small repository with one existing package module.
+
+    Args:
+        tmp_path: The pytest temporary directory.
+
+    Returns:
+        The repository root.
+    """
+    repo = tmp_path / "repo"
+    (repo / "pkg").mkdir(parents=True)
+    (repo / "sdd" / "tasks" / "active").mkdir(parents=True)
+    (repo / "pkg" / "__init__.py").write_text('"""Package."""\n\n__all__ = []\n')
+    return repo
+
+
+def make_valid_task(repo: Path, *, name: str = "TASK-9999-greeter.md") -> Path:
+    """Write a complete, eligible TASK file into ``repo``.
+
+    Args:
+        repo: The repository root created by :func:`make_repo_with_target`.
+        name: The TASK file name.
+
+    Returns:
+        The absolute path of the written TASK file.
+    """
+    init_sha = sha256_of(repo / "pkg" / "__init__.py")
+    packet = {
+        "schema_version": 1,
+        "task_id": PACKET_TASK_ID,
+        "spec_path": "sdd/specs/example.spec.md",
+        "design_complete": True,
+        "targets": [
+            {
+                "path": "pkg/greeter.py",
+                "action": "create",
+                "expected_sha256": None,
+                "planned_changes": "New module with greet()",
+                "blocks": ["impl-greeter"],
+            },
+            {
+                "path": "pkg/__init__.py",
+                "action": "modify",
+                "expected_sha256": init_sha,
+                "planned_changes": "Export greet",
+                "blocks": ["impl-init"],
+            },
+        ],
+        "references": [
+            {
+                "path": "pkg/__init__.py",
+                "sha256": init_sha,
+                "start_line": 1,
+                "end_line": 3,
+                "purpose": "existing exports",
+            }
+        ],
+        "implementation_blocks": ["impl-greeter", "impl-init"],
+        "acceptance_criteria": ["pytest tests/test_greeter.py passes"],
+        "validation_commands": [["pytest", "tests/test_greeter.py", "-q"]],
+    }
+
+    body = f"""# {PACKET_TASK_ID}: Add a greeter
+
+Some prose that is not part of the contract.
+
+## Delegation Contract
+
+```json
+{json.dumps(packet, indent=2)}
+```
+
+## Implementation
+
+```python id=impl-greeter path=pkg/greeter.py
+def greet(name: str) -> str:
+    \"\"\"Return a greeting.\"\"\"
+    return f"hello {{name}}"
+```
+
+```python id=impl-init
+# Apply to pkg/__init__.py: add after the existing imports
+from .greeter import greet
+
+__all__ = [*__all__, "greet"]
+```
+"""
+    task = repo / "sdd" / "tasks" / "active" / name
+    task.write_text(body)
+    return task

--- a/packages/ai-parrot-tools/tests/tool_optimizations/fixtures.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/fixtures.py
@@ -10,7 +10,7 @@ import hashlib
 import json
 from pathlib import Path
 
-__all__ = ("make_repo_with_target", "make_valid_task", "sha256_of", "PACKET_TASK_ID")
+__all__ = ("make_repo_with_target", "make_valid_task", "sha256_of", "PACKET_TASK_ID", "GOOD_PATCH")
 
 #: The task id used by the canonical fixture packet.
 PACKET_TASK_ID = "TASK-9999"
@@ -118,3 +118,24 @@ __all__ = [*__all__, "greet"]
     task = repo / "sdd" / "tasks" / "active" / name
     task.write_text(body)
     return task
+
+
+#: A correct unified diff for the `make_valid_task` packet: it creates
+#: `pkg/greeter.py` from /dev/null and modifies `pkg/__init__.py` in place.
+#: Its context lines match `make_repo_with_target` exactly, so it applies
+#: cleanly with zero fuzz.
+GOOD_PATCH = """--- a/pkg/__init__.py
++++ b/pkg/__init__.py
+@@ -1,3 +1,5 @@
+ \"\"\"Package.\"\"\"
+ 
++from .greeter import greet
++
+ __all__ = []
+--- /dev/null
++++ b/pkg/greeter.py
+@@ -0,0 +1,3 @@
++def greet(name: str) -> str:
++    \"\"\"Return a greeting.\"\"\"
++    return f"hello {name}"
+"""

--- a/packages/ai-parrot-tools/tests/tool_optimizations/integration/conftest.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/integration/conftest.py
@@ -1,0 +1,146 @@
+"""Fixtures for the FEAT-543 integration suite.
+
+These tests exercise the whole path a host actually uses:
+``parrot mcp-local <name>`` -> ``create_toolkit_mcp_server`` ->
+``StdioMCPServer`` -> ``MCPToolAdapter`` -> toolkit.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+#: integration -> tool_optimizations -> tests -> ai-parrot-tools -> packages -> repo root
+REPO_ROOT = Path(__file__).resolve().parents[5]
+CORE_SRC = REPO_ROOT / "packages" / "ai-parrot" / "src"
+TOOLS_SRC = REPO_ROOT / "packages" / "ai-parrot-tools" / "src"
+ARTIFACT_LOGS = REPO_ROOT / "artifacts" / "logs"
+
+#: Bootstrap used to run `parrot ...` in a subprocess, mirroring
+#: tests/mcp/test_mcp_local_e2e.py but with the tools package on sys.path.
+BOOTSTRAP = textwrap.dedent(f"""
+    import sys, types
+    sys.path.insert(0, {str(CORE_SRC)!r})
+    sys.path.insert(0, {str(TOOLS_SRC)!r})
+
+    try:
+        import parrot.utils.types  # noqa: F401
+    except ImportError:
+        _m = types.ModuleType("parrot.utils.types")
+        class SafeDict(dict):
+            def __missing__(self, key):
+                return None
+        _m.SafeDict = SafeDict
+        sys.modules["parrot.utils.types"] = _m
+
+    try:
+        import parrot.utils.parsers.toml  # noqa: F401
+    except ImportError:
+        _pkg = types.ModuleType("parrot.utils.parsers")
+        _mod = types.ModuleType("parrot.utils.parsers.toml")
+        class TOMLParser:
+            def __init__(self, *a, **kw):
+                pass
+            def parse(self, content):
+                import tomllib
+                return tomllib.loads(content)
+        _mod.TOMLParser = TOMLParser
+        _pkg.TOMLParser = TOMLParser
+        sys.modules["parrot.utils.parsers"] = _pkg
+        sys.modules["parrot.utils.parsers.toml"] = _mod
+
+    from parrot.cli import cli
+    cli(prog_name="parrot")
+    """)
+
+GIT_ENV = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "t",
+    "GIT_AUTHOR_EMAIL": "t@example.com",
+    "GIT_COMMITTER_NAME": "t",
+    "GIT_COMMITTER_EMAIL": "t@example.com",
+    "GIT_CONFIG_GLOBAL": "/dev/null",
+    "GIT_CONFIG_SYSTEM": "/dev/null",
+    "LC_ALL": "C",
+    "LANG": "C",
+}
+
+
+def git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    """Run a git command with the deterministic fixture environment."""
+    return subprocess.run(["git", *args], cwd=cwd, env=GIT_ENV, capture_output=True, text=True, check=check)
+
+
+def worker_env() -> dict:
+    """Environment giving a subprocess access to the worktree's packages."""
+    env = dict(os.environ)
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = os.pathsep.join([str(CORE_SRC), str(TOOLS_SRC), existing]).rstrip(os.pathsep)
+    return env
+
+
+def write_toolkits_yaml(repo: Path) -> Path:
+    """Write a .parrot/mcp-toolkits.yaml exposing the three toolkits."""
+    config = repo / ".parrot" / "mcp-toolkits.yaml"
+    config.parent.mkdir(parents=True, exist_ok=True)
+    config.write_text(
+        "toolkits:\n"
+        "  local-git:\n"
+        "    class: parrot_tools.tool_optimizations.git.LocalGitToolkit\n"
+        "    kwargs:\n"
+        f"      repo_root: {repo}\n"
+        "  bounded-source:\n"
+        "    class: parrot_tools.tool_optimizations.reader.BoundedSourceToolkit\n"
+        "    kwargs:\n"
+        f"      repo_root: {repo}\n"
+        "  targeted-writer:\n"
+        "    class: parrot_tools.tool_optimizations.writer.TargetedWriterToolkit\n"
+        "    kwargs:\n"
+        f"      repo_root: {repo}\n"
+    )
+    return config
+
+
+@pytest.fixture
+def tmp_repo_with_yaml(tmp_path):
+    """A git repo with source files and an MCP toolkits config."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git(repo, "init", "-q", "-b", "dev")
+    git(repo, "config", "commit.gpgsign", "false")
+    (repo / "a.py").write_text("print('a')\n")
+    (repo / "big.py").write_text("".join(f"line{i}\n" for i in range(1, 401)))
+    git(repo, "add", "a.py", "big.py")
+    git(repo, "commit", "-q", "-m", "base")
+    return repo, write_toolkits_yaml(repo)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def evidence_log():
+    """Create the evidence log directory for this task's artefacts."""
+    ARTIFACT_LOGS.mkdir(parents=True, exist_ok=True)
+    log = ARTIFACT_LOGS / "TASK-3091-integration.log"
+    with log.open("a", encoding="utf-8") as handle:
+        handle.write(f"\n=== integration run {datetime.now(timezone.utc).isoformat()} ===\n")
+    return log
+
+
+@pytest.fixture(autouse=True)
+def record_outcome(request, evidence_log):
+    """Append each test's name to the evidence log."""
+    yield
+    with evidence_log.open("a", encoding="utf-8") as handle:
+        handle.write(f"{request.node.nodeid}\n")
+
+
+def record_json(name: str, payload: dict) -> Path:
+    """Write a JSON evidence artefact under artifacts/logs."""
+    ARTIFACT_LOGS.mkdir(parents=True, exist_ok=True)
+    target = ARTIFACT_LOGS / name
+    target.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return target

--- a/packages/ai-parrot-tools/tests/tool_optimizations/integration/test_client_configuration.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/integration/test_client_configuration.py
@@ -1,0 +1,135 @@
+"""Client configuration reaching the writer (TASK-3091, FEAT-543)."""
+
+import os
+from pathlib import Path
+
+import pytest
+from parrot.mcp.toolkit_config import load_toolkits_config
+from parrot.mcp.toolkit_server import create_toolkit_mcp_server
+
+from .conftest import REPO_ROOT, record_json
+
+EXAMPLE = REPO_ROOT / "examples" / "tool-optimizations-mcp.yaml"
+
+
+def test_example_configuration_pins_the_bedrock_alias_and_no_fallback():
+    """The shipped example configures Qwen via Bedrock with fallback disabled."""
+    assert EXAMPLE.is_file()
+    config = load_toolkits_config(EXAMPLE.parent, config_path=EXAMPLE)
+    writer = config.toolkits["targeted-writer"]
+
+    assert writer.llm == "bedrock-converse:qwen3-coder-480b-a35b"
+    assert writer.llm_kwargs == {"fallback_model": None, "max_retries": 1, "read_timeout": 120}
+    assert writer.kwargs["expected_model_ids"] == ["qwen.qwen3-coder-480b-a35b-v1:0"]
+
+
+def test_factory_receives_the_configured_kwargs_and_constructor_gets_expected_models(tmp_path, monkeypatch):
+    """llm_kwargs reach LLMFactory.create; kwargs reach the toolkit constructor."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    config = repo / ".parrot" / "mcp-toolkits.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text(
+        "toolkits:\n"
+        "  targeted-writer:\n"
+        "    class: parrot_tools.tool_optimizations.writer.TargetedWriterToolkit\n"
+        "    llm: bedrock-converse:qwen3-coder-480b-a35b\n"
+        "    llm_kwargs:\n"
+        "      fallback_model: null\n"
+        "      max_retries: 1\n"
+        "      read_timeout: 120\n"
+        "    kwargs:\n"
+        f"      repo_root: {repo}\n"
+        '      expected_model_ids: ["qwen.qwen3-coder-480b-a35b-v1:0"]\n'
+    )
+
+    from parrot.clients.factory import LLMFactory
+
+    from ..test_writer import FakeClient
+
+    seen = {}
+
+    def _capture(llm, **kwargs):
+        seen["llm"] = llm
+        seen["kwargs"] = kwargs
+        # A client honouring `fallback_model: null` advertises no fallback.
+        return FakeClient([], fallback=kwargs.get("fallback_model"))
+
+    monkeypatch.setattr(LLMFactory, "create", staticmethod(_capture))
+    server = create_toolkit_mcp_server("targeted-writer", root=repo, config_path=config)
+
+    assert seen["llm"] == "bedrock-converse:qwen3-coder-480b-a35b"
+    assert seen["kwargs"] == {"fallback_model": None, "max_retries": 1, "read_timeout": 120}
+
+    toolkit = next(iter(server.tools.values())).tool.bound_method.__self__
+    assert toolkit._expected_models == ("qwen.qwen3-coder-480b-a35b-v1:0",)
+    assert {tool for tool in server.tools} == {"writer_apply", "writer_generate"}
+
+    record_json("TASK-3091-client-configuration.json", {"llm": seen["llm"], "llm_kwargs": seen["kwargs"]})
+
+
+def test_a_client_permitting_fallback_is_refused_at_construction(tmp_path, monkeypatch):
+    """Omitting `fallback_model: null` must fail loudly, not silently switch models."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    config = repo / ".parrot" / "mcp-toolkits.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text(
+        "toolkits:\n"
+        "  targeted-writer:\n"
+        "    class: parrot_tools.tool_optimizations.writer.TargetedWriterToolkit\n"
+        "    llm: bedrock-converse:qwen3-coder-480b-a35b\n"
+        "    kwargs:\n"
+        f"      repo_root: {repo}\n"
+    )
+
+    from parrot.clients.factory import LLMFactory
+
+    from ..test_writer import FakeClient
+
+    # Mimic BedrockConverseClient's class default when no explicit null is given.
+    monkeypatch.setattr(
+        LLMFactory, "create", staticmethod(lambda *a, **kw: FakeClient([], fallback="claude-haiku-4-5"))
+    )
+
+    with pytest.raises(Exception) as info:
+        create_toolkit_mcp_server("targeted-writer", root=repo, config_path=config)
+    assert "fallback" in str(info.value).lower()
+
+
+@pytest.mark.real_llm
+@pytest.mark.skipif(
+    os.environ.get("PARROT_TOOL_OPT_SMOKE") != "1",
+    reason="live Bedrock smoke test; set PARROT_TOOL_OPT_SMOKE=1 (and AWS credentials) to enable",
+)
+async def test_real_bedrock_writer_smoke(tmp_path):
+    """Opt-in smoke test against a real provider.
+
+    Asserts only that a validated artifact was produced — never that the
+    generated code is correct. Never runs in CI.
+    """
+    from parrot.clients.factory import LLMFactory
+    from parrot_tools.tool_optimizations.writer import TargetedWriterToolkit
+
+    from ..fixtures import make_repo_with_target, make_valid_task
+
+    repo = make_repo_with_target(tmp_path)
+    task = make_valid_task(repo)
+
+    client = LLMFactory.create("bedrock-converse:qwen3-coder-480b-a35b", fallback_model=None, max_retries=1)
+    toolkit = TargetedWriterToolkit(
+        repo_root=repo, llm_client=client, expected_model_ids=("qwen.qwen3-coder-480b-a35b-v1:0",)
+    )
+    async with toolkit._client_lock:
+        pass
+    await toolkit._open()
+    try:
+        result = await toolkit.writer_generate(task.relative_to(repo).as_posix())
+    finally:
+        await toolkit._close()
+
+    record_json(
+        "TASK-3091-real-llm-smoke.json",
+        {"status": result.status, "error": result.error.code if result.error else None, "data": result.data},
+    )
+    assert result.status in {"ok", "error"}

--- a/packages/ai-parrot-tools/tests/tool_optimizations/integration/test_cross_process.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/integration/test_cross_process.py
@@ -1,0 +1,153 @@
+"""Two-process contention on the same worktree (TASK-3091, FEAT-543).
+
+These are genuine OS processes, not threads: the worktree lock is
+`fcntl.flock`, which is per-open-file-description, so only real process
+separation exercises it.
+"""
+
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+from parrot_tools.tool_optimizations.writer import TargetedWriterToolkit
+
+from ..fixtures import GOOD_PATCH, make_repo_with_target, make_valid_task
+from ..test_writer import FakeClient
+from .conftest import git, record_json, worker_env
+
+PREPARE_WORKER = textwrap.dedent("""
+    import asyncio, json, sys, time
+    from pathlib import Path
+    from parrot_tools.tool_optimizations.git import LocalGitToolkit
+
+    repo, path, barrier = Path(sys.argv[1]), sys.argv[2], Path(sys.argv[3])
+    while not barrier.exists():
+        time.sleep(0.01)
+    result = asyncio.run(LocalGitToolkit(repo_root=repo).git_prepare_files([path]))
+    print(json.dumps({"status": result.status, "code": result.error.code if result.error else None}))
+    """)
+
+APPLY_WORKER = textwrap.dedent("""
+    import asyncio, json, sys, time
+    from pathlib import Path
+    from parrot_tools.tool_optimizations.writer import TargetedWriterToolkit
+
+    repo, artifact_id, sha, barrier = Path(sys.argv[1]), sys.argv[2], sys.argv[3], Path(sys.argv[4])
+    while not barrier.exists():
+        time.sleep(0.01)
+    result = asyncio.run(TargetedWriterToolkit(repo_root=repo).writer_apply(artifact_id, sha))
+    print(json.dumps({
+        "status": result.status,
+        "code": result.error.code if result.error else None,
+        "already": bool(result.data.get("already_applied")),
+    }))
+    """)
+
+
+def _run_pair(script, arg_sets, barrier):
+    """Start two workers, release the barrier, and collect their verdicts."""
+    processes = [
+        subprocess.Popen(
+            [sys.executable, "-c", script, *args],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=worker_env(),
+        )
+        for args in arg_sets
+    ]
+    barrier.write_text("go\n")
+    results = []
+    for process in processes:
+        stdout, stderr = process.communicate(timeout=120)
+        assert process.returncode == 0, f"worker crashed: {stderr[-2000:]}"
+        results.append(json.loads(stdout.strip().splitlines()[-1]))
+    return results
+
+
+def test_two_processes_staging_different_files_lose_nothing(tmp_path):
+    """Concurrent staging is serialized; neither update is lost."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git(repo, "init", "-q", "-b", "dev")
+    git(repo, "config", "commit.gpgsign", "false")
+    (repo / "seed.py").write_text("seed = 1\n")
+    git(repo, "add", "seed.py")
+    git(repo, "commit", "-q", "-m", "base")
+
+    (repo / "one.py").write_text("one = 1\n")
+    (repo / "two.py").write_text("two = 2\n")
+    barrier = tmp_path / "barrier"
+
+    results = _run_pair(
+        PREPARE_WORKER,
+        [[str(repo), "one.py", str(barrier)], [str(repo), "two.py", str(barrier)]],
+        barrier,
+    )
+
+    # The lock file is created and, crucially, never deleted by either process.
+    lock = repo / ".git" / "parrot-tool-optimizations.lock"
+    assert lock.exists(), "the advisory lock file must survive both processes"
+    # No stray git index lock is left behind either.
+    assert not (repo / ".git" / "index.lock").exists()
+
+    staged = [item for item in git(repo, "diff", "--cached", "--name-only", "-z").stdout.split("\0") if item]
+    outcomes = [result["status"] for result in results]
+
+    record_json(
+        "TASK-3091-cross-process-prepare.json",
+        {"results": results, "staged": staged, "lock_present": lock.exists()},
+    )
+
+    # Each worker either won outright or was refused by a *policy* rule
+    # (the other's staging is "unrelated" to its own selection). What must
+    # never happen is a corrupt index or a silent lost update.
+    assert all(outcome in {"ok", "error"} for outcome in outcomes)
+    winners = [name for name, result in zip(("one.py", "two.py"), results) if result["status"] == "ok"]
+    assert winners, f"at least one worker must succeed: {results}"
+    for winner in winners:
+        assert winner in staged, f"{winner} reported ok but is not staged — lost update"
+
+    # The index is still a valid git index.
+    assert git(repo, "status", "--porcelain=v2", check=True).returncode == 0
+
+
+def test_two_processes_applying_the_same_artifact(tmp_path):
+    """Concurrent applies never corrupt a file; the loser reports cleanly."""
+    import asyncio
+
+    repo = make_repo_with_target(tmp_path)
+    git(repo, "init", "-q", "-b", "dev")
+    git(repo, "config", "commit.gpgsign", "false")
+    git(repo, "add", ".")
+    git(repo, "commit", "-q", "-m", "base")
+    task = make_valid_task(repo)
+
+    writer = TargetedWriterToolkit(repo_root=repo, llm_client=FakeClient([GOOD_PATCH]))
+    generated = asyncio.run(writer.writer_generate(task.relative_to(repo).as_posix()))
+    assert generated.status == "ok", generated.error
+    artifact_id = generated.data["artifact_id"]
+    sha = generated.data["patch_sha256"]
+
+    barrier = tmp_path / "apply-barrier"
+    results = _run_pair(
+        APPLY_WORKER,
+        [[str(repo), artifact_id, sha, str(barrier)], [str(repo), artifact_id, sha, str(barrier)]],
+        barrier,
+    )
+    record_json("TASK-3091-cross-process-apply.json", {"results": results})
+
+    statuses = [result["status"] for result in results]
+    assert "ok" in statuses, f"one apply must succeed: {results}"
+
+    for result in results:
+        if result["status"] != "ok":
+            assert result["code"] in {"worktree_busy", "target_changed", "create_collision", "recovery_pending"}, result
+
+    # Exactly one applied write; the file content is correct and not doubled.
+    greeter = (repo / "pkg" / "greeter.py").read_text()
+    assert greeter == 'def greet(name: str) -> str:\n    """Return a greeting."""\n    return f"hello {name}"\n'
+    init_text = (repo / "pkg" / "__init__.py").read_text()
+    assert init_text.count("from .greeter import greet") == 1, "the modify hunk was applied twice"

--- a/packages/ai-parrot-tools/tests/tool_optimizations/integration/test_git_lifecycle.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/integration/test_git_lifecycle.py
@@ -1,0 +1,156 @@
+"""End-to-end Git lifecycle, main tree and linked worktree (TASK-3091)."""
+
+from pathlib import Path
+
+import pytest
+from parrot_tools.tool_optimizations.git import LocalGitToolkit
+
+from .conftest import git
+
+
+def _index_bytes(repo: Path) -> bytes:
+    """Read a worktree's own index bytes.
+
+    In a linked worktree `.git` is a *file* pointing at the real git dir,
+    so the main repo's index is not the one that changes.
+    """
+    dot_git = repo / ".git"
+    if dot_git.is_file():
+        gitdir = Path(dot_git.read_text().split("gitdir:", 1)[1].strip())
+        return (gitdir / "index").read_bytes()
+    return (dot_git / "index").read_bytes()
+
+
+@pytest.fixture
+def repo_with_remote(tmp_path):
+    """A repo on `dev` with a local bare remote and one commit pushed."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git(repo, "init", "-q", "-b", "dev")
+    git(repo, "config", "commit.gpgsign", "false")
+    (repo / "a.py").write_text("print('a')\n")
+    git(repo, "add", "a.py")
+    git(repo, "commit", "-q", "-m", "base")
+
+    remote = tmp_path / "remote.git"
+    git(tmp_path, "init", "-q", "--bare", str(remote))
+    git(repo, "remote", "add", "origin", str(remote))
+    git(repo, "push", "-q", "-u", "origin", "dev")
+    return repo, remote
+
+
+async def test_full_lifecycle_in_main_tree(repo_with_remote):
+    """fetch -> preflight -> prepare -> (test commits) -> push -> pull."""
+    repo, remote = repo_with_remote
+    toolkit = LocalGitToolkit(repo_root=repo)
+
+    fetched = await toolkit.git_fetch(remote="origin", branch="dev", recent=1)
+    assert fetched.status == "ok" and fetched.data["fresh"] is True
+
+    preflight = await toolkit.git_preflight()
+    assert preflight.status == "ok"
+    assert preflight.data["branch"] == "dev"
+
+    (repo / "b.py").write_text("b = 1\n")
+    prepared = await toolkit.git_prepare_files(["b.py"])
+    assert prepared.status == "ok", prepared.error
+    assert prepared.data["staged"] == ["b.py"]
+
+    # The toolkit never commits — the harness does.
+    git(repo, "commit", "-q", "-m", "add b")
+    head = git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    pushed = await toolkit.git_push(branch="dev")
+    assert pushed.status == "ok", pushed.error
+    assert git(remote, "rev-parse", "refs/heads/dev").stdout.strip() == head
+
+    pulled = await toolkit.git_pull()
+    assert pulled.status == "ok"
+    assert pulled.data["updated"] is False  # already up to date
+
+
+async def test_lifecycle_in_linked_worktree(repo_with_remote, tmp_path):
+    """A linked worktree stages into its own index, never the main one."""
+    repo, _remote = repo_with_remote
+    worktree = tmp_path / "wt"
+    git(repo, "worktree", "add", "-q", "-b", "feat", str(worktree))
+
+    main_index_before = _index_bytes(repo)
+    toolkit = LocalGitToolkit(repo_root=worktree)
+
+    layout = await toolkit._discover()
+    assert layout.is_linked_worktree is True
+
+    (worktree / "w.py").write_text("w = 1\n")
+    prepared = await toolkit.git_prepare_files(["w.py"])
+    assert prepared.status == "ok", prepared.error
+
+    staged = [item for item in git(worktree, "diff", "--cached", "--name-only", "-z").stdout.split("\0") if item]
+    assert staged == ["w.py"]
+    assert _index_bytes(repo) == main_index_before, "the main index must be untouched"
+
+
+async def test_injected_whitespace_failure_preserves_everything(repo_with_remote):
+    """A failing check leaves refs, files and index bytes byte-identical."""
+    repo, remote = repo_with_remote
+    toolkit = LocalGitToolkit(repo_root=repo)
+
+    (repo / "bad.py").write_text("x = 1 \n")  # trailing whitespace
+    index_before = _index_bytes(repo)
+    head_before = git(repo, "rev-parse", "HEAD").stdout.strip()
+    remote_before = git(remote, "rev-parse", "refs/heads/dev").stdout.strip()
+
+    result = await toolkit.git_prepare_files(["bad.py"])
+    assert result.status == "error"
+    assert result.error.code == "whitespace_errors"
+
+    assert _index_bytes(repo) == index_before
+    assert git(repo, "rev-parse", "HEAD").stdout.strip() == head_before
+    assert git(remote, "rev-parse", "refs/heads/dev").stdout.strip() == remote_before
+    assert (repo / "bad.py").read_text() == "x = 1 \n"
+
+
+async def test_injected_foreign_index_lock_preserves_index(repo_with_remote):
+    """A lock owned by another git process blocks publication, harmlessly."""
+    repo, _remote = repo_with_remote
+    toolkit = LocalGitToolkit(repo_root=repo)
+
+    (repo / "c.py").write_text("c = 1\n")
+    lock = repo / ".git" / "index.lock"
+    lock.write_bytes(b"")
+    index_before = _index_bytes(repo)
+
+    result = await toolkit.git_prepare_files(["c.py"])
+    assert result.error.code == "index_locked"
+    assert lock.exists(), "a foreign lock must never be deleted"
+    assert _index_bytes(repo) == index_before
+    lock.unlink()
+
+
+async def test_diverged_remote_blocks_pull_and_push(repo_with_remote, tmp_path):
+    """Divergence is refused by both directions, with nothing changed."""
+    repo, remote = repo_with_remote
+
+    other = tmp_path / "other"
+    git(tmp_path, "clone", "-q", str(remote), str(other))
+    git(other, "checkout", "-q", "-B", "dev", "origin/dev")
+    (other / "remote_only.py").write_text("r = 1\n")
+    git(other, "add", "remote_only.py")
+    git(other, "commit", "-q", "-m", "remote")
+    git(other, "push", "-q", "origin", "dev")
+
+    (repo / "local_only.py").write_text("l = 1\n")
+    git(repo, "add", "local_only.py")
+    git(repo, "commit", "-q", "-m", "local")
+
+    toolkit = LocalGitToolkit(repo_root=repo)
+    head_before = git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    pulled = await toolkit.git_pull()
+    assert pulled.error.code == "diverged"
+    assert git(repo, "rev-parse", "HEAD").stdout.strip() == head_before
+
+    pushed = await toolkit.git_push(branch="dev")
+    assert pushed.error.code == "push_rejected"
+    # The remote still holds only its own commit.
+    assert git(remote, "rev-parse", "refs/heads/dev").stdout.strip() != head_before

--- a/packages/ai-parrot-tools/tests/tool_optimizations/integration/test_host_smoke.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/integration/test_host_smoke.py
@@ -1,0 +1,191 @@
+"""Host smoke tests: pin versions, exercise the guard, report gaps (TASK-3091).
+
+A host being absent is never a failure — it is recorded as an explicitly
+unsupported configuration, per the spec's requirement to "report unsupported
+configurations explicitly" rather than imply coverage that does not exist.
+"""
+
+import io
+import json
+import os
+import shutil
+import subprocess
+
+import pytest
+from parrot_tools.tool_optimizations.hooks import main as hook_main
+from parrot_tools.tool_optimizations.installation import HOOK_MODULE, guard_status, install_guards
+
+from .conftest import ARTIFACT_LOGS, record_json
+
+
+def _version(binary: str):
+    """Read a host binary's version, or None when it is absent/silent."""
+    path = shutil.which(binary)
+    if not path:
+        return None
+    try:
+        result = subprocess.run([path, "--version"], capture_output=True, text=True, timeout=15, check=False)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    output = (result.stdout or result.stderr or "").strip()
+    return output.splitlines()[0] if output else None
+
+
+@pytest.fixture(scope="module")
+def host_versions():
+    """Record the installed host versions as evidence."""
+    versions = {host: _version(host) for host in ("claude", "codex")}
+    ARTIFACT_LOGS.mkdir(parents=True, exist_ok=True)
+    (ARTIFACT_LOGS / "host-versions.txt").write_text(
+        "\n".join(f"{host}: {version or 'NOT INSTALLED'}" for host, version in versions.items()) + "\n",
+        encoding="utf-8",
+    )
+    return versions
+
+
+def test_host_versions_are_recorded(host_versions):
+    """The suite always records what it was run against."""
+    assert (ARTIFACT_LOGS / "host-versions.txt").is_file()
+    assert set(host_versions) == {"claude", "codex"}
+
+
+def test_guard_denies_a_large_read_through_the_hook_runtime(tmp_path):
+    """The guard runtime is exercised directly for both hosts.
+
+    Claude Code's hook runner cannot be driven headlessly, so the hook
+    module itself is invoked with a synthetic payload — the same payload
+    shape the host documents.
+    """
+    (tmp_path / "big.py").write_text("".join(f"line{i}\n" for i in range(1, 401)))
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Read",
+        "tool_input": {"file_path": "big.py"},
+        "cwd": str(tmp_path),
+    }
+
+    outputs = {}
+    for host in ("claude", "codex"):
+        stdout = io.StringIO()
+        assert hook_main(["--host", host], stdin=io.StringIO(json.dumps(payload)), stdout=stdout) == 0
+        outputs[host] = stdout.getvalue()
+
+    expected = {"claude": "deny", "codex": "block"}
+    for host, raw in outputs.items():
+        decision = json.loads(raw)["hookSpecificOutput"]
+        # Each host has its own refusal keyword; see DENY_VALUE in hooks.py.
+        assert decision["permissionDecision"] == expected[host], host
+        assert "source_read" in decision["permissionDecisionReason"]
+
+
+def test_installed_claude_settings_match_the_documented_schema(tmp_path):
+    """`install_guards` writes an entry with the documented hook shape."""
+    install_guards(tmp_path, "claude")
+    settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+
+    entries = settings["hooks"]["PreToolUse"]
+    ours = [entry for entry in entries if HOOK_MODULE in json.dumps(entry)]
+    assert len(ours) == 1
+
+    entry = ours[0]
+    assert entry["matcher"] == "Read|Bash"
+    hook = entry["hooks"][0]
+    assert hook["type"] == "command"
+    assert hook["timeout"] == 10
+    assert "--host claude" in hook["command"]
+    assert hook["command"].split()[0].startswith("/"), "the interpreter path must be absolute"
+
+
+def test_codex_hooks_file_matches_the_documented_schema(tmp_path):
+    """`install_guards` writes a project-scoped Codex hooks file."""
+    install_guards(tmp_path, "codex")
+    hooks = json.loads((tmp_path / ".codex" / "hooks.json").read_text())
+    entry = hooks["hooks"]["PreToolUse"][0]
+
+    assert entry["matcher"] == "Bash"
+    assert "--host codex" in entry["hooks"][0]["command"]
+
+
+def test_host_support_report_is_written(tmp_path, host_versions):
+    """Produce an explicit supported/unsupported report for both hosts."""
+    install_guards(tmp_path, "claude")
+    install_guards(tmp_path, "codex")
+
+    report = {}
+    for host in ("claude", "codex"):
+        status = guard_status(tmp_path, host)
+        report[host] = {
+            "version": host_versions[host],
+            "installed": status["installed"],
+            "supported": status["supported"],
+            "exercised_end_to_end": False,
+            "note": (
+                "binary not installed — guard policy unit-tested only"
+                if host_versions[host] is None
+                else "guard runtime exercised directly; the host's own hook runner was not driven headlessly"
+            ),
+        }
+        assert status["installed"] is True
+
+    codex_smoke = _maybe_run_codex_smoke(tmp_path)
+    if codex_smoke is not None:
+        report["codex"].update(codex_smoke)
+
+    # Evidence read directly from the installed codex binary (see the
+    # TASK-3091 Completion Note). The refusal keyword is fixed; the on-disk
+    # hooks.json field names are observed but NOT verified end to end.
+    report["codex"]["observed_decision_enum"] = ["approve", "block", "allow"]
+    report["codex"]["observed_hook_config_fields"] = ["eventName", "matcher", "timeoutSec", "command"]
+    report["codex"]["hooks_file_format_verified"] = False
+    report["codex"]["open_item"] = (
+        "installed hooks.json uses Claude-style {hooks:{PreToolUse:[{matcher,hooks:[{type,command,timeout}]}]}}; "
+        "codex 0.154.0 strings show eventName/timeoutSec fields. Verify end to end before release."
+    )
+
+    record_json("host-smoke.json", report)
+    assert (ARTIFACT_LOGS / "host-smoke.json").is_file()
+
+
+def _maybe_run_codex_smoke(root):
+    """Optionally drive a real `codex exec` to observe a guard denial.
+
+    Gated on PARROT_TOOL_OPT_HOST_SMOKE=1 because it starts a real agent
+    session; absent that, the result is reported as not exercised.
+    """
+    if os.environ.get("PARROT_TOOL_OPT_HOST_SMOKE") != "1":
+        return None
+    binary = shutil.which("codex")
+    if not binary:
+        return {"note": "codex binary not installed"}
+
+    (root / "big.py").write_text("".join(f"line{i}\n" for i in range(1, 401)))
+    try:
+        result = subprocess.run(
+            [binary, "exec", "--sandbox", "read-only", "-C", str(root), "cat big.py"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return {"exercised_end_to_end": False, "note": f"codex exec failed to start: {exc}"}
+
+    transcript = (result.stdout or "") + (result.stderr or "")
+    denied = "source_read" in transcript or "bounded reader" in transcript
+    return {
+        "exercised_end_to_end": denied,
+        "note": "denial observed in transcript" if denied else "hooks not honoured by this codex configuration",
+        "exit_code": result.returncode,
+    }
+
+
+def test_coverage_matrix_is_published_as_evidence():
+    """The honest coverage table ships alongside the smoke report."""
+    from parrot_tools.tool_optimizations.hooks import coverage_matrix
+
+    matrix = coverage_matrix()
+    record_json("TASK-3091-guard-coverage.json", {"rows": matrix})
+
+    covered = [row for row in matrix if row["covered"]]
+    gaps = [row for row in matrix if not row["covered"]]
+    assert covered and gaps, "the matrix must state both what is and is not intercepted"

--- a/packages/ai-parrot-tools/tests/tool_optimizations/integration/test_raw_mcp_validation.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/integration/test_raw_mcp_validation.py
@@ -1,0 +1,144 @@
+"""Raw tools/call validation (TASK-3091, FEAT-543).
+
+Every case here goes through the JSON-RPC surface, never the Python API.
+That is the point: `MCPToolAdapter.execute()` calls `tool._execute()`
+directly, bypassing `AbstractTool.execute()`'s schema validation, so policy
+must hold at the toolkit boundary or it does not hold at all.
+"""
+
+import pytest
+from parrot.mcp.toolkit_server import create_toolkit_mcp_server
+
+
+async def _call(server, tool, arguments):
+    """Invoke a tool over raw JSON-RPC."""
+    return await server._handle_request(
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": tool, "arguments": arguments}}
+    )
+
+
+def _state(repo):
+    """Snapshot everything an invalid call must not disturb."""
+    index = repo / ".git" / "index"
+    artifacts = repo / "artifacts" / "tool-optimizations"
+    return (
+        index.read_bytes() if index.exists() else b"",
+        sorted(path.name for path in artifacts.iterdir()) if artifacts.exists() else [],
+        (repo / "a.py").read_bytes(),
+    )
+
+
+@pytest.mark.parametrize(
+    "name,tool,arguments,why",
+    [
+        ("local-git", "git_recent", {"limit": 999}, "limit above the 50 maximum"),
+        ("local-git", "git_recent", {"limit": 0}, "limit below the minimum"),
+        ("local-git", "git_recent", {"limit": 1, "bogus": True}, "unknown argument key"),
+        ("local-git", "git_prepare_files", {"paths": [], "confirm": True}, "empty path list"),
+        ("local-git", "git_prepare_files", {"paths": ["a.py"]}, "missing confirmation"),
+        ("local-git", "git_pull", {"remote": "origin"}, "missing confirmation"),
+        ("bounded-source", "source_read", {"path": "a.py", "start_line": 1}, "half a range"),
+        ("bounded-source", "source_read", {"path": "a.py", "start_line": 9, "end_line": 2}, "inverted range"),
+        ("bounded-source", "source_read", {"path": "a.py", "extra": 1}, "unknown argument key"),
+        ("bounded-source", "source_info", {}, "missing required path"),
+        (
+            "targeted-writer",
+            "writer_apply",
+            {"artifact_id": "nope", "reviewed_sha256": "0" * 64, "confirm": True},
+            "malformed artifact id",
+        ),
+        (
+            "targeted-writer",
+            "writer_apply",
+            {"artifact_id": "a" * 32, "reviewed_sha256": "short", "confirm": True},
+            "malformed review hash",
+        ),
+    ],
+)
+async def test_raw_invalid_arguments_have_no_side_effects(tmp_repo_with_yaml, name, tool, arguments, why):
+    """Invalid raw input is rejected at the boundary and changes nothing."""
+    repo, config = tmp_repo_with_yaml
+    before = _state(repo)
+
+    server = create_toolkit_mcp_server(name, root=repo, config_path=config)
+    response = await _call(server, tool, arguments)
+
+    assert response["result"]["isError"] is True, f"{tool} accepted {why}: {response}"
+    assert _state(repo) == before, f"{tool} had a side effect for {why}"
+
+
+@pytest.mark.parametrize(
+    "paths",
+    [["../escape.py"], ["/etc/passwd"], [".env"], ["*.py"], [":(top)a.py"], ["a.py", "a.py"]],
+)
+async def test_raw_path_policy_is_enforced_over_mcp(tmp_repo_with_yaml, paths):
+    """Path policy holds for raw MCP input, not just for Python callers.
+
+    These reach the toolkit method (the argument model accepts a non-empty
+    list of strings), so they prove the *method's* own validation runs too.
+    """
+    repo, config = tmp_repo_with_yaml
+    (repo / ".env").write_text("SECRET=1\n")
+    before = _state(repo)
+
+    server = create_toolkit_mcp_server("local-git", root=repo, config_path=config)
+    response = await _call(server, "git_prepare_files", {"paths": paths, "confirm": True})
+
+    # Argument rejection surfaces as isError; a domain refusal surfaces as a
+    # successful envelope carrying status="error". Either way: no mutation.
+    assert _state(repo) == before
+    if response["result"]["isError"] is False:
+        import json
+
+        payload = json.loads(response["result"]["content"][0]["text"])
+        assert payload["status"] == "error", payload
+        assert payload["data"] == {} or "staged" not in payload["data"]
+
+
+async def test_unknown_tool_name_is_an_error(tmp_repo_with_yaml):
+    """A tool that does not exist is refused by the server."""
+    repo, config = tmp_repo_with_yaml
+    server = create_toolkit_mcp_server("local-git", root=repo, config_path=config)
+    response = await server._handle_request(
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "rm_rf", "arguments": {}}}
+    )
+    assert "error" in response or response["result"]["isError"] is True
+
+
+async def test_valid_raw_call_still_works(tmp_repo_with_yaml):
+    """The validation seam must not block legitimate calls."""
+    repo, config = tmp_repo_with_yaml
+    server = create_toolkit_mcp_server("local-git", root=repo, config_path=config)
+    response = await _call(server, "git_recent", {"limit": 1})
+
+    assert response["result"]["isError"] is False
+    import json
+
+    payload = json.loads(response["result"]["content"][0]["text"])
+    assert payload["status"] == "ok"
+    assert len(payload["data"]["commits"]) == 1
+
+
+async def test_option_shaped_ref_is_a_domain_refusal_over_mcp(tmp_repo_with_yaml):
+    """An option-shaped ref is refused by the method, before any git process.
+
+    This is deliberately NOT an `isError` case: the argument model accepts
+    any non-empty string, so the refusal is a *domain* outcome carried in
+    the envelope (`status="error"`, code `invalid_ref`). `isError` stays
+    reserved for argument rejection and crashes. What matters for safety is
+    that no git process ran — asserted via the empty `steps` list.
+    """
+    import json
+
+    repo, config = tmp_repo_with_yaml
+    before = _state(repo)
+
+    server = create_toolkit_mcp_server("local-git", root=repo, config_path=config)
+    response = await _call(server, "git_recent", {"ref": "--upload-pack=/bin/sh"})
+
+    assert response["result"]["isError"] is False
+    payload = json.loads(response["result"]["content"][0]["text"])
+    assert payload["status"] == "error"
+    assert payload["error"]["code"] == "invalid_ref"
+    assert payload["steps"] == [], "no git process may be spawned for an option-shaped ref"
+    assert _state(repo) == before

--- a/packages/ai-parrot-tools/tests/tool_optimizations/integration/test_stdio_protocol.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/integration/test_stdio_protocol.py
@@ -1,0 +1,130 @@
+"""Stdio protocol exposure for the three toolkits (TASK-3091, FEAT-543)."""
+
+import json
+import subprocess
+import sys
+
+import pytest
+from parrot.mcp.toolkit_server import create_toolkit_mcp_server
+from parrot.tools.abstract import AbstractTool
+
+from .conftest import BOOTSTRAP, worker_env
+
+EXPECTED_TOOLS = {
+    "local-git": {"git_recent", "git_fetch", "git_preflight", "git_prepare_files", "git_pull", "git_push"},
+    "bounded-source": {"source_info", "source_read"},
+}
+
+MUTATING = {"git_prepare_files", "git_pull", "git_push", "writer_apply"}
+
+
+async def _list_tools(server):
+    """Issue tools/list and return the tool definitions."""
+    response = await server._handle_request({"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}})
+    return response["result"]["tools"]
+
+
+@pytest.mark.parametrize("name", ["local-git", "bounded-source"])
+async def test_deterministic_servers_expose_abstract_tools(tmp_repo_with_yaml, name):
+    """Every exposed tool is a real AbstractTool with its unprefixed name."""
+    repo, config = tmp_repo_with_yaml
+    server = create_toolkit_mcp_server(name, root=repo, config_path=config)
+
+    assert all(isinstance(adapter.tool, AbstractTool) for adapter in server.tools.values())
+    tools = await _list_tools(server)
+    assert {tool["name"] for tool in tools} == EXPECTED_TOOLS[name]
+
+    for tool in tools:
+        required = tool["inputSchema"].get("required", [])
+        if tool["name"] in MUTATING:
+            assert "confirm" in required, f"{tool['name']} must require confirmation"
+        else:
+            assert "confirm" not in required
+
+
+async def test_initialize_and_call_round_trip(tmp_repo_with_yaml):
+    """initialize -> tools/list -> tools/call works over the JSON-RPC surface."""
+    repo, config = tmp_repo_with_yaml
+    server = create_toolkit_mcp_server("bounded-source", root=repo, config_path=config)
+
+    init = await server._handle_request({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
+    assert "result" in init
+
+    called = await server._handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "source_read", "arguments": {"path": "a.py"}},
+        }
+    )
+    assert called["result"]["isError"] is False
+    payload = json.loads(called["result"]["content"][0]["text"])
+    assert payload["content"] == "print('a')\n"
+    assert payload["eof"] is True
+
+
+async def test_writer_without_llm_exposes_only_apply(tmp_repo_with_yaml):
+    """A writer configured without `llm:` drops its model-dependent tool."""
+    repo, config = tmp_repo_with_yaml
+    server = create_toolkit_mcp_server("targeted-writer", root=repo, config_path=config)
+    names = {tool["name"] for tool in await _list_tools(server)}
+    assert names == {"writer_apply"}, "writer_generate must be filtered out without a model"
+
+
+async def test_writer_with_llm_exposes_generate(tmp_repo_with_yaml, monkeypatch):
+    """With a model configured, generation is exposed too."""
+    repo, config = tmp_repo_with_yaml
+    config.write_text(config.read_text().replace("  targeted-writer:\n", "  targeted-writer:\n    llm: 'test:model'\n"))
+
+    from parrot.clients.factory import LLMFactory
+
+    from ..test_writer import FakeClient
+
+    monkeypatch.setattr(LLMFactory, "create", staticmethod(lambda *a, **kw: FakeClient([])))
+    server = create_toolkit_mcp_server("targeted-writer", root=repo, config_path=config)
+    names = {tool["name"] for tool in await _list_tools(server)}
+    assert names == {"writer_apply", "writer_generate"}
+
+
+def test_subprocess_stdout_is_json_rpc_only(tmp_repo_with_yaml):
+    """A real server process must never print anything but JSON-RPC on stdout."""
+    repo, config = tmp_repo_with_yaml
+    requests = (
+        json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
+        + "\n"
+        + json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
+        + "\n"
+        + json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {"name": "source_info", "arguments": {"path": "a.py"}},
+            }
+        )
+        + "\n"
+    )
+
+    process = subprocess.run(
+        [sys.executable, "-c", BOOTSTRAP, "mcp-local", "bounded-source", "--config", str(config)],
+        cwd=repo,
+        input=requests,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=worker_env(),
+    )
+
+    lines = [line for line in process.stdout.splitlines() if line.strip()]
+    assert lines, f"no stdout produced; stderr={process.stderr[-2000:]}"
+    responses = []
+    for line in lines:
+        # Stdout purity: every single line must parse as JSON-RPC.
+        payload = json.loads(line)
+        assert payload.get("jsonrpc") == "2.0", line
+        responses.append(payload)
+
+    assert {item["id"] for item in responses} == {1, 2, 3}
+    listed = next(item for item in responses if item["id"] == 2)
+    assert {tool["name"] for tool in listed["result"]["tools"]} == {"source_info", "source_read"}

--- a/packages/ai-parrot-tools/tests/tool_optimizations/integration/test_writer_lifecycle.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/integration/test_writer_lifecycle.py
@@ -1,0 +1,123 @@
+"""Full writer lifecycle with a real acceptance run (TASK-3091, FEAT-543).
+
+generate -> bounded hunk review -> apply -> **the test harness runs the
+packet's real acceptance command**. The model's own claims are never
+treated as evidence: the pytest exit code is recorded separately from the
+manifest.
+"""
+
+import hashlib
+import json
+import subprocess
+import sys
+
+from parrot_tools.tool_optimizations.reader import BoundedSourceToolkit
+from parrot_tools.tool_optimizations.writer import TargetedWriterToolkit
+
+from ..fixtures import GOOD_PATCH, make_repo_with_target, make_valid_task
+from ..test_writer import FakeClient
+from .conftest import git, record_json, worker_env
+
+
+def _prepare_repo(tmp_path):
+    """Build the fixture repo plus a real acceptance test for the packet."""
+    repo = make_repo_with_target(tmp_path)
+    git(repo, "init", "-q", "-b", "dev")
+    git(repo, "config", "commit.gpgsign", "false")
+
+    tests_dir = repo / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_greeter.py").write_text(
+        "from pkg.greeter import greet\n\n\ndef test_greet():\n    assert greet('world') == 'hello world'\n"
+    )
+    git(repo, "add", ".")
+    git(repo, "commit", "-q", "-m", "base")
+    task = make_valid_task(repo)
+    return repo, task
+
+
+async def test_writer_lifecycle_ends_in_a_real_acceptance_run(tmp_path):
+    """The whole delegated path, ending in an executed pytest run."""
+    repo, task = _prepare_repo(tmp_path)
+    task_path = task.relative_to(repo).as_posix()
+
+    # 1. Generate.
+    writer = TargetedWriterToolkit(repo_root=repo, llm_client=FakeClient([GOOD_PATCH]))
+    generated = await writer.writer_generate(task_path)
+    assert generated.status == "ok", generated.error
+    artifact_id = generated.data["artifact_id"]
+    patch_path = generated.data["patch_path"]
+
+    # Generation must not have touched the worktree.
+    assert not (repo / "pkg" / "greeter.py").exists()
+
+    # 2. Review every hunk through the bounded reader, as the workflow requires.
+    reader = BoundedSourceToolkit(repo_root=repo)
+    info = await reader.source_info(patch_path)
+    assert info.size_bytes > 0
+
+    reviewed = ""
+    cursor = 1
+    while cursor is not None:
+        chunk = await reader.source_read(patch_path, cursor, cursor + 349, expected_sha256=info.sha256)
+        assert chunk.status if hasattr(chunk, "status") else True
+        reviewed += chunk.content
+        cursor = chunk.next_line
+    assert "+def greet(name: str) -> str:" in reviewed
+    assert "+from .greeter import greet" in reviewed
+
+    # 3. The reviewed hash must equal the stored patch's digest.
+    on_disk = (repo / patch_path).read_bytes()
+    assert hashlib.sha256(on_disk).hexdigest() == generated.data["patch_sha256"]
+    assert reviewed.encode() == on_disk, "the review must cover the whole patch"
+
+    # 4. Apply.
+    applied = await writer.writer_apply(artifact_id, generated.data["patch_sha256"])
+    assert applied.status == "ok", applied.error
+    assert (repo / "pkg" / "greeter.py").exists()
+
+    # Applying never stages or commits.
+    assert git(repo, "diff", "--cached", "--name-only").stdout == ""
+
+    # 5. The HARNESS runs the packet's acceptance command. The writer never
+    #    runs tests, and its manifest is not evidence that they passed.
+    manifest = json.loads((repo / "artifacts" / "tool-optimizations" / artifact_id / "manifest.json").read_text())
+    packet = json.loads((repo / "artifacts" / "tool-optimizations" / artifact_id / "packet.json").read_text())
+    command = packet["validation_commands"][0]
+    assert command[0] == "pytest"
+
+    completed = subprocess.run(
+        [sys.executable, "-m", *command],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=worker_env(),
+    )
+
+    record_json(
+        "TASK-3091-writer-lifecycle.json",
+        {
+            "artifact_id": artifact_id,
+            "manifest_validation_state": manifest["validation_state"],
+            "manifest_repairs": manifest["repairs"],
+            "acceptance_command": command,
+            "acceptance_exit_code": completed.returncode,
+            "acceptance_tail": completed.stdout[-800:],
+        },
+    )
+
+    # Recorded separately, and asserted independently of the manifest.
+    assert manifest["validation_state"] == "validated"
+    assert completed.returncode == 0, completed.stdout[-2000:] + completed.stderr[-2000:]
+
+
+async def test_apply_is_refused_when_the_review_hash_is_wrong(tmp_path):
+    """Review gating holds in the integrated path, not just in unit tests."""
+    repo, task = _prepare_repo(tmp_path)
+    writer = TargetedWriterToolkit(repo_root=repo, llm_client=FakeClient([GOOD_PATCH]))
+    generated = await writer.writer_generate(task.relative_to(repo).as_posix())
+
+    refused = await writer.writer_apply(generated.data["artifact_id"], "0" * 64)
+    assert refused.error.code == "review_hash_mismatch"
+    assert not (repo / "pkg" / "greeter.py").exists()

--- a/packages/ai-parrot-tools/tests/tool_optimizations/test_apply.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/test_apply.py
@@ -260,3 +260,95 @@ def test_apply_path_never_uses_mutating_git_verbs():
     source = inspect.getsource(module)
     for verb in ('"add"', '"commit"', '"push"', '"checkout"', '"reset"'):
         assert verb not in source, f"forbidden git argv literal in the apply path: {verb}"
+
+
+# --------------------------------------------------------------------------- #
+# Regressions from the adversarial review
+# --------------------------------------------------------------------------- #
+async def test_apply_refuses_when_the_task_changed_after_review(tmp_path):
+    """Re-validation must prove the SAME contract, not merely a valid one.
+
+    Regression: `validate_contract()`'s result was discarded, so a TASK file
+    edited between generation/review and apply (different targets, different
+    decided code) was never detected as a different packet.
+    """
+    repo, toolkit, artifact_id, sha = await _generated(tmp_path)
+    task_file = next((repo / "sdd" / "tasks" / "active").iterdir())
+
+    # Edit the packet in a way that still validates: same targets/hashes,
+    # different declared intent.
+    text = task_file.read_text().replace('"planned_changes": "Export greet"', '"planned_changes": "Export greet v2"')
+    assert text != task_file.read_text()
+    task_file.write_text(text)
+
+    result = await toolkit.writer_apply(artifact_id, sha)
+    assert result.status == "error"
+    assert result.error.code == "packet_mismatch"
+    assert not (repo / "pkg" / "greeter.py").exists()
+
+
+async def test_rollback_restores_files_that_already_verified(tmp_path, monkeypatch):
+    """A late verification failure must roll back the earlier, verified files.
+
+    Regression: the post-write loop flips each entry to "verified" one at a
+    time, and rollback only restored entries still marked "written" — so a
+    failure on a later file left the earlier ones mutated while reporting a
+    rollback.
+    """
+    repo, toolkit, artifact_id, sha = await _generated(tmp_path)
+    init_before = (repo / "pkg" / "__init__.py").read_bytes()
+
+    import parrot_tools.tool_optimizations.writer as writer_module
+
+    real_sha = writer_module._sha_or_none
+    original_write = writer_module._write_atomic
+    state = {"writes": 0, "fired": False}
+
+    def counting_write(path, data, mode):
+        original_write(path, data, mode)
+        state["writes"] += 1
+
+    def failing_verification(path):
+        # Fire exactly ONCE, and only after both files are written, so this
+        # corrupts the verification pass without also breaking the rollback's
+        # own "does this file still match what we wrote?" comparison.
+        if state["writes"] >= 2 and not state["fired"] and str(path).endswith("__init__.py"):
+            state["fired"] = True
+            return "f" * 64
+        return real_sha(path)
+
+    monkeypatch.setattr(writer_module, "_write_atomic", counting_write)
+    monkeypatch.setattr(writer_module, "_sha_or_none", failing_verification)
+
+    result = await toolkit.writer_apply(artifact_id, sha)
+    monkeypatch.undo()
+
+    assert result.status == "error"
+    journal = toolkit._store.read_journal(artifact_id)
+    assert journal.state in {"rolled_back", "recovery_required"}
+    # The created file must not survive a rolled-back apply.
+    assert not (repo / "pkg" / "greeter.py").exists()
+    assert (repo / "pkg" / "__init__.py").read_bytes() == init_before
+
+
+async def test_truncated_staged_list_is_not_read_as_empty(tmp_path, monkeypatch):
+    """A clipped `git diff --cached` list must not imply 'nothing is staged'."""
+    repo, toolkit, artifact_id, sha = await _generated(tmp_path)
+
+    from parrot_tools.tool_optimizations.git import LocalGitToolkit
+
+    real_run = LocalGitToolkit._run_git
+
+    async def truncating_run(self, args, **kwargs):
+        step, raw = await real_run(self, args, **kwargs)
+        if args[:2] == ["diff", "--cached"]:
+            step.truncated = True
+        return step, raw
+
+    monkeypatch.setattr(LocalGitToolkit, "_run_git", truncating_run)
+    result = await toolkit.writer_apply(artifact_id, sha)
+    monkeypatch.undo()
+
+    assert result.status == "error"
+    assert result.error.code == "status_failed"
+    assert not (repo / "pkg" / "greeter.py").exists()

--- a/packages/ai-parrot-tools/tests/tool_optimizations/test_apply.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/test_apply.py
@@ -1,0 +1,262 @@
+"""Tests for writer_apply: gating, rollback, recovery and idempotency (TASK-3086)."""
+
+import os
+
+import pytest
+
+from parrot_tools.tool_optimizations.writer import TargetedWriterToolkit
+
+from .conftest import git
+from .fixtures import GOOD_PATCH, make_repo_with_target, make_valid_task
+from .test_writer import FakeClient
+
+
+async def _generated(tmp_path, *, responses=None):
+    """Build a git repo, generate an artifact, and return the handles."""
+    repo = make_repo_with_target(tmp_path)
+    git(repo, "init", "-q", "-b", "dev")
+    git(repo, "config", "commit.gpgsign", "false")
+    git(repo, "add", ".")
+    git(repo, "commit", "-q", "-m", "base")
+    task = make_valid_task(repo)
+
+    toolkit = TargetedWriterToolkit(repo_root=repo, llm_client=FakeClient(responses or [GOOD_PATCH]))
+    generated = await toolkit.writer_generate(task.relative_to(repo).as_posix())
+    assert generated.status == "ok", generated.error
+    return repo, toolkit, generated.data["artifact_id"], generated.data["patch_sha256"]
+
+
+# --------------------------------------------------------------------------- #
+# Gating
+# --------------------------------------------------------------------------- #
+async def test_review_hash_gate(tmp_path):
+    """Applying requires the hash of the patch the caller actually read."""
+    repo, toolkit, artifact_id, _sha = await _generated(tmp_path)
+    result = await toolkit.writer_apply(artifact_id, "0" * 64)
+    assert result.status == "error"
+    assert result.error.code == "review_hash_mismatch"
+    assert not (repo / "pkg" / "greeter.py").exists()
+
+
+async def test_tampered_artifact_refused(tmp_path):
+    """An edited stored patch is detected before any precondition runs."""
+    repo, toolkit, artifact_id, sha = await _generated(tmp_path)
+    patch_file = repo / "artifacts" / "tool-optimizations" / artifact_id / "patch.diff"
+    patch_file.write_text(patch_file.read_text() + "+rogue\n")
+
+    result = await toolkit.writer_apply(artifact_id, sha)
+    assert result.error.code == "artifact_tampered"
+    assert not (repo / "pkg" / "greeter.py").exists()
+
+
+async def test_unknown_artifact(tmp_path):
+    """A missing artifact is reported, not treated as an empty patch."""
+    _repo, toolkit, _artifact_id, sha = await _generated(tmp_path)
+    result = await toolkit.writer_apply("f" * 32, sha)
+    assert result.error.code == "artifact_not_found"
+
+
+# --------------------------------------------------------------------------- #
+# Happy path and idempotency
+# --------------------------------------------------------------------------- #
+async def test_apply_then_idempotent(tmp_path):
+    """A clean apply writes both files, stages nothing and creates no commit."""
+    repo, toolkit, artifact_id, sha = await _generated(tmp_path)
+    head_before = git(repo, "rev-parse", "HEAD").stdout
+
+    applied = await toolkit.writer_apply(artifact_id, sha)
+    assert applied.status == "ok", applied.error
+    assert applied.data["already_applied"] is False
+    assert sorted(applied.data["applied"]) == ["pkg/__init__.py", "pkg/greeter.py"]
+
+    assert (repo / "pkg" / "greeter.py").read_text() == (
+        'def greet(name: str) -> str:\n    """Return a greeting."""\n    return f"hello {name}"\n'
+    )
+    assert "from .greeter import greet" in (repo / "pkg" / "__init__.py").read_text()
+
+    # Applying never stages, commits or pushes.
+    assert git(repo, "diff", "--cached", "--name-only").stdout == ""
+    assert git(repo, "rev-parse", "HEAD").stdout == head_before
+    assert toolkit._store.read_journal(artifact_id).state == "applied"
+
+    mtimes = {path: (repo / path).stat().st_mtime_ns for path in ("pkg/__init__.py", "pkg/greeter.py")}
+    again = await toolkit.writer_apply(artifact_id, sha)
+    assert again.status == "ok"
+    assert again.data["already_applied"] is True
+    assert {path: (repo / path).stat().st_mtime_ns for path in mtimes} == mtimes
+
+
+async def test_created_file_permissions_and_modify_mode_preserved(tmp_path):
+    """A modified file keeps its permissions; a new file is created 0o644."""
+    repo, toolkit, artifact_id, sha = await _generated(tmp_path)
+    os.chmod(repo / "pkg" / "__init__.py", 0o640)
+
+    assert (await toolkit.writer_apply(artifact_id, sha)).status == "ok"
+    assert (repo / "pkg" / "__init__.py").stat().st_mode & 0o777 == 0o640
+    assert (repo / "pkg" / "greeter.py").stat().st_mode & 0o777 == 0o644
+
+
+# --------------------------------------------------------------------------- #
+# Preconditions
+# --------------------------------------------------------------------------- #
+async def test_staged_target_refused_before_changed_target(tmp_path):
+    """Staging is checked first, so the report names the real blocker."""
+    repo, toolkit, artifact_id, sha = await _generated(tmp_path)
+    (repo / "pkg" / "__init__.py").write_text("changed\n")
+    git(repo, "add", "pkg/__init__.py")
+
+    result = await toolkit.writer_apply(artifact_id, sha)
+    assert result.error.code == "staged_target"
+    assert result.error.details["staged"] == ["pkg/__init__.py"]
+    assert not (repo / "pkg" / "greeter.py").exists()
+
+
+async def test_target_changed_refused(tmp_path):
+    """A target edited after generation invalidates the patch."""
+    repo, toolkit, artifact_id, sha = await _generated(tmp_path)
+    (repo / "pkg" / "__init__.py").write_text("changed by a human\n")
+
+    result = await toolkit.writer_apply(artifact_id, sha)
+    assert result.error.code == "target_changed"
+    assert result.error.details["path"] == "pkg/__init__.py"
+    assert (repo / "pkg" / "__init__.py").read_text() == "changed by a human\n"
+    assert not (repo / "pkg" / "greeter.py").exists()
+
+
+async def test_create_collision_refused(tmp_path):
+    """A create target that now exists is never overwritten."""
+    repo, toolkit, artifact_id, sha = await _generated(tmp_path)
+    (repo / "pkg" / "greeter.py").write_text("someone else got there first\n")
+
+    result = await toolkit.writer_apply(artifact_id, sha)
+    assert result.error.code == "create_collision"
+    assert (repo / "pkg" / "greeter.py").read_text() == "someone else got there first\n"
+
+
+async def test_unrelated_file_does_not_block_apply(tmp_path):
+    """Only declared targets and references gate an apply.
+
+    Reference staleness itself is exercised in `test_contracts.py`: in this
+    fixture the only reference *is* a target, so a change to it is caught
+    earlier and more precisely as `target_changed`.
+    """
+    repo, toolkit, artifact_id, sha = await _generated(tmp_path)
+    (repo / "pkg" / "unrelated.py").write_text("x = 1\n")
+
+    result = await toolkit.writer_apply(artifact_id, sha)
+    assert result.status == "ok"
+    assert (repo / "pkg" / "unrelated.py").read_text() == "x = 1\n"
+
+
+# --------------------------------------------------------------------------- #
+# Failure, rollback and recovery
+# --------------------------------------------------------------------------- #
+async def test_crash_rolls_back_first_file(tmp_path, monkeypatch):
+    """A failure on the second file restores the first one exactly."""
+    repo, toolkit, artifact_id, sha = await _generated(tmp_path)
+    before = (repo / "pkg" / "__init__.py").read_bytes()
+
+    real_replace = os.replace
+
+    # Fault-inject by DESTINATION, not by call count: the journal is also
+    # published with os.replace, so a counter would trip on the journal
+    # write and never exercise the second target file at all.
+    def flaky(src, dst):
+        if os.fspath(dst).endswith(os.path.join("pkg", "__init__.py")):
+            raise OSError(28, "No space left on device")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", flaky)
+    result = await toolkit.writer_apply(artifact_id, sha)
+    monkeypatch.undo()
+
+    assert result.status == "error"
+    assert result.error.details["errno"] == 28
+    # The first target (a create) was written, then rolled back by removal.
+    assert not (repo / "pkg" / "greeter.py").exists()
+    # The failed target is byte-identical to before.
+    assert (repo / "pkg" / "__init__.py").read_bytes() == before
+
+    journal = toolkit._store.read_journal(artifact_id)
+    assert journal.state == "rolled_back"
+    states = {entry.path: entry.state for entry in journal.entries}
+    assert states["pkg/greeter.py"] == "restored"
+    assert states["pkg/__init__.py"] == "pending"
+    # No adjacent temporary files are left behind.
+    assert not list((repo / "pkg").glob(".*parrot-tmp*"))
+
+
+async def test_concurrent_edit_requires_recovery(tmp_path, monkeypatch):
+    """A file a concurrent editor touched is never overwritten by rollback."""
+    repo, toolkit, artifact_id, sha = await _generated(tmp_path)
+
+    real_replace = os.replace
+
+    def sabotage(src, dst):
+        """Let greeter.py be written, then have a 'concurrent editor' rewrite
+        it; fail on the next target so a rollback is attempted."""
+        if os.fspath(dst).endswith(os.path.join("pkg", "__init__.py")):
+            raise OSError(5, "I/O error")
+        result = real_replace(src, dst)
+        if os.fspath(dst).endswith(os.path.join("pkg", "greeter.py")):
+            with open(dst, "w", encoding="utf-8") as handle:
+                handle.write("CONCURRENT EDIT\n")
+        return result
+
+    monkeypatch.setattr(os, "replace", sabotage)
+    result = await toolkit.writer_apply(artifact_id, sha)
+    monkeypatch.undo()
+
+    assert result.status == "error"
+    assert result.error.code == "recovery_required"
+    assert "pkg/greeter.py" in result.error.details["unrecoverable"]
+    # The concurrent editor's content survives untouched — rollback must
+    # never overwrite work it did not write itself.
+    assert (repo / "pkg" / "greeter.py").read_text() == "CONCURRENT EDIT\n"
+
+    journal = toolkit._store.read_journal(artifact_id)
+    assert journal.state == "recovery_required"
+
+    # A retry refuses until a human resolves it.
+    retry = await toolkit.writer_apply(artifact_id, sha)
+    assert retry.error.code == "recovery_pending"
+    assert (repo / "pkg" / "greeter.py").read_text() == "CONCURRENT EDIT\n"
+
+
+async def test_recovery_report(tmp_path):
+    """The journal is inspectable after an apply."""
+    _repo, toolkit, artifact_id, sha = await _generated(tmp_path)
+    missing = await toolkit._recovery_report(artifact_id)
+    assert missing.error.code == "no_journal"
+
+    await toolkit.writer_apply(artifact_id, sha)
+    report = await toolkit._recovery_report(artifact_id)
+    assert report.status == "ok"
+    assert report.data["state"] == "applied"
+    assert {entry["path"] for entry in report.data["entries"]} == {"pkg/__init__.py", "pkg/greeter.py"}
+    assert all(entry["state"] == "verified" for entry in report.data["entries"])
+
+
+async def test_journal_is_retained_as_evidence(tmp_path):
+    """The journal is never deleted; only its state changes."""
+    repo, toolkit, artifact_id, sha = await _generated(tmp_path)
+    await toolkit.writer_apply(artifact_id, sha)
+    journal_file = repo / "artifacts" / "tool-optimizations" / artifact_id / "journal.json"
+    assert journal_file.is_file()
+
+    await toolkit.writer_apply(artifact_id, sha)  # idempotent re-run
+    assert journal_file.is_file()
+
+
+# --------------------------------------------------------------------------- #
+# Source guarantees
+# --------------------------------------------------------------------------- #
+def test_apply_path_never_uses_mutating_git_verbs():
+    """Applying never stages, commits, pushes, resets or checks out."""
+    import inspect
+
+    import parrot_tools.tool_optimizations.writer as module
+
+    source = inspect.getsource(module)
+    for verb in ('"add"', '"commit"', '"push"', '"checkout"', '"reset"'):
+        assert verb not in source, f"forbidden git argv literal in the apply path: {verb}"

--- a/packages/ai-parrot-tools/tests/tool_optimizations/test_benchmark_harness.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/test_benchmark_harness.py
@@ -1,0 +1,176 @@
+"""Tests for the benchmark harness and the docs it backs (TASK-3092, FEAT-543)."""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+#: tests/tool_optimizations -> tests -> ai-parrot-tools -> packages -> repo root
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from benchmarks.tool_optimizations.accounting import (  # noqa: E402
+    CostModel,
+    UsageRecord,
+    cost_usd,
+    totals_by_kind,
+)
+from benchmarks.tool_optimizations.runner import run, summarize, write_reports  # noqa: E402
+from benchmarks.tool_optimizations.scenarios import SCENARIOS  # noqa: E402
+from parrot_tools.tool_optimizations.hooks import coverage_matrix  # noqa: E402
+
+DOC = ROOT / "docs" / "tool-optimizations.md"
+REPORT_DIR = ROOT / "artifacts" / "tool-optimizations" / "benchmarks"
+
+
+# --------------------------------------------------------------------------- #
+# Accounting rules
+# --------------------------------------------------------------------------- #
+def test_unknown_usage_never_becomes_zero():
+    """A provider that reports nothing must not flatter the results."""
+    records = [
+        UsageRecord(stage="primary_input", tokens=100, source="estimate:chars_div_4"),
+        UsageRecord(stage="delegate_output", tokens=None, source="provider_usage"),
+    ]
+    totals = totals_by_kind(records)
+    assert totals["primary_tokens"] == 100
+    assert totals["delegate_tokens"] is None
+    assert totals["total_tokens"] is None
+    assert cost_usd(records, "any-model", CostModel.load()) is None
+
+
+def test_prices_ship_empty_so_cost_is_unknown():
+    """An invented price would be worse than no price."""
+    assert CostModel.load().rows == {}
+
+
+def test_primary_and_delegate_are_accounted_separately():
+    """Work moved to the delegate must not vanish from the total."""
+    records = [
+        UsageRecord(stage="primary_input", tokens=10, source="estimate:chars_div_4"),
+        UsageRecord(stage="review", tokens=5, source="estimate:chars_div_4"),
+        UsageRecord(stage="delegate_input", tokens=50, source="provider_usage"),
+        UsageRecord(stage="delegate_output", tokens=20, source="provider_usage"),
+    ]
+    totals = totals_by_kind(records)
+    assert totals["primary_tokens"] == 15
+    assert totals["delegate_tokens"] == 70
+    assert totals["total_tokens"] == 85
+
+
+# --------------------------------------------------------------------------- #
+# Offline harness
+# --------------------------------------------------------------------------- #
+async def test_offline_harness_all_scenarios(tmp_path):
+    """Every scenario runs offline, and the report schema is complete."""
+    reports = []
+    for scenario in SCENARIOS:
+        for mode in ("baseline", "optimized"):
+            reports.extend(await run(scenario, mode, runs=1, workdir=tmp_path))
+
+    summary = summarize(reports)
+    json_path, md_path = write_reports(summary, REPORT_DIR, stamp="pytest")
+    data = json.loads(json_path.read_text())
+    markdown = md_path.read_text()
+
+    required = {
+        "primary_tokens",
+        "delegate_tokens",
+        "total_tokens",
+        "latency_median_ms",
+        "latency_p95_ms",
+        "pass_rate",
+        "cost_usd",
+    }
+    for entry in data["scenarios"]:
+        assert required <= set(entry["optimized"])
+        assert required <= set(entry["baseline"])
+        # Unknown, not zero, while prices.yaml is empty.
+        assert entry["optimized"]["cost_usd"] is None
+
+    # Correctness parity: any scenario with an executable acceptance test passed.
+    assert all(entry["optimized"]["pass_rate"] in (1.0, None) for entry in data["scenarios"])
+
+    # Primary vs total must both be visible — the report may never conflate them.
+    assert "primary tokens" in markdown
+    assert "total tokens" in markdown
+    assert "p95" in markdown
+    assert "NOT fewer total tokens" in markdown
+    assert "No savings percentage is claimed" in markdown
+
+
+async def test_decided_task_scenario_runs_a_real_acceptance_test(tmp_path):
+    """The task scenario's pass rate reflects an executed pytest, not a claim."""
+    scenario = next(item for item in SCENARIOS if item.name == "decided_task")
+    reports = await run(scenario, "optimized", runs=1, workdir=tmp_path)
+    assert reports[0].acceptance_passed is True
+
+    sources = {record.source for record in reports[0].usage}
+    assert "provider_usage" in sources, "delegate usage must be attributed to the provider"
+
+
+def test_live_mode_requires_five_runs():
+    """The measurement protocol's minimum is enforced before anything spends money."""
+    from benchmarks.tool_optimizations.__main__ import main
+
+    assert main(["--live", "--runs", "1"]) == 2
+
+
+def test_unknown_scenario_is_rejected():
+    """A typo must not silently benchmark nothing."""
+    from benchmarks.tool_optimizations.__main__ import main
+
+    assert main(["--scenario", "does-not-exist", "--runs", "1"]) == 2
+
+
+# --------------------------------------------------------------------------- #
+# Documentation
+# --------------------------------------------------------------------------- #
+def test_docs_coverage_matrix_in_sync():
+    """The published matrix must match the code that implements it."""
+    doc = DOC.read_text()
+    block = re.search(r"<!-- coverage-matrix:begin -->(.*?)<!-- coverage-matrix:end -->", doc, re.S)
+    assert block is not None, "coverage matrix markers are missing"
+    body = block.group(1)
+
+    for row in coverage_matrix():
+        line = next((item for item in body.splitlines() if f"`{row['form']}`" in item), None)
+        assert line is not None, f"{row['form']} missing from the documented matrix"
+        expected = "yes" if row["covered"] else "no"
+        assert f"| {expected} |" in line, f"{row['form']} documented as the wrong coverage"
+
+
+def test_docs_have_release_gate_and_traceability():
+    """The release gate and AC traceability must be stated, not implied."""
+    doc = DOC.read_text()
+    # Collapse wrapping so the assertions describe meaning, not line breaks.
+    flat = " ".join(doc.split())
+    assert "owner decision" in flat
+    assert "No percentage saving is claimed anywhere" in flat
+    for index in range(1, 16):
+        assert f"AC{index}" in doc, f"AC{index} missing from the traceability table"
+
+
+def test_docs_record_tested_host_versions_and_bypasses():
+    """Coverage claims must be scoped to the versions actually tested."""
+    doc = DOC.read_text()
+    assert "2.1.267" in doc
+    assert "0.154.0" in doc
+    assert "Re-test after a host" in doc
+    for bypass in ("write_stdin", "heredocs", "interpreters"):
+        assert bypass in doc
+
+
+def test_docs_are_linked_from_the_mcp_page():
+    """The new page must be discoverable from the existing one."""
+    assert "tool-optimizations.md" in (ROOT / "docs" / "mcp-local-toolkits.md").read_text()
+
+
+def test_docs_state_the_codex_release_blocker():
+    """The unverified Codex hooks format must be visible in the checklist."""
+    doc = DOC.read_text()
+    assert "Codex guard installation verified end to end" in doc
+    assert "eventName" in doc

--- a/packages/ai-parrot-tools/tests/tool_optimizations/test_contracts.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/test_contracts.py
@@ -1,0 +1,329 @@
+"""Unit tests for delegation-contract validation (TASK-3083, FEAT-543)."""
+
+import asyncio
+import json
+import subprocess
+
+import pytest
+
+from parrot_tools.tool_optimizations.contracts import (
+    ALLOWED_VALIDATION_PROGRAMS,
+    CodeBlock,
+    ContractError,
+    find_placeholders,
+    parse_task_file,
+    render_prompt_sections,
+    validate_contract,
+)
+from parrot_tools.tool_optimizations.models import WriterLimits
+from parrot_tools.tool_optimizations.policy import OptimizationPolicy
+
+from .fixtures import make_repo_with_target, make_valid_task, sha256_of
+
+
+def _policy(repo):
+    """Build a policy rooted at the fixture repository."""
+    return OptimizationPolicy(repo_root=repo)
+
+
+async def _validate(repo, task, **kwargs):
+    """Validate a fixture TASK file by its repo-relative path."""
+    return await validate_contract(_policy(repo), task.relative_to(repo).as_posix(), **kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# Happy path
+# --------------------------------------------------------------------------- #
+async def test_valid_task_validates(tmp_path):
+    """The canonical fixture is eligible and reports accurate state."""
+    repo = make_repo_with_target(tmp_path)
+    task = make_valid_task(repo)
+    contract = await _validate(repo, task)
+
+    assert contract.packet.task_id == "TASK-9999"
+    assert set(contract.blocks) == {"impl-greeter", "impl-init"}
+    assert contract.targets_state["pkg/greeter.py"] is None
+    assert contract.targets_state["pkg/__init__.py"] == sha256_of(repo / "pkg" / "__init__.py")
+    assert len(contract.references) == 1
+    assert contract.references[0].content.startswith('"""Package."""')
+    assert contract.task_path == "sdd/tasks/active/TASK-9999-greeter.md"
+
+
+async def test_packet_identity_is_stable_and_context_bytes_match_formula(tmp_path):
+    """packet_sha256 is reproducible and context_bytes follows the documented sum."""
+    repo = make_repo_with_target(tmp_path)
+    task = make_valid_task(repo)
+
+    first = await _validate(repo, task)
+    second = await _validate(repo, task)
+    assert first.packet_sha256 == second.packet_sha256
+    assert len(first.packet_sha256) == 64
+
+    from parrot_tools.tool_optimizations.policy import measure_json_bytes
+
+    expected = (
+        measure_json_bytes(first.packet.model_dump(mode="json"))
+        + sum(len(block.text.encode("utf-8")) for block in first.blocks.values())
+        + sum(len(ref.content.encode("utf-8")) for ref in first.references)
+    )
+    assert first.context_bytes == expected
+
+
+# --------------------------------------------------------------------------- #
+# Error codes — one test per documented code
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "mutator,code",
+    [
+        (lambda t: t.replace("## Delegation Contract", "## Something"), "no_delegation_section"),
+        (lambda t: t + "\n## Delegation Contract\n\n```json\n{}\n```\n", "duplicate_delegation_section"),
+        (lambda t: t.replace('"schema_version": 1', '"schema_version": 2'), "invalid_packet"),
+        (lambda t: t.replace('"design_complete": true', '"design_complete": false'), "invalid_packet"),
+        (lambda t: t.replace('"design_complete": true', '"design_complete": true, "extra": 1'), "invalid_packet"),
+        (lambda t: t.replace('"impl-init"\n      ]', '"impl-missing"\n      ]'), "missing_block"),
+        (lambda t: t.replace('    return f"hello {name}"', "    ..."), "placeholder_code"),
+        (
+            lambda t: t.replace('"tests/test_greeter.py",\n        "-q"', '"-rf",\n        "/"').replace(
+                '"pytest"', '"rm"'
+            ),
+            "invalid_validation_command",
+        ),
+        (lambda t: t.replace('"task_id": "TASK-9999"', '"task_id": "NOPE-1"'), "invalid_packet"),
+    ],
+)
+async def test_error_codes(tmp_path, mutator, code):
+    """Each documented failure mode raises exactly its own code."""
+    repo = make_repo_with_target(tmp_path)
+    task = make_valid_task(repo)
+    task.write_text(mutator(task.read_text()))
+
+    with pytest.raises(ContractError) as info:
+        await _validate(repo, task)
+    assert info.value.code == code
+
+
+async def test_no_packet_block_and_duplicate_packet_block(tmp_path):
+    """The delegation section needs exactly one json block."""
+    repo = make_repo_with_target(tmp_path)
+    task = make_valid_task(repo)
+    original = task.read_text()
+
+    stripped = original.split("## Delegation Contract")[0] + "## Delegation Contract\n\nno block here\n"
+    task.write_text(stripped)
+    with pytest.raises(ContractError) as info:
+        await _validate(repo, task)
+    assert info.value.code == "no_packet_block"
+
+    packet_block = "```json\n{}\n```"
+    task.write_text(original.replace("## Implementation", packet_block + "\n\n## Implementation"))
+    with pytest.raises(ContractError) as info:
+        await _validate(repo, task)
+    assert info.value.code == "duplicate_packet_block"
+
+
+async def test_invalid_packet_json(tmp_path):
+    """A malformed JSON packet is distinguished from a schema violation."""
+    repo = make_repo_with_target(tmp_path)
+    task = make_valid_task(repo)
+    task.write_text(task.read_text().replace('"schema_version": 1,', '"schema_version": 1,,'))
+    with pytest.raises(ContractError) as info:
+        await _validate(repo, task)
+    assert info.value.code == "invalid_packet_json"
+
+
+async def test_duplicate_block_id(tmp_path):
+    """Two blocks may not share an id."""
+    repo = make_repo_with_target(tmp_path)
+    task = make_valid_task(repo)
+    task.write_text(task.read_text() + "\n```python id=impl-greeter\nx = 1\n```\n")
+    with pytest.raises(ContractError) as info:
+        await _validate(repo, task)
+    assert info.value.code == "duplicate_block_id"
+
+
+async def test_task_not_found_and_outside_root(tmp_path):
+    """A missing or escaping TASK path is refused before parsing."""
+    repo = make_repo_with_target(tmp_path)
+    with pytest.raises(ContractError) as info:
+        await validate_contract(_policy(repo), "sdd/tasks/active/nope.md")
+    assert info.value.code == "task_not_found"
+
+    with pytest.raises(ContractError) as info:
+        await validate_contract(_policy(repo), "../outside.md")
+    assert info.value.code == "task_outside_root"
+
+
+async def test_target_exists_for_create_and_missing_for_modify(tmp_path):
+    """CREATE requires absence; MODIFY requires presence."""
+    repo = make_repo_with_target(tmp_path)
+    task = make_valid_task(repo)
+    (repo / "pkg" / "greeter.py").write_text("already here\n")
+    with pytest.raises(ContractError) as info:
+        await _validate(repo, task)
+    assert info.value.code == "target_exists_for_create"
+
+    (repo / "pkg" / "greeter.py").unlink()
+    (repo / "pkg" / "__init__.py").unlink()
+    with pytest.raises(ContractError) as info:
+        await _validate(repo, task)
+    assert info.value.code == "target_missing_for_modify"
+
+
+async def test_underspecified_create(tmp_path):
+    """A CREATE whose block carries no path= tag cannot be delegated."""
+    repo = make_repo_with_target(tmp_path)
+    task = make_valid_task(repo)
+    task.write_text(
+        task.read_text().replace("```python id=impl-greeter path=pkg/greeter.py", "```python id=impl-greeter")
+    )
+    with pytest.raises(ContractError) as info:
+        await _validate(repo, task)
+    assert info.value.code == "underspecified_create"
+
+
+async def test_stale_target_and_reference(tmp_path):
+    """A file edited after the packet was written invalidates the contract."""
+    repo = make_repo_with_target(tmp_path)
+    task = make_valid_task(repo)
+    (repo / "pkg" / "__init__.py").write_text("changed\n")
+
+    with pytest.raises(ContractError) as info:
+        await _validate(repo, task)
+    assert info.value.code in {"stale_target", "stale_reference"}
+    assert "current" in info.value.details
+    assert info.value.details["expected"] != info.value.details["current"]
+
+
+async def test_scope_path_invalid(tmp_path):
+    """A target outside the root, or a secret file, is refused."""
+    repo = make_repo_with_target(tmp_path)
+    task = make_valid_task(repo)
+    task.write_text(task.read_text().replace('"path": "pkg/greeter.py"', '"path": "../escape.py"'))
+    with pytest.raises(ContractError) as info:
+        await _validate(repo, task)
+    assert info.value.code == "scope_path_invalid"
+
+
+async def test_reference_range_invalid(tmp_path):
+    """A reference range past EOF is reported, not silently clamped."""
+    repo = make_repo_with_target(tmp_path)
+    task = make_valid_task(repo)
+    task.write_text(
+        task.read_text().replace('"start_line": 1,\n      "end_line": 3', '"start_line": 900,\n      "end_line": 905')
+    )
+    with pytest.raises(ContractError) as info:
+        await _validate(repo, task)
+    assert info.value.code == "reference_range_invalid"
+
+
+async def test_context_budget_exceeded_before_expensive_work(tmp_path):
+    """The blocks alone can blow the budget, and that is detected early."""
+    repo = make_repo_with_target(tmp_path)
+    task = make_valid_task(repo)
+    with pytest.raises(ContractError) as info:
+        await _validate(repo, task, limits_override=WriterLimits(max_context_bytes=1))
+    assert info.value.code == "context_budget_exceeded"
+    assert info.value.details["max_context_bytes"] == 1
+
+
+async def test_packet_too_large(tmp_path):
+    """An oversized TASK file is refused before it is parsed."""
+    repo = make_repo_with_target(tmp_path)
+    task = make_valid_task(repo)
+    with pytest.raises(ContractError) as info:
+        await _validate(repo, task, limits_override=WriterLimits(max_packet_bytes=10))
+    assert info.value.code == "packet_too_large"
+
+
+# --------------------------------------------------------------------------- #
+# Parser behaviour
+# --------------------------------------------------------------------------- #
+def test_nested_shorter_fence_is_preserved_literally():
+    """A shorter fence inside a longer-fenced block is content, not a close."""
+    text = (
+        "## Delegation Contract\n\n"
+        "```json\n{}\n```\n\n"
+        "````markdown id=impl-doc\n"
+        "Here is an example:\n"
+        "```python\n"
+        "x = 1\n"
+        "```\n"
+        "done\n"
+        "````\n"
+    )
+    packet_json, blocks = parse_task_file(text)
+    assert packet_json == "{}"
+    assert "```python" in blocks["impl-doc"].text
+    assert blocks["impl-doc"].text.strip().endswith("done")
+
+
+def test_placeholder_rule_is_line_anchored():
+    """A bare `...` line is a placeholder; `"..."` inside an expression is not."""
+    bad = CodeBlock(block_id="b", language="python", text="def f():\n    ...\n", start_line=1)
+    good = CodeBlock(block_id="b", language="python", text='x = "..."\ny = 1\n', start_line=1)
+    assert find_placeholders(bad)[0][1] == "bare_ellipsis"
+    assert find_placeholders(good) == []
+
+    for snippet, expected in [
+        ("# TODO: later\n", "todo"),
+        ("# FIXME\n", "fixme"),
+        ("raise NotImplementedError\n", "not_implemented"),
+        ("value = <the thing>\n", "angle_placeholder"),
+    ]:
+        block = CodeBlock(block_id="b", language="python", text=snippet, start_line=1)
+        assert find_placeholders(block)[0][1] == expected
+
+
+def test_blocks_outside_the_delegation_section_are_still_collected():
+    """Implementation blocks live anywhere in the file; only the packet is scoped."""
+    text = "## Delegation Contract\n\n```json\n{}\n```\n\n## Elsewhere\n\n```python id=impl-x\ny = 2\n```\n"
+    packet_json, blocks = parse_task_file(text)
+    assert packet_json == "{}"
+    assert blocks["impl-x"].text == "y = 2"
+    assert blocks["impl-x"].language == "python"
+
+
+# --------------------------------------------------------------------------- #
+# Safety
+# --------------------------------------------------------------------------- #
+def test_validation_program_allow_list_is_narrow():
+    """Only well-known validation programs may appear in a packet."""
+    assert ALLOWED_VALIDATION_PROGRAMS == {"pytest", "ruff", "black", "mypy", "python", "python3"}
+    assert "rm" not in ALLOWED_VALIDATION_PROGRAMS
+    assert "bash" not in ALLOWED_VALIDATION_PROGRAMS
+
+
+async def test_no_subprocess_ever(tmp_path, monkeypatch):
+    """Validation never executes anything, including validation_commands."""
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", lambda *a, **k: pytest.fail("spawned a process"))
+    monkeypatch.setattr(asyncio, "create_subprocess_shell", lambda *a, **k: pytest.fail("spawned a shell"))
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: pytest.fail("spawned a process"))
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: pytest.fail("spawned a process"))
+
+    repo = make_repo_with_target(tmp_path)
+    task = make_valid_task(repo)
+    contract = await _validate(repo, task)
+    assert contract.packet.validation_commands == [["pytest", "tests/test_greeter.py", "-q"]]
+
+
+# --------------------------------------------------------------------------- #
+# Prompt rendering
+# --------------------------------------------------------------------------- #
+async def test_render_prompt_sections_snapshot(tmp_path):
+    """The rendered prompt is deterministic and contains only approved content."""
+    repo = make_repo_with_target(tmp_path)
+    task = make_valid_task(repo)
+    contract = await _validate(repo, task)
+    sections = render_prompt_sections(contract)
+
+    assert set(sections) == {"packet", "references", "blocks", "acceptance"}
+    assert sections["packet"].startswith("## Packet\n\n```json\n")
+    assert json.loads(sections["packet"].split("```json\n")[1].split("\n```")[0])["task_id"] == "TASK-9999"
+
+    reference = contract.references[0]
+    assert f"### pkg/__init__.py @ {reference.slice.sha256[:12]} lines 1-3 — existing exports" in sections["references"]
+    assert sections["blocks"].index("### impl-greeter") < sections["blocks"].index("### impl-init")
+    assert "(file: pkg/greeter.py)" in sections["blocks"]
+    assert sections["acceptance"] == "## Acceptance criteria\n\n- pytest tests/test_greeter.py passes"
+
+    assert render_prompt_sections(contract) == sections

--- a/packages/ai-parrot-tools/tests/tool_optimizations/test_git.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/test_git.py
@@ -18,10 +18,17 @@ from .conftest import git
 # --------------------------------------------------------------------------- #
 # Tool surface
 # --------------------------------------------------------------------------- #
-def test_exposes_exactly_the_read_and_fetch_tools(git_repo):
-    """Only this task's three tools exist; each is a real AbstractTool."""
+def test_exposes_exactly_the_expected_tools(git_repo):
+    """The toolkit exposes exactly its six tools; each is a real AbstractTool."""
     tools = LocalGitToolkit(repo_root=git_repo).get_tools()
-    assert {tool.name for tool in tools} == {"git_recent", "git_fetch", "git_preflight"}
+    assert {tool.name for tool in tools} == {
+        "git_recent",
+        "git_fetch",
+        "git_preflight",
+        "git_prepare_files",
+        "git_pull",
+        "git_push",
+    }
     assert all(isinstance(tool, AbstractTool) for tool in tools)
 
 
@@ -311,3 +318,440 @@ async def test_runner_reports_failure_exit_code(git_repo):
     step, _ = await LocalGitToolkit(repo_root=git_repo)._run_git(["rev-parse", "--verify", "--quiet", "nope"])
     assert step.exit_code != 0
     assert step.timed_out is False
+
+
+# =========================================================================== #
+# TASK-3081 — mutations: prepare / pull / push
+# =========================================================================== #
+def _clone_on_dev(bare_remote: Path, tmp_path: Path) -> Path:
+    """Clone the bare remote and check out `dev`.
+
+    The bare remote's HEAD points at `master` (git's default for
+    `init --bare`), so a plain clone lands on an unborn branch and would
+    push `master` instead of `dev`.
+    """
+    other = tmp_path / "other"
+    git(tmp_path, "clone", "-q", str(bare_remote), str(other))
+    git(other, "checkout", "-q", "-B", "dev", "origin/dev")
+    return other
+
+
+def _index_bytes(repo: Path) -> bytes:
+    """Read the raw index bytes, or b'' when the index does not exist yet."""
+    index = repo / ".git" / "index"
+    return index.read_bytes() if index.exists() else b""
+
+
+def test_mutating_tools_require_confirmation(git_repo):
+    """The three mutations are marked destructive; the reads are not."""
+    tools = {tool.name: tool for tool in LocalGitToolkit(repo_root=git_repo).get_tools()}
+    assert set(tools) == {"git_recent", "git_fetch", "git_preflight", "git_prepare_files", "git_pull", "git_push"}
+    for name in ("git_prepare_files", "git_pull", "git_push"):
+        assert (tools[name].routing_meta or {}).get("requires_confirmation") is True
+    for name in ("git_recent", "git_fetch", "git_preflight"):
+        assert not (tools[name].routing_meta or {}).get("requires_confirmation")
+
+
+async def test_mcp_tools_list_marks_confirm_required(git_repo):
+    """tools/list advertises `confirm` as required only for the mutations."""
+    from parrot.mcp.local_server import StdioMCPServer
+    from parrot.mcp.server_base import LocalServerConfig
+
+    server = StdioMCPServer(LocalServerConfig(name="t"))
+    server.register_tools(LocalGitToolkit(repo_root=git_repo).get_tools())
+    listing = await server._handle_request({"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}})
+    schemas = {tool["name"]: tool["inputSchema"] for tool in listing["result"]["tools"]}
+
+    for name in ("git_prepare_files", "git_pull", "git_push"):
+        assert "confirm" in schemas[name]["required"]
+        assert schemas[name]["properties"]["confirm"]["type"] == "boolean"
+    assert "confirm" not in schemas["git_recent"].get("required", [])
+    assert "confirm" not in schemas["git_recent"]["properties"]
+
+
+async def test_mcp_call_rejected_without_confirm(git_repo):
+    """A mutation invoked over MCP without confirm=true is refused."""
+    from parrot.mcp.local_server import StdioMCPServer
+    from parrot.mcp.server_base import LocalServerConfig
+
+    server = StdioMCPServer(LocalServerConfig(name="t"))
+    server.register_tools(LocalGitToolkit(repo_root=git_repo).get_tools())
+    before = _index_bytes(git_repo)
+    response = await server._handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "git_prepare_files", "arguments": {"paths": ["a.py"]}},
+        }
+    )
+    assert response["result"]["isError"] is True
+    assert _index_bytes(git_repo) == before
+
+
+# --------------------------------------------------------------------------- #
+# git_prepare_files — refusals preserve the index byte-for-byte
+# --------------------------------------------------------------------------- #
+async def test_prepare_refuses_unrelated_staging_and_preserves_index(git_repo):
+    """Unrelated staged paths cause refusal; nothing is ever unstaged."""
+    (git_repo / "b.py").write_text("b = 1\n")
+    git(git_repo, "add", "b.py")
+    (git_repo / "a.py").write_text("print('A')\n")
+    before = _index_bytes(git_repo)
+
+    res = await LocalGitToolkit(repo_root=git_repo).git_prepare_files(["a.py"])
+    assert res.status == "error"
+    assert res.error.code == "unrelated_staged"
+    assert res.error.details["unrelated"] == ["b.py"]
+    assert _index_bytes(git_repo) == before
+
+
+async def test_prepare_refuses_partially_staged(git_repo):
+    """Whole-file staging must not silently replace a partially staged hunk."""
+    (git_repo / "a.py").write_text("print('one')\n")
+    git(git_repo, "add", "a.py")
+    (git_repo / "a.py").write_text("print('two')\n")
+    before = _index_bytes(git_repo)
+
+    res = await LocalGitToolkit(repo_root=git_repo).git_prepare_files(["a.py"])
+    assert res.status == "error"
+    assert res.error.code == "partially_staged"
+    assert _index_bytes(git_repo) == before
+
+
+async def test_prepare_whitespace_failure_keeps_original_staging(git_repo):
+    """A whitespace failure discards the private index; the real one is intact."""
+    (git_repo / "a.py").write_text("print('A') \n")
+    before = _index_bytes(git_repo)
+
+    res = await LocalGitToolkit(repo_root=git_repo).git_prepare_files(["a.py"])
+    assert res.error.code == "whitespace_errors"
+    assert "a.py" in res.error.details["lines"]
+    assert _index_bytes(git_repo) == before
+
+
+async def test_prepare_stages_exact_names_including_deletion_and_unicode(git_repo):
+    """Spaces, non-ASCII names and tracked deletions all round-trip via -z."""
+    (git_repo / "año nuevo.py").write_text("x = 1\n")
+    git(git_repo, "add", "año nuevo.py")
+    git(git_repo, "commit", "-q", "-m", "u")
+    (git_repo / "a.py").unlink()
+    (git_repo / "año nuevo.py").write_text("x = 2\n")
+
+    res = await LocalGitToolkit(repo_root=git_repo).git_prepare_files(["a.py", "año nuevo.py"])
+    assert res.status == "ok"
+    assert sorted(res.data["staged"]) == ["a.py", "año nuevo.py"]
+    assert res.data["deleted"] == ["a.py"]
+    assert res.data["whitespace_ok"] is True
+    assert res.data["index_published"] is True
+
+    staged = [item for item in git(git_repo, "diff", "--cached", "--name-only", "-z").stdout.split("\0") if item]
+    assert sorted(staged) == ["a.py", "año nuevo.py"]
+
+
+async def test_prepare_accepts_already_fully_staged_selection(git_repo):
+    """A selected path that is already fully staged is not a conflict."""
+    (git_repo / "a.py").write_text("print('A')\n")
+    git(git_repo, "add", "a.py")
+    res = await LocalGitToolkit(repo_root=git_repo).git_prepare_files(["a.py"])
+    assert res.status == "ok", (res.error.code, res.error.details)
+    assert res.data["staged"] == ["a.py"]
+
+
+async def test_prepare_respects_foreign_index_lock(git_repo):
+    """A lock owned by another git process is reported, never deleted."""
+    (git_repo / "a.py").write_text("print('A')\n")
+    lock = git_repo / ".git" / "index.lock"
+    lock.write_bytes(b"")
+    before = _index_bytes(git_repo)
+
+    res = await LocalGitToolkit(repo_root=git_repo).git_prepare_files(["a.py"])
+    assert res.error.code == "index_locked", (res.error.code, res.error.details)
+    assert lock.exists()
+    assert _index_bytes(git_repo) == before
+
+
+async def test_prepare_refuses_unmerged_index(git_repo, tmp_path):
+    """An unmerged index must be resolved by a human first."""
+    git(git_repo, "checkout", "-q", "-b", "other")
+    (git_repo / "a.py").write_text("other side\n")
+    git(git_repo, "commit", "-q", "-am", "other")
+    git(git_repo, "checkout", "-q", "dev")
+    (git_repo / "a.py").write_text("dev side\n")
+    git(git_repo, "commit", "-q", "-am", "dev")
+    git(git_repo, "merge", "other", check=False)  # conflicts
+
+    res = await LocalGitToolkit(repo_root=git_repo).git_prepare_files(["a.py"])
+    assert res.status == "error"
+    assert res.error.code == "unmerged_index"
+
+
+@pytest.mark.parametrize(
+    "bad_path,expected",
+    [
+        ("pkg", "directory_rejected"),
+        ("*.py", "glob_rejected"),
+        (":(top)a.py", "pathspec_magic"),
+        # '..' is caught by the shape check, before path resolution — an
+        # earlier and stricter rejection than containment would give.
+        ("../outside.py", "invalid_path"),
+        (".env", "secret_file"),
+        ("link.py", "symlink_rejected"),
+        ("nope.py", "path_not_found"),
+        ("a.py/", "invalid_path"),
+        ("/etc/passwd", "invalid_path"),
+    ],
+)
+async def test_prepare_rejects_unsafe_paths_before_any_write(git_repo, bad_path, expected):
+    """Every unsafe path shape is refused with the index left untouched."""
+    (git_repo / "pkg").mkdir()
+    (git_repo / ".env").write_text("SECRET=1\n")
+    (git_repo / "link.py").symlink_to(git_repo / "a.py")
+    before = _index_bytes(git_repo)
+
+    res = await LocalGitToolkit(repo_root=git_repo).git_prepare_files([bad_path])
+    assert res.status == "error"
+    assert res.error.code == expected
+    assert _index_bytes(git_repo) == before
+
+
+async def test_prepare_rejects_duplicate_paths(git_repo):
+    """The same file twice is a caller error, not a silent de-duplication."""
+    (git_repo / "a.py").write_text("print('A')\n")
+    res = await LocalGitToolkit(repo_root=git_repo).git_prepare_files(["a.py", "./a.py"])
+    assert res.status == "error"
+    assert res.error.code in {"invalid_path", "duplicate_path"}
+
+
+async def test_prepare_publishes_to_linked_worktree_index(linked_worktree, git_repo):
+    """A linked worktree stages into its own index, not the main one."""
+    main_index_before = _index_bytes(git_repo)
+    (linked_worktree / "w.py").write_text("w = 1\n")
+
+    res = await LocalGitToolkit(repo_root=linked_worktree).git_prepare_files(["w.py"])
+    assert res.status == "ok"
+    assert res.data["staged"] == ["w.py"]
+    assert _index_bytes(git_repo) == main_index_before
+
+    layout = await LocalGitToolkit(repo_root=linked_worktree)._discover()
+    assert ".git/worktrees/" in layout.index_path.as_posix()
+    staged = [item for item in git(linked_worktree, "diff", "--cached", "--name-only", "-z").stdout.split("\0") if item]
+    assert staged == ["w.py"]
+
+
+async def test_prepare_leaves_no_temporary_index_files(git_repo):
+    """The private index copy is always removed, on success and on failure."""
+    (git_repo / "a.py").write_text("print('A')\n")
+    toolkit = LocalGitToolkit(repo_root=git_repo)
+    await toolkit.git_prepare_files(["a.py"])
+    (git_repo / "a.py").write_text("print('B') \n")
+    await toolkit.git_prepare_files(["a.py"])
+    assert list((git_repo / ".git").glob("parrot-index-*")) == []
+
+
+# --------------------------------------------------------------------------- #
+# git_pull
+# --------------------------------------------------------------------------- #
+async def test_pull_ff_only_then_up_to_date(git_repo, bare_remote, tmp_path):
+    """A real fast-forward updates the branch; a second pull is a no-op."""
+    other = _clone_on_dev(bare_remote, tmp_path)
+    (other / "c.py").write_text("c\n")
+    git(other, "add", "c.py")
+    git(other, "commit", "-q", "-m", "c")
+    git(other, "push", "-q")
+    git(git_repo, "branch", "--set-upstream-to", "origin/dev", "dev")
+
+    toolkit = LocalGitToolkit(repo_root=git_repo)
+    first = await toolkit.git_pull()
+    assert first.status == "ok"
+    assert first.data["updated"] is True
+    assert first.data["before"] != first.data["after"]
+    assert (git_repo / "c.py").exists()
+
+    second = await toolkit.git_pull()
+    assert second.status == "ok"
+    assert second.data["updated"] is False
+
+
+async def test_pull_diverged(git_repo, bare_remote, tmp_path):
+    """Divergence is refused; no merge commit is ever created."""
+    other = _clone_on_dev(bare_remote, tmp_path)
+    (other / "c.py").write_text("c\n")
+    git(other, "add", "c.py")
+    git(other, "commit", "-q", "-m", "c")
+    git(other, "push", "-q")
+    (git_repo / "d.py").write_text("d\n")
+    git(git_repo, "add", "d.py")
+    git(git_repo, "commit", "-q", "-m", "d")
+    git(git_repo, "branch", "--set-upstream-to", "origin/dev", "dev")
+
+    res = await LocalGitToolkit(repo_root=git_repo).git_pull()
+    assert res.status == "error"
+    assert res.error.code == "diverged"
+    assert res.error.details["ahead"] == 1
+    assert res.error.details["behind"] == 1
+
+
+async def test_pull_preserves_conflicting_untracked_file(git_repo, bare_remote, tmp_path):
+    """Git refuses to clobber an untracked file, and its content survives."""
+    other = _clone_on_dev(bare_remote, tmp_path)
+    (other / "c.py").write_text("from remote\n")
+    git(other, "add", "c.py")
+    git(other, "commit", "-q", "-m", "c")
+    git(other, "push", "-q")
+    (git_repo / "c.py").write_text("MINE - untracked\n")
+    git(git_repo, "branch", "--set-upstream-to", "origin/dev", "dev")
+
+    res = await LocalGitToolkit(repo_root=git_repo).git_pull()
+    assert res.status == "error"
+    assert res.error.code == "untracked_conflict"
+    assert (git_repo / "c.py").read_text() == "MINE - untracked\n"
+
+
+async def test_pull_refuses_dirty_and_staged_and_detached(git_repo, bare_remote):
+    """Unsafe working-tree states are refused before any network access."""
+    git(git_repo, "branch", "--set-upstream-to", "origin/dev", "dev")
+    toolkit = LocalGitToolkit(repo_root=git_repo)
+
+    (git_repo / "a.py").write_text("dirty\n")
+    assert (await toolkit.git_pull()).error.code == "dirty_worktree"
+
+    git(git_repo, "add", "a.py")
+    assert (await toolkit.git_pull()).error.code == "staged_changes"
+
+    git(git_repo, "restore", "-q", "--staged", "--worktree", "a.py")
+    head = git(git_repo, "rev-parse", "HEAD").stdout.strip()
+    git(git_repo, "checkout", "-q", "--detach", head)
+    assert (await LocalGitToolkit(repo_root=git_repo).git_pull()).error.code == "detached_head"
+
+
+async def test_pull_missing_upstream_and_branch_mismatch(git_repo, bare_remote):
+    """Branch resolution refuses ambiguity rather than guessing."""
+    toolkit = LocalGitToolkit(repo_root=git_repo)
+    assert (await toolkit.git_pull()).error.code == "missing_upstream"
+    assert (await toolkit.git_pull(branch="main")).error.code == "branch_mismatch"
+
+
+# --------------------------------------------------------------------------- #
+# git_push
+# --------------------------------------------------------------------------- #
+async def test_push_succeeds_to_bare_remote(git_repo, bare_remote):
+    """A fast-forward push reports the branch and the remote's new commit."""
+    (git_repo / "d.py").write_text("d\n")
+    git(git_repo, "add", "d.py")
+    git(git_repo, "commit", "-q", "-m", "d")
+    local = git(git_repo, "rev-parse", "HEAD").stdout.strip()
+
+    res = await LocalGitToolkit(repo_root=git_repo).git_push(branch="dev")
+    assert res.status == "ok"
+    assert res.data["branch"] == "dev"
+    assert res.data["local_commit"] == local
+    assert res.data["remote_commit_after"] == local
+    remote_head = git(bare_remote, "rev-parse", "refs/heads/dev").stdout.strip()
+    assert remote_head == local
+
+
+async def test_push_rejected_without_force(git_repo, bare_remote, tmp_path):
+    """A remote that moved ahead rejects the push; it is never forced."""
+    other = _clone_on_dev(bare_remote, tmp_path)
+    (other / "c.py").write_text("c\n")
+    git(other, "add", "c.py")
+    git(other, "commit", "-q", "-m", "c")
+    git(other, "push", "-q")
+    (git_repo / "d.py").write_text("d\n")
+    git(git_repo, "add", "d.py")
+    git(git_repo, "commit", "-q", "-m", "d")
+
+    res = await LocalGitToolkit(repo_root=git_repo).git_push(branch="dev")
+    assert res.status == "error"
+    assert res.error.code == "push_rejected"
+    assert "rejected" in res.error.details["summary"].lower()
+
+
+async def test_push_timeout_is_uncertain_then_resolved(git_repo, bare_remote, tmp_path, monkeypatch):
+    """A timed-out push is uncertain, and is resolved by one read-only probe."""
+    real_git = shutil.which("git")
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_git = fake_bin / "git"
+    fake_git.write_text(textwrap.dedent(f"""\
+            #!/bin/sh
+            for arg in "$@"; do
+              if [ "$arg" = "push" ]; then sleep 30; fi
+            done
+            exec {real_git} "$@"
+            """))
+    fake_git.chmod(fake_git.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    monkeypatch.setenv("PATH", f"{fake_bin}{os.pathsep}{os.environ['PATH']}")
+
+    # The remote already has exactly our HEAD, so ls-remote resolves it to ok.
+    toolkit = LocalGitToolkit(repo_root=git_repo, network_timeout_seconds=0.4)
+    res = await toolkit.git_push(branch="dev")
+    assert res.status == "ok"
+    assert res.data["resolved_after_timeout"] is True
+
+    # Now make the local branch differ, so the probe cannot resolve it.
+    (git_repo / "d.py").write_text("d\n")
+    git(git_repo, "add", "d.py")
+    git(git_repo, "commit", "-q", "-m", "d")
+    unresolved = await LocalGitToolkit(repo_root=git_repo, network_timeout_seconds=0.4).git_push(branch="dev")
+    assert unresolved.status == "uncertain"
+    assert unresolved.error.code == "push_timeout"
+    assert unresolved.data["resolved_after_timeout"] is False
+
+
+async def test_push_refuses_detached_head(git_repo, bare_remote):
+    """A detached HEAD has no branch to publish."""
+    head = git(git_repo, "rev-parse", "HEAD").stdout.strip()
+    git(git_repo, "checkout", "-q", "--detach", head)
+    res = await LocalGitToolkit(repo_root=git_repo).git_push()
+    assert res.error.code == "detached_head"
+
+
+def test_push_porcelain_parsers():
+    """Porcelain flags and commit ranges are parsed, not guessed."""
+    from parrot_tools.tool_optimizations.git import _parse_push_porcelain, _parse_push_range
+
+    ok = "To /tmp/r.git\n \trefs/heads/dev:refs/heads/dev\taaaaaaa..bbbbbbb\nDone\n"
+    assert _parse_push_porcelain(ok) == (" ", "refs/heads/dev:refs/heads/dev", "aaaaaaa..bbbbbbb")
+    assert _parse_push_range("aaaaaaa..bbbbbbb") == ("aaaaaaa", "bbbbbbb")
+    assert _parse_push_range("[new branch]") == (None, None)
+
+    rejected = "To /tmp/r.git\n!\trefs/heads/dev:refs/heads/dev\t[rejected] (fetch first)\nDone\n"
+    assert _parse_push_porcelain(rejected)[0] == "!"
+    assert _parse_push_porcelain("")[0] == ""
+
+
+# --------------------------------------------------------------------------- #
+# Forbidden verbs
+# --------------------------------------------------------------------------- #
+def test_no_forbidden_git_verbs_in_source():
+    """The module can never reset, stash, force-push or push all refs."""
+    import inspect
+
+    import parrot_tools.tool_optimizations.git as module
+
+    src = inspect.getsource(module)
+    for bad in ('"reset"', '"stash"', '"--force"', '"--force-with-lease"', '"--all"', '"--mirror"', '"rebase"'):
+        assert bad not in src, f"forbidden git argv literal present: {bad}"
+
+
+async def test_prepare_stages_same_size_edit_made_in_the_same_clock_tick(git_repo):
+    """A same-size edit right after `git add` must still be staged.
+
+    Regression test. Git decides an index entry is "racily clean" by
+    comparing the entry's mtime against the *index file's* mtime, and
+    re-hashes the file when it is. Copying the index with a fresh mtime
+    silently converts those entries into trusted-clean ones, so a same-size
+    edit made within the same (coarse, ~ms) filesystem clock tick as the
+    last `git add` was not staged. Plain `git diff` never misses it, so
+    neither may this toolkit.
+    """
+    toolkit = LocalGitToolkit(repo_root=git_repo)
+    for index in range(25):
+        # Same byte length as the committed content, written immediately.
+        (git_repo / "a.py").write_text(f"print('{index:02d}')\n")
+        res = await toolkit.git_prepare_files(["a.py"])
+        assert res.status == "ok", (index, res.error.code, res.error.details)
+        assert res.data["staged"] == ["a.py"]
+        git(git_repo, "commit", "-q", "-m", f"c{index}")

--- a/packages/ai-parrot-tools/tests/tool_optimizations/test_git.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/test_git.py
@@ -755,3 +755,54 @@ async def test_prepare_stages_same_size_edit_made_in_the_same_clock_tick(git_rep
         assert res.status == "ok", (index, res.error.code, res.error.details)
         assert res.data["staged"] == ["a.py"]
         git(git_repo, "commit", "-q", "-m", f"c{index}")
+
+
+# =========================================================================== #
+# Push refspec regression (found in adversarial review)
+# =========================================================================== #
+async def test_push_publishes_the_current_branch_not_the_upstream_name(git_repo, bare_remote, tmp_path):
+    """A branch tracking a differently-named upstream must push ITS OWN commits.
+
+    Regression: `_resolve_publication_branch` returns the *upstream* branch
+    name, and that name was used on BOTH sides of the refspec. On a branch
+    tracking `origin/<other>`, this pushed the unrelated local `<other>`
+    branch's history while reporting the current branch's commit — wrong
+    data published, and an untruthful result.
+    """
+    # `dev` already exists and is pushed by the bare_remote fixture.
+    git(git_repo, "checkout", "-q", "-b", "feature")
+    (git_repo / "feature_only.py").write_text("feature = True\n")
+    git(git_repo, "add", "feature_only.py")
+    git(git_repo, "commit", "-q", "-m", "feature work")
+    git(git_repo, "branch", "--set-upstream-to", "origin/dev", "feature")
+
+    dev_sha = git(git_repo, "rev-parse", "dev").stdout.strip()
+    feature_sha = git(git_repo, "rev-parse", "feature").stdout.strip()
+    assert dev_sha != feature_sha
+
+    result = await LocalGitToolkit(repo_root=git_repo).git_push()
+    assert result.status == "ok", result.error
+
+    # Reported identity matches what was actually published.
+    assert result.data["branch"] == "feature"
+    assert result.data["remote_branch"] == "dev"
+    assert result.data["local_commit"] == feature_sha
+
+    published = git(bare_remote, "rev-parse", "refs/heads/dev").stdout.strip()
+    assert published == feature_sha, "the wrong branch's history was published"
+    assert published != dev_sha
+
+
+async def test_push_does_not_publish_tags(git_repo, bare_remote):
+    """`push.followTags` must not turn a branch push into a tag push."""
+    git(git_repo, "config", "push.followTags", "true")
+    git(git_repo, "tag", "-a", "v9.9.9", "-m", "should stay local")
+    (git_repo / "x.py").write_text("x = 1\n")
+    git(git_repo, "add", "x.py")
+    git(git_repo, "commit", "-q", "-m", "work")
+
+    result = await LocalGitToolkit(repo_root=git_repo).git_push(branch="dev")
+    assert result.status == "ok", result.error
+
+    tags = git(bare_remote, "tag", "--list").stdout.strip()
+    assert tags == "", f"tags leaked to the remote: {tags!r}"

--- a/packages/ai-parrot-tools/tests/tool_optimizations/test_git.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/test_git.py
@@ -1,0 +1,313 @@
+"""Unit tests for LocalGitToolkit discovery/read/fetch (TASK-3080, FEAT-543)."""
+
+import os
+import shutil
+import stat
+import textwrap
+from pathlib import Path
+
+import pytest
+from parrot.tools.abstract import AbstractTool
+
+from parrot_tools.tool_optimizations.git import GIT_ENV, LocalGitToolkit, RepoLayout, _parse_status_v2
+from parrot_tools.tool_optimizations.models import OperationResult
+
+from .conftest import git
+
+
+# --------------------------------------------------------------------------- #
+# Tool surface
+# --------------------------------------------------------------------------- #
+def test_exposes_exactly_the_read_and_fetch_tools(git_repo):
+    """Only this task's three tools exist; each is a real AbstractTool."""
+    tools = LocalGitToolkit(repo_root=git_repo).get_tools()
+    assert {tool.name for tool in tools} == {"git_recent", "git_fetch", "git_preflight"}
+    assert all(isinstance(tool, AbstractTool) for tool in tools)
+
+
+def test_git_env_is_noninteractive():
+    """The forced environment cannot prompt, page or interpret pathspec magic."""
+    assert GIT_ENV["GIT_TERMINAL_PROMPT"] == "0"
+    assert GIT_ENV["GIT_LITERAL_PATHSPECS"] == "1"
+    assert GIT_ENV["GIT_OPTIONAL_LOCKS"] == "0"
+    # User config must still apply (remotes, credential helpers).
+    assert "GIT_CONFIG_NOSYSTEM" not in GIT_ENV
+
+
+# --------------------------------------------------------------------------- #
+# git_recent
+# --------------------------------------------------------------------------- #
+async def test_recent_limit_and_option_shaped_ref(git_repo):
+    """History is bounded, and an option-shaped ref never reaches a subprocess."""
+    toolkit = LocalGitToolkit(repo_root=git_repo)
+    res = await toolkit.git_recent(limit=1)
+    assert res.status == "ok"
+    assert len(res.data["commits"]) == 1
+    assert res.data["commits"][0]["subject"] == "init"
+    assert len(res.data["commit"]) == 40
+
+    bad = await toolkit.git_recent(ref="--upload-pack=/bin/sh")
+    assert bad.status == "error"
+    assert bad.error.code == "invalid_ref"
+    assert bad.steps == []
+
+
+async def test_recent_rejects_out_of_range_limit_on_direct_call(git_repo):
+    """A direct Python call is validated too, not only the MCP seam."""
+    toolkit = LocalGitToolkit(repo_root=git_repo)
+    for limit in (0, 51):
+        res = await toolkit.git_recent(limit=limit)
+        assert res.status == "error"
+        assert res.error.code == "invalid_arguments"
+        assert res.steps == []
+
+
+async def test_recent_rejects_out_of_range_limit_via_pre_execute(git_repo):
+    """_pre_execute rejects the same value at the raw-argument boundary."""
+    toolkit = LocalGitToolkit(repo_root=git_repo)
+    with pytest.raises(ValueError, match="invalid arguments"):
+        await toolkit._pre_execute("git_recent", limit=51)
+
+
+async def test_recent_unknown_ref(git_repo):
+    """A syntactically valid but nonexistent ref is reported, not crashed on."""
+    res = await LocalGitToolkit(repo_root=git_repo).git_recent(ref="no-such-branch")
+    assert res.status == "error"
+    assert res.error.code == "unknown_ref"
+
+
+# --------------------------------------------------------------------------- #
+# git_fetch
+# --------------------------------------------------------------------------- #
+async def test_fetch_reports_fetched_and_fresh(git_repo, bare_remote):
+    """A normal fetch reports the fetched commit and a matching tracking ref."""
+    res = await LocalGitToolkit(repo_root=git_repo).git_fetch(remote="origin", branch="dev", recent=1)
+    assert res.status == "ok"
+    assert res.data["fresh"] is True
+    assert res.data["fetched_commit"] == res.data["tracking_commit"]
+    assert res.data["tracking_ref"] == "refs/remotes/origin/dev"
+    assert len(res.data["commits"]) == 1
+
+
+async def test_fetch_unknown_remote_never_fetches(git_repo, bare_remote):
+    """An unconfigured remote is refused before any network step."""
+    res = await LocalGitToolkit(repo_root=git_repo).git_fetch(remote="nope")
+    assert res.status == "error"
+    assert res.error.code == "unknown_remote"
+    assert "fetch" not in [step.name for step in res.steps]
+
+
+@pytest.mark.parametrize("branch", ["origin/dev:dev", "HEAD~1", "dev@{upstream}", "-x", "dev..main", "dev.lock"])
+async def test_fetch_rejects_non_branch_values(git_repo, bare_remote, branch):
+    """Refspecs, revision expressions and option-shaped values are rejected."""
+    res = await LocalGitToolkit(repo_root=git_repo).git_fetch(branch=branch)
+    assert res.status == "error"
+    assert res.error.code == "invalid_branch"
+
+
+async def test_fetch_failure_stops_history(git_repo, bare_remote):
+    """A failed fetch must not fall through to a history lookup."""
+    shutil.rmtree(bare_remote)
+    res = await LocalGitToolkit(repo_root=git_repo).git_fetch()
+    assert res.status == "error"
+    assert res.error.code == "fetch_failed"
+    # Only the fetch step is reported: no history lookup was attempted.
+    assert [step.name for step in res.steps] == ["fetch"]
+
+
+async def test_fetch_rejects_non_fast_forward_tracking_update(git_repo, bare_remote, tmp_path):
+    """Without a '+' refspec a non-fast-forward tracking update is a rejection."""
+    # Rewrite the remote's dev to an unrelated (non-descendant) history.
+    other = tmp_path / "other"
+    other.mkdir()
+    git(other, "init", "-q", "-b", "dev")
+    git(other, "config", "commit.gpgsign", "false")
+    (other / "z.py").write_text("z\n")
+    git(other, "add", "z.py")
+    git(other, "commit", "-q", "-m", "unrelated")
+    git(other, "push", "-q", "--force", str(bare_remote), "dev")
+
+    # Populate a stale remote-tracking ref first, so the next fetch must
+    # move it backwards/sideways.
+    git(git_repo, "update-ref", "refs/remotes/origin/dev", "HEAD")
+
+    res = await LocalGitToolkit(repo_root=git_repo).git_fetch()
+    assert res.status == "error"
+    assert res.error.code == "fetch_rejected"
+    assert [step.name for step in res.steps] == ["fetch"]
+
+
+# --------------------------------------------------------------------------- #
+# git_preflight
+# --------------------------------------------------------------------------- #
+async def test_preflight_runs_every_check(git_repo):
+    """Every check reports a result even when an earlier one fails."""
+    (git_repo / "a.py").write_text("print('a') \n")  # trailing whitespace
+    (git_repo / "b.py").write_text("x = 1\n")
+    git(git_repo, "add", "b.py")
+
+    res = await LocalGitToolkit(repo_root=git_repo).git_preflight()
+    assert set(res.data["checks"]) == {"status", "diff_check", "cached_check", "staged_names"}
+    assert res.data["checks"]["diff_check"]["ok"] is False
+    assert res.data["checks"]["status"]["ok"] is True
+    assert res.data["staged"] == ["b.py"]
+    assert res.status == "error"
+    assert res.error.code == "preflight_failed"
+    assert res.error.details["failed"] == ["diff_check"]
+
+
+async def test_preflight_clean_tree(git_repo):
+    """A clean tree passes every check and reports its branch."""
+    res = await LocalGitToolkit(repo_root=git_repo).git_preflight()
+    assert res.status == "ok"
+    assert res.data["branch"] == "dev"
+    assert res.data["detached"] is False
+    assert res.data["unborn"] is False
+    assert res.data["counts"]["staged"] == 0
+    assert res.data["staged"] == []
+
+
+async def test_preflight_reports_untracked_and_unstaged(git_repo):
+    """Categories are split by the porcelain-v2 XY columns, not guessed."""
+    (git_repo / "a.py").write_text("print('changed')\n")
+    (git_repo / "new.txt").write_text("hello\n")
+    git(git_repo, "add", "a.py")
+    (git_repo / "a.py").write_text("print('changed again')\n")
+
+    res = await LocalGitToolkit(repo_root=git_repo).git_preflight()
+    # a.py is both staged and unstaged (partially staged).
+    assert "a.py" in res.data["paths"]["staged"]
+    assert "a.py" in res.data["paths"]["unstaged"]
+    assert "new.txt" in res.data["paths"]["untracked"]
+
+
+async def test_preflight_detached_head(git_repo):
+    """A detached HEAD is reported explicitly rather than as a branch name."""
+    head = git(git_repo, "rev-parse", "HEAD").stdout.strip()
+    git(git_repo, "checkout", "-q", "--detach", head)
+    res = await LocalGitToolkit(repo_root=git_repo).git_preflight()
+    assert res.data["detached"] is True
+    assert res.data["branch"] is None
+
+
+def test_parse_status_v2_handles_rename_entries():
+    """A '2 ' rename entry consumes two NUL records and is attributed once."""
+    raw = b"\x00".join(
+        [
+            b"# branch.oid abc123",
+            b"# branch.head dev",
+            b"# branch.ab +2 -1",
+            b"2 R. N... 100644 100644 100644 aaa bbb R100 new_name.py",
+            b"old_name.py",
+            b"? untracked.txt",
+            b"",
+        ]
+    )
+    summary = _parse_status_v2(raw)
+    assert summary["branch"] == "dev"
+    assert summary["ahead"] == 2 and summary["behind"] == 1
+    assert summary["paths"]["staged"] == ["new_name.py"]
+    assert summary["paths"]["unstaged"] == []
+    assert summary["paths"]["untracked"] == ["untracked.txt"]
+
+
+# --------------------------------------------------------------------------- #
+# Discovery
+# --------------------------------------------------------------------------- #
+async def test_linked_worktree_discovery(linked_worktree):
+    """A linked worktree resolves its own git dir and index (.git is a file)."""
+    assert (linked_worktree / ".git").is_file()
+    layout = await LocalGitToolkit(repo_root=linked_worktree)._discover()
+    assert isinstance(layout, RepoLayout)
+    assert layout.is_linked_worktree is True
+    assert ".git/worktrees/" in layout.git_dir.as_posix()
+    assert layout.index_path.exists()
+    assert layout.common_dir != layout.git_dir
+    assert layout.lock_path.parent == layout.git_dir
+
+
+async def test_plain_repo_discovery(git_repo):
+    """A normal checkout resolves a relative --git-common-dir correctly."""
+    layout = await LocalGitToolkit(repo_root=git_repo)._discover()
+    assert isinstance(layout, RepoLayout)
+    assert layout.is_linked_worktree is False
+    assert layout.git_dir == layout.common_dir == git_repo / ".git"
+    assert layout.toplevel == git_repo.resolve()
+
+
+async def test_bare_repository_refused(tmp_path):
+    """Worktree operations require a non-bare repository."""
+    bare = tmp_path / "bare.git"
+    git(tmp_path, "init", "-q", "--bare", str(bare))
+    result = await LocalGitToolkit(repo_root=bare)._discover()
+    assert isinstance(result, OperationResult)
+    assert result.error.code == "bare_repository"
+
+
+async def test_root_mismatch_refused(git_repo):
+    """repo_root must be the work-tree toplevel, not a subdirectory."""
+    sub = git_repo / "pkg"
+    sub.mkdir()
+    result = await LocalGitToolkit(repo_root=sub)._discover()
+    assert isinstance(result, OperationResult)
+    assert result.error.code == "root_mismatch"
+
+
+async def test_not_a_repository(tmp_path):
+    """A plain directory is reported, not treated as an empty repository."""
+    result = await LocalGitToolkit(repo_root=tmp_path)._discover()
+    assert isinstance(result, OperationResult)
+    assert result.error.code == "not_a_repository"
+
+
+async def test_discovery_is_cached(git_repo):
+    """The layout is resolved once per instance."""
+    toolkit = LocalGitToolkit(repo_root=git_repo)
+    first = await toolkit._discover()
+    assert await toolkit._discover() is first
+
+
+# --------------------------------------------------------------------------- #
+# Runner: bounded output, timeout, cancellation
+# --------------------------------------------------------------------------- #
+async def test_runner_bounds_large_output_without_deadlock(git_repo):
+    """A multi-megabyte stdout is capped but fully drained (no pipe deadlock)."""
+    big = git_repo / "big.txt"
+    big.write_text("x" * 80 + "\n" * 1)
+    payload = ("y" * 79 + "\n") * 70_000  # ~5.5 MiB
+    big.write_text(payload)
+    git(git_repo, "add", "big.txt")
+    git(git_repo, "commit", "-q", "-m", "big")
+
+    toolkit = LocalGitToolkit(repo_root=git_repo)
+    step, raw = await toolkit._run_git(["show", "--end-of-options", "HEAD:big.txt"], max_capture=1_048_576)
+    assert step.exit_code == 0
+    assert step.timed_out is False
+    assert step.truncated is True
+    assert len(raw) == 1_048_576  # capped, but the child still ran to completion
+
+
+async def test_runner_times_out_and_kills_child(git_repo, tmp_path, monkeypatch):
+    """A hung git is killed and reported as timed out, with no orphan."""
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_git = fake_bin / "git"
+    fake_git.write_text(textwrap.dedent("""\
+        #!/bin/sh
+        sleep 30
+        """))
+    fake_git.chmod(fake_git.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    monkeypatch.setenv("PATH", f"{fake_bin}{os.pathsep}{os.environ['PATH']}")
+
+    toolkit = LocalGitToolkit(repo_root=git_repo, command_timeout_seconds=0.3)
+    step, raw = await toolkit._run_git(["status"])
+    assert step.timed_out is True
+    assert step.exit_code is None
+    assert raw == b""
+
+
+async def test_runner_reports_failure_exit_code(git_repo):
+    """A failing command keeps its exit code; truncation cannot mask it."""
+    step, _ = await LocalGitToolkit(repo_root=git_repo)._run_git(["rev-parse", "--verify", "--quiet", "nope"])
+    assert step.exit_code != 0
+    assert step.timed_out is False

--- a/packages/ai-parrot-tools/tests/tool_optimizations/test_hooks.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/test_hooks.py
@@ -1,0 +1,294 @@
+"""Tests for the opt-in host read guards (TASK-3088, FEAT-543)."""
+
+import io
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from parrot_tools.tool_optimizations.hooks import (
+    GuardPolicy,
+    build_reason,
+    count_lines_bounded,
+    coverage_matrix,
+    evaluate_shell,
+    main,
+    parse_shell_subset,
+)
+from parrot_tools.tool_optimizations.reader import count_lines_bounded as reader_count_lines
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    """A directory holding a large and a small source file."""
+    (tmp_path / "big.py").write_text("".join(f"line{i}\n" for i in range(1, 401)))
+    (tmp_path / "small.py").write_text("".join(f"line{i}\n" for i in range(1, 101)))
+    (tmp_path / "sub").mkdir()
+    return tmp_path
+
+
+def _run(payload, *, host="claude", cwd=None):
+    """Drive main() with a hook payload and return its stdout."""
+    if cwd is not None:
+        payload.setdefault("cwd", str(cwd))
+    stdout = io.StringIO()
+    code = main(["--host", host], stdin=io.StringIO(json.dumps(payload)), stdout=stdout)
+    assert code == 0, "the guard must always exit 0"
+    return stdout.getvalue()
+
+
+def _read_payload(path, **tool_input):
+    """Build a Claude Read payload."""
+    return {"hook_event_name": "PreToolUse", "tool_name": "Read", "tool_input": {"file_path": str(path), **tool_input}}
+
+
+def _bash_payload(command):
+    """Build a Bash payload."""
+    return {"hook_event_name": "PreToolUse", "tool_name": "Bash", "tool_input": {"command": command}}
+
+
+# --------------------------------------------------------------------------- #
+# Structured Read
+# --------------------------------------------------------------------------- #
+def test_structured_read_of_large_file_is_denied(workspace):
+    """A large unbounded Read is denied with an actionable reason."""
+    out = _run(_read_payload(workspace / "big.py"), cwd=workspace)
+    payload = json.loads(out)["hookSpecificOutput"]
+
+    assert payload["hookEventName"] == "PreToolUse"
+    assert payload["permissionDecision"] == "deny"
+    reason = payload["permissionDecisionReason"]
+    assert "parrot-bounded-source" in reason
+    assert "source_read" in reason
+    assert '"start_line": 1' in reason
+    assert '"end_line": 350' in reason
+    assert "next_line" in reason and "expected_sha256" in reason
+    assert "big.py" in reason
+
+
+def test_structured_read_bounded_or_small_is_allowed(workspace):
+    """An explicit limit, or a small file, produces no decision at all."""
+    assert _run(_read_payload(workspace / "big.py", limit=200), cwd=workspace) == ""
+    assert _run(_read_payload(workspace / "small.py"), cwd=workspace) == ""
+
+
+def test_structured_read_limit_above_threshold_is_denied(workspace):
+    """A 'limit' larger than max_lines is not a bound."""
+    assert _run(_read_payload(workspace / "big.py", limit=1000), cwd=workspace) != ""
+
+
+def test_relative_path_is_resolved_against_cwd(workspace):
+    """Hosts may send a repo-relative path."""
+    assert _run(_read_payload("big.py"), cwd=workspace) != ""
+    assert _run(_read_payload("small.py"), cwd=workspace) == ""
+
+
+# --------------------------------------------------------------------------- #
+# Shell subset
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "command,denied",
+    [
+        ("cat big.py", True),
+        ("cat small.py", False),
+        ("head -n 50 big.py", False),
+        ("head -50 big.py", False),
+        ("head -400 big.py", True),
+        ("head -n 400 big.py", True),
+        ("tail -c 1000 big.py", False),
+        ("tail big.py", False),
+        ("head big.py", False),
+        ("less big.py", True),
+        ("more big.py", True),
+        ("cat big.py | head -20", True),
+        ("head -20 small.py | cat", False),
+        ("/bin/cat big.py", True),
+    ],
+)
+def test_shell_subset_decisions(workspace, command, denied):
+    """The documented subset is intercepted; a pipe never excuses a big read."""
+    out = _run(_bash_payload(command), cwd=workspace)
+    assert bool(out) is denied, f"{command!r} produced {out!r}"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cat big.py; rm x",
+        "cat big.py && echo done",
+        "cat big.py || true",
+        "cat $(echo big.py)",
+        "cat `echo big.py`",
+        "cat *.py",
+        "cat < big.py",
+        "cat big.py > out.txt",
+        "sed -n '1,500p' big.py",
+        "awk 'NR<500' big.py",
+        "python -c \"open('big.py').read()\"",
+        "xargs cat",
+        "cat ~/big.py",
+        "cat $HOME/big.py",
+    ],
+)
+def test_coverage_gaps_make_no_decision(workspace, command):
+    """Unrecognised forms leave host behaviour untouched — never a denial."""
+    assert _run(_bash_payload(command), cwd=workspace) == ""
+
+
+def test_stdin_operand_is_not_applicable(workspace):
+    """An explicit '-' reads stdin, not a file."""
+    assert _run(_bash_payload("cat -"), cwd=workspace) == ""
+
+
+def test_multiple_operands_deny_on_the_large_one(workspace):
+    """Every literal operand is evaluated."""
+    assert _run(_bash_payload("cat small.py big.py"), cwd=workspace) != ""
+    assert _run(_bash_payload("cat small.py small.py"), cwd=workspace) == ""
+
+
+def test_parse_shell_subset_rejects_metacharacters():
+    """The parser refuses anything it cannot reason about, before splitting."""
+    assert parse_shell_subset("cat a.py") == [["cat", "a.py"]]
+    assert parse_shell_subset("cat a.py | head -5") == [["cat", "a.py"], ["head", "-5"]]
+    for command in ("cat a; b", "cat `x`", "cat $(x)", "cat *.py", "cat > x", "cat\nb", ""):
+        assert parse_shell_subset(command) is None
+    assert parse_shell_subset('cat "unterminated') is None
+
+
+# --------------------------------------------------------------------------- #
+# Robustness — the guard must never break a session
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"tool_name": "Read", "tool_input": {"file_path": "/nonexistent/nope.py"}},
+        {"tool_name": "Read", "tool_input": {}},
+        {"tool_name": "Bash", "tool_input": {}},
+        {"tool_name": "Grep", "tool_input": {"pattern": "x"}},
+        {"tool_name": "WebFetch", "tool_input": {"url": "https://example.com"}},
+        {},
+    ],
+)
+def test_unactionable_payloads_exit_quietly(workspace, payload):
+    """Missing files, unknown tools and empty payloads produce no output."""
+    assert _run(payload, cwd=workspace) == ""
+
+
+def test_directory_path_is_not_applicable(workspace):
+    """A directory is not a file read."""
+    assert _run(_read_payload(workspace / "sub"), cwd=workspace) == ""
+
+
+def test_malformed_stdin_exits_zero(workspace):
+    """Non-JSON input can never crash the host."""
+    stdout = io.StringIO()
+    assert main(["--host", "claude"], stdin=io.StringIO("not json at all"), stdout=stdout) == 0
+    assert stdout.getvalue() == ""
+
+
+# --------------------------------------------------------------------------- #
+# Hosts and configuration
+# --------------------------------------------------------------------------- #
+def test_codex_host_gets_the_same_denial(workspace):
+    """Codex reads through the shell and accepts the same response shape."""
+    claude_out = _run(_bash_payload("cat big.py"), host="claude", cwd=workspace)
+    codex_out = _run(_bash_payload("cat big.py"), host="codex", cwd=workspace)
+    assert json.loads(codex_out) == json.loads(claude_out)
+    assert json.loads(codex_out)["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_configured_thresholds_change_the_verdict(workspace):
+    """`.parrot/tool-guards.json` drives the policy."""
+    medium = workspace / "medium.py"
+    medium.write_text("".join(f"line{i}\n" for i in range(1, 201)))
+    assert _run(_read_payload(medium), cwd=workspace) == ""
+
+    guards = workspace / ".parrot"
+    guards.mkdir()
+    (guards / "tool-guards.json").write_text(
+        json.dumps({"max_lines": 100, "large_file_bytes": 64000, "reader_server": "my-reader", "tool": "source_read"})
+    )
+    out = _run(_read_payload(medium), cwd=workspace)
+    assert out != ""
+    assert "my-reader" in json.loads(out)["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+def test_broken_guard_config_falls_back_to_defaults(workspace):
+    """A corrupt config must not disable the guard or crash it."""
+    guards = workspace / ".parrot"
+    guards.mkdir()
+    (guards / "tool-guards.json").write_text("{ not json")
+    assert GuardPolicy.load(workspace) == GuardPolicy()
+    assert _run(_read_payload(workspace / "big.py"), cwd=workspace) != ""
+
+
+# --------------------------------------------------------------------------- #
+# Import weight and helper agreement
+# --------------------------------------------------------------------------- #
+def test_hook_import_is_dependency_light():
+    """A hook runs on every tool call; it must not import pydantic or parrot."""
+    code = (
+        "import sys, parrot_tools.tool_optimizations.hooks as h;"
+        "print('pydantic' in sys.modules,"
+        " any(m == 'parrot' or m.startswith('parrot.') for m in sys.modules))"
+    )
+    env = dict(os.environ)
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True, env=env)
+    assert result.stdout.strip() == "False False"
+
+
+@pytest.mark.parametrize("count", [0, 1, 349, 350, 351])
+def test_line_counter_agrees_with_the_reader(tmp_path, count):
+    """The documented duplicate must not drift from the reader's version."""
+    target = tmp_path / "f.txt"
+    target.write_text("".join(f"l{i}\n" for i in range(count)))
+    assert count_lines_bounded(target, 350) == reader_count_lines(target, 350)
+
+    no_final_newline = tmp_path / "g.txt"
+    no_final_newline.write_bytes(b"a\nb\nc")
+    assert count_lines_bounded(no_final_newline, 350) == reader_count_lines(no_final_newline, 350)
+
+
+# --------------------------------------------------------------------------- #
+# Coverage matrix
+# --------------------------------------------------------------------------- #
+def test_coverage_matrix_is_honest_and_complete():
+    """The published matrix must match what the tests above actually prove."""
+    rows = {row["form"]: row for row in coverage_matrix()}
+    assert all(set(row) == {"form", "covered", "note"} for row in rows.values())
+    assert all(row["note"] for row in rows.values())
+
+    covered = {form for form, row in rows.items() if row["covered"]}
+    assert "Claude Read (file_path)" in covered
+    assert "cat FILE" in covered
+    assert "cat FILE | head -20" in covered
+
+    for form in (
+        "cat FILE; other",
+        "cat $(echo FILE)",
+        "cat *.py",
+        "sed -n '1,500p' FILE",
+        "python -c \"open('FILE').read()\"",
+        "xargs cat",
+        "heredoc (<<EOF)",
+        "Codex write_stdin",
+        "Grep / Glob",
+        "WebFetch",
+    ):
+        assert form in rows, f"{form} missing from the coverage matrix"
+        assert rows[form]["covered"] is False, f"{form} is claimed as covered but is not"
+
+
+def test_build_reason_relativises_paths(tmp_path):
+    """The suggested call uses a repo-relative path the reader will accept."""
+    from parrot_tools.tool_optimizations.hooks import GuardDecision
+
+    decision = GuardDecision(
+        deny=True, path=str(tmp_path / "pkg" / "mod.py"), lines=400, size=9000, coverage="structured"
+    )
+    reason = build_reason(decision, GuardPolicy(), tmp_path)
+    assert '"path": "pkg/mod.py"' in reason
+    assert "400 lines" in reason

--- a/packages/ai-parrot-tools/tests/tool_optimizations/test_hooks.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/test_hooks.py
@@ -192,12 +192,34 @@ def test_malformed_stdin_exits_zero(workspace):
 # --------------------------------------------------------------------------- #
 # Hosts and configuration
 # --------------------------------------------------------------------------- #
-def test_codex_host_gets_the_same_denial(workspace):
-    """Codex reads through the shell and accepts the same response shape."""
-    claude_out = _run(_bash_payload("cat big.py"), host="claude", cwd=workspace)
-    codex_out = _run(_bash_payload("cat big.py"), host="codex", cwd=workspace)
-    assert json.loads(codex_out) == json.loads(claude_out)
-    assert json.loads(codex_out)["hookSpecificOutput"]["permissionDecision"] == "deny"
+def test_each_host_gets_its_own_refusal_keyword(workspace):
+    """Regression: Codex rejects `deny`; its enum is approve|block|allow.
+
+    Verified against codex-cli 0.154.0, whose `PreToolUseDecisionWire`
+    serde variants are `approve`, `block`, `allow`, and which reports
+    "PreToolUse hook returned unsupported decision" otherwise. Sending
+    Claude's `deny` to Codex fails open — the large read would proceed.
+    """
+    claude_payload = json.loads(_run(_bash_payload("cat big.py"), host="claude", cwd=workspace))
+    codex_payload = json.loads(_run(_bash_payload("cat big.py"), host="codex", cwd=workspace))
+
+    assert claude_payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert codex_payload["hookSpecificOutput"]["permissionDecision"] == "block"
+
+    # Everything else about the envelope is shared.
+    assert claude_payload["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+    assert codex_payload["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+    assert (
+        claude_payload["hookSpecificOutput"]["permissionDecisionReason"]
+        == codex_payload["hookSpecificOutput"]["permissionDecisionReason"]
+    )
+
+
+def test_deny_value_table_matches_each_host_enum():
+    """The refusal keyword table is explicit, not incidental."""
+    from parrot_tools.tool_optimizations.hooks import DENY_VALUE
+
+    assert DENY_VALUE == {"claude": "deny", "codex": "block"}
 
 
 def test_configured_thresholds_change_the_verdict(workspace):

--- a/packages/ai-parrot-tools/tests/tool_optimizations/test_hooks.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/test_hooks.py
@@ -314,3 +314,72 @@ def test_build_reason_relativises_paths(tmp_path):
     reason = build_reason(decision, GuardPolicy(), tmp_path)
     assert '"path": "pkg/mod.py"' in reason
     assert "400 lines" in reason
+
+
+# --------------------------------------------------------------------------- #
+# Fail-open regressions (found in adversarial review)
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "command,why",
+    [
+        ("tail -n +1 big.py", "a signed count means 'from line 1 to EOF', not '1 line'"),
+        ("tail -n +10 big.py", "signed counts are offsets, not bounds"),
+        ("head -n -1 big.py", "a negative count means 'all but the last N lines'"),
+        ("head --lines=999999 big.py", "the equals form is one token and was missed by a two-token parser"),
+        ("head -n=999999 big.py", "short equals form"),
+        ("tail -f big.py", "follow/streaming is not a bounded read"),
+        ("head -c 999999 big.py", "a byte count above the threshold is not bounded"),
+        ("cat -n big.py", "'-n' numbers lines for cat and takes NO value; it must not swallow the filename"),
+        ("cat -b big.py", "same class of flag for cat"),
+        ("more -n big.py", "'more' does not take a value for -n either"),
+        ("less -N big.py", "'less' does not take a value for -N either"),
+        ("cat -- big.py", "'--' ends flags; the operand after it must still be checked"),
+    ],
+)
+def test_guard_does_not_fail_open(workspace, command, why):
+    """Every one of these silently ALLOWED a large read before the fix.
+
+    A guard that fails open is worse than no guard: it creates the
+    impression of enforcement while the unbounded read proceeds.
+    """
+    assert _run(_bash_payload(command), cwd=workspace) != "", f"fail-open: {command} ({why})"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "head -n 50 big.py",
+        "head -50 big.py",
+        "head --lines=50 big.py",
+        "tail -c 1000 big.py",
+        "head big.py",
+        "tail big.py",
+        "cat small.py",
+        "cat -n small.py",
+    ],
+)
+def test_genuinely_bounded_reads_are_still_allowed(workspace, command):
+    """The fix must not turn legitimate bounded reads into denials."""
+    assert _run(_bash_payload(command), cwd=workspace) == "", f"false denial: {command}"
+
+
+def test_unrecognized_flags_are_not_assumed_bounded():
+    """An unparsed flag means 'cannot reason about it', not 'safe'."""
+    from parrot_tools.tool_optimizations.hooks import _is_bounded_invocation
+
+    policy = GuardPolicy()
+    assert _is_bounded_invocation(["head", "-n", "50", "f"], policy) is True
+    assert _is_bounded_invocation(["head", "f"], policy) is True
+    assert _is_bounded_invocation(["tail", "--follow", "f"], policy) is False
+    assert _is_bounded_invocation(["tail", "-n", "+1", "f"], policy) is False
+    assert _is_bounded_invocation(["head", "--retry", "f"], policy) is False
+
+
+def test_file_operands_respect_per_program_flag_semantics():
+    """Only head/tail consume a value after -n/-c."""
+    from parrot_tools.tool_optimizations.hooks import _file_operands
+
+    assert _file_operands(["cat", "-n", "big.py"], "cat") == ["big.py"]
+    assert _file_operands(["head", "-n", "50", "big.py"], "head") == ["big.py"]
+    assert _file_operands(["cat", "-"], "cat") is None
+    assert _file_operands(["cat", "--", "-weird-name.py"], "cat") == ["-weird-name.py"]

--- a/packages/ai-parrot-tools/tests/tool_optimizations/test_installation.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/test_installation.py
@@ -340,3 +340,72 @@ def test_cli_reports_a_useful_error_when_parrot_tools_is_absent(cli_root, monkey
 
     plain = runner.invoke(claude, ["install", "--path", str(cli_root), "--no-build"])
     assert plain.exit_code == 0, plain.output
+
+
+# --------------------------------------------------------------------------- #
+# Foreign-hook preservation (regression from adversarial review)
+# --------------------------------------------------------------------------- #
+def _guard_hooks(entries):
+    """Flatten every hook handler across all entries."""
+    return [hook for entry in entries for hook in entry.get("hooks", [])]
+
+
+def test_install_preserves_a_foreign_hook_sharing_our_entry(root):
+    """A user's own command under the SAME matcher must survive an update.
+
+    Ownership is per-hook, not per-entry. Before this was fixed, the update
+    path did `entry.clear(); entry.update(ours)` and silently deleted a
+    co-located foreign handler.
+    """
+    install_guards(root, "claude")
+    settings = _settings(root)
+    ours_entry = next(entry for entry in settings["hooks"]["PreToolUse"] if HOOK_MODULE in json.dumps(entry))
+    ours_entry["hooks"].append({"type": "command", "command": "my-own-important-hook.sh", "timeout": 5})
+    # Force the update path by staling our command.
+    ours_entry["hooks"][0]["command"] = f"/old/python -m {HOOK_MODULE} --host claude"
+    (root / ".claude" / "settings.json").write_text(json.dumps(settings, indent=2) + "\n")
+
+    install_guards(root, "claude")
+    hooks = _guard_hooks(_entries(root))
+
+    foreign = [hook for hook in hooks if hook.get("command") == "my-own-important-hook.sh"]
+    assert len(foreign) == 1, "the user's own hook was destroyed"
+    assert foreign[0]["timeout"] == 5, "the user's own hook was modified"
+
+    ours = [hook for hook in hooks if HOOK_MODULE in str(hook.get("command", ""))]
+    assert len(ours) == 1
+    assert ours[0]["command"] == hook_command(root, "claude"), "our hook was not refreshed"
+
+    # The unrelated pre-existing entries are still intact.
+    assert all(entry in _entries(root) for entry in FOREIGN_ENTRIES)
+
+
+def test_uninstall_preserves_a_foreign_hook_sharing_our_entry(root):
+    """Uninstall removes only our handler, keeping the entry for the other."""
+    install_guards(root, "claude")
+    settings = _settings(root)
+    ours_entry = next(entry for entry in settings["hooks"]["PreToolUse"] if HOOK_MODULE in json.dumps(entry))
+    ours_entry["hooks"].append({"type": "command", "command": "my-own-important-hook.sh", "timeout": 5})
+    (root / ".claude" / "settings.json").write_text(json.dumps(settings, indent=2) + "\n")
+
+    uninstall_guards(root, "claude")
+    hooks = _guard_hooks(_entries(root))
+
+    assert any(hook.get("command") == "my-own-important-hook.sh" for hook in hooks), "the user's own hook was destroyed"
+    assert not any(HOOK_MODULE in str(hook.get("command", "")) for hook in hooks), "our hook was not removed"
+    assert all(entry in _entries(root) for entry in FOREIGN_ENTRIES)
+
+
+def test_install_is_still_idempotent_with_a_shared_entry(root):
+    """Detaching from a shared entry must converge, not oscillate."""
+    install_guards(root, "claude")
+    settings = _settings(root)
+    ours_entry = next(entry for entry in settings["hooks"]["PreToolUse"] if HOOK_MODULE in json.dumps(entry))
+    ours_entry["hooks"].append({"type": "command", "command": "other.sh"})
+    (root / ".claude" / "settings.json").write_text(json.dumps(settings, indent=2) + "\n")
+
+    install_guards(root, "claude")
+    first = (root / ".claude" / "settings.json").read_bytes()
+    actions = install_guards(root, "claude")
+    assert (root / ".claude" / "settings.json").read_bytes() == first
+    assert any("already installed" in action for action in actions)

--- a/packages/ai-parrot-tools/tests/tool_optimizations/test_installation.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/test_installation.py
@@ -1,0 +1,342 @@
+"""Tests for managed guard installation (TASK-3089, FEAT-543)."""
+
+import builtins
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from parrot_tools.tool_optimizations.installation import (
+    CLAUDE_MATCHER,
+    CODEX_MATCHER,
+    HOOK_MODULE,
+    guard_status,
+    guard_thresholds,
+    hook_command,
+    install_guards,
+    uninstall_guards,
+)
+
+#: A foreign PreToolUse entry that must survive every operation, modelled on
+#: this repository's own settings.json.
+FOREIGN_ENTRIES = [
+    {
+        "matcher": "Grep|Glob|Read|Bash",
+        "hooks": [{"type": "command", "command": "wikitoolkit claude-hook", "timeout": 10}],
+    },
+    {
+        "matcher": "Bash|Edit|Write|MultiEdit",
+        "hooks": [{"type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/dangerous-actions-blocker.sh"}],
+        "customKey": {"kept": True},
+    },
+]
+
+
+@pytest.fixture
+def root(tmp_path):
+    """A repo root with a Claude settings file carrying foreign entries."""
+    settings = tmp_path / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True)
+    settings.write_text(
+        json.dumps({"hooks": {"PreToolUse": list(FOREIGN_ENTRIES)}, "otherTopLevel": 1}, indent=2) + "\n"
+    )
+    return tmp_path
+
+
+def _settings(root):
+    """Read the Claude settings object."""
+    return json.loads((root / ".claude" / "settings.json").read_text())
+
+
+def _entries(root, relative=".claude/settings.json"):
+    """Read a host's PreToolUse entries, tolerating collapsed containers."""
+    target = root / relative
+    if not target.exists():
+        return []
+    data = json.loads(target.read_text())
+    return data.get("hooks", {}).get("PreToolUse", [])
+
+
+# --------------------------------------------------------------------------- #
+# Install
+# --------------------------------------------------------------------------- #
+def test_install_is_idempotent_and_preserves_foreign_entries(root):
+    """Installing twice is a no-op, and nothing foreign is disturbed."""
+    first = install_guards(root, "claude")
+    assert any("tool guard installed" in action for action in first)
+    after_first = (root / ".claude" / "settings.json").read_bytes()
+
+    second = install_guards(root, "claude")
+    assert any("already installed" in action for action in second)
+    assert (root / ".claude" / "settings.json").read_bytes() == after_first
+
+    entries = _entries(root)
+    ours = [entry for entry in entries if HOOK_MODULE in json.dumps(entry)]
+    theirs = [entry for entry in entries if HOOK_MODULE not in json.dumps(entry)]
+    assert len(ours) == 1
+    assert theirs == FOREIGN_ENTRIES  # byte-for-byte, including 'customKey'
+    assert _settings(root)["otherTopLevel"] == 1
+
+    assert ours[0]["matcher"] == CLAUDE_MATCHER
+    assert ours[0]["hooks"][0]["command"] == hook_command(root, "claude")
+    assert ours[0]["hooks"][0]["timeout"] == 10
+
+
+def test_install_updates_a_stale_entry_in_place(root):
+    """A changed command or matcher is updated, not duplicated."""
+    install_guards(root, "claude")
+    settings = _settings(root)
+    for entry in settings["hooks"]["PreToolUse"]:
+        if HOOK_MODULE in json.dumps(entry):
+            entry["matcher"] = "Read"
+            entry["hooks"][0]["command"] = f"/old/python -m {HOOK_MODULE} --host claude"
+    (root / ".claude" / "settings.json").write_text(json.dumps(settings, indent=2) + "\n")
+
+    actions = install_guards(root, "claude")
+    assert any("tool guard updated" in action for action in actions)
+    ours = [entry for entry in _entries(root) if HOOK_MODULE in json.dumps(entry)]
+    assert len(ours) == 1
+    assert ours[0]["matcher"] == CLAUDE_MATCHER
+
+
+def test_install_codex_writes_project_scoped_hooks(tmp_path):
+    """Codex hooks go to <root>/.codex/hooks.json, never the user's home."""
+    actions = install_guards(tmp_path, "codex")
+    assert any("tool guard installed" in action for action in actions)
+
+    entries = _entries(tmp_path, ".codex/hooks.json")
+    assert entries[0]["matcher"] == CODEX_MATCHER
+    assert "--host codex" in entries[0]["hooks"][0]["command"]
+    assert not (Path.home() / ".codex" / "hooks.json").exists() or True  # never written by us
+
+
+def test_install_codex_preserves_foreign_hooks(tmp_path):
+    """An existing Codex hooks file keeps its other entries and keys."""
+    hooks_file = tmp_path / ".codex" / "hooks.json"
+    hooks_file.parent.mkdir(parents=True)
+    original = {
+        "hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "other-tool"}]}]},
+        "x": 2,
+    }
+    hooks_file.write_text(json.dumps(original, indent=2) + "\n")
+
+    install_guards(tmp_path, "codex")
+    data = json.loads(hooks_file.read_text())
+    assert data["x"] == 2
+    assert original["hooks"]["PreToolUse"][0] in data["hooks"]["PreToolUse"]
+    assert len(data["hooks"]["PreToolUse"]) == 2
+
+
+@pytest.mark.parametrize("host,relative", [("claude", ".claude/settings.json"), ("codex", ".codex/hooks.json")])
+def test_malformed_config_is_never_clobbered(tmp_path, host, relative):
+    """A broken config raises an actionable error and is left untouched."""
+    target = tmp_path / relative
+    target.parent.mkdir(parents=True)
+    target.write_text("{ this is not json")
+    before = target.read_bytes()
+
+    with pytest.raises(RuntimeError, match=str(target.name)):
+        install_guards(tmp_path, host)
+    assert target.read_bytes() == before
+
+    with pytest.raises(RuntimeError):
+        uninstall_guards(tmp_path, host)
+    assert target.read_bytes() == before
+
+
+def test_wrong_container_types_are_refused(tmp_path):
+    """`hooks` or `hooks.PreToolUse` of the wrong type is an error, not a reset."""
+    target = tmp_path / ".claude" / "settings.json"
+    target.parent.mkdir(parents=True)
+    target.write_text(json.dumps({"hooks": []}) + "\n")
+    with pytest.raises(RuntimeError, match="not a JSON object"):
+        install_guards(tmp_path, "claude")
+
+    target.write_text(json.dumps({"hooks": {"PreToolUse": {}}}) + "\n")
+    with pytest.raises(RuntimeError, match="not a list"):
+        install_guards(tmp_path, "claude")
+
+
+# --------------------------------------------------------------------------- #
+# Thresholds
+# --------------------------------------------------------------------------- #
+def test_thresholds_default_when_no_reader_is_configured(tmp_path):
+    """Defaults match the bounded reader's own thresholds."""
+    thresholds = guard_thresholds(tmp_path)
+    assert thresholds == {
+        "max_lines": 350,
+        "large_file_bytes": 64_000,
+        "reader_server": "parrot-bounded-source",
+        "tool": "source_read",
+    }
+    actions = install_guards(tmp_path, "claude")
+    assert any("reader MCP not configured" in action for action in actions)
+
+
+def test_thresholds_follow_the_configured_reader(tmp_path):
+    """The guard uses the same limits as the MCP reader it points at."""
+    config = tmp_path / ".parrot" / "mcp-toolkits.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text(
+        "toolkits:\n"
+        "  bounded-source:\n"
+        "    class: parrot_tools.tool_optimizations.reader.BoundedSourceToolkit\n"
+        "    kwargs:\n"
+        "      repo_root: .\n"
+        "      max_lines: 100\n"
+        "      large_file_bytes: 10000\n"
+    )
+    thresholds = guard_thresholds(tmp_path)
+    assert thresholds["max_lines"] == 100
+    assert thresholds["large_file_bytes"] == 10_000
+    assert thresholds["reader_server"] == "parrot-bounded-source"
+
+    install_guards(tmp_path, "claude")
+    written = json.loads((tmp_path / ".parrot" / "tool-guards.json").read_text())
+    assert written["max_lines"] == 100
+
+
+# --------------------------------------------------------------------------- #
+# Uninstall
+# --------------------------------------------------------------------------- #
+def test_uninstall_removes_only_our_entry(root):
+    """Foreign entries and unrelated keys survive an uninstall."""
+    install_guards(root, "claude")
+    actions = uninstall_guards(root, "claude")
+    assert any("tool guard removed" in action for action in actions)
+
+    assert _entries(root) == FOREIGN_ENTRIES
+    assert _settings(root)["otherTopLevel"] == 1
+    assert not (root / ".parrot" / "tool-guards.json").exists()
+
+
+def test_uninstall_when_nothing_installed(root):
+    """A hand-removed entry yields 'nothing to remove' and no write."""
+    before = (root / ".claude" / "settings.json").read_bytes()
+    actions = uninstall_guards(root, "claude")
+    assert any("nothing to remove" in action for action in actions)
+    assert (root / ".claude" / "settings.json").read_bytes() == before
+
+
+def test_uninstall_collapses_only_containers_we_emptied(tmp_path):
+    """When ours was the only entry, the empty containers are dropped."""
+    install_guards(tmp_path, "claude")
+    uninstall_guards(tmp_path, "claude")
+    data = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+    assert "hooks" not in data
+
+
+def test_thresholds_survive_while_another_host_still_uses_them(tmp_path):
+    """The shared thresholds file is removed only when no host needs it."""
+    install_guards(tmp_path, "claude")
+    install_guards(tmp_path, "codex")
+
+    uninstall_guards(tmp_path, "claude")
+    assert (tmp_path / ".parrot" / "tool-guards.json").exists(), "codex still has a guard installed"
+
+    uninstall_guards(tmp_path, "codex")
+    assert not (tmp_path / ".parrot" / "tool-guards.json").exists()
+
+
+# --------------------------------------------------------------------------- #
+# Status
+# --------------------------------------------------------------------------- #
+def test_guard_status_reports_installation_and_support(tmp_path):
+    """Status never raises and reports what is knowable."""
+    before = guard_status(tmp_path, "claude")
+    assert before["installed"] is False
+    assert before["thresholds"] is None
+    assert before["hook_path"].endswith(".claude/settings.json")
+    assert before["supported"] in (True, False, None)
+
+    install_guards(tmp_path, "claude")
+    after = guard_status(tmp_path, "claude")
+    assert after["installed"] is True
+    assert after["thresholds"]["max_lines"] == 350
+
+
+def test_guard_status_tolerates_a_malformed_config(tmp_path):
+    """Status must not crash on a config that install would refuse."""
+    target = tmp_path / ".claude" / "settings.json"
+    target.parent.mkdir(parents=True)
+    target.write_text("{ broken")
+    assert guard_status(tmp_path, "claude")["installed"] is False
+
+
+def test_unsupported_host_is_rejected(tmp_path):
+    """Only the two documented hosts are accepted."""
+    for function in (install_guards, uninstall_guards, guard_status):
+        with pytest.raises(ValueError, match="unsupported host"):
+            function(tmp_path, "emacs")
+
+
+# --------------------------------------------------------------------------- #
+# CLI integration
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def cli_root(tmp_path):
+    """A minimal repo root that the wiki CLIs will accept."""
+    (tmp_path / ".parrot").mkdir()
+    (tmp_path / ".git").mkdir()
+    return tmp_path
+
+
+def test_claude_cli_installs_and_removes_guards(cli_root):
+    """`--tool-guards` installs; `uninstall` removes; `status --json` reports."""
+    from parrot.knowledge.wiki.claude_code.cli import claude
+
+    runner = CliRunner()
+    result = runner.invoke(claude, ["install", "--path", str(cli_root), "--no-build", "--tool-guards"])
+    assert "tool guard installed" in result.output, result.output
+    assert any(HOOK_MODULE in json.dumps(entry) for entry in _entries(cli_root))
+
+    status = runner.invoke(claude, ["status", "--path", str(cli_root), "--json"])
+    payload = json.loads(status.output)
+    assert payload["tool_guards"]["installed"] is True
+
+    removed = runner.invoke(claude, ["uninstall", "--path", str(cli_root)])
+    assert "tool guard removed" in removed.output
+    assert not any(HOOK_MODULE in json.dumps(entry) for entry in _entries(cli_root))
+
+
+def test_claude_cli_guards_are_off_by_default(cli_root):
+    """The guard is opt-in: a plain install writes no guard entry."""
+    from parrot.knowledge.wiki.claude_code.cli import claude
+
+    CliRunner().invoke(claude, ["install", "--path", str(cli_root), "--no-build"])
+    settings = cli_root / ".claude" / "settings.json"
+    if settings.exists():
+        assert not any(HOOK_MODULE in json.dumps(entry) for entry in _entries(cli_root))
+
+
+def test_codex_cli_installs_guards(cli_root):
+    """The same flag works for Codex."""
+    from parrot.knowledge.wiki.codex.cli import codex
+
+    runner = CliRunner()
+    result = runner.invoke(codex, ["install", "--path", str(cli_root), "--no-build", "--tool-guards"])
+    assert "tool guard installed" in result.output, result.output
+    assert (cli_root / ".codex" / "hooks.json").exists()
+
+
+def test_cli_reports_a_useful_error_when_parrot_tools_is_absent(cli_root, monkeypatch):
+    """Core must not hard-depend on ai-parrot-tools."""
+    from parrot.knowledge.wiki.claude_code.cli import claude
+
+    real_import = builtins.__import__
+
+    def blocked(name, *args, **kwargs):
+        if name.startswith("parrot_tools.tool_optimizations"):
+            raise ImportError("No module named 'parrot_tools'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked)
+    runner = CliRunner()
+
+    guarded = runner.invoke(claude, ["install", "--path", str(cli_root), "--no-build", "--tool-guards"])
+    assert guarded.exit_code != 0
+    assert "uv pip install ai-parrot-tools" in guarded.output
+
+    plain = runner.invoke(claude, ["install", "--path", str(cli_root), "--no-build"])
+    assert plain.exit_code == 0, plain.output

--- a/packages/ai-parrot-tools/tests/tool_optimizations/test_patches.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/test_patches.py
@@ -41,6 +41,7 @@ def _manifest(artifact_id: str, patch_text: str, packet_json: str = "{}") -> Pat
     return PatchManifest(
         artifact_id=artifact_id,
         task_id="TASK-1000",
+        task_path="sdd/tasks/active/TASK-1000-example.md",
         packet_sha256=hashlib.sha256(packet_json.encode()).hexdigest(),
         patch_sha256=hashlib.sha256(patch_text.encode()).hexdigest(),
         before_hashes={"pkg/__init__.py": hashlib.sha256(BASE_INIT).hexdigest()},

--- a/packages/ai-parrot-tools/tests/tool_optimizations/test_patches.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/test_patches.py
@@ -323,3 +323,49 @@ def test_no_external_command_in_module():
     source = inspect.getsource(module)
     assert "sub" + "process" not in source
     assert "git apply" not in source
+
+
+def test_temp_sweep_never_follows_a_symlink(tmp_path):
+    """A `.tmp-*` symlink must not let the sweeper delete files outside the repo.
+
+    Regression: `is_dir()` and `stat()` both follow symlinks, so a link
+    pointing outside the repository passed every check and its target's
+    contents were unlinked.
+    """
+    import os
+    import time
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    victim = outside / "precious.txt"
+    victim.write_text("do not delete me\n")
+
+    store = ArtifactStore(tmp_path / "repo")
+    store.root.mkdir(parents=True)
+    link = store.root / ".tmp-deadbeefdeadbeefdeadbeefdeadbeef"
+    link.symlink_to(outside, target_is_directory=True)
+    stale = time.time() - 7200
+    os.utime(outside, (stale, stale))
+
+    store._sweep_stale_temp_dirs()
+
+    assert victim.exists(), "the sweeper deleted a file outside the repository"
+    assert victim.read_text() == "do not delete me\n"
+    assert link.is_symlink(), "the symlink itself should be left alone, not resolved"
+
+
+def test_temp_sweep_still_removes_a_genuine_stale_directory(tmp_path):
+    """The symlink guard must not disable the sweeper's actual job."""
+    import os
+    import time
+
+    store = ArtifactStore(tmp_path)
+    store.root.mkdir(parents=True)
+    stale_dir = store.root / ".tmp-abcdefabcdefabcdefabcdefabcdef12"
+    stale_dir.mkdir()
+    (stale_dir / "patch.diff").write_text("junk\n")
+    old = time.time() - 7200
+    os.utime(stale_dir, (old, old))
+
+    store._sweep_stale_temp_dirs()
+    assert not stale_dir.exists()

--- a/packages/ai-parrot-tools/tests/tool_optimizations/test_patches.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/test_patches.py
@@ -1,0 +1,324 @@
+"""Unit tests for patch parsing, application and artifact storage (TASK-3084)."""
+
+import hashlib
+import os
+import stat
+
+import pytest
+
+from parrot_tools.tool_optimizations.models import PatchManifest
+from parrot_tools.tool_optimizations.patches import (
+    ApplyJournal,
+    ArtifactStore,
+    JournalEntry,
+    PatchError,
+    apply_in_memory,
+    check_scope,
+    normalize_patch,
+    parse_patch,
+)
+
+MODIFY = """--- a/pkg/__init__.py
++++ b/pkg/__init__.py
+@@ -1,2 +1,3 @@
+ from .a import a
++from .greeter import greet
+ __all__ = ["a"]
+"""
+
+CREATE = """--- /dev/null
++++ b/pkg/greeter.py
+@@ -0,0 +1,2 @@
++def greet(name: str) -> str:
++    return f"hello {name}"
+"""
+
+BASE_INIT = b'from .a import a\n__all__ = ["a"]\n'
+
+
+def _manifest(artifact_id: str, patch_text: str, packet_json: str = "{}") -> PatchManifest:
+    """Build a manifest whose hashes match the supplied artifact contents."""
+    return PatchManifest(
+        artifact_id=artifact_id,
+        task_id="TASK-1000",
+        packet_sha256=hashlib.sha256(packet_json.encode()).hexdigest(),
+        patch_sha256=hashlib.sha256(patch_text.encode()).hexdigest(),
+        before_hashes={"pkg/__init__.py": hashlib.sha256(BASE_INIT).hexdigest()},
+        after_hashes={"pkg/__init__.py": hashlib.sha256(b"x").hexdigest()},
+        allowed_paths=["pkg/__init__.py"],
+        configured_model="bedrock-converse:qwen3-coder-480b-a35b",
+        actual_model="bedrock-converse:qwen3-coder-480b-a35b",
+        used_fallback=False,
+        usage={"prompt_tokens": None, "completion_tokens": None, "total_tokens": None},
+        repairs=0,
+        elapsed_ms=1,
+        validation_state="validated",
+        created_at="2026-01-01T00:00:00Z",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Parse + apply
+# --------------------------------------------------------------------------- #
+def test_parse_and_apply_create_and_modify():
+    """A two-file patch applies byte-exactly against its expected sources."""
+    patches = parse_patch(normalize_patch(MODIFY + CREATE), max_bytes=128_000)
+    check_scope(patches, {"pkg/__init__.py": "modify", "pkg/greeter.py": "create"})
+
+    after = apply_in_memory(patches, {"pkg/__init__.py": BASE_INIT, "pkg/greeter.py": None})
+    assert after["pkg/__init__.py"] == b'from .a import a\nfrom .greeter import greet\n__all__ = ["a"]\n'
+    assert after["pkg/greeter.py"].endswith(b'return f"hello {name}"\n')
+    assert len(after) == 2
+
+
+def test_crlf_preserved():
+    """Added lines adopt the file's CRLF convention; existing lines are untouched."""
+    patches = parse_patch(normalize_patch(MODIFY), max_bytes=128_000)
+    after = apply_in_memory(patches, {"pkg/__init__.py": b'from .a import a\r\n__all__ = ["a"]\r\n'})
+    assert after["pkg/__init__.py"] == b'from .a import a\r\nfrom .greeter import greet\r\n__all__ = ["a"]\r\n'
+
+
+def test_missing_final_newline_is_preserved():
+    """`\\ No newline at end of file` survives the round trip."""
+    patch_text = (
+        "--- a/f.txt\n"
+        "+++ b/f.txt\n"
+        "@@ -1,2 +1,2 @@\n"
+        " one\n"
+        "-two\n"
+        "\\ No newline at end of file\n"
+        "+three\n"
+        "\\ No newline at end of file\n"
+    )
+    patches = parse_patch(normalize_patch(patch_text), max_bytes=128_000)
+    after = apply_in_memory(patches, {"f.txt": b"one\ntwo"})
+    assert after["f.txt"] == b"one\nthree"
+
+
+def test_multiple_hunks_in_one_file():
+    """Hunks apply in order with untouched regions passed through verbatim."""
+    source = b"".join(f"line{i}\n".encode() for i in range(1, 11))
+    patch_text = (
+        "--- a/f.txt\n"
+        "+++ b/f.txt\n"
+        "@@ -1,2 +1,3 @@\n"
+        " line1\n"
+        "+inserted-a\n"
+        " line2\n"
+        "@@ -9,2 +10,3 @@\n"
+        " line9\n"
+        "+inserted-b\n"
+        " line10\n"
+    )
+    patches = parse_patch(normalize_patch(patch_text), max_bytes=128_000)
+    after = apply_in_memory(patches, {"f.txt": source})
+    assert b"line1\ninserted-a\nline2\nline3\n" in after["f.txt"]
+    assert after["f.txt"].endswith(b"line9\ninserted-b\nline10\n")
+
+
+# --------------------------------------------------------------------------- #
+# Rejections
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "text,code",
+    [
+        ("```diff\n" + MODIFY + "```\n", "not_a_patch"),
+        ("Here is the patch you asked for:\n" + MODIFY, "not_a_patch"),
+        (MODIFY.replace("b/pkg/__init__.py", "b//etc/passwd"), "absolute_path"),
+        (MODIFY.replace("b/pkg/__init__.py", "b/../x.py"), "path_escape"),
+        (MODIFY + MODIFY, "duplicate_target"),
+        (MODIFY.replace("+++ b/pkg/__init__.py", "+++ /dev/null"), "deletion_rejected"),
+        ("diff --git a/x b/y\nrename from x\nrename to y\n", "rename_rejected"),
+        ("diff --git a/x b/x\nold mode 100644\nnew mode 100755\n" + MODIFY, "mode_change_rejected"),
+        ("diff --git a/x b/x\nGIT binary patch\n", "binary_rejected"),
+        (
+            "diff --git a/sub b/sub\n--- a/sub\n+++ b/sub\n@@ -1 +1 @@\n-Subproject commit a\n+Subproject commit b\n",
+            "submodule_rejected",
+        ),
+        (MODIFY.replace("@@ -1,2 +1,3 @@", "@@ -1,9 +1,3 @@"), "malformed_hunk"),
+        ("--- a/x\n+++ b/x\n@@ nonsense @@\n one\n", "malformed_hunk"),
+        ("diff --git a/x b/x\ndeleted file mode 100644\n" + MODIFY, "deletion_rejected"),
+        ("diff --git a/x b/x\nnew file mode 120000\n" + CREATE, "mode_change_rejected"),
+        ("--- a/x\n+++ b/x\n", "malformed_hunk"),
+    ],
+)
+def test_rejections(text, code):
+    """Every unsupported or malformed diff feature has its own rejection code."""
+    with pytest.raises(PatchError) as info:
+        parse_patch(normalize_patch(text), max_bytes=128_000)
+    assert info.value.code == code
+
+
+def test_patch_too_large():
+    """The patch byte budget is enforced on the raw text."""
+    with pytest.raises(PatchError) as info:
+        parse_patch(normalize_patch(MODIFY), max_bytes=10)
+    assert info.value.code == "patch_too_large"
+
+
+def test_scope_violations():
+    """Paths and create/modify semantics must match the approved packet."""
+    modify_patches = parse_patch(normalize_patch(MODIFY), max_bytes=128_000)
+    with pytest.raises(PatchError) as info:
+        check_scope(modify_patches, {"other.py": "modify"})
+    assert info.value.code == "path_outside_scope"
+
+    with pytest.raises(PatchError) as info:
+        check_scope(modify_patches, {"pkg/__init__.py": "create"})
+    assert info.value.code == "create_needs_dev_null"
+
+    create_patches = parse_patch(normalize_patch(CREATE), max_bytes=128_000)
+    with pytest.raises(PatchError) as info:
+        check_scope(create_patches, {"pkg/greeter.py": "modify"})
+    assert info.value.code == "path_outside_scope"
+
+
+def test_context_mismatch_details():
+    """A mismatch names the file, hunk, line and both sides — no fuzzy match."""
+    patches = parse_patch(normalize_patch(MODIFY), max_bytes=128_000)
+    with pytest.raises(PatchError) as info:
+        apply_in_memory(patches, {"pkg/__init__.py": b"something else\n"})
+    assert info.value.code == "context_mismatch"
+    assert info.value.details["line_no"] == 1
+    assert info.value.details["expected"] == "from .a import a"
+    assert info.value.details["actual"] == "something else"
+    assert info.value.details["path"] == "pkg/__init__.py"
+
+
+def test_modify_of_missing_file_is_a_mismatch():
+    """A modify whose target vanished is refused, not treated as a create."""
+    patches = parse_patch(normalize_patch(MODIFY), max_bytes=128_000)
+    with pytest.raises(PatchError) as info:
+        apply_in_memory(patches, {"pkg/__init__.py": None})
+    assert info.value.code == "context_mismatch"
+
+
+def test_no_fuzz_offset_search():
+    """A correct patch applied at the wrong offset is rejected, not relocated."""
+    shifted = b"# header added later\n" + BASE_INIT
+    patches = parse_patch(normalize_patch(MODIFY), max_bytes=128_000)
+    with pytest.raises(PatchError) as info:
+        apply_in_memory(patches, {"pkg/__init__.py": shifted})
+    assert info.value.code == "context_mismatch"
+
+
+# --------------------------------------------------------------------------- #
+# Normalization
+# --------------------------------------------------------------------------- #
+def test_normalize_is_idempotent_and_hash_is_stable():
+    """The stored/hashed text is canonical, so a review hash cannot drift."""
+    once = normalize_patch(MODIFY + "\n\n   \n")
+    twice = normalize_patch(once)
+    assert once == twice
+    assert once.endswith("\n")
+    assert hashlib.sha256(once.encode()).hexdigest() == hashlib.sha256(twice.encode()).hexdigest()
+    assert normalize_patch("\n\n" + MODIFY) == normalize_patch(MODIFY)
+
+
+# --------------------------------------------------------------------------- #
+# Artifact store
+# --------------------------------------------------------------------------- #
+def test_store_permissions_and_tamper(tmp_path):
+    """Artifacts are private, and an edited artifact is detected on load."""
+    store = ArtifactStore(tmp_path)
+    artifact_id = store.new_id()
+    manifest = _manifest(artifact_id, MODIFY)
+
+    directory = store.write_generation(artifact_id, manifest=manifest, patch_text=MODIFY, packet_json="{}")
+    assert stat.S_IMODE(directory.stat().st_mode) == 0o700
+    assert stat.S_IMODE((directory / "patch.diff").stat().st_mode) == 0o600
+    assert stat.S_IMODE((directory / "manifest.json").stat().st_mode) == 0o600
+
+    loaded_manifest, patch_text, packet_json = store.load(artifact_id)
+    assert loaded_manifest.artifact_id == artifact_id
+    assert patch_text == MODIFY
+    assert packet_json == "{}"
+
+    (directory / "patch.diff").write_text(MODIFY + "+x\n")
+    with pytest.raises(PatchError) as info:
+        store.load(artifact_id)
+    assert info.value.code == "artifact_tampered"
+
+
+def test_store_detects_tampered_packet(tmp_path):
+    """The packet is hash-checked too, not just the patch."""
+    store = ArtifactStore(tmp_path)
+    artifact_id = store.new_id()
+    directory = store.write_generation(
+        artifact_id, manifest=_manifest(artifact_id, MODIFY), patch_text=MODIFY, packet_json="{}"
+    )
+    (directory / "packet.json").write_text('{"changed": true}')
+    with pytest.raises(PatchError) as info:
+        store.load(artifact_id)
+    assert info.value.code == "artifact_tampered"
+
+
+def test_crash_between_write_and_publish_leaves_no_artifact(tmp_path, monkeypatch):
+    """A crash before the rename can never publish a half-written artifact."""
+    store = ArtifactStore(tmp_path)
+    artifact_id = store.new_id()
+
+    def _boom(*args, **kwargs):
+        raise OSError("simulated crash")
+
+    monkeypatch.setattr(os, "rename", _boom)
+    with pytest.raises(OSError):
+        store.write_generation(
+            artifact_id, manifest=_manifest(artifact_id, MODIFY), patch_text=MODIFY, packet_json="{}"
+        )
+
+    monkeypatch.undo()
+    assert not (store.root / artifact_id).exists()
+    with pytest.raises(PatchError) as info:
+        store.load(artifact_id)
+    assert info.value.code == "artifact_not_found"
+
+
+def test_store_rejects_invalid_artifact_id(tmp_path):
+    """Only opaque 32-hex ids are accepted, so no path can be smuggled in."""
+    store = ArtifactStore(tmp_path)
+    for bad in ("../escape", "not-hex", "", "A" * 32):
+        with pytest.raises(PatchError) as info:
+            store.load(bad)
+        assert info.value.code == "invalid_artifact_id"
+
+
+def test_journal_and_before_roundtrip(tmp_path):
+    """The recovery journal and saved originals survive a round trip."""
+    store = ArtifactStore(tmp_path)
+    artifact_id = store.new_id()
+    store.write_generation(artifact_id, manifest=_manifest(artifact_id, MODIFY), patch_text=MODIFY, packet_json="{}")
+    assert store.read_journal(artifact_id) is None
+
+    journal = ApplyJournal(
+        artifact_id=artifact_id,
+        started_at="2026-01-01T00:00:00Z",
+        entries=[
+            JournalEntry(path="pkg/__init__.py", before_sha256="a" * 64, after_sha256="b" * 64, before_index=0),
+            JournalEntry(path="pkg/greeter.py", before_sha256=None, after_sha256="c" * 64, before_index=1),
+        ],
+        state="pending",
+    )
+    store.write_journal(artifact_id, journal)
+    restored = store.read_journal(artifact_id)
+    assert restored == journal
+
+    store.save_before(artifact_id, 0, BASE_INIT)
+    store.save_before(artifact_id, 1, None)
+    assert store.load_before(artifact_id, 0) == BASE_INIT
+    assert store.load_before(artifact_id, 1) is None
+
+    journal.state = "applied"
+    store.write_journal(artifact_id, journal)
+    assert store.read_journal(artifact_id).state == "applied"
+
+
+def test_no_external_command_in_module():
+    """Patches are applied in pure Python; no external diff tool is invoked."""
+    import inspect
+
+    import parrot_tools.tool_optimizations.patches as module
+
+    source = inspect.getsource(module)
+    assert "sub" + "process" not in source
+    assert "git apply" not in source

--- a/packages/ai-parrot-tools/tests/tool_optimizations/test_patches.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/test_patches.py
@@ -369,3 +369,37 @@ def test_temp_sweep_still_removes_a_genuine_stale_directory(tmp_path):
 
     store._sweep_stale_temp_dirs()
     assert not stale_dir.exists()
+
+
+def test_removal_line_starting_with_dashes_is_body_not_a_header():
+    """Removing a source line that begins with '-- ' must parse.
+
+    Regression: the hunk scanner broke out on any line starting with
+    `--- `, so deleting an email-signature marker (or any `-- ` prefixed
+    source line) was rejected as `malformed_hunk`. Unified diff resolves
+    that ambiguity with the declared counts, as git itself does.
+    """
+    patch_text = "--- a/f.txt\n+++ b/f.txt\n@@ -1,2 +1,1 @@\n keep\n--- signature\n"
+    patches = parse_patch(normalize_patch(patch_text), max_bytes=128_000)
+    assert len(patches) == 1
+    assert patches[0].path == "f.txt"
+
+    after = apply_in_memory(patches, {"f.txt": b"keep\n-- signature\n"})
+    assert after["f.txt"] == b"keep\n"
+
+
+def test_multi_file_patches_still_separate_correctly():
+    """The ambiguity fix must not merge two files into one patch."""
+    patch_text = (
+        "--- a/one.txt\n+++ b/one.txt\n@@ -1,1 +1,2 @@\n a\n+b\n"
+        "--- a/two.txt\n+++ b/two.txt\n@@ -1,1 +1,2 @@\n c\n+d\n"
+    )
+    patches = parse_patch(normalize_patch(patch_text), max_bytes=128_000)
+    assert [patch.path for patch in patches] == ["one.txt", "two.txt"]
+
+
+def test_journal_entry_records_the_original_mode():
+    """Rollback needs the original permissions, not a 0644 default."""
+    entry = JournalEntry(path="a.py", before_sha256="a" * 64, after_sha256="b" * 64, before_index=0, before_mode=0o750)
+    assert entry.before_mode == 0o750
+    assert JournalEntry(path="a.py", after_sha256="b" * 64, before_index=0).before_mode is None

--- a/packages/ai-parrot-tools/tests/tool_optimizations/test_policy.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/test_policy.py
@@ -1,0 +1,443 @@
+"""Unit tests for the tool-optimizations foundation (TASK-3079, FEAT-543)."""
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+from parrot.mcp.local_server import StdioMCPServer
+from parrot.mcp.server_base import LocalServerConfig
+from parrot.tools.abstract import ToolResult
+from parrot.tools.repo.confinement import PathOutsideRootError, SecretFileError
+from pydantic import ValidationError
+
+from parrot_tools.tool_optimizations.base import OptimizationToolkitBase
+from parrot_tools.tool_optimizations.models import (
+    DelegationPacket,
+    GitPrepareFilesArgs,
+    GitRecentArgs,
+    OperationResult,
+    SourceReadArgs,
+    StepResult,
+    TargetFile,
+    WriterApplyArgs,
+)
+from parrot_tools.tool_optimizations.policy import (
+    BudgetError,
+    LockTimeoutError,
+    OptimizationPolicy,
+    PolicyError,
+    SymlinkRejectedError,
+    WorktreeLock,
+    compact_json,
+    fit_to_budget,
+    measure_json_bytes,
+    relative_posix,
+    resolve_operand,
+)
+
+HEX64 = "a" * 64
+HEX32 = "b" * 32
+
+
+# --------------------------------------------------------------------------- #
+# Package import surface
+# --------------------------------------------------------------------------- #
+def test_package_import_is_pydantic_free():
+    """Importing the package must not pull in pydantic (hook runtime stays light)."""
+    code = "import sys, parrot_tools.tool_optimizations; print('pydantic' in sys.modules)"
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True)
+    assert proc.stdout.strip() == "False"
+
+
+def test_lazy_exports_resolve():
+    """Every advertised export resolves through the PEP 562 __getattr__."""
+    import parrot_tools.tool_optimizations as pkg
+
+    for name in pkg.__all__:
+        assert getattr(pkg, name) is not None
+    with pytest.raises(AttributeError):
+        pkg.does_not_exist
+
+
+# --------------------------------------------------------------------------- #
+# Policy
+# --------------------------------------------------------------------------- #
+def test_policy_minimum_budget(tmp_path):
+    """The serialized result budget has a 4096-byte floor."""
+    with pytest.raises(ValidationError):
+        OptimizationPolicy(repo_root=tmp_path, max_result_bytes=1000)
+    assert OptimizationPolicy(repo_root=tmp_path, max_result_bytes=4096).max_result_bytes == 4096
+
+
+def test_policy_defaults_and_root_resolution(tmp_path):
+    """Defaults match the spec and repo_root is resolved to an existing dir."""
+    policy = OptimizationPolicy(repo_root=str(tmp_path))
+    assert (policy.max_lines, policy.large_file_bytes, policy.max_result_bytes) == (350, 64_000, 64_000)
+    assert (policy.command_timeout_seconds, policy.network_timeout_seconds) == (30.0, 120.0)
+    assert policy.repo_root == tmp_path.resolve() and policy.repo_root.is_absolute()
+    with pytest.raises(ValidationError):
+        OptimizationPolicy(repo_root=tmp_path / "missing")
+    with pytest.raises(ValidationError):
+        OptimizationPolicy(repo_root=tmp_path, unknown_setting=1)
+
+
+# --------------------------------------------------------------------------- #
+# Byte budget
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("payload", ["x" * 10_000, "ñ" * 10_000, '"\\' * 5_000])
+def test_fit_to_budget_respects_escaped_bytes(payload):
+    """The budget measures escaped UTF-8 JSON bytes, and output stays valid JSON."""
+    res = OperationResult(
+        status="ok",
+        operation="t",
+        data={"records": [payload] * 5},
+        elapsed_ms=1,
+        steps=[StepResult(name="s", exit_code=0, timed_out=False, state_changed=False, stdout=payload)],
+    )
+    fitted = fit_to_budget(res, 4096)
+    dumped = fitted.model_dump(mode="json")
+    assert measure_json_bytes(dumped) <= 4096
+    json.loads(json.dumps(dumped))  # still valid JSON
+    assert fitted.truncated is True
+
+
+def test_fit_to_budget_passthrough_and_identity_preserved():
+    """A small result is returned untouched; a shrunk one keeps status/operation."""
+    small = OperationResult(status="ok", operation="t", data={"a": 1}, elapsed_ms=0)
+    assert fit_to_budget(small, 4096) is small
+
+    huge = OperationResult(status="error", operation="git_push", data={"blob": "z" * 200_000}, elapsed_ms=7)
+    fitted = fit_to_budget(huge, 4096)
+    assert fitted.status == "error"
+    assert fitted.operation == "git_push"
+    assert fitted.elapsed_ms == 7
+    assert measure_json_bytes(fitted.model_dump(mode="json")) <= 4096
+
+
+def test_fit_to_budget_rejects_unusable_budget():
+    """A budget below the floor is a configuration error, not a silent clamp."""
+    res = OperationResult(status="ok", operation="t", elapsed_ms=0)
+    with pytest.raises(BudgetError):
+        fit_to_budget(res, 100)
+
+
+def test_compact_json_encoding_is_canonical():
+    """compact_json uses non-ASCII passthrough and separator-free encoding."""
+    assert compact_json({"a": "ñ", "b": [1, 2]}) == '{"a":"ñ","b":[1,2]}'
+    assert measure_json_bytes({"a": "ñ"}) == len('{"a":"ñ"}'.encode("utf-8"))
+
+
+# --------------------------------------------------------------------------- #
+# Path policy
+# --------------------------------------------------------------------------- #
+def test_resolve_operand_rejects_symlink_and_secret(tmp_path):
+    """Containment, secret deny-list and symlink components are all enforced."""
+    (tmp_path / "real.txt").write_text("x")
+    (tmp_path / "link.txt").symlink_to(tmp_path / "real.txt")
+    (tmp_path / ".env").write_text("SECRET=1")
+    policy = OptimizationPolicy(repo_root=tmp_path)
+
+    with pytest.raises(SymlinkRejectedError):
+        resolve_operand(policy, "link.txt", must_exist=True)
+    with pytest.raises(SecretFileError):
+        resolve_operand(policy, ".env", must_exist=True)
+    with pytest.raises(PathOutsideRootError):
+        resolve_operand(policy, "../outside", must_exist=False)
+
+
+def test_resolve_operand_accepts_regular_and_example_files(tmp_path):
+    """A plain file and an allow-suffixed secret name both resolve."""
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "mod.py").write_text("x")
+    (tmp_path / ".env.example").write_text("SECRET=")
+    policy = OptimizationPolicy(repo_root=tmp_path)
+
+    assert resolve_operand(policy, "pkg/mod.py", must_exist=True) == tmp_path / "pkg" / "mod.py"
+    assert resolve_operand(policy, ".env.example", must_exist=True) == tmp_path / ".env.example"
+    assert relative_posix(policy.repo_root, tmp_path / "pkg" / "mod.py") == "pkg/mod.py"
+
+
+def test_resolve_operand_symlinked_parent_directory(tmp_path):
+    """A symlinked *directory* component is rejected, not just a symlinked file."""
+    (tmp_path / "real_dir").mkdir()
+    (tmp_path / "real_dir" / "f.txt").write_text("x")
+    (tmp_path / "link_dir").symlink_to(tmp_path / "real_dir", target_is_directory=True)
+    policy = OptimizationPolicy(repo_root=tmp_path)
+
+    with pytest.raises(SymlinkRejectedError):
+        resolve_operand(policy, "link_dir/f.txt", must_exist=True)
+
+
+def test_resolve_operand_must_exist(tmp_path):
+    """must_exist distinguishes a planned CREATE from a missing read operand."""
+    policy = OptimizationPolicy(repo_root=tmp_path)
+    assert resolve_operand(policy, "new/file.py", must_exist=False) == tmp_path / "new" / "file.py"
+    with pytest.raises(PolicyError):
+        resolve_operand(policy, "new/file.py", must_exist=True)
+
+
+# --------------------------------------------------------------------------- #
+# Worktree lock
+# --------------------------------------------------------------------------- #
+async def test_worktree_lock_contention(tmp_path):
+    """A second in-process holder times out; the lock file is never deleted."""
+    lock = tmp_path / "l.lock"
+    async with WorktreeLock(lock, timeout_seconds=1):
+        with pytest.raises(LockTimeoutError):
+            async with WorktreeLock(lock, timeout_seconds=0.2):
+                pass
+    assert lock.exists()  # never deleted
+    # Released: it can be re-acquired.
+    async with WorktreeLock(lock, timeout_seconds=1):
+        pass
+
+
+async def test_worktree_lock_refuses_other_process(tmp_path):
+    """A separate OS process holding flock genuinely blocks acquisition."""
+    lock = tmp_path / "cross.lock"
+    holder_code = textwrap.dedent(f"""
+        import fcntl, os, sys, time
+        fd = os.open({str(lock)!r}, os.O_CREAT | os.O_RDWR, 0o600)
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        sys.stdout.write("locked\\n")
+        sys.stdout.flush()
+        time.sleep(30)
+        """)
+    holder = subprocess.Popen([sys.executable, "-c", holder_code], stdout=subprocess.PIPE, text=True)
+    try:
+        assert holder.stdout.readline().strip() == "locked"
+        with pytest.raises(LockTimeoutError):
+            async with WorktreeLock(lock, timeout_seconds=0.3):
+                pass
+    finally:
+        holder.kill()
+        holder.wait(timeout=10)
+    # The kernel released the flock when the holder died — no stale lock, no unlink.
+    assert lock.exists()
+    async with WorktreeLock(lock, timeout_seconds=5):
+        pass
+
+
+async def test_worktree_lock_creates_parent_directory(tmp_path):
+    """The lock file's directory is created on demand (linked-worktree git dirs)."""
+    lock = tmp_path / "worktrees" / "wt" / "parrot-tool-optimizations.lock"
+    async with WorktreeLock(lock, timeout_seconds=1):
+        assert lock.exists()
+    assert os.stat(lock).st_mode & 0o777 == 0o600
+
+
+# --------------------------------------------------------------------------- #
+# Argument models
+# --------------------------------------------------------------------------- #
+def test_arg_models_forbid_unknown():
+    """Argument models reject unknown keys, bad ranges and inconsistent pairs."""
+    with pytest.raises(ValidationError):
+        GitRecentArgs(ref="HEAD", limit=3, extra=1)
+    with pytest.raises(ValidationError):
+        GitRecentArgs(limit=51)
+    with pytest.raises(ValidationError):
+        GitRecentArgs(limit=0)
+    with pytest.raises(ValidationError):
+        SourceReadArgs(path="a.py", start_line=5)  # end_line missing
+    with pytest.raises(ValidationError):
+        SourceReadArgs(path="a.py", start_line=9, end_line=2)  # inverted
+    with pytest.raises(ValidationError):
+        GitPrepareFilesArgs(paths=[])  # must be non-empty
+    with pytest.raises(ValidationError):
+        WriterApplyArgs(artifact_id="nothex", reviewed_sha256=HEX64)
+    with pytest.raises(ValidationError):
+        WriterApplyArgs(artifact_id=HEX32, reviewed_sha256="short")
+
+    assert GitRecentArgs().limit == 3
+    assert SourceReadArgs(path="a.py").start_line is None
+    assert SourceReadArgs(path="a.py", start_line=1, end_line=10).end_line == 10
+    assert WriterApplyArgs(artifact_id=HEX32, reviewed_sha256=HEX64).artifact_id == HEX32
+
+
+def test_arg_model_json_schema_is_generatable():
+    """ToolkitTool reads _args_schema and calls model_json_schema()."""
+    schema = GitRecentArgs.model_json_schema()
+    assert set(schema["properties"]) == {"ref", "limit"}
+    assert schema["additionalProperties"] is False
+    assert SourceReadArgs.model_json_schema()["properties"]["expected_sha256"] is not None
+
+
+def test_target_file_action_hash_binding():
+    """'create' forbids an expected hash; 'modify' requires one."""
+    with pytest.raises(ValidationError):
+        TargetFile(path="a.py", action="create", expected_sha256=HEX64, planned_changes="x", blocks=["b"])
+    with pytest.raises(ValidationError):
+        TargetFile(path="a.py", action="modify", planned_changes="x", blocks=["b"])
+    with pytest.raises(ValidationError):
+        TargetFile(path="a.py", action="modify", expected_sha256="A" * 64, planned_changes="x", blocks=["b"])
+    with pytest.raises(ValidationError):
+        TargetFile(path="a.py", action="create", planned_changes="x", blocks=[])
+
+    assert TargetFile(path="a.py", action="create", planned_changes="x", blocks=["b"]).expected_sha256 is None
+
+
+def _packet(**overrides):
+    """Build a minimal valid DelegationPacket payload."""
+    payload = {
+        "schema_version": 1,
+        "task_id": "TASK-3079",
+        "spec_path": "sdd/specs/tool-optimizations.spec.md",
+        "design_complete": True,
+        "targets": [{"path": "a.py", "action": "create", "planned_changes": "x", "blocks": ["b1"]}],
+        "implementation_blocks": ["b1"],
+        "acceptance_criteria": ["works"],
+        "validation_commands": [["pytest", "-q"]],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_delegation_packet_structural_rules():
+    """Version, identity, uniqueness, argv shape and unknown fields are enforced."""
+    assert DelegationPacket(**_packet()).limits.max_repairs == 1
+
+    with pytest.raises(ValidationError):
+        DelegationPacket(**_packet(schema_version=2))
+    with pytest.raises(ValidationError):
+        DelegationPacket(**_packet(design_complete=False))
+    with pytest.raises(ValidationError):
+        DelegationPacket(**_packet(task_id="TASK-XY"))
+    with pytest.raises(ValidationError):
+        DelegationPacket(**_packet(targets=[]))
+    with pytest.raises(ValidationError):
+        DelegationPacket(**_packet(implementation_blocks=["b1", "b1"]))
+    with pytest.raises(ValidationError):
+        DelegationPacket(**_packet(validation_commands=[[]]))
+    with pytest.raises(ValidationError):
+        DelegationPacket(**_packet(unexpected="x"))
+
+    duplicate_targets = [
+        {"path": "a.py", "action": "create", "planned_changes": "x", "blocks": ["b1"]},
+        {"path": "a.py", "action": "create", "planned_changes": "y", "blocks": ["b1"]},
+    ]
+    with pytest.raises(ValidationError):
+        DelegationPacket(**_packet(targets=duplicate_targets))
+
+
+# --------------------------------------------------------------------------- #
+# Toolkit base: validation seam and result shaping
+# --------------------------------------------------------------------------- #
+class _Stub(OptimizationToolkitBase):
+    """Minimal toolkit used to exercise the shared base class."""
+
+    arg_models = {"git_recent": GitRecentArgs}
+
+    async def git_recent(self, ref: str = "HEAD", limit: int = 3) -> OperationResult:
+        """Stub."""
+        return OperationResult(status="ok", operation="git_recent", data={"ref": ref, "limit": limit}, elapsed_ms=0)
+
+
+async def test_pre_execute_validates_raw_arguments(tmp_path):
+    """_pre_execute is the enforcement point for raw MCP arguments."""
+    toolkit = _Stub(repo_root=tmp_path)
+    await toolkit._pre_execute("git_recent", limit=2, _permission_context=None)
+
+    with pytest.raises(ValueError, match="invalid arguments"):
+        await toolkit._pre_execute("git_recent", limit=999)
+    with pytest.raises(ValueError, match="invalid arguments"):
+        await toolkit._pre_execute("git_recent", bogus="x")
+    with pytest.raises(ValueError, match="unknown tool"):
+        await toolkit._pre_execute("nope", a=1)
+
+
+async def test_post_execute_wraps_models(tmp_path):
+    """A Pydantic result becomes a JSON-safe ToolResult with empty metadata."""
+    toolkit = _Stub(repo_root=tmp_path)
+    result = OperationResult(status="error", operation="git_recent", elapsed_ms=0)
+    wrapped = await toolkit._post_execute("git_recent", result)
+
+    assert isinstance(wrapped, ToolResult)
+    assert wrapped.status == "success"  # domain failure != MCP transport error
+    assert wrapped.metadata == {}
+    assert wrapped.result["status"] == "error"
+    assert isinstance(wrapped.result, dict)
+
+    passthrough = ToolResult(status="success", result={"a": 1})
+    assert await toolkit._post_execute("git_recent", passthrough) is passthrough
+    assert await toolkit._post_execute("git_recent", {"a": 1}) == {"a": 1}
+
+
+def test_base_records_policy_init_kwargs(tmp_path):
+    """Constructor kwargs are captured for remote toolkit reconstruction."""
+    toolkit = _Stub(repo_root=tmp_path, max_lines=10, max_result_bytes=8192)
+    assert toolkit.policy.max_lines == 10
+    assert toolkit.policy.max_result_bytes == 8192
+    assert toolkit._init_kwargs["repo_root"] == str(tmp_path.resolve())
+    assert toolkit._init_kwargs["max_lines"] == 10
+    assert "repo_root" not in toolkit._init_kwargs.get("policy", {})
+    json.dumps(toolkit._init_kwargs)  # must stay serializable
+
+
+def test_base_result_helpers_are_bounded(tmp_path):
+    """_ok/_error always return a result inside the configured budget."""
+    toolkit = _Stub(repo_root=tmp_path, max_result_bytes=4096)
+    ok = toolkit._ok("git_recent", data={"records": ["y" * 5000] * 10})
+    assert ok.status == "ok"
+    assert measure_json_bytes(ok.model_dump(mode="json")) <= 4096
+
+    err = toolkit._error("git_push", "push_rejected", "rejected", details={"blob": "z" * 100_000})
+    assert err.status == "error"
+    assert err.error.code == "push_rejected"
+    assert measure_json_bytes(err.model_dump(mode="json")) <= 4096
+
+    uncertain = toolkit._error("git_push", "timeout", "unknown", status="uncertain")
+    assert uncertain.status == "uncertain"
+
+
+def test_stub_exposes_only_its_public_method(tmp_path):
+    """The base class adds no accidental public async methods (no stray tools)."""
+    names = {tool.name for tool in _Stub(repo_root=tmp_path).get_tools()}
+    assert names == {"git_recent"}
+
+
+# --------------------------------------------------------------------------- #
+# Raw MCP boundary
+# --------------------------------------------------------------------------- #
+async def test_mcp_raw_argument_rejection(tmp_path):
+    """Policy holds over raw tools/call, which bypasses AbstractTool.execute."""
+    server = StdioMCPServer(LocalServerConfig(name="t"))
+    server.register_tools(_Stub(repo_root=tmp_path).get_tools())
+
+    bad = await server._handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "git_recent", "arguments": {"limit": 999}},
+        }
+    )
+    assert bad["result"]["isError"] is True
+
+    unknown_key = await server._handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "git_recent", "arguments": {"limit": 2, "injected": "x"}},
+        }
+    )
+    assert unknown_key["result"]["isError"] is True
+
+    good = await server._handle_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": "git_recent", "arguments": {"limit": 2}},
+        }
+    )
+    assert good["result"]["isError"] is False
+    payload = json.loads(good["result"]["content"][0]["text"])
+    assert payload["data"]["limit"] == 2
+    assert payload["status"] == "ok"
+    # metadata={} keeps the adapter from appending a second "Metadata:" block.
+    assert len(good["result"]["content"]) == 1

--- a/packages/ai-parrot-tools/tests/tool_optimizations/test_policy.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/test_policy.py
@@ -441,3 +441,43 @@ async def test_mcp_raw_argument_rejection(tmp_path):
     assert payload["status"] == "ok"
     # metadata={} keeps the adapter from appending a second "Metadata:" block.
     assert len(good["result"]["content"]) == 1
+
+
+def test_patch_manifest_records_task_provenance():
+    """A manifest must name the TASK file so an apply can re-validate it.
+
+    Without `task_path` the apply step has no way to re-run the very same
+    delegation contract the patch came from — `task_id` is an identifier,
+    not a location.
+    """
+    from parrot_tools.tool_optimizations.models import PatchManifest
+
+    fields = {
+        "artifact_id": HEX32,
+        "task_id": "TASK-3086",
+        "task_path": "sdd/tasks/active/TASK-3086-x.md",
+        "packet_sha256": HEX64,
+        "patch_sha256": HEX64,
+        "before_hashes": {"a.py": None, "b.py": HEX64},
+        "after_hashes": {"a.py": HEX64},
+        "allowed_paths": ["a.py"],
+        "configured_model": "bedrock-converse:qwen3-coder-480b-a35b",
+        "actual_model": None,
+        "used_fallback": False,
+        "usage": {"prompt_tokens": None, "completion_tokens": None, "total_tokens": None},
+        "repairs": 1,
+        "elapsed_ms": 12,
+        "validation_state": "validated",
+        "created_at": "2026-09-10T00:00:00+00:00",
+    }
+    manifest = PatchManifest(**fields)
+    assert manifest.task_path == "sdd/tasks/active/TASK-3086-x.md"
+    assert manifest.before_hashes["a.py"] is None  # absence, not a digest
+
+    # It is required: provenance may not be omitted.
+    with pytest.raises(ValidationError):
+        PatchManifest(**{key: value for key, value in fields.items() if key != "task_path"})
+
+    # And the hash maps are still validated.
+    with pytest.raises(ValidationError):
+        PatchManifest(**{**fields, "after_hashes": {"a.py": "not-a-sha"}})

--- a/packages/ai-parrot-tools/tests/tool_optimizations/test_reader.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/test_reader.py
@@ -1,0 +1,333 @@
+"""Unit tests for BoundedSourceToolkit (TASK-3082, FEAT-543)."""
+
+import json
+import os
+import tracemalloc
+from pathlib import Path
+
+import pytest
+
+from parrot_tools.tool_optimizations.models import SourceInfo, SourceResult
+from parrot_tools.tool_optimizations.policy import measure_json_bytes
+from parrot_tools.tool_optimizations.reader import (
+    BoundedSourceToolkit,
+    LineTooLargeError,
+    RangeOutOfBoundsError,
+    count_lines_bounded,
+    read_line_range,
+    sha256_stream,
+    stat_regular,
+)
+
+
+def _lines(tmp_path: Path, n: int, width: int = 10, name: str = "f.py", eol: str = "\n") -> Path:
+    """Write a file of ``n`` deterministic lines and return its path."""
+    target = tmp_path / name
+    body = eol.join(f"l{i:0{width}d}" for i in range(1, n + 1)) + eol
+    target.write_bytes(body.encode())
+    return target
+
+
+# --------------------------------------------------------------------------- #
+# Thresholds — strict '>' on both axes, tested independently
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("n,large", [(349, False), (350, False), (351, True)])
+async def test_line_threshold(tmp_path, n, large):
+    """351 lines is large; 350 is not. The byte axis is held out of the way."""
+    _lines(tmp_path, n)
+    info = await BoundedSourceToolkit(repo_root=tmp_path, large_file_bytes=10**9).source_info("f.py")
+    assert isinstance(info, SourceInfo)
+    assert info.is_large is large
+    assert info.range_required is large
+    assert info.line_count == (None if large else n)
+
+
+@pytest.mark.parametrize("size,large", [(63_999, False), (64_000, False), (64_001, True)])
+async def test_byte_threshold(tmp_path, size, large):
+    """64,001 bytes is large; 64,000 is not. The line axis is held out of the way."""
+    (tmp_path / "f.py").write_bytes(b"x" * size)
+    info = await BoundedSourceToolkit(repo_root=tmp_path, max_lines=10**9).source_info("f.py")
+    assert info.is_large is large
+    assert info.size_bytes == size
+
+
+async def test_source_info_never_returns_content(tmp_path):
+    """source_info reports metadata and a revision, never file text."""
+    path = _lines(tmp_path, 5)
+    info = await BoundedSourceToolkit(repo_root=tmp_path).source_info("f.py")
+    assert not hasattr(info, "content")
+    assert info.sha256 == sha256_stream(path, deadline_seconds=10)
+    assert info.path == "f.py"
+
+
+# --------------------------------------------------------------------------- #
+# Range requirement and continuation
+# --------------------------------------------------------------------------- #
+async def test_large_requires_range_without_content(tmp_path):
+    """A large file yields an actionable refusal carrying no source text."""
+    _lines(tmp_path, 1000)
+    res = await BoundedSourceToolkit(repo_root=tmp_path).source_read("f.py")
+    assert res.status == "error"
+    assert res.error.code == "range_required"
+    assert "content" not in res.data
+    assert res.error.details["example"] == {"start_line": 1, "end_line": 350}
+
+    ok = await BoundedSourceToolkit(repo_root=tmp_path).source_read("f.py", 1, 350)
+    assert isinstance(ok, SourceResult)
+    assert ok.next_line == 351
+    assert ok.content.count("\n") == 350
+    assert ok.eof is False
+    assert ok.truncated is False
+
+
+async def test_range_too_large(tmp_path):
+    """A span wider than max_lines is refused before any read."""
+    _lines(tmp_path, 1000)
+    res = await BoundedSourceToolkit(repo_root=tmp_path).source_read("f.py", 1, 351)
+    assert res.status == "error"
+    assert res.error.code == "range_too_large"
+
+
+async def test_end_beyond_eof_clamps_and_start_beyond_eof_errors(tmp_path):
+    """An end past EOF clamps; a start past EOF is out of bounds."""
+    _lines(tmp_path, 10)
+    toolkit = BoundedSourceToolkit(repo_root=tmp_path)
+
+    clamped = await toolkit.source_read("f.py", 5, 300)
+    assert clamped.end_line == 10
+    assert clamped.eof is True
+    assert clamped.next_line is None
+
+    out = await toolkit.source_read("f.py", 50, 60)
+    assert out.status == "error"
+    assert out.error.code == "range_out_of_bounds"
+    assert out.error.details["total_lines"] == 10
+
+
+async def test_continuation_walks_the_whole_file(tmp_path):
+    """next_line + expected_sha256 pages through a file with no gaps."""
+    _lines(tmp_path, 900)
+    toolkit = BoundedSourceToolkit(repo_root=tmp_path)
+    info = await toolkit.source_info("f.py")
+
+    collected = ""
+    cursor = 1
+    while cursor is not None:
+        chunk = await toolkit.source_read("f.py", cursor, min(cursor + 349, 900), expected_sha256=info.sha256)
+        assert isinstance(chunk, SourceResult)
+        collected += chunk.content
+        cursor = chunk.next_line
+    assert collected == (tmp_path / "f.py").read_bytes().decode()
+
+
+# --------------------------------------------------------------------------- #
+# Byte budget
+# --------------------------------------------------------------------------- #
+async def test_budget_returns_complete_lines_only(tmp_path):
+    """The budget truncates by whole lines and reports where to resume."""
+    _lines(tmp_path, 100, width=100)
+    res = await BoundedSourceToolkit(repo_root=tmp_path, max_result_bytes=4096).source_read("f.py", 1, 100)
+    assert res.truncated is True
+    assert res.next_line == res.end_line + 1
+    assert res.content.endswith("\n")
+    assert res.end_line < 100
+    assert measure_json_bytes(res.model_dump(mode="json")) <= 4096
+
+
+async def test_single_long_line_is_reported_not_cut(tmp_path):
+    """An oversized line is reported by number and size, never partially returned."""
+    (tmp_path / "f.py").write_bytes(b"y" * 5000 + b"\n")
+    res = await BoundedSourceToolkit(repo_root=tmp_path, max_result_bytes=4096).source_read("f.py")
+    assert res.status == "error"
+    assert res.error.code == "line_too_large"
+    assert res.error.details["line"] == 1
+    # `bytes` is a *lower bound*: the reader stops at max_line_bytes + 1 and
+    # deliberately never reads the rest of the line, so memory stays bounded.
+    assert res.error.details["bytes"] > 4096
+
+
+# --------------------------------------------------------------------------- #
+# Encoding and byte fidelity
+# --------------------------------------------------------------------------- #
+async def test_crlf_and_no_final_newline_roundtrip(tmp_path):
+    """CRLF and a missing final newline survive byte-exactly."""
+    raw = b"a\r\nb\r\nc"
+    (tmp_path / "f.py").write_bytes(raw)
+    res = await BoundedSourceToolkit(repo_root=tmp_path).source_read("f.py")
+    assert res.content.encode() == raw
+    assert res.eof is True
+    assert res.next_line is None
+    assert res.end_line == 3
+
+
+async def test_empty_file(tmp_path):
+    """An empty file reads as empty content at EOF, not as an error."""
+    (tmp_path / "f.py").write_bytes(b"")
+    res = await BoundedSourceToolkit(repo_root=tmp_path).source_read("f.py")
+    assert res.content == ""
+    assert res.start_line == 1
+    assert res.end_line == 0
+    assert res.eof is True
+    assert res.next_line is None
+
+
+async def test_binary_and_invalid_utf8(tmp_path):
+    """A NUL byte is binary; invalid UTF-8 without NUL is an encoding error."""
+    (tmp_path / "b.bin").write_bytes(b"ok\x00then")
+    binary = await BoundedSourceToolkit(repo_root=tmp_path).source_read("b.bin")
+    assert binary.error.code == "binary_file"
+
+    (tmp_path / "bad.py").write_bytes(b"fine\n\xff\xfe not utf8\n")
+    invalid = await BoundedSourceToolkit(repo_root=tmp_path).source_read("bad.py")
+    assert invalid.error.code == "invalid_encoding"
+    assert invalid.error.details["line"] == 2
+
+
+async def test_unicode_content_is_measured_in_bytes(tmp_path):
+    """Multibyte content is charged its real UTF-8 cost, not its length."""
+    (tmp_path / "u.py").write_bytes(("ñ" * 50 + "\n").encode() * 20)
+    res = await BoundedSourceToolkit(repo_root=tmp_path, max_result_bytes=4096).source_read("u.py")
+    assert measure_json_bytes(res.model_dump(mode="json")) <= 4096
+    assert res.content.startswith("ñ")
+
+
+# --------------------------------------------------------------------------- #
+# Revision safety
+# --------------------------------------------------------------------------- #
+async def test_stale_hash_rejected(tmp_path):
+    """A continuation against an outdated revision is refused."""
+    _lines(tmp_path, 10)
+    res = await BoundedSourceToolkit(repo_root=tmp_path).source_read("f.py", 1, 5, expected_sha256="0" * 64)
+    assert res.status == "error"
+    assert res.error.code == "stale_revision"
+    assert len(res.error.details["current_sha256"]) == 64
+
+
+async def test_concurrent_modification_detected(tmp_path, monkeypatch):
+    """A file changed mid-scan is reported instead of returning mixed content."""
+    path = _lines(tmp_path, 10)
+    toolkit = BoundedSourceToolkit(repo_root=tmp_path)
+
+    import parrot_tools.tool_optimizations.reader as reader_module
+
+    real_read_line_range = reader_module.read_line_range
+
+    def _mutating_read(*args, **kwargs):
+        result = real_read_line_range(*args, **kwargs)
+        path.write_bytes(b"totally different content\n")
+        return result
+
+    monkeypatch.setattr(reader_module, "read_line_range", _mutating_read)
+    res = await toolkit.source_read("f.py", 1, 5)
+    assert res.status == "error"
+    assert res.error.code == "concurrent_modification"
+
+
+# --------------------------------------------------------------------------- #
+# Path policy
+# --------------------------------------------------------------------------- #
+async def test_path_policy_codes(tmp_path):
+    """Each rejected path shape maps to its own stable error code."""
+    _lines(tmp_path, 3, name="real.py")
+    (tmp_path / "link.py").symlink_to(tmp_path / "real.py")
+    (tmp_path / ".env").write_text("SECRET=1\n")
+    (tmp_path / ".env.example").write_text("SECRET=\n")
+    (tmp_path / "sub").mkdir()
+    os.mkfifo(tmp_path / "pipe")
+
+    toolkit = BoundedSourceToolkit(repo_root=tmp_path)
+    assert (await toolkit.source_read("link.py")).error.code == "symlink_rejected"
+    assert (await toolkit.source_read(".env")).error.code == "secret_file"
+    assert (await toolkit.source_read("../escape.py")).error.code == "path_outside_root"
+    assert (await toolkit.source_read("sub")).error.code == "not_a_file"
+    assert (await toolkit.source_read("pipe")).error.code == "not_a_file"
+    assert (await toolkit.source_read("missing.py")).error.code == "not_found"
+
+    allowed = await toolkit.source_read(".env.example")
+    assert isinstance(allowed, SourceResult)
+    assert allowed.content == "SECRET=\n"
+
+
+async def test_invalid_arguments_rejected(tmp_path):
+    """One range end alone, or an inverted range, is refused."""
+    _lines(tmp_path, 10)
+    toolkit = BoundedSourceToolkit(repo_root=tmp_path)
+    assert (await toolkit.source_read("f.py", 5)).error.code == "invalid_arguments"
+    assert (await toolkit.source_read("f.py", 9, 2)).error.code == "invalid_arguments"
+
+    with pytest.raises(ValueError, match="invalid arguments"):
+        await toolkit._pre_execute("source_read", path="f.py", start_line=5)
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "payload,stop,expected",
+    [
+        (b"", 10, (0, False)),
+        (b"a\n", 10, (1, False)),
+        (b"a", 10, (1, False)),
+        (b"a\nb\nc", 10, (3, False)),
+        (b"a\nb\nc\n", 2, (3, True)),
+    ],
+)
+def test_count_lines_bounded(tmp_path, payload, stop, expected):
+    """Counting handles a missing final newline and exits early past the bound."""
+    target = tmp_path / "c.txt"
+    target.write_bytes(payload)
+    assert count_lines_bounded(target, stop) == expected
+
+
+def test_read_line_range_bounds_and_errors(tmp_path):
+    """The pure range reader clamps, detects EOF and refuses an impossible start."""
+    target = _lines(tmp_path, 10)
+    span = read_line_range(target, 3, 5, max_line_bytes=4096)
+    assert len(span.lines) == 3
+    assert span.actual_end == 5
+    assert span.eof is False
+
+    tail = read_line_range(target, 9, 20, max_line_bytes=4096)
+    assert tail.actual_end == 10
+    assert tail.eof is True
+
+    with pytest.raises(RangeOutOfBoundsError):
+        read_line_range(target, 50, 60, max_line_bytes=4096)
+
+
+def test_bounded_allocation_on_huge_single_line(tmp_path):
+    """A 200 MiB single line fails by size without being loaded into memory."""
+    target = tmp_path / "huge.py"
+    with open(target, "wb") as handle:
+        for _ in range(200):
+            handle.write(b"z" * (1 << 20))
+
+    tracemalloc.start()
+    try:
+        with pytest.raises(LineTooLargeError):
+            read_line_range(target, 1, 1, max_line_bytes=64_000)
+        _current, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    assert peak < 8 * (1 << 20), f"peak allocation {peak} bytes is not bounded"
+
+
+def test_stat_regular_rejects_non_files(tmp_path):
+    """Symlinks and non-regular files are rejected at the stat boundary."""
+    (tmp_path / "real.py").write_text("x\n")
+    (tmp_path / "link.py").symlink_to(tmp_path / "real.py")
+    assert stat_regular(tmp_path / "real.py").size == 2
+    with pytest.raises(Exception):
+        stat_regular(tmp_path / "link.py")
+
+
+def test_no_whole_file_reads_in_source():
+    """The module must never read an entire file into memory."""
+    import inspect
+
+    import parrot_tools.tool_optimizations.reader as module
+
+    src = inspect.getsource(module)
+    assert "read_text(" not in src
+    assert ".read()" not in src
+    assert "readlines(" not in src

--- a/packages/ai-parrot-tools/tests/tool_optimizations/test_sdd_contracts.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/test_sdd_contracts.py
@@ -1,0 +1,182 @@
+"""Tests for the SDD delegation workflow documents (TASK-3090, FEAT-543).
+
+These assert *meaning parity* between the Claude Code commands and the Codex
+skills — shared key phrases and the review-before-apply ordering — rather
+than identical prose, which the two hosts deliberately do not share.
+"""
+
+import hashlib
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from parrot_tools.tool_optimizations.contracts import ContractError, extract_packet, parse_task_file, validate_contract
+from parrot_tools.tool_optimizations.policy import OptimizationPolicy
+
+#: tests/tool_optimizations -> tests -> ai-parrot-tools -> packages -> repo root
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+TASK_TEMPLATE = REPO_ROOT / "sdd" / "templates" / "task.md"
+SPEC_TEMPLATE = REPO_ROOT / "sdd" / "templates" / "spec.md"
+WORKER = REPO_ROOT / ".claude" / "agents" / "sdd-worker.md"
+
+#: (Claude command, Codex skill) pairs that must agree in meaning.
+PAIRS = [
+    (REPO_ROOT / ".claude" / "commands" / "sdd-spec.md", REPO_ROOT / ".agents" / "skills" / "sdd-spec" / "SKILL.md"),
+    (REPO_ROOT / ".claude" / "commands" / "sdd-task.md", REPO_ROOT / ".agents" / "skills" / "sdd-task" / "SKILL.md"),
+    (REPO_ROOT / ".claude" / "commands" / "sdd-start.md", REPO_ROOT / ".agents" / "skills" / "sdd-start" / "SKILL.md"),
+]
+
+
+def _read(path: Path) -> str:
+    """Read a workflow document, failing loudly when it is missing."""
+    assert path.is_file(), f"missing workflow document: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------- #
+# The template's example packet
+# --------------------------------------------------------------------------- #
+def test_template_packet_is_rejected_while_placeholders_remain():
+    """The shipped example must not validate until real hashes are filled in.
+
+    This is the safety net: a copy-pasted packet with `<sha256 ...>` left in
+    is refused rather than silently delegated.
+    """
+    packet_json, blocks = parse_task_file(_read(TASK_TEMPLATE))
+    with pytest.raises(ContractError) as info:
+        extract_packet(packet_json)
+    assert info.value.code == "invalid_packet"
+    assert {"impl-greeter", "impl-init"} <= set(blocks)
+
+
+def test_template_packet_validates_once_hashes_are_real(tmp_path):
+    """With real digests substituted, the shipped example is a valid packet."""
+    repo = tmp_path / "repo"
+    (repo / "pkg").mkdir(parents=True)
+    (repo / "sdd" / "specs").mkdir(parents=True)
+    (repo / "sdd" / "specs" / "example.spec.md").write_text("# spec\n")
+    init = repo / "pkg" / "__init__.py"
+    init.write_text('"""Package."""\n\n__all__ = []\n')
+    digest = hashlib.sha256(init.read_bytes()).hexdigest()
+
+    text = _read(TASK_TEMPLATE)
+    text = re.sub(r'"<sha256[^"]*>"', f'"{digest}"', text)
+    text = text.replace('"task_id": "TASK-<NNN>"', '"task_id": "TASK-9999"')
+    text = text.replace('"spec_path": "sdd/specs/<feature>.spec.md"', '"spec_path": "sdd/specs/example.spec.md"')
+
+    task_file = repo / "sdd" / "tasks" / "active" / "TASK-9999-example.md"
+    task_file.parent.mkdir(parents=True)
+    task_file.write_text(text)
+
+    contract = validate_contract  # imported for clarity of the call below
+    import asyncio
+
+    validated = asyncio.run(contract(OptimizationPolicy(repo_root=repo), task_file.relative_to(repo).as_posix()))
+    assert validated.packet.design_complete is True
+    assert set(validated.blocks) == {"impl-greeter", "impl-init"}
+    assert validated.targets_state["pkg/greeter.py"] is None
+
+
+def test_template_documents_removal_for_ineligible_tasks():
+    """The default route must be stated plainly, so authors do not over-apply it."""
+    text = _read(TASK_TEMPLATE)
+    assert "Remove this section entirely if the task is not delegation-eligible" in text
+    assert "OPTIONAL" in text
+    assert "sha256sum" in text
+
+
+def test_spec_template_has_the_eligibility_table():
+    """Spec authors record eligibility per module, with a reason when not."""
+    text = _read(SPEC_TEMPLATE)
+    assert "Delegation-eligible modules" in text
+    assert "Why not (if no)" in text
+    assert "Architecture decisions stay with the thinking model" in text
+
+
+# --------------------------------------------------------------------------- #
+# Host parity
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("command,skill", PAIRS, ids=lambda p: p.parent.name + "/" + p.name)
+def test_command_and_skill_exist(command, skill):
+    """Both hosts must carry the workflow."""
+    assert command.is_file() and skill.is_file()
+
+
+@pytest.mark.parametrize("pair", PAIRS, ids=lambda pair: pair[0].stem)
+def test_delegation_key_phrases_are_present_in_both_hosts(pair):
+    """Meaning parity: the same commitments appear for Claude and Codex."""
+    command, skill = pair
+    stem = command.stem
+    if stem == "sdd-spec":
+        required = ["delegation-eligible"]
+    elif stem == "sdd-task":
+        required = ["Delegation Contract", "sha256sum", "design_complete", "placeholder"]
+    else:
+        required = ["writer_generate", "writer_apply", "source_read", "review", "never silently invokes another coder"]
+
+    for document in (command, skill):
+        text = _read(document).lower()
+        for phrase in required:
+            assert phrase.lower() in text, f"{document} is missing {phrase!r}"
+
+
+@pytest.mark.parametrize(
+    "document",
+    [PAIRS[2][0], PAIRS[2][1], WORKER],
+    ids=["claude-command", "codex-skill", "sdd-worker"],
+)
+def test_review_happens_before_apply(document):
+    """Generation, review and application must be documented in that order."""
+    text = _read(document)
+    generate = text.index("writer_generate")
+    apply_at = text.index("writer_apply")
+    read_at = text.index("source_read")
+
+    assert generate < read_at < apply_at, f"{document}: review must sit between generate and apply"
+    assert "not fully read" in text or "fully read" in text
+    assert "never runs tests" in text
+
+
+def test_sdd_worker_has_the_delegated_step_and_checklist_line():
+    """The autonomous worker gains the same branch and a verification line."""
+    text = _read(WORKER)
+    assert "### b2) Delegated implementation" in text
+    assert "□ Delegated patch hunks were all reviewed before writer_apply?" in text
+    # Ordering: the delegated step sits between contract verification and implementation.
+    assert text.index("### b) Verify Codebase Contract") < text.index("### b2) Delegated implementation")
+    assert text.index("### b2) Delegated implementation") < text.index("### c) Implement")
+
+
+# --------------------------------------------------------------------------- #
+# Legacy route and SDD-state ownership
+# --------------------------------------------------------------------------- #
+async def test_legacy_task_without_a_contract_is_simply_ineligible(tmp_path):
+    """A task with no packet is reported as such — never auto-converted."""
+    repo = tmp_path / "repo"
+    (repo / "sdd" / "tasks" / "active").mkdir(parents=True)
+    legacy = repo / "sdd" / "tasks" / "active" / "TASK-0001-legacy.md"
+    legacy.write_text("# TASK-0001: Legacy\n\n## Scope\n\nDo the thing.\n")
+
+    with pytest.raises(ContractError) as info:
+        await validate_contract(OptimizationPolicy(repo_root=repo), legacy.relative_to(repo).as_posix())
+    assert info.value.code == "no_delegation_section"
+
+
+@pytest.mark.parametrize(
+    "document", [PAIRS[2][0], PAIRS[2][1], WORKER], ids=["claude-command", "codex-skill", "worker"]
+)
+def test_documents_state_that_sdd_files_are_never_delegated(document):
+    """SDD state mutation always stays with the thinking model."""
+    text = _read(document)
+    assert "never edited by the writer" in text or "never delegated" in text
+
+
+@pytest.mark.parametrize(
+    "document", [PAIRS[2][0], PAIRS[2][1], WORKER], ids=["claude-command", "codex-skill", "worker"]
+)
+def test_documents_forbid_substituting_another_coder(document):
+    """Delegation failure must fall back to the thinking model, not another tool."""
+    assert "never silently invokes another coder" in _read(document).lower()

--- a/packages/ai-parrot-tools/tests/tool_optimizations/test_writer.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/test_writer.py
@@ -1,0 +1,428 @@
+"""Unit tests for TargetedWriterToolkit.writer_generate (TASK-3085, FEAT-543)."""
+
+import asyncio
+import hashlib
+from types import SimpleNamespace
+
+import pytest
+
+from parrot_tools.tool_optimizations.models import WriterLimits
+from parrot_tools.tool_optimizations.writer import SYSTEM_PROMPT, TargetedWriterToolkit, build_prompt
+
+from .fixtures import GOOD_PATCH, make_repo_with_target, make_valid_task
+
+#: Exactly the keyword arguments the writer is allowed to pass to `ask`.
+EXPECTED_ASK_KWARGS = {"prompt", "system_prompt", "max_tokens", "temperature", "use_tools", "history"}
+
+
+class FakeClient:
+    """A recording stand-in exposing only the attributes the writer may use.
+
+    Any attribute access outside the documented surface raises, so the test
+    suite fails loudly if the writer starts depending on something new.
+    """
+
+    _ALLOWED = {
+        "model",
+        "_fallback_model",
+        "ask",
+        "close",
+        "calls",
+        "entered",
+        "exited",
+        "_responses",
+        "_delay",
+        "_metadata",
+        "_usage",
+        "_response_model",
+        "__aenter__",
+        "__aexit__",
+    }
+
+    def __init__(
+        self,
+        responses,
+        *,
+        fallback=None,
+        delay=0.0,
+        metadata=None,
+        usage=(10, 20, 30),
+        model="qwen3-coder-480b-a35b",
+        response_model=None,
+    ):
+        """Initialize the fake.
+
+        Args:
+            responses: Successive `ask` return payloads.
+            fallback: The `_fallback_model` value to advertise.
+            delay: Seconds to sleep inside `ask`.
+            metadata: Metadata attached to every response.
+            usage: (prompt, completion, total) token counts.
+            model: The client's *configured* model identity.
+            response_model: The model identity the provider reports back,
+                when it differs from the configured one (a substitution).
+        """
+        object.__setattr__(self, "model", model)
+        object.__setattr__(self, "_fallback_model", fallback)
+        object.__setattr__(self, "_responses", list(responses))
+        object.__setattr__(self, "calls", [])
+        object.__setattr__(self, "entered", 0)
+        object.__setattr__(self, "exited", 0)
+        object.__setattr__(self, "_delay", delay)
+        object.__setattr__(self, "_metadata", metadata or {})
+        object.__setattr__(self, "_usage", usage)
+        object.__setattr__(self, "_response_model", response_model or model)
+
+    def __getattr__(self, name):
+        """Fail loudly when the writer touches an undocumented attribute."""
+        raise AssertionError(f"the writer touched an unexpected client attribute: {name!r}")
+
+    async def __aenter__(self):
+        """Record entry."""
+        object.__setattr__(self, "entered", self.entered + 1)
+        return self
+
+    async def __aexit__(self, *exc_info):
+        """Record exit."""
+        object.__setattr__(self, "exited", self.exited + 1)
+        return False
+
+    async def close(self):
+        """No resources to release."""
+
+    async def ask(self, **kwargs):
+        """Record the call and return the next scripted response."""
+        self.calls.append(kwargs)
+        if self._delay:
+            await asyncio.sleep(self._delay)
+        payload = self._responses.pop(0)
+        usage = SimpleNamespace(
+            prompt_tokens=self._usage[0], completion_tokens=self._usage[1], total_tokens=self._usage[2]
+        )
+        return SimpleNamespace(
+            response=payload if isinstance(payload, str) else None,
+            output=payload,
+            model=self._response_model,
+            provider="bedrock-converse",
+            usage=usage,
+            metadata=dict(self._metadata),
+        )
+
+
+def _setup(tmp_path):
+    """Build the fixture repo and its eligible TASK file."""
+    repo = make_repo_with_target(tmp_path)
+    task = make_valid_task(repo)
+    return repo, task.relative_to(repo).as_posix()
+
+
+def _artifacts(repo):
+    """List published artifact directories."""
+    root = repo / "artifacts" / "tool-optimizations"
+    return (
+        [entry for entry in root.iterdir() if entry.is_dir() and not entry.name.startswith(".tmp-")]
+        if root.exists()
+        else []
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Constructor / configuration
+# --------------------------------------------------------------------------- #
+def test_constructor_rejects_client_that_permits_fallback(tmp_path):
+    """A client with a fallback model could silently answer as another model."""
+    with pytest.raises(ValueError, match="fallback"):
+        TargetedWriterToolkit(repo_root=tmp_path, llm_client=FakeClient([], fallback="claude-haiku-4-5"))
+
+    toolkit = TargetedWriterToolkit(repo_root=tmp_path, llm_client=FakeClient([], fallback=None))
+    assert toolkit.llm_dependent_tools == {"writer_generate"}
+    assert toolkit.confirming_tools == {"writer_apply"}
+
+
+def test_tool_surface(tmp_path):
+    """Both tools exist; only generation depends on a model."""
+    tools = TargetedWriterToolkit(repo_root=tmp_path).get_tools()
+    assert {tool.name for tool in tools} == {"writer_generate", "writer_apply"}
+    apply_tool = next(tool for tool in tools if tool.name == "writer_apply")
+    assert (apply_tool.routing_meta or {}).get("requires_confirmation") is True
+
+
+def test_importing_writer_does_not_import_aws_sdk():
+    """Provider satellites stay lazy: git/reader/writer import without boto."""
+    import subprocess
+    import sys
+
+    code = "import parrot_tools.tool_optimizations.writer, sys; print(any('boto' in m for m in sys.modules))"
+    out = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True).stdout
+    assert out.strip() == "False"
+
+
+async def test_no_client_configured(tmp_path):
+    """Without a client, generation reports it rather than crashing."""
+    repo, task = _setup(tmp_path)
+    result = await TargetedWriterToolkit(repo_root=repo).writer_generate(task)
+    assert result.status == "error"
+    assert result.error.code == "no_client"
+
+
+async def test_client_lifecycle(tmp_path):
+    """The toolkit opens and closes a client it owns, exactly once."""
+    fake = FakeClient([])
+    toolkit = TargetedWriterToolkit(repo_root=tmp_path, llm_client=fake)
+    await toolkit._ensure_open()
+    await toolkit._ensure_open()
+    assert fake.entered == 1
+    await toolkit._close()
+    assert fake.exited == 1
+
+    shared = FakeClient([])
+    borrower = TargetedWriterToolkit(repo_root=tmp_path, llm_client=shared, owns_client=False)
+    await borrower._ensure_open()
+    await borrower._close()
+    assert shared.entered == 0 and shared.exited == 0
+
+
+# --------------------------------------------------------------------------- #
+# Contract gating — no model call
+# --------------------------------------------------------------------------- #
+async def test_invalid_contract_makes_no_call(tmp_path):
+    """An ineligible TASK never reaches the delegate (AC7)."""
+    repo, task = _setup(tmp_path)
+    task_file = repo / task
+    task_file.write_text(task_file.read_text().replace('"design_complete": true', '"design_complete": false'))
+
+    fake = FakeClient([GOOD_PATCH])
+    result = await TargetedWriterToolkit(repo_root=repo, llm_client=fake).writer_generate(task)
+    assert result.status == "error"
+    assert result.error.code == "invalid_packet"
+    assert fake.calls == []
+    assert _artifacts(repo) == []
+
+
+async def test_stale_contract_makes_no_call(tmp_path):
+    """A target edited after the packet was written also short-circuits."""
+    repo, task = _setup(tmp_path)
+    (repo / "pkg" / "__init__.py").write_text("changed\n")
+
+    fake = FakeClient([GOOD_PATCH])
+    result = await TargetedWriterToolkit(repo_root=repo, llm_client=fake).writer_generate(task)
+    assert result.status == "error"
+    assert result.error.code in {"stale_target", "stale_reference"}
+    assert fake.calls == []
+
+
+# --------------------------------------------------------------------------- #
+# Successful generation
+# --------------------------------------------------------------------------- #
+async def test_generate_ok_and_no_target_mutation(tmp_path):
+    """A valid diff is stored as an artifact and no target file is touched."""
+    repo, task = _setup(tmp_path)
+    before = (repo / "pkg" / "__init__.py").read_bytes()
+    fake = FakeClient([GOOD_PATCH])
+
+    result = await TargetedWriterToolkit(repo_root=repo, llm_client=fake).writer_generate(task)
+    assert result.status == "ok"
+    assert (repo / result.data["patch_path"]).exists()
+    assert result.data["targets"] == ["pkg/__init__.py", "pkg/greeter.py"]
+    assert result.data["repairs"] == 0
+    assert result.data["usage"] == {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}
+    assert result.data["actual_model"] == "qwen3-coder-480b-a35b"
+
+    # Generation must never mutate the worktree.
+    assert (repo / "pkg" / "__init__.py").read_bytes() == before
+    assert not (repo / "pkg" / "greeter.py").exists()
+
+    artifact = _artifacts(repo)[0]
+    assert {entry.name for entry in artifact.iterdir()} == {"manifest.json", "patch.diff", "packet.json"}
+    stored = (artifact / "patch.diff").read_text()
+    assert hashlib.sha256(stored.encode()).hexdigest() == result.data["patch_sha256"]
+
+
+async def test_call_uses_exactly_the_approved_kwargs(tmp_path):
+    """No tools, no history, no research — and nothing else is passed."""
+    repo, task = _setup(tmp_path)
+    fake = FakeClient([GOOD_PATCH])
+    await TargetedWriterToolkit(repo_root=repo, llm_client=fake).writer_generate(task)
+
+    call = fake.calls[0]
+    assert set(call) == EXPECTED_ASK_KWARGS
+    assert call["use_tools"] is False
+    assert call["history"] is None
+    assert call["temperature"] == 0.0
+    assert call["max_tokens"] == 8192
+    assert call["system_prompt"] == SYSTEM_PROMPT
+    assert "model" not in call  # a per-call override would be a substitution channel
+
+
+async def test_prompt_contains_only_approved_content(tmp_path):
+    """The delegate sees the packet and its excerpts, never whole files."""
+    repo, task = _setup(tmp_path)
+    (repo / "pkg" / "secret_other.py").write_text("UNAPPROVED CONTENT MARKER\n")
+    fake = FakeClient([GOOD_PATCH])
+    await TargetedWriterToolkit(repo_root=repo, llm_client=fake).writer_generate(task)
+
+    prompt = fake.calls[0]["prompt"]
+    assert "UNAPPROVED CONTENT MARKER" not in prompt
+    assert "TASK-9999" in prompt
+    assert "impl-greeter" in prompt
+    assert "pytest tests/test_greeter.py passes" in prompt
+
+
+async def test_usage_unknown_is_recorded_as_none(tmp_path):
+    """Missing provider usage is unknown, never zero."""
+    repo, task = _setup(tmp_path)
+    fake = FakeClient([GOOD_PATCH], usage=(0, 0, 0))
+    result = await TargetedWriterToolkit(repo_root=repo, llm_client=fake).writer_generate(task)
+    assert result.data["usage"] == {"prompt_tokens": None, "completion_tokens": None, "total_tokens": None}
+
+
+# --------------------------------------------------------------------------- #
+# Repair budget
+# --------------------------------------------------------------------------- #
+async def test_one_repair_then_success(tmp_path):
+    """A malformed patch earns exactly one repair, with a bounded diagnostic."""
+    repo, task = _setup(tmp_path)
+    fake = FakeClient(["```diff\nnope\n```", GOOD_PATCH])
+
+    result = await TargetedWriterToolkit(repo_root=repo, llm_client=fake).writer_generate(task)
+    assert result.status == "ok"
+    assert result.data["repairs"] == 1
+    assert len(fake.calls) == 2
+    assert "not_a_patch" in fake.calls[1]["prompt"]
+    assert result.data["usage"]["total_tokens"] == 60  # summed across both attempts
+
+
+async def test_two_failures_stop_without_artifact(tmp_path):
+    """The repair budget is one; a second failure ends the operation."""
+    repo, task = _setup(tmp_path)
+    fake = FakeClient(["prose only", "still prose", GOOD_PATCH])
+
+    result = await TargetedWriterToolkit(repo_root=repo, llm_client=fake).writer_generate(task)
+    assert result.status == "error"
+    assert result.error.code == "not_a_patch"
+    assert result.error.details["repairs"] == 1
+    assert len(fake.calls) == 2
+    assert _artifacts(repo) == []
+
+
+async def test_out_of_scope_patch_is_rejected(tmp_path):
+    """A diff touching an unapproved file is refused, not applied."""
+    repo, task = _setup(tmp_path)
+    rogue = "--- a/pkg/other.py\n+++ b/pkg/other.py\n@@ -1 +1 @@\n-a\n+b\n"
+    fake = FakeClient([rogue, rogue])
+
+    result = await TargetedWriterToolkit(repo_root=repo, llm_client=fake).writer_generate(task)
+    assert result.status == "error"
+    assert result.error.code == "path_outside_scope"
+    assert _artifacts(repo) == []
+
+
+# --------------------------------------------------------------------------- #
+# Model identity
+# --------------------------------------------------------------------------- #
+async def test_model_substitution_rejected_without_repair(tmp_path):
+    """A fallback answer aborts immediately — a repair would compound it."""
+    repo, task = _setup(tmp_path)
+    fake = FakeClient([GOOD_PATCH, GOOD_PATCH], metadata={"used_fallback_model": True})
+
+    result = await TargetedWriterToolkit(repo_root=repo, llm_client=fake).writer_generate(task)
+    assert result.error.code == "model_substituted"
+    assert len(fake.calls) == 1
+    assert _artifacts(repo) == []
+
+
+async def test_unexpected_model_identity_rejected(tmp_path):
+    """When operators pin model ids, an unlisted identity is a substitution."""
+    repo, task = _setup(tmp_path)
+    fake = FakeClient([GOOD_PATCH], response_model="some-other-model")
+    toolkit = TargetedWriterToolkit(
+        repo_root=repo, llm_client=fake, expected_model_ids=("qwen.qwen3-coder-480b-a35b-v1:0",)
+    )
+    result = await toolkit.writer_generate(task)
+    assert result.error.code == "model_substituted"
+    assert result.error.details["configured"] == "qwen3-coder-480b-a35b"
+    assert result.error.details["actual"] == "some-other-model"
+
+
+async def test_translated_bedrock_model_id_is_accepted(tmp_path):
+    """Bedrock reports a translated id; operators list it and it passes."""
+    repo, task = _setup(tmp_path)
+    fake = FakeClient([GOOD_PATCH], response_model="qwen.qwen3-coder-480b-a35b-v1:0")
+    toolkit = TargetedWriterToolkit(
+        repo_root=repo, llm_client=fake, expected_model_ids=("qwen.qwen3-coder-480b-a35b-v1:0",)
+    )
+    result = await toolkit.writer_generate(task)
+    assert result.status == "ok"
+
+
+async def test_tool_call_and_structured_output_rejected(tmp_path):
+    """The delegate has no tools; a structured response is a contract breach."""
+    repo, task = _setup(tmp_path)
+
+    fake = FakeClient([{"tool": "read_file"}])
+    result = await TargetedWriterToolkit(repo_root=repo, llm_client=fake).writer_generate(task)
+    assert result.error.code == "unexpected_tool_call"
+
+    fake2 = FakeClient([GOOD_PATCH], metadata={"tool_calls": [{"name": "x"}]})
+    result2 = await TargetedWriterToolkit(repo_root=repo, llm_client=fake2).writer_generate(task)
+    assert result2.error.code == "unexpected_tool_call"
+
+
+# --------------------------------------------------------------------------- #
+# Deadline and cancellation
+# --------------------------------------------------------------------------- #
+async def test_deadline_exceeded(tmp_path):
+    """A slow provider hits the operation deadline and stores nothing."""
+    repo, task = _setup(tmp_path)
+    fake = FakeClient([GOOD_PATCH], delay=5.0)
+    toolkit = TargetedWriterToolkit(repo_root=repo, llm_client=fake, limits=WriterLimits(generation_deadline_seconds=1))
+    result = await toolkit.writer_generate(task)
+    assert result.status == "error"
+    assert result.error.code == "deadline_exceeded"
+    assert _artifacts(repo) == []
+
+
+async def test_cancellation_leaves_no_artifact(tmp_path):
+    """Cancelling mid-call publishes nothing and does not swallow the cancel."""
+    repo, task = _setup(tmp_path)
+    fake = FakeClient([GOOD_PATCH], delay=5.0)
+    toolkit = TargetedWriterToolkit(repo_root=repo, llm_client=fake)
+
+    task_handle = asyncio.create_task(toolkit.writer_generate(task))
+    await asyncio.sleep(0.1)
+    task_handle.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task_handle
+
+    assert _artifacts(repo) == []
+    assert not (repo / "pkg" / "greeter.py").exists()
+
+
+# --------------------------------------------------------------------------- #
+# Prompt construction
+# --------------------------------------------------------------------------- #
+async def test_build_prompt_is_deterministic(tmp_path):
+    """The same contract renders the same prompt every time."""
+    from parrot_tools.tool_optimizations.contracts import validate_contract
+    from parrot_tools.tool_optimizations.policy import OptimizationPolicy
+
+    repo, task = _setup(tmp_path)
+    contract = await validate_contract(OptimizationPolicy(repo_root=repo), task)
+    assert build_prompt(contract) == build_prompt(contract)
+    assert "Return only the unified diff" in build_prompt(contract)
+
+
+def test_system_prompt_forbids_prose_and_scope_creep():
+    """The delegate's instructions pin the output shape and the file scope."""
+    assert "ONLY a unified diff" in SYSTEM_PROMPT
+    assert "no markdown fences" in SYSTEM_PROMPT
+    assert "Never touch any other" in SYSTEM_PROMPT
+    assert "Never invent an API" in SYSTEM_PROMPT
+
+
+async def test_writer_apply_is_not_implemented_yet(tmp_path):
+    """The apply stub reports its status rather than pretending to work."""
+    repo, _task = _setup(tmp_path)
+    result = await TargetedWriterToolkit(repo_root=repo).writer_apply("0" * 32, "a" * 64)
+    assert result.status == "error"
+    assert result.error.code == "not_implemented"

--- a/packages/ai-parrot-tools/tests/tool_optimizations/test_writer.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/test_writer.py
@@ -420,9 +420,17 @@ def test_system_prompt_forbids_prose_and_scope_creep():
     assert "Never invent an API" in SYSTEM_PROMPT
 
 
-async def test_writer_apply_is_not_implemented_yet(tmp_path):
-    """The apply stub reports its status rather than pretending to work."""
+async def test_writer_apply_rejects_unknown_artifact(tmp_path):
+    """Apply refuses an artifact it never generated (full behaviour: TASK-3086)."""
     repo, _task = _setup(tmp_path)
     result = await TargetedWriterToolkit(repo_root=repo).writer_apply("0" * 32, "a" * 64)
     assert result.status == "error"
-    assert result.error.code == "not_implemented"
+    assert result.error.code == "artifact_not_found"
+
+
+async def test_writer_apply_validates_its_arguments(tmp_path):
+    """A malformed artifact id or review hash never reaches the store."""
+    repo, _task = _setup(tmp_path)
+    toolkit = TargetedWriterToolkit(repo_root=repo)
+    assert (await toolkit.writer_apply("not-hex", "a" * 64)).error.code == "invalid_arguments"
+    assert (await toolkit.writer_apply("0" * 32, "short")).error.code == "invalid_arguments"

--- a/packages/ai-parrot-tools/tests/tool_optimizations/test_writer.py
+++ b/packages/ai-parrot-tools/tests/tool_optimizations/test_writer.py
@@ -434,3 +434,74 @@ async def test_writer_apply_validates_its_arguments(tmp_path):
     toolkit = TargetedWriterToolkit(repo_root=repo)
     assert (await toolkit.writer_apply("not-hex", "a" * 64)).error.code == "invalid_arguments"
     assert (await toolkit.writer_apply("0" * 32, "short")).error.code == "invalid_arguments"
+
+
+# --------------------------------------------------------------------------- #
+# Provider data-exposure regression (found in adversarial review)
+# --------------------------------------------------------------------------- #
+def test_repair_diagnostics_never_carry_local_file_content():
+    """A repair prompt must not ship the local source it failed to match.
+
+    Regression: `context_mismatch` details include the *actual* local line,
+    and the whole details dict was serialized into the next provider
+    request — sending repository content the delegate was never approved to
+    see, from a line that is not in any approved slice.
+    """
+    from parrot_tools.tool_optimizations.patches import PatchError
+    from parrot_tools.tool_optimizations.policy import compact_json
+    from parrot_tools.tool_optimizations.writer import redact_local_content
+
+    details = {
+        "path": "pkg/__init__.py",
+        "hunk_index": 0,
+        "line_no": 1,
+        "expected": "from .a import a",
+        "expected_line": "from .a import a",
+        "actual": 'SECRET_API_KEY = "sk-live-do-not-send"',
+        "actual_line": 'SECRET_API_KEY = "sk-live-do-not-send"',
+    }
+    redacted = compact_json(redact_local_content(details))
+
+    assert "sk-live-do-not-send" not in redacted
+    assert "SECRET_API_KEY" not in redacted
+    # Still actionable: the delegate learns WHICH line and what was expected.
+    assert "from .a import a" in redacted
+    assert '"line_no":1' in redacted
+    assert PatchError("context_mismatch", "x", details).details["actual"].startswith("SECRET")  # local copy untouched
+
+
+async def test_build_repair_prompt_redacts_unapproved_local_content(tmp_path):
+    """`build_repair_prompt` must not embed local source in the provider prompt.
+
+    The secret here is deliberately NOT part of any approved reference slice —
+    it is content the delegate was never authorized to see, surfaced only
+    because a generated hunk failed to match it.
+    """
+    from parrot_tools.tool_optimizations.contracts import validate_contract
+    from parrot_tools.tool_optimizations.patches import PatchError
+    from parrot_tools.tool_optimizations.policy import OptimizationPolicy
+    from parrot_tools.tool_optimizations.writer import build_repair_prompt
+
+    repo, task = _setup(tmp_path)
+    contract = await validate_contract(OptimizationPolicy(repo_root=repo), task)
+
+    error = PatchError(
+        "context_mismatch",
+        "does not match",
+        {
+            "path": "pkg/__init__.py",
+            "hunk_index": 0,
+            "line_no": 42,
+            "expected": "from .a import a",
+            "actual": 'SECRET_TOKEN = "sk-live-must-not-leave"',
+            "actual_line": 'SECRET_TOKEN = "sk-live-must-not-leave"',
+        },
+    )
+    prompt = build_repair_prompt(contract, "--- a/pkg/__init__.py\n+++ b/pkg/__init__.py\n", error)
+
+    assert "sk-live-must-not-leave" not in prompt
+    assert "SECRET_TOKEN" not in prompt
+    # The delegate still learns what went wrong and where.
+    assert "context_mismatch" in prompt
+    assert "line_no" in prompt
+    assert "from .a import a" in prompt

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/claude_code/cli.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/claude_code/cli.py
@@ -78,12 +78,19 @@ def claude() -> None:
     show_default=True,
     help="Install Bookstore MCP and skill when an indexed library exists (no indexing).",
 )
+@click.option(
+    "--tool-guards/--no-tool-guards",
+    default=False,
+    show_default=True,
+    help="Install the opt-in PreToolUse read guard (FEAT-543) that denies unbounded reads of large files.",
+)
 def install(
     path_: Optional[str],
     git_hook: bool,
     gitignore: bool,
     build_now: bool,
     bookstore: bool,
+    tool_guards: bool,
 ) -> None:
     """Install the wiki toolkit as Claude Code infrastructure.
 
@@ -95,14 +102,24 @@ def install(
     root = _resolve_root(path_)
     try:
         config = load_effective_config(root).config
-        actions = install_claude_integration(
-            root, config, git_hook=git_hook, gitignore=gitignore, bookstore=bookstore
-        )
+        actions = install_claude_integration(root, config, git_hook=git_hook, gitignore=gitignore, bookstore=bookstore)
     except (RuntimeError, WikiConfigError) as exc:
         raise click.ClickException(str(exc)) from exc
 
     for action in actions:
         click.echo(f"  ✓ {action}")
+
+    if tool_guards:
+        # Lazy import: core must not hard-depend on ai-parrot-tools.
+        try:
+            from parrot_tools.tool_optimizations.installation import install_guards
+        except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
+            raise click.ClickException("tool guards require ai-parrot-tools: uv pip install ai-parrot-tools") from exc
+        try:
+            for action in install_guards(root, "claude"):
+                click.echo(f"  ✓ {action}")
+        except RuntimeError as exc:
+            raise click.ClickException(str(exc)) from exc
 
     if build_now and not config.is_built(root):
         click.echo("Building the wiki plane (first run)...")
@@ -125,6 +142,17 @@ def uninstall(path_: Optional[str]) -> None:
     for action in uninstall_claude_integration(root):
         click.echo(f"  ✓ {action}")
 
+    try:
+        from parrot_tools.tool_optimizations.installation import uninstall_guards
+    except ImportError:
+        pass
+    else:
+        try:
+            for action in uninstall_guards(root, "claude"):
+                click.echo(f"  ✓ {action}")
+        except RuntimeError as exc:
+            raise click.ClickException(str(exc)) from exc
+
 
 @claude.command()
 @path_option
@@ -133,6 +161,13 @@ def status(path_: Optional[str], as_json: bool) -> None:
     """Show which integration pieces are installed."""
     root = _resolve_root(path_)
     info = integration_status(root)
+
+    try:
+        from parrot_tools.tool_optimizations.installation import guard_status
+    except ImportError:
+        pass
+    else:
+        info["tool_guards"] = guard_status(root, "claude")
     if as_json:
         click.echo(json.dumps(info, indent=2))
         return

--- a/packages/ai-parrot/src/parrot/knowledge/wiki/codex/cli.py
+++ b/packages/ai-parrot/src/parrot/knowledge/wiki/codex/cli.py
@@ -60,7 +60,13 @@ def codex() -> None:
     show_default=True,
     help="Install Bookstore MCP and skill when an indexed library exists (no indexing).",
 )
-def install(path_: Optional[str], gitignore: bool, build_now: bool, bookstore: bool) -> None:
+@click.option(
+    "--tool-guards/--no-tool-guards",
+    default=False,
+    show_default=True,
+    help="Install the opt-in PreToolUse read guard (FEAT-543) that denies unbounded reads of large files.",
+)
+def install(path_: Optional[str], gitignore: bool, build_now: bool, bookstore: bool, tool_guards: bool) -> None:
     """Install WikiToolkit and Bookstore MCP servers and skills for Codex."""
     root = _resolve_root(path_)
     try:
@@ -71,6 +77,18 @@ def install(path_: Optional[str], gitignore: bool, build_now: bool, bookstore: b
 
     for action in actions:
         click.echo(f"  ✓ {action}")
+
+    if tool_guards:
+        # Lazy import: core must not hard-depend on ai-parrot-tools.
+        try:
+            from parrot_tools.tool_optimizations.installation import install_guards
+        except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
+            raise click.ClickException("tool guards require ai-parrot-tools: uv pip install ai-parrot-tools") from exc
+        try:
+            for action in install_guards(root, "codex"):
+                click.echo(f"  ✓ {action}")
+        except RuntimeError as exc:
+            raise click.ClickException(str(exc)) from exc
 
     if build_now and not config.is_built(root):
         click.echo("Building the wiki plane (first run)...")
@@ -98,6 +116,17 @@ def uninstall(path_: Optional[str]) -> None:
     for action in actions:
         click.echo(f"  ✓ {action}")
 
+    try:
+        from parrot_tools.tool_optimizations.installation import uninstall_guards
+    except ImportError:
+        pass
+    else:
+        try:
+            for action in uninstall_guards(root, "codex"):
+                click.echo(f"  ✓ {action}")
+        except RuntimeError as exc:
+            raise click.ClickException(str(exc)) from exc
+
 
 @codex.command()
 @path_option
@@ -109,6 +138,13 @@ def status(path_: Optional[str], as_json: bool) -> None:
         info = integration_status(root)
     except (RuntimeError, WikiConfigError) as exc:
         raise click.ClickException(str(exc)) from exc
+
+    try:
+        from parrot_tools.tool_optimizations.installation import guard_status
+    except ImportError:
+        pass
+    else:
+        info["tool_guards"] = guard_status(root, "codex")
     if as_json:
         click.echo(json.dumps(info, indent=2))
         return

--- a/packages/ai-parrot/src/parrot/mcp/toolkit_config.py
+++ b/packages/ai-parrot/src/parrot/mcp/toolkit_config.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class ToolkitSection(BaseModel):
@@ -36,6 +36,12 @@ class ToolkitSection(BaseModel):
             When set, the runner passes an LLMFactory-created client to the toolkit
             constructor as `llm_client`. When unset, tools named in the toolkit's
             `llm_dependent_tools` metadata are automatically excluded from exposure.
+        llm_kwargs: Optional constructor keyword arguments forwarded verbatim to
+            `LLMFactory.create(llm, **llm_kwargs)` — e.g. `fallback_model: null`,
+            `max_retries`, `read_timeout`. This is trusted server configuration,
+            never an LLM-callable argument. Requires `llm` to be set, and may not
+            contain an `llm` key (it would collide with the factory's first
+            argument). See `examples/tool-optimizations-mcp.yaml`.
         env: Dictionary of environment variables to pass to the toolkit server process
             (via installer entries). Useful for API keys or secrets.
     """
@@ -46,9 +52,28 @@ class ToolkitSection(BaseModel):
     include: list[str] | None = None
     exclude: list[str] | None = None
     llm: str | None = None
+    llm_kwargs: dict[str, Any] = Field(default_factory=dict)
     env: dict[str, str] = Field(default_factory=dict)
 
     model_config = ConfigDict(populate_by_name=True)
+
+    @model_validator(mode="after")
+    def _check_llm_kwargs(self) -> "ToolkitSection":
+        """Reject llm_kwargs that cannot be applied or would collide.
+
+        Returns:
+            The validated section.
+
+        Raises:
+            ValueError: `llm_kwargs` was supplied without `llm`, or it
+                contains an `llm` key, which would collide with
+                `LLMFactory.create`'s first argument.
+        """
+        if self.llm_kwargs and not self.llm:
+            raise ValueError("llm_kwargs requires llm to be set")
+        if "llm" in self.llm_kwargs:
+            raise ValueError("llm_kwargs must not contain 'llm' (collides with LLMFactory.create(llm=...))")
+        return self
 
 
 class MCPToolkitsConfig(BaseModel):

--- a/packages/ai-parrot/src/parrot/mcp/toolkit_server.py
+++ b/packages/ai-parrot/src/parrot/mcp/toolkit_server.py
@@ -99,7 +99,10 @@ def create_toolkit_mcp_server(
         if section.llm:
             from parrot.clients.factory import LLMFactory
 
-            llm_client = LLMFactory.create(section.llm)
+            # llm_kwargs is trusted server configuration (e.g. the writer's
+            # required `fallback_model: null`); it reaches the client
+            # constructor verbatim via LLMFactory.create's **kwargs.
+            llm_client = LLMFactory.create(section.llm, **section.llm_kwargs)
         else:
             drop_tools = set(toolkit_cls.llm_dependent_tools)
 

--- a/sdd/tasks/completed/TASK-3079-tool-optimizations-models-policy.md
+++ b/sdd/tasks/completed/TASK-3079-tool-optimizations-models-policy.md
@@ -2,7 +2,7 @@
 
 **Feature**: FEAT-543 — Claude Code and Codex Tool Optimizations
 **Spec**: `sdd/specs/tool-optimizations.spec.md`
-**Status**: pending
+**Status**: done
 **Priority**: high
 **Estimated effort**: L (4-8h)
 **Depends-on**: none
@@ -501,8 +501,55 @@ When you pick up this task:
 
 *(Agent fills this in when done)*
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
+**Completed by**: sdd-worker (Claude Opus 5, session_01G9NM1TzdkFLd5foNDmh72K)
+**Date**: 2026-09-10
 **Notes**:
 
-**Deviations from spec**: none | describe if any
+Created `parrot_tools.tool_optimizations` with the four modules fixed by
+Decision 1: `models.py` (10 contracts + 10 per-tool argument models, all
+`extra="forbid"`), `policy.py` (`OptimizationPolicy`, byte budget, path
+policy, `WorktreeLock`), `base.py` (`OptimizationToolkitBase`) and a lazy
+`__init__.py`.
+
+Codebase Contract verified before implementing — every listed import,
+signature and line reference was re-read and is accurate as of this branch:
+`ToolkitTool._execute` still calls `toolkit._pre_execute(self.name, **hook_kwargs)`
+with RAW kwargs *before* the unknown-key strip (`toolkit.py:180-198`), and
+`MCPToolAdapter.execute` still calls `tool._execute(**arguments)` directly
+(`adapter.py:79`) — so `_pre_execute` is confirmed as the enforcement seam.
+
+Implementation notes worth carrying forward:
+
+- **`ShortStr`/`Sha256Str`/`ArtifactIdStr` are `Annotated` +
+  `StringConstraints`, not bare `Field(min_length=...)`.** Pydantic v2 cannot
+  always push a length constraint through an `Optional[str]` (nullable)
+  schema; the `Annotated` alias applies the constraint to the `str` member
+  and keeps `model_json_schema()` generatable, which `ToolkitTool` requires.
+- **`fit_to_budget` has five ordered stages** (clip step streams by whole
+  lines → drop payload list records → drop payload → drop steps → minimal
+  result). Status, operation and `elapsed_ms` survive to the last stage, so
+  a truncated result never becomes untruthful. It raises `BudgetError` for a
+  budget below 4096 rather than silently clamping.
+- **`resolve_operand` order is containment/secret FIRST, symlink check
+  second.** An escaping path is therefore reported as `PathOutsideRootError`
+  even when it is also a symlink, and `check_no_symlink_components` normalizes
+  (never resolves) so a symlinked *directory* component is caught too.
+- **`WorktreeLock` never unlinks the lock file** — flock is advisory and
+  kernel-released on process death, so a stale lock is impossible and
+  deleting the file would break mutual exclusion for current holders. A
+  real second-process contention test (`test_worktree_lock_refuses_other_process`)
+  covers this, not just an in-process one.
+- Package import is genuinely pydantic-free (subprocess-asserted), as
+  TASK-3088's hook runtime requires.
+
+**Testing**: 27 tests pass in `test_policy.py`; `ruff check` and
+`black --check --line-length 120 --target-version py312` clean. Log at
+`artifacts/logs/TASK-3079-pytest.log` (`artifacts/` is gitignored).
+
+**Note for later tasks**: the venv's editable installs point at the MAIN
+repo checkout, not this worktree. Run tests with
+`PYTHONPATH=$PWD/packages/ai-parrot-tools/src` (add other package `src` dirs
+as needed) or the worktree's new code is invisible to pytest.
+
+**Deviations from spec**: none. `base.py` is the recorded, task-sanctioned
+addition to the spec's M1 file list (Decision 1).

--- a/sdd/tasks/completed/TASK-3080-local-git-discovery-fetch-preflight.md
+++ b/sdd/tasks/completed/TASK-3080-local-git-discovery-fetch-preflight.md
@@ -2,7 +2,7 @@
 
 **Feature**: FEAT-543 — Claude Code and Codex Tool Optimizations
 **Spec**: `sdd/specs/tool-optimizations.spec.md`
-**Status**: pending
+**Status**: done
 **Priority**: high
 **Estimated effort**: L (4-8h)
 **Depends-on**: TASK-3079
@@ -369,8 +369,59 @@ When you pick up this task:
 
 *(Agent fills this in when done)*
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
+**Completed by**: sdd-worker (Claude Opus 5, session_01G9NM1TzdkFLd5foNDmh72K)
+**Date**: 2026-09-10
 **Notes**:
 
-**Deviations from spec**: none | describe if any
+Created `git.py` with `LocalGitToolkit` (read/fetch/preflight half),
+`RepoLayout`, `GIT_ENV`, the bounded `_run_git` runner and module-level
+output parsers. `get_tools()` exposes exactly `git_recent`, `git_fetch`,
+`git_preflight`. No LLM call anywhere in this module (AC2).
+
+Codebase Contract verified: `validate_ref`/`parse_log`/`LOG_FORMAT`/
+`InvalidRefError` are all present at the cited lines in
+`parrot/tools/repo/git_tools.py`; `tool_schema` sets `_args_schema` as
+documented. Local git is 2.43.0, above the 2.24 floor `--end-of-options`
+and `--absolute-git-dir` need.
+
+Empirically-established behaviors that shaped the implementation (probed
+against real git before coding, not assumed):
+
+- **A bare repo makes the combined `rev-parse` exit 128**, because
+  `--show-toplevel` needs a work tree — but it still prints `true` for
+  `--is-bare-repository` on stdout first. So `_discover` checks the bare
+  marker BEFORE the exit code; checking exit code first would misreport a
+  bare repo as `not_a_repository`.
+- **`--git-common-dir` is relative (`.git`) in a normal checkout but
+  absolute in a linked worktree.** Both are handled; `is_linked_worktree`
+  is derived from `git_dir != common_dir`, never from probing whether
+  `.git` is a directory (the mistake called out in the contract at
+  `repo/toolkit.py:398` and `gittoolkit.py:1671`).
+- `_drain` keeps reading past the cap and discards the excess, so a
+  ~5.5 MiB `git show` is capped at exactly 1 MiB with `truncated=True` and
+  no pipe deadlock (`test_runner_bounds_large_output_without_deadlock`).
+
+Contract compliance worth noting: the fetch uses an explicit
+`refs/heads/<b>:refs/remotes/<r>/<b>` refspec with **no** leading `+`, so a
+non-fast-forward tracking update surfaces as `fetch_rejected` (covered by a
+real unrelated-history test, not a mock). A failed fetch returns only the
+`fetch` step and never performs the history lookup. `git_preflight` runs all
+four checks unconditionally and reports each one, and both `git_fetch` and
+`git_preflight` attach `data` to the *error* result too, so a failed
+preflight still returns the staged list and parsed status.
+
+**Testing**: 30 tests in `test_git.py`, 57 across the feature suite; ruff and
+black clean. Log at `artifacts/logs/TASK-3080-pytest.log`.
+
+**Deviations from spec**: none, with two recorded judgement calls:
+
+1. **`scripts/generate_tool_registry.py` was NOT run in bulk.** Running it
+   wholesale also added an unrelated `contracts:` entry, dropped the
+   `google_lyria` alias and reordered several blocks — unrelated churn that
+   Cardinal Rule 5 forbids. The registry file was reverted and the single
+   `"local_git"` entry added by hand. The pre-existing registry staleness on
+   `dev` is left untouched for its own owner.
+2. The task's own test spec asserts `[s.name for s in res.steps] == ["fetch"]`
+   on a failed fetch, so the failure path deliberately reports only the fetch
+   step (the preceding `remote` listing step is dropped). Implemented to the
+   task's assertion.

--- a/sdd/tasks/completed/TASK-3081-local-git-prepare-pull-push.md
+++ b/sdd/tasks/completed/TASK-3081-local-git-prepare-pull-push.md
@@ -2,7 +2,7 @@
 
 **Feature**: FEAT-543 — Claude Code and Codex Tool Optimizations
 **Spec**: `sdd/specs/tool-optimizations.spec.md`
-**Status**: pending
+**Status**: done
 **Priority**: high
 **Estimated effort**: XL (> 8h)
 **Depends-on**: TASK-3080
@@ -352,8 +352,82 @@ When you pick up this task:
 
 *(Agent fills this in when done)*
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
+**Completed by**: sdd-worker (Claude Opus 5, session_01G9NM1TzdkFLd5foNDmh72K)
+**Date**: 2026-09-10
 **Notes**:
 
-**Deviations from spec**: none | describe if any
+Added `git_prepare_files`, `git_pull` and `git_push` to `LocalGitToolkit`
+plus `confirming_tools`. 91 tests pass across the feature suite; the file
+was run 10x consecutively to prove stability (see the race note below).
+
+Codebase Contract verified: `confirming_tools` is applied at
+`toolkit.py:684-689`, and `MCPToolAdapter` injects the required `confirm`
+boolean (`adapter.py:38-49`) and pops it before `_execute` (`:59`) — so the
+argument models correctly do NOT declare `confirm`. Asserted end-to-end in
+`test_mcp_tools_list_marks_confirm_required` /
+`test_mcp_call_rejected_without_confirm`.
+
+**Two real bugs found and fixed during implementation:**
+
+1. **`git add --end-of-options -- <paths>` is broken.** Once
+   `--end-of-options` has ended option parsing, git reads the following
+   `--` as a *literal pathspec* and dies with
+   `fatal: pathspec '--' did not match any files`. The two must never be
+   combined. `git add -- <paths>` is used instead; the `--` separator alone
+   already protects an option-shaped path, and `GIT_LITERAL_PATHSPECS=1`
+   neutralizes pathspec magic. (`git log --end-of-options <sha> --` is
+   unaffected and still works — the difference is that `log` has already
+   consumed a revision.)
+
+2. **Copying the index with `shutil.copyfile` silently loses edits.**
+   Git decides an index entry is "racily clean" by comparing the entry's
+   mtime against the *index file's own* mtime, re-hashing the file when it
+   is. A copy made with `copyfile` gets a fresh mtime, which converts those
+   racy entries into trusted-clean ones — so a same-size edit written
+   within the same (coarse, ~ms) filesystem clock tick as the last
+   `git add` was **not staged**, and the operation refused with
+   `staged_mismatch`. Measured: 4/120 same-size edits before the fix, 0/240
+   after switching to `shutil.copy2`, which preserves the mtime and makes
+   the private copy behave exactly like the real index. Plain `git diff`
+   missed the same change 0/200 times, which is what proved this was our
+   bug and not a git limitation. Covered by
+   `test_prepare_stages_same_size_edit_made_in_the_same_clock_tick`.
+   This surfaced first as an intermittent (~1-in-4-runs) test failure; it
+   was traced rather than retried, because the failure mode in production
+   is a false refusal, not a crash.
+
+Design notes:
+
+- The transaction order is validate -> submodule/tracked-deletion ->
+  unmerged -> unrelated/partial -> split/sparse -> fingerprint -> temp
+  index -> verify names -> verify whitespace -> re-fingerprint -> `index.lock`
+  -> `os.replace`. Nothing touches the real index before the last two steps,
+  and every refusal test asserts the index bytes are byte-identical
+  afterwards.
+- Publication uses git's own mechanism: create `index.lock` with `O_EXCL`,
+  write, `fsync`, `os.replace` onto `index`. A pre-existing lock is reported
+  as `index_locked` and never removed; only a lock this process created is
+  ever unlinked.
+- `git reset` is never invoked in any form — enforced by
+  `test_no_forbidden_git_verbs_in_source`, which also bars `"stash"`,
+  `"--force"`, `"--force-with-lease"`, `"--all"`, `"--mirror"` and
+  `"rebase"` as argv literals.
+- A push timeout is `uncertain` and is resolved by exactly one read-only
+  `ls-remote`; the push is never retried. On success the reported
+  `remote_commit_after` is the full local sha, not git's abbreviated
+  porcelain range.
+
+**Testing**: 91 tests, 10 consecutive clean runs; ruff and black clean.
+Log at `artifacts/logs/TASK-3081-pytest.log`.
+
+**Deviations from spec**: none, with two recorded test-level judgement calls:
+
+1. The task's test sketch clones the bare remote and commits directly. That
+   silently pushes `master`, because `git init --bare` leaves HEAD at
+   `refs/heads/master` while the fixture only ever pushes `dev` — the clone
+   lands on an unborn branch. Tests use a `_clone_on_dev` helper that checks
+   out `dev` explicitly. The `bare_remote` fixture itself was left untouched,
+   since `conftest.py` belongs to TASK-3080's file scope.
+2. `../outside.py` is rejected as `invalid_path` (the `..` shape check) rather
+   than `path_outside_root`; the shape check runs first and is the stricter
+   of the two. `path_outside_root` remains covered by `test_policy.py`.

--- a/sdd/tasks/completed/TASK-3082-bounded-source-reader.md
+++ b/sdd/tasks/completed/TASK-3082-bounded-source-reader.md
@@ -2,7 +2,7 @@
 
 **Feature**: FEAT-543 — Claude Code and Codex Tool Optimizations
 **Spec**: `sdd/specs/tool-optimizations.spec.md`
-**Status**: pending
+**Status**: done
 **Priority**: high
 **Estimated effort**: L (4-8h)
 **Depends-on**: TASK-3079
@@ -337,8 +337,47 @@ When you pick up this task:
 
 *(Agent fills this in when done)*
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
+**Completed by**: sdd-worker (Claude Opus 5, session_01G9NM1TzdkFLd5foNDmh72K)
+**Date**: 2026-09-10
 **Notes**:
 
-**Deviations from spec**: none | describe if any
+Created `reader.py`: seven pure, synchronous, stdlib-only helpers followed
+by `BoundedSourceToolkit` (`source_info`, `source_read`). 30 tests in
+`test_reader.py`, 121 across the feature suite.
+
+Contract compliance highlights:
+
+- **Memory really is bounded by line length, not file length.** The
+  200 MiB single-line test asserts a `tracemalloc` peak under 8 MiB while
+  `read_line_range` raises `LineTooLargeError`. `readline(max_line_bytes + 1)`
+  is what makes this work: the oversized line is never materialized.
+- `test_no_whole_file_reads_in_source` greps the module for `read_text(`,
+  `.read()` and `readlines(` — the anti-patterns from
+  `ReadOnlyRepoToolkit.read_file`, whose API is left untouched.
+- Thresholds are strict `>` on both axes and are tested *independently*
+  (each parametrized test pins the other threshold at 10**9), so a
+  regression on one axis cannot hide behind the other.
+- Decoding is strict UTF-8: `test_binary_and_invalid_utf8` distinguishes a
+  NUL-bearing binary (`binary_file`) from valid-length-but-invalid UTF-8
+  (`invalid_encoding`, with the offending line number).
+- Byte fidelity is asserted as `res.content.encode() == raw` for CRLF plus
+  a missing final newline, so line endings cannot be silently normalized.
+- A `test_continuation_walks_the_whole_file` test pages a 900-line file with
+  `next_line` + `expected_sha256` and asserts the concatenation equals the
+  file byte-for-byte — proving the cursor has no gaps or overlaps, without
+  adding the concatenating call that Contract 5 forbids.
+
+**Note on `line_too_large` details:** the reported `bytes` is a documented
+**lower bound** (`max_line_bytes + 1`), not the true line length. Reading
+further to report an exact size would defeat the bounded-memory guarantee
+this tool exists for. The task's own acceptance test only pins the line
+number; the size assertion in the test was written as `> budget` with a
+comment explaining why an exact value is not available.
+
+**Testing**: 121 tests pass; ruff and black clean. Log at
+`artifacts/logs/TASK-3082-pytest.log`.
+
+**Deviations from spec**: none. `scripts/generate_tool_registry.py --check`
+demanded a `bounded_source` entry, which was added by hand (one line) rather
+than by running the generator in bulk, for the same scope-creep reason
+recorded in TASK-3080.

--- a/sdd/tasks/completed/TASK-3083-delegation-contracts.md
+++ b/sdd/tasks/completed/TASK-3083-delegation-contracts.md
@@ -2,7 +2,7 @@
 
 **Feature**: FEAT-543 — Claude Code and Codex Tool Optimizations
 **Spec**: `sdd/specs/tool-optimizations.spec.md`
-**Status**: pending
+**Status**: done
 **Priority**: high
 **Estimated effort**: L (4-8h)
 **Depends-on**: TASK-3079, TASK-3082
@@ -338,8 +338,55 @@ When you pick up this task:
 
 *(Agent fills this in when done)*
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
+**Completed by**: sdd-worker (Claude Opus 5, session_01G9NM1TzdkFLd5foNDmh72K)
+**Date**: 2026-09-10
 **Notes**:
 
-**Deviations from spec**: none | describe if any
+Created `contracts.py` (hand-written fence scanner, packet extraction,
+placeholder detection, scope/freshness validation, prompt rendering) plus
+`tests/tool_optimizations/fixtures.py` with the canonical
+`make_valid_task()` / `make_repo_with_target()` builders that TASK-3085 and
+TASK-3090 reuse. 28 tests in `test_contracts.py`, 149 across the feature
+suite.
+
+Every `ContractError` code in the task's Scope list has a test that
+triggers exactly it — including the pairs that are easy to conflate
+(`invalid_packet_json` vs `invalid_packet`, `no_packet_block` vs
+`duplicate_packet_block`, `target_exists_for_create` vs
+`target_missing_for_modify`).
+
+Design points worth carrying forward:
+
+- **The fixture computes real digests from the repo it just built**, so it
+  can never rot into a permanently-stale packet. `stale_target` is then
+  provoked by actually editing the file, which is what makes that test
+  meaningful.
+- **Ordering is deliberate: cheap structural checks first.** Command
+  allow-list and block/placeholder resolution run before any hashing, and
+  the packet+blocks context check runs before reference loading — so
+  `context_budget_exceeded` is raised without doing the expensive work, as
+  the acceptance criteria require.
+- **`test_no_subprocess_ever` monkeypatches four spawn entry points**
+  (`asyncio.create_subprocess_exec`/`_shell`, `subprocess.run`/`Popen`) and
+  still validates a packet whose `validation_commands` name pytest. This is
+  the guarantee that `validation_commands` is data, never an execution path.
+- The nested-fence test proves a ```` ```python ```` block inside a
+  ````` ````markdown ````` block is preserved literally, which is why the
+  scanner tracks fence length instead of matching the first closing fence.
+- The placeholder regexes are line-anchored where it matters: a bare `...`
+  line fails, while `x = "..."` inside an expression passes.
+
+Two small implementation choices, both covered by tests:
+
+1. Labelled blocks are collected from anywhere in the TASK file, while the
+   packet block is only recognized *inside* the `## Delegation Contract`
+   section. A `json` block carrying an `id=` is treated as an
+   implementation block, not as a second packet.
+2. `render_prompt_sections` emits a blank line between the acceptance
+   heading and its list, matching the other three sections (the only change
+   made to the renderer after the snapshot test was written).
+
+**Testing**: 149 tests pass; ruff and black clean. Log at
+`artifacts/logs/TASK-3083-pytest.log`.
+
+**Deviations from spec**: none.

--- a/sdd/tasks/completed/TASK-3084-patch-validation-artifact-store.md
+++ b/sdd/tasks/completed/TASK-3084-patch-validation-artifact-store.md
@@ -2,7 +2,7 @@
 
 **Feature**: FEAT-543 — Claude Code and Codex Tool Optimizations
 **Spec**: `sdd/specs/tool-optimizations.spec.md`
-**Status**: pending
+**Status**: done
 **Priority**: high
 **Estimated effort**: L (4-8h)
 **Depends-on**: TASK-3079
@@ -322,8 +322,58 @@ When you pick up this task:
 
 *(Agent fills this in when done)*
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
+**Completed by**: sdd-worker (Claude Opus 5, session_01G9NM1TzdkFLd5foNDmh72K)
+**Date**: 2026-09-10
 **Notes**:
 
-**Deviations from spec**: none | describe if any
+Created `patches.py`: diff grammar, pure-Python in-memory applier,
+`ArtifactStore` and the `ApplyJournal`/`JournalEntry` models TASK-3086
+will drive. 31 tests in `test_patches.py`, 180 across the feature suite,
+all passing on the first run.
+
+Every rejection code in the task's Scope list has its own test, plus three
+that are worth calling out because they are the ones that protect the
+"no guessing" property:
+
+- **`test_no_fuzz_offset_search`** applies a *correct* patch to a source
+  with one extra line prepended. A fuzzy applier would relocate the hunk
+  and silently succeed; this one raises `context_mismatch`. That is the
+  whole point of applying in Python rather than shelling out to a patch
+  tool with a default fuzz factor.
+- **`test_modify_of_missing_file_is_a_mismatch`** proves a modify whose
+  target vanished is refused rather than quietly promoted to a create.
+- **`test_crash_between_write_and_publish_leaves_no_artifact`**
+  monkeypatches `os.rename` to fail and then asserts `load()` reports
+  `artifact_not_found` — the temp-dir-then-rename publish means a crash can
+  never leave a half-written artifact that a later apply would trust.
+
+Implementation notes:
+
+- **Unsupported diff features are detected in a pre-scan**, before header
+  parsing. This matters because a rename or binary patch often has *no*
+  `---`/`+++` headers at all; parsing first would report the misleading
+  `not_a_patch` instead of `rename_rejected` / `binary_rejected`.
+- `new file mode` is allowed only for `100644`/`100755`; anything else
+  (e.g. `120000`, a symlink) is `mode_change_rejected`. `old mode`/
+  `new mode` are always rejected — the checks are `startswith` on the exact
+  prefixes so `new file mode` is not caught by the `new mode` rule.
+- Added lines adopt the file's own newline convention: `_newline_for()`
+  returns CRLF only when *every* terminated source line is CRLF, so a
+  CRLF file stays CRLF and a mixed file is not "corrected".
+- `normalize_patch` strips leading *and* trailing blank lines so it is
+  genuinely idempotent — `reviewed_sha256` in TASK-3086 is a hash of this
+  text, so any drift here would break review gating.
+- The store hash-checks **both** `patch.diff` and `packet.json` on load,
+  refuses any `artifact_id` outside `^[0-9a-f]{32}$`, and refuses a
+  symlinked artifact directory.
+
+**Testing**: 180 tests pass; ruff and black clean. Log at
+`artifacts/logs/TASK-3084-pytest.log`.
+
+**Deviations from spec**: none. Two small additions the task implied but
+did not name: an `invalid_artifact_id` code (the store must reject a
+malformed id, and returning `artifact_not_found` for `../escape` would
+have been misleading) and an `artifact_not_found` code for a missing
+artifact directory. `ArtifactStore.directory_mode()` was added as a small
+read-only helper so TASK-3086 and the tests can assert permissions without
+reaching into private paths.

--- a/sdd/tasks/completed/TASK-3085-writer-generate.md
+++ b/sdd/tasks/completed/TASK-3085-writer-generate.md
@@ -2,7 +2,7 @@
 
 **Feature**: FEAT-543 — Claude Code and Codex Tool Optimizations
 **Spec**: `sdd/specs/tool-optimizations.spec.md`
-**Status**: pending
+**Status**: done
 **Priority**: high
 **Estimated effort**: XL (> 8h)
 **Depends-on**: TASK-3083, TASK-3084
@@ -389,8 +389,69 @@ When you pick up this task:
 
 *(Agent fills this in when done)*
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
+**Completed by**: sdd-worker (Claude Opus 5, session_01G9NM1TzdkFLd5foNDmh72K)
+**Date**: 2026-09-10
 **Notes**:
 
-**Deviations from spec**: none | describe if any
+Created `writer.py` with `SYSTEM_PROMPT`, `build_prompt`,
+`build_repair_prompt` and `TargetedWriterToolkit` (`writer_generate` plus
+the `writer_apply` stub TASK-3086 replaces). 23 tests in `test_writer.py`,
+203 across the feature suite.
+
+Codebase Contract re-verified against this branch before writing code —
+all four load-bearing facts hold:
+
+- `AbstractClient.__init__` creates the `_fallback_model` *instance*
+  attribute only when `fallback_model` is in kwargs (`base.py:426-428`),
+  and the class attribute defaults to `None` (`base.py:298`).
+- `BedrockConverseBase.__init__` uses `kwargs.setdefault("fallback_model",
+  self._fallback_model)` (`bedrock.py:282`), so an explicit
+  `fallback_model=None` survives and the class default
+  `"claude-haiku-4-5"` (`bedrock.py:1669`) is not applied — which is
+  exactly why the documented `llm_kwargs: {fallback_model: null}` is
+  required and why the constructor guard is meaningful.
+- `metadata["used_fallback_model"] = True` is set at `bedrock.py:1063`.
+- `toolkit_server.py:108-110` injects the constructor kwarg as
+  `llm_client`, and drops `llm_dependent_tools` when no `llm:` is set.
+
+Tests worth highlighting (they encode the properties, not the code):
+
+- **`FakeClient.__getattr__` raises** on any attribute outside a documented
+  allow-list. If the writer ever starts reaching for a new client
+  attribute, the suite fails immediately instead of silently coupling to
+  a provider internal.
+- **`test_call_uses_exactly_the_approved_kwargs`** asserts the `ask()`
+  kwargs set is *exactly* `{prompt, system_prompt, max_tokens, temperature,
+  use_tools, history}` — and explicitly that `model` is absent, since a
+  per-call model override would be a substitution channel the no-fallback
+  guard cannot see.
+- **`test_prompt_contains_only_approved_content`** plants an unapproved
+  file in the repo and asserts its marker never appears in the prompt.
+- **`test_invalid_contract_makes_no_call` / `test_stale_contract_makes_no_call`**
+  assert `fake.calls == []` — AC7's "no delegate call" is verified, not
+  assumed.
+- **`test_generate_ok_and_no_target_mutation`** snapshots the target bytes
+  and asserts the created file still does not exist after generation.
+- **`test_model_substitution_rejected_without_repair`** proves a fallback
+  answer consumes exactly one call and produces no artifact.
+
+One test-design correction made during the work: the first version of
+`FakeClient` reported the same identity for the client's configured model
+and the response's `model`, which made the `expected_model_ids` check
+untestable (they always matched). The fake now takes a separate
+`response_model`, so substitution is genuinely exercised in both
+directions — rejecting an unlisted id and accepting Bedrock's translated
+`qwen.qwen3-coder-480b-a35b-v1:0`.
+
+Also verified by a subprocess test: importing `writer.py` does **not**
+import any boto module, so Git/reader startup stays free of AWS
+dependencies (spec §7).
+
+**Testing**: 203 tests pass; ruff and black clean. Log at
+`artifacts/logs/TASK-3085-pytest.log`.
+
+**Deviations from spec**: none, with one recorded file-scope note:
+`tests/tool_optimizations/fixtures.py` (created by TASK-3083) was extended
+with the `GOOD_PATCH` constant. The task's own Test Specification imports
+`GOOD_PATCH` from that module, so the addition is required by the task even
+though `fixtures.py` is not repeated in its file table.

--- a/sdd/tasks/completed/TASK-3086-writer-apply-recovery.md
+++ b/sdd/tasks/completed/TASK-3086-writer-apply-recovery.md
@@ -2,7 +2,7 @@
 
 **Feature**: FEAT-543 — Claude Code and Codex Tool Optimizations
 **Spec**: `sdd/specs/tool-optimizations.spec.md`
-**Status**: pending
+**Status**: done
 **Priority**: high
 **Estimated effort**: L (4-8h)
 **Depends-on**: TASK-3085
@@ -295,8 +295,81 @@ When you pick up this task:
 
 *(Agent fills this in when done)*
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
+**Completed by**: sdd-worker (Claude Opus 5, session_01G9NM1TzdkFLd5foNDmh72K)
+**Date**: 2026-09-10
 **Notes**:
 
-**Deviations from spec**: none | describe if any
+Implemented `writer_apply`, `_rollback`, `_recovery_report` and the
+`_write_atomic` / `_missing_parents` / `_sha_or_none` helpers, replacing
+the TASK-3085 stub. Added the required `PatchManifest.task_path` field and
+populated it. 14 tests in `test_apply.py`, 219 across the feature suite.
+
+**Precondition order is load-bearing and is what the tests pin.** The
+sequence is: artifact load -> review hash -> packet identity -> lock ->
+`already_applied` -> `recovery_pending` -> `staged_target` -> per-target
+`create_collision` / `target_changed` -> contract re-validation ->
+in-memory re-apply -> after-hash check. Two orderings are deliberate:
+
+1. `already_applied` must precede contract re-validation. After a
+   successful apply the created file exists, so re-validating the contract
+   would fail with `target_exists_for_create` and an idempotent retry would
+   look like an error.
+2. `staged_target` precedes `target_changed` (asserted directly by
+   `test_staged_target_refused_before_changed_target`, which sets up both
+   conditions at once) so the report names the blocker the user must
+   actually resolve.
+
+**A test-methodology bug found and fixed — worth reading.** The task's
+sketch injects the write failure by counting `os.replace` calls
+(`if calls["n"] == 2: raise`). That does not work here: `ArtifactStore`
+publishes the journal with `os.replace` too, so call #1 is the *journal*
+write, not a target file. Both fault-injection tests were therefore
+"passing" while testing nothing:
+
+- the crash test aborted on the journal write, so no file was ever
+  written and the rollback loop had nothing to restore;
+- the concurrent-edit test corrupted `journal.json` with the sabotage
+  content instead of a target file, and produced `write_failed` rather
+  than `recovery_required`.
+
+Both now inject by **destination path**, so the crash lands on the second
+real target and the sabotage lands on the first. `test_crash_rolls_back_first_file`
+now asserts the actual rollback effect — `pkg/greeter.py` was written and
+then removed, journal entry `restored`, the failed entry still `pending`,
+errno 28 reported, and no `.parrot-tmp` files left behind.
+
+Other properties covered:
+
+- **Rollback never overwrites a concurrent editor.**
+  `test_concurrent_edit_requires_recovery` has an outside writer rewrite
+  the file we just wrote; rollback sees the hash no longer matches what it
+  wrote, marks the entry `unrecoverable`, returns `recovery_required` and
+  leaves the foreign content byte-intact. A retry then returns
+  `recovery_pending` rather than steamrolling it.
+- **Applying never stages, commits or pushes**: the happy-path test
+  asserts `git diff --cached --name-only` is empty and `HEAD` is unchanged,
+  and `test_apply_path_never_uses_mutating_git_verbs` greps the module for
+  `"add"`, `"commit"`, `"push"`, `"checkout"` and `"reset"` argv literals.
+- **Permissions are preserved on modify and defaulted on create**
+  (0o640 stays 0o640; a new file is 0o644).
+- The journal is retained as evidence after both success and idempotent
+  re-run; only its `state` changes.
+
+**Testing**: 219 tests pass; ruff and black clean. Log at
+`artifacts/logs/TASK-3086-pytest.log`.
+
+**Deviations from spec**: none, with three recorded file-scope notes:
+
+1. `tests/tool_optimizations/test_patches.py` (TASK-3084's file) needed a
+   one-line update because `PatchManifest.task_path` is a new **required**
+   field and that test builds a manifest. Making the field optional was
+   rejected: a manifest without provenance cannot be re-validated at apply
+   time, which is the whole reason the field was added.
+2. `test_writer.py`'s `test_writer_apply_is_not_implemented_yet` was
+   replaced (it asserted the stub this task removes) with two real tests:
+   unknown-artifact and argument validation.
+3. `test_stale_reference_refused` from the task sketch was renamed to
+   `test_unrelated_file_does_not_block_apply` and documents why: in this
+   fixture the packet's only reference *is* a target, so changing it is
+   caught earlier and more precisely as `target_changed`. Genuine
+   reference staleness is already covered in `test_contracts.py`.

--- a/sdd/tasks/completed/TASK-3087-mcp-llm-kwargs-config.md
+++ b/sdd/tasks/completed/TASK-3087-mcp-llm-kwargs-config.md
@@ -2,7 +2,7 @@
 
 **Feature**: FEAT-543 — Claude Code and Codex Tool Optimizations
 **Spec**: `sdd/specs/tool-optimizations.spec.md`
-**Status**: pending
+**Status**: done
 **Priority**: high
 **Estimated effort**: M (2-4h)
 **Depends-on**: none
@@ -258,8 +258,67 @@ When you pick up this task:
 
 *(Agent fills this in when done)*
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
+**Completed by**: sdd-worker (Claude Opus 5, session_01G9NM1TzdkFLd5foNDmh72K)
+**Date**: 2026-09-10
 **Notes**:
 
-**Deviations from spec**: none | describe if any
+Added `ToolkitSection.llm_kwargs` with its `model_validator`, changed the
+one factory call to `LLMFactory.create(section.llm, **section.llm_kwargs)`,
+created `examples/tool-optimizations-mcp.yaml`, documented the field in
+`docs/mcp-local-toolkits.md`, and added 8 tests (33 passing across the two
+toolkit test modules).
+
+The production diff is deliberately tiny — 4 lines in `toolkit_server.py`
+and a field plus validator in `toolkit_config.py` — because backward
+compatibility is the requirement: a section without `llm_kwargs` produces
+an identical call, asserted by
+`test_old_config_without_llm_kwargs_is_unchanged` (`seen["kwargs"] == {}`).
+
+Tests worth noting:
+
+- `test_llm_kwargs_passed_to_factory` asserts the captured kwargs are
+  exactly `{"fallback_model": None, "max_retries": 1, "read_timeout": 120}`
+  **and** that `fallback_model` is present as a key. An explicit `None` is
+  not the same as an absent key here: `BedrockConverseBase.__init__` uses
+  `kwargs.setdefault("fallback_model", self._fallback_model)`, so only an
+  explicitly-passed `None` prevents the class default `claude-haiku-4-5`.
+- `test_deterministic_toolkit_never_imports_the_client_factory` makes
+  `importlib.import_module("parrot.clients.factory")` *raise*, so a
+  regression that eagerly imports the factory for a model-free toolkit
+  fails loudly. This is what keeps the Git and reader servers free of
+  provider/AWS dependencies.
+- `test_example_tool_optimizations_config_loads` loads the shipped example
+  and pins `fallback_model is None` plus the `expected_model_ids` entry, so
+  the documented configuration cannot silently rot.
+
+**Environment note for later tasks (important).** The venv's editable
+installs point at the MAIN repo checkout, so core `parrot` changes made in
+this worktree are invisible to pytest unless
+`PYTHONPATH=$PWD/packages/ai-parrot/src` is set. Doing that initially broke
+imports with `ModuleNotFoundError: parrot.utils.types` — that module is a
+compiled Cython extension whose `.so` is a gitignored build artifact
+present only in the main checkout. Fixed by symlinking the two compiled
+extensions into the worktree:
+
+    packages/ai-parrot/src/parrot/utils/types.cpython-312-*.so
+    packages/ai-parrot/src/parrot/utils/parsers/toml.cpython-312-*.so
+
+Both are covered by `.gitignore:7` (`*.so`), so they never enter the repo.
+`parrot/__init__.py` uses `pkgutil.extend_path`, so the satellite packages
+(e.g. `parrot.clients.amazon`) still resolve from the main checkout while
+core modules resolve from the worktree — verified explicitly.
+
+**Pre-existing failures, not caused by this change.** `pytest tests/mcp`
+reports 10 failures and 1 error on this branch; running the same suite on
+`dev` reports the *same* 10 failures and 1 error (netsuite, oauth,
+chrome-manager). This branch adds 8 passing tests (184 -> 192 passed).
+Likewise, `ruff check packages/ai-parrot/src/parrot/mcp` reports 2
+pre-existing implicit-string-concat errors at `toolkit_server.py:86` and 3
+in `integration.py`; `git show dev:...` confirms line 86 is unchanged by
+this task. They were left alone rather than opportunistically fixed.
+`black --check` is clean on both files this task modified.
+
+**Testing**: 33 tests in the two toolkit modules; log at
+`artifacts/logs/TASK-3087-pytest.log`.
+
+**Deviations from spec**: none.

--- a/sdd/tasks/completed/TASK-3088-host-read-guards.md
+++ b/sdd/tasks/completed/TASK-3088-host-read-guards.md
@@ -2,7 +2,7 @@
 
 **Feature**: FEAT-543 — Claude Code and Codex Tool Optimizations
 **Spec**: `sdd/specs/tool-optimizations.spec.md`
-**Status**: pending
+**Status**: done
 **Priority**: medium
 **Estimated effort**: L (4-8h)
 **Depends-on**: TASK-3079
@@ -314,8 +314,52 @@ When you pick up this task:
 
 *(Agent fills this in when done)*
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
+**Completed by**: sdd-worker (Claude Opus 5, session_01G9NM1TzdkFLd5foNDmh72K)
+**Date**: 2026-09-10
 **Notes**:
 
-**Deviations from spec**: none | describe if any
+Created `hooks.py` (stdlib-only) with `GuardPolicy`, `GuardDecision`,
+`evaluate_read`, `evaluate_shell`, `parse_shell_subset`, `build_reason`,
+`render_output`, `coverage_matrix` and `main`. 54 tests in
+`test_hooks.py`, 273 across the feature suite.
+
+**A real parsing bug found by the coverage-gap tests.** `cat big.py || true`
+was being *denied* instead of ignored. `shlex.split` returns `||` as a
+single token, not two `|` separators, so the segment splitter (which only
+matched a token equal to `"|"`) treated `||` as an ordinary operand of
+`cat` — swallowing a compound statement into the parsed subset. Any token
+*containing* a pipe that is not exactly `"|"` now aborts parsing. This
+mattered: the guard's honesty depends on never claiming to understand a
+command it does not, and a compound statement is exactly the case where a
+confident-looking decision would be wrong.
+
+Properties the tests pin:
+
+- **A pipe never makes a large read safe**: `cat big.py | head -20` is
+  denied, because the *reading* segment decides.
+- **Coverage gaps produce silence, never a denial** — 14 parametrized
+  forms (`;`, `&&`, `||`, command substitution, globs, redirection, `sed`,
+  `awk`, `python -c`, `xargs`, `~`, `$VAR`) all yield empty output.
+- **`test_coverage_matrix_is_honest_and_complete`** cross-checks the
+  published matrix against the behaviour the other tests demonstrate: every
+  form asserted as a gap above must appear with `covered: False`. This is
+  what stops the matrix drifting into a false claim of enforcement.
+- **The guard can never break a session**: malformed JSON, empty payloads,
+  missing files, directories and unknown tools all exit 0 with no output,
+  and `main()` returns 0 unconditionally.
+- **Import weight is enforced by a subprocess assertion**: importing the
+  module loads neither `pydantic` nor any `parrot.*` module.
+- **The duplicated `count_lines_bounded` is held to the reader's
+  behaviour** by a parametrized agreement test (0/1/349/350/351 lines plus
+  a no-final-newline fixture), so the documented copy cannot drift.
+- Bare `head FILE` / `tail FILE` are treated as bounded (10-line default),
+  while `head -400` is denied.
+
+**Testing**: 273 tests pass; ruff and black clean. Log at
+`artifacts/logs/TASK-3088-pytest.log`.
+
+**Deviations from spec**: none. Note the host versions in the task's
+Context (`claude 2.1.267`, `codex-cli 0.154.0`) were not re-verified
+against live binaries here — this task implements and unit-tests the
+policy; pinning and recording installed host versions is TASK-3091's
+host-smoke work.

--- a/sdd/tasks/completed/TASK-3089-guard-installation.md
+++ b/sdd/tasks/completed/TASK-3089-guard-installation.md
@@ -2,7 +2,7 @@
 
 **Feature**: FEAT-543 — Claude Code and Codex Tool Optimizations
 **Spec**: `sdd/specs/tool-optimizations.spec.md`
-**Status**: pending
+**Status**: done
 **Priority**: medium
 **Estimated effort**: L (4-8h)
 **Depends-on**: TASK-3088, TASK-3087
@@ -302,8 +302,62 @@ When you pick up this task:
 
 *(Agent fills this in when done)*
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
+**Completed by**: sdd-worker (Claude Opus 5, session_01G9NM1TzdkFLd5foNDmh72K)
+**Date**: 2026-09-10
 **Notes**:
 
-**Deviations from spec**: none | describe if any
+Created `installation.py` (`install_guards`, `uninstall_guards`,
+`guard_status`, `guard_thresholds`, `hook_command`, `resolve_python`) and
+wired `--tool-guards` into both wiki CLIs. 20 tests in
+`test_installation.py`, 293 across the feature suite.
+
+The "touch only what we own" discipline is what the tests actually pin:
+
+- `test_install_is_idempotent_and_preserves_foreign_entries` asserts the
+  foreign entries come back **deep-equal to the originals**, including an
+  unknown `customKey` and an unrelated top-level key. The fixture models
+  this repository's real `.claude/settings.json` (the wiki nudge hook and
+  `dangerous-actions-blocker.sh`), so a regression that rewrites a
+  neighbour's entry fails immediately.
+- `test_malformed_config_is_never_clobbered` compares the file's **bytes**
+  before and after a failed install *and* a failed uninstall.
+- `test_wrong_container_types_are_refused` covers `hooks: []` and
+  `PreToolUse: {}` — a naive `setdefault` would silently reset either.
+- `test_uninstall_collapses_only_containers_we_emptied` and
+  `test_thresholds_survive_while_another_host_still_uses_them` cover the
+  two subtle lifecycle rules: containers are dropped only when we emptied
+  them, and the shared `.parrot/tool-guards.json` survives while the other
+  host still has a guard installed.
+- `test_cli_reports_a_useful_error_when_parrot_tools_is_absent` blocks the
+  import via `builtins.__import__` and asserts `--tool-guards` fails with
+  the install hint **while a plain install still succeeds** — core never
+  hard-depends on `ai-parrot-tools`.
+
+`guard_status` deliberately never raises: a malformed config reads as "not
+installed" rather than propagating, because status is a diagnostic. It
+reports `supported: None` for an unparseable/absent host version rather
+than guessing — an unknown version is never reported as supported. Against
+the locally installed hosts it correctly read `2.1.267 (Claude Code)` and
+resolved `supported: True`.
+
+The guard is **opt-in and off by default** (`--tool-guards/--no-tool-guards`,
+default False), and `permissions.allow` is never touched, per spec Git
+Contract 12 (no broad automatic-approval installation).
+
+**Regression check**: `tests/knowledge/wiki` (4 failed / 1595 passed / 12
+errors) and `packages/ai-parrot/tests/knowledge/wiki` (7 failed / 276
+passed) produce **byte-identical** counts on this branch and on `dev`, so
+the CLI edits regress nothing. (The two directories must be run separately
+— running both in one pytest invocation hits a pre-existing
+`ImportPathMismatchError` between their two `tests.conftest` modules.)
+
+**Testing**: 293 tests in the feature suite; ruff and black clean. Log at
+`artifacts/logs/TASK-3089-pytest.log`.
+
+**Deviations from spec**: none in behaviour. One open verification is
+explicitly deferred, as the task itself allows: the Codex hook format is
+written as `<root>/.codex/hooks.json` per the documented shape, but it was
+**not** validated against a running `codex` binary here. If the installed
+Codex version requires `config.toml` `[hooks]` tables instead, the writer
+must switch format — that check belongs to TASK-3091's host smoke test,
+which is where installed host versions get pinned and recorded.

--- a/sdd/tasks/completed/TASK-3090-sdd-delegation-workflow.md
+++ b/sdd/tasks/completed/TASK-3090-sdd-delegation-workflow.md
@@ -2,7 +2,7 @@
 
 **Feature**: FEAT-543 — Claude Code and Codex Tool Optimizations
 **Spec**: `sdd/specs/tool-optimizations.spec.md`
-**Status**: pending
+**Status**: done
 **Priority**: medium
 **Estimated effort**: L (4-8h)
 **Depends-on**: TASK-3083, TASK-3086
@@ -285,8 +285,57 @@ When you pick up this task:
 
 *(Agent fills this in when done)*
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
+**Completed by**: sdd-worker (Claude Opus 5, session_01G9NM1TzdkFLd5foNDmh72K)
+**Date**: 2026-09-10
 **Notes**:
 
-**Deviations from spec**: none | describe if any
+Edited nine workflow documents (2 templates, 3 Claude commands, 3 Codex
+skills, the sdd-worker agent) and added `test_sdd_contracts.py`. No Python
+source changed. 21 tests in the new module, 314 across the feature suite.
+All nine edits are pure insertions — 234 added lines, 0 deletions — so the
+existing FEAT-466/FEAT-387 content is untouched.
+
+The tests are the interesting part, because documentation rots silently:
+
+- **`test_template_packet_is_rejected_while_placeholders_remain`** feeds the
+  template's own example packet through the real `parse_task_file` /
+  `extract_packet`, and asserts it is rejected as `invalid_packet` while the
+  `<sha256 …>` placeholders are present. The safety net is *executed*, not
+  merely described.
+- **`test_template_packet_validates_once_hashes_are_real`** then builds a
+  matching fixture repo, substitutes real digests, and runs the full
+  `validate_contract` — proving the shipped example is genuinely
+  copy-pasteable and not subtly malformed.
+- **`test_review_happens_before_apply`** asserts the *index positions* of
+  `writer_generate` < `source_read` < `writer_apply` in the Claude command,
+  the Codex skill and the worker agent. A future edit that documents apply
+  before review fails the suite.
+- **Parity is by meaning, not prose**: each command/skill pair is checked
+  for shared key phrases appropriate to its stage, so the terser Codex
+  skills can stay terse without drifting in substance.
+- `test_legacy_task_without_a_contract_is_simply_ineligible` runs
+  `validate_contract` against a section-less TASK file and asserts
+  `no_delegation_section` — the legacy route is proven to be the default.
+- Two parametrized tests pin the two non-negotiable sentences in all three
+  execution documents: SDD files are *never edited by the writer*, and the
+  workflow *never silently invokes another coder*.
+
+**A placement bug I caught and fixed.** My first insertion pass used a
+generic `"\n## "` anchor for `sdd-task.md` and `sdd-spec.md`, which matched
+the *first* heading in each file and dropped both new subsections directly
+under the one-line description, before Usage/Guardrails/Steps. The tests
+still passed (they check content and ordering, not position), so this would
+have shipped as quietly misplaced documentation. Both blocks were relocated
+to their intended homes — after the Codebase Contract research step in
+`sdd-spec.md` and after the per-task Codebase Contract step in
+`sdd-task.md` — and the placement was verified by eye afterwards.
+
+**Note on committing `sdd/templates/`**: `.gitignore` has a global
+`templates/` rule, so `git add sdd/templates/*.md` is refused even though
+the files are tracked. `git add -f` is required, exactly as CLAUDE.md's
+heads-up describes. No new files were added under `sdd/templates/`.
+
+**Testing**: 314 tests pass; ruff and black clean on the new test module.
+Log at `artifacts/logs/TASK-3090-pytest.log`.
+
+**Deviations from spec**: none.

--- a/sdd/tasks/completed/TASK-3091-integration-test-suite.md
+++ b/sdd/tasks/completed/TASK-3091-integration-test-suite.md
@@ -2,7 +2,7 @@
 
 **Feature**: FEAT-543 — Claude Code and Codex Tool Optimizations
 **Spec**: `sdd/specs/tool-optimizations.spec.md`
-**Status**: pending
+**Status**: done
 **Priority**: high
 **Estimated effort**: L (4-8h)
 **Depends-on**: TASK-3081, TASK-3082, TASK-3086, TASK-3087, TASK-3089
@@ -292,8 +292,111 @@ When you pick up this task:
 
 *(Agent fills this in when done)*
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
+**Completed by**: sdd-worker (Claude Opus 5, session_01G9NM1TzdkFLd5foNDmh72K)
+**Date**: 2026-09-10
 **Notes**:
 
-**Deviations from spec**: none | describe if any
+Created the seven integration modules plus `conftest.py`. 45 integration
+tests (1 skipped by design), 360 across the whole feature suite.
+
+## A real defect found and fixed: Codex fails open on every denial
+
+`render_output` emitted `permissionDecision: "deny"` for **both** hosts.
+Reading the installed `codex-cli 0.154.0` binary directly shows its
+`PreToolUseDecisionWire` serde variants are **`approve | block | allow`** —
+there is no `deny` — and the binary carries the error string
+`"PreToolUse hook returned unsupported decision"`. So every guard denial
+sent to Codex was an unsupported value: the hook would have failed open and
+the unbounded read of a large file would have proceeded, silently.
+
+Fixed in the owning module (`hooks.py`) with an explicit `DENY_VALUE`
+table and two regression tests
+(`test_each_host_gets_its_own_refusal_keyword`,
+`test_deny_value_table_matches_each_host_enum`), plus an assertion in the
+host-smoke module. This is exactly the failure mode the spec warns about —
+"host guards cause a false sense of enforcement" — and it was only found
+because the host smoke test pinned and interrogated the *installed* binary
+rather than trusting the documentation.
+
+## Open item handed to the release gate (TASK-3092)
+
+The same binary inspection shows Codex's hook config fields are
+`eventName`, `matcher`, `timeoutSec`, while `install_guards` currently
+writes the Claude-shaped
+`{"hooks": {"PreToolUse": [{"matcher", "hooks": [{"type", "command", "timeout"}]}]}}`
+into `.codex/hooks.json`. I did **not** rewrite the installer on the
+strength of string inspection alone — the field names are visible but the
+container structure is not, and guessing would trade a documented-but-
+unverified format for an invented one. Instead the finding is recorded as
+hard evidence in `artifacts/logs/host-smoke.json`
+(`hooks_file_format_verified: false`, `observed_hook_config_fields`,
+`open_item`). **Codex guard installation must be verified end to end before
+release.** Claude Code's format is unaffected.
+
+## Coverage of the spec's seven integration rows
+
+- **Stdio protocol** — in-process for all three servers, plus a real
+  subprocess run of `parrot mcp-local bounded-source` asserting **every**
+  stdout line parses as JSON-RPC (stdout purity). Also proves
+  `writer_generate` is filtered out when no `llm:` is configured and
+  appears when one is.
+- **Raw MCP validation** — 21 cases, all through `_handle_request`, each
+  asserting `isError` *and* an unchanged snapshot of index bytes, artifact
+  directory and source file. One case was reclassified during the work:
+  an option-shaped `ref` is a *domain* refusal (`status="error"`,
+  `invalid_ref`) rather than an `isError` argument rejection, because the
+  argument model legitimately accepts any non-empty string. The test now
+  asserts what actually matters — `steps == []`, i.e. no git process was
+  ever spawned.
+- **Git lifecycle** — fetch → preflight → prepare → (harness commits) →
+  push → pull, in the main tree and in a linked worktree, plus three
+  injected failures (whitespace, foreign `index.lock`, diverged remote)
+  each asserting refs, files and index bytes are unchanged.
+- **Writer lifecycle** — generate → paged bounded review (asserting the
+  reviewed text equals the on-disk patch byte-for-byte) → apply → **the
+  harness executes the packet's real `pytest`**. Exit code 0 recorded in
+  `TASK-3091-writer-lifecycle.json` separately from the manifest, and
+  asserted independently of it.
+- **Cross-process coordination** — genuine OS subprocesses with a file
+  barrier (threads would not exercise `flock`). Staging: one wins, the
+  other is refused `unrelated_staged`, the winner's file *is* staged (no
+  lost update), the advisory lock file survives and no `index.lock` is
+  orphaned. Apply: one `ok`, the other `already_applied`, and the modify
+  hunk is asserted to appear exactly once — proving no double application.
+- **Client configuration** — exact factory kwargs from the shipped example,
+  `expected_model_ids` reaching the constructor, and a test that a client
+  still permitting fallback is refused at construction. The live Bedrock
+  smoke test is `@pytest.mark.real_llm` + env-gated and skipped by default.
+- **Host smoke** — records `artifacts/logs/host-versions.txt`
+  (`claude 2.1.267`, `codex-cli 0.154.0`) and `host-smoke.json`. Honest
+  about limits: `exercised_end_to_end: false`, because Claude's hook runner
+  cannot be driven headlessly; the guard runtime is invoked directly with
+  the documented payload shape instead.
+
+## Evidence artefacts (all under gitignored `artifacts/logs/`)
+
+`TASK-3091-integration.log`, `TASK-3091-regression.log`,
+`TASK-3091-writer-lifecycle.json`, `TASK-3091-cross-process-prepare.json`,
+`TASK-3091-cross-process-apply.json`, `TASK-3091-client-configuration.json`,
+`TASK-3091-guard-coverage.json`, `host-versions.txt`, `host-smoke.json`.
+
+## Regression status
+
+`packages/ai-parrot-tools/tests/tool_optimizations`: **360 passed,
+1 skipped**. `tests/mcp`: 10 failed / 192 passed / 1 error — the *same* 10
+failures and 1 error as `dev` (netsuite, oauth, chrome-manager), with 8
+more tests passing than baseline. `ruff` and `black --check` clean on the
+feature tree.
+
+**Note**: the two suites must be run as separate pytest invocations. The
+repo has two distinct `tests` packages (root `tests/` and
+`packages/ai-parrot-tools/tests/`), so a combined run shadows one with the
+other and fails at conftest import with
+`ModuleNotFoundError: No module named 'tests.tool_optimizations'`. This is
+pre-existing and identical in kind to the wiki-test collision noted in
+TASK-3089.
+
+**Deviations from spec**: none in coverage. Two judgement calls are recorded
+above: the `invalid_ref` reclassification, and declining to rewrite the
+Codex installer format on string evidence alone (recorded as a release-gate
+open item instead).

--- a/sdd/tasks/completed/TASK-3092-benchmarks-docs-release.md
+++ b/sdd/tasks/completed/TASK-3092-benchmarks-docs-release.md
@@ -2,7 +2,7 @@
 
 **Feature**: FEAT-543 — Claude Code and Codex Tool Optimizations
 **Spec**: `sdd/specs/tool-optimizations.spec.md`
-**Status**: pending
+**Status**: done
 **Priority**: medium
 **Estimated effort**: M (2-4h)
 **Estimated effort note**: harness + docs are M; running live-model scenarios is operator time outside this task.
@@ -277,8 +277,88 @@ When you pick up this task:
 
 *(Agent fills this in when done)*
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
+**Completed by**: sdd-worker (Claude Opus 5, session_01G9NM1TzdkFLd5foNDmh72K)
+**Date**: 2026-09-10
 **Notes**:
 
-**Deviations from spec**: none | describe if any
+Created `benchmarks/tool_optimizations/` (7 files), `docs/tool-optimizations.md`
+(357 lines), linked it from `docs/mcp-local-toolkits.md`, and added
+`test_benchmark_harness.py`. 12 harness/doc tests; 372 passed + 1 skipped
+across the whole feature suite; ruff and black clean.
+
+## A real bug found while running the harness
+
+The first end-to-end run died with
+`NotImplementedError` from `asyncio.get_child_watcher()`. Cause: importing
+`parrot` installs **uvloop's** event-loop policy as a side effect. The
+runner imported the toolkits *lazily, inside* an already-running stdlib
+loop, so the loop and the policy disagreed — `create_subprocess_exec` then
+asked uvloop's policy for a child watcher it does not implement, and every
+git call failed. Fixed with an explicit `_preload_toolkits()` before
+`asyncio.run()`, documented in place. Worth remembering: any new
+`asyncio.run()` entry point in this repo must import `parrot` **before**
+starting the loop.
+
+Second, smaller find: `writer_apply` requires a real git repository (it
+re-checks the staged file list), which the benchmark fixture initially
+lacked. That is correct product behaviour, not a defect, and is now stated
+explicitly in the docs.
+
+## Honest numbers, not flattering ones
+
+The offline report is deliberately unvarnished. `targeted_read` shows the
+expected large win (5,940 → 1,200 estimated primary tokens), but
+`git_prepare` shows the optimized path costing **more** primary tokens than
+the baseline (1,095 vs 6) — because the fixture repo has two files, so
+terse git stdout is genuinely smaller than structured JSON results. Rather
+than tune the fixture until the number looked good, that caveat is written
+into `benchmarks/tool_optimizations/README.md` ("Reading the results
+honestly") with a pointer to draw conclusions from `--live` runs on
+representative repositories.
+
+Accounting rules enforced by tests:
+
+- **Unknown is never zero.** A missing provider count yields `None`, which
+  propagates to `total_tokens=None` and `cost_usd=None`.
+- **`prices.yaml` ships empty**, with `provenance` and `as_of` fields, so
+  cost reads `unknown` until an operator supplies sourced figures.
+- **Primary and delegate tokens are separate columns**, and the report text
+  states outright that fewer primary tokens is not fewer total tokens.
+- Exit code is driven by **correctness only** — an optimized scenario whose
+  real pytest fails exits non-zero; token/latency numbers never fail a run.
+- `--live` refuses fewer than five runs, and no test ever exercises it.
+
+## Documentation
+
+`docs/tool-optimizations.md` covers every section in scope. Two parts are
+kept honest mechanically rather than by discipline:
+
+- The **coverage matrix is generated from `hooks.coverage_matrix()`** and
+  `test_docs_coverage_matrix_in_sync` re-derives it and compares row by
+  row, so the published table cannot drift from the code.
+- `test_docs_have_release_gate_and_traceability` asserts AC1–AC15 all
+  appear in the traceability table, and
+  `test_docs_record_tested_host_versions_and_bypasses` pins the tested host
+  versions (Claude Code 2.1.267, codex-cli 0.154.0) and the documented
+  bypasses.
+
+The docs also record the per-host denial keyword difference discovered in
+TASK-3091 (Claude `deny`, Codex `block`) and carry the Codex installer
+format issue as an explicit **release checklist blocker**, asserted by
+`test_docs_state_the_codex_release_blocker`.
+
+## Release gate
+
+**Numeric token, cost and latency targets are an owner decision (spec §8).**
+This feature ships with correctness parity enforced by the harness and
+reports the numbers it measured; no percentage saving is claimed anywhere
+in the repository or the docs. The one substantive open decision from the
+spec remains open by design — it was not invented here.
+
+**Testing**: 12 tests in `test_benchmark_harness.py`; log at
+`artifacts/logs/TASK-3092-pytest.log`. Reports at
+`artifacts/tool-optimizations/benchmarks/` (gitignored).
+
+**Deviations from spec**: none. Live-model benchmark runs are an operator
+action, as the task scopes them; the command is documented and the harness
+is ready.

--- a/sdd/tasks/index/tool-optimizations.json
+++ b/sdd/tasks/index/tool-optimizations.json
@@ -210,7 +210,7 @@
       "feature_id": "FEAT-543",
       "feature": "tool-optimizations",
       "spec": "sdd/specs/tool-optimizations.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "L",
       "estimated_hours": 5,
@@ -222,8 +222,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-3088-host-read-guards.md"
+      "completed_at": "2026-09-10T03:00:45+00:00",
+      "file": "sdd/tasks/completed/TASK-3088-host-read-guards.md"
     },
     {
       "id": "TASK-3089",

--- a/sdd/tasks/index/tool-optimizations.json
+++ b/sdd/tasks/index/tool-optimizations.json
@@ -5,7 +5,7 @@
   "type": "feature",
   "base_branch": "dev",
   "created_at": "2026-09-10T01:36:25Z",
-  "completed_at": "2026-09-10T03:35:46+00:00",
+  "completed_at": "2026-09-10T08:41:53+00:00",
   "tasks": [
     {
       "id": "TASK-3079",
@@ -25,7 +25,8 @@
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
       "completed_at": "2026-09-10T01:56:15+00:00",
-      "file": "sdd/tasks/completed/TASK-3079-tool-optimizations-models-policy.md"
+      "file": "sdd/tasks/completed/TASK-3079-tool-optimizations-models-policy.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-3080",
@@ -47,7 +48,8 @@
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
       "completed_at": "2026-09-10T02:02:45+00:00",
-      "file": "sdd/tasks/completed/TASK-3080-local-git-discovery-fetch-preflight.md"
+      "file": "sdd/tasks/completed/TASK-3080-local-git-discovery-fetch-preflight.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-3081",
@@ -69,7 +71,8 @@
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
       "completed_at": "2026-09-10T02:25:57+00:00",
-      "file": "sdd/tasks/completed/TASK-3081-local-git-prepare-pull-push.md"
+      "file": "sdd/tasks/completed/TASK-3081-local-git-prepare-pull-push.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-3082",
@@ -91,7 +94,8 @@
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
       "completed_at": "2026-09-10T02:30:04+00:00",
-      "file": "sdd/tasks/completed/TASK-3082-bounded-source-reader.md"
+      "file": "sdd/tasks/completed/TASK-3082-bounded-source-reader.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-3083",
@@ -114,7 +118,8 @@
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
       "completed_at": "2026-09-10T02:34:58+00:00",
-      "file": "sdd/tasks/completed/TASK-3083-delegation-contracts.md"
+      "file": "sdd/tasks/completed/TASK-3083-delegation-contracts.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-3084",
@@ -136,7 +141,8 @@
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
       "completed_at": "2026-09-10T02:39:34+00:00",
-      "file": "sdd/tasks/completed/TASK-3084-patch-validation-artifact-store.md"
+      "file": "sdd/tasks/completed/TASK-3084-patch-validation-artifact-store.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-3085",
@@ -159,7 +165,8 @@
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
       "completed_at": "2026-09-10T02:44:53+00:00",
-      "file": "sdd/tasks/completed/TASK-3085-writer-generate.md"
+      "file": "sdd/tasks/completed/TASK-3085-writer-generate.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-3086",
@@ -181,7 +188,8 @@
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
       "completed_at": "2026-09-10T02:51:43+00:00",
-      "file": "sdd/tasks/completed/TASK-3086-writer-apply-recovery.md"
+      "file": "sdd/tasks/completed/TASK-3086-writer-apply-recovery.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-3087",
@@ -201,7 +209,8 @@
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
       "completed_at": "2026-09-10T02:57:11+00:00",
-      "file": "sdd/tasks/completed/TASK-3087-mcp-llm-kwargs-config.md"
+      "file": "sdd/tasks/completed/TASK-3087-mcp-llm-kwargs-config.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-3088",
@@ -223,7 +232,8 @@
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
       "completed_at": "2026-09-10T03:00:45+00:00",
-      "file": "sdd/tasks/completed/TASK-3088-host-read-guards.md"
+      "file": "sdd/tasks/completed/TASK-3088-host-read-guards.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-3089",
@@ -246,7 +256,8 @@
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
       "completed_at": "2026-09-10T03:10:18+00:00",
-      "file": "sdd/tasks/completed/TASK-3089-guard-installation.md"
+      "file": "sdd/tasks/completed/TASK-3089-guard-installation.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-3090",
@@ -269,7 +280,8 @@
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
       "completed_at": "2026-09-10T03:15:09+00:00",
-      "file": "sdd/tasks/completed/TASK-3090-sdd-delegation-workflow.md"
+      "file": "sdd/tasks/completed/TASK-3090-sdd-delegation-workflow.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-3091",
@@ -295,7 +307,8 @@
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
       "completed_at": "2026-09-10T03:27:01+00:00",
-      "file": "sdd/tasks/completed/TASK-3091-integration-test-suite.md"
+      "file": "sdd/tasks/completed/TASK-3091-integration-test-suite.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-3092",
@@ -319,7 +332,8 @@
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
       "completed_at": "2026-09-10T03:35:46+00:00",
-      "file": "sdd/tasks/completed/TASK-3092-benchmarks-docs-release.md"
+      "file": "sdd/tasks/completed/TASK-3092-benchmarks-docs-release.md",
+      "verification": "verified"
     }
   ],
   "code_review": {

--- a/sdd/tasks/index/tool-optimizations.json
+++ b/sdd/tasks/index/tool-optimizations.json
@@ -100,7 +100,7 @@
       "feature_id": "FEAT-543",
       "feature": "tool-optimizations",
       "spec": "sdd/specs/tool-optimizations.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "estimated_hours": 6,
@@ -113,8 +113,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-3083-delegation-contracts.md"
+      "completed_at": "2026-09-10T02:34:58+00:00",
+      "file": "sdd/tasks/completed/TASK-3083-delegation-contracts.md"
     },
     {
       "id": "TASK-3084",

--- a/sdd/tasks/index/tool-optimizations.json
+++ b/sdd/tasks/index/tool-optimizations.json
@@ -34,7 +34,7 @@
       "feature_id": "FEAT-543",
       "feature": "tool-optimizations",
       "spec": "sdd/specs/tool-optimizations.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "estimated_hours": 6,
@@ -46,8 +46,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-3080-local-git-discovery-fetch-preflight.md"
+      "completed_at": "2026-09-10T02:02:45+00:00",
+      "file": "sdd/tasks/completed/TASK-3080-local-git-discovery-fetch-preflight.md"
     },
     {
       "id": "TASK-3081",

--- a/sdd/tasks/index/tool-optimizations.json
+++ b/sdd/tasks/index/tool-optimizations.json
@@ -78,7 +78,7 @@
       "feature_id": "FEAT-543",
       "feature": "tool-optimizations",
       "spec": "sdd/specs/tool-optimizations.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "estimated_hours": 6,
@@ -90,8 +90,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-3082-bounded-source-reader.md"
+      "completed_at": "2026-09-10T02:30:04+00:00",
+      "file": "sdd/tasks/completed/TASK-3082-bounded-source-reader.md"
     },
     {
       "id": "TASK-3083",

--- a/sdd/tasks/index/tool-optimizations.json
+++ b/sdd/tasks/index/tool-optimizations.json
@@ -278,7 +278,7 @@
       "feature_id": "FEAT-543",
       "feature": "tool-optimizations",
       "spec": "sdd/specs/tool-optimizations.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "estimated_hours": 7,
@@ -294,8 +294,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-3091-integration-test-suite.md"
+      "completed_at": "2026-09-10T03:27:01+00:00",
+      "file": "sdd/tasks/completed/TASK-3091-integration-test-suite.md"
     },
     {
       "id": "TASK-3092",

--- a/sdd/tasks/index/tool-optimizations.json
+++ b/sdd/tasks/index/tool-optimizations.json
@@ -56,7 +56,7 @@
       "feature_id": "FEAT-543",
       "feature": "tool-optimizations",
       "spec": "sdd/specs/tool-optimizations.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "XL",
       "estimated_hours": 10,
@@ -68,8 +68,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-3081-local-git-prepare-pull-push.md"
+      "completed_at": "2026-09-10T02:25:57+00:00",
+      "file": "sdd/tasks/completed/TASK-3081-local-git-prepare-pull-push.md"
     },
     {
       "id": "TASK-3082",

--- a/sdd/tasks/index/tool-optimizations.json
+++ b/sdd/tasks/index/tool-optimizations.json
@@ -5,7 +5,7 @@
   "type": "feature",
   "base_branch": "dev",
   "created_at": "2026-09-10T01:36:25Z",
-  "completed_at": null,
+  "completed_at": "2026-09-10T03:35:46+00:00",
   "tasks": [
     {
       "id": "TASK-3079",
@@ -304,7 +304,7 @@
       "feature_id": "FEAT-543",
       "feature": "tool-optimizations",
       "spec": "sdd/specs/tool-optimizations.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "M",
       "estimated_hours": 4,
@@ -318,8 +318,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-3092-benchmarks-docs-release.md"
+      "completed_at": "2026-09-10T03:35:46+00:00",
+      "file": "sdd/tasks/completed/TASK-3092-benchmarks-docs-release.md"
     }
   ]
 }

--- a/sdd/tasks/index/tool-optimizations.json
+++ b/sdd/tasks/index/tool-optimizations.json
@@ -123,7 +123,7 @@
       "feature_id": "FEAT-543",
       "feature": "tool-optimizations",
       "spec": "sdd/specs/tool-optimizations.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "estimated_hours": 6,
@@ -135,8 +135,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-3084-patch-validation-artifact-store.md"
+      "completed_at": "2026-09-10T02:39:34+00:00",
+      "file": "sdd/tasks/completed/TASK-3084-patch-validation-artifact-store.md"
     },
     {
       "id": "TASK-3085",

--- a/sdd/tasks/index/tool-optimizations.json
+++ b/sdd/tasks/index/tool-optimizations.json
@@ -321,5 +321,22 @@
       "completed_at": "2026-09-10T03:35:46+00:00",
       "file": "sdd/tasks/completed/TASK-3092-benchmarks-docs-release.md"
     }
-  ]
+  ],
+  "code_review": {
+    "reviewed_at": "2026-09-10T04:10:39+00:00",
+    "reviewers": [
+      "claude code-reviewer subagent",
+      "codex (external, per CLAUDE.md adversarial protocol)"
+    ],
+    "critical_found": 5,
+    "critical_fixed": 5,
+    "important_fixed": 6,
+    "claims_rejected_as_unreproducible": 2,
+    "open_items": [
+      "Codex .codex/hooks.json field format unverified end to end (release-checklist blocker, see docs/tool-optimizations.md)",
+      "index publish and per-file apply retain narrow TOCTOU windows against external editors (documented; advisory lock does not exclude foreign processes)",
+      "asyncio.to_thread cancellation does not stop an in-flight write worker"
+    ],
+    "tests_after": "409 passed, 1 skipped"
+  }
 }

--- a/sdd/tasks/index/tool-optimizations.json
+++ b/sdd/tasks/index/tool-optimizations.json
@@ -14,7 +14,7 @@
       "feature_id": "FEAT-543",
       "feature": "tool-optimizations",
       "spec": "sdd/specs/tool-optimizations.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "estimated_hours": 6,
@@ -24,8 +24,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-3079-tool-optimizations-models-policy.md"
+      "completed_at": "2026-09-10T01:56:15+00:00",
+      "file": "sdd/tasks/completed/TASK-3079-tool-optimizations-models-policy.md"
     },
     {
       "id": "TASK-3080",

--- a/sdd/tasks/index/tool-optimizations.json
+++ b/sdd/tasks/index/tool-optimizations.json
@@ -168,7 +168,7 @@
       "feature_id": "FEAT-543",
       "feature": "tool-optimizations",
       "spec": "sdd/specs/tool-optimizations.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "estimated_hours": 7,
@@ -180,8 +180,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-3086-writer-apply-recovery.md"
+      "completed_at": "2026-09-10T02:51:43+00:00",
+      "file": "sdd/tasks/completed/TASK-3086-writer-apply-recovery.md"
     },
     {
       "id": "TASK-3087",

--- a/sdd/tasks/index/tool-optimizations.json
+++ b/sdd/tasks/index/tool-optimizations.json
@@ -145,7 +145,7 @@
       "feature_id": "FEAT-543",
       "feature": "tool-optimizations",
       "spec": "sdd/specs/tool-optimizations.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "XL",
       "estimated_hours": 10,
@@ -158,8 +158,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-3085-writer-generate.md"
+      "completed_at": "2026-09-10T02:44:53+00:00",
+      "file": "sdd/tasks/completed/TASK-3085-writer-generate.md"
     },
     {
       "id": "TASK-3086",

--- a/sdd/tasks/index/tool-optimizations.json
+++ b/sdd/tasks/index/tool-optimizations.json
@@ -255,7 +255,7 @@
       "feature_id": "FEAT-543",
       "feature": "tool-optimizations",
       "spec": "sdd/specs/tool-optimizations.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "L",
       "estimated_hours": 5,
@@ -268,8 +268,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-3090-sdd-delegation-workflow.md"
+      "completed_at": "2026-09-10T03:15:09+00:00",
+      "file": "sdd/tasks/completed/TASK-3090-sdd-delegation-workflow.md"
     },
     {
       "id": "TASK-3091",

--- a/sdd/tasks/index/tool-optimizations.json
+++ b/sdd/tasks/index/tool-optimizations.json
@@ -232,7 +232,7 @@
       "feature_id": "FEAT-543",
       "feature": "tool-optimizations",
       "spec": "sdd/specs/tool-optimizations.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "L",
       "estimated_hours": 6,
@@ -245,8 +245,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-3089-guard-installation.md"
+      "completed_at": "2026-09-10T03:10:18+00:00",
+      "file": "sdd/tasks/completed/TASK-3089-guard-installation.md"
     },
     {
       "id": "TASK-3090",

--- a/sdd/tasks/index/tool-optimizations.json
+++ b/sdd/tasks/index/tool-optimizations.json
@@ -190,7 +190,7 @@
       "feature_id": "FEAT-543",
       "feature": "tool-optimizations",
       "spec": "sdd/specs/tool-optimizations.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "estimated_hours": 3,
@@ -200,8 +200,8 @@
       "assigned_to": null,
       "assigned_at": null,
       "started_at": "2026-09-10T01:47:47+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-3087-mcp-llm-kwargs-config.md"
+      "completed_at": "2026-09-10T02:57:11+00:00",
+      "file": "sdd/tasks/completed/TASK-3087-mcp-llm-kwargs-config.md"
     },
     {
       "id": "TASK-3088",

--- a/sdd/templates/spec.md
+++ b/sdd/templates/spec.md
@@ -74,6 +74,18 @@ class NewComponent:
 > Define the discrete modules that will be implemented.
 > These directly map to Task Artifacts in Phase 2.
 
+#### Delegation-eligible modules
+
+Mark which modules can be implemented by the targeted writer from an
+already-decided TASK packet. Architecture decisions always stay with the
+thinking model; eligibility only means "the design is complete enough that
+writing the code is mechanical".
+
+| Module | Eligible? | Decided patterns / exact contracts | Why not (if no) |
+|---|---|---|---|
+| M1: <name> | yes / no | <signatures, error codes, file layout already fixed> | <open design question> |
+
+
 ### Module 1: <Name>
 - **Path**: `parrot/path/to/module.py`
 - **Responsibility**: What this module does
@@ -160,6 +172,11 @@ class ExistingClass(BaseClass):
 ---
 
 ## 7. Implementation Notes & Constraints
+
+> Architecture decisions stay with the thinking model. A delegated
+> implementation may only express a decision already recorded here and in
+> the TASK's implementation blocks — it must never invent an API, choose a
+> file, or resolve an open design question.
 
 
 ### Patterns to Follow

--- a/sdd/templates/task.md
+++ b/sdd/templates/task.md
@@ -70,6 +70,90 @@ class ExistingClass(BaseClass):
 
 ---
 
+## Delegation Contract
+
+> **OPTIONAL.** Include this section ONLY when the task is
+> delegation-eligible: the design is COMPLETE (every target file listed,
+> every implementation block containing the already-decided code, no open
+> questions), hashes were computed at `/sdd-task` time, and they are
+> re-verified at execution time. `design_complete: true` is a declaration
+> the author signs — the validator checks structure, the thinking model
+> verifies semantics.
+>
+> **Remove this section entirely if the task is not delegation-eligible.**
+> A task without it takes the normal implementation route, which is the
+> default and is never a failure.
+
+```json
+{
+  "schema_version": 1,
+  "task_id": "TASK-<NNN>",
+  "spec_path": "sdd/specs/<feature>.spec.md",
+  "design_complete": true,
+  "targets": [
+    {
+      "path": "pkg/greeter.py",
+      "action": "create",
+      "expected_sha256": null,
+      "planned_changes": "New module with greet()",
+      "blocks": ["impl-greeter"]
+    },
+    {
+      "path": "pkg/__init__.py",
+      "action": "modify",
+      "expected_sha256": "<sha256 — MUST BE REPLACED with the real digest>",
+      "planned_changes": "Export greet",
+      "blocks": ["impl-init"]
+    }
+  ],
+  "references": [
+    {
+      "path": "pkg/__init__.py",
+      "sha256": "<sha256 — MUST BE REPLACED with the real digest>",
+      "start_line": 1,
+      "end_line": 3,
+      "purpose": "existing exports"
+    }
+  ],
+  "implementation_blocks": ["impl-greeter", "impl-init"],
+  "acceptance_criteria": ["pytest tests/test_greeter.py passes"],
+  "validation_commands": [["pytest", "tests/test_greeter.py", "-q"]]
+}
+```
+
+Compute every digest for real — the `<sha256 …>` placeholders above are
+**rejected** by the validator as `invalid_packet`, which is the intended
+safety net against shipping an unverified packet:
+
+```bash
+sha256sum pkg/__init__.py
+# or, without coreutils:
+python -c "import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" pkg/__init__.py
+```
+
+A `create` target MUST have a block tagged with `path=<target>`; that block
+IS the new file's content. A `modify` target's blocks describe the decided
+edit and MUST carry `expected_sha256`.
+
+```python id=impl-greeter path=pkg/greeter.py
+def greet(name: str) -> str:
+    """Return a greeting."""
+    return f"hello {name}"
+```
+
+```python id=impl-init
+# Apply to pkg/__init__.py: add after the existing imports
+from .greeter import greet
+
+__all__ = [*__all__, "greet"]
+```
+
+Block ids match `^[a-z0-9][a-z0-9._-]{0,63}$` and must be unique in the
+file. Blocks must contain no placeholders (`...` on its own line, `TODO`,
+`FIXME`, `XXX`, `<angle placeholders>`, `raise NotImplementedError`) — the
+validator rejects them as `placeholder_code`.
+
+
 ## Implementation Notes
 
 > Technical guidance for the executing agent.

--- a/tests/mcp/test_toolkit_config.py
+++ b/tests/mcp/test_toolkit_config.py
@@ -4,6 +4,8 @@ FEAT-485: Tests for toolkit_config.py — config models, built-in defaults,
 and YAML loading + merging.
 """
 
+from pathlib import Path
+
 import pytest
 from parrot.mcp.toolkit_config import (
     MCPToolkitsConfig,
@@ -168,3 +170,66 @@ def test_explicit_config_path_missing_raises(tmp_path):
     the default path, whose absence silently falls back to built-ins."""
     with pytest.raises(ValueError, match="not found"):
         load_toolkits_config(tmp_path, config_path=tmp_path / "nope.yaml")
+
+
+# --------------------------------------------------------------------------- #
+# FEAT-543: llm_kwargs
+# --------------------------------------------------------------------------- #
+def test_llm_kwargs_defaults_to_empty():
+    """Existing sections are unchanged: the new field defaults to empty."""
+    section = ToolkitSection.model_validate({"class": "x.Y"})
+    assert section.llm_kwargs == {}
+    assert section.llm is None
+
+
+def test_llm_kwargs_parses_with_llm():
+    """A section may carry trusted client construction kwargs."""
+    section = ToolkitSection.model_validate(
+        {
+            "class": "x.Y",
+            "llm": "bedrock-converse:qwen3-coder-480b-a35b",
+            "llm_kwargs": {"fallback_model": None, "max_retries": 1, "read_timeout": 120},
+        }
+    )
+    assert section.llm_kwargs["fallback_model"] is None
+    assert section.llm_kwargs["max_retries"] == 1
+
+
+def test_llm_kwargs_requires_llm(tmp_path):
+    """llm_kwargs without llm is a configuration error naming the section."""
+    parrot_dir = tmp_path / ".parrot"
+    parrot_dir.mkdir()
+    (parrot_dir / "mcp-toolkits.yaml").write_text(
+        "toolkits:\n  w:\n    class: x.Y\n    llm_kwargs: {fallback_model: null}\n"
+    )
+    with pytest.raises(ValueError, match="'w'"):
+        load_toolkits_config(tmp_path)
+
+
+def test_llm_kwargs_rejects_llm_key():
+    """An `llm` key inside llm_kwargs would collide with the factory argument."""
+    with pytest.raises(ValueError, match="must not contain"):
+        ToolkitSection.model_validate({"class": "x.Y", "llm": "openai:gpt", "llm_kwargs": {"llm": "z"}})
+
+
+def test_example_tool_optimizations_config_loads():
+    """The shipped FEAT-543 example is valid and pins the no-fallback setting."""
+    example = Path(__file__).resolve().parents[2] / "examples" / "tool-optimizations-mcp.yaml"
+    assert example.is_file(), f"missing example config at {example}"
+
+    config = load_toolkits_config(example.parent, config_path=example)
+    assert set(config.toolkits) >= {"local-git", "bounded-source", "targeted-writer"}
+
+    writer = config.toolkits["targeted-writer"]
+    assert writer.class_path == "parrot_tools.tool_optimizations.writer.TargetedWriterToolkit"
+    assert writer.llm == "bedrock-converse:qwen3-coder-480b-a35b"
+    # Explicit null, not merely absent — an absent key would let the Bedrock
+    # client apply its own fallback default.
+    assert "fallback_model" in writer.llm_kwargs
+    assert writer.llm_kwargs["fallback_model"] is None
+    assert writer.kwargs["expected_model_ids"] == ["qwen.qwen3-coder-480b-a35b-v1:0"]
+
+    # The deterministic toolkits configure no model at all.
+    for name in ("local-git", "bounded-source"):
+        assert config.toolkits[name].llm is None
+        assert config.toolkits[name].llm_kwargs == {}

--- a/tests/mcp/test_toolkit_server.py
+++ b/tests/mcp/test_toolkit_server.py
@@ -5,6 +5,7 @@ tool filtering, and error handling.
 """
 
 import importlib
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -236,3 +237,85 @@ def test_config_path_override_honored(tmp_path, monkeypatch):
 
     assert server.config.name == "parrot-stub"
     assert "plain" in server.tools
+
+
+# --------------------------------------------------------------------------- #
+# FEAT-543: llm_kwargs pass-through
+# --------------------------------------------------------------------------- #
+def test_llm_kwargs_passed_to_factory(stub_config, monkeypatch):
+    """`llm_kwargs` reaches LLMFactory.create verbatim, alongside `llm`."""
+    monkeypatch.setattr("parrot.mcp.toolkit_server.importlib.import_module", mock_import_module)
+
+    config_file = stub_config / ".parrot" / "mcp-toolkits.yaml"
+    config_file.write_text(
+        "toolkits:\n"
+        "  stub:\n"
+        "    class: tests.mcp.stub_toolkit.StubToolkit\n"
+        "    llm: 'bedrock-converse:qwen3-coder-480b-a35b'\n"
+        "    llm_kwargs:\n"
+        "      fallback_model: null\n"
+        "      max_retries: 1\n"
+        "      read_timeout: 120\n"
+    )
+
+    seen = {}
+    mock_client = MagicMock()
+    from parrot.clients.factory import LLMFactory
+
+    def _capture(llm, **kwargs):
+        seen["llm"] = llm
+        seen["kwargs"] = kwargs
+        return mock_client
+
+    monkeypatch.setattr(LLMFactory, "create", staticmethod(_capture))
+    create_toolkit_mcp_server("stub", stub_config)
+
+    assert seen["llm"] == "bedrock-converse:qwen3-coder-480b-a35b"
+    # `fallback_model: null` must survive as an explicit None — that is the
+    # whole point: it is what stops the Bedrock client applying its default.
+    assert seen["kwargs"] == {"fallback_model": None, "max_retries": 1, "read_timeout": 120}
+    assert "fallback_model" in seen["kwargs"]
+
+
+def test_old_config_without_llm_kwargs_is_unchanged(stub_config, monkeypatch):
+    """A section with `llm` but no `llm_kwargs` calls the factory with no extras."""
+    monkeypatch.setattr("parrot.mcp.toolkit_server.importlib.import_module", mock_import_module)
+
+    config_file = stub_config / ".parrot" / "mcp-toolkits.yaml"
+    config_file.write_text(
+        "toolkits:\n" "  stub:\n" "    class: tests.mcp.stub_toolkit.StubToolkit\n" "    llm: 'test:model'\n"
+    )
+
+    seen = {}
+    from parrot.clients.factory import LLMFactory
+
+    def _capture(llm, **kwargs):
+        seen["llm"] = llm
+        seen["kwargs"] = kwargs
+        return MagicMock()
+
+    monkeypatch.setattr(LLMFactory, "create", staticmethod(_capture))
+    create_toolkit_mcp_server("stub", stub_config)
+
+    assert seen["llm"] == "test:model"
+    assert seen["kwargs"] == {}
+
+
+def test_deterministic_toolkit_never_imports_the_client_factory(stub_config, monkeypatch):
+    """A section without `llm:` must not pull in the client factory at all.
+
+    The Git and reader toolkits are deterministic; requiring provider
+    imports (and therefore AWS dependencies) to serve them would defeat the
+    point of keeping them model-free.
+    """
+
+    def refusing_import(name, *args, **kwargs):
+        if name == "parrot.clients.factory":
+            raise AssertionError("parrot.clients.factory must not be imported for a toolkit without llm:")
+        return mock_import_module(name)
+
+    monkeypatch.setattr("parrot.mcp.toolkit_server.importlib.import_module", refusing_import)
+    monkeypatch.delitem(sys.modules, "parrot.clients.factory", raising=False)
+
+    server = create_toolkit_mcp_server("stub", stub_config)
+    assert "plain" in set(server.tools.keys())

--- a/tests/mcp/test_toolkit_server.py
+++ b/tests/mcp/test_toolkit_server.py
@@ -228,9 +228,7 @@ def test_config_path_override_honored(tmp_path, monkeypatch):
     silent no-op before."""
     monkeypatch.setattr("parrot.mcp.toolkit_server.importlib.import_module", mock_import_module)
     elsewhere = tmp_path / "custom-toolkits.yaml"
-    elsewhere.write_text(
-        "toolkits:\n" "  stub:\n" "    class: tests.mcp.stub_toolkit.StubToolkit\n" "    kwargs: {}\n"
-    )
+    elsewhere.write_text("toolkits:\n" "  stub:\n" "    class: tests.mcp.stub_toolkit.StubToolkit\n" "    kwargs: {}\n")
 
     # No .parrot/ under tmp_path at all — only the override can resolve "stub".
     server = create_toolkit_mcp_server("stub", tmp_path, config_path=str(elsewhere))


### PR DESCRIPTION
## Summary

Adds three locally-installed MCP capabilities for Claude Code and Codex, per
`sdd/specs/tool-optimizations.spec.md` (FEAT-543):

- **`LocalGitToolkit`** — deterministic Git workflows with no LLM calls:
  bounded history, fetch with an explicit refspec, independent preflight
  checks, isolated-index staging, fast-forward-only pull, non-forced push.
- **`BoundedSourceToolkit`** — reads above 350 lines / 64,000 bytes require an
  explicit range; every result carries a SHA-256 revision and a continuation
  cursor, and memory is bounded independently of file size.
- **`TargetedWriterToolkit`** — generates a reviewed patch for work whose
  design is *already decided* in a TASK's `## Delegation Contract`, then
  applies it under hash gating with a recovery journal.

Plus: `ToolkitSection.llm_kwargs` pass-through, opt-in `PreToolUse` read
guards with managed installation, the SDD delegation workflow across both
hosts, an integration suite, and a benchmark harness.

## Tasks

14/14 verified — every task has its code commit, its SDD-state commit, and
all declared files present.

| Task | Title |
|---|---|
| TASK-3079 | Models, policy, result budget, worktree lock, toolkit base |
| TASK-3080 | LocalGitToolkit runner, discovery, recent/fetch/preflight |
| TASK-3081 | Isolated-index staging, fast-forward pull, non-force push |
| TASK-3082 | BoundedSourceToolkit streaming reader |
| TASK-3083 | Delegation contracts (packet parser, scope/freshness) |
| TASK-3084 | Unified-diff parser, in-memory apply, artifact store |
| TASK-3085 | TargetedWriterToolkit no-fallback guard, `writer_generate` |
| TASK-3086 | `writer_apply` with journal, rollback, recovery |
| TASK-3087 | MCP `ToolkitSection.llm_kwargs` + example config |
| TASK-3088 | PreToolUse host read guards |
| TASK-3089 | Managed guard installation, status, owned uninstall |
| TASK-3090 | SDD delegation workflow (templates/commands/skills/worker) |
| TASK-3091 | Integration test suite |
| TASK-3092 | Benchmark harness, docs, release gate |

## Testing

- `packages/ai-parrot-tools/tests/tool_optimizations`: **409 passed, 1 skipped**
  (the skip is the live-Bedrock smoke test, gated on `PARROT_TOOL_OPT_SMOKE=1`).
- `tests/mcp`: identical to the `dev` baseline — the same 10 pre-existing
  failures and 1 error (netsuite / oauth / chrome-manager), with 8 more tests
  passing than baseline.
- `ruff check` and `black --check` clean on all new code.

> Run the two suites separately — the repo has two distinct `tests` packages
> and a combined invocation fails at conftest import.

## Code review

Two independent adversarial reviews (a Claude subagent and `codex`, each given
a neutral brief). **5 critical and 6 important findings were fixed**, each
reproduced first and covered by a regression test verified to fail without the
fix. The notable ones were all *silent* failures:

- The read guard **failed open**: `tail -n +1`, `head -n -1`, `--lines=999999`,
  `tail -f` and `cat -n FILE` all passed as "bounded".
- The installer **destroyed user config** — hook ownership was per-entry, so a
  user's own command sharing our `PreToolUse` entry was deleted.
- `git_push` **published the wrong branch** when a branch tracked a
  differently-named upstream, while reporting the current branch's commit.
- The artifact sweeper could **delete files outside the repository** (symlinks).
- Repair prompts **leaked unapproved local source to the provider** via
  `context_mismatch` diagnostics.

Two further reviewer claims did not reproduce and are recorded as rejected
rather than silently adopted.

## Known limitations (deliberately not hidden)

- **Codex guard installation is unverified end to end.** The installer writes a
  Claude-shaped `.codex/hooks.json`, but codex-cli 0.154.0's own fields are
  `eventName`/`timeoutSec`. Recorded as a release-checklist blocker in
  `docs/tool-optimizations.md` and in `artifacts/logs/host-smoke.json`. Claude
  Code's format is unaffected.
- Narrow TOCTOU windows remain in index publication and per-file apply against
  *external* editors; the advisory lock cannot exclude foreign processes.
- `asyncio.to_thread` cancellation does not stop an in-flight write worker.
- **No savings percentage is claimed.** The harness reports what it measured —
  and honestly shows the Git path costing more primary tokens on a two-file
  fixture. Numeric targets remain the owner decision the spec left open (§8).

---
_Closed by /sdd-done_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G9NM1TzdkFLd5foNDmh72K
