### PR TITLE
feat(worktree-creation-ownership): FEAT-552 — Worktree Creation Ownership

### DIFF
--- a/.agent/workflows/sdd-start.md
+++ b/.agent/workflows/sdd-start.md
@@ -51,20 +51,38 @@ Check:
   ```
   and STOP.
 
-### 3. Detect Context
+### 3. Ensure the Worktree
 
-With per-spec indexes (FEAT-145), commits land in whatever branch you are on
-— worktree or main repo. Both are safe because each feature owns its own
-index file, so there is no shared mutable state to collide on.
+The worktree is created by whoever is about to write code in it — not at
+planning time (FEAT-552). `/sdd-task` no longer creates one, so this step
+provisions it, idempotently: already inside the right worktree, it is a no-op
+that prints the path you are already in.
+
+Everything the step needs is in the per-spec index header resolved in §1
+(`feature_id`, `feature`, `spec`, `type`, `base_branch`):
 
 ```bash
-CURRENT_DIR=$(pwd)
-CURRENT_BRANCH=$(git branch --show-current)
+WT=$(python -m scripts.sdd.ensure_worktree \
+       --slug "<feature-slug>" \
+       --feature-id "<FEAT-ID>" \
+       --spec "<spec-path>" \
+       --index "sdd/tasks/index/<feature-slug>.json")
+cd "$WT"
 ```
 
-For the recommended layout, you should be inside a feature worktree (path
-contains `.claude/worktrees/`). If not, that's fine — just confirm the
-branch matches the feature you intend to work on.
+For a hotfix (`type: hotfix` in the index header) pass `--jira-key <KEY>`
+instead of `--feature-id`; the CLI applies the FEAT-466 naming and branches
+from `origin/main`.
+
+If the command exits non-zero, **STOP** and show its message verbatim. Do NOT
+fall back to implementing on `<base_branch>` — an un-isolated implementation is
+exactly what this step exists to prevent. The two messages you are most likely
+to see are a leftover branch with no worktree, and task artifacts missing from
+the base you branched off (fetch and re-run).
+
+With per-spec indexes (FEAT-145), commits then land in the worktree's own
+branch. Each feature owns its own index file, so parallel worktrees never
+collide on shared mutable state.
 
 ### 4. Mark In-Progress (in place)
 

--- a/.agent/workflows/sdd-task.md
+++ b/.agent/workflows/sdd-task.md
@@ -29,7 +29,9 @@ Decompose an approved Feature Specification into atomic, assignable implementati
   dev-loop planner dispatches) can silently allocate the same number to
   different features. See §4 below.
 - **Must run on the spec's `base_branch`** (read from frontmatter — `dev` for features, `main` for hotfixes). Not inside a worktree.
-- **Always commit task files and per-spec index to `base_branch`** before creating the worktree.
+- **Always commit task files and per-spec index to `base_branch`** — they are
+  versioned artifacts, and the machine that implements the feature pulls them
+  from there. This command creates no worktree (FEAT-552).
 
 ## Steps
 
@@ -314,24 +316,16 @@ git diff --cached --name-only
 git commit -m "sdd: add <N> tasks for FEAT-<ID> — <feature-name>"
 ```
 
-### 6. Create the Worktree
+### 6. Output
 
-After committing to `<BASE>`, create the worktree so it inherits the tasks.
-Naming and base ref depend on `TYPE` (FEAT-466 — a hotfix has no reserved
-id, so it is named from its Jira key, and always branches from
-`origin/main`, never `HEAD`):
+Before printing the summary, count the delegation-eligible tasks. This is the
+number the targeted writer will actually receive when the worker runs, so it
+is worth seeing up front:
 
 ```bash
-# type: feature
-git worktree add -b feat-<FEAT-ID>-<slug> \
-  .claude/worktrees/feat-<FEAT-ID>-<slug> HEAD
-
-# type: hotfix (the rare case /sdd-task ran directly against a hotfix spec)
-git worktree add -b hotfix-<JIRA-KEY>-<slug> \
-  .claude/worktrees/hotfix-<JIRA-KEY>-<slug> origin/main
+grep -l '^## Delegation Contract' sdd/tasks/active/TASK-*.md | wc -l
 ```
 
-### 7. Output
 ```
 ✅ Generated and committed <N> tasks for FEAT-<ID> — <feature-name>
    (hotfix: for Jira <KEY> — <feature-name>, no FEAT-<NNN>/TASK-<NNN> reserved)
@@ -341,14 +335,16 @@ Tasks created:
   HOTFIX-<JIRA-KEY>-<N> — <title> [<priority>/<effort>]  # hotfix
 
 Blueprints: <N>/<N> tasks carry an Implementation Blueprint
+Delegated:  <D>/<N> tasks carry a Delegation Contract (targeted writer)
+            TASK-<NNN>, TASK-<NNN>          # list them, or "none"
 
-Worktree created:
-  .claude/worktrees/feat-<FEAT-ID>-<slug>              # feature
-  .claude/worktrees/hotfix-<JIRA-KEY>-<slug>           # hotfix
+Worktree: not created. /sdd-task produces versioned artifacts only — the
+          worktree is created by whoever implements, on the machine that
+          implements (FEAT-552).
 
 Next:
-  cd .claude/worktrees/<worktree-name>
-  /sdd-start <task-id>   # begin first task
+  /sdd-start <task-id>        # creates the worktree, then begins the task
+  # or, unattended:  claude --agent sdd-worker --model sonnet --verbose
 ```
 
 ## Reference

--- a/.claude/agents/sdd-autopilot.md
+++ b/.claude/agents/sdd-autopilot.md
@@ -250,8 +250,10 @@ After spec approval, automatically runs task decomposition.
 #### 6. Create Worktree
 
 ```bash
-git worktree add -b feat-<FEAT-ID>-<slug> \
-  .claude/worktrees/feat-<FEAT-ID>-<slug> HEAD
+python -m scripts.sdd.ensure_worktree --json \
+  --slug <slug> --feature-id FEAT-<NNN> \
+  --spec sdd/specs/<slug>.spec.md \
+  --index sdd/tasks/index/<slug>.json
 ```
 
 #### 7. Output & Handoff

--- a/.claude/agents/sdd-planner.md
+++ b/.claude/agents/sdd-planner.md
@@ -51,11 +51,16 @@ Given the input brief (``document_path``, ``document_kind``, optional
    per-spec task index (``sdd/tasks/index/<slug>.json``) and the task
    artifacts under ``sdd/tasks/active/``. If a task index for this feature
    already exists and is complete, validate it instead of regenerating.
-4. **Create the worktree** at ``.claude/worktrees/feat-<id>-<slug>/``
-   using
-   ``git worktree add -b feat-<id>-<slug> .claude/worktrees/feat-<id>-<slug> HEAD``
-   from the base branch (``dev``, unless the spec's frontmatter says
-   otherwise).
+4. **Create the worktree** through the shared rule — never hand-build the
+   name or the base ref (FEAT-552)::
+
+       python -m scripts.sdd.ensure_worktree --json \
+         --slug <slug> --feature-id FEAT-<NNN> \
+         --spec sdd/specs/<slug>.spec.md \
+         --index sdd/tasks/index/<slug>.json
+
+   Take ``worktree_path`` from the JSON object it prints for your output contract. The
+   command is idempotent: it reuses an existing worktree rather than failing.
 
 ## Cardinal rules
 
@@ -65,8 +70,9 @@ Given the input brief (``document_path``, ``document_kind``, optional
   Jira is optional and link-only — if ``jira_issue_key`` is present on the
   input brief, pass it straight through to your output unchanged; if it
   is absent, leave the output field empty. Do not invent one.
-- The worktree branch name MUST match ``feat-<id>-<slug>`` so the
-  ``pull_request.closed`` webhook can clean it up automatically.
+- The worktree name is whatever ``scripts.sdd.sdd_meta.plan_worktree``
+  returns — never hand-built. Today that is ``feat-FEAT-<NNN>-<slug>``; the
+  rule, not this sentence, is authoritative.
 
 ## Output Contract
 

--- a/.claude/agents/sdd-research.md
+++ b/.claude/agents/sdd-research.md
@@ -6,7 +6,7 @@ description: |
   creates a Jira ticket, scaffolds an SDD spec via /sdd-spec, decomposes
   it into tasks via /sdd-task (feature runs only — FEAT-466 skips this for
   hotfixes), and creates the worktree at
-  .claude/worktrees/feat-<id>-<slug>/ (feature) or
+  .claude/worktrees/feat-FEAT-<NNN>-<slug>/ (feature) or
   .claude/worktrees/hotfix-<JIRA-KEY>-<slug>/ (hotfix, no id reserved).
 
   The agent emits ONE final JSON object matching the ResearchOutput

--- a/.claude/agents/sdd-research.md
+++ b/.claude/agents/sdd-research.md
@@ -91,11 +91,19 @@ criteria) you must:
    dev-loop's single-agent development path from the spec alone; there is
    no per-spec task index and no `TASK-<NNN>` id to reserve. Proceed
    straight to step 5.
-5. **Create the worktree**. The base ref and branch/worktree naming depend
-   on the spec's ``type`` (FEAT-466 — a hotfix has no reserved id, so its
-   name is built from the Jira key instead):
-   - ``hotfix``: ``git worktree add -b hotfix-<JIRA-KEY>-<slug> .claude/worktrees/hotfix-<JIRA-KEY>-<slug> origin/main``
-   - ``feature``: ``git worktree add -b feat-<id>-<slug> .claude/worktrees/feat-<id>-<slug> origin/dev``
+5. **Create the worktree** through the shared rule. Naming and base ref follow
+   the spec's ``type`` automatically (FEAT-466: a hotfix has no reserved id, so
+   it is named from its Jira key and branches from ``origin/main``)::
+
+       # feature
+       python -m scripts.sdd.ensure_worktree --json \
+         --slug <slug> --feature-id FEAT-<NNN>
+
+       # hotfix
+       python -m scripts.sdd.ensure_worktree --json \
+         --slug <slug> --jira-key <JIRA-KEY>
+
+   Take ``worktree_path`` from the JSON object for your output contract.
 
 ## Cardinal rules
 
@@ -107,9 +115,9 @@ criteria) you must:
   ``sdd/`` (specs, tasks) and to git plumbing for the worktree.
 - The Jira ticket MUST be created BEFORE the spec/tasks/worktree, so the
   reporter sees a ticket even if scaffolding fails later.
-- The worktree branch name MUST match ``feat-<id>-<slug>`` (features) or
-  ``hotfix-<JIRA-KEY>-<slug>`` (hotfixes — no id is reserved, FEAT-466) so
-  the ``pull_request.closed`` webhook can clean it up automatically.
+- The worktree name is whatever ``scripts.sdd.sdd_meta.plan_worktree``
+  returns — never hand-built. Today that is ``feat-FEAT-<NNN>-<slug>``; the
+  rule, not this sentence, is authoritative; for a hotfix that is ``hotfix-<JIRA-KEY>-<slug>``.
 
 ## Output Contract
 

--- a/.claude/agents/sdd-worker.md
+++ b/.claude/agents/sdd-worker.md
@@ -180,29 +180,36 @@ git add "$INDEX"
 git commit -m "sdd: start FEAT-<ID> — <feature-slug> (<N> tasks)"
 ```
 
-### 3. Create the Worktree
+### 3. Ensure the Worktree
 
-The worktree branches from HEAD (which is `BASE_BRANCH` after §0). For
-features that's `dev`; for hotfixes that's `main`. The branch name follows
-the existing convention regardless of flow type.
+Provision it through the shared rule — never hand-build the name or the base
+ref (FEAT-552). The command is idempotent: it reuses an existing worktree and
+creates one only when absent.
 
 ```bash
-WORKTREE_NAME="feat-<FEAT-ID>-<feature-slug>"
-WORKTREE_PATH=".claude/worktrees/${WORKTREE_NAME}"
-
-# Check if worktree already exists
-git worktree list | grep "${WORKTREE_NAME}" && echo "Reusing existing worktree" || \
-  git worktree add -b "${WORKTREE_NAME}" "${WORKTREE_PATH}" HEAD
-
-cd "${WORKTREE_PATH}"
+WORKTREE_PATH=$(python -m scripts.sdd.ensure_worktree \
+  --slug "<feature-slug>" \
+  --feature-id "<FEAT-ID>" \
+  --spec "<spec-path>" \
+  --index "sdd/tasks/index/<feature-slug>.json")
+cd "$WORKTREE_PATH"
 ```
+
+For a hotfix (`type: hotfix` in the per-spec index header) pass
+`--jira-key <KEY>` instead of `--feature-id`. This is a real behaviour change:
+the previous block always produced `feat-<FEAT-ID>-<slug>` from `HEAD`, so a
+hotfix inherited unreleased `dev` commits (FEAT-466). Naming and base ref now
+come from `scripts.sdd.sdd_meta.plan_worktree`.
+
+If the command exits non-zero, STOP and report its message. Do not implement on
+`<BASE_BRANCH>`.
 
 ### 4. Verify SDD Files Are Visible
-```bash
-test -f sdd/tasks/index/<feature-slug>.json && echo "Per-spec index OK" || echo "INDEX MISSING"
-test -f <spec-path> && echo "Spec OK" || echo "SPEC MISSING"
-```
-If either is missing, STOP with a clear error message.
+
+Already enforced: §3 passed `--spec` and `--index`, and the CLI refuses to hand
+back a worktree in which either is missing. If you reached this point, both are
+present. A failure here means the base branch does not carry the task artifacts
+yet — fetch and re-run §3 rather than working around it.
 
 ### 5. Read the Spec
 Read the spec file referenced by the tasks.

--- a/.claude/commands/sdd-start.md
+++ b/.claude/commands/sdd-start.md
@@ -47,20 +47,38 @@ Check:
   ```
   and STOP.
 
-### 3. Detect Context
+### 3. Ensure the Worktree
 
-With per-spec indexes (FEAT-145), commits land in whatever branch you are on
-— worktree or main repo. Both are safe because each feature owns its own
-index file, so there is no shared mutable state to collide on.
+The worktree is created by whoever is about to write code in it — not at
+planning time (FEAT-552). `/sdd-task` no longer creates one, so this step
+provisions it, idempotently: already inside the right worktree, it is a no-op
+that prints the path you are already in.
+
+Everything the step needs is in the per-spec index header resolved in §1
+(`feature_id`, `feature`, `spec`, `type`, `base_branch`):
 
 ```bash
-CURRENT_DIR=$(pwd)
-CURRENT_BRANCH=$(git branch --show-current)
+WT=$(python -m scripts.sdd.ensure_worktree \
+       --slug "<feature-slug>" \
+       --feature-id "<FEAT-ID>" \
+       --spec "<spec-path>" \
+       --index "sdd/tasks/index/<feature-slug>.json")
+cd "$WT"
 ```
 
-For the recommended layout, you should be inside a feature worktree (path
-contains `.claude/worktrees/`). If not, that's fine — just confirm the
-branch matches the feature you intend to work on.
+For a hotfix (`type: hotfix` in the index header) pass `--jira-key <KEY>`
+instead of `--feature-id`; the CLI applies the FEAT-466 naming and branches
+from `origin/main`.
+
+If the command exits non-zero, **STOP** and show its message verbatim. Do NOT
+fall back to implementing on `<base_branch>` — an un-isolated implementation is
+exactly what this step exists to prevent. The two messages you are most likely
+to see are a leftover branch with no worktree, and task artifacts missing from
+the base you branched off (fetch and re-run).
+
+With per-spec indexes (FEAT-145), commits then land in the worktree's own
+branch. Each feature owns its own index file, so parallel worktrees never
+collide on shared mutable state.
 
 ### 4. Mark In-Progress (in place)
 

--- a/.claude/commands/sdd-task.md
+++ b/.claude/commands/sdd-task.md
@@ -25,7 +25,9 @@ Decompose an approved Feature Specification into atomic, assignable implementati
   dev-loop planner dispatches) can silently allocate the same number to
   different features. See §4 below.
 - **Must run on the spec's `base_branch`** (read from frontmatter — `dev` for features, `main` for hotfixes). Not inside a worktree.
-- **Always commit task files and per-spec index to `base_branch`** before creating the worktree.
+- **Always commit task files and per-spec index to `base_branch`** — they are
+  versioned artifacts, and the machine that implements the feature pulls them
+  from there. This command creates no worktree (FEAT-552).
 
 ## Steps
 
@@ -310,24 +312,7 @@ git diff --cached --name-only
 git commit -m "sdd: add <N> tasks for FEAT-<ID> — <feature-name>"
 ```
 
-### 6. Create the Worktree
-
-After committing to `<BASE>`, create the worktree so it inherits the tasks.
-Naming and base ref depend on `TYPE` (FEAT-466 — a hotfix has no reserved
-id, so it is named from its Jira key, and always branches from
-`origin/main`, never `HEAD`):
-
-```bash
-# type: feature
-git worktree add -b feat-<FEAT-ID>-<slug> \
-  .claude/worktrees/feat-<FEAT-ID>-<slug> HEAD
-
-# type: hotfix (the rare case /sdd-task ran directly against a hotfix spec)
-git worktree add -b hotfix-<JIRA-KEY>-<slug> \
-  .claude/worktrees/hotfix-<JIRA-KEY>-<slug> origin/main
-```
-
-### 7. Output
+### 6. Output
 
 Before printing the summary, count the delegation-eligible tasks. This is the
 number the targeted writer will actually receive when the worker runs, so it
@@ -349,13 +334,13 @@ Blueprints: <N>/<N> tasks carry an Implementation Blueprint
 Delegated:  <D>/<N> tasks carry a Delegation Contract (targeted writer)
             TASK-<NNN>, TASK-<NNN>          # list them, or "none"
 
-Worktree created:
-  .claude/worktrees/feat-<FEAT-ID>-<slug>              # feature
-  .claude/worktrees/hotfix-<JIRA-KEY>-<slug>           # hotfix
+Worktree: not created. /sdd-task produces versioned artifacts only — the
+          worktree is created by whoever implements, on the machine that
+          implements (FEAT-552).
 
 Next:
-  cd .claude/worktrees/<worktree-name>
-  /sdd-start <task-id>   # begin first task
+  /sdd-start <task-id>        # creates the worktree, then begins the task
+  # or, unattended:  claude --agent sdd-worker --model sonnet --verbose
 ```
 
 ## Reference

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,7 +240,12 @@ the Action fails (or the user is offline), run
 should require PRs, passing CI, and signed commits. Not configured
 declaratively in this repo — set via GitHub repo settings.
 
-- **Worktrees branch from `base_branch`** (which `/sdd-task` and `sdd-worker` ensure HEAD is on before creating the worktree). Hotfix worktrees branch from `main`; feature worktrees branch from `dev` or `staging` (during a release freeze).
+- **Worktrees branch from `origin/<base_branch>`**, and are created by whoever
+  implements: `/sdd-start` and `sdd-worker` for the normal lanes, and the
+  dev-loop orchestrators (`sdd-planner`, `sdd-research`, `sdd-autopilot`) which
+  plan and dispatch in one run. `/sdd-task` creates none (FEAT-552). Naming and
+  base ref come from `scripts.sdd.sdd_meta.plan_worktree` via
+  `python -m scripts.sdd.ensure_worktree` — never hand-built.
 
 ## Worktree Creation
 
@@ -254,22 +259,21 @@ declaratively in this repo — set via GitHub repo settings.
 git worktree add -b <branch-name> .claude/worktrees/<worktree-name> HEAD
 ```
 
-> **Carve-out (FEAT-466): "from the current branch … `HEAD`" is shorthand,
-> not the rule.** The actual rule is **worktrees branch from `base_branch`**
-> (§ Git Configuration above). `HEAD` only works as shorthand when `HEAD`
-> already *is* the intended base — true for `/sdd-task` and `sdd-worker`,
-> which always `git checkout "$BASE_BRANCH"` immediately beforehand. It is
-> **not** true for a hotfix: `sdd-research.md` branches
-> `hotfix-<JIRA-KEY>-<slug>` explicitly from `origin/main`, regardless of
-> what branch happens to be checked out in the main repo at the time (a
-> hotfix must never inherit unreleased `dev` commits — this is the FEAT-466
-> root cause, PR #1250). When base and `HEAD` might differ, name the ref
-> explicitly:
+> **Carve-out (FEAT-466): a hotfix must never branch from `HEAD` or inherit
+> unreleased `dev` commits.** That used to depend on the caller already
+> being on the right branch when `HEAD` was used as shorthand for
+> `base_branch` — fragile, because whatever branch happened to be checked
+> out in the main repo at the time silently became the base (the FEAT-466
+> root cause, PR #1250). `plan_worktree` (`scripts/sdd/sdd_meta.py`) now
+> enforces the rule directly: it always resolves `base_ref` to
+> `origin/<base_branch>`, so a worktree can never inherit a local, unpushed
+> `HEAD` — for a hotfix that `base_ref` is `origin/main` by construction.
+> Use the shared CLI, never hand-build the `git worktree add` line:
 > ```bash
 > # Feature — from the base branch (dev, or staging during a freeze)
-> git worktree add -b feat-<id>-<slug> .claude/worktrees/feat-<id>-<slug> origin/dev
+> python -m scripts.sdd.ensure_worktree --slug <slug> --feature-id FEAT-<NNN>
 > # Hotfix — ALWAYS from origin/main, never from HEAD/dev
-> git worktree add -b hotfix-<JIRA-KEY>-<slug> .claude/worktrees/hotfix-<JIRA-KEY>-<slug> origin/main
+> python -m scripts.sdd.ensure_worktree --slug <slug> --jira-key <JIRA-KEY>
 > ```
 
 ### Quick reference
@@ -318,7 +322,7 @@ git worktree prune
 | `/sdd-brainstorm` | `sdd/proposals/<n>.brainstorm.md` (with frontmatter) | `base_branch` |
 | `/sdd-proposal`   | `sdd/proposals/<n>.proposal.md` (with frontmatter)  | `base_branch` |
 | `/sdd-spec`       | `sdd/specs/<n>.spec.md` (with frontmatter) + a `reserve_ids.py` FEAT-ID reservation commit to `sdd/tasks/.id_ledger.json` (FEAT-387) | `base_branch` |
-| `/sdd-task`       | `sdd/tasks/index/<feature>.json` + `sdd/tasks/active/TASK-*` + a `reserve_ids.py` TASK-ID reservation commit to `sdd/tasks/.id_ledger.json` (FEAT-387) | `base_branch` |
+| `/sdd-task`       | `sdd/tasks/index/<feature>.json` + `sdd/tasks/active/TASK-*` + a `reserve_ids.py` TASK-ID reservation commit to `sdd/tasks/.id_ledger.json` (FEAT-387) — and NO worktree (FEAT-552: it is created by the implementing lane) | `base_branch` |
 | `/sdd-start`      | Per-spec index status update + implementation code  | worktree (feature branch) |
 | `/sdd-done`       | Verification stamp on per-spec index (committed on feature branch); merges feature → `base_branch` | worktree (feature branch), merged to `base_branch` by Step 9 |
 
@@ -373,9 +377,8 @@ git checkout dev && git pull origin dev
 /sdd-spec videoreel-visual-changes -- ...
 /sdd-task sdd/specs/videoreel-visual-changes.spec.md
 
-# 3. Create worktree from dev
-git worktree add -b feat-014-videoreel-visual-changes \
-  .claude/worktrees/feat-014 HEAD
+# 3. Start a task — creates the worktree on this machine, idempotently
+/sdd-start TASK-069
 
 # 4. Enter worktree and work
 cd .claude/worktrees/feat-014

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/_subagent_data/sdd-autopilot.md
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/_subagent_data/sdd-autopilot.md
@@ -250,8 +250,10 @@ After spec approval, automatically runs task decomposition.
 #### 6. Create Worktree
 
 ```bash
-git worktree add -b feat-<FEAT-ID>-<slug> \
-  .claude/worktrees/feat-<FEAT-ID>-<slug> HEAD
+python -m scripts.sdd.ensure_worktree --json \
+  --slug <slug> --feature-id FEAT-<NNN> \
+  --spec sdd/specs/<slug>.spec.md \
+  --index sdd/tasks/index/<slug>.json
 ```
 
 #### 7. Output & Handoff

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/_subagent_data/sdd-planner.md
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/_subagent_data/sdd-planner.md
@@ -51,11 +51,16 @@ Given the input brief (``document_path``, ``document_kind``, optional
    per-spec task index (``sdd/tasks/index/<slug>.json``) and the task
    artifacts under ``sdd/tasks/active/``. If a task index for this feature
    already exists and is complete, validate it instead of regenerating.
-4. **Create the worktree** at ``.claude/worktrees/feat-<id>-<slug>/``
-   using
-   ``git worktree add -b feat-<id>-<slug> .claude/worktrees/feat-<id>-<slug> HEAD``
-   from the base branch (``dev``, unless the spec's frontmatter says
-   otherwise).
+4. **Create the worktree** through the shared rule — never hand-build the
+   name or the base ref (FEAT-552)::
+
+       python -m scripts.sdd.ensure_worktree --json \
+         --slug <slug> --feature-id FEAT-<NNN> \
+         --spec sdd/specs/<slug>.spec.md \
+         --index sdd/tasks/index/<slug>.json
+
+   Take ``worktree_path`` from the JSON object it prints for your output contract. The
+   command is idempotent: it reuses an existing worktree rather than failing.
 
 ## Cardinal rules
 
@@ -65,8 +70,9 @@ Given the input brief (``document_path``, ``document_kind``, optional
   Jira is optional and link-only — if ``jira_issue_key`` is present on the
   input brief, pass it straight through to your output unchanged; if it
   is absent, leave the output field empty. Do not invent one.
-- The worktree branch name MUST match ``feat-<id>-<slug>`` so the
-  ``pull_request.closed`` webhook can clean it up automatically.
+- The worktree name is whatever ``scripts.sdd.sdd_meta.plan_worktree``
+  returns — never hand-built. Today that is ``feat-FEAT-<NNN>-<slug>``; the
+  rule, not this sentence, is authoritative.
 
 ## Output Contract
 

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/_subagent_data/sdd-research.md
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/_subagent_data/sdd-research.md
@@ -6,7 +6,7 @@ description: |
   creates a Jira ticket, scaffolds an SDD spec via /sdd-spec, decomposes
   it into tasks via /sdd-task (feature runs only — FEAT-466 skips this for
   hotfixes), and creates the worktree at
-  .claude/worktrees/feat-<id>-<slug>/ (feature) or
+  .claude/worktrees/feat-FEAT-<NNN>-<slug>/ (feature) or
   .claude/worktrees/hotfix-<JIRA-KEY>-<slug>/ (hotfix, no id reserved).
 
   The agent emits ONE final JSON object matching the ResearchOutput

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/_subagent_data/sdd-research.md
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/_subagent_data/sdd-research.md
@@ -91,11 +91,19 @@ criteria) you must:
    dev-loop's single-agent development path from the spec alone; there is
    no per-spec task index and no `TASK-<NNN>` id to reserve. Proceed
    straight to step 5.
-5. **Create the worktree**. The base ref and branch/worktree naming depend
-   on the spec's ``type`` (FEAT-466 — a hotfix has no reserved id, so its
-   name is built from the Jira key instead):
-   - ``hotfix``: ``git worktree add -b hotfix-<JIRA-KEY>-<slug> .claude/worktrees/hotfix-<JIRA-KEY>-<slug> origin/main``
-   - ``feature``: ``git worktree add -b feat-<id>-<slug> .claude/worktrees/feat-<id>-<slug> origin/dev``
+5. **Create the worktree** through the shared rule. Naming and base ref follow
+   the spec's ``type`` automatically (FEAT-466: a hotfix has no reserved id, so
+   it is named from its Jira key and branches from ``origin/main``)::
+
+       # feature
+       python -m scripts.sdd.ensure_worktree --json \
+         --slug <slug> --feature-id FEAT-<NNN>
+
+       # hotfix
+       python -m scripts.sdd.ensure_worktree --json \
+         --slug <slug> --jira-key <JIRA-KEY>
+
+   Take ``worktree_path`` from the JSON object for your output contract.
 
 ## Cardinal rules
 
@@ -107,9 +115,9 @@ criteria) you must:
   ``sdd/`` (specs, tasks) and to git plumbing for the worktree.
 - The Jira ticket MUST be created BEFORE the spec/tasks/worktree, so the
   reporter sees a ticket even if scaffolding fails later.
-- The worktree branch name MUST match ``feat-<id>-<slug>`` (features) or
-  ``hotfix-<JIRA-KEY>-<slug>`` (hotfixes — no id is reserved, FEAT-466) so
-  the ``pull_request.closed`` webhook can clean it up automatically.
+- The worktree name is whatever ``scripts.sdd.sdd_meta.plan_worktree``
+  returns — never hand-built. Today that is ``feat-FEAT-<NNN>-<slug>``; the
+  rule, not this sentence, is authoritative; for a hotfix that is ``hotfix-<JIRA-KEY>-<slug>``.
 
 ## Output Contract
 

--- a/packages/ai-parrot/src/parrot/flows/dev_loop/_subagent_data/sdd-worker.md
+++ b/packages/ai-parrot/src/parrot/flows/dev_loop/_subagent_data/sdd-worker.md
@@ -180,29 +180,36 @@ git add "$INDEX"
 git commit -m "sdd: start FEAT-<ID> — <feature-slug> (<N> tasks)"
 ```
 
-### 3. Create the Worktree
+### 3. Ensure the Worktree
 
-The worktree branches from HEAD (which is `BASE_BRANCH` after §0). For
-features that's `dev`; for hotfixes that's `main`. The branch name follows
-the existing convention regardless of flow type.
+Provision it through the shared rule — never hand-build the name or the base
+ref (FEAT-552). The command is idempotent: it reuses an existing worktree and
+creates one only when absent.
 
 ```bash
-WORKTREE_NAME="feat-<FEAT-ID>-<feature-slug>"
-WORKTREE_PATH=".claude/worktrees/${WORKTREE_NAME}"
-
-# Check if worktree already exists
-git worktree list | grep "${WORKTREE_NAME}" && echo "Reusing existing worktree" || \
-  git worktree add -b "${WORKTREE_NAME}" "${WORKTREE_PATH}" HEAD
-
-cd "${WORKTREE_PATH}"
+WORKTREE_PATH=$(python -m scripts.sdd.ensure_worktree \
+  --slug "<feature-slug>" \
+  --feature-id "<FEAT-ID>" \
+  --spec "<spec-path>" \
+  --index "sdd/tasks/index/<feature-slug>.json")
+cd "$WORKTREE_PATH"
 ```
+
+For a hotfix (`type: hotfix` in the per-spec index header) pass
+`--jira-key <KEY>` instead of `--feature-id`. This is a real behaviour change:
+the previous block always produced `feat-<FEAT-ID>-<slug>` from `HEAD`, so a
+hotfix inherited unreleased `dev` commits (FEAT-466). Naming and base ref now
+come from `scripts.sdd.sdd_meta.plan_worktree`.
+
+If the command exits non-zero, STOP and report its message. Do not implement on
+`<BASE_BRANCH>`.
 
 ### 4. Verify SDD Files Are Visible
-```bash
-test -f sdd/tasks/index/<feature-slug>.json && echo "Per-spec index OK" || echo "INDEX MISSING"
-test -f <spec-path> && echo "Spec OK" || echo "SPEC MISSING"
-```
-If either is missing, STOP with a clear error message.
+
+Already enforced: §3 passed `--spec` and `--index`, and the CLI refuses to hand
+back a worktree in which either is missing. If you reached this point, both are
+present. A failure here means the base branch does not carry the task artifacts
+yet — fetch and re-run §3 rather than working around it.
 
 ### 5. Read the Spec
 Read the spec file referenced by the tasks.

--- a/scripts/sdd/ensure_worktree.py
+++ b/scripts/sdd/ensure_worktree.py
@@ -1,0 +1,282 @@
+"""Idempotent feature/hotfix worktree provisioning for SDD commands (FEAT-552).
+
+Replaces the hand-rolled ``git worktree add`` blocks that used to live in
+``/sdd-task``, ``/sdd-start``, ``sdd-worker``, ``sdd-planner``,
+``sdd-research`` and ``sdd-autopilot``. Naming and base ref come from
+``scripts.sdd.sdd_meta.plan_worktree`` — never built here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from scripts.sdd.sdd_meta import WorktreePlan, plan_worktree, resolve_flow
+
+logger = logging.getLogger(__name__)
+
+
+class EnsureWorktreeError(RuntimeError):
+    """Raised when the worktree cannot be provisioned (CLI exit code 1)."""
+
+
+def _git(*args: str, cwd: Path) -> str:
+    """Run a git command, returning stdout; raise EnsureWorktreeError on failure."""
+    res = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if res.returncode != 0:
+        cmd_str = " ".join(["git", *args])
+        raise EnsureWorktreeError(
+            f"Command '{cmd_str}' failed with exit code {res.returncode}.\n"
+            f"stdout: {res.stdout.strip()}\n"
+            f"stderr: {res.stderr.strip()}"
+        )
+    return res.stdout
+
+
+def ensure(
+    plan: WorktreePlan,
+    *,
+    repo_root: Path,
+    sync: bool = True,
+    require_paths: Sequence[str] = (),
+    dry_run: bool = False,
+) -> tuple[Path, bool]:
+    """Create the worktree if absent, reuse it if present, and verify it.
+
+    Steps, in order:
+      1. Reuse — if ``git worktree list --porcelain`` already lists a worktree
+         whose path basename is ``plan.name``, confirm its checked-out branch
+         is ``plan.name`` and return it. A path holding a DIFFERENT branch is
+         an error, never a silent reuse.
+      2. Sync (skipped when ``sync`` is False) — ``git fetch origin
+         <base_branch>``. No local branch is checked out; no local commit moves.
+      3. Refuse when a branch named ``plan.name`` exists but is checked out
+         nowhere — the operator decides (reuse it, or pick another slug).
+      4. Create — ``git worktree add -b <name> <path> <base_ref>``.
+      5. Verify — every ``require_paths`` entry must exist inside the worktree.
+         A miss means the base does not carry the task artifacts yet.
+      6. Return ``(absolute_path, created)``.
+
+    Args:
+        plan: The naming/base-ref decision from ``plan_worktree``.
+        repo_root: Absolute path to the main clone.
+        sync: Fetch ``origin/<base_branch>`` before creating.
+        require_paths: Repo-relative paths that must exist in the worktree.
+        dry_run: Resolve and report without running any mutating git command.
+
+    Returns:
+        ``(path, created)`` — ``created`` is False when an existing worktree
+        was reused.
+
+    Raises:
+        EnsureWorktreeError: On any refusal above, or a failing git command.
+    """
+    target_path = (repo_root / plan.path).resolve()
+
+    # Step 1: Reuse check
+    # git worktree list --porcelain outputs blocks like:
+    # worktree /path/to/worktree
+    # branch refs/heads/branch-name
+    # (or bare worktree line for the main worktree)
+    wt_list_out = _git("worktree", "list", "--porcelain", cwd=repo_root)
+    current_wt_path = None
+    wt_to_branch = {}
+    for line in wt_list_out.splitlines():
+        line = line.strip()
+        if line.startswith("worktree "):
+            current_wt_path = Path(line[9:]).resolve()
+        elif line.startswith("branch ") and current_wt_path is not None:
+            branch_ref = line[7:]
+            if branch_ref.startswith("refs/heads/"):
+                wt_to_branch[current_wt_path] = branch_ref[11:]
+
+    # Check if any existing worktree has the target path or basename plan.name
+    reused_path = None
+    for wt_path, branch_name in wt_to_branch.items():
+        if wt_path == target_path or wt_path.name == plan.name:
+            if branch_name != plan.name:
+                raise EnsureWorktreeError(
+                    f"Worktree at {wt_path} is checked out on branch {branch_name!r}, "
+                    f"but expected branch {plan.name!r}."
+                )
+            reused_path = wt_path
+            break
+
+    if reused_path is not None:
+        # Verify require_paths in the reused worktree
+        for req in require_paths:
+            if not (reused_path / req).exists():
+                raise EnsureWorktreeError(
+                    f"Required path {req!r} does not exist in reused worktree {reused_path}."
+                )
+        return reused_path, False
+
+    if dry_run:
+        return target_path, True
+
+    # Step 2: Sync
+    if sync:
+        # base_ref is origin/<base_branch>
+        base_branch = plan.base_ref.split("/", 1)[1]
+        _git("fetch", "origin", base_branch, cwd=repo_root)
+
+    # Step 3: Refuse when a branch named plan.name exists but is checked out nowhere
+    # git branch --list plan.name
+    branch_list_out = _git("branch", "--list", plan.name, cwd=repo_root)
+    has_branch = False
+    for line in branch_list_out.splitlines():
+        if line.strip().replace("*", "").strip() == plan.name:
+            has_branch = True
+            break
+
+    if has_branch:
+        # It exists, but we already checked all active worktrees and none of them checked it out.
+        raise EnsureWorktreeError(
+            f"Branch {plan.name!r} already exists but is not checked out in any worktree."
+        )
+
+    # Step 4: Create
+    # git worktree add -b <name> <path> <base_ref>
+    # We must ensure the parent directory of target_path exists
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        _git("worktree", "add", "-b", plan.name, str(target_path), plan.base_ref, cwd=repo_root)
+    except EnsureWorktreeError as e:
+        # Clean up target_path if it was created but git worktree add failed
+        if target_path.exists():
+            try:
+                _git("worktree", "prune", cwd=repo_root)
+            except Exception:
+                pass
+        raise e
+
+    # Step 5: Verify
+    missing_paths = []
+    for req in require_paths:
+        if not (target_path / req).exists():
+            missing_paths.append(req)
+
+    if missing_paths:
+        # Clean up the worktree we just created
+        # Since we cannot use git worktree remove, we can use git worktree prune after deleting the directory,
+        # or we can use git worktree prune. Wait, AC-9 says:
+        # "The module contains no git worktree remove, git branch -D, reset --hard, or checkout of a local branch"
+        # But we can delete the directory and run git worktree prune, or we can use git worktree prune.
+        # Let's delete the directory and run git worktree prune to clean up the worktree registration.
+        try:
+            import shutil
+            if target_path.is_dir():
+                shutil.rmtree(target_path)
+            _git("worktree", "prune", cwd=repo_root)
+            # Also delete the branch we created
+            _git("branch", "-d", plan.name, cwd=repo_root)
+        except Exception as cleanup_err:
+            logger.warning("Failed to clean up worktree/branch after verification failure: %s", cleanup_err)
+        raise EnsureWorktreeError(
+            f"Verification failed: the following required paths were missing from the new worktree: "
+            f"{', '.join(missing_paths)}"
+        )
+
+    return target_path, True
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point. Prints the worktree path to stdout; 0 on success.
+
+    With ``--json``, prints one object instead —
+    ``{"name": …, "path": …, "base_ref": …, "created": bool}`` — so
+    ``sdd-planner``/``sdd-research`` can lift ``worktree_path`` straight into
+    their ``PlannerOutput``/``ResearchOutput`` contracts (spec §8).
+    """
+    parser = argparse.ArgumentParser(
+        description="Idempotent feature/hotfix worktree provisioning for SDD commands."
+    )
+    parser.add_argument("--slug", required=True, help="Feature slug, kebab-case.")
+    parser.add_argument("--feature-id", help="FEAT-<NNN>; required for feature runs.")
+    parser.add_argument("--jira-key", help="Jira issue key; required for hotfix runs.")
+    parser.add_argument("--spec", help="Path to spec markdown file.")
+    parser.add_argument("--index", help="Path to index JSON file.")
+    parser.add_argument("--base-branch", help="Override base branch.")
+    parser.add_argument(
+        "--type", choices=["feature", "hotfix"], help="Override flow type."
+    )
+    parser.add_argument(
+        "--no-sync", action="store_true", help="Skip fetching origin/<base_branch>."
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Resolve and report without mutating git."
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Output JSON instead of bare path."
+    )
+
+    args = parser.parse_args(argv if argv is not None else sys.argv[1:])
+
+    try:
+        # Resolve flow
+        doc_path = Path(args.spec) if args.spec else None
+        meta = resolve_flow(
+            doc_path=doc_path,
+            type_override=args.type,
+            base_branch_override=args.base_branch,
+        )
+
+        # Plan worktree
+        plan = plan_worktree(
+            meta,
+            slug=args.slug,
+            feature_id=args.feature_id,
+            jira_key=args.jira_key,
+        )
+
+        # Determine require_paths
+        require_paths = []
+        if args.spec:
+            require_paths.append(args.spec)
+        if args.index:
+            require_paths.append(args.index)
+
+        # Run ensure
+        repo_root = Path.cwd()
+        path, created = ensure(
+            plan,
+            repo_root=repo_root,
+            sync=not args.no_sync,
+            require_paths=require_paths,
+            dry_run=args.dry_run,
+        )
+
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "name": plan.name,
+                        "path": str(path),
+                        "base_ref": plan.base_ref,
+                        "created": created,
+                    }
+                )
+            )
+        else:
+            print(str(path))
+
+        return 0
+
+    except Exception as e:
+        sys.stderr.write(f"Error: {e}\n")
+        return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/sdd/ensure_worktree.py
+++ b/scripts/sdd/ensure_worktree.py
@@ -117,9 +117,7 @@ def ensure(
         # Verify require_paths in the reused worktree
         for req in require_paths:
             if not (reused_path / req).exists():
-                raise EnsureWorktreeError(
-                    f"Required path {req!r} does not exist in reused worktree {reused_path}."
-                )
+                raise EnsureWorktreeError(f"Required path {req!r} does not exist in reused worktree {reused_path}.")
         return reused_path, False
 
     if dry_run:
@@ -142,9 +140,7 @@ def ensure(
 
     if has_branch:
         # It exists, but we already checked all active worktrees and none of them checked it out.
-        raise EnsureWorktreeError(
-            f"Branch {plan.name!r} already exists but is not checked out in any worktree."
-        )
+        raise EnsureWorktreeError(f"Branch {plan.name!r} already exists but is not checked out in any worktree.")
 
     # Step 4: Create
     # git worktree add -b <name> <path> <base_ref>
@@ -175,6 +171,7 @@ def ensure(
         # of a branch that might hold real work).
         try:
             import shutil
+
             if target_path.is_dir():
                 shutil.rmtree(target_path)
             _git("worktree", "prune", cwd=repo_root)
@@ -198,27 +195,17 @@ def main(argv: Sequence[str] | None = None) -> int:
     ``sdd-planner``/``sdd-research`` can lift ``worktree_path`` straight into
     their ``PlannerOutput``/``ResearchOutput`` contracts (spec §8).
     """
-    parser = argparse.ArgumentParser(
-        description="Idempotent feature/hotfix worktree provisioning for SDD commands."
-    )
+    parser = argparse.ArgumentParser(description="Idempotent feature/hotfix worktree provisioning for SDD commands.")
     parser.add_argument("--slug", required=True, help="Feature slug, kebab-case.")
     parser.add_argument("--feature-id", help="FEAT-<NNN>; required for feature runs.")
     parser.add_argument("--jira-key", help="Jira issue key; required for hotfix runs.")
     parser.add_argument("--spec", help="Path to spec markdown file.")
     parser.add_argument("--index", help="Path to index JSON file.")
     parser.add_argument("--base-branch", help="Override base branch.")
-    parser.add_argument(
-        "--type", choices=["feature", "hotfix"], help="Override flow type."
-    )
-    parser.add_argument(
-        "--no-sync", action="store_true", help="Skip fetching origin/<base_branch>."
-    )
-    parser.add_argument(
-        "--dry-run", action="store_true", help="Resolve and report without mutating git."
-    )
-    parser.add_argument(
-        "--json", action="store_true", help="Output JSON instead of bare path."
-    )
+    parser.add_argument("--type", choices=["feature", "hotfix"], help="Override flow type.")
+    parser.add_argument("--no-sync", action="store_true", help="Skip fetching origin/<base_branch>.")
+    parser.add_argument("--dry-run", action="store_true", help="Resolve and report without mutating git.")
+    parser.add_argument("--json", action="store_true", help="Output JSON instead of bare path.")
 
     args = parser.parse_args(argv if argv is not None else sys.argv[1:])
 

--- a/scripts/sdd/ensure_worktree.py
+++ b/scripts/sdd/ensure_worktree.py
@@ -82,6 +82,14 @@ def ensure(
     Raises:
         EnsureWorktreeError: On any refusal above, or a failing git command.
     """
+    # `Path(x) / y` silently discards `x` when `y` is absolute, which would
+    # make the Step 5 verification below report success for a path that was
+    # never actually inside the new worktree. require_paths is documented as
+    # repo-relative — enforce that instead of failing open.
+    for req in require_paths:
+        if Path(req).is_absolute():
+            raise EnsureWorktreeError(f"require_paths entries must be repo-relative, got absolute path: {req!r}")
+
     target_path = (repo_root / plan.path).resolve()
 
     # Step 1: Reuse check
@@ -168,7 +176,12 @@ def ensure(
         # `git worktree prune` drop the now-stale registration, then remove
         # the branch we created (a plain, non-forced delete of an unpushed
         # branch that carries no commits of its own — never a forced delete
-        # of a branch that might hold real work).
+        # of a branch that might hold real work). `prune` is repo-wide by
+        # git's own design, but it is intentionally harmless here: it only
+        # forgets registrations whose directory is already gone from disk,
+        # so a concurrent process's still-live worktree is never touched —
+        # this was verified empirically (an unrelated live worktree/branch
+        # survives a run that hits this cleanup path).
         try:
             import shutil
 
@@ -198,7 +211,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Idempotent feature/hotfix worktree provisioning for SDD commands.")
     parser.add_argument("--slug", required=True, help="Feature slug, kebab-case.")
     parser.add_argument("--feature-id", help="FEAT-<NNN>; required for feature runs.")
-    parser.add_argument("--jira-key", help="Jira issue key; required for hotfix runs.")
+    parser.add_argument(
+        "--jira-key",
+        help="Jira issue key; required for hotfix runs. Implies --type hotfix "
+        "and --base-branch main unless either is passed explicitly.",
+    )
     parser.add_argument("--spec", help="Path to spec markdown file.")
     parser.add_argument("--index", help="Path to index JSON file.")
     parser.add_argument("--base-branch", help="Override base branch.")
@@ -210,12 +227,24 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv if argv is not None else sys.argv[1:])
 
     try:
-        # Resolve flow
+        # Resolve flow. `--jira-key` with no explicit `--type` implies a
+        # hotfix (and therefore `origin/main`) — without this, the
+        # documented invocation `--slug <slug> --jira-key <KEY>` (see
+        # CLAUDE.md and sdd-research.md) would fail with "feature_id is
+        # required", since resolve_flow() defaults to type="feature" and
+        # has no other signal here that this is a hotfix run.
+        type_override = args.type
+        base_branch_override = args.base_branch
+        if args.jira_key and not type_override:
+            type_override = "hotfix"
+            if not base_branch_override:
+                base_branch_override = "main"
+
         doc_path = Path(args.spec) if args.spec else None
         meta = resolve_flow(
             doc_path=doc_path,
-            type_override=args.type,
-            base_branch_override=args.base_branch,
+            type_override=type_override,
+            base_branch_override=base_branch_override,
         )
 
         # Plan worktree
@@ -249,6 +278,11 @@ def main(argv: Sequence[str] | None = None) -> int:
                     {
                         "name": plan.name,
                         "path": str(path),
+                        # Alias of "path" — sdd-planner/sdd-research read this
+                        # key name into their PlannerOutput/ResearchOutput
+                        # `worktree_path` field (spec §8); both keys always
+                        # carry the same value.
+                        "worktree_path": str(path),
                         "base_ref": plan.base_ref,
                         "created": created,
                     }

--- a/scripts/sdd/ensure_worktree.py
+++ b/scripts/sdd/ensure_worktree.py
@@ -168,12 +168,11 @@ def ensure(
             missing_paths.append(req)
 
     if missing_paths:
-        # Clean up the worktree we just created
-        # Since we cannot use git worktree remove, we can use git worktree prune after deleting the directory,
-        # or we can use git worktree prune. Wait, AC-9 says:
-        # "The module contains no git worktree remove, git branch -D, reset --hard, or checkout of a local branch"
-        # But we can delete the directory and run git worktree prune, or we can use git worktree prune.
-        # Let's delete the directory and run git worktree prune to clean up the worktree registration.
+        # Clean up the worktree we just created: delete the directory and let
+        # `git worktree prune` drop the now-stale registration, then remove
+        # the branch we created (a plain, non-forced delete of an unpushed
+        # branch that carries no commits of its own — never a forced delete
+        # of a branch that might hold real work).
         try:
             import shutil
             if target_path.is_dir():

--- a/scripts/sdd/sdd_meta.py
+++ b/scripts/sdd/sdd_meta.py
@@ -13,6 +13,7 @@ frontmatter is present (so legacy specs keep working), and a symmetric
 from __future__ import annotations
 
 import logging
+import re
 from pathlib import Path
 from typing import Literal
 
@@ -157,3 +158,76 @@ def resolve_flow(
             sorted(KNOWN_BRANCHES),
         )
     return FlowMeta(type=final_type, base_branch=final_base)
+
+
+#: Every SDD worktree lives directly under this repo-relative directory.
+WORKTREE_ROOT: str = ".claude/worktrees"
+
+#: A reserved feature id, e.g. ``FEAT-552``. Bare numbers are rejected.
+_FEATURE_ID_RE = re.compile(r"^FEAT-\d+$")
+
+
+class WorktreePlan(BaseModel):
+    """Where a feature/hotfix worktree goes and what it branches from."""
+
+    name: str
+    path: str
+    base_ref: str
+
+
+def plan_worktree(
+    meta: FlowMeta,
+    *,
+    slug: str,
+    feature_id: str | None = None,
+    jira_key: str | None = None,
+) -> WorktreePlan:
+    """Resolve the canonical worktree name, path and base ref for a run.
+
+    Naming (confirmed canonical 2026-09-11 — it is what /sdd-done greps on):
+      * ``type == "feature"`` -> ``feat-<feature_id>-<slug>``, e.g.
+        ``feat-FEAT-552-worktree-creation-ownership``. The doubled
+        ``feat-FEAT-`` prefix is intentional, not a bug.
+      * ``type == "hotfix"``  -> ``hotfix-<jira_key>-<slug>`` (FEAT-466: a
+        hotfix reserves no FEAT-<NNN>; its identity is the Jira key).
+
+    ``base_ref`` is always ``origin/<meta.base_branch>`` so a worktree can
+    never inherit an unpushed local HEAD. For a hotfix that is ``origin/main``
+    by construction — ``FlowMeta`` already refuses any other base branch for
+    a hotfix (see ``_hotfix_implies_main``).
+
+    Args:
+        meta: Resolved flow metadata.
+        slug: Feature slug, kebab-case.
+        feature_id: ``FEAT-<NNN>``; required when ``meta.type == "feature"``.
+        jira_key: Jira issue key; required when ``meta.type == "hotfix"``.
+
+    Returns:
+        A ``WorktreePlan`` whose ``path`` is repo-relative.
+
+    Raises:
+        ValueError: When ``slug`` is empty or blank; when a feature run has no
+            ``feature_id`` or one not matching ``^FEAT-\\d+$``; when a hotfix
+            run has no ``jira_key``.
+    """
+    if not slug or not slug.strip():
+        raise ValueError("slug cannot be empty or blank")
+
+    if meta.type == "feature":
+        if not feature_id:
+            raise ValueError("feature_id is required for feature runs")
+        if not _FEATURE_ID_RE.match(feature_id):
+            raise ValueError(f"feature_id must match ^FEAT-\\d+$, got {feature_id!r}")
+        name = f"feat-{feature_id}-{slug}"
+    elif meta.type == "hotfix":
+        if not jira_key or not jira_key.strip():
+            raise ValueError("jira_key is required for hotfix runs")
+        name = f"hotfix-{jira_key}-{slug}"
+    else:
+        raise ValueError(f"Unsupported flow type: {meta.type}")
+
+    path = f"{WORKTREE_ROOT}/{name}"
+    base_ref = f"origin/{meta.base_branch}"
+
+    return WorktreePlan(name=name, path=path, base_ref=base_ref)
+

--- a/scripts/sdd/sdd_meta.py
+++ b/scripts/sdd/sdd_meta.py
@@ -230,4 +230,3 @@ def plan_worktree(
     base_ref = f"origin/{meta.base_branch}"
 
     return WorktreePlan(name=name, path=path, base_ref=base_ref)
-

--- a/sdd/tasks/completed/TASK-3153-plan-worktree-rule.md
+++ b/sdd/tasks/completed/TASK-3153-plan-worktree-rule.md
@@ -303,10 +303,14 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker orchestrator (FEAT-549 pool)
+**Date**: 2026-09-11
+**Notes**: Implemented `WORKTREE_ROOT`, `WorktreePlan`, and `plan_worktree()`
+in `scripts/sdd/sdd_meta.py` exactly per the blueprint; all 9 tests in
+`tests/sdd_scripts/test_worktree_plan.py` pass, existing `test_sdd_meta.py`
++ `test_sdd_meta_resolve_flow.py` suites (21 tests) stay green, and
+`ruff check` is clean on both files.
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
-**Notes**:
+**Deviations from spec**: none
 
-**Deviations from spec**: none | describe if any
+Seat: gemini · Backend: google-compat · Model: gemini-3.5-flash · Attempts: 2 (1 qwen/nova timeout, 1 gemini/google-compat success) · Duration: 583.97s · Tokens: 188644 in / 2637 out

--- a/sdd/tasks/completed/TASK-3154-ensure-worktree-cli.md
+++ b/sdd/tasks/completed/TASK-3154-ensure-worktree-cli.md
@@ -380,10 +380,22 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker orchestrator (FEAT-549 pool) + sdd-worker fixup
+**Date**: 2026-09-11
+**Notes**: Implemented `ensure()`, `EnsureWorktreeError`, and `main()`/CLI in
+`scripts/sdd/ensure_worktree.py` with `tests/sdd_scripts/test_ensure_worktree.py`;
+all 7 tests pass. AC-1 through AC-8 verified (help exits 0, bare-path and
+`--json` stdout shapes checked live, `--dry-run` leaves `git worktree list`
+unchanged). AC-9 initially FAILED on merge — the cleanup-on-failed-verification
+branch had a comment that quoted the forbidden git-command substrings in
+prose (explaining what NOT to do), which the literal grep matched even
+though the actual code only calls a plain non-forced branch delete on a
+branch it just created. Fixed by rewording the comment only, no behavior
+change; re-verified AC-9 grep returns nothing, tests still 7/7, ruff clean.
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
-**Notes**:
+**Deviations from spec**: none (the AC-9 fix touched only the file already
+listed for this task)
 
-**Deviations from spec**: none | describe if any
+Seat: gemini · Backend: google-compat · Model: gemini-3.5-flash · Attempts: 1
+(merged first try) · Duration: 43.01s · Tokens: 287432 in / 5714 out
+(+ sdd-worker direct fixup for AC-9 comment reword, untimed)

--- a/sdd/tasks/completed/TASK-3155-sdd-start-ensures-worktree.md
+++ b/sdd/tasks/completed/TASK-3155-sdd-start-ensures-worktree.md
@@ -215,10 +215,26 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (fallback — the parrot-sdd-coder codex-spark
+attempt failed instantly on a CLI argument mismatch, `--ask-for-approval`;
+the qwen/nova retry then timed out after ~9 minutes)
+**Date**: 2026-09-11
+**Notes**: Replaced `### 3. Detect Context` with `### 3. Ensure the
+Worktree` in `.claude/commands/sdd-start.md`, applying the blueprint text
+verbatim, and mirrored the identical edit into `.agent/workflows/sdd-start.md`
+(preserving its `description:` frontmatter). Verified all 7 acceptance
+criteria: the new heading exists and the old one is gone, the section
+invokes `python -m scripts.sdd.ensure_worktree` and `cd`s to `$WT`, no
+`git worktree add` remains, §1-§9 headings are each present exactly once
+and unrenumbered, the twin carries the same section with its frontmatter
+intact, `pytest tests/sdd_scripts/test_command_twin_parity.py -q` still
+reports `2 passed` (no worse than the TASK-3156 baseline), and the section
+reads `type`/`base_branch` from the per-spec index header, not spec
+frontmatter.
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
-**Notes**:
+**Deviations from spec**: none
 
-**Deviations from spec**: none | describe if any
+Seat: sdd-worker (sonnet, direct) · Backend: n/a (fallback after two MCP-seat
+failures) · Model: claude-sonnet-5 · Attempts: 3 (codex-spark CLI-arg error
+1.08s, qwen/nova timeout 551.89s, direct fallback success) · Duration: n/a
+(fallback) · Tokens: n/a

--- a/sdd/tasks/completed/TASK-3156-sdd-task-drops-worktree.md
+++ b/sdd/tasks/completed/TASK-3156-sdd-task-drops-worktree.md
@@ -245,10 +245,24 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (fallback — the parrot-sdd-coder gemini attempt
+failed: its sandbox blocked python invocations containing the literal
+substring "TASK-", so it could not run the twin-regeneration script)
+**Date**: 2026-09-11
+**Notes**: Baseline parity check measured `1 failed, 1 passed` as expected.
+Deleted §6 "Create the Worktree", renumbered §7 "Output" → §6, rewrote the
+"Worktree created" stanza to "Worktree: not created…" plus the `Next:`
+block, and reworded the §Guardrails commit bullet — all exactly per the
+blueprint. Regenerated `.agent/workflows/sdd-task.md` programmatically from
+the edited original (frontmatter preserved, the one documented `CLAUDE.md`→
+`AGENTS.md` substitution re-applied), healing the pre-existing FEAT-545
+drift in the same stroke. `pytest tests/sdd_scripts/test_command_twin_parity.py -q`
+now reports `2 passed`. All 7 acceptance criteria (AC-1 through AC-7)
+verified individually.
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
-**Notes**:
+**Deviations from spec**: none
 
-**Deviations from spec**: none | describe if any
+Seat: sdd-worker (sonnet, direct) · Backend: n/a (fallback after MCP-seat
+failure) · Model: claude-sonnet-5 · Attempts: 2 (1 gemini/google-compat
+sandbox failure, 1 direct fallback success) · Duration: 152.7s (failed MCP
+attempt) + fallback · Tokens: n/a

--- a/sdd/tasks/completed/TASK-3157-sdd-worker-shared-rule.md
+++ b/sdd/tasks/completed/TASK-3157-sdd-worker-shared-rule.md
@@ -207,10 +207,28 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (direct implementation — the native haiku
+seat's attempt committed the right code changes but also moved the task
+file and edited the per-spec index INSIDE its own sub-worktree, which
+`coder_merge` correctly flagged as `fidelity_violation` per the sdd-coder
+contract "commits code only, never touches sdd/"; per the orchestrator's
+consolidation rule that outcome is never merged by hand, so this task was
+re-implemented from a clean, untouched copy of both files)
+**Date**: 2026-09-11
+**Notes**: Replaced §3's body with the `scripts.sdd.ensure_worktree` call
+and reduced §4 to a restatement, exactly per the blueprint; `cp`'d the
+result over the `_subagent_data/` twin. Verified all 6 acceptance
+criteria: no `git worktree add` remains, `scripts.sdd.ensure_worktree` and
+`--jira-key` are both documented, the old `WORKTREE_NAME=` template is
+gone, `cmp` exits 0 on the twin pair,
+`pytest packages/ai-parrot/tests/flows/dev_loop/test_subagent_parity.py -q`
+reports `10 passed, 1 skipped`, and §3/§4/§5 keep their numbers (§0-§2
+unaffected).
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
-**Notes**:
+**Deviations from spec**: none
 
-**Deviations from spec**: none | describe if any
+Seat: haiku (native) — attempt discarded for fidelity_violation, redone
+directly by sdd-worker · Backend: n/a · Model: claude-sonnet-5 (redo) ·
+Attempts: 2 (1 native haiku fidelity_violation, 1 direct redo success) ·
+Duration: 220.10s (discarded attempt) + direct redo · Tokens: 71370 in
+(discarded attempt, input+output combined per agent report)

--- a/sdd/tasks/completed/TASK-3158-orchestrators-shared-rule.md
+++ b/sdd/tasks/completed/TASK-3158-orchestrators-shared-rule.md
@@ -251,10 +251,27 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker orchestrator (FEAT-549 pool) + sdd-worker fixup
+**Date**: 2026-09-11
+**Notes**: Replaced the inline `git worktree add` in `sdd-planner` step 4,
+`sdd-research` step 5, and `sdd-autopilot` §6 with
+`python -m scripts.sdd.ensure_worktree --json`; restated each cardinal
+rule to defer to `plan_worktree`; mirrored all three edits to
+`_subagent_data/`. AC checks initially found one gap the merged attempt
+missed: `sdd-research.md`'s YAML frontmatter `description` (line 9) still
+quoted the legacy `feat-<id>-<slug>` template — AC-2's repo-wide grep
+covers all of `.claude/`, not just the numbered steps. Fixed the command
+and its twin; `cmp` exits 0 for all three pairs and
+`pytest packages/ai-parrot/tests/flows/dev_loop/test_subagent_parity.py -q`
+now reports `10 passed, 1 skipped`. (Note: this worktree needed its
+compiled Cython `.so` extensions copied over from the main checkout
+before that suite could even import `parrot` — a known environment gap,
+unrelated to this task, harmless since `.so` artifacts are gitignored.)
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
-**Notes**:
+**Deviations from spec**: none (the frontmatter fix touched only a file
+already listed for this task)
 
-**Deviations from spec**: none | describe if any
+Seat: gemini · Backend: google-compat · Model: gemini-3.5-flash · Attempts: 2
+(1 qwen/nova timeout, 1 gemini/google-compat success) · Duration: 631.06s ·
+Tokens: 1173485 in / 3455 out (+ sdd-worker direct fixup for the residual
+frontmatter template, untimed)

--- a/sdd/tasks/completed/TASK-3159-docs-worktree-ownership.md
+++ b/sdd/tasks/completed/TASK-3159-docs-worktree-ownership.md
@@ -197,10 +197,29 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker (fallback — the parrot-sdd-coder codex-spark
+attempt failed instantly on a CLI argument mismatch, `--ask-for-approval`;
+the qwen/nova retry then timed out after ~9 minutes)
+**Date**: 2026-09-11
+**Notes**: Made all four anchored edits exactly per the blueprint: (1) the
+base-branch bullet now says worktrees branch from `origin/<base_branch>`
+and names every creator plus `/sdd-task`'s exclusion; (2) the FEAT-466
+carve-out is shortened to state the guarantee is now enforced by
+`plan_worktree`, keeps the FEAT-466/PR #1250 attribution, and its example
+now calls `python -m scripts.sdd.ensure_worktree` instead of hand-building
+`git worktree add`; (3) the `/sdd-task` row of the Auto-Commit table now
+notes it creates no worktree; (4) Typical Workflow step 3 now reads
+`/sdd-start TASK-069` instead of a raw `git worktree add`. Verified all 7
+acceptance criteria individually (AC-1 empty grep, AC-2 no remaining
+`/sdd-task`-creates-worktree claim, AC-3 step 3 confirmed, AC-4 carve-out
+still cites FEAT-466/PR #1250 and `origin/main`, AC-5 three
+`scripts.sdd.ensure_worktree` mentions, AC-6 Worktree Creation
+heading/Cleanup/.gitignore/Quick reference untouched, AC-7 `git diff CLAUDE.md`
+shows exactly 4 reviewable hunks in one file).
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
-**Notes**:
+**Deviations from spec**: none
 
-**Deviations from spec**: none | describe if any
+Seat: sdd-worker (sonnet, direct) · Backend: n/a (fallback after two MCP-seat
+failures) · Model: claude-sonnet-5 · Attempts: 3 (codex-spark CLI-arg error
+1.05s, qwen/nova timeout 552.25s, direct fallback success) · Duration: n/a
+(fallback) · Tokens: n/a

--- a/sdd/tasks/completed/TASK-3160-guard-tests.md
+++ b/sdd/tasks/completed/TASK-3160-guard-tests.md
@@ -225,10 +225,37 @@ When you pick up this task:
 
 ## Completion Note
 
-*(Agent fills this in when done)*
+**Completed by**: sdd-worker orchestrator (FEAT-549 pool, native haiku seat) +
+sdd-worker verification
+**Date**: 2026-09-11
+**Notes**: Created `tests/sdd_scripts/test_command_contracts.py` with three
+guard tests: `test_no_command_hand_rolls_a_worktree` (parametrized over the
+six creator files), `test_every_creator_calls_ensure_worktree`
+(parametrized over the five that must call `scripts.sdd.ensure_worktree`),
+and `test_no_legacy_naming_template_remains` (repo-wide walk of `.claude/`
+excluding `worktrees/`). 12 cases collected and all pass, none skipped.
+Verified AC-2 live: temporarily reintroduced a `git worktree add` line into
+`.claude/commands/sdd-task.md`, confirmed
+`test_no_command_hand_rolls_a_worktree[.claude/commands/sdd-task.md]` fails
+with an assertion naming the offending file, then reverted (working tree
+confirmed clean afterward). Confirmed the tests never read
+`.claude/worktrees/` (guarded by `"worktrees" in md_file.parts`). Full
+`tests/sdd_scripts/` suite: `142 passed`. `ruff check` clean. The exact
+combined command in the spec's last AC
+(`pytest tests/sdd_scripts/ packages/ai-parrot/tests/flows/dev_loop/test_subagent_parity.py -q`)
+hits a pre-existing, repo-wide pytest rootdir collision
+(`ImportPathMismatchError` on `tests.conftest` — both `tests/` and
+`packages/ai-parrot/tests/` package as `tests`) that is reproducible on
+unmodified `dev` with unrelated test files, unrelated to this feature; ran
+the two suites separately instead (`142 passed` and `10 passed, 1 skipped`
+respectively), both green.
 
-**Completed by**: <session or agent ID>
-**Date**: YYYY-MM-DD
-**Notes**:
+**Deviations from spec**: none. (Note: this worktree also needed its
+compiled Cython `.so` extensions copied from the main checkout before any
+suite importing `parrot` would even collect — a known, harmless,
+gitignored environment gap unrelated to this task.)
 
-**Deviations from spec**: none | describe if any
+Seat: haiku (native) · Backend: n/a · Model: claude-sonnet-5 (haiku
+implementation, sonnet verification) · Attempts: 1 (merged first try,
+correctly scoped this time — commits only the listed test file) ·
+Duration: 234.06s · Tokens: 71871 (subagent-reported combined)

--- a/sdd/tasks/index/worktree-creation-ownership.json
+++ b/sdd/tasks/index/worktree-creation-ownership.json
@@ -110,7 +110,7 @@
       "feature_id": "FEAT-552",
       "feature": "worktree-creation-ownership",
       "spec": "sdd/specs/worktree-creation-ownership.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "M",
       "depends_on": [
@@ -120,8 +120,8 @@
       "parallelism_notes": "Only task touching the planner/research/autopilot pair of copies.",
       "assigned_to": null,
       "started_at": "2026-09-11T00:16:19+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-3158-orchestrators-shared-rule.md"
+      "completed_at": "2026-09-11T00:56:17+00:00",
+      "file": "sdd/tasks/completed/TASK-3158-orchestrators-shared-rule.md"
     },
     {
       "id": "TASK-3159",

--- a/sdd/tasks/index/worktree-creation-ownership.json
+++ b/sdd/tasks/index/worktree-creation-ownership.json
@@ -32,7 +32,7 @@
       "feature_id": "FEAT-552",
       "feature": "worktree-creation-ownership",
       "spec": "sdd/specs/worktree-creation-ownership.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "L",
       "depends_on": [
@@ -42,8 +42,8 @@
       "parallelism_notes": "Imports plan_worktree/WorktreePlan from TASK-3153.",
       "assigned_to": null,
       "started_at": "2026-09-11T00:16:19+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-3154-ensure-worktree-cli.md"
+      "completed_at": "2026-09-11T00:41:15+00:00",
+      "file": "sdd/tasks/completed/TASK-3154-ensure-worktree-cli.md"
     },
     {
       "id": "TASK-3155",

--- a/sdd/tasks/index/worktree-creation-ownership.json
+++ b/sdd/tasks/index/worktree-creation-ownership.json
@@ -14,7 +14,7 @@
       "feature_id": "FEAT-552",
       "feature": "worktree-creation-ownership",
       "spec": "sdd/specs/worktree-creation-ownership.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [],
@@ -22,8 +22,8 @@
       "parallelism_notes": "Touches only scripts/sdd/sdd_meta.py and a new test file; no other task writes there.",
       "assigned_to": null,
       "started_at": "2026-09-11T00:16:19+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-3153-plan-worktree-rule.md"
+      "completed_at": "2026-09-11T00:27:51+00:00",
+      "file": "sdd/tasks/completed/TASK-3153-plan-worktree-rule.md"
     },
     {
       "id": "TASK-3154",

--- a/sdd/tasks/index/worktree-creation-ownership.json
+++ b/sdd/tasks/index/worktree-creation-ownership.json
@@ -150,7 +150,7 @@
       "feature_id": "FEAT-552",
       "feature": "worktree-creation-ownership",
       "spec": "sdd/specs/worktree-creation-ownership.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "S",
       "depends_on": [
@@ -164,8 +164,8 @@
       "parallelism_notes": "Asserts the end state; every assertion is false until the five markdown tasks land.",
       "assigned_to": null,
       "started_at": "2026-09-11T00:16:19+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-3160-guard-tests.md"
+      "completed_at": "2026-09-11T01:06:11+00:00",
+      "file": "sdd/tasks/completed/TASK-3160-guard-tests.md"
     }
   ]
 }

--- a/sdd/tasks/index/worktree-creation-ownership.json
+++ b/sdd/tasks/index/worktree-creation-ownership.json
@@ -72,7 +72,7 @@
       "feature_id": "FEAT-552",
       "feature": "worktree-creation-ownership",
       "spec": "sdd/specs/worktree-creation-ownership.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "S",
       "depends_on": [],
@@ -80,8 +80,8 @@
       "parallelism_notes": "Pure deletion in sdd-task.md + its twin; shares no file with any other task and needs no CLI.",
       "assigned_to": null,
       "started_at": "2026-09-11T00:16:19+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-3156-sdd-task-drops-worktree.md"
+      "completed_at": "2026-09-11T00:29:52+00:00",
+      "file": "sdd/tasks/completed/TASK-3156-sdd-task-drops-worktree.md"
     },
     {
       "id": "TASK-3157",

--- a/sdd/tasks/index/worktree-creation-ownership.json
+++ b/sdd/tasks/index/worktree-creation-ownership.json
@@ -5,7 +5,7 @@
   "type": "feature",
   "base_branch": "dev",
   "created_at": "2026-09-11T00:14:25+00:00",
-  "completed_at": null,
+  "completed_at": "2026-09-11T01:06:28+00:00",
   "tasks": [
     {
       "id": "TASK-3153",

--- a/sdd/tasks/index/worktree-creation-ownership.json
+++ b/sdd/tasks/index/worktree-creation-ownership.json
@@ -90,7 +90,7 @@
       "feature_id": "FEAT-552",
       "feature": "worktree-creation-ownership",
       "spec": "sdd/specs/worktree-creation-ownership.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "S",
       "depends_on": [
@@ -100,8 +100,8 @@
       "parallelism_notes": "Only task touching sdd-worker.md and its _subagent_data twin.",
       "assigned_to": null,
       "started_at": "2026-09-11T00:16:19+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-3157-sdd-worker-shared-rule.md"
+      "completed_at": "2026-09-11T00:58:58+00:00",
+      "file": "sdd/tasks/completed/TASK-3157-sdd-worker-shared-rule.md"
     },
     {
       "id": "TASK-3158",

--- a/sdd/tasks/index/worktree-creation-ownership.json
+++ b/sdd/tasks/index/worktree-creation-ownership.json
@@ -52,7 +52,7 @@
       "feature_id": "FEAT-552",
       "feature": "worktree-creation-ownership",
       "spec": "sdd/specs/worktree-creation-ownership.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "depends_on": [
@@ -62,8 +62,8 @@
       "parallelism_notes": "Markdown-only, and the only task touching sdd-start.md; parallel with 3156-3158 once the CLI exists.",
       "assigned_to": null,
       "started_at": "2026-09-11T00:16:19+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-3155-sdd-start-ensures-worktree.md"
+      "completed_at": "2026-09-11T00:57:40+00:00",
+      "file": "sdd/tasks/completed/TASK-3155-sdd-start-ensures-worktree.md"
     },
     {
       "id": "TASK-3156",

--- a/sdd/tasks/index/worktree-creation-ownership.json
+++ b/sdd/tasks/index/worktree-creation-ownership.json
@@ -5,7 +5,7 @@
   "type": "feature",
   "base_branch": "dev",
   "created_at": "2026-09-11T00:14:25+00:00",
-  "completed_at": "2026-09-11T01:06:28+00:00",
+  "completed_at": "2026-09-11T13:40:18+00:00",
   "tasks": [
     {
       "id": "TASK-3153",
@@ -23,7 +23,8 @@
       "assigned_to": null,
       "started_at": "2026-09-11T00:16:19+00:00",
       "completed_at": "2026-09-11T00:27:51+00:00",
-      "file": "sdd/tasks/completed/TASK-3153-plan-worktree-rule.md"
+      "file": "sdd/tasks/completed/TASK-3153-plan-worktree-rule.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-3154",
@@ -43,7 +44,8 @@
       "assigned_to": null,
       "started_at": "2026-09-11T00:16:19+00:00",
       "completed_at": "2026-09-11T00:41:15+00:00",
-      "file": "sdd/tasks/completed/TASK-3154-ensure-worktree-cli.md"
+      "file": "sdd/tasks/completed/TASK-3154-ensure-worktree-cli.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-3155",
@@ -63,7 +65,8 @@
       "assigned_to": null,
       "started_at": "2026-09-11T00:16:19+00:00",
       "completed_at": "2026-09-11T00:57:40+00:00",
-      "file": "sdd/tasks/completed/TASK-3155-sdd-start-ensures-worktree.md"
+      "file": "sdd/tasks/completed/TASK-3155-sdd-start-ensures-worktree.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-3156",
@@ -81,7 +84,8 @@
       "assigned_to": null,
       "started_at": "2026-09-11T00:16:19+00:00",
       "completed_at": "2026-09-11T00:29:52+00:00",
-      "file": "sdd/tasks/completed/TASK-3156-sdd-task-drops-worktree.md"
+      "file": "sdd/tasks/completed/TASK-3156-sdd-task-drops-worktree.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-3157",
@@ -101,7 +105,8 @@
       "assigned_to": null,
       "started_at": "2026-09-11T00:16:19+00:00",
       "completed_at": "2026-09-11T00:58:58+00:00",
-      "file": "sdd/tasks/completed/TASK-3157-sdd-worker-shared-rule.md"
+      "file": "sdd/tasks/completed/TASK-3157-sdd-worker-shared-rule.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-3158",
@@ -121,7 +126,8 @@
       "assigned_to": null,
       "started_at": "2026-09-11T00:16:19+00:00",
       "completed_at": "2026-09-11T00:56:17+00:00",
-      "file": "sdd/tasks/completed/TASK-3158-orchestrators-shared-rule.md"
+      "file": "sdd/tasks/completed/TASK-3158-orchestrators-shared-rule.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-3159",
@@ -141,7 +147,8 @@
       "assigned_to": null,
       "started_at": "2026-09-11T00:16:19+00:00",
       "completed_at": "2026-09-11T00:42:50+00:00",
-      "file": "sdd/tasks/completed/TASK-3159-docs-worktree-ownership.md"
+      "file": "sdd/tasks/completed/TASK-3159-docs-worktree-ownership.md",
+      "verification": "verified"
     },
     {
       "id": "TASK-3160",
@@ -165,7 +172,8 @@
       "assigned_to": null,
       "started_at": "2026-09-11T00:16:19+00:00",
       "completed_at": "2026-09-11T01:06:11+00:00",
-      "file": "sdd/tasks/completed/TASK-3160-guard-tests.md"
+      "file": "sdd/tasks/completed/TASK-3160-guard-tests.md",
+      "verification": "verified"
     }
   ]
 }

--- a/sdd/tasks/index/worktree-creation-ownership.json
+++ b/sdd/tasks/index/worktree-creation-ownership.json
@@ -130,7 +130,7 @@
       "feature_id": "FEAT-552",
       "feature": "worktree-creation-ownership",
       "spec": "sdd/specs/worktree-creation-ownership.spec.md",
-      "status": "in-progress",
+      "status": "done",
       "priority": "medium",
       "effort": "S",
       "depends_on": [
@@ -140,8 +140,8 @@
       "parallelism_notes": "Only task touching CLAUDE.md; gated on 3156 so the docs describe a /sdd-task that really stopped.",
       "assigned_to": null,
       "started_at": "2026-09-11T00:16:19+00:00",
-      "completed_at": null,
-      "file": "sdd/tasks/active/TASK-3159-docs-worktree-ownership.md"
+      "completed_at": "2026-09-11T00:42:50+00:00",
+      "file": "sdd/tasks/completed/TASK-3159-docs-worktree-ownership.md"
     },
     {
       "id": "TASK-3160",

--- a/tests/sdd_scripts/test_command_contracts.py
+++ b/tests/sdd_scripts/test_command_contracts.py
@@ -43,19 +43,16 @@ def _read(rel: str) -> str:
 def test_no_command_hand_rolls_a_worktree(rel: str) -> None:
     """No SDD command or agent runs `git worktree add` itself (FEAT-552)."""
     assert "git worktree add" not in _read(rel), (
-        f"{rel} hand-rolls a worktree; call "
-        "`python -m scripts.sdd.ensure_worktree` instead"
+        f"{rel} hand-rolls a worktree; call " "`python -m scripts.sdd.ensure_worktree` instead"
     )
 
 
-@pytest.mark.parametrize(
-    "rel", sorted(r for r, needs_cli in _CREATORS.items() if needs_cli)
-)
+@pytest.mark.parametrize("rel", sorted(r for r, needs_cli in _CREATORS.items() if needs_cli))
 def test_every_creator_calls_ensure_worktree(rel: str) -> None:
     """Each lane that provisions a worktree goes through the shared CLI."""
-    assert "scripts.sdd.ensure_worktree" in _read(rel), (
-        f"{rel} must call `python -m scripts.sdd.ensure_worktree` to provision worktrees"
-    )
+    assert "scripts.sdd.ensure_worktree" in _read(
+        rel
+    ), f"{rel} must call `python -m scripts.sdd.ensure_worktree` to provision worktrees"
 
 
 def test_no_legacy_naming_template_remains() -> None:
@@ -77,7 +74,4 @@ def test_no_legacy_naming_template_remains() -> None:
         if _LEGACY_TEMPLATE in content:
             offenders.append(md_file.relative_to(_REPO_ROOT))
 
-    assert not offenders, (
-        f"Legacy template `{_LEGACY_TEMPLATE}` found in: "
-        + ", ".join(str(p) for p in offenders)
-    )
+    assert not offenders, f"Legacy template `{_LEGACY_TEMPLATE}` found in: " + ", ".join(str(p) for p in offenders)

--- a/tests/sdd_scripts/test_command_contracts.py
+++ b/tests/sdd_scripts/test_command_contracts.py
@@ -1,0 +1,83 @@
+"""Convention guards for SDD worktree ownership — FEAT-552 / TASK-3160.
+
+Worktree creation belongs to whoever writes code in the worktree
+(`/sdd-start`, `sdd-worker`) and to the dev-loop orchestrators that plan and
+dispatch in one run (`sdd-planner`, `sdd-research`, `sdd-autopilot`). Planning
+alone (`/sdd-task`) creates none. All of them go through
+`scripts.sdd.ensure_worktree`, so exactly one naming rule exists.
+
+These tests keep that true. `.claude/worktrees/` is never inspected: those are
+separate checkouts of older branches and legitimately hold the old text.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: Files that must not hand-roll a worktree, and whether they must instead
+#: name the shared CLI.
+_CREATORS: dict[str, bool] = {
+    ".claude/commands/sdd-task.md": False,
+    ".claude/commands/sdd-start.md": True,
+    ".claude/agents/sdd-worker.md": True,
+    ".claude/agents/sdd-planner.md": True,
+    ".claude/agents/sdd-research.md": True,
+    ".claude/agents/sdd-autopilot.md": True,
+}
+
+_LEGACY_TEMPLATE = "feat-<id>-<slug>"
+
+
+def _read(rel: str) -> str:
+    path = _REPO_ROOT / rel
+    if not path.is_file():
+        pytest.skip(f"{rel} missing at this checkout")
+    return path.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("rel", sorted(_CREATORS))
+def test_no_command_hand_rolls_a_worktree(rel: str) -> None:
+    """No SDD command or agent runs `git worktree add` itself (FEAT-552)."""
+    assert "git worktree add" not in _read(rel), (
+        f"{rel} hand-rolls a worktree; call "
+        "`python -m scripts.sdd.ensure_worktree` instead"
+    )
+
+
+@pytest.mark.parametrize(
+    "rel", sorted(r for r, needs_cli in _CREATORS.items() if needs_cli)
+)
+def test_every_creator_calls_ensure_worktree(rel: str) -> None:
+    """Each lane that provisions a worktree goes through the shared CLI."""
+    assert "scripts.sdd.ensure_worktree" in _read(rel), (
+        f"{rel} must call `python -m scripts.sdd.ensure_worktree` to provision worktrees"
+    )
+
+
+def test_no_legacy_naming_template_remains() -> None:
+    """`feat-<id>-<slug>` is gone: one template, owned by plan_worktree."""
+    claude_dir = _REPO_ROOT / ".claude"
+    if not claude_dir.is_dir():
+        pytest.skip(".claude/ directory not found at this checkout")
+
+    offenders = []
+    for md_file in claude_dir.rglob("*.md"):
+        # Skip files under .claude/worktrees/ (separate checkouts)
+        if "worktrees" in md_file.parts:
+            continue
+        # Skip CLAUDE.md (examples are allowed there)
+        if md_file.name == "CLAUDE.md":
+            continue
+
+        content = md_file.read_text(encoding="utf-8")
+        if _LEGACY_TEMPLATE in content:
+            offenders.append(md_file.relative_to(_REPO_ROOT))
+
+    assert not offenders, (
+        f"Legacy template `{_LEGACY_TEMPLATE}` found in: "
+        + ", ".join(str(p) for p in offenders)
+    )

--- a/tests/sdd_scripts/test_ensure_worktree.py
+++ b/tests/sdd_scripts/test_ensure_worktree.py
@@ -1,0 +1,161 @@
+"""Tests for ``scripts.sdd.ensure_worktree`` — FEAT-552 / TASK-3154."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.sdd.ensure_worktree import EnsureWorktreeError, ensure, main
+from scripts.sdd.sdd_meta import FlowMeta, plan_worktree
+
+SLUG = "demo-feature"
+FEATURE_ID = "FEAT-999"
+
+
+@pytest.fixture
+def tmp_git_repo(tmp_path: Path) -> Path:
+    """A clone with an `origin` remote, a `dev` branch, and the SDD artifacts.
+
+    Shape: `origin.git` (bare) <- `work` (the clone under test). `work` has
+    sdd/specs/demo-feature.spec.md and sdd/tasks/index/demo-feature.json
+    committed on `dev` and pushed, so `origin/dev` carries them.
+    """
+    origin_dir = tmp_path / "origin.git"
+    work_dir = tmp_path / "work"
+
+    # Init bare origin
+    subprocess.run(["git", "init", "--bare", str(origin_dir)], check=True)
+
+    # Init work clone
+    subprocess.run(["git", "init", str(work_dir)], check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=work_dir, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=work_dir, check=True)
+
+    # Create SDD files
+    spec_path = work_dir / "sdd/specs/demo-feature.spec.md"
+    index_path = work_dir / "sdd/tasks/index/demo-feature.json"
+    spec_path.parent.mkdir(parents=True, exist_ok=True)
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+
+    spec_path.write_text("# Demo Feature Spec", encoding="utf-8")
+    index_path.write_text('{"status": "pending"}', encoding="utf-8")
+
+    # Commit and push to origin
+    subprocess.run(["git", "add", "."], cwd=work_dir, check=True)
+    subprocess.run(["git", "commit", "-m", "initial commit"], cwd=work_dir, check=True)
+    subprocess.run(["git", "branch", "-M", "dev"], cwd=work_dir, check=True)
+    subprocess.run(["git", "remote", "add", "origin", str(origin_dir)], cwd=work_dir, check=True)
+    subprocess.run(["git", "push", "-u", "origin", "dev"], cwd=work_dir, check=True)
+
+    return work_dir
+
+
+def _plan(branch: str = "dev"):
+    return plan_worktree(
+        FlowMeta(type="feature", base_branch=branch), slug=SLUG, feature_id=FEATURE_ID
+    )
+
+
+def test_ensure_creates_worktree_when_absent(tmp_git_repo: Path) -> None:
+    """First call creates the branch and the directory and reports created=True."""
+    path, created = ensure(_plan(), repo_root=tmp_git_repo)
+    assert created is True
+    assert path.is_dir()
+    assert path.name == f"feat-{FEATURE_ID}-{SLUG}"
+
+
+def test_ensure_is_idempotent(tmp_git_repo: Path) -> None:
+    """Second call reuses: same path, created=False, still exactly one branch."""
+    first, _ = ensure(_plan(), repo_root=tmp_git_repo)
+    second, created = ensure(_plan(), repo_root=tmp_git_repo)
+    assert second == first and created is False
+
+    # Assert `git branch --list feat-FEAT-999-demo-feature` yields one line
+    res = subprocess.run(
+        ["git", "branch", "--list", f"feat-{FEATURE_ID}-{SLUG}"],
+        cwd=tmp_git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    lines = [line.strip() for line in res.stdout.splitlines() if line.strip()]
+    assert len(lines) == 1
+
+
+def test_ensure_rejects_path_with_foreign_branch(tmp_git_repo: Path) -> None:
+    """A worktree at the target path on another branch is an error, not a reuse."""
+    # Create the worktree first
+    plan = _plan()
+    path, created = ensure(plan, repo_root=tmp_git_repo)
+    assert created is True
+
+    # Force its branch elsewhere or create a different branch and check it out there.
+    # Let's create a new branch 'other-branch' and check it out in that worktree.
+    subprocess.run(["git", "checkout", "-b", "other-branch"], cwd=path, check=True)
+
+    with pytest.raises(EnsureWorktreeError) as exc_info:
+        ensure(plan, repo_root=tmp_git_repo)
+    assert "expected branch" in str(exc_info.value)
+
+
+def test_ensure_rejects_existing_unchecked_branch(tmp_git_repo: Path) -> None:
+    """A leftover branch with no worktree must be reported, not reused blindly."""
+    plan = _plan()
+    # Create a branch with the target name but no worktree
+    subprocess.run(["git", "branch", plan.name], cwd=tmp_git_repo, check=True)
+
+    with pytest.raises(EnsureWorktreeError) as exc_info:
+        ensure(plan, repo_root=tmp_git_repo)
+    assert plan.name in str(exc_info.value)
+    assert "already exists but is not checked out" in str(exc_info.value)
+
+
+def test_ensure_requires_paths_visible(tmp_git_repo: Path) -> None:
+    """Branching from a base that lacks the task artifacts must fail loudly."""
+    plan = _plan()
+    with pytest.raises(EnsureWorktreeError) as exc_info:
+        ensure(plan, repo_root=tmp_git_repo, require_paths=["sdd/tasks/index/absent.json"])
+    assert "Verification failed" in str(exc_info.value)
+
+    # Assert that the half-created worktree is not left behind
+    target_path = (tmp_git_repo / plan.path).resolve()
+    assert not target_path.exists()
+
+
+def test_ensure_dry_run_mutates_nothing(tmp_git_repo: Path) -> None:
+    """--dry-run resolves and reports; `git worktree list` is unchanged."""
+    res_before = subprocess.run(["git", "worktree", "list"], cwd=tmp_git_repo, capture_output=True, text=True, check=True)
+    before_list = res_before.stdout
+
+    path, created = ensure(_plan(), repo_root=tmp_git_repo, dry_run=True)
+    assert created is True
+
+    res_after = subprocess.run(["git", "worktree", "list"], cwd=tmp_git_repo, capture_output=True, text=True, check=True)
+    after_list = res_after.stdout
+
+    assert before_list == after_list
+
+
+def test_ensure_json_output_shape(tmp_git_repo: Path, capsys, monkeypatch) -> None:
+    """--json emits one object with name/path/base_ref/created."""
+    monkeypatch.chdir(tmp_git_repo)
+
+    # First run (creates)
+    ret = main(["--slug", SLUG, "--feature-id", FEATURE_ID, "--json"])
+    assert ret == 0
+    out, err = capsys.readouterr()
+    data = json.loads(out.strip())
+    assert data["name"] == f"feat-{FEATURE_ID}-{SLUG}"
+    assert data["created"] is True
+    assert "base_ref" in data
+    assert "path" in data
+
+    # Second run (reuses)
+    ret = main(["--slug", SLUG, "--feature-id", FEATURE_ID, "--json"])
+    assert ret == 0
+    out, err = capsys.readouterr()
+    data = json.loads(out.strip())
+    assert data["created"] is False

--- a/tests/sdd_scripts/test_ensure_worktree.py
+++ b/tests/sdd_scripts/test_ensure_worktree.py
@@ -54,9 +54,7 @@ def tmp_git_repo(tmp_path: Path) -> Path:
 
 
 def _plan(branch: str = "dev"):
-    return plan_worktree(
-        FlowMeta(type="feature", base_branch=branch), slug=SLUG, feature_id=FEATURE_ID
-    )
+    return plan_worktree(FlowMeta(type="feature", base_branch=branch), slug=SLUG, feature_id=FEATURE_ID)
 
 
 def test_ensure_creates_worktree_when_absent(tmp_git_repo: Path) -> None:
@@ -127,13 +125,17 @@ def test_ensure_requires_paths_visible(tmp_git_repo: Path) -> None:
 
 def test_ensure_dry_run_mutates_nothing(tmp_git_repo: Path) -> None:
     """--dry-run resolves and reports; `git worktree list` is unchanged."""
-    res_before = subprocess.run(["git", "worktree", "list"], cwd=tmp_git_repo, capture_output=True, text=True, check=True)
+    res_before = subprocess.run(
+        ["git", "worktree", "list"], cwd=tmp_git_repo, capture_output=True, text=True, check=True
+    )
     before_list = res_before.stdout
 
     path, created = ensure(_plan(), repo_root=tmp_git_repo, dry_run=True)
     assert created is True
 
-    res_after = subprocess.run(["git", "worktree", "list"], cwd=tmp_git_repo, capture_output=True, text=True, check=True)
+    res_after = subprocess.run(
+        ["git", "worktree", "list"], cwd=tmp_git_repo, capture_output=True, text=True, check=True
+    )
     after_list = res_after.stdout
 
     assert before_list == after_list

--- a/tests/sdd_scripts/test_ensure_worktree.py
+++ b/tests/sdd_scripts/test_ensure_worktree.py
@@ -161,3 +161,46 @@ def test_ensure_json_output_shape(tmp_git_repo: Path, capsys, monkeypatch) -> No
     out, err = capsys.readouterr()
     data = json.loads(out.strip())
     assert data["created"] is False
+
+
+def test_json_output_includes_worktree_path_alias(tmp_git_repo: Path, capsys, monkeypatch) -> None:
+    """sdd-planner/sdd-research read ``worktree_path`` from the JSON object
+    for their PlannerOutput/ResearchOutput contracts (spec §8) — the CLI
+    must actually emit that key, not just ``path`` (code review fixup)."""
+    monkeypatch.chdir(tmp_git_repo)
+
+    ret = main(["--slug", SLUG, "--feature-id", FEATURE_ID, "--json"])
+    assert ret == 0
+    out, _err = capsys.readouterr()
+    data = json.loads(out.strip())
+    assert "worktree_path" in data
+    assert data["worktree_path"] == data["path"]
+
+
+def test_main_infers_hotfix_from_jira_key_alone(tmp_git_repo: Path, capsys, monkeypatch) -> None:
+    """The documented invocation ``--slug <slug> --jira-key <KEY>`` (CLAUDE.md,
+    sdd-research.md) must work without also requiring ``--type``/
+    ``--base-branch`` — ``resolve_flow()`` has no other signal here that this
+    is a hotfix run, so ``main()`` must infer it (code review fixup)."""
+    # Hotfix worktrees branch from origin/main; give the fixture's origin a
+    # main branch mirroring dev so the fetch/worktree-add in ensure() succeeds.
+    subprocess.run(["git", "push", "origin", "dev:main"], cwd=tmp_git_repo, check=True)
+    monkeypatch.chdir(tmp_git_repo)
+
+    ret = main(["--slug", SLUG, "--jira-key", "NAV-8036", "--json"])
+    assert ret == 0
+    out, _err = capsys.readouterr()
+    data = json.loads(out.strip())
+    assert data["name"] == f"hotfix-NAV-8036-{SLUG}"
+    assert data["base_ref"] == "origin/main"
+
+
+def test_ensure_rejects_absolute_require_paths(tmp_git_repo: Path) -> None:
+    """An absolute ``require_paths`` entry must be rejected outright, not
+    silently pass verification — ``Path(x) / <absolute>`` discards ``x``,
+    which would make Step 5 check a path outside the worktree entirely and
+    report success regardless (code review fixup)."""
+    plan = _plan()
+    with pytest.raises(EnsureWorktreeError) as exc_info:
+        ensure(plan, repo_root=tmp_git_repo, require_paths=["/etc/hostname"])
+    assert "repo-relative" in str(exc_info.value)

--- a/tests/sdd_scripts/test_worktree_plan.py
+++ b/tests/sdd_scripts/test_worktree_plan.py
@@ -1,0 +1,62 @@
+"""Unit tests for ``scripts.sdd.sdd_meta.plan_worktree`` — FEAT-552 / TASK-3153."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.sdd.sdd_meta import WORKTREE_ROOT, FlowMeta, WorktreePlan, plan_worktree
+
+SLUG = "worktree-creation-ownership"
+
+
+def test_plan_feature_name_keeps_feat_prefix() -> None:
+    """A feature keeps the doubled `feat-FEAT-` prefix — /sdd-done greps it."""
+    plan = plan_worktree(
+        FlowMeta(type="feature", base_branch="dev"), slug=SLUG, feature_id="FEAT-552"
+    )
+    assert isinstance(plan, WorktreePlan)
+    assert plan.name == f"feat-FEAT-552-{SLUG}"
+    assert plan.path == f"{WORKTREE_ROOT}/feat-FEAT-552-{SLUG}"
+
+
+@pytest.mark.parametrize("branch", ["dev", "staging"])
+def test_plan_feature_base_ref_is_remote_qualified(branch: str) -> None:
+    """base_ref is always origin/<base_branch> — never a local HEAD."""
+    plan = plan_worktree(
+        FlowMeta(type="feature", base_branch=branch), slug=SLUG, feature_id="FEAT-552"
+    )
+    assert plan.base_ref == f"origin/{branch}"
+
+
+def test_plan_hotfix_uses_jira_key_and_origin_main() -> None:
+    """FEAT-466: a hotfix is named from its Jira key and branches from main."""
+    plan = plan_worktree(
+        FlowMeta(type="hotfix", base_branch="main"), slug=SLUG, jira_key="NAV-8036"
+    )
+    assert plan.name == f"hotfix-NAV-8036-{SLUG}"
+    assert plan.base_ref == "origin/main"
+
+
+def test_plan_feature_without_feature_id_raises() -> None:
+    """A feature with no id is a programming error, not a default."""
+    with pytest.raises(ValueError, match="feature_id"):
+        plan_worktree(FlowMeta(type="feature", base_branch="dev"), slug=SLUG)
+
+
+def test_plan_feature_with_bare_number_raises() -> None:
+    """`552` is not `FEAT-552` — reject it rather than emit a legacy-style name."""
+    with pytest.raises(ValueError, match="feature_id"):
+        plan_worktree(FlowMeta(type="feature", base_branch="dev"), slug=SLUG, feature_id="552")
+
+
+def test_plan_hotfix_without_jira_key_raises() -> None:
+    """A hotfix has no FEAT id, so the Jira key is mandatory."""
+    with pytest.raises(ValueError, match="jira_key"):
+        plan_worktree(FlowMeta(type="hotfix", base_branch="main"), slug=SLUG)
+
+
+@pytest.mark.parametrize("slug", ["", "   "])
+def test_plan_empty_slug_raises(slug: str) -> None:
+    """An empty slug would yield `feat-FEAT-552-` — refuse it."""
+    with pytest.raises(ValueError, match="slug"):
+        plan_worktree(FlowMeta(type="feature", base_branch="dev"), slug=slug, feature_id="FEAT-552")

--- a/tests/sdd_scripts/test_worktree_plan.py
+++ b/tests/sdd_scripts/test_worktree_plan.py
@@ -11,9 +11,7 @@ SLUG = "worktree-creation-ownership"
 
 def test_plan_feature_name_keeps_feat_prefix() -> None:
     """A feature keeps the doubled `feat-FEAT-` prefix — /sdd-done greps it."""
-    plan = plan_worktree(
-        FlowMeta(type="feature", base_branch="dev"), slug=SLUG, feature_id="FEAT-552"
-    )
+    plan = plan_worktree(FlowMeta(type="feature", base_branch="dev"), slug=SLUG, feature_id="FEAT-552")
     assert isinstance(plan, WorktreePlan)
     assert plan.name == f"feat-FEAT-552-{SLUG}"
     assert plan.path == f"{WORKTREE_ROOT}/feat-FEAT-552-{SLUG}"
@@ -22,17 +20,13 @@ def test_plan_feature_name_keeps_feat_prefix() -> None:
 @pytest.mark.parametrize("branch", ["dev", "staging"])
 def test_plan_feature_base_ref_is_remote_qualified(branch: str) -> None:
     """base_ref is always origin/<base_branch> — never a local HEAD."""
-    plan = plan_worktree(
-        FlowMeta(type="feature", base_branch=branch), slug=SLUG, feature_id="FEAT-552"
-    )
+    plan = plan_worktree(FlowMeta(type="feature", base_branch=branch), slug=SLUG, feature_id="FEAT-552")
     assert plan.base_ref == f"origin/{branch}"
 
 
 def test_plan_hotfix_uses_jira_key_and_origin_main() -> None:
     """FEAT-466: a hotfix is named from its Jira key and branches from main."""
-    plan = plan_worktree(
-        FlowMeta(type="hotfix", base_branch="main"), slug=SLUG, jira_key="NAV-8036"
-    )
+    plan = plan_worktree(FlowMeta(type="hotfix", base_branch="main"), slug=SLUG, jira_key="NAV-8036")
     assert plan.name == f"hotfix-NAV-8036-{SLUG}"
     assert plan.base_ref == "origin/main"
 


### PR DESCRIPTION
## Summary

Establishes a single, code-backed rule for worktree naming/provisioning
(`plan_worktree()` in `scripts/sdd/sdd_meta.py`) and a shared idempotent CLI
(`scripts/sdd/ensure_worktree.py`) that every SDD command/agent now goes
through, instead of each one hand-rolling its own `git worktree add`
invocation.

- `/sdd-start` now provisions its own worktree via the shared CLI.
- `/sdd-task` no longer creates worktrees (worktree creation moved to
  `/sdd-start`'s ownership).
- `sdd-worker`, `sdd-planner`, `sdd-research`, and `sdd-autopilot` all
  route worktree creation through the same shared rule.
- `CLAUDE.md` documents the new ownership split.
- Guard tests (`tests/sdd_scripts/test_ensure_worktree.py`,
  `test_worktree_plan.py`, `test_command_contracts.py`) lock in naming,
  idempotency, and the contract that `/sdd-task` no longer touches
  worktrees.

## Tasks

8/8 tasks verified (TASK-3153 – TASK-3160). Commits found and files
present for every task; per-spec index stamped `verification: verified`
and `completed_at` set.

## Test plan

- [x] `pytest tests/sdd_scripts/test_ensure_worktree.py
      tests/sdd_scripts/test_worktree_plan.py
      tests/sdd_scripts/test_command_contracts.py -q` — 31 passed
- [x] Adversarial code review completed during implementation
      (fixups applied in `a4f35b055`)

---
_Closed by /sdd-done_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJ6VmWsEXEpA58DiPircCD