### PR TITLE
fix(lancedb-vector-store): TASK-3068 follow-up — certify AC6 with a real offline run

### DIFF
--- a/docs/lancedb-offline-profile.md
+++ b/docs/lancedb-offline-profile.md
@@ -41,6 +41,15 @@ never downloaded at runtime, and never falling back to a remote provider.
    llama.cpp, LM Studio) — see
    `packages/ai-parrot-client-local/src/parrot/clients/local/client.py`.
 
+   **If the local model is a reasoning model**, start the server with thinking
+   disabled (llama.cpp: `--reasoning off`, or `--reasoning-budget 0`).
+   `run_cycle()` reads `response.content`; with `--reasoning-format deepseek`
+   a thinking model puts its chain of thought in `reasoning_content` and can
+   spend its entire token budget there, leaving `content` empty. Observed
+   directly: Qwen3.6-35B-A3B emitted 3 849 reasoning tokens (~15 min at
+   4.5 t/s) for a one-sentence retrieval question before being cut off. This
+   is a property of the *model configuration*, not of the offline path.
+
 3. **LanceDB collection directory.** A plain local filesystem path — no
    provisioning step beyond having free disk space. No PostgreSQL, no
    Docker, no storage account, no remote endpoint.
@@ -66,6 +75,8 @@ The test is gated behind the existing `real_llm` marker (registered in
 | `PARROT_LOCAL_EMBEDDING_MODEL_PATH` | Local filesystem path to the provisioned embedding model (step 1 above). |
 | `PARROT_LOCAL_LLM_BASE_URL` | Base URL of the provisioned local LLM server (step 2 above), e.g. `http://localhost:11434/v1`. |
 | `PARROT_LOCAL_LLM_MODEL` | Optional; model identity served by that URL. Defaults to `llama3.1:8b`. |
+| `LOCAL_LLM_API_KEY` | Optional; bearer token, when the local server was started with one (llama.cpp's `--api-key` / `LLAMA_API_KEY`). Read by `LocalLLMClient` itself, not by the test. A key for a loopback server is not a remote credential — the profile still refuses any non-loopback `--llm-base-url`. |
+| `HF_HUB_OFFLINE=1`, `TRANSFORMERS_OFFLINE=1` | Recommended. Stops `sentence-transformers`/`transformers` from making revision-check calls to huggingface.co for a locally-saved model. Without them the egress guard is what catches the attempt — as an `AssertionError`, not a skip. |
 
 Without these set, the test **skips with an explicit reason** rather than
 running against a fake provider — a deterministic fake embedding/LLM
@@ -73,6 +84,28 @@ provider is NOT offline certification for AC6 (spec v0.2). General/unit
 tests elsewhere in this feature use the deterministic 8-D fixture; this one
 specific test is the one that must run against real local assets to certify
 the offline claim.
+
+## Verified run (evidence)
+
+AC6 was certified on 2026-09-10 against real local assets on this hardware:
+
+| Component | What was actually used |
+|---|---|
+| Embedding model | `sentence-transformers/all-mpnet-base-v2`, saved to a local directory (768-dim), loaded on `cuda` from that path — never a hub identifier |
+| LLM server | llama.cpp (`ai-parrot/llama-server:cuda`, container `parrot-llama-server`), `http://localhost:8089/v1`, model alias `qwen3.6-35b-a3b` (`bartowski/Qwen_Qwen3.6-35B-A3B-GGUF:Q4_K_M`) |
+| Store | `LanceDBStore` on a `tmp_path` directory, `lancedb==0.38.0`, hybrid `LanceDBOrigin` |
+| Egress | `socket.socket.connect` patched to allow only the loopback LLM host; the whole ingest → vector/FTS/hybrid → answer path ran under it |
+
+Full command and output: `artifacts/logs/TASK-3068-lancedb.log`.
+
+Note on the client lifecycle: `run_cycle()` enters the client as an async
+context manager (`async with llm_client as client`). `AbstractClient.__aenter__`
+is what builds the per-event-loop SDK client via `_ensure_client()`; calling
+`ask()` on a merely-constructed `LocalLLMClient` raises
+`AttributeError: 'NoneType' object has no attribute 'chat'`. That defect was
+present until the real run exercised it — a deterministic fake client would
+never have caught it, which is the concrete argument for AC6 requiring a real
+run.
 
 ## Failure modes
 

--- a/examples/lancedb_local_agent.py
+++ b/examples/lancedb_local_agent.py
@@ -117,6 +117,11 @@ async def build_agent(args: argparse.Namespace):
 
     origin = LanceDBOrigin(store, name="lancedb-local", mode="hybrid", collection=args.collection)
 
+    # ``LocalLLMClient`` resolves an optional bearer token from the
+    # ``LOCAL_LLM_API_KEY`` environment variable — required by servers started
+    # with a key (e.g. llama.cpp's ``--api-key`` / ``LLAMA_API_KEY``), ignored
+    # by servers that accept anonymous requests. A local key is not "remote
+    # credentials": the profile still refuses any non-loopback base URL above.
     llm_client = LocalLLMClient(base_url=args.llm_base_url, model=args.llm_model)
 
     return store, origin, llm_client
@@ -135,7 +140,13 @@ async def run_cycle(origin, llm_client, query: str) -> str:
         "not contain the answer, say so explicitly.\n\n"
         f"Context:\n{context}\n\nQuestion: {query}\nAnswer:"
     )
-    response = await llm_client.ask(prompt)
+    # ``AbstractClient.__aenter__`` is what builds the per-event-loop SDK
+    # client (``_ensure_client()``); calling ``ask()`` on a merely-constructed
+    # client raises ``AttributeError: 'NoneType' object has no attribute
+    # 'chat'``. The context manager is the documented public lifecycle —
+    # entering it here keeps ``build_agent()``'s return contract unchanged.
+    async with llm_client as client:
+        response = await client.ask(prompt)
     return getattr(response, "content", str(response))
 
 

--- a/sdd/tasks/completed/TASK-3068-lancedb-offline-agent-profile.md
+++ b/sdd/tasks/completed/TASK-3068-lancedb-offline-agent-profile.md
@@ -317,3 +317,48 @@ These are test contracts, not executed test results or placeholder production im
 
 **AC6 completion status — honest, not hidden**: `TestRealOfflineRun::test_full_cycle_with_egress_denied` SKIPPED in this environment (`PARROT_TEST_REAL_LLM` unset), consistent with TASK-3057's gate finding that no embedding-model weights are cached here and no local LLM server is running. Per this task's own Acceptance Criteria ("feature acceptance cannot claim AC6 complete until the actual real-model run passes"), **AC6 is NOT fully certified by this session** — the test, environment variables (`PARROT_TEST_REAL_LLM=1`, `PARROT_LOCAL_EMBEDDING_MODEL_PATH`, `PARROT_LOCAL_LLM_BASE_URL`) and egress-denial mechanism are implemented and ready; a future run on a machine with provisioned local model/server assets is required to close AC6. This is a known, explicitly-flagged gap, not a fabricated pass — the deterministic-fake-provider path (already covered by the guard tests and every other FEAT-542 test module) is explicitly NOT accepted as AC6 certification per spec v0.2.
 **Deviations from spec**: None beyond the documented BasicAgent-vs-direct-wiring scope decision above.
+
+---
+
+### Follow-up: AC6 certified (2026-09-10, interactive session)
+
+**AC6 is now CLOSED.** `TestRealOfflineRun::test_full_cycle_with_egress_denied`
+**PASSED for real** — 1 passed in 20.55 s — against provisioned local assets on
+this machine:
+
+- embedding: `all-mpnet-base-v2` (768-d) saved to a local directory, loaded on
+  `cuda` from that path;
+- LLM: the repository's own `llama_server/` stack (`parrot-llama-server`,
+  llama.cpp CUDA) serving `qwen3.6-35b-a3b`
+  (`bartowski/Qwen_Qwen3.6-35B-A3B-GGUF:Q4_K_M`) at `http://localhost:8089/v1`;
+- store: `lancedb==0.38.0`, hybrid `LanceDBOrigin`;
+- egress: `socket.socket.connect` patched to loopback-only for the whole
+  ingest → vector/FTS/hybrid → answer path; the guard never fired.
+
+Full evidence: `artifacts/logs/TASK-3068-lancedb.log`.
+
+**The real run found a real defect** that every fake-provider test had missed:
+`run_cycle()` called `llm_client.ask()` on a never-entered client, so
+`self.client` was `None` (`AttributeError: 'NoneType' object has no attribute
+'chat'` at `parrot/clients/openai_base.py:261`). `AbstractClient.__aenter__` is
+what builds the per-loop SDK client via `_ensure_client()`. Fixed by entering
+the client as an async context manager in `run_cycle()`. This is the concrete
+justification for spec v0.2's rule that a deterministic fake provider is not
+AC6 certification.
+
+Second finding, documented rather than coded around: a reasoning model with
+`--reasoning-format deepseek` puts its chain of thought in `reasoning_content`
+and can exhaust its whole token budget there, leaving `content` empty —
+observed at 3 849 reasoning tokens for a one-sentence question. The local
+server must be started with `--reasoning off` / `--reasoning-budget 0`. Added
+to `docs/lancedb-offline-profile.md` §Provisioning.
+
+Also recorded there: `LOCAL_LLM_API_KEY` (for local servers started with a
+bearer token) and `HF_HUB_OFFLINE=1` / `TRANSFORMERS_OFFLINE=1`.
+
+Not completed: a standalone `python examples/lancedb_local_agent.py` run to
+capture a human-readable answer. Ingest and hybrid retrieval succeeded, then
+llama-server aborted with `CUDA error: unspecified launch failure` and
+`nvidia-smi` reported `[GPU requires reset]`. No reset was attempted (the
+desktop session shares the card). Infrastructure fault, not an AC6 failure —
+§3b had already passed.


### PR DESCRIPTION
Follow-up to #1357. Closes the **"AC6 partial — real-model run pending"** gap that TASK-3068's completion note left open: the offline-agent profile shipped with all its guard tests green, but the real-model path had never actually executed.

## AC6 is now certified

`TestRealOfflineRun::test_full_cycle_with_egress_denied` — **1 passed in 20.55s** — against provisioned local assets, with `socket.socket.connect` patched to reject every non-loopback destination across the whole ingest → vector/FTS/hybrid → answer path.

| | |
|---|---|
| Store | `lancedb==0.38.0`, hybrid `LanceDBOrigin` |
| Embeddings | `all-mpnet-base-v2` (768-d), saved to a local directory, loaded on `cuda` **from that path** — never a hub identifier |
| LLM | this repo's own `llama_server/` stack (llama.cpp CUDA) serving `qwen3.6-35b-a3b` at `http://localhost:8089/v1` |
| Egress guard | never fired |

Retrieval surfaced the ingested `ZXQ731` document before the LLM call; the model answered in 17 generated tokens. Evidence: `artifacts/logs/TASK-3068-lancedb.log` (`artifacts/` is gitignored, so the log is not in this diff).

## The real run found a real defect

`run_cycle()` called `llm_client.ask()` on a never-entered client, so `self.client` was `None`:

```
packages/ai-parrot/src/parrot/clients/openai_base.py:261:
AttributeError: 'NoneType' object has no attribute 'chat'
```

`AbstractClient.__aenter__` is what builds the per-event-loop SDK client via `_ensure_client()`; `ask()` does not. Fixed by entering the client as an async context manager, which leaves `build_agent()`'s return contract (and therefore the test) unchanged.

Every deterministic fake-provider test passed while this path was broken — which is precisely the argument spec v0.2 makes for AC6 requiring a real run rather than a fake provider.

## Documentation

`docs/lancedb-offline-profile.md` gains what the real run showed is actually needed:

- **`--reasoning off` / `--reasoning-budget 0`** for reasoning models. With `--reasoning-format deepseek` and thinking enabled, Qwen3.6-35B-A3B spent **3 849 tokens** in `reasoning_content` for a one-sentence retrieval question and left `content` empty — `run_cycle()` reads `content`. This is a property of the model configuration, not of the offline path.
- **`LOCAL_LLM_API_KEY`** — how `LocalLLMClient` picks up a bearer token from a local server started with one (llama.cpp's `--api-key`). A key for a loopback server is not a remote credential; the profile still refuses any non-loopback `--llm-base-url`.
- **`HF_HUB_OFFLINE=1` / `TRANSFORMERS_OFFLINE=1`** — stops `transformers` making revision-check calls for a locally-saved model.
- A **Verified run (evidence)** section naming the exact assets used.

## Scope

Three files, +90/−1. No production `parrot.*` source is touched — only the example, the doc, and the SDD task's completion note. Guard tests still 4/4; `ruff` and `black` clean.

## Not included

A standalone `python examples/lancedb_local_agent.py` run capturing a human-readable answer. Ingest and hybrid retrieval completed, then llama-server aborted with `CUDA error: unspecified launch failure` and `nvidia-smi` reported `[GPU requires reset]`. No reset was attempted (the desktop shares the card). Infrastructure fault, not an AC6 failure — the assertion-backed acceptance run above had already passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qr7rJmQKv2Huo4a8kzgHvr
