### PR TITLE
fix(sdd-worker-prompt-twin-sync): FEAT-547 — Sync sdd-worker Packaged Prompt Twin

### DIFF
--- a/packages/ai-parrot/src/parrot/flows/dev_loop/_subagent_data/sdd-worker.md
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/_subagent_data/sdd-worker.md
@@ -226,6 +226,30 @@ Before writing ANY code, verify the task's `## Codebase Contract` section:
 - **NEVER guess an import, attribute, or method. If it's not in the contract
   and you're unsure, verify with `grep` or `read` before using it.**
 
+### b2) Delegated implementation (ONLY when a Delegation Contract exists)
+
+Skip this entire step unless the task file contains a `## Delegation Contract`
+section AND the `parrot-targeted-writer` MCP server is available. A task
+without one takes the normal route in step (c) — that is the default, not a
+failure.
+
+1. Call MCP tool `writer_generate` (server `parrot-targeted-writer`) with `task_path`.
+2. On `status: error` with a contract code (`stale_target`, `missing_block`,
+   `placeholder_code`, `underspecified_create`, …): fix the packet in the task file
+   (refresh hashes with `sha256sum`, complete the design) and retry once, or implement
+   the task yourself in step (c). **Never silently invokes another coder** — no other
+   coding tool is substituted when delegation fails.
+3. On `ok`: read `data.patch_path` with `source_read` in ranges of at most 350 lines and
+   review EVERY hunk against the task's Codebase Contract. Never apply a patch you have
+   not fully read. If a hunk is wrong, do not apply: fix the packet/blocks and regenerate
+   at most once more, else implement normally.
+4. Call `writer_apply` with `artifact_id` and `reviewed_sha256 = data.patch_sha256`
+   (verify it equals `sha256sum artifacts/tool-optimizations/<id>/patch.diff`).
+5. Run the task's acceptance tests yourself in step (e). The writer never runs tests, and
+   a model's claim that tests passed is not execution evidence.
+6. SDD state is never delegated: the index and task files are edited only by you,
+   in step (g).
+
 ### c) Implement — EXACTLY as specified (in worktree)
 - Create/modify ONLY the files listed in the task.
 - Use ONLY the class names, method signatures, and patterns specified.
@@ -240,6 +264,7 @@ VERIFICATION CHECKLIST for TASK-<NNN>:
 □ No files were created that are NOT listed in the task?
 □ Class/interface names match the task specification?
 □ No unrelated changes were made?
+□ Delegated patch hunks were all reviewed before writer_apply?
 ```
 If ANY check fails, fix or STOP.
 

--- a/sdd/tasks/completed/TASK-3106-sync-sdd-worker-prompt-twin.md
+++ b/sdd/tasks/completed/TASK-3106-sync-sdd-worker-prompt-twin.md
@@ -197,10 +197,24 @@ diff .claude/agents/sdd-worker.md packages/ai-parrot/src/parrot/flows/dev_loop/_
 
 ## Completion Note
 
-*(Agent fills this in when done)*
-
-**Completed by**:
-**Date**:
-**Notes**:
-
-**Deviations from spec**: none | describe if any
+**Completed by**: sdd-worker (Claude Sonnet 5)
+**Date**: 2026-09-10
+**Notes**: Implemented exactly per blueprint — re-verified the Codebase
+Contract's `diff` claim before copying (still exactly the 24-line "b2)"
+block + one checklist line), then `cp .claude/agents/sdd-worker.md
+packages/ai-parrot/src/parrot/flows/dev_loop/_subagent_data/sdd-worker.md`.
+All 4 acceptance criteria verified:
+- AC-1: `diff` between the two files produces no output.
+- AC-2: `pytest packages/ai-parrot/tests/flows/dev_loop/test_subagent_parity.py -v`
+  → 9 passed, 1 skipped (the intentionally-excluded `sdd-codereview`), 0
+  failed — `test_prompt_parity[sdd-worker]` is green for the first time
+  since FEAT-543/TASK-3090 landed.
+- AC-3: `git diff --stat` shows exactly one file changed.
+- AC-4: `load_subagent_definition("sdd-worker")` returns a 14,499-char body
+  containing both `FEAT-145` and `per-spec index`.
+(Worktree note, not a repo change: `packages/ai-parrot/src/parrot/utils/
+types*.so` and `.../utils/parsers/toml*.so` were missing in this worktree,
+same known gap as FEAT-546's TASK-3105 — copied in locally from the main
+checkout only to make the test importable; both are gitignored build
+artifacts, not committed.)
+**Deviations from spec**: none

--- a/sdd/tasks/index/sdd-worker-prompt-twin-sync.json
+++ b/sdd/tasks/index/sdd-worker-prompt-twin-sync.json
@@ -14,14 +14,14 @@
       "feature_id": "FEAT-547",
       "feature": "sdd-worker-prompt-twin-sync",
       "spec": "sdd/specs/sdd-worker-prompt-twin-sync.spec.md",
-      "status": "pending",
+      "status": "in-progress",
       "priority": "medium",
       "effort": "S",
       "depends_on": [],
       "parallel": false,
       "parallelism_notes": "Single task, single file — no parallelism to coordinate.",
       "assigned_to": null,
-      "started_at": null,
+      "started_at": "2026-09-10T10:50:12+00:00",
       "completed_at": null,
       "file": "sdd/tasks/active/TASK-3106-sync-sdd-worker-prompt-twin.md"
     }

--- a/sdd/tasks/index/sdd-worker-prompt-twin-sync.json
+++ b/sdd/tasks/index/sdd-worker-prompt-twin-sync.json
@@ -5,7 +5,7 @@
   "type": "feature",
   "base_branch": "dev",
   "created_at": "2026-09-10T10:36:16+00:00",
-  "completed_at": "2026-09-10T10:51:24+00:00",
+  "completed_at": "2026-09-10T10:57:55+00:00",
   "tasks": [
     {
       "id": "TASK-3106",

--- a/sdd/tasks/index/sdd-worker-prompt-twin-sync.json
+++ b/sdd/tasks/index/sdd-worker-prompt-twin-sync.json
@@ -5,7 +5,7 @@
   "type": "feature",
   "base_branch": "dev",
   "created_at": "2026-09-10T10:36:16+00:00",
-  "completed_at": null,
+  "completed_at": "2026-09-10T10:51:24+00:00",
   "tasks": [
     {
       "id": "TASK-3106",
@@ -14,7 +14,7 @@
       "feature_id": "FEAT-547",
       "feature": "sdd-worker-prompt-twin-sync",
       "spec": "sdd/specs/sdd-worker-prompt-twin-sync.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "S",
       "depends_on": [],
@@ -22,8 +22,9 @@
       "parallelism_notes": "Single task, single file — no parallelism to coordinate.",
       "assigned_to": null,
       "started_at": "2026-09-10T10:50:12+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-3106-sync-sdd-worker-prompt-twin.md"
+      "completed_at": "2026-09-10T10:51:24+00:00",
+      "file": "sdd/tasks/completed/TASK-3106-sync-sdd-worker-prompt-twin.md",
+      "verification": "verified"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Follow-up to FEAT-546's own TASK-3105 (AC-10), which found (but did not fix,
per its own non-goal) that `packages/ai-parrot/src/parrot/flows/dev_loop/
_subagent_data/sdd-worker.md` had drifted from its repo twin,
`.claude/agents/sdd-worker.md`.

**Root cause**: commit `461b74c2e` (FEAT-543/TASK-3090) added a 24-line
"b2) Delegated implementation" section plus one checklist line to the
interactive copy but never applied the matching edit to the package-vendored
copy that `DevelopmentNode`'s dev-loop dispatch actually reads via
`load_subagent_definition("sdd-worker")`. Same class of drift `41869c675`
fixed once before for a different missing section.

**Effect**: every dev-loop dispatch of `sdd-worker` was silently missing the
Delegation Contract instructions — a dispatched worker would never attempt
`writer_generate`/`writer_apply` delegation for an eligible task. Not a
crash, a silent capability gap, and `test_subagent_parity.py::
test_prompt_parity[sdd-worker]` was red on `dev`.

## Fix

Single full-file copy: `.claude/agents/sdd-worker.md` (source of truth) →
`packages/ai-parrot/src/parrot/flows/dev_loop/_subagent_data/sdd-worker.md`
(target). No automation added — a general anti-drift mechanism for all four
dual-sourced prompts is left as an explicit open question in the spec (§8)
for a human to decide separately.

## Tasks

1/1 task verified (TASK-3106).

## Test evidence

```
diff .claude/agents/sdd-worker.md packages/ai-parrot/src/parrot/flows/dev_loop/_subagent_data/sdd-worker.md
→ (no output — byte-identical)

pytest packages/ai-parrot/tests/flows/dev_loop/test_subagent_parity.py -v
→ 9 passed, 1 skipped, 0 failed
```

---
_Closed by /sdd-done_

🤖 Generated with [Claude Code](https://claude.com/claude-code)